### PR TITLE
chore(deps): block TypeScript 7 pending Astro support

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,16 @@
     ],
     "packageRules": [
         {
+            "description": "Keep TypeScript on v6 until Astro Check supports the native compiler API",
+            "matchManagers": [
+                "npm"
+            ],
+            "matchPackageNames": [
+                "typescript"
+            ],
+            "allowedVersions": "<7"
+        },
+        {
             "description": "Group non-major Composer development dependency updates",
             "matchManagers": [
                 "composer"


### PR DESCRIPTION
## Summary

- keep Renovate TypeScript updates below version 7
- document the Astro Check compatibility constraint in Renovate config

## Context

Supersedes #27. TypeScript 7 uses the native compiler and does not currently expose the programmatic API required by Astro Check, so the upgrade cannot install or pass the documentation check. Support is tracked in https://github.com/withastro/roadmap/discussions/1321.