### PR TITLE
fix: exclude nested dependencies from prose checks

### DIFF
--- a/tests/Acceptance/ProseCheckTest.php
+++ b/tests/Acceptance/ProseCheckTest.php
@@ -303,6 +303,20 @@ final readonly class ProseCheckTest
     }
 
     #[Test]
+    public function excludesDependenciesAtAnyDirectoryDepth(): void
+    {
+        [$root, $baseline] = $this->workspace('dependency-exclusion');
+        $invalid = "The worker doesn't use the configured colour; it stops.\n";
+        $this->write($root, 'vendor/package/README.md', $invalid);
+        $this->write($root, 'website/node_modules/package/README.md', $invalid);
+        $this->write($root, 'packages/example/vendor/package/README.md', $invalid);
+        $this->write($root, 'packages/example/node_modules/package/README.md', $invalid);
+
+        $result = $this->run('check', $root, $baseline);
+        Expect::that($result->exitCode)->toBe(0);
+    }
+
+    #[Test]
     public function createsAnInitialBaselineThatAllowsExistingFindings(): void
     {
         [$root, $baseline] = $this->workspace('baseline-create');

--- a/tools/prose-check.php
+++ b/tools/prose-check.php
@@ -13,10 +13,13 @@ const PROSE_BLOCKING_RULES = [
 const PROSE_EXCLUDED_DIRECTORIES = [
     '.git',
     '.phpstan-api-stubs',
-    'node_modules',
     'tests/Fixture',
-    'vendor',
     'website/dist',
+];
+
+const PROSE_EXCLUDED_DIRECTORY_NAMES = [
+    'node_modules',
+    'vendor',
 ];
 
 const PROSE_CONTRACTIONS = [
@@ -259,7 +262,13 @@ function proseFiles(string $root): array
 
 function proseIsExcluded(string $relativePath): bool
 {
-    return \array_any(PROSE_EXCLUDED_DIRECTORIES, fn($directory) => $relativePath === $directory || \str_starts_with($relativePath, $directory . '/'));
+    if (\array_any(PROSE_EXCLUDED_DIRECTORIES, fn($directory) => $relativePath === $directory || \str_starts_with($relativePath, $directory . '/'))) {
+        return true;
+    }
+
+    $segments = \explode('/', $relativePath);
+
+    return \array_any(PROSE_EXCLUDED_DIRECTORY_NAMES, fn(string $directory): bool => \in_array($directory, $segments, true));
 }
 
 function proseRelativePath(string $root, string $path): string


### PR DESCRIPTION
## Summary

- Exclude `node_modules` and `vendor` directories at every path depth.
- Add acceptance coverage for root and nested dependency directories.
- Prevent `make docs-check` from making later prose checks scan installed packages.

## Continuation point

- Base commit: `1fd3e9b226f7a5ec607212adad7a8b5eff0f0bfb`
- Result commit: `acfd3c3`
- Owned paths: `tools/prose-check.php` and `tests/Acceptance/ProseCheckTest.php`
- Blocking groups before and after: 294; no baseline change
- Terminology decisions: none
- Commands recorded: focused `ProseCheckTest`, `composer prose:check`, `composer static-analysis`, and `composer tests`
- Next unclaimed shard: introductory documentation
