### PR TITLE
docs: rewrite user reference in STE

### DIFF
--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -1,10 +1,10 @@
 # Test attachments
 
-Attachments keep diagnostic data with the test result that produced it, without
-writing the data to captured stdout. Tests and worker-side plugins can attach
-JSON values, text, bytes, or existing files.
+Attachments keep diagnostic data with the related test result. They do not write this
+data to captured stdout. Tests and worker-side plugins can attach JSON values,
+text, bytes, or files that already exist.
 
-## Adding attachments
+## Attachment creation
 
 Ask for `Greenlight\Core\Artifact\Attachments` through constructor injection:
 
@@ -37,13 +37,13 @@ final readonly class CheckoutTest
 media type. `file()` copies a regular file and detects its media type when
 possible.
 
-Greenlight copies the content before the method returns. A temporary source file
-can be removed as soon as `file()` returns, and later changes to a value or file
-do not affect the attachment.
+Greenlight copies the content before the method returns. You can remove a
+temporary source file after `file()` returns. Later changes to a value or file
+do not change the attachment.
 
-Attachments are retained when the attempt fails or errors. This includes a
-passing attempt changed to another outcome by result policy. To retain an
-attachment from a passing attempt, set its retention to
+Greenlight retains attachments when the attempt fails or has an error. This
+rule includes a successful attempt that result policy changes to another
+outcome. To retain an attachment from a successful attempt, set its retention to
 `AttachmentRetention::Always`:
 
 ```php
@@ -54,16 +54,16 @@ $attachments->text(
 );
 ```
 
-Each retry has its own attachments. Attachments from failed attempts remain on
+Each retry has separate attachments. Attachments from failed attempts stay on
 the final result even if a later attempt passes. The `attempt` field identifies
-the attempt that produced each attachment. Attachments from the passing attempt
-are discarded unless their retention is `always`.
+the source attempt for each attachment. Greenlight discards attachments from
+the successful attempt unless their retention is `always`.
 
 ## Output directory
 
-Retained attachments from each run go into a unique directory below
-`build/greenlight-artifacts` by default. Runs with no retained attachments do
-not create an empty directory. Change the parent directory in `greenlight.php`:
+By default, Greenlight writes retained attachments to a unique run directory
+below `build/greenlight-artifacts`. A run with no retained attachments does not
+create an empty directory. Change the parent directory in `greenlight.php`:
 
 ```php
 use Greenlight\Config\ArtifactBuilder;
@@ -79,8 +79,8 @@ Use `--artifacts-dir` to override it for one run:
 greenlight run --artifacts-dir=build/ci-evidence
 ```
 
-Greenlight does not delete completed run directories. Remove them locally or use
-the artifact retention settings in CI.
+Greenlight does not delete completed run directories. For local runs, remove
+these directories. In CI, use the artifact retention settings.
 
 ## Metadata and names
 
@@ -93,18 +93,18 @@ separators, control characters, `.` or `..`. Repeated names within one attempt
 receive `-2`, `-3`, and later suffixes in their published filenames. Their
 logical names remain unchanged in the result metadata.
 
-Test identifiers are slugged and hashed before Greenlight uses them in paths.
+Greenlight converts test IDs to slugs and hashes before it uses them in paths.
 
 ## File safety
 
 Source files must be regular files, not symlinks. Greenlight verifies that a
-source does not change while it is copied. Published paths remain inside the
-configured run directory. Artifact files are created with private permissions
-where the platform supports them.
+source does not change during the copy operation. Published paths stay in the
+configured run directory. Greenlight creates artifact files with private
+permissions on supported platforms.
 
-Greenlight does not inspect or redact attachment contents. Remove secrets and
-personal data before attaching a value or file. Access to the output directory
-should follow the same policy as other sensitive CI artifacts.
+Greenlight does not inspect attachment content. It does not redact attachment
+content. Before you attach a value or file, remove secrets and personal data.
+Apply the policy for sensitive CI artifacts to the output directory.
 
 ## Limits
 
@@ -116,22 +116,22 @@ The defaults are:
 * 10,000 attachments per run
 * 1 GiB across all attachments for one run
 
-Configure them with `maxAttachmentsPerTest()`, `maxAttachmentSize()`,
+Configure the limits with `maxAttachmentsPerTest()`, `maxAttachmentSize()`,
 `maxTestSize()`, `maxRunAttachments()`, and `maxRunSize()` on
-`ArtifactBuilder`. Size methods accept values such as `10M` and `2G`. Exceeding
-a limit fails the active test with an attachment error. Greenlight does not
+`ArtifactBuilder`. Size methods accept values such as `10M` and `2G`. A limit
+violation fails the active test with an attachment error. Greenlight does not
 truncate attachment content.
 
-Run-wide limits are coordinated through private shared staging, so they
+Greenlight coordinates run limits through private shared staging. Thus, they
 apply across parallel workers. Per-test limits include all attempts, even when
-some attachments are later discarded. Run quota is released when an attachment
-is discarded.
+Greenlight discards some attachments later. Greenlight releases run quota when
+it discards an attachment.
 
 ## Plugins
 
-`$context->attachments` exposes the same attempt-owned object to
+`$context->attachments` gives the same attempt-owned object to
 `TestLifecycleSubscriber::beforeTest()` and `afterTest()`. A plugin can attach
-data before the test or after inspecting its result.
+data before the test or after it examines the result.
 
 A retry decider receives attachment metadata on the `TestResult`, but it cannot
 read the content through the result. See [writing plugins](plugins.md) for the
@@ -148,5 +148,5 @@ JSONL includes attachment metadata and reports the run directory in
 `run-started.artifactsDirectory`. See the [JSONL
 schema](architecture/jsonl.md).
 
-For other CI systems, upload the reported run directory from a post-test step
-that runs even when the test command fails.
+For other CI systems, use a post-test step that always runs. Upload the reported
+run directory from this step.

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -1,6 +1,6 @@
 # Attributes
 
-Test metadata is declared with attributes from the `Greenlight\Attribute`
+Declare test metadata with attributes from the `Greenlight\Attribute`
 namespace.
 
 There are no method-name conventions and no annotations. Attributes on a class
@@ -18,15 +18,16 @@ bool $capture = true
 
 Marks a public method as a test.
 
-Output capture is enabled by default. Greenlight records output written through
-PHP's output buffer, such as `echo` and `print`, together with notices, warnings,
-and deprecations raised during the test. Reporters can then associate that
-output with the test that produced it.
+Greenlight enables output capture by default. It records output from PHP's
+output buffer, such as `echo` and `print`. It also records notices, warnings,
+and deprecations from the test. Reporters can associate this output with its
+test.
 
 Direct writes to the `STDOUT` and `STDERR` stream resources bypass PHP's output
-buffer and are not captured. They can also interfere with terminal output, so
-tests should not use them for diagnostics. Use test attachments when diagnostic
-content must be retained; see [test attachments](attachments.md).
+buffer. Greenlight does not capture these writes. They can also interfere with
+terminal output. Do not use these resources for test diagnostics. Use test
+attachments to retain diagnostic content. See [test
+attachments](attachments.md).
 
 Set `capture: false` only when a test needs to control PHP's output buffer or
 error handler itself. With capture disabled, Greenlight does not record output
@@ -48,10 +49,11 @@ No parameters.
 
 Marks a public method to run before each test in the class.
 
-If a class has multiple before-hooks, they run in declaration order.
+If a class has multiple before-hooks, Greenlight runs them in declaration
+order.
 
-A `SkipTest` thrown from a before-hook skips the test. Any other throwable marks
-the test as errored.
+A before-hook can throw `SkipTest` to skip the test. A throwable other than
+`SkipTest` gives the test an error.
 
 ## After
 
@@ -59,15 +61,14 @@ Target: method.
 
 No parameters.
 
-Marks a public method to run after each test in the class, including tests that
-fail or error.
+Marks a public method to run after each test in the class. The method also runs
+after a test failure or error.
 
-If a class has multiple after-hooks, they run in reverse declaration order. This
-mirrors before-hooks as a stack.
+If a class has multiple after-hooks, Greenlight runs them in reverse declaration
+order. Thus, the before-hooks and after-hooks form a stack.
 
-Every after-hook is called, even if an earlier one throws. If the test did not
-already fail or error, the first throwable from an after-hook becomes the test's
-cause.
+Greenlight calls each after-hook, even if an earlier hook throws. If the test
+does not have a failure or error, the first throwable becomes its cause.
 
 ## DataSet
 
@@ -81,8 +82,8 @@ string $provider
 ```
 
 With one argument, references a public static provider method on the test
-class. With two arguments, the first is a provider class and the second is its
-public static method:
+class. With two arguments, the first argument is a provider class. The second
+argument is its public static method:
 
 ```php
 #[DataSet('currencies')]
@@ -96,10 +97,10 @@ or:
 
 The provider must return an iterable of named data sets for the test method.
 
-Providers run at discovery time, before any tests execute. Keep them pure: no
-I/O and no global state.
+Providers run at discovery time before tests execute. Do not use I/O or global
+state in a provider.
 
-Each provider key names a data set and appears in test ids and reports. Each
+Each provider key names a data set and appears in test IDs and reports. Each
 provider value is the argument list for one test invocation.
 
 ```php
@@ -132,11 +133,12 @@ final class CurrencyDataSets
 public function roundsSharedCurrencyCases(Currency $currency, string $expected): void { ... }
 ```
 
-The bundled PHPStan extension validates providers statically: the provider
-must exist, be public and static, and return an iterable of argument arrays,
-and row shapes PHPStan can see (such as the `array{...}` return type above)
-are checked against the test method's parameters. `#[DataRow]` literals get
-the same check. See [static analysis with PHPStan](phpstan.md).
+The bundled PHPStan extension validates providers without their execution. Each
+provider must exist, be public and static, and return an iterable of argument
+arrays. PHPStan compares visible row shapes with the test method parameters.
+The `array{...}` return type above is one visible row shape. The extension
+applies the same check to `#[DataRow]` literals. See [static analysis with
+PHPStan](phpstan.md).
 
 ## DataRow
 
@@ -154,15 +156,15 @@ array $arguments
 Adds one inline data set.
 
 `$arguments` contains the test arguments in parameter order. The label becomes
-the data-set key in test ids and reports. If no label is provided, the key is
-`#<position>` among the inline rows.
+the data-set key in test IDs and reports. Without a label, Greenlight uses
+`#<position>` as the key for the inline row.
 
-Inline rows are limited to values that PHP attributes can express, such as
-scalars, arrays, and constants. For computed rows, ranges, or objects, use a
-`#[DataSet]` provider.
+Inline rows can contain only values that PHP attributes can express. Examples
+include scalars, arrays, and constants. Use a `#[DataSet]` provider for
+calculated rows, ranges, or objects.
 
-`#[DataRow]` and `#[DataSet]` can be used on the same method. They share one
-data-set key space, so duplicate keys are a discovery error.
+You can use `#[DataRow]` and `#[DataSet]` on the same method. They use one
+data-set key space. Thus, duplicate keys cause a discovery error.
 
 ```php
 #[Test]
@@ -177,13 +179,13 @@ Target: method.
 
 No parameters.
 
-Declares that the test is expected to verify no expectations.
+Declares that the test intentionally verifies no expectations.
 
-Use this for tests that pass by not throwing. Risky-test detection and
+Use this for tests that pass and do not throw. Risky-test detection and
 `--fail-on-risky` ignore tests marked with this attribute.
 
-The attribute makes the intent explicit, so a deliberate zero-expectation test is
-not confused with a forgotten assertion.
+The attribute makes the intent explicit. Thus, Greenlight does not confuse this
+test with a test that has a missing assertion.
 
 An `eventually()` or `consistently()` matcher counts as one expectation.
 
@@ -201,7 +203,7 @@ string $name
 
 Tags a test method, or every test in a class, with a group name.
 
-Groups can be selected at run time with `--group=<name>`. The flag is
+Select groups at run time with `--group=<name>`. The flag is
 repeatable. `list-tests` applies the same filter.
 
 ```php
@@ -222,9 +224,9 @@ string $reason
 
 Skips the test method, or every test in the class, unconditionally.
 
-The reason is required and appears in the report.
+You must give a reason. The reason appears in the report.
 
-Skipped tests are not constructed.
+Greenlight does not construct skipped tests.
 
 ## SkipUnless
 
@@ -239,12 +241,13 @@ mixed ...$arguments
 
 `$condition` must be a class-string for `Greenlight\Core\Condition`.
 
-Skips the test unless the condition is satisfied.
+Skips the test if the condition is false.
 
-Any further attribute arguments are passed to the condition's constructor.
-Arguments must be scalars or null, because they travel to parallel workers;
-anything else is a discovery error. The constructor must only store them, and
-evaluation happens in `isSatisfied()` without side effects:
+Greenlight passes the remaining attribute arguments to the condition
+constructor. Arguments must be scalars or null because Greenlight sends them to
+parallel workers. Another argument type causes a discovery error. The
+constructor must only store the arguments. The `isSatisfied()` method must
+evaluate the condition without side effects:
 
 ```php
 interface Condition
@@ -253,11 +256,11 @@ interface Condition
 }
 ```
 
-The condition is evaluated in the worker at execution time, before the test class
-is constructed. If the condition is not satisfied, constructor injection and
-harness services are not used.
+The worker evaluates the condition before it constructs the test class. If the
+condition is false, Greenlight does not use constructor injection or harness
+services.
 
-If the condition throws, the test errors instead of being skipped.
+If the condition throws, the test has an error. Greenlight does not skip it.
 
 ```php
 #[Test]
@@ -274,8 +277,8 @@ public function usesTheRedisExtension(): void { ... }
 The `Greenlight\Condition` namespace ships conditions for the common
 environment checks, so most `#[SkipUnless]` uses need no hand-written class:
 
-* `ExtensionLoaded('redis')` checks that the extension is loaded.
-* `ExtensionMissing('xdebug')` checks that the extension is not loaded.
+* `ExtensionLoaded('redis')` checks for the extension.
+* `ExtensionMissing('xdebug')` checks for the absence of the extension.
 * `EnvironmentVariableSet('CI')` checks that `getenv()` returns a value.
 * `EnvironmentVariableEquals('APP_ENV', 'test')` checks that the variable
   equals the value exactly.
@@ -302,15 +305,16 @@ int $times
 ?string $onlyOn = null
 ```
 
-Retries a failing test up to `$times` additional attempts.
+Retries a failed test up to `$times` additional attempts.
 
 `$times` must be at least 1.
 
-When `$onlyOn` is provided, it must be a throwable class-string. Only failures
-caused by that throwable type are retried. Other failures fail immediately.
+When you supply `$onlyOn`, it must be a throwable class-string. Greenlight
+retries only failures with that throwable type. It does not retry other
+failures.
 
-Each attempt gets a fresh test instance and a fresh per-test scope, so state does
-not leak between attempts.
+Greenlight gives each attempt a new test instance and a new per-test scope.
+Thus, state does not pass between attempts.
 
 Each retry also starts `eventually()` and `consistently()` with a new deadline
 and an empty observation log. `retryOnException()` retries a probe within the
@@ -336,16 +340,16 @@ float $seconds
 
 Fails the test if it runs longer than the configured budget.
 
-Timeout enforcement has two layers. Inside the worker, elapsed time is checked
-cooperatively and an over-budget test is marked failed. The orchestrator also
-hard-kills a worker if its current test exceeds the budget without returning.
+Greenlight enforces a timeout in two layers. The worker checks elapsed time
+cooperatively and fails a test that exceeds its budget. If the worker does not
+return, the orchestrator terminates it after the hard-kill grace period.
 
-A killed worker is replaced and the run continues.
+The orchestrator replaces the stopped worker and continues the run.
 
-An `eventually()` or `consistently()` duration cannot run past the current test
-timeout. The failure names the requested polling duration when the test timeout
-comes first. A blocked probe remains subject to the orchestrator's hard-kill
-grace.
+An `eventually()` or `consistently()` matcher cannot run past the current test
+timeout. If the test timeout occurs first, the failure gives the requested
+duration. A blocked probe remains subject to the orchestrator hard-kill grace
+period.
 
 ```php
 #[Test]
@@ -363,9 +367,9 @@ Parameters:
 string $name
 ```
 
-Marks a test as requiring one slot of a named resource. A name must start with a
-lowercase letter or digit. The rest may also contain dots, underscores, and
-hyphens.
+Marks a test that requires one slot of a named resource. A name must start with
+a lowercase letter or digit. After the first character, the name accepts dots,
+underscores, and hyphens.
 
 ```php
 #[RequiresResource('postgres')]
@@ -373,8 +377,8 @@ hyphens.
 final class OrderRepositoryTest { ... }
 ```
 
-Class-level requirements apply to every method. Method-level requirements are
-combined with them. Repeating the same name has no effect.
+Class-level requirements apply to each method. Greenlight combines method-level
+requirements with them. Multiple occurrences of the same name have no effect.
 
 Greenlight assigns work by class, so it combines the requirements from every
 method and holds those resources until the class finishes. A requirement on one
@@ -383,7 +387,7 @@ method can therefore reduce concurrency for other methods in the same class.
 Resources default to a limit of one. Use `resourceLimit()` in `greenlight.php`
 or `--resource-limit` to set a larger limit.
 
-The requirement controls when a class may start. It does not select a concrete
+The requirement controls the class start time. It does not select a concrete
 resource instance or provide a lease identifier. Use `TestChannel` when every
 worker can have its own instance. A smaller set of distinct instances still
 needs an application-owned allocator.
@@ -397,8 +401,8 @@ Target: method or class.
 
 No parameters.
 
-Runs the test method, or every test in the class, in a dedicated fresh worker.
-That worker is discarded afterwards.
+Runs the test method, or each test in the class, in a dedicated new worker.
+Greenlight discards that worker after the test.
 
 Use this for tests that modify process-global state, such as ini settings,
 environment variables, or static caches.
@@ -409,9 +413,9 @@ Target: class, method, or function.
 
 No parameters.
 
-Excludes the declaration from coverage. Ignored lines are removed from both the
-covered and executable totals, so they never move a percentage, an export, or a
-baseline diff.
+Excludes the declaration from coverage. Greenlight removes ignored lines from
+the covered and executable totals. Thus, they do not change a percentage,
+export, or baseline diff.
 
 ```php
 final class Config
@@ -426,11 +430,11 @@ final class Config
 function dumpDebugState(): void { ... }
 ```
 
-The attribute is matched by name without loading the code it's applied to, so
-an aliased import (`use Greenlight\Attribute\CoverageIgnore as Ignore`) is not
-recognised.
+Greenlight matches the attribute name and does not load the related code.
+Therefore, it does not recognize an aliased import
+(`use Greenlight\Attribute\CoverageIgnore as Ignore`).
 
-The PHPUnit comment annotations work unchanged: `@codeCoverageIgnore` in a
-docblock before a declaration, `@codeCoverageIgnoreStart` and
-`@codeCoverageIgnoreEnd` around a block, and a trailing `// @codeCoverageIgnore`
-on a single line.
+The PHPUnit comment annotations work without changes. Put
+`@codeCoverageIgnore` in a docblock before a declaration. Put
+`@codeCoverageIgnoreStart` and `@codeCoverageIgnoreEnd` around a block. Put
+`// @codeCoverageIgnore` at the end of one line.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,15 +1,14 @@
 # Configuration
 
-Greenlight is configured with a single file: `greenlight.php` at the project
-root.
+Configure Greenlight with one `greenlight.php` file at the project root.
 
 The file returns a `Greenlight\Config\GreenlightConfig` builder. The CLI loads
-the builder, applies command-line overrides, then freezes the result into an
-immutable configuration object.
+the builder and applies command-line overrides. It then creates an immutable
+configuration object.
 
 ## Precedence
 
-Configuration is applied in this order:
+Greenlight applies configuration in this order:
 
 1. Built-in defaults
 2. `greenlight.php`
@@ -17,7 +16,7 @@ Configuration is applied in this order:
 
 Later layers override earlier ones.
 
-For example, this config:
+For example, use this configuration:
 
 ```php
 ->workers('auto')
@@ -39,13 +38,13 @@ Create the builder with:
 GreenlightConfig::create()
 ```
 
-Every builder method returns `$this`, so calls can be chained.
+Every builder method returns `$this`. Thus, you can chain method calls.
 
 ### paths(array $tests): self
 
 Default: `['tests']`.
 
-Sets the directories Greenlight scans when no suite is selected.
+Sets the directories that Greenlight scans when you do not select a suite.
 
 Paths must be non-empty strings. The list itself must not be empty.
 
@@ -53,10 +52,11 @@ Paths must be non-empty strings. The list itself must not be empty.
 
 Default: no suites.
 
-Declares a named suite. The configurator receives a `SuiteBuilder` and must add
-at least one path. Its return value is ignored, so arrow functions are fine.
+Declares a named suite. Greenlight gives a `SuiteBuilder` to the configurator.
+The configurator must add at least one path. Greenlight ignores its return
+value. Thus, you can use an arrow function.
 
-Declaring the same suite name twice is an error.
+A second declaration with the same suite name causes an error.
 
 ```php
 ->suite('unit', fn ($s) => $s->in('tests/Unit'))
@@ -70,14 +70,16 @@ Declaring the same suite name twice is an error.
 
 ### workers(int|string $count = 'auto', ?int $recycleAfterTests = null, string $recycleAboveMemory = '256M'): self
 
-Default: `'auto'` workers, recycled above `256M`, with no test-count recycling.
+Default: `'auto'` workers, a `256M` memory recycle limit, and no test-count
+recycle limit.
 
-Workers pull one class at a time from a queue held by the orchestrator. As soon
-as a worker finishes a class, it takes the next one. This avoids a worker sitting
-idle behind another worker's long batch.
+Workers pull one class at a time from the orchestrator queue. When a worker
+finishes a class, it takes the next one. Thus, a long batch for one worker does
+not make another worker idle.
 
-The queue is ordered longest-first using durations recorded from the previous
-run. Classes that failed previously still go first.
+The orchestrator orders the queue by the class durations from the previous run.
+The longest classes go first. Classes that failed in that run go before other
+classes.
 
 Worker placement is load-dependent. The stable parts are:
 
@@ -85,23 +87,24 @@ Worker placement is load-dependent. The stable parts are:
 * method order within each class under the selected seed
 * per-class results
 
-The seed reproduces ordering-related failures, not exact worker placement.
+The seed reproduces failures related to order. It does not reproduce exact
+worker placement.
 
 `$count` accepts a positive integer or `'auto'`. With `'auto'`, Greenlight uses
 one worker per CPU core. Install the suggested `fidry/cpu-core-counter` package
 for CPU detection that respects cgroup limits in containers.
 
-A worker is recycled when either condition is met:
+Greenlight recycles a worker when one of these conditions is true:
 
 * it has run `$recycleAfterTests` tests
 * its memory usage exceeds `$recycleAboveMemory`
 
 `$recycleAboveMemory` is a size string such as `'256M'` or `'1G'`.
 
-Count-based recycling is opt-in because every recycle requires a full worker
-boot, and that worker's lane is idle during the boot. Use it for suites that
-accumulate per-process state that memory checks cannot see, such as connections
-or file handles.
+Test-count recycle is optional because each recycle requires a complete worker
+boot. The worker channel is idle during the boot. Use this limit for suites
+that collect per-process state that memory checks cannot detect. Examples
+include connections and file handles.
 
 ### resourceLimit(string $name, int $limit = 1): self
 
@@ -116,8 +119,8 @@ return GreenlightConfig::create()
     ->resourceLimit('payments-sandbox');
 ```
 
-Limits must be positive. Names must match `[a-z0-9][a-z0-9._-]*`, and each name
-may be configured only once.
+Limits must be positive. Names must match `[a-z0-9][a-z0-9._-]*`. Configure
+each name only one time.
 
 A class that requires several resources waits until all of them have capacity.
 Greenlight claims the slots together, so a class never starts with only part of
@@ -135,10 +138,10 @@ instance.
 
 Default: coverage off.
 
-Calling `coverage()` enables coverage collection. The configurator receives a
-`CoverageBuilder`.
+The `coverage()` method enables coverage collection. Greenlight gives a
+`CoverageBuilder` to the configurator.
 
-Calling `coverage()` more than once reuses the same builder, so settings
+Multiple calls to `coverage()` use the same builder. Thus, its settings
 accumulate.
 
 `CoverageBuilder` methods:
@@ -160,22 +163,24 @@ accumulate.
     ->export('html', 'coverage/html'))
 ```
 
-When coverage is configured, the run prints the total percentage and writes each
-configured export.
+When you configure coverage, the run prints the total percentage and writes
+each coverage export.
 
 If no worker can collect coverage because neither pcov nor Xdebug coverage mode
 is available, Greenlight warns on stderr. That warning does not fail the run by
 itself.
 
-Workers are not the only processes measured. On a parallel run the
-orchestrator collects its own coverage, so code that only executes on its side
-of the pool shows up in the export. A coverage-enabled run also exports
-`GREENLIGHT_COVERAGE_DIR` and `GREENLIGHT_COVERAGE_INCLUDE` to everything it
-spawns. Any `bin/greenlight` process that inherits them, for example one an
-acceptance test launches to drive the real CLI, writes its own coverage into
-the shared directory, and the run folds those dumps into the result before
-exporting. Like worker collection this fails soft, and the include paths you
-configured filter all of it.
+The workers are not the only measured processes. In a parallel run, the
+orchestrator collects its own coverage. Thus, the export includes code that
+executes only in the orchestrator. A coverage run also exports
+`GREENLIGHT_COVERAGE_DIR` and `GREENLIGHT_COVERAGE_INCLUDE` to each process that
+it starts. A `bin/greenlight` process writes coverage to the shared directory
+if it inherits these variables. For example, an acceptance test can start this
+process to operate the real CLI.
+
+Before export, the run adds these coverage files to the
+result. This collection operation does not fail the run. The configured include
+paths filter coverage from all processes.
 
 ### watch(callable $configurator): self
 
@@ -188,8 +193,8 @@ The configurator receives a `WatchBuilder`.
 * `debounceMilliseconds(int $milliseconds): self` sets the quiet period before a
   rerun starts. The value must be at least 1.
 
-A rerun fires only after no further file changes have arrived for the configured
-period, so save bursts collapse into one run.
+A rerun starts after the configured period has no file changes. Thus, a group
+of save operations starts only one run.
 
 ```php
 ->watch(fn ($w) => $w->debounceMilliseconds(500))
@@ -202,11 +207,10 @@ Default: off.
 Fails a test that otherwise passed if its captured diagnostics contain a
 deprecation.
 
-The change is recorded as a result transformation, so the exit code, `--bail`,
-Junit output, and plugins all see the same final result.
+The worker records the change as a result transformation. Thus, the exit code,
+`--bail`, JUnit output, and plugins use the same final result.
 
-This policy is applied by the worker after retries and after
-`afterTest()` subscribers.
+The worker applies this policy after retries and `afterTest()` subscribers.
 
 Also available as `--fail-on-deprecation`.
 
@@ -216,19 +220,21 @@ Default: off.
 
 Fails a test that otherwise passed if its captured diagnostics contain a notice.
 
-Like `failOnDeprecation()`, the change is recorded as a result transformation
-and is applied after retries and `afterTest()` subscribers.
+As with `failOnDeprecation()`, the worker records the change as a result
+transformation. It applies the change after retries and `afterTest()`
+subscribers.
 
 Also available as `--fail-on-notice`.
 
-### ignoreDeprecationsMatching(string ...$patterns): self
+### `ignoreDeprecationsMatching(string ...$patterns): self`
 
 Default: none.
 
-Exempts matching deprecations from `failOnDeprecation()`.
+Exempts deprecations that match a pattern from `failOnDeprecation()`.
 
-Patterns are matched case-insensitively. A plain pattern is treated as a
-substring match. A pattern containing `*` or `?` must match the whole message.
+Greenlight compares patterns without regard to case. A plain pattern matches a
+part of the message. A pattern that contains `*` or `?` must match the complete
+message.
 
 The method is repeatable and patterns accumulate.
 
@@ -238,11 +244,12 @@ Use this for dependency deprecations you cannot fix yet.
 
 Default: off.
 
-A test is risky if it passes without verifying any expectations. That means no
-`Expect` calls and no mock expectations verified at teardown.
+A successful test is risky if it does not verify an expectation. Such a test has
+no `Expect` calls and no mock expectations that Greenlight verifies at
+teardown.
 
-The `tty` and `plain` reporters list risky tests after the summary regardless of
-this setting. Enabling `failOnRisky()` upgrades risky tests to failures.
+The `tty` and `plain` reporters always list risky tests after the summary. The
+`failOnRisky()` method changes risky tests to failures.
 
 A test that intentionally has no expectations can opt out with
 `#[NoExpectations]`.
@@ -264,8 +271,8 @@ The method is repeatable and instances accumulate.
 
 Default: output below `build/greenlight-artifacts`, with failure-only retention.
 
-The configurator receives an `ArtifactBuilder`. Repeated calls reuse the same
-builder.
+Greenlight gives an `ArtifactBuilder` to the configurator. Repeated calls use
+the same builder.
 
 ```php
 ->artifacts(fn ($artifacts) => $artifacts
@@ -277,10 +284,10 @@ builder.
     ->maxRunSize('500M'))
 ```
 
-Defaults are 32 attachments and 100 MiB per test, 25 MiB per attachment,
-10,000 attachments and 1 GiB per run. Per-test limits cover all retry attempts,
-including attachments later discarded by retention policy. Run-wide quota is
-released when passing attachments are discarded.
+Defaults are 32 attachments and 100 MiB per test. Each attachment has a 25 MiB
+limit. Each run has limits of 10,000 attachments and 1 GiB. Per-test limits
+include all retry attempts, even if retention policy discards attachments
+later. Greenlight releases run quota when it discards an attachment.
 
 See [test attachments](attachments.md) for the runtime API and security model.
 
@@ -296,39 +303,39 @@ Default: declared order, no seed.
 
 Randomizes class order.
 
-If `$seed` is `null`, Greenlight chooses one at runtime and prints it, so the
-same order can be reproduced with `--seed`.
+If `$seed` is `null`, Greenlight selects and prints a seed at run time. Use
+`--seed` with that value to reproduce the same order.
 
 ### build(): Configuration
 
-Called by the loader, not by user config.
+The loader calls this method. User configuration does not call it.
 
 `build()` validates the builder and returns the immutable configuration object.
 
-Your `greenlight.php` should return the builder itself without calling
-`build()`.
+Return the builder from `greenlight.php`. Do not call `build()`.
 
 ## Channels and resource limits
 
 Every worker process runs in a channel: a stable slot numbered from 1 to the
 worker count.
 
-Use the channel to derive external resources that parallel tests must not share,
-such as database names, ports, virtual hosts, or temp directories.
+Use the channel to derive external resources that parallel tests must not share.
+Examples include database names, ports, virtual hosts, and temporary
+directories.
 
-Use a channel when every worker can have its own resource. Use
-`#[RequiresResource]` when workers use the same dependency and its safe
-concurrency is lower than the worker count. A resource limit controls how many
-classes may run; it does not assign an instance to either class.
+Use a channel when each worker can have a separate resource. Use
+`#[RequiresResource]` when workers share a dependency with lower safe
+concurrency. A resource limit controls the number of classes that can run. It
+does not assign a resource instance to a class.
 
-Two tests running at the same time never share a channel. Channel numbers always
-stay within 1 and the worker count, regardless of how many worker processes are
-spawned during the run. When a worker is recycled or crashes, its replacement
-reuses the freed slot.
+Two concurrent tests do not share a channel. Channel numbers are from 1 through
+the worker count. The number of worker processes during the run does not change
+this range. After a worker recycle or crash, its replacement reuses the freed
+slot.
 
 A `--workers=1` run executes in-process on channel 1.
 
-The channel is exposed in two ways:
+Greenlight makes the channel available in two ways:
 
 * `GREENLIGHT_CHANNEL`, set in each worker environment for bootstrap files and
   tools that use `getenv()`
@@ -339,12 +346,12 @@ The channel is exposed in two ways:
 
 `TestChannel->label()` returns `gl-<number>` for resource names.
 
-Because channel slots are reused, resources derived from a channel can persist
-across worker recycling. A replacement worker on channel 2 sees whatever the
-previous channel-2 worker left behind.
+Because Greenlight uses channel slots again, channel resources can persist
+after a worker recycle. A replacement worker on channel 2 can access resources
+from the previous channel-2 worker.
 
-This makes one-resource-per-channel setups cheap. For example, one database
-schema can be created per channel and reused for the whole run.
+This design reduces the cost of one-resource-per-channel setups. For example,
+you can create one database schema per channel and use it for the complete run.
 
 A test can use both. Its channel can select a private database while
 `#[RequiresResource('payments-sandbox')]` limits access to a shared external
@@ -362,11 +369,11 @@ greenlight [command] [options]
 
 Discovers and executes tests.
 
-This is the default command when no command is given.
+This is the default command if you do not give a command.
 
 ### list-tests
 
-Prints every discovered test id, one per line, followed by a count.
+Prints each discovered test ID on a separate line. It then prints the count.
 
 ### coverage:diff
 
@@ -383,7 +390,7 @@ Exits with code 1 when coverage regressed against the baseline.
 
 ### profile:report
 
-Renders a run profile from a saved jsonl event stream.
+Renders a run profile from a saved JSONL event stream.
 
 Requires:
 
@@ -407,7 +414,8 @@ Override it with:
 --output=<path>
 ```
 
-Gitignore the generated file and regenerate it after changing matchers.
+Add the generated file to `.gitignore`. Regenerate the file after a matcher
+change.
 
 ### completion
 
@@ -421,13 +429,13 @@ source <(greenlight completion zsh)
 greenlight completion fish > ~/.config/fish/completions/greenlight.fish
 ```
 
-For zsh, run `compinit` before sourcing the completion script.
+For zsh, run `compinit` before you source the completion script.
 
 ## Options
 
 ### --config=<path>
 
-Uses this config file instead of `./greenlight.php`.
+Uses this configuration file instead of `./greenlight.php`.
 
 ### --workers=<n|auto>
 
@@ -435,7 +443,7 @@ Overrides the worker process count.
 
 ### --resource-limit=<name>=<n>
 
-Sets a resource limit for this run, overriding `greenlight.php`.
+Sets a resource limit for this run and overrides `greenlight.php`.
 
 ```sh
 vendor/bin/greenlight run \
@@ -443,8 +451,8 @@ vendor/bin/greenlight run \
     --resource-limit=payments-sandbox=1
 ```
 
-Repeat the option to set limits for different resources. Each name may appear
-only once.
+Repeat the option to set limits for different resources. Use each name only one
+time.
 
 ### --bail[=<n>]
 
@@ -460,21 +468,21 @@ Repeatable.
 
 ### --filter=<pattern>
 
-Runs only tests whose id matches the pattern.
+Runs only tests with a test ID that matches the pattern.
 
-A test id is `Class::method`, including the data-set label when present.
+A test ID is `Class::method` with an optional data-set label.
 
-Matching is case-insensitive substring matching by default. A pattern containing
-`*` or `?` must match the whole id.
+By default, Greenlight matches substrings without regard to case. A pattern
+that contains `*` or `?` must match the complete test ID.
 
-Repeatable. Multiple filters are unioned.
+Repeatable. Multiple filters form a union.
 
 ### --test-id=<id>
 
-Runs only the exact test id. Unlike `--filter`, this option never performs
-substring or wildcard matching.
+Runs only the exact test ID. Unlike `--filter`, this option does not compare
+substrings or wildcard patterns.
 
-Use the ids printed by `list-tests` or `--list-tests`, including the data-set
+Use the test IDs printed by `list-tests` or `--list-tests`. Include the data-set
 label when present:
 
 ```sh
@@ -482,8 +490,8 @@ greenlight run \
     '--test-id=App\Tests\OrderTest::placesOrder[card]'
 ```
 
-Repeatable. Multiple exact ids are unioned with each other and with
-`--filter`. Exclusions still take precedence.
+Repeatable. Multiple exact test IDs and `--filter` patterns form a union.
+Exclusions have precedence.
 
 ### --exclude-group=<name>
 
@@ -493,19 +501,19 @@ Repeatable. Exclusions take precedence over `--group` and `--filter`.
 
 ### --exclude-class=<pattern>
 
-Excludes classes matching the pattern.
+Excludes classes with names that match the pattern.
 
-Matching is case-insensitive substring matching by default. A pattern containing
-`*` or `?` must match the whole class name.
+By default, Greenlight matches substrings without regard to case. A pattern
+that contains `*` or `?` must match the complete class name.
 
 Repeatable.
 
 ### --exclude-method=<pattern>
 
-Excludes methods matching the pattern.
+Excludes methods with names that match the pattern.
 
-Matching is case-insensitive substring matching by default. A pattern containing
-`*` or `?` must match the whole method name.
+By default, Greenlight matches substrings without regard to case. A pattern
+that contains `*` or `?` must match the complete method name.
 
 Repeatable.
 
@@ -513,68 +521,70 @@ Repeatable.
 
 Excludes tests whose source file is below the path prefix.
 
-Relative prefixes are resolved from the working directory. Repeatable.
+Greenlight resolves relative prefixes from the current directory. Repeatable.
 
 ### --list-tests
 
-Prints the selected test ids instead of running them.
+Prints the selected test IDs. It does not run them.
 
 ### --list-groups
 
-Prints each selected group and its test count instead of running tests.
+Prints each selected group and its test count. It does not run tests.
 
 ### --list-suites
 
-Prints the configured named suites instead of discovering or running tests.
+Prints the configured named suites. It does not discover or run tests.
 
 ### --repeat=<n>
 
 Runs the selected tests in `<n>` fresh iterations.
 
-The command exits non-zero if any iteration fails. `--repeat=1` is equivalent to
-an ordinary run.
+The command exits with a nonzero code if an iteration fails. `--repeat=1` is
+equivalent to an ordinary run.
 
 ### --repeat-until-failure
 
 Repeats fresh runs until an iteration fails.
 
-On its own, the command stops after 100 passing iterations. Combine it with
-`--repeat=<n>` to set a different limit. It cannot be combined with `--watch`.
+On its own, the command stops after 100 successful iterations. Use
+`--repeat=<n>` to set a different limit. Do not use it with `--watch`.
 
 ### --shard=n/m
 
 Runs the nth of m disjoint slices of the plan.
 
-Shards are selected by stable class hash, so CI machines can split a suite
-without coordination. The union of all shards is exactly the full suite.
+Greenlight selects shards by a stable class hash. Thus, CI machines can split a
+suite without coordination. Together, all shards contain the complete suite.
 
 Only whole classes move between shards. Individual methods are not split.
 
-Combines with `--group` and `--filter` by sharding the filtered plan.
+Combines with `--group` and `--filter`. Greenlight divides the filtered plan
+into shards.
 
 Each shard enforces its own resource limits. If four shards each use
-`postgres=2`, up to eight tests may use PostgreSQL across the CI job.
+`postgres=2`, up to eight tests can use PostgreSQL across the CI job.
 
 ### --failed
 
 Reruns only tests that did not pass in the previous run.
 
-Failure state is recorded on every run under the system temp directory.
+Greenlight records failure state for each run in the system temporary
+directory.
 
 If no previous failure state exists, this is a usage error.
 
 If the previous run passed completely, Greenlight reports that there is nothing
 to rerun and exits 0.
 
-When failure state exists, normal runs also place previously failed classes
-first. This ordering is skipped under `--seed`.
+When failure state exists, normal runs put previously failed classes first.
+`--seed` disables this order.
 
 ### --seed=<n>
 
 Randomizes class order with this seed.
 
-Seeded runs skip timing-cache ordering, so the order is exactly the one produced
-from the seed.
+Seeded runs do not use the timing-cache order. The seed determines the complete
+order.
 
 ### --reporter=<name>
 
@@ -593,9 +603,10 @@ Repeatable. Multiple reporters write concurrently.
 
 Default: `tty` on an interactive terminal, otherwise `plain`.
 
-The `tty` reporter is parallel-aware. It keeps one live line per in-flight class,
-with a spinner and running count, and finalizes each line in place when the class
-finishes. Multi-worker output does not interleave randomly.
+The `tty` reporter supports parallel work. It keeps one live line for each
+active class. Each line has a spinner and a current count. The reporter
+completes the line in place when the class finishes. Multi-worker output does
+not interleave randomly.
 
 The `teamcity` reporter includes IDE navigation metadata: `php_qn://` location
 hints for click-to-source, plus a per-class `flowId` to keep parallel output
@@ -619,16 +630,16 @@ Sets the current coverage JSON file for `coverage:diff`.
 
 Reruns on file changes.
 
-While watching:
+In watch mode:
 
 * Enter reruns everything.
 * `q` quits.
 
 ### --detect-leaks
 
-Verifies that every test instance is garbage-collected after its test.
+Verifies that garbage collection removes each test instance after its test.
 
-Any detected leak fails the run.
+A detected leak fails the run.
 
 ### --fail-on-deprecation
 
@@ -656,8 +667,8 @@ The profile includes:
 * makespan spread between the first and last worker to finish
 * the ten slowest classes
 
-The profile is derived entirely from the event stream. A saved jsonl artifact can
-be rendered later with:
+The event stream supplies all profile data. You can render a saved JSONL
+artifact later with:
 
 ```sh
 greenlight profile:report --input=<file>
@@ -675,7 +686,7 @@ Default: `_greenlight_ide_helper.php`.
 
 ### --dry-run
 
-Prints the resolved configuration without executing tests.
+Prints the resolved configuration and does not run tests.
 
 ### --verbose
 
@@ -683,12 +694,12 @@ In interactive output, prints a permanent line for every completed class.
 
 ### --no-ansi
 
-Disables colours and the live progress window. Output becomes plain and
+Disables colors and the live progress window. Output becomes plain and
 append-only.
 
 A truthy `CI` environment variable has the same effect.
 
-`NO_COLOR` disables colours only.
+`NO_COLOR` disables colors only.
 
 ### -h, --help
 
@@ -703,13 +714,13 @@ Shows the version.
 Greenlight uses these exit codes:
 
 * `0`: success
-* `1`: failure, including failing or erroring tests, invalid config, discovery
+* `1`: failure from failed tests, test errors, invalid configuration, discovery
   errors, coverage export errors, detected leaks, and zero discovered tests
 * `64`: usage error, such as an unknown command, unknown flag, or malformed
   option value
 
-A run that discovers zero tests is treated as a configuration problem, not a
-success.
+Greenlight treats a run with zero tests as a configuration problem. It does not
+treat the run as a success.
 
 ## Interruption
 
@@ -717,13 +728,13 @@ The first Ctrl+C, SIGINT, or SIGTERM starts a graceful shutdown.
 
 During graceful shutdown, Greenlight:
 
-* stops assigning new work
+* stops new assignments
 * lets workers finish their in-flight test
 * drains worker output
 * prints the summary for completed work
 * records the failure state used by `--failed`
-* records the timing cache
-* restores the terminal when exiting watch mode
+* records class durations in the timing cache
+* restores the terminal when it exits watch mode
 
 The run then exits with:
 
@@ -733,15 +744,15 @@ The run then exits with:
 A second signal during shutdown terminates immediately.
 
 Graceful shutdown requires `ext-pcntl`. Without it, PHP uses its default signal
-behaviour and exits at once.
+behavior and exits immediately.
 
 ## Discovery cache
 
 Greenlight caches discovery results per file under the system temp directory.
 
-The cache key includes the file path, mtime, and size. Unchanged files can skip
-re-parsing on the next run. If anything is uncertain, Greenlight parses the file
-again.
+The cache key includes the file path, mtime, and size. Greenlight can reuse
+discovery data for an unchanged file in the next run. If the cache data is
+uncertain, Greenlight parses the file again.
 
 Watch mode benefits most because every iteration rediscovers the suite.
 
@@ -753,21 +764,21 @@ In an interactive terminal, the `tty` reporter shows a bounded live window:
 * in-flight classes
 * at most ten live lines, clamped to the terminal height
 
-Failures and skips are printed permanently as soon as their class finishes.
+The reporter prints failures and skips permanently when their class finishes.
 
-Passing classes only advance the counter unless `--verbose` is enabled.
+Classes that pass only advance the counter unless you enable `--verbose`.
 
-Both human reporters start with a one-line header containing:
+Both human reporters start with a one-line header that contains:
 
 * Greenlight version
 * PHP version
-* config file
+* configuration file
 * seed, when randomized
 * worker count
 
-They end with a "Slowest tests" block when any test took at least 500 ms. The
+They end with a "Slowest tests" block when a test took at least 500 ms. The
 block lists the five slowest tests.
 
 Fast suites do not print the block.
 
-With `--profile`, the slowest-test list is extended to 25 entries.
+`--profile` extends the slowest-test list to 25 entries.

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -1,7 +1,7 @@
 # Expectations
 
-Greenlight expectations start with a subject value and apply one or more typed
-matchers to it:
+A Greenlight expectation starts with a subject value. It applies one or more
+typed matchers to that value:
 
 ```php
 use Greenlight\Expect\Expect;
@@ -9,11 +9,11 @@ use Greenlight\Expect\Expect;
 Expect::that($order->status())->toBe(OrderStatus::Paid);
 ```
 
-A matcher that does not pass throws immediately. Greenlight reports the source
-location and includes expected and actual values when the matcher can provide
+A matcher throws immediately if it does not pass. Greenlight reports the source
+location. It also reports expected and actual values when the matcher supplies
 them.
 
-## Chaining
+## Matcher chains
 
 `and()` starts a new chain from another value:
 
@@ -37,17 +37,19 @@ Expect::that($result)->not()->toBeNull()
   identical with `===`.
 * `toEqual(mixed $expected)` passes when the values are deeply equal.
 * `toEqualCanonicalizing(mixed $expected)` passes when the values are deeply
-  equal after list order is ignored recursively.
+  equal after the matcher recursively ignores list order.
 * `toBeOneOf(mixed ...$options)` passes when the subject is identical to one
   option.
 * `toBeIn(iterable $haystack)` passes when the subject is identical to an item
   in the iterable.
 
-`toEqual()` compares integers and floats by numeric value. Other scalars compare
-strictly. Arrays compare by key and recursively equal values. Objects must have
-the same class and recursively equal properties, including private properties.
-Enum cases compare by identity, and `DateTimeInterface` values compare by
-instant at microsecond precision.
+`toEqual()` compares integers and floats by numeric value. It compares other
+scalars strictly. It compares arrays by key and recursively equal values.
+Objects must have the same class and recursively equal properties. This rule
+includes private properties.
+
+Enum cases compare by identity.
+`DateTimeInterface` values compare by instant at microsecond precision.
 
 ### Type predicates
 
@@ -100,7 +102,7 @@ Numeric matchers accept integer or float subjects:
 
 ### JSON
 
-`toBeJson()` requires a string containing valid JSON.
+`toBeJson()` requires a string that contains valid JSON.
 
 `toMatchJson(string $expected)` decodes both strings and compares their
 structures with `toEqual()` semantics. JSON object key order does not matter.
@@ -130,10 +132,10 @@ Expect::that($callback)->toThrow(
 
 `message:` and `matching:` are mutually exclusive.
 
-## Waiting for asynchronous state
+## Asynchronous state
 
-`Expect::eventually()` calls a probe immediately, then polls until its matcher
-passes or `within()` expires:
+`Expect::eventually()` calls a probe immediately. It then polls until its
+matcher passes or `within()` expires:
 
 ```php
 Expect::eventually(fn() => $repository->find($id))
@@ -142,8 +144,8 @@ Expect::eventually(fn() => $repository->find($id))
     ->toEqual($expected);
 ```
 
-The default polling interval is 25ms. Probe exceptions stop polling unless
-their types are listed with `retryOnException()`:
+The default poll interval is 25 ms. A probe exception stops the polls unless
+`retryOnException()` lists its type:
 
 ```php
 Expect::eventually(fn() => $client->fetch($id))
@@ -162,13 +164,13 @@ Expect::consistently(fn() => $outbox->messagesFor($id))
     ->toHaveCount(1);
 ```
 
-Each polling matcher counts as one expectation. The test timeout limits its
-duration, and the worker timeout remains the hard limit for a blocked probe.
+Each temporal matcher counts as one expectation. The test timeout limits its
+duration. The worker timeout remains the hard limit for a blocked probe.
 
-## Failing explicitly
+## Explicit failures
 
-Use `Fail::because()` when a test reaches an invalid state that does not fit a
-matcher:
+If a test reaches an invalid state that does not fit a matcher, use
+`Fail::because()`:
 
 ```php
 use Greenlight\Expect\Fail;
@@ -182,4 +184,4 @@ if (!$response instanceof SuccessResponse) {
 ```
 
 The call counts as an expectation and reports itself as the failure location.
-Use a manual guard when the IDE needs type narrowing.
+If the IDE cannot determine the type, use a manual guard.

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -1,7 +1,8 @@
 # Test doubles
 
-Greenlight provides strict mocks, inert stubs, and recording spies through the
-per-test `Doubles` service. Ask for it through constructor injection:
+Greenlight provides strict mocks, inert stubs, and spies that record calls. The
+per-test `Doubles` service supplies these doubles. Request this service through
+constructor injection:
 
 ```php
 use Greenlight\Attribute\Test;
@@ -33,20 +34,20 @@ final class CheckoutServiceTest
 }
 ```
 
-Mocks are verified automatically when the test ends.
+Greenlight verifies mocks when the test ends.
 
-## Choosing a double
+## Double selection
 
-* Use `mock(Type::class, $plan)` when the test expects specific calls and
-  responses. An unplanned interaction fails immediately.
-* Use `stub(Type::class)` when a dependency must exist but must not be used.
-  Any interaction fails immediately.
-* Use `spy(Type::class)` when the test needs to inspect void-returning calls
-  afterwards. An unplanned call is recorded.
+* If the test expects specific calls and responses, use
+  `mock(Type::class, $plan)`. An unplanned interaction fails immediately.
+* If the test needs an unused dependency, use `stub(Type::class)`. Each
+  interaction fails immediately.
+* If the test must examine void-returning calls after they occur, use
+  `spy(Type::class)`. The spy records an unplanned call.
 
-Calling a value-returning method on a spy fails the test.
+A call to a value-returning method on a spy fails the test.
 
-## Planning mock calls
+## Mock call plans
 
 The plan passed to `mock()` declares expectations with `expects()`:
 
@@ -57,20 +58,21 @@ $plan->expects('reserve')
     ->andReturns(true);
 ```
 
-Each method expectation defaults to at least one call. Change its cardinality
-with:
+Each method expectation has a default cardinality of at least one call. Use one
+of these methods to change its cardinality:
 
 * `once()`
 * `times(int $count)`
 * `atLeast(int $count)`
 * `never()`
 
-A call that matches no expectation fails immediately. Unmet expectations fail
-at teardown, and Greenlight reports all of them together.
+A call that does not match an expectation fails immediately. At teardown, an
+unmet expectation fails the test. Greenlight reports all unmet expectations
+together.
 
-## Configuring responses
+## Mock responses
 
-Every value-returning mock method needs an explicit response:
+Each value-returning mock method needs an explicit response:
 
 ```php
 $plan->expects('nextId')->andReturns('id-1');
@@ -86,10 +88,10 @@ $plan->expects('load')
     ->andThrows(new NotFound('Missing record.'));
 ```
 
-`andReturnsSequence()` consumes one value per matching call. Calling the method
-after the sequence is exhausted is an authoring error.
+`andReturnsSequence()` consumes one value for each call that matches. A call
+after the sequence is empty causes an authoring error.
 
-## Matching arguments
+## Argument matches
 
 Bare values passed to `with()` use the same deep equality as `toEqual()`:
 
@@ -120,7 +122,7 @@ Available matchers are:
 * `Argument::equals(mixed $value)`
 * `Argument::captor()`
 
-## Capturing arguments
+## Argument capture
 
 Capture one argument from every matched call:
 
@@ -136,13 +138,13 @@ Expect::that($captor->values())->toHaveCount(2);
 Expect::that($captor->value())->toBeInstanceOf(Order::class);
 ```
 
-`values()` returns every captured value. `value()` returns the last one and
-fails if nothing was captured.
+`values()` returns each captured value. `value()` returns the last value. It
+fails if `Argument::captor()` did not capture a value.
 
-An explicit `Argument::captor()` can be placed directly inside `with()` when a
-plan needs more than one captor.
+If a plan must capture more than one argument, put an explicit
+`Argument::captor()` inside `with()` for each argument.
 
-## Reading spy calls
+## Spy calls
 
 `callsTo()` returns argument lists in call order:
 
@@ -158,9 +160,9 @@ Expect::that(
 
 ## Supported types and limits
 
-Interfaces and non-final classes can be doubled. Greenlight does not run the
-class constructor when it creates a double.
+Greenlight can create doubles for interfaces and non-final classes. It does not
+run the class constructor when it creates a double.
 
-Final classes, readonly classes, and enums are rejected. Greenlight does not
-support partial mocks or static method interception. Prefer doubling an
+Greenlight rejects final classes, readonly classes, and enums. It does not
+support partial mocks or static method interception. Prefer a double for an
 interface at the application boundary.

--- a/tools/prose-baseline/docs-guides.json
+++ b/tools/prose-baseline/docs-guides.json
@@ -1,87 +1,10 @@
 [
     {
-        "fingerprint": "64684965cc299001e9aed5a33c439453900c5f754bf8ea851000ef4a2a1e5b77",
-        "path": "docs/attributes.md",
-        "rule": "british-spelling",
-        "passage": "the attribute is matched by name without loading the code it's applied to, so an aliased import ( literal ) is not recognised.",
-        "count": 1
-    },
-    {
-        "fingerprint": "43c509078d2ae283def713bd1f2ab14ee046661796321c92eef8054f7b50fe8d",
-        "path": "docs/attributes.md",
-        "rule": "contraction",
-        "passage": "the attribute is matched by name without loading the code it's applied to, so an aliased import ( literal ) is not recognised.",
-        "count": 1
-    },
-    {
-        "fingerprint": "623afe4c8fe053a605cc44d15e247ec577367df7cbca43a3aef79eb842ea609f",
-        "path": "docs/attributes.md",
-        "rule": "semicolon",
-        "passage": "any further attribute arguments are passed to the condition's constructor. arguments must be scalars or null, because they travel to parallel workers; anything else is a discovery error. the constructor must only store them, and evaluation happens in literal without side effects:",
-        "count": 1
-    },
-    {
-        "fingerprint": "dbf73af573faa08567470bb915e7bb092faa686e38d09d0ff0ba6cace6b03f2a",
-        "path": "docs/attributes.md",
-        "rule": "semicolon",
-        "passage": "direct writes to the literal and literal stream resources bypass php's output buffer and are not captured. they can also interfere with terminal output, so tests should not use them for diagnostics. use test attachments when diagnostic content must be retained; see literal .",
-        "count": 1
-    },
-    {
-        "fingerprint": "b151b754156192f212064ee970064b7484ae93c6f2f28971aebcdac3dbdec9af",
-        "path": "docs/attributes.md",
-        "rule": "sentence-length",
-        "passage": "the bundled phpstan extension validates providers statically: the provider must exist, be public and static, and return an iterable of argument arrays, and row shapes phpstan can see (such as the literal return type above) are checked against the test method's parameters. literal literals get the same check. see literal .",
-        "count": 1
-    },
-    {
-        "fingerprint": "c97617c47b7ed6aff1ef05947808594da3ec65ef14007acffea03c9fb4184a54",
-        "path": "docs/attributes.md",
-        "rule": "sentence-length",
-        "passage": "the phpunit comment annotations work unchanged: literal in a docblock before a declaration, literal and literal around a block, and a trailing literal on a single line.",
-        "count": 1
-    },
-    {
         "fingerprint": "0b6e06e2bdcc43d08a6e7d10be5a077376053d3dc478d043af1718e21e2978c2",
         "path": "docs/benchmarks.md",
         "rule": "semicolon",
         "passage": "update this document by rerunning the full benchmark on an idle machine whenever the runner changes materially. record the greenlight commit and run date with the results. comparison-tool versions are pinned in literal ; update the constants and this page together.",
         "count": 1
-    },
-    {
-        "fingerprint": "9bc650f0985de3cb0067f38ea65eb41c8fbbda8da70c2b366669b9cf668f6168",
-        "path": "docs/configuration.md",
-        "rule": "british-spelling",
-        "passage": "disables colours and the live progress window. output becomes plain and append-only.",
-        "count": 1
-    },
-    {
-        "fingerprint": "63ca8bf8a03b6c7304af0d3abddcf1078c64c591f733ab358b3417004b6ac463",
-        "path": "docs/configuration.md",
-        "rule": "british-spelling",
-        "passage": "graceful shutdown requires literal . without it, php uses its default signal behaviour and exits at once.",
-        "count": 1
-    },
-    {
-        "fingerprint": "497335588b1ba43bfdf1f99d2d31d8ab07a907a72e2f62b3e0bd9d19ec4b3f15",
-        "path": "docs/configuration.md",
-        "rule": "british-spelling",
-        "passage": "literal disables colours only.",
-        "count": 1
-    },
-    {
-        "fingerprint": "e7adfb351c108e11fc420b8a38bd835bb36e8ac595a900d70e32925cd9ce59c1",
-        "path": "docs/configuration.md",
-        "rule": "semicolon",
-        "passage": "use a channel when every worker can have its own resource. use literal when workers use the same dependency and its safe concurrency is lower than the worker count. a resource limit controls how many classes may run; it does not assign an instance to either class.",
-        "count": 1
-    },
-    {
-        "fingerprint": "8325a1ef8c299a18a3926aa9ae1c3a17bf1ca7b936670368179d7baecb9bfcf7",
-        "path": "docs/configuration.md",
-        "rule": "sentence-length",
-        "passage": "workers are not the only processes measured. on a parallel run the orchestrator collects its own coverage, so code that only executes on its side of the pool shows up in the export. a coverage-enabled run also exports literal and literal to everything it spawns. any literal process that inherits them, for example one an acceptance test launches to drive the real cli, writes its own coverage into the shared directory, and the run folds those dumps into the result before exporting. like worker collection this fails soft, and the include paths you configured filter all of it.",
-        "count": 2
     },
     {
         "fingerprint": "c381a6e49d3cae291f5be1e95c8b56271105fb6e02178c85b7d269d9b7429ae4",


### PR DESCRIPTION
## Summary

Rewrites configuration, attributes, expectations, test doubles, and attachments in simplified technical English. Preserves public identifiers, commands, flags, output contracts, and technical behavior.

## Continuation record

- Base commit: bb2e4f3928a0a84328297a03c0eab8d46d1cb108
- Result commit: 2815f42
- Owned paths: docs/configuration.md, docs/attributes.md, docs/expectations.md, docs/test-doubles.md, docs/attachments.md, and tools/prose-baseline/docs-guides.json
- Blocking groups: 11 owned groups before, 0 owned groups after. The guide shard decreases from 21 to 10 groups.
- Advisory review: all applicable findings resolved. Retained findings are precise return-type modifiers, registered staging, and the timing-cache technical noun.
- Terminology decisions: canonical configuration, test ID, data set, data-set, run time, and American spellings are applied. Remaining project-term additions are recorded for the primary-owned consolidated register update.
- Commands recorded: composer prose:check; php tools/prose-check.php review with an owned-path review; make docs-check; git diff --check.
- Next unclaimed shard: integration guides in docs/plugins.md, docs/symfony.md, docs/phpstan.md, and docs/benchmarks.md.

The pull request template is unchanged.