### PR TITLE
docs: rewrite repository and community prose in STE

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -13,10 +13,10 @@ body:
     id: reproduction
     attributes:
       label: Minimal reproduction
-      description: The smallest test class, config, and command that reproduce the problem.
+      description: Provide the smallest test class, configuration, and command that reproduce the problem.
       placeholder: |
         ```php
-        // test class and config here
+        // test class and configuration here
         ```
         Command: bin/greenlight ...
     validations:
@@ -24,14 +24,14 @@ body:
   - type: textarea
     id: expected
     attributes:
-      label: Expected behaviour
+      label: Expected behavior
     validations:
       required: true
   - type: textarea
     id: actual
     attributes:
-      label: Actual behaviour
-      description: Include full output or a stack trace where relevant.
+      label: Actual behavior
+      description: If available, include the full output or a stack trace.
     validations:
       required: true
   - type: input
@@ -45,13 +45,13 @@ body:
     id: greenlight-version
     attributes:
       label: Greenlight version
-      placeholder: "e.g. 0.1.0 or a commit hash"
+      placeholder: "For example, 0.1.0 or a commit hash"
     validations:
       required: true
   - type: input
     id: os
     attributes:
       label: Operating system
-      placeholder: "e.g. Ubuntu 24.04, macOS 26"
+      placeholder: "For example, Ubuntu 24.04 or macOS 26"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -6,17 +6,17 @@ body:
     id: problem
     attributes:
       label: Problem
-      description: What problem does this solve? Describe the situation, not the solution.
+      description: Describe the situation. Do not describe the solution.
     validations:
       required: true
   - type: textarea
     id: api-sketch
     attributes:
       label: Proposed API sketch
-      description: Rough typed PHP showing how a test author or plugin would use it.
+      description: Provide an approximate typed PHP example. Show how a test author or plugin uses the API.
       placeholder: |
         ```php
-        // attribute, method, or config sketch here
+        // attribute, method, or configuration sketch here
         ```
     validations:
       required: true
@@ -24,6 +24,6 @@ body:
     id: alternatives
     attributes:
       label: Alternatives considered
-      description: Other designs you thought about and why you set them aside.
+      description: List the other designs that you considered. Give the reason that you rejected each design.
     validations:
       required: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,8 +61,8 @@ jobs:
   ci:
     name: "CI (PHP ${{ matrix.php-version }}, ${{ matrix.dependencies }} deps${{ matrix.symfony-version && format(', Symfony {0}', matrix.symfony-version) || '' }})"
     runs-on: "ubuntu-latest"
-    # Xdebug stays off for the suite itself; the coverage acceptance tests
-    # opt in per spawned process with XDEBUG_MODE=coverage.
+    # The suite does not use Xdebug. Coverage acceptance tests set
+    # XDEBUG_MODE=coverage for each process that they start.
     env:
       XDEBUG_MODE: "off"
     strategy:
@@ -74,8 +74,8 @@ jobs:
         dependencies:
           - "lowest"
           - "locked"
-        # Symfony fan-out only makes sense on "highest": "lowest" always
-        # resolves 6.4 and "locked" ignores SYMFONY_REQUIRE entirely.
+        # Run Symfony version jobs only with "highest". "lowest" always
+        # resolves 6.4. "locked" ignores SYMFONY_REQUIRE.
         include:
           - php-version: "8.4"
             dependencies: "highest"
@@ -105,8 +105,9 @@ jobs:
         if: "matrix.dependencies != 'locked' && matrix.php-version == '8.5'"
         run: "composer config platform.php 8.5.0"
 
-      # Flex filters every symfony/* package to SYMFONY_REQUIRE during
-      # resolution. Installed globally so composer.json stays untouched.
+      # Symfony Flex filters every symfony/* package to SYMFONY_REQUIRE during
+      # dependency resolution. CI installs Flex globally and does not change
+      # composer.json.
       - name: "Set up Symfony Flex"
         if: "matrix.symfony-version"
         run: |
@@ -124,9 +125,10 @@ jobs:
         if: "matrix.dependencies == 'locked' && matrix.php-version == '8.4'"
         run: "composer static-analysis"
 
-      # No phpstan on the lowest leg: the lowest allowed phpstan lacks the
-      # type inference the codebase relies on (proc_open narrowing,
-      # ReflectionClass variance), so every finding is tool-age noise.
+      # PHPStan does not run in the "lowest" jobs. The oldest permitted PHPStan
+      # cannot infer types that the code requires. Examples are proc_open type
+      # narrowing and ReflectionClass variance. Consequently, all PHPStan
+      # reports in these jobs are false.
       - name: "Tests"
         run: "composer tests"
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,11 @@
-# Composer (composer.lock is committed)
+# Composer dependencies (Git tracks composer.lock)
 /vendor/
 
-# Tooling caches
+# Tool caches
 .php-cs-fixer.cache
 .deptrac.cache
 
-# PHPStan API sources extracted from phpstan.phar for IDE indexing
+# Extracted PHPStan API sources for IDE completion
 /.phpstan-api-stubs/
 
 # Coverage exports

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 use PhpCsFixer\Config;
 use PhpCsFixer\Finder;
 
-// bin/greenlight is excluded: its shebang line confuses import-adding fixers
-// into placing use statements before declare(strict_types=1), which is fatal.
-// Fixtures are excluded because they encode deliberate patterns.
+// Exclude bin/greenlight because its shebang causes import fixers to put use statements
+// before declare(strict_types=1). PHP stops with an error if this occurs.
+// Exclude fixtures because they contain deliberate patterns.
 $finder = Finder::create()
     ->in([__DIR__ . '/src', __DIR__ . '/tests', __DIR__ . '/tools'])
     ->exclude('Fixture')

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,14 @@
 # Repository guidance
 
-- Greenlight requires PHP 8.4+ and must retain zero runtime dependencies.
-- Follow `docs/architecture/conventions.md` and the dependency boundaries in `deptrac.yaml`.
-- Follow `docs/architecture/technical-writing.md` for all repository-owned technical prose.
-- Technical prose includes documentation, PHPDoc, comments, contributor material, accessibility copy, diagnostics, CLI help, and human-readable output.
-- Use ASD-STE100 Issue 9 for technical prose. Uppercase `MUST`, `MUST NOT`, `SHOULD`, `SHOULD NOT`, and `MAY` are approved normative tokens.
-- Use STE clarity principles for marketing copy. The controlled vocabulary is optional in marketing copy.
-- Add focused unit or acceptance coverage, use `Greenlight\Expect`, and treat shared fixture directories as append-only.
+- Use PHP 8.4 or a later version. Greenlight MUST have zero runtime dependencies.
+- Obey `docs/architecture/conventions.md` and the dependency boundaries in `deptrac.yaml`.
+- Use `docs/architecture/technical-writing.md` for all repository-owned technical prose.
+- Technical prose includes documentation, PHPDoc, comments, contributor material, accessibility text, diagnostics, CLI help, and human-readable output.
+- Use ASD-STE100 Issue 9 for technical prose.
+- Use uppercase `MUST`, `MUST NOT`, `SHOULD`, `SHOULD NOT`, and `MAY` as normative tokens.
+- Use STE clarity principles for promotional copy. The controlled vocabulary is optional for promotional copy.
+- Add focused unit or acceptance tests. Use `Greenlight\Expect`. Treat shared fixture directories as append-only.
 - Run focused tests with `php bin/greenlight run --filter=<test-id>`.
-- Before finishing PHP changes, run `composer static-analysis && composer tests`.
+- Before you complete PHP changes, run `composer static-analysis && composer tests`.
 - For website changes, run `make docs-check`.
 - Use Conventional Commits for commit messages and pull request titles.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,28 +1,28 @@
-# Contributing to Greenlight
+# Contribute to Greenlight
 
-Thank you for your interest in contributing. These rules apply to every change.
+Thank you for your interest in Greenlight. These rules apply to every change.
 
 ## Requirements
 
 Greenlight requires PHP 8.4 or later.
 
-## Technical writing
+## Technical prose
 
-Follow the [technical writing standard](docs/architecture/technical-writing.md)
-for all repository-owned technical prose. The standard applies ASD-STE100
-Issue 9 to documentation, PHPDoc, comments, contributor material,
-accessibility copy, diagnostics, CLI help, and human-readable output.
+Use the [technical writing standard](docs/architecture/technical-writing.md)
+for all repository-owned technical prose. The standard applies ASD-STE100 Issue
+9 to documentation, PHPDoc, comments, contributor material, accessibility text,
+diagnostics, CLI help, and human-readable output.
 
-Uppercase `MUST`, `MUST NOT`, `SHOULD`, `SHOULD NOT`, and `MAY` are approved
-normative tokens. Marketing copy must use STE clarity principles, but it does
-not require the controlled vocabulary.
+Use uppercase `MUST`, `MUST NOT`, `SHOULD`, `SHOULD NOT`, and `MAY` as
+normative tokens. Use STE clarity principles for promotional copy. The
+controlled vocabulary is optional for promotional copy.
 
-Before you push prose changes, do a manual review:
+Before you push prose changes, review the prose:
 
-- Confirm that each word has the approved meaning.
-- Confirm that technical prose uses the controlled vocabulary.
+- Check each word for its approved definition.
+- Check technical prose for the controlled vocabulary.
 - Use active voice when you know the agent.
-- Check each `-ing` form and correct verbal uses.
+- Review each `-ing` form. Correct each verbal use.
 - Put only one instruction in each sentence.
 
 ## Before you push
@@ -35,14 +35,14 @@ composer tests
 make docs-check
 ```
 
-CI runs the same checks, so all three must pass locally.
+CI runs the same checks. All three MUST pass locally.
 
 ## Commits and pull requests
 
-Submit changes through pull requests targeting `main`.
+Submit changes in pull requests to `main`.
 
 Greenlight uses squash merges. The pull request title becomes the commit
-message. It must follow the
+message. It MUST use the
 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
 format:
 
@@ -62,18 +62,18 @@ chore: bump php-cs-fixer to 3.76
 ```
 
 Common types include `feat`, `fix`, `docs`, `refactor`, `test`, and `chore`.
-Add a scope when it provides useful context.
+Add a scope if it gives useful context.
 
 ## IDE completion for the PHPStan API
 
 The `phpstan/phpstan` development dependency is a PHAR. Editors cannot index
-the PHPStan classes in `src/PhpStan/`.
+the PHPStan classes in `src/PhpStan/` directly.
 
 `composer install` and `composer update` extract the API sources into
-`.phpstan-api-stubs/` for IDE indexing. Git ignores this directory. Greenlight
-does not execute its contents.
+`.phpstan-api-stubs/`. Editors use these sources for IDE completion. Git ignores
+this directory. Greenlight does not execute its contents.
 
-If completion for `PHPStan\` symbols is missing, run:
+If completion for `PHPStan\` symbols is absent, run:
 
 ```bash
 composer phpstan:stubs
@@ -81,11 +81,11 @@ composer phpstan:stubs
 
 ## Zero runtime dependencies
 
-Greenlight is a development dependency. A runtime dependency can conflict
-with the project under test. Implement each necessary capability in
-Greenlight.
+Greenlight is a development dependency. A runtime dependency can conflict with
+the project under test. Implement each necessary capability in Greenlight.
 
-Development dependencies for tooling are allowed. Runtime dependencies are not.
+You MAY add development dependencies for tools. You MUST NOT add runtime
+dependencies.
 
 ## Questions
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,10 +2,15 @@
 
 ## Supported versions
 
-Greenlight is pre-1.0. Only the latest minor release receives security fixes. Once 1.0 ships, this policy will be revisited.
+Greenlight is pre-1.0. We give security fixes only for the latest minor release.
+We will review this policy after we release version 1.0.
 
-## Reporting a vulnerability
+## Vulnerability reports
 
-Please do not open a public issue for security problems. Instead, report them privately through GitHub Security Advisories on this repository: go to the Security tab and choose "Report a vulnerability".
+Do not open a public issue for a security problem.
 
-You will get an acknowledgement as soon as possible, and a fix or mitigation plan will be coordinated with you before any public disclosure.
+Report the problem privately through GitHub Security Advisories in this
+repository. On the Security tab, select "Report a vulnerability".
+
+We will acknowledge your report as soon as possible. We will coordinate a fix
+or mitigation plan with you before public disclosure.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "greenlight/greenlight",
-    "description": "An opinionated testing framework for PHP 8.4+: typed attribute-driven tests, parallel-first execution with flat memory, lifecycle-safe test doubles.",
+    "description": "A test framework for PHP 8.4+ with typed attributes, parallel execution, flat memory use, and lifecycle-safe test doubles.",
     "license": "MIT",
     "type": "library",
     "keywords": [
@@ -31,11 +31,11 @@
         "symfony/http-kernel": "^6.4 || ^7.0 || ^8.0"
     },
     "suggest": {
-        "ext-pcov": "Fast line coverage collection",
-        "fidry/cpu-core-counter": "Sharper core detection for workers: auto (cgroup limits, more platforms)",
+        "ext-pcov": "Collects line coverage quickly",
+        "fidry/cpu-core-counter": "Improves worker core detection for auto with cgroup limits and more platforms",
         "phpstan/extension-installer": "Registers the bundled PHPStan extension automatically",
-        "phpstan/phpstan": "Type-checks extension matcher calls and data providers via the bundled extension.neon",
-        "symfony/framework-bundle": "Kernel-aware Symfony tests: container service injection via the SymfonyPlugin bridge"
+        "phpstan/phpstan": "Type-checks extension matcher calls and data providers with the bundled extension.neon",
+        "symfony/framework-bundle": "Enables container service injection into kernel-aware Symfony tests through the SymfonyPlugin bridge"
     },
     "autoload": {
         "psr-4": {

--- a/docs/architecture/technical-writing.md
+++ b/docs/architecture/technical-writing.md
@@ -100,7 +100,9 @@ and meaning. Use the singular form unless the context requires a plural.
 | condition | Technical noun | A rule that determines if Greenlight skips a test |
 | configuration | Technical noun | The settings that control a Greenlight run |
 | configurator | Technical noun | A callable that changes a builder |
+| consumer | Technical noun | A program or tool that reads Greenlight output |
 | coverage export | Technical noun | A file or directory that contains coverage results |
+| coverage gate | Technical noun | A repository check that enforces a coverage requirement |
 | coverage map | Technical noun | Data that identifies executable and covered source lines |
 | data provider | Technical noun | A public static method that supplies named data sets |
 | data set | Technical noun | One named set of arguments for a test method |
@@ -114,6 +116,7 @@ and meaning. Use the singular form unless the context requires a plural.
 | expectation | Technical noun | A required condition for a test value |
 | extension matcher | Technical noun | A matcher that an expectation extension supplies |
 | fixture | Technical noun | Test support code or data with a controlled purpose |
+| flat memory | Technical noun | Memory use that does not increase with the number of completed tests |
 | frame | Technical noun | One length-prefixed worker-protocol message |
 | harness | Technical noun | The test environment that supplies application services to a worker |
 | harness provider | Technical noun | A plugin that supplies services to the Greenlight harness |
@@ -126,6 +129,7 @@ and meaning. Use the singular form unless the context requires a plural.
 | mutant | Technical noun | A source version that contains one deliberate change |
 | orchestrator | Technical noun | The process that plans and controls a run |
 | output capture | Technical noun | The collection of test output and PHP diagnostics for one result |
+| payload | Technical noun | The data that an event envelope contains |
 | poll | Technical noun | One observation of a probe value |
 | poll | Technical verb | To observe a probe until a condition or deadline stops the operation |
 | probe | Technical noun | A callable that supplies values to a temporal expectation |
@@ -148,6 +152,7 @@ and meaning. Use the singular form unless the context requires a plural.
 | staged | Noun modifier | Stored in staging before publication |
 | staging | Technical noun | A private area that stores attachment content before publication |
 | storage key | Technical noun | An opaque value that identifies staged attachment content |
+| stream | Technical noun | An ordered sequence of reporter events or JSONL lines |
 | stub | Technical noun | An inert double that supplies a dependency |
 | suite | Technical noun | A selected group of test classes |
 | Symfony bridge | Technical noun | The component that connects the Greenlight harness to a Symfony kernel and container |

--- a/greenlight.coverage.php
+++ b/greenlight.coverage.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 use Greenlight\Config\CoverageBuilder;
 use Greenlight\Config\GreenlightConfig;
 
-// Layers coverage collection on the base config so the gate always measures
-// the same test set the real suite runs.
+// This configuration adds coverage collection to the base configuration.
+// The gate measures the same test set as the base suite.
 $config = require __DIR__ . '/greenlight.php';
 \assert($config instanceof GreenlightConfig);
 

--- a/greenlight.php
+++ b/greenlight.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 use Greenlight\Config\GreenlightConfig;
 
 return GreenlightConfig::create()
-    // tests/Fixture must never be included here: its Hang/Crash/Leak suites
-    // call sleep(60)/exit(9) and are only safe when driven as subprocesses
-    // by acceptance tests.
+    // tests/Fixture MUST NOT be part of this suite.
+    // Its Hang, Crash, and Leak suites call sleep(60) or exit(9).
+    // Only acceptance tests can safely run these suites as subprocesses.
     ->paths(['tests/Unit', 'tests/Acceptance'])
     ->workers(count: 'auto')
     ->randomizeOrder();

--- a/rector.php
+++ b/rector.php
@@ -8,9 +8,9 @@ use Rector\DeadCode\Rector\ClassMethod\RemoveEmptyClassMethodRector;
 return RectorConfig::configure()
     ->withPaths([__DIR__ . '/src', __DIR__ . '/tests', __DIR__ . '/tools'])
     ->withSkip([
-        // Empty test methods and hooks are meaningful in a testing framework.
+        // Empty test methods and hooks have a purpose in a test framework.
         RemoveEmptyClassMethodRector::class,
-        // Fixtures encode deliberate patterns, including ones rector would "fix".
+        // Fixtures contain deliberate patterns. Without this exclusion, Rector changes some of these patterns.
         __DIR__ . '/tests/Fixture',
     ])
     ->withPhpSets(php84: true)

--- a/renovate.json
+++ b/renovate.json
@@ -15,7 +15,7 @@
     "customManagers": [
         {
             "customType": "regex",
-            "description": "Update the Renovate config validator used by CI",
+            "description": "Update the Renovate configuration validator that CI uses",
             "managerFilePatterns": [
                 "/^\\.github/workflows/ci\\.yml$/"
             ],
@@ -29,7 +29,7 @@
     ],
     "packageRules": [
         {
-            "description": "Keep TypeScript on v6 until Astro Check supports the native compiler API",
+            "description": "Keep TypeScript at version 6 until Astro Check supports the native compiler API",
             "matchManagers": [
                 "npm"
             ],

--- a/resources/schema/jsonl-v1.schema.json
+++ b/resources/schema/jsonl-v1.schema.json
@@ -1,8 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://raw.githubusercontent.com/ben-challis/greenlight/main/resources/schema/jsonl-v1.schema.json",
-    "title": "Greenlight jsonl reporter line (v1)",
-    "description": "One line of the jsonl reporter stream. Version 1 changes additively only: payloads may gain new keys and new event tags may appear in newer streams, so consumers should skip lines whose event tag this schema does not define before validating. Prose reference: docs/architecture/jsonl.md.",
+    "title": "Greenlight JSONL reporter line (version 1)",
+    "description": "One line from the JSONL reporter stream. Version 1 changes only by addition. Newer payloads can have new keys. New event tags can occur in newer streams. Validation applies only to lines with an event tag that this schema defines. Prose reference: docs/architecture/jsonl.md.",
     "type": "object",
     "required": ["v", "event", "data"],
     "properties": {
@@ -81,7 +81,7 @@
     ],
     "definitions": {
         "occurredAt": {
-            "description": "Unix timestamp with microsecond precision. JSON round trips may narrow whole-number floats to integers.",
+            "description": "A Unix timestamp with microsecond precision. A JSON round trip can convert a whole-number float to an integer.",
             "type": "number"
         },
         "runStarted": {
@@ -216,7 +216,7 @@
                 },
                 "risky": {"type": "boolean"},
                 "expectations": {
-                    "description": "Expectations verified during the final attempt. Older streams omit this key; treat a missing value as 0.",
+                    "description": "The number of expectations that Greenlight verified in the final attempt. Older streams do not have this key. If this key is absent, use 0.",
                     "type": "integer",
                     "minimum": 0
                 }

--- a/resources/schema/jsonl-v2.schema.json
+++ b/resources/schema/jsonl-v2.schema.json
@@ -1,8 +1,8 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "id": "https://raw.githubusercontent.com/ben-challis/greenlight/main/resources/schema/jsonl-v2.schema.json",
-    "title": "Greenlight jsonl reporter line (v2)",
-    "description": "One line of the jsonl reporter stream. Prose reference: docs/architecture/jsonl.md.",
+    "title": "Greenlight JSONL reporter line (version 2)",
+    "description": "One line from the JSONL reporter stream. Prose reference: docs/architecture/jsonl.md.",
     "type": "object",
     "required": ["v", "event", "data"],
     "properties": {
@@ -81,7 +81,7 @@
     ],
     "definitions": {
         "occurredAt": {
-            "description": "Unix timestamp with microsecond precision. JSON round trips may narrow whole-number floats to integers.",
+            "description": "A Unix timestamp with microsecond precision. A JSON round trip can convert a whole-number float to an integer.",
             "type": "number"
         },
         "runStarted": {
@@ -221,12 +221,12 @@
                 },
                 "risky": {"type": "boolean"},
                 "expectations": {
-                    "description": "Expectations verified during the final attempt.",
+                    "description": "The number of expectations that Greenlight verified in the final attempt.",
                     "type": "integer",
                     "minimum": 0
                 },
                 "attachments": {
-                    "description": "Retained attachment metadata. Content is stored out of band at path.",
+                    "description": "Metadata for a retained attachment. Greenlight stores the content separately at the specified path.",
                     "type": "array",
                     "items": {"$ref": "#/definitions/attachment"}
                 }

--- a/tools/prose-baseline/root.json
+++ b/tools/prose-baseline/root.json
@@ -1,9 +1,0 @@
-[
-    {
-        "fingerprint": "12cc49d1ee6bb2be2e0ff0d37555114f5a4148af3b1b0019b2f07159e3957692",
-        "path": "greenlight.php",
-        "rule": "sentence-length",
-        "passage": "tests/fixture must never be included here: its hang/crash/leak suites call sleep(60)/exit(9) and are only safe when driven as subprocesses by acceptance tests.",
-        "count": 1
-    }
-]


### PR DESCRIPTION
## Continuation record

- Base commit: `20f04cee4873a24f7cad16f531ed70811d6e85fe`.
- Result commit: `68ddbc752998e47e9d8224581196bc40dfde9cd3`.
- Owned paths: root policy and community files, issue templates, owned configuration comments, package and schema descriptions, the term register, and `tools/prose-baseline/root.json`.
- Blocking findings: the root shard changes from 1 to 0. The repository total changes from 228 to 227.
- Advisory review: an independent review corrected ambiguous conditions, passive schema prose, requirement-level drift, and inaccurate package descriptions. It accepted the policy document advisory candidates as defined terms, noun uses, or registered literal text.
- Terminology decisions: the register now defines consumer, coverage gate, flat memory, payload, and stream. Schema keys, protocol values, public identifiers, and runtime messages do not change.
- Checks run: `composer prose:check`, `make docs-check`, `composer validate --strict`, `composer static-analysis`, `composer tests`, and `git diff --check`. The full suite passed 844 tests with 843 passed and 1 skipped.
- The pull-request template is byte-for-byte unchanged.
- Next unclaimed shards: `src-expect.json` and `src-doubles.json`.