### PR TITLE
docs(website): simplify website copy

### DIFF
--- a/tools/prose-baseline/website.json
+++ b/tools/prose-baseline/website.json
@@ -1,9 +1,0 @@
-[
-    {
-        "fingerprint": "da272bfa0ef2b43c554a934da3552ec63ccb773b6528264ec513b57c52c8a49d",
-        "path": "website/src/components/Footer.astro",
-        "rule": "british-spelling",
-        "passage": "mit licence",
-        "count": 1
-    }
-]

--- a/website/scripts/check-built-site.mjs
+++ b/website/scripts/check-built-site.mjs
@@ -57,7 +57,7 @@ const documentedOptions = new Set(
 
 for (const option of registeredOptions) {
   if (!documentedOptions.has(option)) {
-    errors.push(`configuration.md: missing CLI option section for --${option}`);
+    errors.push(`configuration.md: No section exists for CLI option --${option}.`);
   }
 }
 
@@ -68,27 +68,27 @@ for (const file of htmlFiles) {
   const label = relative(root, file);
 
   if (!/<title>[^<]+<\/title>/.test(html)) {
-    errors.push(`${label}: missing title`);
+    errors.push(`${label}: The page does not contain a title.`);
   }
 
   if (!/<meta name="description" content="[^"]+">/.test(html)) {
-    errors.push(`${label}: missing description`);
+    errors.push(`${label}: The page does not contain a description.`);
   }
 
   if (!/<link rel="canonical" href="https:\/\/ben-challis\.github\.io\/greenlight\//.test(html)) {
-    errors.push(`${label}: missing or invalid canonical URL`);
+    errors.push(`${label}: The page does not contain a valid canonical URL.`);
   }
 
   const attributes = html.matchAll(/\b(?:href|src)="([^"]+)"/g);
 
   for (const [, url] of attributes) {
     if (url.endsWith('.md') && !url.startsWith('https://github.com/')) {
-      errors.push(`${label}: source Markdown link leaked into the built site (${url})`);
+      errors.push(`${label}: The built site contains a source Markdown link (${url}).`);
       continue;
     }
 
     if (url.startsWith('/') && !url.startsWith(`${base}/`)) {
-      errors.push(`${label}: root-relative URL is missing the Pages base path (${url})`);
+      errors.push(`${label}: The root-relative URL does not include the Pages base path (${url}).`);
       continue;
     }
 
@@ -96,7 +96,7 @@ for (const file of htmlFiles) {
       const id = decodeURIComponent(url.slice(1));
 
       if (id !== '' && !html.includes(`id="${id}"`)) {
-        errors.push(`${label}: missing local fragment target (${url})`);
+        errors.push(`${label}: Local fragment target does not exist (${url}).`);
       }
 
       continue;
@@ -110,7 +110,7 @@ for (const file of htmlFiles) {
     const target = targetFile(parsed.pathname);
 
     if (!(await exists(target))) {
-      errors.push(`${label}: missing internal target (${url})`);
+      errors.push(`${label}: Internal target does not exist (${url}).`);
       continue;
     }
 
@@ -119,23 +119,23 @@ for (const file of htmlFiles) {
       const id = decodeURIComponent(parsed.hash.slice(1));
 
       if (!targetHtml.includes(`id="${id}"`)) {
-        errors.push(`${label}: missing cross-page fragment target (${url})`);
+        errors.push(`${label}: Cross-page fragment target does not exist (${url}).`);
       }
     }
   }
 }
 
 if (!(await exists(join(root, '_pagefind', 'pagefind.js')))) {
-  errors.push('Pagefind search index is missing');
+  errors.push('The Pagefind search index does not exist.');
 }
 
 if (await exists(join(root, 'docs', 'architecture', 'index.html'))) {
-  errors.push('Repository-only architecture documentation was published');
+  errors.push('The site contains repository-only architecture documentation.');
 }
 
 if (errors.length > 0) {
   console.error(errors.join('\n'));
   process.exitCode = 1;
 } else {
-  console.log(`Validated ${htmlFiles.length} HTML pages and their internal targets.`);
+  console.log(`The site check validated ${htmlFiles.length} HTML pages and their internal targets.`);
 }

--- a/website/src/components/Footer.astro
+++ b/website/src/components/Footer.astro
@@ -10,7 +10,7 @@ import { githubUrl, sitePath } from '../lib/paths';
     <nav aria-label="Footer navigation">
       <a href={sitePath('docs/getting-started/')}>Documentation</a>
       <a href={githubUrl}>Source</a>
-      <a href={`${githubUrl}/blob/main/LICENSE`}>MIT licence</a>
+      <a href={`${githubUrl}/blob/main/LICENSE`}>MIT License</a>
     </nav>
   </div>
 </footer>

--- a/website/src/components/Search.astro
+++ b/website/src/components/Search.astro
@@ -14,7 +14,7 @@ const pagefindScript = sitePath('_pagefind/pagefind-ui.js');
   </summary>
   <div class="search-surface" role="dialog" aria-label="Search documentation">
     <div id="pagefind-search">
-      <p class="search-loading">Start typing to search the documentation.</p>
+      <p class="search-loading">Enter text to search the documentation.</p>
     </div>
   </div>
 </details>
@@ -51,7 +51,7 @@ const pagefindScript = sitePath('_pagefind/pagefind-ui.js');
     script.onerror = () => {
       const loading = document.querySelector('.search-loading');
       if (loading) {
-        loading.textContent = 'Search is available in the production build.';
+        loading.textContent = 'Search is not available.';
       }
     };
     document.head.append(script);

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -37,7 +37,7 @@ const socialImage = new URL(sitePath('og.png'), Astro.site);
     <meta property="og:image" content={socialImage} />
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
-    <meta property="og:image:alt" content="Greenlight parallel test lanes converging on a passed result." />
+    <meta property="og:image:alt" content="Greenlight parallel test lanes converge on a passed result." />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={description} />

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -62,7 +62,7 @@ const { previous, next } = adjacentDocs(doc.id);
     <article class="docs-article" data-pagefind-body>
       <slot />
 
-      <nav class="doc-pagination" aria-label="Adjacent documentation" data-pagefind-ignore="all">
+      <nav class="doc-pagination" aria-label="Previous and next documentation pages" data-pagefind-ignore="all">
         {
           previous ? (
             <a class="previous" href={docPath(previous.id)}>

--- a/website/src/lib/copy-command.ts
+++ b/website/src/lib/copy-command.ts
@@ -28,8 +28,8 @@ function copyIcon(state: CopyState): SVGSVGElement {
 function setCopyState(button: HTMLButtonElement, state: CopyState): void {
   const labels = {
     idle: 'Copy command to clipboard',
-    copied: 'Command copied to clipboard',
-    error: 'Copy failed, try again',
+    copied: 'The clipboard contains the command.',
+    error: 'Copy failed. Try again.',
   };
 
   button.replaceChildren(copyIcon(state));
@@ -49,7 +49,7 @@ async function writeToClipboard(text: string): Promise<void> {
       await navigator.clipboard.writeText(text);
       return;
     } catch {
-      // Fall back for browsers that expose the API but deny clipboard access.
+      // If the browser denies clipboard access, use the compatibility method.
     }
   }
 
@@ -72,7 +72,7 @@ async function writeToClipboard(text: string): Promise<void> {
   activeElement?.focus();
 
   if (!copied) {
-    throw new Error('Unable to copy command');
+    throw new Error('The browser could not copy the command.');
   }
 }
 

--- a/website/src/lib/docs.ts
+++ b/website/src/lib/docs.ts
@@ -8,13 +8,13 @@ export const docSections = [
     items: [
       {
         id: 'getting-started',
-        title: 'Getting started',
-        description: 'Install Greenlight, write a first test, and understand the runner.',
+        title: 'Start with Greenlight',
+        description: 'This guide explains how to install Greenlight, write your first test, and use the runner.',
       },
       {
         id: 'migrating-from-phpunit',
-        title: 'Migrating from PHPUnit',
-        description: 'Map familiar PHPUnit concepts onto Greenlight deliberately.',
+        title: 'Move from PHPUnit',
+        description: 'This guide compares PHPUnit and Greenlight concepts and explains the required changes.',
       },
     ],
   },
@@ -24,27 +24,27 @@ export const docSections = [
       {
         id: 'configuration',
         title: 'Configuration',
-        description: 'Configure suites, workers, resource limits, coverage, and the CLI.',
+        description: 'This reference explains configuration for suites, workers, resource limits, coverage, and the CLI.',
       },
       {
         id: 'attributes',
         title: 'Attributes',
-        description: 'Reference every test, lifecycle, data, and execution attribute.',
+        description: 'This reference explains attributes for tests, hooks, data sets, and execution.',
       },
       {
         id: 'expectations',
         title: 'Expectations',
-        description: 'Assert values, exceptions, and asynchronous state.',
+        description: 'This reference explains value, exception, and temporal expectations.',
       },
       {
         id: 'test-doubles',
         title: 'Doubles',
-        description: 'Plan strict mocks, use inert stubs, and inspect spies.',
+        description: 'This guide explains mocks, stubs, and spies.',
       },
       {
         id: 'attachments',
         title: 'Attachments',
-        description: 'Attach structured values and files to individual test results.',
+        description: 'This guide explains how to attach structured values and files to one test result.',
       },
     ],
   },
@@ -54,17 +54,17 @@ export const docSections = [
       {
         id: 'symfony',
         title: 'Symfony',
-        description: 'Use kernel-aware tests and inject services from the container.',
+        description: 'This guide explains how tests use a kernel and receive container services.',
       },
       {
         id: 'phpstan',
         title: 'PHPStan',
-        description: 'Type-check matchers, providers, and custom expectations.',
+        description: 'This guide explains how PHPStan checks matchers, data providers, and extension matchers.',
       },
       {
         id: 'plugins',
-        title: 'Writing plugins',
-        description: 'Extend lifecycle, retries, services, expectations, and reporting.',
+        title: 'Plugins',
+        description: 'This guide explains plugins for hooks, retry deciders, harness services, expectations, and reporters.',
       },
     ],
   },
@@ -74,7 +74,7 @@ export const docSections = [
       {
         id: 'benchmarks',
         title: 'Benchmarks',
-        description: 'Review the generated benchmark method, results, and limitations.',
+        description: 'This guide explains the generated benchmark method, results, and limitations.',
       },
     ],
   },
@@ -93,7 +93,7 @@ export function docById(id: string): DocDefinition {
   const doc = docs.find((candidate) => candidate.id === id);
 
   if (!doc) {
-    throw new Error(`No documentation metadata exists for "${id}".`);
+    throw new Error(`Documentation metadata does not exist for "${id}".`);
   }
 
   return doc;
@@ -131,15 +131,15 @@ export function assertCompleteDocCollection(
   if (missingMetadata.length > 0 || missingFiles.length > 0) {
     const details = [
       missingMetadata.length > 0
-        ? `missing metadata: ${missingMetadata.join(', ')}`
+        ? `No metadata exists for these documentation entries: ${missingMetadata.join(', ')}.`
         : undefined,
       missingFiles.length > 0
-        ? `missing Markdown: ${missingFiles.join(', ')}`
+        ? `No Markdown file exists for these metadata entries: ${missingFiles.join(', ')}.`
         : undefined,
     ]
       .filter(Boolean)
-      .join('; ');
+      .join(' ');
 
-    throw new Error(`Documentation collection is incomplete (${details}).`);
+    throw new Error(`Documentation collection is incomplete. ${details}`);
   }
 }

--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -8,9 +8,9 @@ import { sitePath } from '../lib/paths';
   description="The requested Greenlight documentation page does not exist."
 >
   <main id="main-content" class="not-found">
-    <p class="eyebrow">404 · No test collected</p>
-    <h1>This page is not in the execution plan.</h1>
-    <p>Return to the documentation index and pick up from a known route.</p>
+    <p class="eyebrow">404 · Page not found</p>
+    <h1>The requested documentation page does not exist.</h1>
+    <p>Return to the documentation index to select an available page.</p>
     <a class="button primary" href={sitePath('docs/getting-started/')}>Browse documentation</a>
   </main>
 </BaseLayout>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -42,7 +42,7 @@ final class PriceTest
           worker pool for parallel execution by default.
         </p>
         <div class="hero-actions">
-          <a class="button primary" href={sitePath('docs/getting-started/')}>Get started</a>
+          <a class="button primary" href={sitePath('docs/getting-started/')}>Start with Greenlight</a>
           <a class="button secondary" href={githubUrl}>View on GitHub</a>
         </div>
         <div class="install-command" aria-label="Composer installation command" data-copy-command>
@@ -55,9 +55,9 @@ final class PriceTest
     </section>
 
     <section class="proof-line" aria-label="Greenlight characteristics">
-      <p><strong>Use every available core</strong><span>Parallel execution is built into the runner.</span></p>
-      <p><strong>Keep tests as plain PHP</strong><span>No base class or method-name convention.</span></p>
-      <p><strong>Stay inside your tools</strong><span>Typed APIs work with your IDE and PHPStan.</span></p>
+      <p><strong>Use every available core</strong><span>The runner executes test classes in parallel.</span></p>
+      <p><strong>Use plain PHP tests</strong><span>Tests need no base class or method-name convention.</span></p>
+      <p><strong>Use your current tools</strong><span>Typed APIs work with your IDE and PHPStan.</span></p>
     </section>
 
     <section class="code-proof section-shell">
@@ -86,15 +86,15 @@ final class PriceTest
         <li>
           <span>01</span>
           <div>
-            <h3>Start one command</h3>
-            <p>Greenlight discovers the suite once and builds the run plan.</p>
+            <h3>Run one command</h3>
+            <p>Greenlight discovers the suite once and builds the execution plan.</p>
           </div>
         </li>
         <li>
           <span>02</span>
           <div>
             <h3>Keep every worker busy</h3>
-            <p>Free workers take the next class, with known slow and failed tests starting early.</p>
+            <p>Free workers take the next class. Greenlight starts known slow classes and previously failed classes early.</p>
           </div>
         </li>
         <li>
@@ -109,13 +109,13 @@ final class PriceTest
 
     <section class="runner-proof section-shell">
       <div class="runner-copy">
-        <p class="eyebrow">When a test misbehaves</p>
+        <p class="eyebrow">Test failures</p>
         <h2>Failures stay contained and readable.</h2>
         <div class="capability-list">
-          <p><strong>Crashed worker</strong><span>Queued classes return to the pool and a replacement takes over.</span></p>
-          <p><strong>Hung test</strong><span>A hard timeout stops the worker so the rest of the suite can finish.</span></p>
-          <p><strong>External resources</strong><span>Channels isolate per-worker resources; named limits cap access to shared dependencies.</span></p>
-          <p><strong>Missed mock call</strong><span>Strict doubles verify at teardown and report unmet expectations.</span></p>
+          <p><strong>Crashed worker</strong><span>The orchestrator returns the rest of the assignment to the queue and starts a replacement worker.</span></p>
+          <p><strong>Hung test</strong><span>A hard timeout stops the worker. A replacement worker continues the suite.</span></p>
+          <p><strong>External resources</strong><span>Use channels to select separate resources for each worker. Resource limits restrict concurrent access to shared dependencies.</span></p>
+          <p><strong>Missed mock call</strong><span>At teardown, strict doubles verify interactions and report unmet expectations.</span></p>
         </div>
       </div>
       <div class="terminal-window" aria-label="Example Greenlight terminal output">
@@ -129,12 +129,12 @@ final class PriceTest
 
     <section class="migration section-shell">
       <div class="migration-copy">
-        <p class="eyebrow">Coming from PHPUnit?</p>
+        <p class="eyebrow">Move from PHPUnit</p>
         <h2>Move one test class at a time.</h2>
         <p>
-          Greenlight changes the test scaffolding, not the code you are testing.
-          Start with a leaf class, run it with one worker, then enable parallel
-          execution when it passes.
+          Greenlight changes the test support code but does not change the code
+          under test. Start with one small test class that has few dependencies.
+          Run it with one worker. After it passes, enable parallel execution.
         </p>
         <a class="text-link" href={sitePath('docs/migrating-from-phpunit/')}>
           Read the PHPUnit migration guide
@@ -167,9 +167,9 @@ final class PriceTest
     <section class="closing-cta">
       <div class="closing-cta-intro">
         <p class="eyebrow">Try one test class</p>
-        <h2>Go from install to first run.</h2>
+        <h2>Go from installation to your first run.</h2>
         <p>
-          You can see a passing Greenlight run before changing the rest of your suite.
+          Before you change the rest of your suite, run one test class successfully.
         </p>
       </div>
       <ol class="setup-steps">
@@ -191,7 +191,7 @@ final class PriceTest
       </ol>
       <div class="hero-actions">
         <a class="button primary" href={sitePath('docs/getting-started/')}>
-          Follow the getting-started guide
+          Read the Start with Greenlight guide
         </a>
       </div>
     </section>


### PR DESCRIPTION
## Continuation record

- Base commit: `20f04cee4873a24f7cad16f531ed70811d6e85fe`.
- Result commit: `7c2b6ce6a0a99258625eab5ecde33ede5e54c66f`.
- Owned paths: website metadata, navigation descriptions, accessibility text, interface status text, landing-page copy, and `tools/prose-baseline/website.json`.
- Blocking findings: the website shard changes from 1 to 0. The repository total changes from 228 to 227. After both PRs in this wave merge, the total is 226.
- Advisory review: an independent review corrected an inaccurate search state, resource-limit wording, unclear migration terms, and a vague link name. It accepted established nouns in component names and clarity-only promotional headlines.
- Terminology decisions: technical copy uses channel, resource limit, extension matcher, and test support code. The change adds no new project term.
- Checks run: `composer prose:check`, `make docs-check`, the advisory review, and `git diff --check`. The site check built and validated 13 HTML pages.
- Code samples, commands, paths, URLs, terminal samples, and machine contracts do not change.
- Next unclaimed shards: `src-expect.json` and `src-doubles.json`.