### PR TITLE
test: guard empty JUnit output

### DIFF
--- a/tests/Acceptance/ReporterSmokeTest.php
+++ b/tests/Acceptance/ReporterSmokeTest.php
@@ -6,6 +6,7 @@ namespace Greenlight\Tests\Acceptance;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
 use Greenlight\Tests\Support\GreenlightCli;
@@ -22,6 +23,11 @@ final readonly class ReporterSmokeTest
         // corrupt the document that the parser must accept as a complete unit.
         $result = GreenlightCli::run($project->directory, ['run', '--reporter=junit']);
         Expect::that($result->exitCode)->toBe(1);
+
+        if ($result->stdout === '') {
+            Fail::because('The JUnit reporter did not write XML to stdout.');
+        }
+
         $document = new \DOMDocument();
         Expect::that($document->loadXML($result->stdout))->toBeTrue();
         $testcases = $document->getElementsByTagName('testcase');


### PR DESCRIPTION
Fail explicitly when the JUnit reporter writes no XML to stdout. This gives an actionable diagnostic before `DOMDocument::loadXML()` receives an empty string.

Extracted from #77 so that the Renovate pull request remains dependency-only.