### PR TITLE
fix(laravel): isolate bridge lifecycle state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,10 +74,15 @@ jobs:
         dependencies:
           - "lowest"
           - "locked"
-        # Run Symfony version jobs only with "highest". "locked" ignores
-        # SYMFONY_REQUIRE. laravel/framework requires Symfony >= 7.4, so
-        # "lowest" resolves Symfony 7.4 and the 6.4 job removes Laravel first.
+        # "locked" ignores SYMFONY_REQUIRE. The lowest jobs and the Symfony
+        # 6.4 job remove Laravel because Laravel 13 requires Symfony >= 7.4.
         include:
+          - php-version: "8.4"
+            dependencies: "lowest"
+            symfony-version: "6.4.*"
+          - php-version: "8.5"
+            dependencies: "lowest"
+            symfony-version: "6.4.*"
           - php-version: "8.4"
             dependencies: "highest"
             symfony-version: "6.4.*"

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "suggest": {
         "ext-pcov": "Collects line coverage quickly",
         "fidry/cpu-core-counter": "Improves worker core detection for auto with cgroup limits and more platforms",
-        "laravel/framework": "Enables container service injection into application-aware Laravel tests through the LaravelPlugin bridge",
+        "laravel/framework": "Provides the complete Laravel 13 framework that LaravelPlugin requires",
         "phpstan/extension-installer": "Registers the bundled PHPStan extension automatically",
         "phpstan/phpstan": "Type-checks extension matcher calls and data providers with the bundled extension.neon",
         "symfony/framework-bundle": "Enables container service injection into kernel-aware Symfony tests through the SymfonyPlugin bridge"

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -96,7 +96,7 @@ deptrac:
     - name: LaravelFramework
       collectors:
         - type: classNameRegex
-          value: /^Illuminate\\(Container|Contracts\\(Console|Foundation)|Support\\Facades)\\/
+          value: /^Illuminate\\/
     - name: CpuCoreCounter
       collectors:
         - type: classNameRegex

--- a/docs/architecture/technical-writing.md
+++ b/docs/architecture/technical-writing.md
@@ -92,6 +92,7 @@ and meaning. Use the singular form unless the context requires a plural.
 | attachment | Technical noun | Evidence that belongs to one test result |
 | attempt | Technical noun | One execution of a test before Greenlight reports a result or starts a retry |
 | benchmark shape | Technical noun | A generated test-suite structure that one benchmark measures |
+| binding | Technical noun | A container rule that maps an ID to a value or construction method |
 | builder | Technical noun | A mutable object that collects configuration for one part of a run |
 | capability interface | Technical noun | A plugin interface that adds one defined type of behavior |
 | captor | Technical noun | An object that stores argument values from matched mock calls |

--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -31,10 +31,14 @@ new LaravelPlugin(static fn(): Application => Application::configure(basePath: _
     ->create());
 ```
 
-The plugin sets `APP_ENV` before each boot. The default value is `testing`.
-Pass `env:` to select another environment. Laravel loads `.env` without a
-change to variables that already exist, so the plugin value wins. When a
-`.env.testing` file exists, Laravel prefers it over `.env`.
+The plugin sets `APP_ENV` while the application is active. The default value is
+`testing`. Pass `env:` to select another environment. Laravel loads `.env`
+without a change to variables that already exist, so the plugin value wins.
+When a `.env.testing` file exists, Laravel prefers it over `.env`.
+
+The plugin restores the previous `APP_ENV` value after it discards the
+application. If you disable refreshes, the selected value stays active for the
+worker lifetime.
 
 The application boots when a test first requests a container service. A worker
 does not boot Laravel when its tests do not use the container. Greenlight tests
@@ -98,20 +102,22 @@ application in its own container.
 
 ## State between tests
 
-The bridge discards the application after each test.
+The bridge discards the application after each test. Configuration changes,
+facade roots, singleton state, and container registrations cannot reach the
+next test.
 
-Each test that uses container services receives a fresh boot. This is the same
-isolation model as Laravel's own test harness. Configuration changes, facade
-roots, singleton state, and container registrations from one test cannot reach
-the next test. The bridge also clears Laravel's static facade and container
-references after each test.
+This scope is smaller than the isolation in Laravel's `TestCase`. Laravel's
+test harness resets framework static state for its helpers and fakes. The
+bridge does not supply these features.
 
-Laravel installs global error and exception handlers during boot. The bridge
-restores the previous handlers immediately after boot, so Greenlight keeps
-ownership of test diagnostics.
+Laravel normally installs process-global diagnostic handlers during boot. The
+bridge disables this Laravel bootstrapper, so Greenlight keeps ownership of
+test diagnostics. The bridge also clears Laravel framework state that can
+retain a discarded application.
 
-Static state outside the container remains the test suite's responsibility. An
-example is `Carbon::setTestNow()`. Reset such state in an `#[After]` hook.
+Static state outside the application container remains the test suite's
+responsibility. An example is `Carbon::setTestNow()`. Reset such state in an
+`#[After]` hook.
 
 For a container that has no stateful services, pass `refreshBetweenTests:
 false` to the plugin. The application then boots once for each worker and no

--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -5,8 +5,12 @@ supplies these services together with the built-in Greenlight harness services.
 
 The bridge boots a fresh application for each test that uses it. The bridge is
 in the `Greenlight\Laravel` namespace and is part of Greenlight. Register it to
-activate it. Laravel remains a development dependency of your application.
-Greenlight does not require Laravel.
+activate it. Your Laravel application includes `laravel/framework` as an
+application dependency. Greenlight does not require Laravel.
+
+`LaravelPlugin` requires `laravel/framework` 13. It does not support
+applications that install individual `illuminate/*` components. A standard
+Laravel 13 application already has the required package.
 
 ## Setup
 
@@ -42,7 +46,7 @@ worker lifetime.
 
 The application boots when a test first requests a container service. A worker
 does not boot Laravel when its tests do not use the container. Greenlight tests
-the bridge with `laravel/framework` 13.
+the bridge with each `laravel/framework` 13 release.
 
 ## Container services
 

--- a/src/Laravel/LaravelBridgeError.php
+++ b/src/Laravel/LaravelBridgeError.php
@@ -26,6 +26,24 @@ final class LaravelBridgeError extends \RuntimeException
         ));
     }
 
+    public static function frameworkUnavailable(): self
+    {
+        return new self(
+            'The Laravel framework is not available. LaravelPlugin requires the complete '
+            . 'laravel/framework 13 package. Install laravel/framework 13 before you activate '
+            . 'the plugin.',
+        );
+    }
+
+    public static function frameworkVersionUnsupported(string $version): self
+    {
+        return new self(\sprintf(
+            'LaravelPlugin found laravel/framework "%s", but it requires major version 13. '
+            . 'Install laravel/framework 13.',
+            $version,
+        ));
+    }
+
     public static function notAnApplication(string $actual): self
     {
         return new self(\sprintf(

--- a/src/Laravel/LaravelBridgeError.php
+++ b/src/Laravel/LaravelBridgeError.php
@@ -4,7 +4,11 @@ declare(strict_types=1);
 
 namespace Greenlight\Laravel;
 
-/** @internal */
+/**
+ * Reports a Laravel bridge configuration or run-time failure.
+ *
+ * @internal
+ */
 final class LaravelBridgeError extends \RuntimeException
 {
     private function __construct(string $message)
@@ -40,6 +44,15 @@ final class LaravelBridgeError extends \RuntimeException
             . 'bootstrap it. Create the application with Application::configure(...)->create(), '
             . 'which registers the kernel bindings.',
         );
+    }
+
+    public static function consoleKernelTypeMismatch(string $actual): self
+    {
+        return new self(\sprintf(
+            'The Laravel console kernel binding contains "%s" instead of an '
+            . 'Illuminate\Contracts\Console\Kernel instance, so LaravelPlugin cannot boot it.',
+            $actual,
+        ));
     }
 
     public static function unknownServiceId(string $id, string $type): self

--- a/src/Laravel/LaravelFrameworkRequirement.php
+++ b/src/Laravel/LaravelFrameworkRequirement.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Laravel;
+
+use Illuminate\Foundation\Application;
+
+/**
+ * Checks whether LaravelPlugin can use Laravel.
+ * The bridge supports major version 13.
+ *
+ * @internal
+ */
+final class LaravelFrameworkRequirement
+{
+    public static function check(): void
+    {
+        self::checkVersion(self::installedVersion());
+    }
+
+    public static function checkVersion(?string $version): void
+    {
+        if ($version === null) {
+            throw LaravelBridgeError::frameworkUnavailable();
+        }
+
+        if (\preg_match('/^13(?:\\.|$)/D', $version) !== 1) {
+            throw LaravelBridgeError::frameworkVersionUnsupported($version);
+        }
+    }
+
+    private static function installedVersion(): ?string
+    {
+        if (!\class_exists(Application::class)) {
+            return null;
+        }
+
+        return Application::VERSION;
+    }
+}

--- a/src/Laravel/LaravelPlugin.php
+++ b/src/Laravel/LaravelPlugin.php
@@ -130,6 +130,7 @@ final class LaravelPlugin implements HarnessProvider, ServiceResolver, TestLifec
             return $this->app;
         }
 
+        LaravelFrameworkRequirement::check();
         $this->processState = LaravelProcessState::setEnvironment($this->env);
 
         try {

--- a/src/Laravel/LaravelPlugin.php
+++ b/src/Laravel/LaravelPlugin.php
@@ -11,19 +11,15 @@ use Greenlight\Harness\ServiceResolver;
 use Greenlight\Plugin\HarnessProvider;
 use Greenlight\Plugin\TestContext;
 use Greenlight\Plugin\TestLifecycleSubscriber;
-use Illuminate\Container\Container;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Contracts\Foundation\Application;
-use Illuminate\Support\Facades\Facade;
+use Illuminate\Foundation\Bootstrap\HandleExceptions;
+use Illuminate\Foundation\Bootstrap\RegisterProviders;
 
 /**
- * The application boots lazily and lives for one test, so container state,
- * facade roots, and singletons cannot carry over between tests.
- *
- * Only bound services resolve. The bridge does not use Laravel's implicit
- * resolution for unbound classes. #[Service] overrides type-based lookup
- * with an explicit binding id. External resources must be isolated by
- * GREENLIGHT_CHANNEL.
+ * Boots one Laravel application lazily for a test and resolves bound services.
+ * #[Service] selects an explicit binding ID. Tests MUST isolate external
+ * resources by GREENLIGHT_CHANNEL.
  */
 final class LaravelPlugin implements HarnessProvider, ServiceResolver, TestLifecycleSubscriber
 {
@@ -32,11 +28,10 @@ final class LaravelPlugin implements HarnessProvider, ServiceResolver, TestLifec
      */
     private readonly \Closure $factory;
 
-    /**
-     * A constructor injection that fails after boot leaves the application
-     * here for one test. The next completed test's afterTest flushes it.
-     */
+    /** The active application belongs to the current test attempt. */
     private ?Application $app = null;
+
+    private ?LaravelProcessState $processState = null;
 
     /**
      * @param string|\Closure(): Application $application
@@ -123,51 +118,87 @@ final class LaravelPlugin implements HarnessProvider, ServiceResolver, TestLifec
             return $result;
         }
 
-        $app = $this->app;
-        // Cleared first so a throwing teardown cannot leak a half-dead application.
-        $this->app = null;
-
-        $app->flush();
-        Facade::clearResolvedInstances();
-        Facade::setFacadeApplication(null);
-        Container::setInstance();
+        $this->releaseApplication();
 
         return $result;
     }
 
-    /** An invalid application is not cached, so each use fails instead of running unisolated. */
+    /** An invalid application fails before Greenlight supplies a container service. */
     private function application(): Application
     {
         if ($this->app instanceof Application) {
             return $this->app;
         }
 
-        // Applied before every boot. Laravel loads .env without a change to
-        // existing environment variables, so this value wins.
-        $_ENV['APP_ENV'] = $this->env;
-        $_SERVER['APP_ENV'] = $this->env;
-        \putenv('APP_ENV=' . $this->env);
+        $this->processState = LaravelProcessState::setEnvironment($this->env);
 
-        $app = ($this->factory)();
+        try {
+            $app = ($this->factory)();
 
-        if (!$app instanceof Application) {
-            throw LaravelBridgeError::notAnApplication(\get_debug_type($app));
+            if (!$app instanceof Application) {
+                throw LaravelBridgeError::notAnApplication(\get_debug_type($app));
+            }
+
+            $this->app = $app;
+
+            if (!$app->bound(Kernel::class)) {
+                throw LaravelBridgeError::consoleKernelUnavailable();
+            }
+
+            $kernel = $this->containerEntry($app, Kernel::class);
+
+            if (!$kernel instanceof Kernel) {
+                throw LaravelBridgeError::consoleKernelTypeMismatch(\get_debug_type($kernel));
+            }
+
+            $this->preserveDiagnosticHandlers($app);
+            $kernel->bootstrap();
+
+            return $app;
+        } catch (\Throwable $threw) {
+            $this->releaseApplication();
+
+            throw $threw;
+        } finally {
+            RegisterProviders::flushState();
         }
+    }
 
-        if (!$app->bound(Kernel::class)) {
-            throw LaravelBridgeError::consoleKernelUnavailable();
+    /**
+     * Laravel's bootstrapper installs process-global diagnostic handlers and a
+     * shutdown callback. Greenlight owns diagnostics for the worker lifetime.
+     */
+    private function preserveDiagnosticHandlers(Application $app): void
+    {
+        $app->extend(
+            HandleExceptions::class,
+            static fn(): HandleExceptions => new class extends HandleExceptions {
+                #[\Override]
+                public function bootstrap(Application $app): void {}
+            },
+        );
+    }
+
+    private function containerEntry(Application $app, string $id): mixed
+    {
+        return $app->get($id);
+    }
+
+    private function releaseApplication(): void
+    {
+        $app = $this->app;
+        $state = $this->processState;
+        $this->app = null;
+        $this->processState = null;
+
+        try {
+            $app?->flush();
+        } finally {
+            try {
+                LaravelStateResetter::reset();
+            } finally {
+                $state?->restore();
+            }
         }
-
-        $app->make(Kernel::class)->bootstrap();
-
-        // The boot pushed one Laravel error handler and one exception handler
-        // above Greenlight's capture handlers. Pop both so Greenlight keeps
-        // ownership of diagnostics.
-        \restore_error_handler();
-        \restore_exception_handler();
-
-        $this->app = $app;
-
-        return $app;
     }
 }

--- a/src/Laravel/LaravelProcessState.php
+++ b/src/Laravel/LaravelProcessState.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Laravel;
+
+use Illuminate\Container\Container;
+use Illuminate\Contracts\Container\Container as ContainerContract;
+use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Support\Facades\Facade;
+
+/**
+ * Records the process state that Laravel application construction changes.
+ * restore() returns each recorded value after the application lifetime ends.
+ *
+ * @internal
+ */
+final readonly class LaravelProcessState
+{
+    private function __construct(
+        private ContainerContract $container,
+        private ?Application $facadeApplication,
+        private string|false $processEnvironment,
+        private bool $environmentWasSet,
+        private mixed $environment,
+        private bool $serverEnvironmentWasSet,
+        private mixed $serverEnvironment,
+    ) {}
+
+    public static function setEnvironment(string $environment): self
+    {
+        $state = new self(
+            Container::getInstance(),
+            Facade::getFacadeApplication(),
+            \getenv('APP_ENV'),
+            \array_key_exists('APP_ENV', $_ENV),
+            $_ENV['APP_ENV'] ?? null,
+            \array_key_exists('APP_ENV', $_SERVER),
+            $_SERVER['APP_ENV'] ?? null,
+        );
+
+        \putenv('APP_ENV=' . $environment);
+        $_ENV['APP_ENV'] = $environment;
+        $_SERVER['APP_ENV'] = $environment;
+
+        return $state;
+    }
+
+    public function restore(): void
+    {
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication($this->facadeApplication);
+        Container::setInstance($this->container);
+
+        if ($this->processEnvironment === false) {
+            \putenv('APP_ENV');
+        } else {
+            \putenv('APP_ENV=' . $this->processEnvironment);
+        }
+
+        if ($this->environmentWasSet) {
+            $_ENV['APP_ENV'] = $this->environment;
+        } else {
+            unset($_ENV['APP_ENV']);
+        }
+
+        if ($this->serverEnvironmentWasSet) {
+            $_SERVER['APP_ENV'] = $this->serverEnvironment;
+        } else {
+            unset($_SERVER['APP_ENV']);
+        }
+    }
+}

--- a/src/Laravel/LaravelStateResetter.php
+++ b/src/Laravel/LaravelStateResetter.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Laravel;
+
+use Illuminate\Console\Application as Artisan;
+use Illuminate\Cookie\Middleware\EncryptCookies;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Migrations\Migrator;
+use Illuminate\Foundation\Bootstrap\RegisterProviders;
+use Illuminate\Foundation\Console\AboutCommand;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Foundation\Http\Middleware\ConvertEmptyStringsToNull;
+use Illuminate\Foundation\Http\Middleware\PreventRequestForgery;
+use Illuminate\Foundation\Http\Middleware\PreventRequestsDuringMaintenance;
+use Illuminate\Foundation\Http\Middleware\TrimStrings;
+use Illuminate\Http\Client\Response;
+use Illuminate\Http\Middleware\HandleCors;
+use Illuminate\Http\Middleware\TrustHosts;
+use Illuminate\Http\Middleware\TrustProxies;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Http\Resources\JsonApi\JsonApiResource;
+use Illuminate\Mail\Markdown;
+use Illuminate\Queue\Console\WorkCommand;
+use Illuminate\Queue\Queue;
+use Illuminate\Support\EncodedHtmlString;
+use Illuminate\Support\Lottery;
+use Illuminate\Support\Once;
+use Illuminate\Support\Sleep;
+use Illuminate\Support\Str;
+use Illuminate\Validation\Validator;
+use Illuminate\View\Component;
+
+/**
+ * Clears Laravel framework state that can retain one discarded application.
+ * The reset list follows Laravel 13 test application teardown.
+ *
+ * @internal
+ */
+final class LaravelStateResetter
+{
+    public static function reset(): void
+    {
+        AboutCommand::flushState();
+        Artisan::forgetBootstrappers();
+        Component::flushCache();
+        Component::forgetFactory();
+        ConvertEmptyStringsToNull::flushState();
+        Factory::flushState();
+        FormRequest::flushState();
+        EncodedHtmlString::flushState();
+        EncryptCookies::flushState();
+        HandleCors::flushState();
+        JsonApiResource::flushState();
+        JsonResource::flushState();
+        Lottery::determineResultsNormally();
+        Markdown::flushState();
+        Migrator::withoutMigrations([]);
+        Once::flush();
+        PreventRequestsDuringMaintenance::flushState();
+        Queue::createPayloadUsing(null);
+        RegisterProviders::flushState();
+        Response::flushState();
+        Sleep::fake(false);
+        Str::resetFactoryState();
+        TrimStrings::flushState();
+        TrustProxies::flushState();
+        TrustHosts::flushState();
+        PreventRequestForgery::flushState();
+        Validator::flushState();
+        WorkCommand::flushState();
+    }
+}

--- a/tests/Fixture/Laravel/ThrowingKernel.php
+++ b/tests/Fixture/Laravel/ThrowingKernel.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Laravel;
+
+use Illuminate\Contracts\Console\Kernel;
+
+/**
+ * Throws when the bridge starts the console kernel.
+ */
+final class ThrowingKernel implements Kernel
+{
+    #[\Override]
+    public function bootstrap(): void
+    {
+        throw new \RuntimeException('The fixture kernel could not bootstrap.');
+    }
+
+    #[\Override]
+    public function handle(mixed $input, mixed $output = null): int
+    {
+        return 0;
+    }
+
+    /**
+     * @param array<array-key, mixed> $parameters
+     */
+    #[\Override]
+    public function call(mixed $command, array $parameters = [], mixed $outputBuffer = null): int
+    {
+        return 0;
+    }
+
+    /**
+     * @param array<array-key, mixed> $parameters
+     */
+    #[\Override]
+    public function queue(mixed $command, array $parameters = []): never
+    {
+        throw new \LogicException('The fixture kernel cannot queue a command.');
+    }
+
+    /**
+     * @return array<never, never>
+     */
+    #[\Override]
+    public function all(): array
+    {
+        return [];
+    }
+
+    #[\Override]
+    public function output(): string
+    {
+        return '';
+    }
+
+    #[\Override]
+    public function terminate(mixed $input, mixed $status): void {}
+}

--- a/tests/Unit/Laravel/LaravelPluginTest.php
+++ b/tests/Unit/Laravel/LaravelPluginTest.php
@@ -14,6 +14,7 @@ use Greenlight\Core\Test\TestId;
 use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
+use Greenlight\Fixture\EnvironmentSandbox;
 use Greenlight\Harness\HarnessRegistry;
 use Greenlight\Harness\HarnessScopes;
 use Greenlight\Harness\Scope;
@@ -24,18 +25,33 @@ use Greenlight\Plugin\TestContext;
 use Greenlight\Tests\Fixture\Laravel\FixtureApplication;
 use Greenlight\Tests\Fixture\Laravel\Greeter;
 use Greenlight\Tests\Fixture\Laravel\NamedGreeter;
+use Greenlight\Tests\Fixture\Laravel\ThrowingKernel;
 use Greenlight\Tests\Fixture\Laravel\VisitCounter;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Contracts\Foundation\Application;
+use Illuminate\Foundation\Application as LaravelApplication;
 use Illuminate\Support\Facades\Facade;
 
-#[SkipUnless(ClassAvailable::class, \Illuminate\Foundation\Application::class)]
+#[SkipUnless(ClassAvailable::class, LaravelApplication::class)]
 final class LaravelPluginTest
 {
-    /** A failed expectation must not leak Laravel statics into other tests. */
+    /**
+     * @var list<LaravelPlugin>
+     */
+    private array $plugins = [];
+
+    public function __construct(private readonly EnvironmentSandbox $environment) {}
+
+    /** A failed expectation MUST NOT leak a Laravel application into another test. */
     #[After]
-    public function forgetLaravelStatics(): void
+    public function releaseLaravelApplications(): void
     {
+        foreach ($this->plugins as $plugin) {
+            $plugin->afterTest($this->context(), $this->result());
+        }
+
+        $this->plugins = [];
         Facade::clearResolvedInstances();
         Facade::setFacadeApplication(null);
         Container::setInstance();
@@ -110,21 +126,73 @@ final class LaravelPluginTest
     #[Test]
     public function aBootstrapFileThatDoesNotExistFailsLoudly(): void
     {
-        $plugin = new LaravelPlugin($this->fixtureDir() . '/missing-bootstrap.php');
+        $this->environment->set('APP_ENV', 'before-laravel');
+        $plugin = $this->track(new LaravelPlugin($this->fixtureDir() . '/missing-bootstrap.php'));
 
         Expect::that(static function () use ($plugin): void {
             $plugin->resolve(Greeter::class, []);
-        })->toThrow(LaravelBridgeError::class, matching: '/does not exist.*bootstrap\/app\.php/s');
+        })->toThrow(LaravelBridgeError::class, matching: '/does not exist.*bootstrap\/app\.php/s')
+            ->and(\getenv('APP_ENV'))->toBe('before-laravel')
+            ->and($_ENV['APP_ENV'] ?? null)->toBe('before-laravel')
+            ->and($_SERVER['APP_ENV'] ?? null)->toBe('before-laravel');
     }
 
     #[Test]
     public function aBootstrapThatDoesNotReturnAnApplicationFailsLoudly(): void
     {
-        $plugin = new LaravelPlugin($this->fixtureDir() . '/bootstrap-invalid.php');
+        $plugin = $this->track(new LaravelPlugin($this->fixtureDir() . '/bootstrap-invalid.php'));
 
         Expect::that(static function () use ($plugin): void {
             $plugin->resolve(Greeter::class, []);
         })->toThrow(LaravelBridgeError::class, matching: '/returned "stdClass".*Application::configure/s');
+    }
+
+    #[Test]
+    public function anApplicationWithoutAConsoleKernelFailsLoudly(): void
+    {
+        $plugin = $this->track(new LaravelPlugin(
+            fn(): Application => $this->bareApplication(),
+        ));
+
+        Expect::that(static function () use ($plugin): void {
+            $plugin->resolve(Greeter::class, []);
+        })->toThrow(LaravelBridgeError::class, matching: '/no console kernel binding/');
+    }
+
+    #[Test]
+    public function aConsoleKernelBindingOfTheWrongTypeFailsLoudly(): void
+    {
+        $plugin = $this->track(new LaravelPlugin(function (): Application {
+            $app = $this->bareApplication();
+            $app->instance(Kernel::class, new \stdClass());
+
+            return $app;
+        }));
+
+        Expect::that(static function () use ($plugin): void {
+            $plugin->resolve(Greeter::class, []);
+        })->toThrow(LaravelBridgeError::class, matching: '/contains "stdClass" instead of/');
+    }
+
+    #[Test]
+    public function aFailedKernelBootstrapRestoresProcessState(): void
+    {
+        $this->environment->set('APP_ENV', 'before-laravel');
+        $container = Container::getInstance();
+        $plugin = $this->track(new LaravelPlugin(function (): Application {
+            $app = $this->bareApplication();
+            $app->instance(Kernel::class, new ThrowingKernel());
+
+            return $app;
+        }));
+
+        Expect::that(static function () use ($plugin): void {
+            $plugin->resolve(Greeter::class, []);
+        })->toThrow(\RuntimeException::class, matching: '/could not bootstrap/')
+            ->and(Container::getInstance())->toBe($container)
+            ->and(\getenv('APP_ENV'))->toBe('before-laravel')
+            ->and($_ENV['APP_ENV'] ?? null)->toBe('before-laravel')
+            ->and($_SERVER['APP_ENV'] ?? null)->toBe('before-laravel');
     }
 
     #[Test]
@@ -152,7 +220,10 @@ final class LaravelPluginTest
     #[Test]
     public function theApplicationIsAPerRunHarnessServiceWithoutRefresh(): void
     {
-        $plugin = new LaravelPlugin($this->fixtureDir() . '/bootstrap.php', refreshBetweenTests: false);
+        $plugin = $this->track(new LaravelPlugin(
+            $this->fixtureDir() . '/bootstrap.php',
+            refreshBetweenTests: false,
+        ));
 
         Expect::that($plugin->services()[0]->scope)->toBe(Scope::PerRun);
     }
@@ -160,7 +231,9 @@ final class LaravelPluginTest
     #[Test]
     public function aClosureFactoryBootsTheApplicationItProduces(): void
     {
-        $plugin = new LaravelPlugin(static fn(): Application => FixtureApplication::create());
+        $plugin = $this->track(new LaravelPlugin(
+            static fn(): Application => FixtureApplication::create(),
+        ));
 
         Expect::that($plugin->resolve(Greeter::class, []))->toBeInstanceOf(Greeter::class);
     }
@@ -186,7 +259,7 @@ final class LaravelPluginTest
         $plugin = $this->plugin();
         $app = ($plugin->services()[0]->factory)();
 
-        Expect::that($plugin->resolve(\Illuminate\Foundation\Application::class, []))->toBe($app);
+        Expect::that($plugin->resolve(LaravelApplication::class, []))->toBe($app);
     }
 
     #[Test]
@@ -222,7 +295,11 @@ final class LaravelPluginTest
     #[Test]
     public function waivedRefreshKeepsTheApplicationAndItsState(): void
     {
-        $plugin = new LaravelPlugin($this->fixtureDir() . '/bootstrap.php', refreshBetweenTests: false);
+        $this->environment->set('APP_ENV', 'before-laravel');
+        $plugin = $this->track(new LaravelPlugin(
+            $this->fixtureDir() . '/bootstrap.php',
+            refreshBetweenTests: false,
+        ));
         $counter = $plugin->resolve(VisitCounter::class, []);
 
         if (!$counter instanceof VisitCounter) {
@@ -243,11 +320,11 @@ final class LaravelPluginTest
     public function afterTestWithoutABootedApplicationIsANoOp(): void
     {
         $booted = false;
-        $plugin = new LaravelPlugin(static function () use (&$booted): Application {
+        $plugin = $this->track(new LaravelPlugin(static function () use (&$booted): Application {
             $booted = true;
 
             return FixtureApplication::create();
-        });
+        }));
 
         $result = $this->result();
         $returned = $plugin->afterTest($this->context(), $result);
@@ -258,6 +335,8 @@ final class LaravelPluginTest
     #[Test]
     public function afterTestClearsFacadeAndContainerStatics(): void
     {
+        $this->environment->set('APP_ENV', 'before-laravel');
+        $container = Container::getInstance();
         $plugin = $this->plugin();
         $app = ($plugin->services()[0]->factory)();
 
@@ -267,7 +346,10 @@ final class LaravelPluginTest
         $plugin->afterTest($this->context(), $this->result());
 
         Expect::that(Facade::getFacadeApplication())->toBeNull()
-            ->and(Container::getInstance() === $app)->toBe(false);
+            ->and(Container::getInstance())->toBe($container)
+            ->and(\getenv('APP_ENV'))->toBe('before-laravel')
+            ->and($_ENV['APP_ENV'] ?? null)->toBe('before-laravel')
+            ->and($_SERVER['APP_ENV'] ?? null)->toBe('before-laravel');
     }
 
     #[Test]
@@ -277,6 +359,7 @@ final class LaravelPluginTest
         \restore_error_handler();
         $exceptionBefore = \set_exception_handler(null);
         \restore_exception_handler();
+        $reportingBefore = \error_reporting();
 
         $this->plugin()->resolve(Greeter::class, []);
 
@@ -286,12 +369,52 @@ final class LaravelPluginTest
         \restore_exception_handler();
 
         Expect::that($errorAfter)->toBe($errorBefore)
-            ->and($exceptionAfter)->toBe($exceptionBefore);
+            ->and($exceptionAfter)->toBe($exceptionBefore)
+            ->and(\error_reporting())->toBe($reportingBefore);
+    }
+
+    #[Test]
+    public function repeatedApplicationRefreshesKeepMemoryFlat(): void
+    {
+        $plugin = $this->plugin();
+
+        for ($index = 0; $index < 10; ++$index) {
+            $this->refreshApplication($plugin);
+        }
+
+        \gc_collect_cycles();
+        $memoryBefore = \memory_get_usage();
+
+        for ($index = 0; $index < 60; ++$index) {
+            $this->refreshApplication($plugin);
+        }
+
+        \gc_collect_cycles();
+
+        Expect::that(\memory_get_usage() - $memoryBefore)->toBeLessThan(262_144);
     }
 
     private function plugin(): LaravelPlugin
     {
-        return new LaravelPlugin($this->fixtureDir() . '/bootstrap.php');
+        return $this->track(new LaravelPlugin($this->fixtureDir() . '/bootstrap.php'));
+    }
+
+    private function track(LaravelPlugin $plugin): LaravelPlugin
+    {
+        $this->plugins[] = $plugin;
+
+        return $plugin;
+    }
+
+    private function bareApplication(): LaravelApplication
+    {
+        return new LaravelApplication($this->fixtureDir());
+    }
+
+    private function refreshApplication(LaravelPlugin $plugin): void
+    {
+        $plugin->resolve(Greeter::class, []);
+        $plugin->afterTest($this->context(), $this->result());
     }
 
     private function fixtureDir(): string

--- a/tests/Unit/Laravel/LaravelPluginTest.php
+++ b/tests/Unit/Laravel/LaravelPluginTest.php
@@ -19,6 +19,7 @@ use Greenlight\Harness\HarnessRegistry;
 use Greenlight\Harness\HarnessScopes;
 use Greenlight\Harness\Scope;
 use Greenlight\Laravel\LaravelBridgeError;
+use Greenlight\Laravel\LaravelFrameworkRequirement;
 use Greenlight\Laravel\LaravelPlugin;
 use Greenlight\Laravel\Service;
 use Greenlight\Plugin\TestContext;
@@ -135,6 +136,28 @@ final class LaravelPluginTest
             ->and(\getenv('APP_ENV'))->toBe('before-laravel')
             ->and($_ENV['APP_ENV'] ?? null)->toBe('before-laravel')
             ->and($_SERVER['APP_ENV'] ?? null)->toBe('before-laravel');
+    }
+
+    #[Test]
+    public function aComponentOnlyIlluminateInstallationCannotUseTheBridge(): void
+    {
+        Expect::that(static function (): void {
+            LaravelFrameworkRequirement::checkVersion(null);
+        })->toThrow(
+            LaravelBridgeError::class,
+            matching: '/requires the complete laravel\\/framework 13 package/',
+        );
+    }
+
+    #[Test]
+    public function anUnsupportedLaravelMajorVersionCannotUseTheBridge(): void
+    {
+        Expect::that(static function (): void {
+            LaravelFrameworkRequirement::checkVersion('12.9.0');
+        })->toThrow(
+            LaravelBridgeError::class,
+            matching: '/found laravel\\/framework "12\\.9\\.0".*requires major version 13/s',
+        );
     }
 
     #[Test]


### PR DESCRIPTION
Prevents Laravel from replacing Greenlight diagnostic handlers or registering per-test shutdown callbacks. Restores the process environment and container after successful and failed application boots, clears Laravel framework static state between refreshed applications, and validates console kernel bindings. Requires the complete laravel/framework 13 package and reports unsupported component-only or major-version configurations before application construction. Restores Symfony 6.4 prefer-lowest coverage and clarifies the bridge isolation contract.