### PR TITLE
build: exclude incompatible PHPStan 2.2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "justinrainbow/json-schema": "^6.10",
         "php-cs-fixer/shim": "^3.75",
         "php-parallel-lint/php-parallel-lint": "^1.4",
-        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan": "^2.1 !=2.2.6",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "rector/rector": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7755b50064f5850a583472717e1777fb",
+    "content-hash": "e9f2f9ceb4ecd540cf91689eb8a48a7a",
     "packages": [],
     "packages-dev": [
         {


### PR DESCRIPTION
## What

- Exclude PHPStan 2.2.6 from the development dependency constraint.
- Refresh the Composer lock hash.

## Why

Rector 2.5.7 cannot start with PHPStan 2.2.6 because PHPStan removed a private parser property that Rector reads. This exact exclusion keeps highest-dependency builds operational and permits later PHPStan releases.

Upstream issue: https://github.com/rectorphp/rector/issues/9824
Upstream fix: https://github.com/rectorphp/rector-src/pull/8208
Removal tracker: #86