### PR TITLE
refactor(cli): simplify CLI and discovery diagnostics

### DIFF
--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -88,60 +88,64 @@ final readonly class Application
           greenlight [command] [options]
 
         Commands:
-          run            Discover and execute tests (default)
-          list-tests     List every discovered test id, one per line
+          run            Find and run tests (default)
+          list-tests     List each found test ID, one per line
           coverage:diff  Compare two coverage JSON exports (--baseline, --current)
-          profile:report Render the run profile from a saved jsonl stream (--input)
+          profile:report Create a run profile from a saved JSONL stream (--input)
           ide-helper     Write the IDE autocomplete helper for extension matchers
                          (--output, default _greenlight_ide_helper.php)
           completion     Print a shell completion script for bash, zsh, or fish
-                         to stdout, e.g. source <(greenlight completion bash)
+                         to standard output, for example:
+                         source <(greenlight completion bash)
 
         Options:
-          --config=<path>    Use this config file instead of ./greenlight.php
-          --workers=<n|auto> Worker process count
+          --config=<path>    Use this configuration file instead of ./greenlight.php
+          --workers=<n|auto> Set the worker process count
           --resource-limit=<name>=<n>
-                             Override a named resource concurrency limit;
-                             repeatable
+                             Set a named resource limit. You can repeat this option.
           --bail[=<n>]       Stop after <n> failures (default 1)
-          --group=<name>     Only run this group; repeatable
-          --filter=<pattern> Only run tests whose id matches; substring, or
-                             full match with * wildcards; repeatable
-          --test-id=<id>     Only run this exact id; repeatable
-          --exclude-group=<name>     Skip tests in this group; repeatable
-          --exclude-class=<pattern>  Skip classes matching this pattern;
-                             substring or * wildcards; repeatable
-          --exclude-method=<pattern> Skip methods matching this pattern;
-                             substring or * wildcards; repeatable
-          --exclude-path=<prefix>    Skip test files under this path prefix;
-                             relative prefixes are resolved against the
-                             working directory; repeatable
-          --failed           Only re-run tests that failed in the previous run
-          --list-tests       Print the selected test ids instead of running
+          --group=<name>     Run only this group. You can repeat this option.
+          --filter=<pattern> Run only tests with a matching test ID. Use a
+                             substring or a full match with * wildcards.
+                             You can repeat this option.
+          --test-id=<id>     Run only this exact test ID. You can repeat this option.
+          --exclude-group=<name>     Skip tests in this group. You can repeat this option.
+          --exclude-class=<pattern>  Skip classes that match this pattern.
+                             Use a substring or * wildcards. You can repeat this option.
+          --exclude-method=<pattern> Skip methods that match this pattern.
+                             Use a substring or * wildcards. You can repeat this option.
+          --exclude-path=<prefix>    Skip test files under this path prefix.
+                             Greenlight resolves relative prefixes against the
+                             working directory. You can repeat this option.
+          --failed           Run only tests that failed in the previous run
+          --list-tests       Print the selected test IDs. Do not run the tests.
           --list-groups      Print each selected group and its test count
           --list-suites      Print the configured suites
-          --repeat=<n>       Run the selected tests n times in fresh runs;
-                             any failing iteration fails the command
+          --repeat=<n>       Run the selected tests n times in separate runs.
+                             A failed iteration fails the command.
           --repeat-until-failure  Repeat until an iteration fails, up to
                              --repeat times (default at most 100)
-          --shard=<n>/<m>    Run the nth of m disjoint slices of the plan; whole
-                             classes, stable across machines, no coordination
+          --shard=<n>/<m>    Run shard n of m. Shards are disjoint and contain
+                             whole classes. They are stable across machines and
+                             need no coordination.
           --seed=<n>         Randomize class order with this seed
-          --reporter=<name>  Output format: tty, plain, junit, jsonl, github, teamcity; repeatable
+          --reporter=<name>  Select tty, plain, junit, jsonl, github, or teamcity.
+                             You can repeat this option.
           --artifacts-dir=<path> Persistent directory for retained test attachments
-          --watch            Re-run on file changes; Enter re-runs everything, q quits
-          --detect-leaks     Verify every test instance is collected; leaks fail the run
+          --watch            Run tests again after file changes. Enter runs all tests.
+                             q quits.
+          --detect-leaks     Verify collection of each test instance. Leaks fail the run.
           --verbose          Print a permanent line per completed class in
                              interactive output
-          --no-ansi          Disable colours and the live progress window;
-                             plain append-only output
+          --no-ansi          Disable colors and the live progress window.
+                             Use plain append-only output.
           --fail-on-deprecation  Fail passed tests that captured a deprecation
           --fail-on-notice   Fail passed tests that captured a notice
           --fail-on-risky    Fail passed tests that verified no expectations
-          --profile          Append a run profile (worker utilisation, boot latency,
-                             makespan spread, slowest classes) after the summary
-                             and extend the slowest-tests list
-          --dry-run          Print the resolved configuration without executing
+          --profile          Add a run profile after the summary. It contains worker
+                             utilization, boot latency, makespan spread, and slow classes.
+                             It also extends the slow-test list.
+          --dry-run          Print the resolved configuration. Do not run tests.
           -h, --help         Show this help
           -V, --version      Show the version
 
@@ -253,7 +257,7 @@ final readonly class Application
             return $this->ideHelperCommand($arguments, $workingDirectory);
         }
 
-        $this->printError(\sprintf("Unknown command '%s'. Run greenlight --help for the available commands.", $command), $arguments->has('no-ansi'));
+        $this->printError(\sprintf("Unknown command '%s'. Use greenlight --help to list commands.", $command), $arguments->has('no-ansi'));
 
         return self::EXIT_USAGE;
     }
@@ -274,7 +278,7 @@ final readonly class Application
         }
 
         if ($arguments->has('watch') && ($overrides->repeat !== null || $overrides->repeatUntilFailure)) {
-            $this->printError('--watch cannot be combined with --repeat or --repeat-until-failure.', $arguments->has('no-ansi'));
+            $this->printError('Do not use --watch with --repeat or --repeat-until-failure.', $arguments->has('no-ansi'));
 
             return self::EXIT_USAGE;
         }
@@ -326,13 +330,13 @@ final readonly class Application
 
         if ($arguments->has('failed')) {
             if ($previousFailures === null) {
-                $this->printError('--failed needs a previous run to have recorded state for this project; run once without it first.', $arguments->has('no-ansi'));
+                $this->printError('--failed requires state from a previous run. Run Greenlight once without --failed.', $arguments->has('no-ansi'));
 
                 return self::EXIT_USAGE;
             }
 
             if ($previousFailures === []) {
-                ($this->out)("Nothing failed in the previous run; nothing to re-run.\n");
+                ($this->out)("No tests failed in the previous run. There are no tests to run again.\n");
 
                 return self::EXIT_OK;
             }
@@ -422,7 +426,7 @@ final readonly class Application
         // run includes it even if it passes in another iteration.
         $this->persistRunState($state, $failedTests, $lastClassSeconds);
 
-        ($this->out)(\sprintf("Repeat: failed on iteration(s) %s\n", \implode(', ', $failedIterations)));
+        ($this->out)(\sprintf("Repeat: failed iterations: %s\n", \implode(', ', $failedIterations)));
 
         return self::EXIT_FAILURE;
     }
@@ -515,13 +519,13 @@ final readonly class Application
         $interruptExit = $shutdown->exitCode();
 
         if ($interruptExit !== null) {
-            ($this->err)("Interrupted. The summary covers only the tests that completed before shutdown.\n");
+            ($this->err)("Interrupted. The summary includes only tests that finished before shutdown.\n");
 
             return $interruptExit;
         }
 
         if ($run->plannedTests === 0) {
-            ($this->err)("No tests found. A misconfigured run must not pass.\n");
+            ($this->err)("Greenlight found no tests. Check the configuration, test paths, and filters.\n");
 
             return self::EXIT_FAILURE;
         }
@@ -530,7 +534,7 @@ final readonly class Application
 
         if ($coverageConfig instanceof CoverageConfiguration) {
             if (!$coverage instanceof CoverageMap) {
-                ($this->err)("Coverage was requested but no worker could collect it. Is pcov or xdebug (mode=coverage) available?\n");
+                ($this->err)("No worker collected the requested coverage. Install pcov or enable Xdebug with coverage mode.\n");
             } elseif (!$this->writeCoverage($coverageConfig, $coverage, $workingDirectory, $this->stdoutStyle($arguments->has('no-ansi')))) {
                 return self::EXIT_FAILURE;
             }
@@ -556,7 +560,7 @@ final readonly class Application
     private function persistRunState(RunState $state, array $failedTests, array $classSeconds): void
     {
         if (!$state->record($failedTests, $classSeconds)) {
-            ($this->err)("Run state was not saved; --failed and longest-first scheduling start cold next run.\n");
+            ($this->err)("Greenlight did not save run state. On the next run, --failed and longest-first scheduling have no prior data.\n");
         }
     }
 
@@ -578,7 +582,7 @@ final readonly class Application
 
         foreach ($resolved->excludePaths as $prefix) {
             if (!\array_any($files, static fn(string $file): bool => \str_starts_with($file, $prefix))) {
-                ($this->err)($this->stderrStyle($noAnsiFlag)->warn(\sprintf('Warning: --exclude-path "%s" matched no discovered test file.', $prefix)) . "\n");
+                ($this->err)($this->stderrStyle($noAnsiFlag)->warn(\sprintf('Warning: --exclude-path "%s" did not match a discovered test file.', $prefix)) . "\n");
             }
         }
     }
@@ -754,7 +758,7 @@ final readonly class Application
                 try {
                     AtomicFile::write($target, \reset($files));
                 } catch (AtomicFileError $error) {
-                    ($this->err)(\sprintf("Could not write coverage export to \"%s\": %s\n", $target, $error->getMessage()));
+                    ($this->err)(\sprintf("Greenlight could not write the coverage export to \"%s\": %s\n", $target, $error->getMessage()));
 
                     return false;
                 }
@@ -765,7 +769,7 @@ final readonly class Application
                     try {
                         AtomicFile::write($target . '/' . $name, $content);
                     } catch (AtomicFileError $error) {
-                        ($this->err)(\sprintf("Could not write coverage export to \"%s\": %s\n", $target . '/' . $name, $error->getMessage()));
+                        ($this->err)(\sprintf("Greenlight could not write the coverage export to \"%s\": %s\n", $target . '/' . $name, $error->getMessage()));
 
                         return false;
                     }
@@ -808,7 +812,7 @@ final readonly class Application
             $json = ErrorTrap::run(static fn(): string|false => \file_get_contents($absolute), $warning);
 
             if ($json === false) {
-                $this->printError(\sprintf('Could not read the %s coverage export at "%s"%s.', $label, $path, $warning === null ? '' : ': ' . $warning), $arguments->has('no-ansi'));
+                $this->printError(\sprintf('Greenlight could not read the %s coverage export at "%s"%s.', $label, $path, $warning === null ? '' : ': ' . $warning), $arguments->has('no-ansi'));
 
                 return self::EXIT_FAILURE;
             }
@@ -939,7 +943,7 @@ final readonly class Application
         }
 
         if ($map->names() === []) {
-            ($this->out)("No extension matchers are configured; nothing to generate.\n");
+            ($this->out)("The configuration has no extension matchers. There is no helper to generate.\n");
 
             return self::EXIT_OK;
         }
@@ -950,13 +954,13 @@ final readonly class Application
         try {
             AtomicFile::write($path, IdeHelper::render($map));
         } catch (AtomicFileError $error) {
-            ($this->err)(\sprintf("Could not write \"%s\": %s\n", $path, $error->getMessage()));
+            ($this->err)(\sprintf("Greenlight could not write \"%s\": %s\n", $path, $error->getMessage()));
 
             return self::EXIT_FAILURE;
         }
 
         ($this->out)(\sprintf(
-            "Wrote %s with %d matchers. Gitignore it and regenerate after changing matchers.\n",
+            "Wrote %s with %d matchers. Add it to .gitignore. Generate it again after matcher changes.\n",
             $path,
             \count($map->names()),
         ));
@@ -982,7 +986,7 @@ final readonly class Application
         $script = new CompletionScripts($this->optionSpecs())->render($shell);
 
         if ($script === null) {
-            ($this->err)(\sprintf("Unknown shell \"%s\". Available: %s.\n", $shell, \implode(', ', CompletionScripts::SHELLS)));
+            ($this->err)(\sprintf("Unknown shell \"%s\". Select one of: %s.\n", $shell, \implode(', ', CompletionScripts::SHELLS)));
 
             return self::EXIT_USAGE;
         }
@@ -992,13 +996,13 @@ final readonly class Application
         return self::EXIT_OK;
     }
 
-    /** Recreates a run profile from a saved jsonl event stream. */
+    /** Creates a run profile from a saved JSONL event stream. */
     private function profileReportCommand(ParsedArguments $arguments, string $workingDirectory): int
     {
         $input = $arguments->value('input');
 
         if ($input === null || $input === '') {
-            ($this->err)("profile:report requires --input=<path to a jsonl stream>.\n");
+            ($this->err)("profile:report requires --input=<path to a JSONL stream>.\n");
 
             return self::EXIT_USAGE;
         }
@@ -1007,7 +1011,7 @@ final readonly class Application
         $raw = ErrorTrap::run(static fn(): string|false => \file_get_contents($path), $warning);
 
         if (!\is_string($raw)) {
-            ($this->err)(\sprintf("Could not read \"%s\"%s.\n", $path, $warning === null ? '' : ': ' . $warning));
+            ($this->err)(\sprintf("Greenlight could not read \"%s\"%s.\n", $path, $warning === null ? '' : ': ' . $warning));
 
             return self::EXIT_FAILURE;
         }
@@ -1022,13 +1026,13 @@ final readonly class Application
             try {
                 $decoded = \json_decode($line, true, 32, \JSON_THROW_ON_ERROR);
             } catch (\JsonException) {
-                ($this->err)("The input is not a jsonl event stream: a line is not valid JSON.\n");
+                ($this->err)("The input is not a JSONL event stream. A line is not valid JSON.\n");
 
                 return self::EXIT_FAILURE;
             }
 
             if (!\is_array($decoded) || !\is_string($decoded['event'] ?? null) || !\is_array($decoded['data'] ?? null)) {
-                ($this->err)("The input is not a jsonl event stream: a line is missing the event envelope.\n");
+                ($this->err)("The input is not a JSONL event stream. A line does not contain an event envelope.\n");
 
                 return self::EXIT_FAILURE;
             }
@@ -1050,7 +1054,7 @@ final readonly class Application
             try {
                 $aggregator->onEvent($class::fromWire($data));
             } catch (InvalidWirePayload $error) {
-                $this->printError(\sprintf('Could not decode a "%s" event: %s', $decoded['event'], $error->getMessage()), $arguments->has('no-ansi'));
+                $this->printError(\sprintf('Greenlight could not decode a "%s" event: %s', $decoded['event'], $error->getMessage()), $arguments->has('no-ansi'));
 
                 return self::EXIT_FAILURE;
             }
@@ -1063,7 +1067,7 @@ final readonly class Application
         )->colour));
 
         if ($report === '') {
-            ($this->err)("The stream contains no finished run to profile.\n");
+            ($this->err)("The stream has no finished run to profile.\n");
 
             return self::EXIT_FAILURE;
         }

--- a/src/Cli/CliError.php
+++ b/src/Cli/CliError.php
@@ -14,12 +14,12 @@ final class CliError extends \RuntimeException
 
     public static function unknownOption(string $option): self
     {
-        return new self(\sprintf('Unknown option "%s". Run greenlight --help for the available options.', $option));
+        return new self(\sprintf('Unknown option "%s". Use greenlight --help to list options.', $option));
     }
 
     public static function bareDoubleDash(): self
     {
-        return new self('Unexpected bare "--".');
+        return new self('"--" requires an option name.');
     }
 
     public static function optionTakesNoValue(string $name): self
@@ -29,12 +29,12 @@ final class CliError extends \RuntimeException
 
     public static function optionRequiresValue(string $name): self
     {
-        return new self(\sprintf('Option --%s requires a value, use --%s=<value>.', $name, $name));
+        return new self(\sprintf('Option --%s requires a value. Use --%s=<value>.', $name, $name));
     }
 
     public static function shortOptionRequiresValue(string $short, string $name): self
     {
-        return new self(\sprintf('Option -%s requires a value, use --%s=<value>.', $short, $name));
+        return new self(\sprintf('Option -%s requires a value. Use --%s=<value>.', $short, $name));
     }
 
     public static function unexpectedArgument(string $argument): self
@@ -44,30 +44,30 @@ final class CliError extends \RuntimeException
 
     public static function duplicateOption(string $name): self
     {
-        return new self(\sprintf('Option --%s cannot be given more than once.', $name));
+        return new self(\sprintf('Specify option --%s only once.', $name));
     }
 
     public static function emptyGroupName(): self
     {
-        return new self('--group requires a non-empty group name.');
+        return new self('--group requires a group name.');
     }
 
     public static function emptyFilterPattern(): self
     {
-        return new self('--filter requires a non-empty pattern.');
+        return new self('--filter requires a pattern.');
     }
 
     public static function malformedShard(string $raw): self
     {
-        return new self(\sprintf('--shard must look like <n>/<m>, for example 1/4, got "%s".', $raw));
+        return new self(\sprintf('--shard requires <n>/<m>, such as 1/4. Received "%s".', $raw));
     }
 
     public static function shardOutOfRange(string $raw, int $count): self
     {
-        $message = \sprintf('--shard needs 1 <= n <= m, got "%s".', $raw);
+        $message = \sprintf('--shard requires 1 <= n <= m. Received "%s".', $raw);
 
         if ($count >= 1) {
-            $message .= \sprintf(' With %d shards, n must be between 1 and %d.', $count, $count);
+            $message .= \sprintf(' Valid n values for %d shards are 1 through %d.', $count, $count);
         }
 
         return new self($message);
@@ -75,31 +75,31 @@ final class CliError extends \RuntimeException
 
     public static function invalidSeed(string $raw): self
     {
-        return new self(\sprintf('--seed must be a non-negative integer, got "%s".', $raw));
+        return new self(\sprintf('--seed requires a nonnegative integer. Received "%s".', $raw));
     }
 
     public static function notAPositiveInteger(string $flag, string $raw): self
     {
-        return new self(\sprintf('%s must be a positive integer, got "%s".', $flag, $raw));
+        return new self(\sprintf('%s requires a positive integer. Received "%s".', $flag, $raw));
     }
 
     public static function malformedResourceLimit(string $raw): self
     {
         return new self(\sprintf(
-            '--resource-limit must look like <name>=<limit>, for example postgres=2, got "%s".',
+            '--resource-limit requires <name>=<limit>, such as postgres=2. Received "%s".',
             $raw,
         ));
     }
 
     public static function duplicateResourceLimit(string $name): self
     {
-        return new self(\sprintf('Resource limit "%s" cannot be overridden more than once.', $name));
+        return new self(\sprintf('Set resource limit "%s" only once.', $name));
     }
 
     public static function unknownReporter(string $name): self
     {
         return new self(\sprintf(
-            'Unknown reporter "%s". Available: tty, plain, junit, jsonl, github, teamcity.',
+            'Unknown reporter "%s". Select tty, plain, junit, jsonl, github, or teamcity.',
             $name,
         ));
     }

--- a/src/Cli/CompletionScripts.php
+++ b/src/Cli/CompletionScripts.php
@@ -15,12 +15,12 @@ final readonly class CompletionScripts
     public const array SHELLS = ['bash', 'zsh', 'fish'];
 
     private const array COMMANDS = [
-        'run' => 'Discover and execute tests (default)',
-        'list-tests' => 'List every discovered test id, one per line',
+        'run' => 'Find and run tests (default)',
+        'list-tests' => 'List each found test ID, one per line',
         'coverage:diff' => 'Compare two coverage JSON exports',
-        'profile:report' => 'Render the run profile from a saved jsonl stream',
+        'profile:report' => 'Create a run profile from a saved JSONL stream',
         'ide-helper' => 'Write the IDE autocomplete helper for extension matchers',
-        'completion' => 'Print a shell completion script to stdout',
+        'completion' => 'Print a shell completion script to standard output',
     ];
 
     private const array FLAG_VALUES = [
@@ -60,7 +60,7 @@ final readonly class CompletionScripts
         }
 
         $template = <<<'BASH'
-            # bash completion for greenlight. Load it into the current shell with:
+            # bash completion for Greenlight. Load it into the current shell with:
             #   source <(greenlight completion bash)
 
             _greenlight_completions()
@@ -70,8 +70,8 @@ final readonly class CompletionScripts
 
                 # COMP_WORDBREAKS normally contains ':' and '=', so bash splits
                 # 'coverage:diff' and '--reporter=tty' across several COMP_WORDS.
-                # Reassemble the logical word; the lead bash keeps on the line is
-                # stripped from every candidate afterwards.
+                # Reassemble the logical word. Remove from each candidate the
+                # leading part that bash keeps on the line.
                 local logical=$cur
                 while (( i > 1 )) && [[ ${COMP_WORDS[i-1]} == [:=] || $logical == [:=]* ]]; do
                     (( i-- ))
@@ -144,7 +144,7 @@ final readonly class CompletionScripts
 
         $template = <<<'ZSH'
             #compdef greenlight
-            # zsh completion for greenlight. Load it into the current shell with:
+            # zsh completion for Greenlight. Load it into the current shell with:
             #   source <(greenlight completion zsh)
 
             _greenlight()
@@ -191,7 +191,7 @@ final readonly class CompletionScripts
     private function fish(): string
     {
         $lines = [
-            '# fish completion for greenlight. Install it with:',
+            '# fish completion for Greenlight. Install it with:',
             '#   greenlight completion fish > ~/.config/fish/completions/greenlight.fish',
             '',
         ];

--- a/src/Cli/PlanFormatter.php
+++ b/src/Cli/PlanFormatter.php
@@ -18,7 +18,7 @@ final class PlanFormatter
     {
         $lines = [];
         $lines[] = 'Run plan';
-        $lines[] = '  config file: ' . $configFile;
+        $lines[] = '  configuration file: ' . $configFile;
         $lines[] = '  test paths: ' . \implode(', ', $configuration->paths);
 
         if ($configuration->suites === []) {
@@ -80,12 +80,9 @@ final class PlanFormatter
                 $exports[] = $export->format . ' -> ' . $export->target;
             }
 
-            $lines[] = \sprintf(
-                '  coverage: include %s; driver %s; exports %s',
-                $configuration->coverage->includePaths === [] ? '(nothing)' : \implode(', ', $configuration->coverage->includePaths),
-                $configuration->coverage->driver ?? '(auto)',
-                $exports === [] ? '(none)' : \implode(', ', $exports),
-            );
+            $lines[] = '  coverage include paths: ' . ($configuration->coverage->includePaths === [] ? '(none)' : \implode(', ', $configuration->coverage->includePaths));
+            $lines[] = '  coverage driver: ' . ($configuration->coverage->driver ?? '(auto)');
+            $lines[] = '  coverage exports: ' . ($exports === [] ? '(none)' : \implode(', ', $exports));
         }
 
         return \implode("\n", $lines) . "\n";

--- a/src/Cli/RunState.php
+++ b/src/Cli/RunState.php
@@ -10,7 +10,7 @@ use Greenlight\Core\ErrorTrap;
 
 /**
  * Stores failures and class durations in the system temporary directory.
- * The working directory identifies the state.
+ * The project directory identifies the state.
  *
  * @internal
  */

--- a/src/Cli/Terminal.php
+++ b/src/Cli/Terminal.php
@@ -7,8 +7,8 @@ namespace Greenlight\Cli;
 use Greenlight\Core\ErrorTrap;
 
 /**
- * Determines whether a stream is attached to an interactive terminal. The probe
- * does not send engine warnings to host error handlers.
+ * Checks whether a stream connects to an interactive terminal. The probe does
+ * not send engine warnings to host error handlers.
  *
  * @internal
  */

--- a/src/Cli/Watch/Debouncer.php
+++ b/src/Cli/Watch/Debouncer.php
@@ -20,7 +20,7 @@ final class Debouncer
     public function __construct(private readonly float $quietSeconds)
     {
         if ($quietSeconds < 0.0) {
-            throw new \InvalidArgumentException('The quiet period cannot be negative.');
+            throw new \InvalidArgumentException('Set the quiet period to zero seconds or more.');
         }
     }
 

--- a/src/Cli/Watch/StdinKeyInput.php
+++ b/src/Cli/Watch/StdinKeyInput.php
@@ -8,14 +8,14 @@ use Greenlight\Cli\Terminal;
 use Greenlight\Core\ErrorTrap;
 
 /**
- * Reads single keys from stdin without blocking.
+ * Reads available single keys from standard input.
  *
  * On an interactive terminal, the constructor disables canonical mode. Thus,
  * keys arrive without a newline. restore() enables canonical mode when the
  * loop ends.
  *
- * A piped stdin does not require a mode change. The acceptance tests use this
- * form.
+ * Standard input from a pipe does not require a mode change. The acceptance
+ * tests use this form.
  *
  * @internal
  */

--- a/src/Cli/Watch/WatchLoop.php
+++ b/src/Cli/Watch/WatchLoop.php
@@ -48,7 +48,7 @@ final readonly class WatchLoop
     {
         $failedClasses = $runOnce([]);
         $iterations = 1;
-        ($this->out)("\nWatching for changes. Enter re-runs everything, q quits.\n");
+        ($this->out)("\nWaiting for changes. Press Enter to run all tests. Press q to quit.\n");
 
         while ($maxIterations === null || $iterations < $maxIterations) {
             if ($this->shutdown?->requested() === true) {
@@ -65,7 +65,8 @@ final readonly class WatchLoop
             $changes = $this->detector->poll();
 
             if ($changes !== []) {
-                ($this->out)(\sprintf("Change detected in %d file(s).\n", \count($changes)));
+                $count = \count($changes);
+                ($this->out)(\sprintf("Detected changes in %d %s.\n", $count, $count === 1 ? 'file' : 'files'));
                 $this->debouncer->noteChange($this->clock->now());
             }
 
@@ -73,7 +74,7 @@ final readonly class WatchLoop
                 $this->debouncer->reset();
                 $failedClasses = $runOnce($runNow ? [] : $failedClasses);
                 ++$iterations;
-                ($this->out)("\nWatching for changes. Enter re-runs everything, q quits.\n");
+                ($this->out)("\nWaiting for changes. Press Enter to run all tests. Press q to quit.\n");
 
                 continue;
             }

--- a/src/Discovery/DiscoveryError.php
+++ b/src/Discovery/DiscoveryError.php
@@ -22,13 +22,13 @@ final class DiscoveryError extends \RuntimeException
 
     public static function directoryNotFound(string $directory): self
     {
-        return new self(\sprintf('Discovery directory "%s" does not exist or is not a directory.', $directory));
+        return new self(\sprintf('Discovery directory "%s" is missing or is not a directory.', $directory));
     }
 
     public static function unreadableFile(string $file, ?string $reason = null): self
     {
         return new self(\sprintf(
-            'Test file "%s" could not be read%s.',
+            'Greenlight cannot read test file "%s"%s.',
             $file,
             $reason === null ? '' : ': ' . $reason,
         ));
@@ -36,13 +36,13 @@ final class DiscoveryError extends \RuntimeException
 
     public static function noClassInFile(string $file): self
     {
-        return new self(\sprintf('Test file "%s" does not declare any class, interface, trait, or enum.', $file));
+        return new self(\sprintf('Test file "%s" does not declare a class, interface, trait, or enum.', $file));
     }
 
     public static function classNameMismatch(string $file, string $declared, string $expected): self
     {
         return new self(\sprintf(
-            'Test file "%s" declares "%s" but its file name requires a declaration named "%s". Rename the class or the file so they agree.',
+            'Test file "%s" declares "%s". Its file name requires "%s". Rename the class or file so the names match.',
             $file,
             $declared,
             $expected,
@@ -52,7 +52,7 @@ final class DiscoveryError extends \RuntimeException
     public static function classNotAutoloadable(string $file, string $class): self
     {
         return new self(\sprintf(
-            'Class "%s" declared in "%s" is not autoloadable. The namespace probably does not match the PSR-4 mapping for that path.',
+            'The autoloader cannot load class "%s" from "%s". Check that the namespace matches the PSR-4 mapping for this path.',
             $class,
             $file,
         ));
@@ -61,22 +61,22 @@ final class DiscoveryError extends \RuntimeException
     public static function classLoadedFromOtherFile(string $file, string $class, string $actualFile): self
     {
         return new self(\sprintf(
-            'Class "%s" declared in "%s" was autoloaded from "%s" instead. Two files must not declare the same class.',
+            'The autoloader loaded class "%s" from "%s". It expected the class in "%s". Only one file can declare a class.',
             $class,
-            $file,
             $actualFile,
+            $file,
         ));
     }
 
     public static function testMethodNotRunnable(string $class, string $method, string $why): self
     {
-        return new self(\sprintf('Test method %s::%s() cannot run: %s.', $class, $method, $why));
+        return new self(\sprintf('Greenlight cannot run test method %s::%s() because %s.', $class, $method, $why));
     }
 
     public static function invalidAttribute(string $where, \Throwable $cause): self
     {
         return new self(
-            \sprintf('Invalid attribute on %s: %s', $where, $cause->getMessage()),
+            \sprintf('Attribute on %s is invalid: %s', $where, $cause->getMessage()),
             $cause,
         );
     }
@@ -84,21 +84,21 @@ final class DiscoveryError extends \RuntimeException
     public static function providerClassMissing(string $class, string $method, string $providerClass): self
     {
         return new self(\sprintf(
-            'Data-set provider class "%s" referenced by %s::%s() does not exist.',
-            $providerClass,
+            'Test method %s::%s() references missing data-set provider class "%s".',
             $class,
             $method,
+            $providerClass,
         ));
     }
 
     public static function providerMissing(string $class, string $method, string $providerClass, string $provider): self
     {
         return new self(\sprintf(
-            'Data-set provider "%s" referenced by %s::%s() does not exist on %s.',
-            $provider,
+            'Test method %s::%s() references data-set provider %s::%s(), but the provider does not exist.',
             $class,
             $method,
             $providerClass,
+            $provider,
         ));
     }
 
@@ -109,18 +109,18 @@ final class DiscoveryError extends \RuntimeException
         string $provider,
     ): self {
         return new self(\sprintf(
-            'Data-set provider %s::%s() referenced by %s::%s() must be public and static.',
-            $providerClass,
-            $provider,
+            'Test method %s::%s() references data-set provider %s::%s(). Declare the provider as public and static.',
             $class,
             $method,
+            $providerClass,
+            $provider,
         ));
     }
 
     public static function providerNotIterable(string $class, string $provider, string $actualType): self
     {
         return new self(\sprintf(
-            'Data-set provider %s::%s() must return an iterable, got %s.',
+            'Data-set provider %s::%s() returned %s. Return an iterable from the provider.',
             $class,
             $provider,
             $actualType,
@@ -144,7 +144,7 @@ final class DiscoveryError extends \RuntimeException
     public static function providerTooSlow(string $class, string $provider, float $budgetSeconds): self
     {
         return new self(\sprintf(
-            'Data-set provider %s::%s() exceeded the discovery time budget of %.3f seconds. Providers run at plan time and must be pure and fast.',
+            'Data-set provider %s::%s() exceeded the %.3f-second discovery time budget. Providers run during plan creation. Keep them pure and fast.',
             $class,
             $provider,
             $budgetSeconds,
@@ -154,7 +154,7 @@ final class DiscoveryError extends \RuntimeException
     public static function providerYieldedNothing(string $class, string $provider): self
     {
         return new self(\sprintf(
-            'Data-set provider %s::%s() yielded no data sets. A provider must produce at least one.',
+            'Data-set provider %s::%s() produced no data sets. Produce at least one data set.',
             $class,
             $provider,
         ));
@@ -163,7 +163,7 @@ final class DiscoveryError extends \RuntimeException
     public static function providerKeyInvalid(string $class, string $provider, string $keyType): self
     {
         return new self(\sprintf(
-            'Data-set provider %s::%s() yielded a key of type %s. Keys must be strings or integers.',
+            'Data-set provider %s::%s() produced a key of type %s. Use string or integer keys.',
             $class,
             $provider,
             $keyType,
@@ -173,7 +173,7 @@ final class DiscoveryError extends \RuntimeException
     public static function duplicateDataSetKey(string $class, string $method, string $key): self
     {
         return new self(\sprintf(
-            'Data sets for %s::%s() produced the key "%s" more than once. Keys must be unique per test method.',
+            'Data sets for %s::%s() contain key "%s" more than once. Use each key only once for the test method.',
             $class,
             $method,
             $key,

--- a/src/Discovery/ExecutionPlan.php
+++ b/src/Discovery/ExecutionPlan.php
@@ -39,7 +39,7 @@ final readonly class ExecutionPlan implements WireSerializable, \Countable
 
             if (isset($seen[$class])) {
                 throw new \InvalidArgumentException(\sprintf(
-                    'Execution plan entries must be grouped by class; "%s" appears in more than one block.',
+                    'Group execution plan entries by class. "%s" occurs in more than one block.',
                     $class,
                 ));
             }

--- a/src/Discovery/MetadataFactory.php
+++ b/src/Discovery/MetadataFactory.php
@@ -115,7 +115,7 @@ final class MetadataFactory
         foreach ($skipUnless->arguments as $index => $argument) {
             if ($argument !== null && !\is_scalar($argument)) {
                 throw DiscoveryError::invalidAttribute($where, new \InvalidArgumentException(\sprintf(
-                    '#[SkipUnless] argument %d for condition "%s" must be a scalar or null, got %s.',
+                    'Use a scalar or null for #[SkipUnless] argument %d of condition "%s". Received %s.',
                     $index + 1,
                     $skipUnless->condition,
                     \get_debug_type($argument),

--- a/src/Discovery/TestDiscoverer.php
+++ b/src/Discovery/TestDiscoverer.php
@@ -27,7 +27,7 @@ final readonly class TestDiscoverer
         private float $providerTimeBudgetSeconds = 5.0,
     ) {
         if ($providerTimeBudgetSeconds <= 0.0) {
-            throw new \InvalidArgumentException('Provider time budget must be greater than zero seconds.');
+            throw new \InvalidArgumentException('Set the provider time budget to a value greater than zero seconds.');
         }
 
         $this->metadataFactory = new MetadataFactory();

--- a/tests/Acceptance/CliTest.php
+++ b/tests/Acceptance/CliTest.php
@@ -108,7 +108,7 @@ final readonly class CliTest
         $result = $this->runCli(['run'], 'tests/Fixture/RunEmptyConfig');
 
         Expect::that($result->exitCode)->because('run with no tests exits one')->toBe(1);
-        Expect::that($result->output())->because('run with no tests exits one')->toContain('No tests found');
+        Expect::that($result->output())->because('run with no tests exits one')->toContain('Greenlight found no tests');
     }
 
     #[Test]

--- a/tests/Acceptance/CommandErrorsTest.php
+++ b/tests/Acceptance/CommandErrorsTest.php
@@ -40,7 +40,7 @@ final readonly class CommandErrorsTest
         $project = AcceptanceProject::create($this->tempDirectory, 'command-errors');
         $result = GreenlightCli::run($project->directory, ['profile:report', '--input=nowhere.jsonl']);
         Expect::that($result->exitCode)->because('profile report with a missing input file fails cleanly')->toBe(1)
-            ->and($result->output())->toContain('Could not read')
+            ->and($result->output())->toContain('Greenlight could not read')
             ->toContain('nowhere.jsonl');
     }
 
@@ -66,7 +66,7 @@ final readonly class CommandErrorsTest
                 '--output=' . $readOnlyDirectory . '/helper.php',
             ]);
 
-            Expect::that($result->exitCode)->toBe(1)->and($result->output())->toContain('Could not write');
+            Expect::that($result->exitCode)->toBe(1)->and($result->output())->toContain('Greenlight could not write');
         } finally {
             \chmod($readOnlyDirectory, 0o755);
         }

--- a/tests/Acceptance/CoverageRunTest.php
+++ b/tests/Acceptance/CoverageRunTest.php
@@ -64,7 +64,7 @@ final readonly class CoverageRunTest
         $result = $this->runIn($project, ['run', '--reporter=plain'], 'off');
 
         Expect::that($result->exitCode)->because('missing driver warns without failing the run')->toBe(0)
-            ->and($result->output())->toContain('Coverage was requested but no worker could collect it')
+            ->and($result->output())->toContain('No worker collected the requested coverage')
             ->and(\is_dir($project->path('coverage-out')))->toBeFalse();
     }
 

--- a/tests/Acceptance/ExcludeSelectionTest.php
+++ b/tests/Acceptance/ExcludeSelectionTest.php
@@ -123,12 +123,12 @@ final readonly class ExcludeSelectionTest
         $project = $this->writeProject();
         $result = GreenlightCli::run($project->directory, ['list-tests', '--exclude-path=tests/MissingProbeTest.php']);
         Expect::that($result->exitCode)->because('exclude path warns when the prefix matches no test file')->toBe(0)
-            ->and($result->output())->toContain('matched no discovered test file')
+            ->and($result->output())->toContain('did not match a discovered test file')
             ->toContain('MissingProbeTest.php')
             ->toContain('3 tests');
         $result = GreenlightCli::run($project->directory, ['run', '--reporter=plain', '--exclude-path=tests/MissingProbeTest.php']);
         Expect::that($result->exitCode)->because('exclude path warns when the prefix matches no test file')->toBe(0)
-            ->and($result->output())->toContain('matched no discovered test file')
+            ->and($result->output())->toContain('did not match a discovered test file')
             ->toContain('3 tests, 3 passed');
     }
 
@@ -138,7 +138,7 @@ final readonly class ExcludeSelectionTest
         $project = $this->writeProject();
         $result = GreenlightCli::run($project->directory, ['list-tests', '--exclude-path=tests/CExcludeProbeTest.php']);
         Expect::that($result->exitCode)->because('exclude path does not warn when the prefix matches a test file')->toBe(0)
-            ->and($result->output())->not()->toContain('matched no discovered test file');
+            ->and($result->output())->not()->toContain('did not match a discovered test file');
     }
 
     /**

--- a/tests/Acceptance/IdeHelperTest.php
+++ b/tests/Acceptance/IdeHelperTest.php
@@ -33,7 +33,7 @@ final readonly class IdeHelperTest
 
         $result = GreenlightCli::run($root . '/tests/Fixture/ListTestsConfig', ['ide-helper', '--output=' . $target . '.none']);
         Expect::that($result->exitCode)->because('writes a lintable helper and skips when nothing is configured')->toBe(0)
-            ->and($result->output())->toContain('No extension matchers')
+            ->and($result->output())->toContain('The configuration has no extension matchers')
             ->and(\is_file($target . '.none'))->toBeFalse();
     }
 }

--- a/tests/Acceptance/RepeatTest.php
+++ b/tests/Acceptance/RepeatTest.php
@@ -34,7 +34,7 @@ final readonly class RepeatTest
         $result = $this->run($project, [], '--repeat=2');
         Expect::that($result->exitCode)->because('repeat reports every failing iteration')->toBe(1)
             ->and($result->output())->toContain('Repeat: iteration 2 of 2')
-            ->toContain('Repeat: failed on iteration(s) 1, 2');
+            ->toContain('Repeat: failed iterations: 1, 2');
     }
 
     #[Test]
@@ -45,7 +45,7 @@ final readonly class RepeatTest
         $result = $this->run($project, ['GREENLIGHT_REPEAT_STATE' => $state], '--repeat-until-failure');
         Expect::that($result->exitCode)->because('repeat until failure stops at the first failing iteration')->toBe(1)
             ->and($result->output())->toContain('Repeat: iteration 3 of at most 100')
-            ->toContain('Repeat: failed on iteration(s) 3')
+            ->toContain('Repeat: failed iterations: 3')
             ->not()->toContain('Repeat: iteration 4');
     }
 
@@ -79,9 +79,9 @@ final readonly class RepeatTest
     {
         $project = $this->writeProject(passing: true);
         $result = $this->run($project, [], '--watch', '--repeat=2');
-        Expect::that($result->exitCode)->because('watch cannot be combined with repeat')->toBe(64)->and($result->output())->toContain('cannot be combined');
+        Expect::that($result->exitCode)->because('watch cannot be combined with repeat')->toBe(64)->and($result->output())->toContain('Do not use --watch with');
         $result = $this->run($project, [], '--watch', '--repeat-until-failure');
-        Expect::that($result->exitCode)->because('watch cannot be combined with repeat')->toBe(64)->and($result->output())->toContain('cannot be combined');
+        Expect::that($result->exitCode)->because('watch cannot be combined with repeat')->toBe(64)->and($result->output())->toContain('Do not use --watch with');
     }
 
     /**

--- a/tests/Acceptance/SelectionTest.php
+++ b/tests/Acceptance/SelectionTest.php
@@ -26,7 +26,7 @@ final readonly class SelectionTest
         $result = $this->run($project, '--filter=*::breaks?ometimes');
         Expect::that($result->exitCode)->because('filter selects by method class and wildcard')->toBe(1)->and($result->output())->toContain('1 test, 0 passed, 1 errored');
         $result = $this->run($project, '--filter=nothingMatchesThis');
-        Expect::that($result->exitCode)->because('filter selects by method class and wildcard')->toBe(1)->and($result->output())->toContain('No tests found');
+        Expect::that($result->exitCode)->because('filter selects by method class and wildcard')->toBe(1)->and($result->output())->toContain('Greenlight found no tests');
     }
 
     #[Test]
@@ -48,7 +48,7 @@ final readonly class SelectionTest
         );
 
         Expect::that($result->exitCode)->because('test ID selects only an exact ID')->toBe(1)
-            ->and($result->output())->toContain('No tests found');
+            ->and($result->output())->toContain('Greenlight found no tests');
     }
 
     #[Test]
@@ -76,7 +76,7 @@ final readonly class SelectionTest
     {
         $project = $this->writeProject();
         $result = $this->run($project, '--filter=alwaysPasses', '--exclude-method=alwaysPasses');
-        Expect::that($result->exitCode)->because('exclude wins over an include filter')->toBe(1)->and($result->output())->toContain('No tests found');
+        Expect::that($result->exitCode)->because('exclude wins over an include filter')->toBe(1)->and($result->output())->toContain('Greenlight found no tests');
         $result = $this->run($project, '--group=fast', '--group=slow', '--exclude-group=slow');
         Expect::that($result->exitCode)->because('exclude wins over an include filter')->toBe(0)->and($result->output())->toContain('1 test, 1 passed');
     }
@@ -96,7 +96,7 @@ final readonly class SelectionTest
         $result = $this->run($project, '--filter=alwaysPasses');
         Expect::that($result->exitCode)->because('failed reruns exactly the previous failures')->toBe(0);
         $result = $this->run($project, '--failed');
-        Expect::that($result->exitCode)->because('failed reruns exactly the previous failures')->toBe(0)->and($result->output())->toContain('Nothing failed');
+        Expect::that($result->exitCode)->because('failed reruns exactly the previous failures')->toBe(0)->and($result->output())->toContain('No tests failed');
     }
 
     #[Test]
@@ -116,7 +116,7 @@ final readonly class SelectionTest
         );
         Expect::that($result->exitCode)->because('unpersistable run state warns without failing the run')->toBe(0)
             ->and($result->output())->toContain('1 test, 1 passed')
-            ->toContain('Run state was not saved');
+            ->toContain('Greenlight did not save run state');
     }
 
     private function run(AcceptanceProject $project, string ...$flags): ProcessResult

--- a/tests/Acceptance/ShardingTest.php
+++ b/tests/Acceptance/ShardingTest.php
@@ -42,7 +42,7 @@ final readonly class ShardingTest
             Expect::that($result->exitCode)->toBe(64)->and($result->output())->toContain('greenlight: --shard');
         }
         $result = GreenlightCli::run($project->directory, ['list-tests', '--shard=4/3']);
-        Expect::that($result->output())->because('malformed shard specs are usage errors')->toContain('n must be between 1 and 3');
+        Expect::that($result->output())->because('malformed shard specs are usage errors')->toContain('Valid n values for 3 shards are 1 through 3.');
     }
 
     /**

--- a/tests/Acceptance/WatchModeTest.php
+++ b/tests/Acceptance/WatchModeTest.php
@@ -28,15 +28,15 @@ final readonly class WatchModeTest
         $process = GreenlightCli::start($project->directory, ['run', '--watch', '--reporter=plain']);
 
         try {
-            $output = $process->readStdoutUntil('Watching for changes', 20.0);
+            $output = $process->readStdoutUntil('Waiting for changes', 20.0);
             Expect::that($output)->toContain('1 test, 1 passed');
 
             // Append a comment to make a synthetic change. The size changes, but
             // the modification time can remain equal.
             $project->writeFile('tests/WatchProbeTest.php', $original . "// touched\n");
 
-            $output = $process->readStdoutUntil('Watching for changes', 20.0);
-            Expect::that($output)->toContain('Change detected')
+            $output = $process->readStdoutUntil('Waiting for changes', 20.0);
+            Expect::that($output)->toContain('Detected changes')
                 ->toContain('1 test, 1 passed');
 
             $process->write('q');

--- a/tests/Unit/Cli/CliErrorTest.php
+++ b/tests/Unit/Cli/CliErrorTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\CliError;
+use Greenlight\Expect\Expect;
+
+final class CliErrorTest
+{
+    #[Test]
+    public function optionErrorsGiveExactGuidance(): void
+    {
+        $actual = [
+            CliError::unknownOption('--unknown')->getMessage(),
+            CliError::bareDoubleDash()->getMessage(),
+            CliError::optionTakesNoValue('watch')->getMessage(),
+            CliError::optionRequiresValue('workers')->getMessage(),
+            CliError::shortOptionRequiresValue('c', 'config')->getMessage(),
+            CliError::unexpectedArgument('extra')->getMessage(),
+            CliError::duplicateOption('workers')->getMessage(),
+            CliError::emptyGroupName()->getMessage(),
+            CliError::emptyFilterPattern()->getMessage(),
+        ];
+
+        Expect::that($actual)->toBe([
+            'Unknown option "--unknown". Use greenlight --help to list options.',
+            '"--" requires an option name.',
+            'Option --watch does not take a value.',
+            'Option --workers requires a value. Use --workers=<value>.',
+            'Option -c requires a value. Use --config=<value>.',
+            'Unexpected argument "extra".',
+            'Specify option --workers only once.',
+            '--group requires a group name.',
+            '--filter requires a pattern.',
+        ]);
+    }
+
+    #[Test]
+    public function valueErrorsGiveExactGuidance(): void
+    {
+        $actual = [
+            CliError::malformedShard('first')->getMessage(),
+            CliError::shardOutOfRange('9/4', 4)->getMessage(),
+            CliError::shardOutOfRange('1/0', 0)->getMessage(),
+            CliError::invalidSeed('-1')->getMessage(),
+            CliError::notAPositiveInteger('--workers', '0')->getMessage(),
+            CliError::malformedResourceLimit('postgres')->getMessage(),
+            CliError::duplicateResourceLimit('postgres')->getMessage(),
+            CliError::unknownReporter('verbose')->getMessage(),
+        ];
+
+        Expect::that($actual)->toBe([
+            '--shard requires <n>/<m>, such as 1/4. Received "first".',
+            '--shard requires 1 <= n <= m. Received "9/4". Valid n values for 4 shards are 1 through 4.',
+            '--shard requires 1 <= n <= m. Received "1/0".',
+            '--seed requires a nonnegative integer. Received "-1".',
+            '--workers requires a positive integer. Received "0".',
+            '--resource-limit requires <name>=<limit>, such as postgres=2. Received "postgres".',
+            'Set resource limit "postgres" only once.',
+            'Unknown reporter "verbose". Select tty, plain, junit, jsonl, github, or teamcity.',
+        ]);
+    }
+}

--- a/tests/Unit/Cli/CliOverridesTest.php
+++ b/tests/Unit/Cli/CliOverridesTest.php
@@ -115,7 +115,7 @@ final class CliOverridesTest
             CliOverrides::fromArguments(new ParsedArguments(null, ['shard' => ['632/13']]));
         } catch (CliError $error) {
             Expect::that($error->getMessage())->toBe(
-                '--shard needs 1 <= n <= m, got "632/13". With 13 shards, n must be between 1 and 13.',
+                '--shard requires 1 <= n <= m. Received "632/13". Valid n values for 13 shards are 1 through 13.',
             );
 
             return;
@@ -130,7 +130,7 @@ final class CliOverridesTest
         try {
             CliOverrides::fromArguments(new ParsedArguments(null, ['shard' => ['1/0']]));
         } catch (CliError $error) {
-            Expect::that($error->getMessage())->toBe('--shard needs 1 <= n <= m, got "1/0".');
+            Expect::that($error->getMessage())->toBe('--shard requires 1 <= n <= m. Received "1/0".');
 
             return;
         }

--- a/tests/Unit/Cli/CompletionScriptsTest.php
+++ b/tests/Unit/Cli/CompletionScriptsTest.php
@@ -27,6 +27,22 @@ final class CompletionScriptsTest
     }
 
     #[Test]
+    public function rendersExactCommandDescriptionsWhenTheShellSupportsThem(): void
+    {
+        foreach (['zsh', 'fish'] as $shell) {
+            $script = (string) $this->scripts()->render($shell);
+
+            Expect::that($script)
+                ->toContain('Find and run tests (default)')
+                ->toContain('List each found test ID, one per line')
+                ->toContain('Compare two coverage JSON exports')
+                ->toContain('Create a run profile from a saved JSONL stream')
+                ->toContain('Write the IDE autocomplete helper for extension matchers')
+                ->toContain('Print a shell completion script to standard output');
+        }
+    }
+
+    #[Test]
     public function generatesFlagCandidatesFromTheOptionSpecList(): void
     {
         foreach (['bash', 'zsh'] as $shell) {

--- a/tests/Unit/Cli/PlanFormatterTest.php
+++ b/tests/Unit/Cli/PlanFormatterTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\PlanFormatter;
+use Greenlight\Config\Configuration;
+use Greenlight\Config\CoverageConfiguration;
+use Greenlight\Config\CoverageExport;
+use Greenlight\Config\WatchConfiguration;
+use Greenlight\Config\WorkerCount;
+use Greenlight\Core\Result\ResultPolicy;
+use Greenlight\Expect\Expect;
+
+final class PlanFormatterTest
+{
+    #[Test]
+    public function formatsTheResolvedPlanWithExactLabels(): void
+    {
+        $configuration = new Configuration(
+            paths: ['tests'],
+            suites: [],
+            workers: WorkerCount::auto(),
+            recycleAfterTests: null,
+            recycleAboveMemoryBytes: 128 * 1024 * 1024,
+            coverage: new CoverageConfiguration(
+                includePaths: ['src'],
+                driver: 'xdebug',
+                exports: [new CoverageExport('json', 'build/coverage.json')],
+            ),
+            watch: new WatchConfiguration(),
+            plugins: [],
+            policy: new ResultPolicy(),
+            stopAfterFailures: null,
+            randomizeOrder: false,
+            randomSeed: null,
+        );
+
+        Expect::that(PlanFormatter::format($configuration, '/project/greenlight.php'))->toBe(
+            <<<'PLAN'
+                Run plan
+                  configuration file: /project/greenlight.php
+                  test paths: tests
+                  suites: (none)
+                  workers: auto
+                  resource limits: (default 1 per required resource)
+                  recycle: above 128M memory
+                  stop after: never
+                  order: declared
+                  groups: (all)
+                  plugins: (none)
+                  artifacts: build/greenlight-artifacts
+                  coverage include paths: src
+                  coverage driver: xdebug
+                  coverage exports: json -> build/coverage.json
+
+                PLAN,
+        );
+    }
+}

--- a/tests/Unit/Cli/WatchTest.php
+++ b/tests/Unit/Cli/WatchTest.php
@@ -16,6 +16,17 @@ use Greenlight\Expect\Expect;
 final class WatchTest
 {
     #[Test]
+    public function rejectsANegativeQuietPeriodWithExactGuidance(): void
+    {
+        Expect::that(
+            static fn(): Debouncer => new Debouncer(-0.1),
+        )->toThrow(
+            \InvalidArgumentException::class,
+            message: 'Set the quiet period to zero seconds or more.',
+        );
+    }
+
+    #[Test]
     public function debounceFiresOnlyAfterTheQuietPeriod(): void
     {
         $debouncer = new Debouncer(0.2);
@@ -136,6 +147,6 @@ final class WatchTest
             ->and($runs[0])->toBe([])
             ->and($runs[1])->toBe(['App\\BrokenTest'])
             ->and($runs[2])->toBe([])
-            ->and($output)->toContain('Change detected in 1 file(s).');
+            ->and($output)->toContain('Detected changes in 1 file.');
     }
 }

--- a/tests/Unit/Discovery/AttributeMergeTest.php
+++ b/tests/Unit/Discovery/AttributeMergeTest.php
@@ -109,11 +109,10 @@ final class AttributeMergeTest
         try {
             new TestDiscoverer()->discover([$dir]);
         } catch (DiscoveryError $error) {
-            $message = $error->getMessage();
-            Expect::that($message)
-                ->toContain('NonScalarArgumentTest')
-                ->toContain('neverDiscovered')
-                ->toContain('array');
+            Expect::that($error->getMessage())->toBe(
+                'Attribute on Greenlight\Tests\Fixture\DiscoveryAttributeArgumentsInvalid\NonScalarArgumentTest::neverDiscovered() is invalid: '
+                . 'Use a scalar or null for #[SkipUnless] argument 1 of condition "Greenlight\Condition\EnvironmentVariableEquals". Received array.',
+            );
 
             return;
         }

--- a/tests/Unit/Discovery/DataSetExpansionTest.php
+++ b/tests/Unit/Discovery/DataSetExpansionTest.php
@@ -104,7 +104,7 @@ final class DataSetExpansionTest
     {
         $message = $this->discoveryErrorMessage('DiscoveryProviderInvalid');
 
-        Expect::that($message)->because('non static provider is rejected')->toContain('must be public and static');
+        Expect::that($message)->because('non static provider is rejected')->toContain('Declare the provider as public and static');
         Expect::that($message)->because('non static provider is rejected')->toContain('instanceProvider');
     }
 
@@ -113,7 +113,7 @@ final class DataSetExpansionTest
     {
         $message = $this->discoveryErrorMessage('DiscoveryProviderNotIterable');
 
-        Expect::that($message)->because('non iterable provider is rejected')->toContain('must return an iterable');
+        Expect::that($message)->because('non iterable provider is rejected')->toContain('Return an iterable from the provider');
         Expect::that($message)->because('non iterable provider is rejected')->toContain('string');
     }
 
@@ -148,7 +148,7 @@ final class DataSetExpansionTest
     {
         $message = $this->discoveryErrorMessage('DiscoveryProviderEmpty');
 
-        Expect::that($message)->because('empty provider is rejected')->toContain('yielded no data sets');
+        Expect::that($message)->because('empty provider is rejected')->toContain('produced no data sets');
     }
 
     #[Test]

--- a/tests/Unit/Discovery/DiscoveryErrorTest.php
+++ b/tests/Unit/Discovery/DiscoveryErrorTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\DiscoveryError;
+use Greenlight\Expect\Expect;
+
+final class DiscoveryErrorTest
+{
+    #[Test]
+    public function fileAndTestErrorsIdentifyTheExactSource(): void
+    {
+        $cause = new \InvalidArgumentException('bad value');
+        $attributeError = DiscoveryError::invalidAttribute('App\ExampleTest::checksValue()', $cause);
+
+        $actual = [
+            DiscoveryError::directoryNotFound('/project/tests')->getMessage(),
+            DiscoveryError::unreadableFile('/project/tests/ExampleTest.php')->getMessage(),
+            DiscoveryError::unreadableFile('/project/tests/ExampleTest.php', 'permission denied')->getMessage(),
+            DiscoveryError::noClassInFile('/project/tests/ExampleTest.php')->getMessage(),
+            DiscoveryError::classNameMismatch('/project/tests/ExampleTest.php', 'OtherTest', 'ExampleTest')->getMessage(),
+            DiscoveryError::classNotAutoloadable('/project/tests/ExampleTest.php', 'App\ExampleTest')->getMessage(),
+            DiscoveryError::classLoadedFromOtherFile(
+                '/project/tests/ExampleTest.php',
+                'App\ExampleTest',
+                '/project/vendor/ExampleTest.php',
+            )->getMessage(),
+            DiscoveryError::testMethodNotRunnable('App\ExampleTest', 'checksValue', 'it is static')->getMessage(),
+            $attributeError->getMessage(),
+        ];
+
+        Expect::that($actual)->toBe([
+            'Discovery directory "/project/tests" is missing or is not a directory.',
+            'Greenlight cannot read test file "/project/tests/ExampleTest.php".',
+            'Greenlight cannot read test file "/project/tests/ExampleTest.php": permission denied.',
+            'Test file "/project/tests/ExampleTest.php" does not declare a class, interface, trait, or enum.',
+            'Test file "/project/tests/ExampleTest.php" declares "OtherTest". Its file name requires "ExampleTest". Rename the class or file so the names match.',
+            'The autoloader cannot load class "App\ExampleTest" from "/project/tests/ExampleTest.php". Check that the namespace matches the PSR-4 mapping for this path.',
+            'The autoloader loaded class "App\ExampleTest" from "/project/vendor/ExampleTest.php". It expected the class in "/project/tests/ExampleTest.php". Only one file can declare a class.',
+            'Greenlight cannot run test method App\ExampleTest::checksValue() because it is static.',
+            'Attribute on App\ExampleTest::checksValue() is invalid: bad value',
+        ]);
+        Expect::that($attributeError->getPrevious())->toBe($cause);
+    }
+
+    #[Test]
+    public function dataProviderErrorsGiveExactGuidance(): void
+    {
+        $cause = new \RuntimeException('provider failed');
+        $providerError = DiscoveryError::providerThrew('App\ExampleTest', 'rows', $cause);
+
+        $actual = [
+            DiscoveryError::providerClassMissing('App\ExampleTest', 'checksValue', 'App\Rows')->getMessage(),
+            DiscoveryError::providerMissing('App\ExampleTest', 'checksValue', 'App\Rows', 'values')->getMessage(),
+            DiscoveryError::providerNotPublicStatic('App\ExampleTest', 'checksValue', 'App\Rows', 'values')->getMessage(),
+            DiscoveryError::providerNotIterable('App\Rows', 'values', 'string')->getMessage(),
+            $providerError->getMessage(),
+            DiscoveryError::providerTooSlow('App\Rows', 'values', 0.125)->getMessage(),
+            DiscoveryError::providerYieldedNothing('App\Rows', 'values')->getMessage(),
+            DiscoveryError::providerKeyInvalid('App\Rows', 'values', 'float')->getMessage(),
+            DiscoveryError::duplicateDataSetKey('App\ExampleTest', 'checksValue', 'same')->getMessage(),
+        ];
+
+        Expect::that($actual)->toBe([
+            'Test method App\ExampleTest::checksValue() references missing data-set provider class "App\Rows".',
+            'Test method App\ExampleTest::checksValue() references data-set provider App\Rows::values(), but the provider does not exist.',
+            'Test method App\ExampleTest::checksValue() references data-set provider App\Rows::values(). Declare the provider as public and static.',
+            'Data-set provider App\Rows::values() returned string. Return an iterable from the provider.',
+            'Data-set provider App\ExampleTest::rows() threw RuntimeException: provider failed',
+            'Data-set provider App\Rows::values() exceeded the 0.125-second discovery time budget. Providers run during plan creation. Keep them pure and fast.',
+            'Data-set provider App\Rows::values() produced no data sets. Produce at least one data set.',
+            'Data-set provider App\Rows::values() produced a key of type float. Use string or integer keys.',
+            'Data sets for App\ExampleTest::checksValue() contain key "same" more than once. Use each key only once for the test method.',
+        ]);
+        Expect::that($providerError->getPrevious())->toBe($cause);
+    }
+}

--- a/tests/Unit/Discovery/ExecutionPlanTest.php
+++ b/tests/Unit/Discovery/ExecutionPlanTest.php
@@ -52,7 +52,10 @@ final class ExecutionPlanTest
                 self::entry('App\BarTest', 'c'),
                 self::entry('App\FooTest', 'b'),
             ]),
-        )->because('rejects entries not grouped by class')->toThrow(\InvalidArgumentException::class);
+        )->because('rejects entries not grouped by class')->toThrow(
+            \InvalidArgumentException::class,
+            message: 'Group execution plan entries by class. "App\FooTest" occurs in more than one block.',
+        );
     }
 
     #[Test]

--- a/tests/Unit/Discovery/Psr4ViolationTest.php
+++ b/tests/Unit/Discovery/Psr4ViolationTest.php
@@ -29,7 +29,7 @@ final class Psr4ViolationTest
     {
         $message = $this->discoveryErrorMessage('DiscoveryPsr4Violation');
 
-        Expect::that($message)->because('wrong namespace produces a typed error naming file and class')->toContain('not autoloadable');
+        Expect::that($message)->because('wrong namespace produces a typed error naming file and class')->toContain('The autoloader cannot load class');
         Expect::that($message)->because('wrong namespace produces a typed error naming file and class')->toContain(MismatchTest::class);
         Expect::that($message)->because('wrong namespace produces a typed error naming file and class')->toContain('MismatchTest.php');
     }
@@ -48,7 +48,7 @@ final class Psr4ViolationTest
     {
         $message = $this->discoveryErrorMessage('DiscoveryNoClass');
 
-        Expect::that($message)->because('file without any declaration produces a typed error')->toContain('does not declare any class');
+        Expect::that($message)->because('file without any declaration produces a typed error')->toContain('does not declare a class');
         Expect::that($message)->because('file without any declaration produces a typed error')->toContain('NothingHereTest.php');
     }
 }

--- a/tests/Unit/Discovery/TestDiscovererTest.php
+++ b/tests/Unit/Discovery/TestDiscovererTest.php
@@ -16,7 +16,7 @@ final class TestDiscovererTest
     /**
      * @return non-empty-string
      */
-    private static function fixtureDir(string $name): string
+    private function fixtureDir(string $name): string
     {
         return \dirname(__DIR__, 2) . '/Fixture/' . $name;
     }
@@ -36,9 +36,20 @@ final class TestDiscovererTest
     }
 
     #[Test]
+    public function rejectsANonpositiveProviderTimeBudgetWithExactGuidance(): void
+    {
+        Expect::that(
+            static fn(): TestDiscoverer => new TestDiscoverer(0.0),
+        )->toThrow(
+            \InvalidArgumentException::class,
+            message: 'Set the provider time budget to a value greater than zero seconds.',
+        );
+    }
+
+    #[Test]
     public function discoversBasicSuiteInFileOrderWithoutSeed(): void
     {
-        $plan = new TestDiscoverer()->discover([self::fixtureDir('DiscoveryBasic')]);
+        $plan = new TestDiscoverer()->discover([$this->fixtureDir('DiscoveryBasic')]);
 
         Expect::that($this->ids($plan))->because('discovers basic suite in file order without seed')->toBe([
             'Greenlight\Tests\Fixture\DiscoveryBasic\AlphaTest::one',
@@ -57,7 +68,7 @@ final class TestDiscovererTest
     #[Test]
     public function abstractClassesAndClassesWithoutTestsAreSkipped(): void
     {
-        $plan = new TestDiscoverer()->discover([self::fixtureDir('DiscoveryBasic')]);
+        $plan = new TestDiscoverer()->discover([$this->fixtureDir('DiscoveryBasic')]);
 
         foreach ($plan->classes() as $class) {
             Expect::that($class)
@@ -70,8 +81,8 @@ final class TestDiscovererTest
     public function sameSeedProducesByteIdenticalPlans(): void
     {
         $discoverer = new TestDiscoverer();
-        $first = $discoverer->discover([self::fixtureDir('DiscoveryBasic')], null, 1234);
-        $second = $discoverer->discover([self::fixtureDir('DiscoveryBasic')], null, 1234);
+        $first = $discoverer->discover([$this->fixtureDir('DiscoveryBasic')], null, 1234);
+        $second = $discoverer->discover([$this->fixtureDir('DiscoveryBasic')], null, 1234);
 
         Expect::that(\json_encode($second->toWire(), \JSON_THROW_ON_ERROR))->because('same seed produces byte identical plans')
             ->toBe(\json_encode($first->toWire(), \JSON_THROW_ON_ERROR));
@@ -85,7 +96,7 @@ final class TestDiscovererTest
         $orders = [];
 
         foreach ([1, 2, 3, 4, 5] as $seed) {
-            $orders[] = \implode(',', $discoverer->discover([self::fixtureDir('DiscoveryBasic')], null, $seed)->classes());
+            $orders[] = \implode(',', $discoverer->discover([$this->fixtureDir('DiscoveryBasic')], null, $seed)->classes());
         }
 
         Expect::that(\count(\array_unique($orders)))->because('different seeds produce different class order')->toBeGreaterThan(1);
@@ -94,7 +105,7 @@ final class TestDiscovererTest
     #[Test]
     public function seededPlanKeepsMethodDeclarationOrderWithinClass(): void
     {
-        $plan = new TestDiscoverer()->discover([self::fixtureDir('DiscoveryBasic')], null, 42);
+        $plan = new TestDiscoverer()->discover([$this->fixtureDir('DiscoveryBasic')], null, 42);
         $bravoMethods = [];
 
         foreach ($plan->entries as $entry) {
@@ -109,7 +120,7 @@ final class TestDiscovererTest
     #[Test]
     public function seededPlanSurvivesTheWire(): void
     {
-        $plan = new TestDiscoverer()->discover([self::fixtureDir('DiscoveryBasic')], null, 99);
+        $plan = new TestDiscoverer()->discover([$this->fixtureDir('DiscoveryBasic')], null, 99);
         $restored = ExecutionPlan::fromWire(JsonWire::roundTrip($plan->toWire()));
 
         Expect::that(\json_encode($restored->toWire(), \JSON_THROW_ON_ERROR))->because('seeded plan survives the wire')
@@ -119,15 +130,20 @@ final class TestDiscovererTest
     #[Test]
     public function unknownDirectoryFailsLoudly(): void
     {
+        $directory = $this->fixtureDir('DoesNotExist');
+
         Expect::that(
-            static fn(): ExecutionPlan => new TestDiscoverer()->discover([self::fixtureDir('DoesNotExist')]),
-        )->because('unknown directory fails loudly')->toThrow(DiscoveryError::class);
+            static fn(): ExecutionPlan => new TestDiscoverer()->discover([$directory]),
+        )->because('unknown directory fails loudly')->toThrow(
+            DiscoveryError::class,
+            message: \sprintf('Discovery directory "%s" is missing or is not a directory.', $directory),
+        );
     }
 
     #[Test]
     public function overlappingDirectoriesDoNotDuplicateEntries(): void
     {
-        $dir = self::fixtureDir('DiscoveryBasic');
+        $dir = $this->fixtureDir('DiscoveryBasic');
         $plan = new TestDiscoverer()->discover([$dir, $dir]);
 
         Expect::that($plan->count())->because('overlapping directories do not duplicate entries')->toBe(7);


### PR DESCRIPTION
## Summary

- Simplify CLI help, command diagnostics, watch output, plan output, and discovery errors.
- Add exact-output tests for the rewritten diagnostics.
- Preserve commands, flags, exit codes, test IDs, and other machine contracts.

Human-readable wording changes are intentional. The change does not alter public APIs or runtime dependencies.

## Continuation record

- Base commit: `4d9b7d5b0c4ff48d8ba47d1f9082a3834fe141d7`
- Result commit: `2105eb20c2dc707bf370682ce13f8f59af0ae852`
- Owned paths: `src/Cli/**`, `src/Discovery/**`, and their focused unit and acceptance assertions
- Blocking prose findings: 0 before, 0 after
- Advisory review: removes three candidates from changed comments and adds none; remaining repository advisories stay for the final audit
- Terminology: uses `configuration`, `test ID`, `data set` or `data-set`, `working directory`, and `JSONL` in their canonical forms
- Checks run: `composer prose:check`; `composer prose:review`; focused CLI and discovery checks; `composer static-analysis`; `composer tests` (865 tests, 864 passed, one expected Xdebug skip); `git diff --check`
- Next unclaimed shard: final repository audit after the three runtime-message PRs merge
