### PR TITLE
refactor(runner): simplify runner, reporting, coverage, artifact, Symfony, and tool output

### DIFF
--- a/src/Coverage/Driver/DriverSelector.php
+++ b/src/Coverage/Driver/DriverSelector.php
@@ -29,7 +29,7 @@ final readonly class DriverSelector
         }
 
         if ($this->candidates === []) {
-            return DriverSelection::unavailable('No coverage driver is available: no drivers are configured.');
+            return DriverSelection::unavailable('No coverage driver is configured.');
         }
 
         $names = \array_map(
@@ -42,7 +42,8 @@ final readonly class DriverSelector
         );
 
         return DriverSelection::unavailable(\sprintf(
-            'No coverage driver is available: tried %s. Install pcov, or enable xdebug with "coverage" in xdebug.mode or the XDEBUG_MODE environment variable.',
+            'No coverage driver is available. Greenlight tried %s. Install pcov or enable Xdebug coverage mode. '
+            . 'Set xdebug.mode to "coverage", or set the XDEBUG_MODE environment variable.',
             \implode(', ', $names),
         ));
     }

--- a/src/Coverage/Driver/PcovDriver.php
+++ b/src/Coverage/Driver/PcovDriver.php
@@ -37,7 +37,7 @@ final class PcovDriver implements CoverageDriver
     public function start(): void
     {
         if ($this->collecting) {
-            throw new \LogicException('pcov collection window is already open; stop() must be called first.');
+            throw new \LogicException('The pcov collection window is already open. Call stop() before start().');
         }
 
         \pcov\start();
@@ -48,7 +48,7 @@ final class PcovDriver implements CoverageDriver
     public function stop(): RawCoverage
     {
         if (!$this->collecting) {
-            throw new \LogicException('pcov collection window is not open; start() must be called first.');
+            throw new \LogicException('The pcov collection window is not open. Call start() before stop().');
         }
 
         $collected = \pcov\collect();

--- a/src/Coverage/Driver/XdebugDriver.php
+++ b/src/Coverage/Driver/XdebugDriver.php
@@ -37,7 +37,7 @@ final class XdebugDriver implements CoverageDriver
     public function start(): void
     {
         if ($this->collecting) {
-            throw new \LogicException('Xdebug collection window is already open; stop() must be called first.');
+            throw new \LogicException('The Xdebug collection window is already open. Call stop() before start().');
         }
 
         \xdebug_start_code_coverage(\XDEBUG_CC_UNUSED | \XDEBUG_CC_DEAD_CODE);
@@ -48,7 +48,7 @@ final class XdebugDriver implements CoverageDriver
     public function stop(): RawCoverage
     {
         if (!$this->collecting) {
-            throw new \LogicException('Xdebug collection window is not open; start() must be called first.');
+            throw new \LogicException('The Xdebug collection window is not open. Call start() before stop().');
         }
 
         $collected = \xdebug_get_code_coverage();

--- a/src/Coverage/Export/JsonExporter.php
+++ b/src/Coverage/Export/JsonExporter.php
@@ -58,7 +58,7 @@ final readonly class JsonExporter implements CoverageExporter
         }
 
         if (!\is_array($document)) {
-            throw CoverageError::invalidJson('the top level must be an object.');
+            throw CoverageError::invalidJson('use an object at the top level.');
         }
 
         if (($document['v'] ?? null) !== self::VERSION) {
@@ -68,14 +68,14 @@ final readonly class JsonExporter implements CoverageExporter
         $rawFiles = $document['files'] ?? null;
 
         if (!\is_array($rawFiles)) {
-            throw CoverageError::invalidJson('"files" must be an object.');
+            throw CoverageError::invalidJson('use an object for "files".');
         }
 
         $files = [];
 
         foreach ($rawFiles as $path => $entry) {
             if (!\is_string($path) || $path === '' || !\is_array($entry)) {
-                throw CoverageError::invalidJson('every "files" entry must map a file path to an object.');
+                throw CoverageError::invalidJson('map each file path in "files" to an object.');
             }
 
             $files[] = new FileCoverage(
@@ -98,14 +98,14 @@ final readonly class JsonExporter implements CoverageExporter
         $value = $entry[$key] ?? null;
 
         if (!\is_array($value) || !\array_is_list($value)) {
-            throw CoverageError::invalidJson(\sprintf('"%s" for file "%s" must be a list of line numbers.', $key, $path));
+            throw CoverageError::invalidJson(\sprintf('use a list of line numbers for "%s" in file "%s".', $key, $path));
         }
 
         $lines = [];
 
         foreach ($value as $line) {
             if (!\is_int($line) || $line < 1) {
-                throw CoverageError::invalidJson(\sprintf('"%s" for file "%s" must contain positive integers only.', $key, $path));
+                throw CoverageError::invalidJson(\sprintf('use only positive integers in "%s" for file "%s".', $key, $path));
             }
 
             $lines[] = $line;

--- a/src/Coverage/FileCoverage.php
+++ b/src/Coverage/FileCoverage.php
@@ -97,7 +97,7 @@ final readonly class FileCoverage
 
         foreach ($lines as $line) {
             if ($line < 1) {
-                throw new \InvalidArgumentException(\sprintf('Coverage line numbers must be positive, got %d.', $line));
+                throw new \InvalidArgumentException(\sprintf('Use positive coverage line numbers. Actual value: %d.', $line));
             }
 
             $set[$line] = true;

--- a/src/Coverage/PathFilter.php
+++ b/src/Coverage/PathFilter.php
@@ -30,7 +30,7 @@ final readonly class PathFilter
             $trimmed = \rtrim($directory, '/');
 
             if ($trimmed === '') {
-                throw new \InvalidArgumentException('Coverage include directories must be non-empty paths.');
+                throw new \InvalidArgumentException('Use nonempty paths for coverage include directories.');
             }
 
             $prefixes[] = $trimmed . '/';

--- a/src/Reporting/PlainReporter.php
+++ b/src/Reporting/PlainReporter.php
@@ -178,7 +178,9 @@ final class PlainReporter implements Reporter
 
         if ($this->risky !== []) {
             $this->output->write(\sprintf(
-                "\nRisky: %d passed without verifying any expectation (opt out with #[NoExpectations], enforce with --fail-on-risky):\n%s\n",
+                "\nRisky tests: %d\n"
+                . "These tests passed without a verified expectation.\n"
+                . "Add #[NoExpectations] to accept this result. Use --fail-on-risky to fail the run.\n%s\n",
                 \count($this->risky),
                 \implode("\n", \array_map(static fn(string $id): string => '  ' . $id, $this->risky)),
             ));

--- a/src/Reporting/ReportingError.php
+++ b/src/Reporting/ReportingError.php
@@ -14,7 +14,7 @@ final class ReportingError extends \RuntimeException
 
     public static function writeFailed(): self
     {
-        return new self('Could not write reporter output to the underlying stream.');
+        return new self('Greenlight did not write reporter output to the stream.');
     }
 
     /**
@@ -22,7 +22,7 @@ final class ReportingError extends \RuntimeException
      */
     public static function unmappedEvent(string $eventClass): self
     {
-        return new self(\sprintf('Event "%s" has no stable tag. Add it to the tag map before emitting it.', $eventClass));
+        return new self(\sprintf('Event "%s" has no stable tag. Add the event to the tag map before Greenlight writes it.', $eventClass));
     }
 
     public static function xmlUnavailable(): self

--- a/src/Reporting/SummaryFormat.php
+++ b/src/Reporting/SummaryFormat.php
@@ -118,7 +118,7 @@ final class SummaryFormat
             return '';
         }
 
-        $lines = ["\n" . $style->error('Leaks (the test instance survived its test):')];
+        $lines = ["\n" . $style->error('Test instance leaks:')];
 
         foreach ($leaks as $leak) {
             $lines[] = '  ' . $leak;

--- a/src/Reporting/TtyReporter.php
+++ b/src/Reporting/TtyReporter.php
@@ -273,7 +273,9 @@ final class TtyReporter implements Reporter, Ticking
 
         if ($this->risky !== []) {
             $this->output->write(\sprintf(
-                "\nRisky: %d passed without verifying any expectation (opt out with #[NoExpectations], enforce with --fail-on-risky):\n%s\n",
+                "\nRisky tests: %d\n"
+                . "These tests passed without a verified expectation.\n"
+                . "Add #[NoExpectations] to accept this result. Use --fail-on-risky to fail the run.\n%s\n",
                 \count($this->risky),
                 \implode("\n", \array_map(static fn(string $id): string => '  ' . $id, $this->risky)),
             ));

--- a/src/Runner/Artifact/ArtifactStore.php
+++ b/src/Runner/Artifact/ArtifactStore.php
@@ -45,7 +45,7 @@ final class ArtifactStore
         if (!\str_starts_with($configured, '/')
             && \in_array('..', \explode('/', $configured), true)
         ) {
-            throw AttachmentError::storage('Relative attachment output directory must stay inside the working directory');
+            throw AttachmentError::storage('Keep a relative attachment output directory inside the working directory');
         }
 
         if (\str_starts_with($configured, '/') && ($resolved = \realpath($configured)) !== false) {
@@ -132,7 +132,7 @@ final class ArtifactStore
             $stream = \fopen($part, 'xb');
 
             if ($stream === false) {
-                throw AttachmentError::storage('Failed to create attachment staging file');
+                throw AttachmentError::storage('Greenlight did not create the attachment staging file');
             }
 
             try {
@@ -179,7 +179,7 @@ final class ArtifactStore
         ArtifactConfiguration $configuration,
     ): StagedAttachment {
         if (\is_link($sourcePath)) {
-            throw AttachmentError::source($sourcePath, 'must not be a symbolic link');
+            throw AttachmentError::source($sourcePath, 'Use a source path that is not a symbolic link');
         }
 
         $source = \fopen($sourcePath, 'rb');
@@ -207,7 +207,7 @@ final class ArtifactStore
                 $destination = \fopen($part, 'xb');
 
                 if ($destination === false) {
-                    throw AttachmentError::storage('Failed to create attachment staging file');
+                    throw AttachmentError::storage('Greenlight did not create the attachment staging file');
                 }
 
                 $hash = \hash_init('sha256');
@@ -330,7 +330,7 @@ final class ArtifactStore
             if (\file_exists($destination) || \is_link($destination)
                 || \file_exists($part) || \is_link($part)
             ) {
-                throw AttachmentError::storage('Attachment output would overwrite an existing file');
+                throw AttachmentError::storage('An attachment output path already exists');
             }
 
             if (\filesize($source) !== $attachment->sizeBytes || \hash_file('sha256', $source) !== $attachment->sha256) {
@@ -460,7 +460,7 @@ final class ArtifactStore
 
         if ($size > $configuration->maxAttachmentBytes) {
             throw AttachmentError::limit(\sprintf(
-                'Attachment size %d exceeds the %d byte limit',
+                'Attachment size %d exceeds the limit of %d bytes',
                 $size,
                 $configuration->maxAttachmentBytes,
             ));
@@ -508,14 +508,14 @@ final class ArtifactStore
         $this->updateQuota(function (int $count, int $used) use ($bytes): array {
             if ($count + 1 > $this->configuration->maxRunAttachments) {
                 throw AttachmentError::limit(\sprintf(
-                    'This run exceeds the %d attachment limit',
+                    'This run has reached the limit of %d attachments',
                     $this->configuration->maxRunAttachments,
                 ));
             }
 
             if ($used + $bytes > $this->configuration->maxRunBytes) {
                 throw AttachmentError::limit(\sprintf(
-                    'Attachments for this run exceed the %d byte limit',
+                    'Attachments for this run exceed the limit of %d bytes',
                     $this->configuration->maxRunBytes,
                 ));
             }
@@ -618,7 +618,7 @@ final class ArtifactStore
         if (\file_put_contents($part, $encoded . "\n", \LOCK_EX) === false) {
             @\unlink($part);
 
-            throw AttachmentError::storage('Failed to write attachment recovery metadata');
+            throw AttachmentError::storage('Greenlight did not write attachment recovery metadata');
         }
 
         \chmod($part, 0o600);
@@ -656,7 +656,7 @@ final class ArtifactStore
         if (!\rename($part, $path)) {
             @\unlink($part);
 
-            throw AttachmentError::storage('Failed to record the current test attempt');
+            throw AttachmentError::storage('Greenlight did not finalize the current test attempt record');
         }
     }
 
@@ -702,7 +702,7 @@ final class ArtifactStore
         }
 
         if (!\unlink($path)) {
-            throw AttachmentError::storage('Failed to remove ' . $description);
+            throw AttachmentError::storage('Greenlight did not remove ' . $description);
         }
     }
 

--- a/src/Runner/Artifact/StagedAttachments.php
+++ b/src/Runner/Artifact/StagedAttachments.php
@@ -166,7 +166,7 @@ final class StagedAttachments implements Attachments
             $this->store->discard($attachment);
 
             throw AttachmentError::limit(\sprintf(
-                'Attachments for this test exceed the %d byte limit',
+                'Attachments for this test exceed the limit of %d bytes',
                 $this->configuration->maxTestBytes,
             ));
         }
@@ -184,7 +184,7 @@ final class StagedAttachments implements Attachments
 
         if ($this->budget->attachments >= $this->configuration->maxAttachmentsPerTest) {
             throw AttachmentError::limit(\sprintf(
-                'This test exceeds the %d attachment limit',
+                'This test has reached the limit of %d attachments',
                 $this->configuration->maxAttachmentsPerTest,
             ));
         }

--- a/src/Runner/Orchestrator/ChannelAllocator.php
+++ b/src/Runner/Orchestrator/ChannelAllocator.php
@@ -36,7 +36,7 @@ final class ChannelAllocator
         }
 
         throw new \LogicException(\sprintf(
-            'All %d worker channels are in use; a channel was not released when its worker finished.',
+            'All %d worker channels are in use. A worker finished without releasing its channel.',
             $this->bound,
         ));
     }
@@ -45,7 +45,7 @@ final class ChannelAllocator
     {
         if (!isset($this->inUse[$channel])) {
             throw new \LogicException(\sprintf(
-                'Channel %d is not allocated; releasing it twice hides a lifecycle bug.',
+                'Channel %d is not allocated. A second release indicates a lifecycle error.',
                 $channel,
             ));
         }

--- a/src/Runner/Orchestrator/Orchestrator.php
+++ b/src/Runner/Orchestrator/Orchestrator.php
@@ -242,13 +242,13 @@ final class Orchestrator
         });
 
         if (!\is_resource($server)) {
-            throw ProtocolError::malformedFrame('could not open an orchestrator socket: ' . $errorMessage);
+            throw ProtocolError::malformedFrame('Greenlight did not open an orchestrator socket: ' . $errorMessage);
         }
 
         $name = \stream_socket_get_name($server, false);
 
         if ($name === false || $name === '') {
-            throw ProtocolError::malformedFrame('could not resolve the orchestrator socket address');
+            throw ProtocolError::malformedFrame('Greenlight did not resolve the orchestrator socket address');
         }
 
         return [$server, 'tcp://' . $name, null];
@@ -278,7 +278,8 @@ final class Orchestrator
 
             if ($this->spawnedCount > $this->spawnBudget) {
                 throw ProtocolError::malformedFrame(\sprintf(
-                    'spawned %d workers for a plan that should need far fewer; a respawn loop is a bug, not a retry strategy',
+                    'Greenlight started %d workers for this execution plan. '
+                    . 'This count indicates a worker replacement loop',
                     $this->spawnedCount,
                 ));
             }
@@ -296,7 +297,7 @@ final class Orchestrator
             if (!\is_resource($process)) {
                 $channels->release($channelNumber);
 
-                throw ProtocolError::malformedFrame('could not spawn a worker process', $warning);
+                throw ProtocolError::malformedFrame('Greenlight did not start a worker process', $warning);
             }
 
             \assert(isset($pipes[0], $pipes[1], $pipes[2]));
@@ -753,7 +754,7 @@ final class Orchestrator
         if ($inFlight instanceof TestId) {
             $duration = \max(0.0, \microtime(true) - $handle->inFlightSince);
             $message = \sprintf(
-                'The test exceeded its %.3fs timeout budget; worker "%s" was killed after %.3fs.',
+                'The test exceeded its %.3f-second time limit. Greenlight stopped worker "%s" after %.3f seconds.',
                 $budget,
                 $handle->workerId,
                 $duration,
@@ -782,7 +783,7 @@ final class Orchestrator
 
         if ($inFlight instanceof TestId) {
             $diagnostics = \trim($handle->diagnostics);
-            $message = \sprintf('Worker "%s" crashed while running this test: %s.', $handle->workerId, $reason);
+            $message = \sprintf('Worker "%s" crashed during this test: %s.', $handle->workerId, $reason);
 
             if ($diagnostics !== '') {
                 $message .= "\nWorker output:\n" . \substr($diagnostics, -2048);

--- a/src/Runner/Protocol/JsonFrameCodec.php
+++ b/src/Runner/Protocol/JsonFrameCodec.php
@@ -25,7 +25,7 @@ final readonly class JsonFrameCodec implements FrameCodec
         try {
             $json = \json_encode($envelope, \JSON_THROW_ON_ERROR | \JSON_INVALID_UTF8_SUBSTITUTE);
         } catch (\JsonException $e) {
-            throw ProtocolError::malformedFrame('payload cannot be JSON encoded: ' . $e->getMessage());
+            throw ProtocolError::malformedFrame('Greenlight cannot encode the payload as JSON: ' . $e->getMessage());
         }
 
         $length = \strlen($json);

--- a/src/Runner/Protocol/ProtocolError.php
+++ b/src/Runner/Protocol/ProtocolError.php
@@ -51,8 +51,8 @@ final class ProtocolError extends \RuntimeException
     public static function summaryMismatch(string $workerId, string $expected, string $reported): self
     {
         return new self(\sprintf(
-            'Worker "%s" reported a summary of %s but its event stream tallies %s. '
-            . 'A bookkeeping bug must fail the run, never report green.',
+            'Worker "%s" reported a summary of %s, but its event stream totals %s. '
+            . 'This difference indicates an internal accounting error. Greenlight stopped the run.',
             $workerId,
             $reported,
             $expected,
@@ -67,20 +67,21 @@ final class ProtocolError extends \RuntimeException
         int $expectedAttempt,
     ): self {
         return new self(\sprintf(
-            'Worker "%s" reported attempt %d for "%s"; expected attempt %d for %s.',
+            'Worker "%s" reported attempt %d for "%s". Greenlight expected attempt %d. Active test: %s.',
             $workerId,
             $reportedAttempt,
             $reportedTest,
             $expectedAttempt,
-            $inFlightTest === null ? 'no in-flight test' : '"' . $inFlightTest . '"',
+            $inFlightTest === null ? 'none' : '"' . $inFlightTest . '"',
         ));
     }
 
     public static function workerNeverConnected(string $workerId, float $deadlineSeconds, string $diagnostics): self
     {
         $message = \sprintf(
-            'Worker "%s" spawned but never connected within %.1fs. '
-            . 'The machine may be too starved to boot worker processes; failing the run beats waiting forever.',
+            'Worker "%s" did not connect within %.1f seconds. '
+            . 'The machine can have insufficient resources to start a worker. '
+            . 'Greenlight stopped the run to prevent an unlimited wait.',
             $workerId,
             $deadlineSeconds,
         );
@@ -95,8 +96,8 @@ final class ProtocolError extends \RuntimeException
     public static function workerStalled(string $workerId, float $deadlineSeconds, string $diagnostics): self
     {
         $message = \sprintf(
-            'Worker "%s" connected but then sent nothing for %.1fs with no test in flight. '
-            . 'The worker process stopped responding between messages; failing the run beats waiting forever.',
+            'Worker "%s" sent no message for %.1f seconds after connection. No test was active. '
+            . 'The worker stopped responding between protocol messages. Greenlight stopped the run to prevent an unlimited wait.',
             $workerId,
             $deadlineSeconds,
         );
@@ -111,7 +112,7 @@ final class ProtocolError extends \RuntimeException
     public static function workerFatal(string $workerId, string $message, string $file, int $line): self
     {
         return new self(\sprintf(
-            'Worker "%s" reported a fatal framework error: %s (%s:%d)',
+            'Worker "%s" reported a fatal Greenlight error: %s (%s:%d)',
             $workerId,
             $message,
             $file,

--- a/src/Runner/Worker/ClassContext.php
+++ b/src/Runner/Worker/ClassContext.php
@@ -46,7 +46,7 @@ final class ClassContext
     {
         if (!\class_exists($class)) {
             throw new \RuntimeException(\sprintf(
-                'Test class "%s" from the plan is not loadable in this process.',
+                'This process cannot load test class "%s" from the execution plan.',
                 $class,
             ));
         }
@@ -106,8 +106,8 @@ final class ClassContext
 
         if (!\array_key_exists($key, $sets)) {
             throw new \RuntimeException(\sprintf(
-                'Data set "%s" of "%s::%s()" is in the plan but the method\'s data sets no longer include it. '
-                . 'Re-run discovery.',
+                'The execution plan contains data set "%s" for "%s::%s()", but its data provider no longer returns it. '
+                . 'Run discovery again.',
                 $key,
                 $this->reflection->getName(),
                 $testMethod,
@@ -118,7 +118,7 @@ final class ClassContext
 
         if (!\is_array($value)) {
             throw new \RuntimeException(\sprintf(
-                'Data set "%s" of "%s::%s()" must be an array of arguments, got %s.',
+                'Data set "%s" of "%s::%s()" requires an argument array. Actual type: %s.',
                 $key,
                 $this->reflection->getName(),
                 $testMethod,

--- a/src/Runner/Worker/TestExecutor.php
+++ b/src/Runner/Worker/TestExecutor.php
@@ -178,7 +178,7 @@ final readonly class TestExecutor
                     break;
                 } catch (\Throwable $threw) {
                     $cause = new \RuntimeException(\sprintf(
-                        'Plugin "%s" failed in beforeTest: %s',
+                        'Plugin "%s" caused an error during beforeTest(): %s',
                         $subscriber::class,
                         $threw->getMessage(),
                     ), 0, $threw);
@@ -265,7 +265,7 @@ final readonly class TestExecutor
         if ($budget !== null && $durationSeconds > $budget && $outcome === Outcome::Passed) {
             $outcome = Outcome::Failed;
             $failures = [new FailureDetail(\sprintf(
-                'Timed out: budget %.3fs, took %.3fs.',
+                'The configured time limit is %.3f seconds. The test took %.3f seconds.',
                 $budget,
                 $durationSeconds,
             ))];
@@ -320,7 +320,7 @@ final readonly class TestExecutor
                 if ($result->outcome->isSuccessful()) {
                     $result = $result->erroredBy(
                         ThrowableDetail::fromThrowable(new \RuntimeException(\sprintf(
-                            'Plugin "%s" failed in afterTest: %s',
+                            'Plugin "%s" caused an error during afterTest(): %s',
                             $subscriber::class,
                             $threw->getMessage(),
                         ), 0, $threw)),
@@ -329,7 +329,7 @@ final readonly class TestExecutor
                     $result = $result->withFailures([
                         ...$result->failures,
                         new FailureDetail(\sprintf(
-                            'Plugin "%s" failed in afterTest: %s',
+                            'Plugin "%s" caused an error during afterTest(): %s',
                             $subscriber::class,
                             $threw->getMessage(),
                         )),
@@ -344,7 +344,7 @@ final readonly class TestExecutor
             ) {
                 $result = $result->erroredBy(
                     ThrowableDetail::fromThrowable(new \RuntimeException(\sprintf(
-                        'Plugin "%s" changed the outcome from %s to %s without withOutcome() provenance.',
+                        'Plugin "%s" changed the outcome from %s to %s without a new transformation-log entry from withOutcome().',
                         $subscriber::class,
                         $result->outcome->value,
                         $replacement->outcome->value,
@@ -415,7 +415,7 @@ final readonly class TestExecutor
 
             if (!$condition instanceof Condition) {
                 return new \RuntimeException(\sprintf(
-                    'Condition class "%s" must implement %s.',
+                    'Condition class "%s" does not implement %s.',
                     $conditionClass,
                     Condition::class,
                 ));

--- a/src/Runner/Worker/WorkerProcess.php
+++ b/src/Runner/Worker/WorkerProcess.php
@@ -60,7 +60,7 @@ final readonly class WorkerProcess
         });
 
         if ($stream === false) {
-            \fwrite(\STDERR, \sprintf("Worker could not connect to %s: %s\n", $address, $errorMessage));
+            \fwrite(\STDERR, \sprintf("The worker did not connect to %s: %s\n", $address, $errorMessage));
 
             return 1;
         }

--- a/src/Symfony/SymfonyBridgeError.php
+++ b/src/Symfony/SymfonyBridgeError.php
@@ -15,10 +15,10 @@ final class SymfonyBridgeError extends \RuntimeException
     public static function testContainerUnavailable(string $environment): self
     {
         return new self(\sprintf(
-            'The kernel booted in the "%s" environment without Symfony\'s test container, '
-            . 'so container services cannot reach tests. Enable framework.test for this '
-            . 'environment (framework-bundle\'s standard test config, usually APP_ENV=test), '
-            . 'or point SymfonyPlugin at an environment that has it.',
+            'The kernel started in the "%s" environment without the Symfony test container. '
+            . 'Container services cannot reach tests. Enable framework.test for this environment. '
+            . 'The standard FrameworkBundle test configuration usually uses APP_ENV=test. '
+            . 'You can also configure SymfonyPlugin to use an environment that provides the test container.',
             $environment,
         ));
     }
@@ -26,11 +26,10 @@ final class SymfonyBridgeError extends \RuntimeException
     public static function resetterUnavailable(string $environment): self
     {
         return new self(\sprintf(
-            'The kernel booted in the "%s" environment without services_resetter, so state '
-            . 'cannot be reset between tests and the kernel-per-worker strategy would run '
-            . 'unisolated. Enable framework-bundle\'s test configuration so services_resetter '
-            . 'exists, or pass resetBetweenTests: false to SymfonyPlugin to deliberately waive '
-            . 'resets (unsafe with any stateful service).',
+            'The kernel started in the "%s" environment without services_resetter. '
+            . 'Symfony cannot reset service state between tests. Tests on the same worker can share state. '
+            . 'Enable the FrameworkBundle test configuration. To accept this risk, pass resetBetweenTests: false to SymfonyPlugin. '
+            . 'Use this option only if services do not keep state.',
             $environment,
         ));
     }
@@ -38,9 +37,9 @@ final class SymfonyBridgeError extends \RuntimeException
     public static function unknownServiceId(string $id, string $type): self
     {
         return new self(\sprintf(
-            'The Symfony container has no service "%s", requested for a parameter of type "%s". '
-            . 'Check the id for typos; private services are reachable through the test '
-            . 'container, so an unknown id means the compiled container never had it.',
+            'The Symfony container has no service "%s" for the parameter of type "%s". '
+            . 'Check the service ID. The test container exposes private services. '
+            . 'The compiled container does not define the requested service.',
             $id,
             $type,
         ));
@@ -49,7 +48,7 @@ final class SymfonyBridgeError extends \RuntimeException
     public static function serviceTypeMismatch(string $id, string $type, string $actual): self
     {
         return new self(\sprintf(
-            'The Symfony service "%s" is an instance of "%s", but the parameter declares "%s".',
+            'Symfony service "%s" has type "%s". The parameter requires type "%s".',
             $id,
             $actual,
             $type,
@@ -59,8 +58,8 @@ final class SymfonyBridgeError extends \RuntimeException
     public static function notAKernel(string $class): self
     {
         return new self(\sprintf(
-            '"%s" does not implement Symfony\Component\HttpKernel\KernelInterface, '
-            . 'so SymfonyPlugin cannot boot it.',
+            'Class "%s" does not implement Symfony\Component\HttpKernel\KernelInterface. '
+            . 'SymfonyPlugin cannot use this class as a kernel.',
             $class,
         ));
     }

--- a/tests/Acceptance/ParallelRunTest.php
+++ b/tests/Acceptance/ParallelRunTest.php
@@ -42,7 +42,7 @@ final readonly class ParallelRunTest
 
         Expect::that($result->exitCode)->because('crashed workers are contained and the run completes')->toBe(1)
             ->and($this->summaryLine($result->output()))->toBe('3 tests, 2 passed, 1 errored, 0 expectations')
-            ->and($result->output())->toContain('crashed while running');
+            ->and($result->output())->toContain('crashed during this test');
     }
 
     #[Test]
@@ -117,7 +117,7 @@ final readonly class ParallelRunTest
         $withFlag = $this->runIn('LeakConfig', ['run', '--detect-leaks', '--workers=2']);
 
         Expect::that($withFlag->exitCode)->because('leak detection names the leak and fails the run')->toBe(1)
-            ->and($withFlag->output())->toContain('Leaks (the test instance survived its test):')
+            ->and($withFlag->output())->toContain('Test instance leaks:')
             ->toContain('  Greenlight\Tests\Fixture\LeakSuite\LeakyTest::passesButLeaksItself');
 
         $withoutFlag = $this->runIn('LeakConfig', ['run', '--workers=2']);
@@ -157,7 +157,7 @@ final readonly class ParallelRunTest
         }
 
         Expect::that($result->exitCode)->because('hanging tests are hard killed by the orchestrator')->toBe(1)
-            ->and($result->output())->toContain('timeout budget')
+            ->and($result->output())->toContain('time limit')
             ->and($durationSeconds)->toBeLessThan(20.0)
             ->and($finished->result->outcome)->toBe(Outcome::Failed)
             ->and($finished->result->durationSeconds)->toBeGreaterThan(0.1)

--- a/tests/Acceptance/PolicyTest.php
+++ b/tests/Acceptance/PolicyTest.php
@@ -48,9 +48,10 @@ final readonly class PolicyTest
         $project = $this->writeProject();
         $result = $this->run($project, '--filter=RiskyProbeTest');
         $output = $result->output();
-        $riskyBlock = \substr($output, (int) \strpos($output, 'Risky:'));
+        $riskyBlock = \substr($output, (int) \strpos($output, 'Risky tests:'));
         Expect::that($result->exitCode)->because('risky tests warn by default and fail under the flag')->toBe(0)
-            ->and($riskyBlock)->toContain('Risky: 1 passed without verifying any expectation')
+            ->and($riskyBlock)->toContain('Risky tests: 1')
+            ->and($riskyBlock)->toContain('These tests passed without a verified expectation.')
             ->toContain('RiskyProbeTest::assertsNothing')
             ->not()->toContain('optedOut')
             ->not()->toContain('mocksOnly')

--- a/tests/Unit/Artifact/AttachmentsTest.php
+++ b/tests/Unit/Artifact/AttachmentsTest.php
@@ -7,12 +7,15 @@ namespace Greenlight\Tests\Unit\Artifact;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Core\Artifact\AttachmentKind;
 use Greenlight\Core\Artifact\AttachmentRetention;
+use Greenlight\Core\Artifact\StagedAttachment;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\ArtifactSession;
 use Greenlight\Runner\Artifact\ArtifactStore;
 use Greenlight\Runner\Artifact\TestArtifactBudget;
 
@@ -137,18 +140,30 @@ final readonly class AttachmentsTest
         Expect::that(static fn() => $attachments->text('../secret', 'x'))->because('unsafe names symlinks and limits fail loudly')
             ->toThrow(AttachmentError::class);
         Expect::that(static fn() => $attachments->bytes('large.bin', '12345'))->because('unsafe names symlinks and limits fail loudly')
-            ->toThrow(AttachmentError::class);
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Attachment size 5 exceeds the limit of 4 bytes.',
+            );
 
         $attachments->text('one.txt', '1234');
 
         Expect::that(static fn() => $attachments->text('two.txt', 'x'))->because('unsafe names symlinks and limits fail loudly')
-            ->toThrow(AttachmentError::class);
+            ->toThrow(
+                AttachmentError::class,
+                message: 'This test has reached the limit of 1 attachments.',
+            );
         $retry = $store->forAttempt($id, 2, $budget);
         Expect::that(static fn() => $retry->text('retry.txt', 'x'))->because('unsafe names symlinks and limits fail loudly')
-            ->toThrow(AttachmentError::class);
+            ->toThrow(
+                AttachmentError::class,
+                message: 'This test has reached the limit of 1 attachments.',
+            );
         $runLimited = $store->forAttempt(new TestId('Example\EvidenceTest', 'run-limit'), 1, new TestArtifactBudget());
         Expect::that(static fn() => $runLimited->text('other.txt', 'x'))->because('unsafe names symlinks and limits fail loudly')
-            ->toThrow(AttachmentError::class);
+            ->toThrow(
+                AttachmentError::class,
+                message: 'This run has reached the limit of 1 attachments.',
+            );
 
         $source = $this->tempDirectory->path() . '/target.txt';
         $link = $this->tempDirectory->path() . '/link.txt';
@@ -157,7 +172,211 @@ final readonly class AttachmentsTest
         $other = $store->forAttempt(new TestId('Example\EvidenceTest', 'symlink'), 1, new TestArtifactBudget());
 
         Expect::that(static fn() => $other->file('link.txt', $link))->because('unsafe names symlinks and limits fail loudly')
-            ->toThrow(AttachmentError::class);
+            ->toThrow(
+                AttachmentError::class,
+                message: \sprintf(
+                    'Attachment source "%s" Use a source path that is not a symbolic link.',
+                    $link,
+                ),
+            );
+
+        $store->cleanup();
+    }
+
+    #[Test]
+    public function aggregateByteLimitsReportExactValues(): void
+    {
+        $testRoot = $this->tempDirectory->subdirectory('test-byte-limit');
+        $testConfiguration = new ArtifactConfiguration(
+            $testRoot,
+            maxAttachmentsPerTest: 10,
+            maxAttachmentBytes: 10,
+            maxTestBytes: 4,
+            maxRunAttachments: 10,
+            maxRunBytes: 10,
+        );
+        $testStore = ArtifactStore::open($testConfiguration, $testRoot, 'run-test-limit');
+        $testAttachments = $testStore->forAttempt(
+            new TestId('Example\EvidenceTest', 'testByteLimit'),
+            1,
+            new TestArtifactBudget(),
+        );
+        $testAttachments->text('one.txt', '1234');
+
+        Expect::that(static fn() => $testAttachments->text('two.txt', 'x'))
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Attachments for this test exceed the limit of 4 bytes.',
+            );
+
+        $testStore->cleanup();
+
+        $runRoot = $this->tempDirectory->subdirectory('run-byte-limit');
+        $runConfiguration = new ArtifactConfiguration(
+            $runRoot,
+            maxAttachmentsPerTest: 10,
+            maxAttachmentBytes: 10,
+            maxTestBytes: 10,
+            maxRunAttachments: 10,
+            maxRunBytes: 4,
+        );
+        $runStore = ArtifactStore::open($runConfiguration, $runRoot, 'run-run-limit');
+        $runStore->forAttempt(
+            new TestId('Example\EvidenceTest', 'first'),
+            1,
+            new TestArtifactBudget(),
+        )->text('one.txt', '1234');
+        $runAttachments = $runStore->forAttempt(
+            new TestId('Example\EvidenceTest', 'second'),
+            1,
+            new TestArtifactBudget(),
+        );
+
+        Expect::that(static fn() => $runAttachments->text('two.txt', 'x'))
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Attachments for this run exceed the limit of 4 bytes.',
+            );
+
+        $runStore->cleanup();
+    }
+
+    #[Test]
+    public function rejectsAParentSegmentInARelativeOutputDirectoryExactly(): void
+    {
+        $workingDirectory = $this->tempDirectory->subdirectory('relative-output');
+
+        Expect::that(static fn(): ArtifactStore => ArtifactStore::open(
+            new ArtifactConfiguration('../outside'),
+            $workingDirectory,
+            'run-relative',
+        ))->toThrow(
+            AttachmentError::class,
+            message: 'Keep a relative attachment output directory inside the working directory.',
+        );
+    }
+
+    #[Test]
+    public function reportsAnExistingStagingPartExactly(): void
+    {
+        $root = $this->tempDirectory->subdirectory('existing-staging-part');
+        $staging = $root . '/staging';
+        $storageKey = 'Example-EvidenceTest/attempt-1/01-evidence.txt';
+        \mkdir(\dirname($staging . '/' . $storageKey), 0o777, true);
+        \file_put_contents($staging . '/' . $storageKey . '.part', 'occupied');
+
+        $configuration = new ArtifactConfiguration($root . '/published');
+        $store = ArtifactStore::fromSession(
+            new ArtifactSession($staging, $root . '/published/run-1'),
+            $configuration,
+        );
+
+        Expect::that(static fn() => $store->stageBytes(
+            'evidence',
+            'evidence.txt',
+            $storageKey,
+            'text/plain',
+            AttachmentKind::Text,
+            1,
+            AttachmentRetention::OnFailure,
+            $configuration,
+        ))->toThrow(
+            AttachmentError::class,
+            message: 'Greenlight did not create the attachment staging file.',
+        );
+    }
+
+    #[Test]
+    public function reportsMetadataAndAttemptRecordFailuresExactly(): void
+    {
+        $root = $this->tempDirectory->subdirectory('metadata-failures');
+        $staging = $root . '/staging';
+        \mkdir($staging);
+        $configuration = new ArtifactConfiguration($root . '/published');
+        $store = ArtifactStore::fromSession(
+            new ArtifactSession($staging, $root . '/published/run-1'),
+            $configuration,
+        );
+
+        Expect::that(static fn() => $store->stageBytes(
+            'evidence',
+            'evidence.txt',
+            \str_repeat('a', 250),
+            'text/plain',
+            AttachmentKind::Text,
+            1,
+            AttachmentRetention::OnFailure,
+            $configuration,
+        ))->toThrow(
+            AttachmentError::class,
+            message: 'Greenlight did not write attachment recovery metadata.',
+        );
+
+        $id = new TestId('Example\EvidenceTest', 'attemptRecord');
+        $testDirectory = $staging . '/' . ArtifactStore::testDirectory($id);
+        \mkdir($testDirectory, 0o777, true);
+        \mkdir($testDirectory . '/.attempt');
+
+        Expect::that(static fn() => $store->recordAttempt($id, 2))
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Greenlight did not finalize the current test attempt record.',
+            );
+    }
+
+    #[Test]
+    public function reportsAnAttachmentCleanupFailureExactly(): void
+    {
+        $root = $this->tempDirectory->subdirectory('cleanup-failure');
+        $staging = $root . '/staging';
+        $storageKey = 'test/attempt-1/01-evidence.txt';
+        \mkdir($staging . '/' . $storageKey . '.meta.json', 0o777, true);
+        $store = ArtifactStore::fromSession(
+            new ArtifactSession($staging, $root . '/published/run-1'),
+            new ArtifactConfiguration($root . '/published'),
+        );
+        $attachment = new StagedAttachment(
+            'evidence.txt',
+            AttachmentKind::Text,
+            'text/plain',
+            1,
+            \hash('sha256', 'x'),
+            1,
+            $root . '/published/run-1/' . $storageKey,
+            AttachmentRetention::OnFailure,
+            $storageKey,
+        );
+
+        Expect::that(static fn() => $store->discard($attachment))
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Greenlight did not remove attachment recovery metadata.',
+            );
+    }
+
+    #[Test]
+    public function reportsAnExistingAttachmentOutputExactly(): void
+    {
+        $root = $this->tempDirectory->subdirectory('existing-output');
+        $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-output');
+        $id = new TestId('Example\EvidenceTest', 'fails');
+        $attachments = $store->forAttempt($id, 1, new TestArtifactBudget());
+        $attachments->text('evidence.txt', 'evidence');
+        $staged = $attachments->seal()[0];
+        $destination = $store->publicDirectory() . '/' . $staged->storageKey;
+        \mkdir(\dirname($destination), 0o777, true);
+        \file_put_contents($destination, 'occupied');
+
+        Expect::that(static fn(): TestResult => $store->publish(new TestResult(
+            $id,
+            Outcome::Failed,
+            0.1,
+            0,
+            attachments: [$staged],
+        )))->toThrow(
+            AttachmentError::class,
+            message: 'An attachment output path already exists.',
+        );
 
         $store->cleanup();
     }

--- a/tests/Unit/Coverage/DriverSelectorTest.php
+++ b/tests/Unit/Coverage/DriverSelectorTest.php
@@ -19,7 +19,7 @@ final class DriverSelectorTest
         $selection = new DriverSelector([])->select();
 
         Expect::that($selection->driver)->because('empty candidate list yields no driver and a reason')->toBeNull()
-            ->and($selection->reason)->toBe('No coverage driver is available: no drivers are configured.');
+            ->and($selection->reason)->toBe('No coverage driver is configured.');
     }
 
     #[Test]
@@ -37,7 +37,10 @@ final class DriverSelectorTest
         $selection = new DriverSelector([UnavailableFakeDriver::class])->select();
 
         Expect::that($selection->driver)->because('no available candidate yields no driver and a named reason')->toBeNull()
-            ->and($selection->reason)->toBe('No coverage driver is available: tried UnavailableFakeDriver. Install pcov, or enable xdebug with "coverage" in xdebug.mode or the XDEBUG_MODE environment variable.');
+            ->and($selection->reason)->toBe(
+                'No coverage driver is available. Greenlight tried UnavailableFakeDriver. Install pcov or enable Xdebug coverage mode. '
+                . 'Set xdebug.mode to "coverage", or set the XDEBUG_MODE environment variable.',
+            );
     }
 
     #[Test]

--- a/tests/Unit/Coverage/FileCoverageTest.php
+++ b/tests/Unit/Coverage/FileCoverageTest.php
@@ -70,6 +70,9 @@ final class FileCoverageTest
     public function nonPositiveLineNumbersAreRejected(): void
     {
         Expect::that(static fn(): FileCoverage => new FileCoverage('/src/A.php', [0], []))->because('nonpositive line numbers are rejected')
-            ->toThrow(\InvalidArgumentException::class, '/must be positive/');
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Use positive coverage line numbers. Actual value: 0.',
+            );
     }
 }

--- a/tests/Unit/Coverage/JsonExporterTest.php
+++ b/tests/Unit/Coverage/JsonExporterTest.php
@@ -67,8 +67,36 @@ final class JsonExporterTest
         Expect::that(static fn(): CoverageMap => JsonExporter::import('not json'))->because('import rejects malformed documents')
             ->toThrow(CoverageError::class)
             ->and(static fn(): CoverageMap => JsonExporter::import('{"v":2,"files":{}}'))
-            ->toThrow(CoverageError::class, '/schema version/')
-            ->and(static fn(): CoverageMap => JsonExporter::import('{"v":1,"files":{"/a.php":{"covered":["x"],"uncovered":[]}}}'))
-            ->toThrow(CoverageError::class, '/positive integers/');
+            ->toThrow(CoverageError::class, '/schema version/');
+    }
+
+    #[Test]
+    public function importReportsEachInvalidDocumentShapeExactly(): void
+    {
+        Expect::that(static fn(): CoverageMap => JsonExporter::import('"invalid"'))
+            ->toThrow(
+                CoverageError::class,
+                message: 'Coverage JSON document is invalid: use an object at the top level.',
+            )
+            ->and(static fn(): CoverageMap => JsonExporter::import('{"v":1,"files":"invalid"}'))
+            ->toThrow(
+                CoverageError::class,
+                message: 'Coverage JSON document is invalid: use an object for "files".',
+            )
+            ->and(static fn(): CoverageMap => JsonExporter::import('{"v":1,"files":{"":{}}}'))
+            ->toThrow(
+                CoverageError::class,
+                message: 'Coverage JSON document is invalid: map each file path in "files" to an object.',
+            )
+            ->and(static fn(): CoverageMap => JsonExporter::import('{"v":1,"files":{"/a.php":{"covered":{"line":1},"uncovered":[]}}}'))
+            ->toThrow(
+                CoverageError::class,
+                message: 'Coverage JSON document is invalid: use a list of line numbers for "covered" in file "/a.php".',
+            )
+            ->and(static fn(): CoverageMap => JsonExporter::import('{"v":1,"files":{"/a.php":{"covered":[0],"uncovered":[]}}}'))
+            ->toThrow(
+                CoverageError::class,
+                message: 'Coverage JSON document is invalid: use only positive integers in "covered" for file "/a.php".',
+            );
     }
 }

--- a/tests/Unit/Coverage/PathFilterTest.php
+++ b/tests/Unit/Coverage/PathFilterTest.php
@@ -39,6 +39,9 @@ final class PathFilterTest
     public function emptyDirectoryEntriesAreRejected(): void
     {
         Expect::that(static fn(): PathFilter => new PathFilter(['']))->because('empty directory entries are rejected')
-            ->toThrow(\InvalidArgumentException::class, '/non-empty paths/');
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Use nonempty paths for coverage include directories.',
+            );
     }
 }

--- a/tests/Unit/Coverage/PcovDriverTest.php
+++ b/tests/Unit/Coverage/PcovDriverTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\Driver\PcovDriver;
+use Greenlight\Expect\Expect;
+
+final class PcovDriverTest
+{
+    #[Test]
+    public function reportsInvalidCollectionStateExactly(): void
+    {
+        $driver = new \ReflectionClass(PcovDriver::class)->newInstanceWithoutConstructor();
+
+        Expect::that(static fn(): mixed => $driver->stop())
+            ->toThrow(
+                \LogicException::class,
+                message: 'The pcov collection window is not open. Call start() before stop().',
+            );
+
+        $collecting = new \ReflectionProperty(PcovDriver::class, 'collecting');
+        $collecting->setValue($driver, true);
+
+        Expect::that(static fn() => $driver->start())
+            ->toThrow(
+                \LogicException::class,
+                message: 'The pcov collection window is already open. Call stop() before start().',
+            );
+    }
+}

--- a/tests/Unit/Coverage/XdebugDriverTest.php
+++ b/tests/Unit/Coverage/XdebugDriverTest.php
@@ -15,6 +15,27 @@ use Greenlight\Tests\Fixture\Coverage\Adder;
 final class XdebugDriverTest
 {
     #[Test]
+    public function reportsInvalidCollectionStateExactly(): void
+    {
+        $driver = new \ReflectionClass(XdebugDriver::class)->newInstanceWithoutConstructor();
+
+        Expect::that(static fn(): mixed => $driver->stop())
+            ->toThrow(
+                \LogicException::class,
+                message: 'The Xdebug collection window is not open. Call start() before stop().',
+            );
+
+        $collecting = new \ReflectionProperty(XdebugDriver::class, 'collecting');
+        $collecting->setValue($driver, true);
+
+        Expect::that(static fn() => $driver->start())
+            ->toThrow(
+                \LogicException::class,
+                message: 'The Xdebug collection window is already open. Call stop() before start().',
+            );
+    }
+
+    #[Test]
     public function collectsRealLineCoverageOverTheFixture(): void
     {
         if (!XdebugDriver::isAvailable()) {

--- a/tests/Unit/Plugin/PluginTest.php
+++ b/tests/Unit/Plugin/PluginTest.php
@@ -67,7 +67,7 @@ final class PluginTest
         [, $results] = $this->runSuite('Lifecycle/Order', [$rogue]);
 
         Expect::that($results[0]->outcome)->because('unattributed outcome changes error the test naming the plugin')->toBe(Outcome::Errored)
-            ->and($results[0]->error?->message)->toContain('without withOutcome() provenance');
+            ->and($results[0]->error?->message)->toContain('without a new transformation-log entry from withOutcome()');
     }
 
     #[Test]
@@ -90,7 +90,7 @@ final class PluginTest
         [, $results] = $this->runSuite('Lifecycle/Order', [$broken]);
 
         Expect::that($results[0]->outcome)->because('throwing before test errors the test naming the plugin')->toBe(Outcome::Errored)
-            ->and($results[0]->error?->message)->toContain('failed in beforeTest')
+            ->and($results[0]->error?->message)->toContain('caused an error during beforeTest()')
             ->toContain('plugin exploded');
     }
 
@@ -118,7 +118,7 @@ final class PluginTest
 
         // The passed test becomes an error that names the plugin.
         Expect::that($byMethod['passes']->outcome)->because('throwing after test keeps the outcome and records the plugin failure')->toBe(Outcome::Errored)
-            ->and($byMethod['passes']->error?->message)->toContain('failed in afterTest')
+            ->and($byMethod['passes']->error?->message)->toContain('caused an error during afterTest()')
             ->toContain('plugin exploded');
 
         // The test keeps its original error. Greenlight records the plugin
@@ -126,7 +126,7 @@ final class PluginTest
         $errored = $byMethod['explodes'];
         Expect::that($errored->outcome)->because('throwing after test keeps the outcome and records the plugin failure')->toBe(Outcome::Errored)
             ->and($errored->error?->message)->toContain('intentional boom')
-            ->and($errored->failures[0]->message ?? '')->toContain('failed in afterTest')
+            ->and($errored->failures[0]->message ?? '')->toContain('caused an error during afterTest()')
             ->toContain('plugin exploded');
     }
 

--- a/tests/Unit/Reporting/JsonLinesReporterTest.php
+++ b/tests/Unit/Reporting/JsonLinesReporterTest.php
@@ -109,6 +109,12 @@ final class JsonLinesReporterTest
         };
 
         Expect::that(static fn() => $reporter->onEvent($event))->because('an unmapped event is rejected')
-            ->toThrow(ReportingError::class, '/no stable tag/');
+            ->toThrow(
+                ReportingError::class,
+                message: \sprintf(
+                    'Event "%s" has no stable tag. Add the event to the tag map before Greenlight writes it.',
+                    $event::class,
+                ),
+            );
     }
 }

--- a/tests/Unit/Reporting/ReportingErrorTest.php
+++ b/tests/Unit/Reporting/ReportingErrorTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\ReportingError;
+
+final class ReportingErrorTest
+{
+    #[Test]
+    public function reportsWriteFailureExactly(): void
+    {
+        Expect::that(ReportingError::writeFailed()->getMessage())
+            ->toBe('Greenlight did not write reporter output to the stream.');
+    }
+
+    #[Test]
+    public function reportsAnUnmappedEventExactly(): void
+    {
+        Expect::that(ReportingError::unmappedEvent(self::class)->getMessage())
+            ->toBe(\sprintf(
+                'Event "%s" has no stable tag. Add the event to the tag map before Greenlight writes it.',
+                self::class,
+            ));
+    }
+}

--- a/tests/Unit/Reporting/SummaryFormatTest.php
+++ b/tests/Unit/Reporting/SummaryFormatTest.php
@@ -79,7 +79,7 @@ final class SummaryFormatTest
         ], new Style(ansi: false));
 
         Expect::that($block)->because('leaks list every test under one header')->toBe(
-            "\nLeaks (the test instance survived its test):\n"
+            "\nTest instance leaks:\n"
             . "  App\AlphaTest::one\n"
             . "  App\BetaTest::two\n",
         );
@@ -90,7 +90,7 @@ final class SummaryFormatTest
     {
         $block = SummaryFormat::leaks([new TestId('App\AlphaTest', 'one')], new Style(ansi: true));
 
-        Expect::that($block)->because('leaks color the header red and nothing without leaks')->toContain("\x1b[31mLeaks (the test instance survived its test):\x1b[0m")
+        Expect::that($block)->because('leaks color the header red and nothing without leaks')->toContain("\x1b[31mTest instance leaks:\x1b[0m")
             ->and(SummaryFormat::leaks([], new Style(ansi: true)))->toBe('');
     }
 

--- a/tests/Unit/Runner/Orchestrator/OrchestratorTest.php
+++ b/tests/Unit/Runner/Orchestrator/OrchestratorTest.php
@@ -34,7 +34,7 @@ final class OrchestratorTest
         );
 
         Expect::that(fn(): ResultSummary => $orchestrator->run($this->plan(), new CollectingEventSink(), 1))->because('a spawned worker that never connects fails the run instead of hanging it')
-            ->toThrow(ProtocolError::class, '/never connected within 0\.5s/');
+            ->toThrow(ProtocolError::class, '/did not connect within 0\.5 seconds/');
     }
 
     #[Test]
@@ -61,7 +61,7 @@ final class OrchestratorTest
         );
 
         Expect::that(fn(): ResultSummary => $orchestrator->run($this->plan(), new CollectingEventSink(), 1))->because('a connected worker that goes silent before starting its assignment fails the run')
-            ->toThrow(ProtocolError::class, '/sent nothing for 0\.5s/');
+            ->toThrow(ProtocolError::class, '/sent no message for 0\.5 seconds/');
     }
 
     #[Test]
@@ -116,7 +116,7 @@ final class OrchestratorTest
         );
 
         Expect::that(fn(): ResultSummary => $orchestrator->run($this->plan(), new CollectingEventSink(), 1))->because('a recycling worker with a mismatched summary fails the run')
-            ->toThrow(ProtocolError::class, '/reported a summary .* but its event stream tallies/');
+            ->toThrow(ProtocolError::class, '/reported a summary .* but its event stream totals/');
     }
 
     #[Test]

--- a/tests/Unit/Runner/WorkerTest.php
+++ b/tests/Unit/Runner/WorkerTest.php
@@ -101,7 +101,7 @@ final class WorkerTest
         [, $results] = $this->runFixture('SlowTimeout');
 
         Expect::that($results[0]->outcome)->because('timeout fails a slow test after the fact')->toBe(Outcome::Failed)
-            ->and($results[0]->failures[0]->message)->toContain('Timed out');
+            ->and($results[0]->failures[0]->message)->toContain('configured time limit');
     }
 
     #[Test]

--- a/tests/Unit/Symfony/SymfonyPluginTest.php
+++ b/tests/Unit/Symfony/SymfonyPluginTest.php
@@ -78,7 +78,7 @@ final class SymfonyPluginTest
 
         Expect::that(static function () use ($plugin): void {
             $plugin->resolve(Greeter::class, [new Service('fixture.missing')]);
-        })->because('an unknown explicit ID fails loudly')->toThrow(SymfonyBridgeError::class, matching: '/no service "fixture\.missing".*Check the id for typos/s');
+        })->because('an unknown explicit ID fails loudly')->toThrow(SymfonyBridgeError::class, matching: '/no service "fixture\.missing".*Check the service ID/s');
     }
 
     #[Test]
@@ -88,7 +88,7 @@ final class SymfonyPluginTest
 
         Expect::that(static function () use ($plugin): void {
             $plugin->resolve(VisitCounter::class, [new Service('fixture.named_greeter')]);
-        })->because('an explicit ID of the wrong type fails loudly')->toThrow(SymfonyBridgeError::class, matching: '/is an instance of .* but the parameter declares/');
+        })->because('an explicit ID of the wrong type fails loudly')->toThrow(SymfonyBridgeError::class, matching: '/has type .* The parameter requires type/');
     }
 
     #[Test]

--- a/tests/Unit/Tools/RuntimeMessageTest.php
+++ b/tests/Unit/Tools/RuntimeMessageTest.php
@@ -1,0 +1,269 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Tools;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\Subprocess;
+
+final readonly class RuntimeMessageTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function coverageGateReportsAMissingExportExactly(): void
+    {
+        [$root, $script] = $this->toolSandbox('coverage-missing', 'coverage-gate.php');
+        $summary = $root . '/summary.md';
+        $result = Subprocess::run(
+            $root,
+            [\PHP_BINARY, $script],
+            ['GITHUB_STEP_SUMMARY' => $summary],
+        );
+
+        Expect::that($result->exitCode)->toBe(1)
+            ->and($result->stderr)->toContain(
+                \sprintf(
+                    'Coverage export not found at %s/build/coverage/coverage.json. Run `composer tests:coverage` first.',
+                    (string) \realpath($root),
+                ),
+            )
+            ->and((string) \file_get_contents($summary))->toBe(
+                "## Code coverage\n\n"
+                . "**Coverage unavailable.** The coverage run did not produce an export.\n\n",
+            );
+    }
+
+    #[Test]
+    public function coverageGateReportsASummaryWriteFailureExactly(): void
+    {
+        [$root, $script] = $this->toolSandbox('coverage-summary-write', 'coverage-gate.php');
+        $summaryDirectory = $this->tempDirectory->subdirectory('coverage-summary-write/summary');
+        $result = Subprocess::run(
+            $root,
+            [\PHP_BINARY, $script],
+            ['GITHUB_STEP_SUMMARY' => $summaryDirectory],
+        );
+
+        Expect::that($result->exitCode)->toBe(1)
+            ->and($result->stderr)->toContain(
+                'Warning: Greenlight did not write the GitHub Actions job summary.',
+            );
+    }
+
+    #[Test]
+    public function phpStanExtractionReportsMissingAndExtractedSourcesExactly(): void
+    {
+        [$missingRoot, $missingScript] = $this->toolSandbox('phpstan-missing', 'extract-phpstan-api.php');
+        $missing = Subprocess::run($missingRoot, [\PHP_BINARY, $missingScript]);
+
+        Expect::that($missing->exitCode)->toBe(0)
+            ->and($missing->stdout)->toBe(
+                'The tool cannot extract the PHPStan API stubs because phpstan.phar is not installed.',
+            );
+
+        [$successRoot, $successScript] = $this->toolSandbox('phpstan-success', 'extract-phpstan-api.php');
+        $pharPath = $successRoot . '/vendor/phpstan/phpstan/phpstan.phar';
+        \mkdir(\dirname($pharPath), 0o777, true);
+        $builder = Subprocess::run(
+            $successRoot,
+            [
+                \PHP_BINARY,
+                '-d',
+                'phar.readonly=0',
+                '-r',
+                <<<'PHP'
+                $phar = new Phar($argv[1]);
+                $phar->startBuffering();
+                $phar->addFromString('src/Fixture.php', "<?php\n");
+                $phar->setStub("<?php __HALT_COMPILER();");
+                $phar->stopBuffering();
+                PHP,
+                $pharPath,
+            ],
+        );
+
+        Expect::that($builder->exitCode)->toBe(0);
+
+        $success = Subprocess::run($successRoot, [\PHP_BINARY, $successScript]);
+        $target = \realpath($successRoot) . '/.phpstan-api-stubs';
+
+        Expect::that($success->exitCode)->toBe(0)
+            ->and($success->stdout)->toBe(
+                \sprintf(
+                    'Greenlight extracted the PHPStan API sources to %s. Editors can index these sources.',
+                    $target,
+                ),
+            )
+            ->and(\is_file($target . '/src/Fixture.php'))->toBeTrue();
+    }
+
+    #[Test]
+    public function proseCheckReportsTheNewExactDiagnostics(): void
+    {
+        $root = $this->tempDirectory->subdirectory('prose-check/project');
+        $baseline = $this->tempDirectory->path() . '/prose-check/baseline';
+        \file_put_contents(
+            $root . '/sample.md',
+            "# Sample\n\n"
+            . "The orchestrator collects every selected test class from the configured directories and sends one complete assignment "
+            . "to each available worker before the test run starts in parallel.\n",
+        );
+        $script = $this->repositoryRoot() . '/tools/prose-check.php';
+        $sentence = Subprocess::run($root, [
+            \PHP_BINARY,
+            $script,
+            'check',
+            '--root=' . $root,
+            '--baseline-dir=' . $baseline,
+        ]);
+
+        Expect::that($sentence->exitCode)->toBe(1)
+            ->and($sentence->stdout)->toContain(
+                'sample.md:3: sentence-length: Write no more than 25 words in a descriptive sentence. Found 27 words. [new finding]',
+            );
+
+        \file_put_contents($root . '/sample.md', "# Sample\n\nThe worker stops.\n");
+        \mkdir($baseline);
+        \file_put_contents($baseline . '/root.json', '"invalid"');
+        $invalidBaseline = Subprocess::run($root, [
+            \PHP_BINARY,
+            $script,
+            'check',
+            '--root=' . $root,
+            '--baseline-dir=' . $baseline,
+        ]);
+
+        Expect::that($invalidBaseline->exitCode)->toBe(1)
+            ->and($invalidBaseline->stderr)->toContain(
+                \sprintf('Use an array in baseline file "%s/root.json".', $baseline),
+            );
+    }
+
+    #[Test]
+    public function memoryGateReportsMissingSamplesAndTheFinalMeasurementsExactly(): void
+    {
+        [$missingRoot, $missingScript] = $this->toolSandbox('memory-missing', 'memory-gate.php');
+        $missing = Subprocess::run($missingRoot, [\PHP_BINARY, $missingScript]);
+
+        Expect::that($missing->exitCode)->toBe(1)
+            ->and($missing->stderr)->toContain(
+                'The memory probe wrote no samples. The run did not reach the sample points.',
+            );
+
+        [$successRoot, $successScript] = $this->toolSandbox('memory-success', 'memory-gate.php');
+        $binDirectory = $this->tempDirectory->subdirectory('memory-success/bin');
+        \file_put_contents(
+            $binDirectory . '/greenlight',
+            <<<'PHP'
+            <?php
+
+            $configuration = (string) file_get_contents(getcwd() . '/greenlight.php');
+            preg_match("~MemoryProbe\\('([^']+)'~", $configuration, $matches);
+            file_put_contents(
+                $matches[1],
+                json_encode(['2000' => 1_048_576, '10000' => 1_572_864]),
+            );
+            echo "Synthetic memory probe completed.\n";
+            PHP,
+        );
+
+        $success = Subprocess::run($successRoot, [\PHP_BINARY, $successScript]);
+
+        Expect::that($success->exitCode)->toBe(0)
+            ->and($success->stdout)->toContain(
+                'Memory after 2000 tests: 1.00 MiB. Memory after 10000 tests: 1.50 MiB. '
+                . 'Drift: +524288 bytes. Limit: 1048576 bytes.',
+            );
+    }
+
+    #[Test]
+    public function memoryGateReportsDirectoryCreationFailureExactly(): void
+    {
+        [$root, $script] = $this->toolSandbox('memory-directory', 'memory-gate.php');
+        $blockedTemp = $root . '/not-a-directory';
+        \file_put_contents($blockedTemp, 'blocked');
+        $result = Subprocess::run($root, [
+            \PHP_BINARY,
+            '-d',
+            'sys_temp_dir=' . $blockedTemp,
+            $script,
+        ]);
+
+        Expect::that($result->exitCode)->toBe(255)
+            ->and($result->stderr)->toContain('Greenlight did not create directory "')
+            ->toContain('/suite".');
+    }
+
+    #[Test]
+    public function benchmarkReportsDirectoryAndComposerFailuresExactly(): void
+    {
+        [$blockedRoot, $blockedScript] = $this->toolSandbox('benchmark-directory', 'benchmark.php');
+        $blockedTemp = $blockedRoot . '/not-a-directory';
+        \file_put_contents($blockedTemp, 'blocked');
+        $directoryFailure = Subprocess::run($blockedRoot, [
+            \PHP_BINARY,
+            '-d',
+            'sys_temp_dir=' . $blockedTemp,
+            $blockedScript,
+            '--shape=many-fast',
+            '--scale=1',
+            '--runs=1',
+        ]);
+
+        Expect::that($directoryFailure->exitCode)->toBe(1)
+            ->and($directoryFailure->stderr)->toContain(
+                'Greenlight did not create the benchmark project directory.',
+            );
+
+        $fakeBin = $this->tempDirectory->subdirectory('benchmark-composer/bin');
+        \file_put_contents(
+            $fakeBin . '/composer',
+            "#!/bin/sh\nprintf 'fixture composer failure\\n'\nexit 12\n",
+        );
+        \chmod($fakeBin . '/composer', 0o700);
+        $benchmarkTemp = $this->tempDirectory->subdirectory('benchmark-composer/temp');
+        $path = \getenv('PATH');
+        $composerFailure = Subprocess::run(
+            $this->repositoryRoot(),
+            [
+                \PHP_BINARY,
+                '-d',
+                'sys_temp_dir=' . $benchmarkTemp,
+                $this->repositoryRoot() . '/tools/benchmark.php',
+                '--shape=giant-dataset',
+                '--scale=1',
+                '--workers=1',
+                '--runs=1',
+                '--with-phpunit',
+            ],
+            ['PATH' => $fakeBin . \PATH_SEPARATOR . (\is_string($path) ? $path : '')],
+        );
+
+        Expect::that($composerFailure->exitCode)->toBe(1)
+            ->and($composerFailure->stderr)->toContain(
+                "Composer did not install PHPUnit and ParaTest:\nfixture composer failure",
+            );
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function toolSandbox(string $name, string $tool): array
+    {
+        $root = $this->tempDirectory->subdirectory($name);
+        $tools = $this->tempDirectory->subdirectory($name . '/tools');
+        $script = $tools . '/' . $tool;
+        \copy($this->repositoryRoot() . '/tools/' . $tool, $script);
+
+        return [$root, $script];
+    }
+
+    private function repositoryRoot(): string
+    {
+        return \dirname(__DIR__, 3);
+    }
+}

--- a/tools/benchmark.php
+++ b/tools/benchmark.php
@@ -136,7 +136,7 @@ function median(array $samples): float
 function generateShape(string $shape, int $scale, string $project): int
 {
     if (!\mkdir($project . '/tests/gl', 0o777, true) || !\mkdir($project . '/tests/pu', 0o777, true)) {
-        \fwrite(\STDERR, "Could not create the benchmark project directory.\n");
+        \fwrite(\STDERR, "Greenlight did not create the benchmark project directory.\n");
         exit(1);
     }
 
@@ -333,7 +333,7 @@ function install(string $project): void
     ), $output, $exit);
 
     if ($exit !== 0) {
-        \fwrite(\STDERR, "composer install of phpunit/paratest failed:\n" . \implode("\n", $output) . "\n");
+        \fwrite(\STDERR, "Composer did not install PHPUnit and ParaTest:\n" . \implode("\n", $output) . "\n");
         exit(1);
     }
 }

--- a/tools/coverage-gate.php
+++ b/tools/coverage-gate.php
@@ -16,7 +16,7 @@ $summaryFile = \getenv('GITHUB_STEP_SUMMARY');
 $summaryFile = \is_string($summaryFile) && $summaryFile !== '' ? $summaryFile : null;
 
 if (!\is_file($exportFile)) {
-    \appendGithubSummary($summaryFile, \unavailableSummary('The coverage export was not produced.'));
+    \appendGithubSummary($summaryFile, \unavailableSummary('The coverage run did not produce an export.'));
     \fwrite(\STDERR, \sprintf(
         "Coverage export not found at %s. Run `composer tests:coverage` first.\n",
         $exportFile,
@@ -226,6 +226,6 @@ function appendGithubSummary(?string $summaryFile, string $summary): void
     }
 
     if (@\file_put_contents($summaryFile, $summary, \FILE_APPEND | \LOCK_EX) === false) {
-        \fwrite(\STDERR, "Warning: Could not write the GitHub Actions job summary.\n");
+        \fwrite(\STDERR, "Warning: Greenlight did not write the GitHub Actions job summary.\n");
     }
 }

--- a/tools/extract-phpstan-api.php
+++ b/tools/extract-phpstan-api.php
@@ -14,7 +14,7 @@ $pharPath = $root . '/vendor/phpstan/phpstan/phpstan.phar';
 $target = $root . '/.phpstan-api-stubs';
 
 if (!\is_file($pharPath)) {
-    echo "phpstan.phar is not installed; skipping the PHPStan API stub extraction.\n";
+    echo "The tool cannot extract the PHPStan API stubs because phpstan.phar is not installed.\n";
     exit(0);
 }
 
@@ -26,5 +26,5 @@ if (\is_dir($target)) {
 $phar = new Phar($pharPath);
 $phar->extractTo($target, 'src/', true);
 
-echo \sprintf("Extracted the PHPStan API sources to %s for IDE indexing.\n", $target);
+echo \sprintf("Greenlight extracted the PHPStan API sources to %s. Editors can index these sources.\n", $target);
 exit(0);

--- a/tools/memory-gate.php
+++ b/tools/memory-gate.php
@@ -24,7 +24,7 @@ $suiteDir = $workDir . '/suite';
 $samplesFile = $workDir . '/samples.json';
 
 if (!\mkdir($suiteDir, 0o777, true) && !\is_dir($suiteDir)) {
-    throw new RuntimeException(\sprintf('Directory "%s" was not created', $suiteDir));
+    throw new RuntimeException(\sprintf('Greenlight did not create directory "%s".', $suiteDir));
 }
 
 $totalTests = CLASS_COUNT * METHODS_PER_CLASS * ROWS_PER_METHOD;
@@ -172,7 +172,7 @@ $cleanup = static function () use ($workDir): void {
 $samplesJson = \is_file($samplesFile) ? \file_get_contents($samplesFile) : false;
 
 if ($samplesJson === false) {
-    \fwrite(\STDERR, "The memory probe wrote no samples; the run did not reach the sampling points.\n");
+    \fwrite(\STDERR, "The memory probe wrote no samples. The run did not reach the sample points.\n");
     $cleanup();
     exit(1);
 }
@@ -197,7 +197,7 @@ if ($baseline === null || $final === null) {
 $drift = $final - $baseline;
 
 echo \sprintf(
-    "Memory after %d tests: %.2f MiB; after %d tests: %.2f MiB; drift: %+d bytes (limit %d).\n",
+    "Memory after %d tests: %.2f MiB. Memory after %d tests: %.2f MiB. Drift: %+d bytes. Limit: %d bytes.\n",
     WARMUP_TESTS,
     $baseline / 1_048_576,
     $totalTests,

--- a/tools/prose-check.php
+++ b/tools/prose-check.php
@@ -617,7 +617,7 @@ function proseAnalyze(array $passage): array
             $add(
                 'sentence-length',
                 'blocking',
-                \sprintf('Write no more than 25 words in a descriptive sentence; found %d.', $wordCount),
+                \sprintf('Write no more than 25 words in a descriptive sentence. Found %d words.', $wordCount),
             );
         }
 
@@ -958,7 +958,7 @@ function proseReadBaseline(string $directory): array
         $values = \json_decode($contents, true, flags: \JSON_THROW_ON_ERROR);
 
         if (!\is_array($values)) {
-            \proseFail(\sprintf('Baseline file "%s" must contain an array.', $file));
+            \proseFail(\sprintf('Use an array in baseline file "%s".', $file));
         }
 
         foreach ($values as $value) {


### PR DESCRIPTION
## Summary

- Simplify human-readable runner, reporting, coverage, artifact, Symfony, and tool output.
- Add exact-output tests for rewritten diagnostics, including deterministic artifact failure paths.
- Retain original wording for nondeterministic filesystem and stream failures that cannot have stable exact-output tests.

Human-readable wording changes are intentional. Status tokens, JSON and JSONL fields, CI protocol syntax, schema versions, paths, flags, and other machine contracts do not change.

## Continuation record

- Base commit: `4d9b7d5b0c4ff48d8ba47d1f9082a3834fe141d7`
- Result commit: `eb961af0feb006b12adb0b14c05f192fe80880aa`
- Owned paths: `src/Coverage/**`, `src/Reporting/**`, `src/Runner/**`, `src/Symfony/**`, `tools/**`, and their focused assertions
- Blocking prose findings: 0 before, 0 after
- Advisory review: no new or removed advisory candidates; remaining repository advisories stay for the final audit
- Terminology: preserves protocol tokens and uses `worker`, `execution plan`, `time limit`, `attachment`, `artifact`, and `coverage` consistently
- Checks run: `composer prose:check`; `composer prose:review`; focused runner and output checks; `composer static-analysis`; `composer tests` (875 tests, 874 passed, one expected Xdebug skip); `git diff --check`
- Next unclaimed shard: final repository audit after the three runtime-message PRs merge
