### PR TITLE
chore: complete simplified technical English enforcement

### DIFF
--- a/docs/architecture/artifacts.md
+++ b/docs/architecture/artifacts.md
@@ -50,8 +50,8 @@ partial copies, which have no complete sidecar, during cleanup.
 
 After a test has staged evidence, a small marker records later retry attempts.
 Thus, a synthetic crash result has the correct attempt count. This also applies
-when the crashing attempt adds no attachment. Recovery accepts only storage
-keys that resolve inside the staging directory.
+when a worker crashes during an attempt that has no attachment. Recovery accepts
+only storage keys that resolve inside the staging directory.
 
 ## Limits
 

--- a/docs/architecture/compatibility.md
+++ b/docs/architecture/compatibility.md
@@ -43,8 +43,8 @@ Integrations **SHOULD** use exit codes or machine-readable reporters. They
 The envelope version selects the complete line schema. Within one JSONL
 version:
 
-- Existing event tags, required keys, value types, enum values, and meanings
-  stay fixed.
+- The schema keeps event tags, required keys, value types, enum values, and
+  meanings fixed.
 - Greenlight **MAY** add optional payload keys. Consumers **MUST** ignore
   unknown keys.
 - Field order is not significant.
@@ -79,9 +79,9 @@ Coverage JSON version 1 **MAY** receive optional top-level or per-file fields.
 Readers **MUST** ignore unknown keys. They **MUST** calculate derived totals
 from `covered` and `uncovered`.
 
-A change to path semantics or line-status meaning requires a new version. A
-change to required fields or existing field types also requires a new version.
-For example, v1 cannot change from absolute paths to project-relative paths.
+A change to path semantics or a line-status definition requires a new version.
+A change to a required field or a field type also requires a new version. For
+example, v1 cannot change from absolute paths to project-relative paths.
 
 ## Paths and portability
 

--- a/docs/architecture/conventions.md
+++ b/docs/architecture/conventions.md
@@ -23,6 +23,8 @@ are not in the controlled vocabulary.
 Uppercase normative tokens are an approved exception to the controlled
 vocabulary.
 
+Code identifiers **MUST** use American English spelling.
+
 ## Exceptions
 
 Modules **SHOULD** expose one exception class at each caller seam.

--- a/docs/architecture/coverage-json.md
+++ b/docs/architecture/coverage-json.md
@@ -131,14 +131,14 @@ Therefore, a percentage edit cannot change the imported coverage.
 
 The file uses UTF-8 JSON, unescaped slashes, and a newline at its end.
 
-## Versioning
+## Versions
 
 Version `1` **MAY** receive additive fields.
 
 Readers **MUST** ignore unknown keys.
 
-Each change to the meaning or shape of an existing field **MUST** use a new
-`v` value.
+If version 1 defines a field, a change to its definition or shape **MUST** use a
+new `v` value.
 
 Greenlight **MAY** add per-test coverage maps later as an optional extension.
 This extension **MUST** use an additive key and separate documentation.

--- a/docs/architecture/jsonl.md
+++ b/docs/architecture/jsonl.md
@@ -40,7 +40,7 @@ Output uses UTF-8 JSON. Greenlight cleans captured strings that contain invalid
 UTF-8 before they reach the reporter. The encoder replaces invalid sequences
 that remain.
 
-## Versioning
+## Versions
 
 The `v` field identifies the schema version.
 
@@ -50,8 +50,7 @@ cannot parse.
 
 Greenlight **MAY** add optional payload keys within a version. Consumers
 **MUST** ignore unknown keys. New required keys, event tags, or enum values
-require a new version. Changes to existing types and meanings also require a
-new version.
+require a new version. When a type or its definition changes, use a new version.
 
 [Compatibility](compatibility.md) defines the complete policy, order
 guarantees, and incomplete-output behavior.

--- a/docs/architecture/technical-writing.md
+++ b/docs/architecture/technical-writing.md
@@ -75,9 +75,9 @@ Do not rewrite these items only to comply with this policy:
 Rewrite the technical prose around these items. A human-readable string remains
 in scope when its source representation is a PHP string.
 
-Do not rename a public identifier to change its spelling. For example, preserve
-an existing identifier that contains `colour`. Use `color` in the related
-prose.
+The checker excludes code identifiers. Use American English spelling in all
+repository-owned identifiers. Update each reference when you correct an
+identifier.
 
 ## Technical-term register
 
@@ -133,6 +133,7 @@ and meaning. Use the singular form unless the context requires a plural.
 | hook | Technical noun | A method or subscriber callback that runs before or after a test |
 | interaction | Technical noun | One call from code under test to a double |
 | live window | Technical noun | The bounded terminal area that shows active test classes |
+| marketing copy | Technical noun | Promotional text that uses STE clarity principles without a controlled-vocabulary requirement |
 | matcher | Technical noun | An operation that checks an expectation |
 | matcher map | Technical noun | The configured names and signatures of extension matchers |
 | memory gate | Technical noun | A repository check that detects memory growth across a long test run |
@@ -207,14 +208,12 @@ Use `run time` as a noun. Use `runtime` only as a modifier.
 Review technical prose as follows:
 
 1. Confirm that the text preserves its technical meaning.
-2. Confirm that each general word is approved for its use.
+2. Confirm that the approved vocabulary includes each general word.
 3. Confirm that each project term is in the register.
 4. Run `composer prose:check`.
 5. Run `composer prose:review`.
 6. Review each advisory message and correct each applicable problem.
 
-The checker baseline records existing mechanical findings during the rollout.
-Do not add a new finding to the baseline.
-
-Use `php tools/prose-check.php baseline --prune` after you remove findings. The
-command must not accept new findings.
+The mandatory check has no baseline. It must report zero errors. The advisory
+review can report approved nouns, exact literals, and marketing copy. Record the
+reason when you retain an advisory candidate.

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -42,10 +42,10 @@ Greenlight verifies mocks when the test ends.
   `mock(Type::class, $plan)`. An unplanned interaction fails immediately.
 * If the test needs an unused dependency, use `stub(Type::class)`. Each
   interaction fails immediately.
-* If the test must examine void-returning calls after they occur, use
-  `spy(Type::class)`. The spy records an unplanned call.
+* If the test must examine calls that return void, use `spy(Type::class)`. The
+  spy records an unplanned call.
 
-A call to a value-returning method on a spy fails the test.
+A call to a spy method that returns a value fails the test.
 
 ## Mock call plans
 
@@ -72,7 +72,7 @@ together.
 
 ## Mock responses
 
-Each value-returning mock method needs an explicit response:
+Each mock method that returns a value needs an explicit response:
 
 ```php
 $plan->expects('nextId')->andReturns('id-1');
@@ -88,8 +88,8 @@ $plan->expects('load')
     ->andThrows(new NotFound('Missing record.'));
 ```
 
-`andReturnsSequence()` consumes one value for each call that matches. A call
-after the sequence is empty causes an authoring error.
+`andReturnsSequence()` consumes one value for each call that matches. Greenlight
+reports an error if a call occurs after the sequence is empty.
 
 ## Argument matches
 

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -613,7 +613,7 @@ final readonly class Application
             $noAnsiFlag,
         );
 
-        return new Style($capabilities->colour);
+        return new Style($capabilities->color);
     }
 
     private function stderrStyle(bool $noAnsiFlag): Style
@@ -624,7 +624,7 @@ final readonly class Application
             $noAnsiFlag,
         );
 
-        return new Style($capabilities->colour);
+        return new Style($capabilities->color);
     }
 
     private function watchCommand(
@@ -892,7 +892,7 @@ final readonly class Application
             $reporters[] = match ($name) {
                 'tty' => new TtyReporter(
                     $output,
-                    $capabilities->colour,
+                    $capabilities->color,
                     $capabilities->interactive,
                     $header,
                     extendedSlowTests: $profile,
@@ -909,7 +909,7 @@ final readonly class Application
         }
 
         if ($profile) {
-            $reporters[] = new ProfileReporter($output, new Style($capabilities->colour));
+            $reporters[] = new ProfileReporter($output, new Style($capabilities->color));
         }
 
         return \count($reporters) === 1 ? $reporters[0] : new CompositeReporter($reporters);
@@ -1064,7 +1064,7 @@ final readonly class Application
             Terminal::isTty(\STDOUT),
             ['CI' => \getenv('CI'), 'NO_COLOR' => \getenv('NO_COLOR')],
             $arguments->has('no-ansi'),
-        )->colour));
+        )->color));
 
         if ($report === '') {
             ($this->err)("The stream has no finished run to profile.\n");
@@ -1210,7 +1210,7 @@ final readonly class Application
 
     /**
      * Discovery reports absolute file paths after it resolves symbolic links.
-     * This method resolves prefixes against the working directory. If a prefix
+     * This method resolves prefixes against the current directory. If a prefix
      * exists, it converts the prefix to its canonical form before comparison.
      * A prefix that does not exist keeps its absolute noncanonical form.
      *
@@ -1250,7 +1250,7 @@ final readonly class Application
     /**
      * Returns unique configured top-level and suite paths.
      *
-     * The method resolves the paths against the working directory.
+     * The method resolves the paths against the current directory.
      *
      * @return list<non-empty-string>
      */

--- a/src/Cli/TerminalCapabilities.php
+++ b/src/Cli/TerminalCapabilities.php
@@ -15,7 +15,7 @@ final readonly class TerminalCapabilities
 {
     public function __construct(
         public bool $interactive,
-        public bool $colour,
+        public bool $color,
     ) {}
 
     /**

--- a/src/Config/GreenlightConfig.php
+++ b/src/Config/GreenlightConfig.php
@@ -228,8 +228,10 @@ final class GreenlightConfig
 
     /**
      * Fails an otherwise passed test if captured output contains a
-     * deprecation. The diagnostic becomes the failure detail. Use
-     * ignoreDeprecationsMatching() to exempt known dependency messages.
+     * deprecation. The diagnostic becomes the failure detail. Use a regular
+     * expression to exempt known dependency messages.
+     *
+     * @see self::ignoreDeprecationsMatching()
      */
     public function failOnDeprecation(bool $enabled = true): self
     {

--- a/src/Coverage/Driver/PcovDriver.php
+++ b/src/Coverage/Driver/PcovDriver.php
@@ -56,7 +56,7 @@ final class PcovDriver implements CoverageDriver
         \pcov\clear();
         $this->collecting = false;
 
-        return new RawCoverage($this->normalise($collected));
+        return new RawCoverage($this->normalize($collected));
     }
 
     /**
@@ -64,7 +64,7 @@ final class PcovDriver implements CoverageDriver
      *
      * @return array<string, array<int, int>>
      */
-    private function normalise(array $collected): array
+    private function normalize(array $collected): array
     {
         $lines = [];
 

--- a/src/Coverage/Driver/XdebugDriver.php
+++ b/src/Coverage/Driver/XdebugDriver.php
@@ -55,7 +55,7 @@ final class XdebugDriver implements CoverageDriver
         \xdebug_stop_code_coverage();
         $this->collecting = false;
 
-        return new RawCoverage($this->normalise($collected));
+        return new RawCoverage($this->normalize($collected));
     }
 
     /**
@@ -93,7 +93,7 @@ final class XdebugDriver implements CoverageDriver
      *
      * @return array<string, array<int, int>>
      */
-    private function normalise(array $collected): array
+    private function normalize(array $collected): array
     {
         $lines = [];
 

--- a/src/Coverage/FileCoverage.php
+++ b/src/Coverage/FileCoverage.php
@@ -33,11 +33,11 @@ final readonly class FileCoverage
         array $coveredLines,
         array $uncoveredLines,
     ) {
-        $covered = $this->normaliseLines($coveredLines);
+        $covered = $this->normalizeLines($coveredLines);
         $coveredSet = \array_fill_keys($covered, true);
         $uncovered = [];
 
-        foreach ($this->normaliseLines($uncoveredLines) as $line) {
+        foreach ($this->normalizeLines($uncoveredLines) as $line) {
             if (!isset($coveredSet[$line])) {
                 $uncovered[] = $line;
             }
@@ -91,7 +91,7 @@ final readonly class FileCoverage
      *
      * @return list<positive-int>
      */
-    private function normaliseLines(array $lines): array
+    private function normalizeLines(array $lines): array
     {
         $set = [];
 

--- a/src/PhpStan/ToThrowMessageRule.php
+++ b/src/PhpStan/ToThrowMessageRule.php
@@ -19,8 +19,9 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 
 /**
- * For compatibility, the toThrow() signature keeps matching and message
- * nullable. A call-site rule makes these arguments mutually exclusive.
+ * For compatibility, the toThrow() signature keeps the pattern and
+ * exact-message arguments nullable. A call-site rule makes these arguments
+ * mutually exclusive.
  *
  * @implements Rule<MethodCall>
  */

--- a/src/Reporting/CompositeReporter.php
+++ b/src/Reporting/CompositeReporter.php
@@ -11,7 +11,7 @@ use Greenlight\Core\Event\Event;
  *
  * onEvent() and finish() invoke reporters in construction order. Thus, all
  * reporters receive events and the finish signal in the same order. tick()
- * invokes only reporters that implement Ticking.
+ * invokes only reporters that support periodic updates.
  *
  * @internal
  */

--- a/src/Reporting/ProfileAggregator.php
+++ b/src/Reporting/ProfileAggregator.php
@@ -139,7 +139,7 @@ final class ProfileAggregator
                 continue;
             }
 
-            $rows[] = [$id, (string) $worker->classes, \sprintf('%.3fs', $worker->busy), $worker->utilisationPercent()];
+            $rows[] = [$id, (string) $worker->classes, \sprintf('%.3fs', $worker->busy), $worker->utilizationPercent()];
         }
 
         if ($rows !== []) {
@@ -206,7 +206,7 @@ final class ProfileAggregator
             // change the alignment.
             $util = $percent === null
                 ? ''
-                : \str_repeat(' ', $utilWidth - \strlen($percent . '%')) . $this->utilisation($style, $percent);
+                : \str_repeat(' ', $utilWidth - \strlen($percent . '%')) . $this->utilization($style, $percent);
 
             $lines[] = \rtrim(\sprintf(
                 '  %s  %s  %s  %s',
@@ -224,7 +224,7 @@ final class ProfileAggregator
      * Uses green for utilization of 90 percent or more. Uses yellow from 70
      * percent. Uses red below 70 percent. Thus, idle workers are easy to see.
      */
-    private function utilisation(Style $style, int $percent): string
+    private function utilization(Style $style, int $percent): string
     {
         $text = $percent . '%';
 

--- a/src/Reporting/TtyReporter.php
+++ b/src/Reporting/TtyReporter.php
@@ -96,14 +96,14 @@ final class TtyReporter implements Reporter, Ticking
 
     public function __construct(
         private readonly Output\Output $output,
-        bool $colour,
+        bool $color,
         private readonly bool $cursor,
         private readonly ?RunHeader $header = null,
         bool $extendedSlowTests = false,
         private readonly bool $verbose = false,
         int $terminalRows = 24,
     ) {
-        $this->style = new Style($colour);
+        $this->style = new Style($color);
         $this->slowTests = new SlowTests($extendedSlowTests);
         $this->windowCapacity = self::windowCapacity($terminalRows);
     }

--- a/src/Reporting/WorkerProfile.php
+++ b/src/Reporting/WorkerProfile.php
@@ -84,7 +84,7 @@ final class WorkerProfile
      *
      * The maximum is 100. Returns null for an empty period.
      */
-    public function utilisationPercent(): ?int
+    public function utilizationPercent(): ?int
     {
         $window = $this->window();
 

--- a/src/Runner/Worker/LeakDetector.php
+++ b/src/Runner/Worker/LeakDetector.php
@@ -15,7 +15,7 @@ use Greenlight\Core\Test\TestId;
  *
  * The detector reports each leak one time.
  *
- * environmentWarning() identifies environments that prevent correct detection.
+ * The environment check identifies settings that prevent correct detection.
  * Xdebug develop mode retains the stack frames of a caught
  * exception until shutdown. These frames include $this. Thus, the detector
  * reports a leak for a test that throws and catches an exception.

--- a/tests/Acceptance/CliTest.php
+++ b/tests/Acceptance/CliTest.php
@@ -124,7 +124,7 @@ final readonly class CliTest
     }
 
     #[Test]
-    public function listTestsHonoursGroupFilters(): void
+    public function listTestsHonorsGroupFilters(): void
     {
         $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'cli');
         $result = GreenlightCli::run($project->directory, ['list-tests', '--group=slow']);

--- a/tests/Acceptance/PhpStanDataProviderRuleTest.php
+++ b/tests/Acceptance/PhpStanDataProviderRuleTest.php
@@ -16,7 +16,7 @@ final readonly class PhpStanDataProviderRuleTest
     #[Test]
     public function providerAndRowShapesAreCheckedAgainstTheSignature(): void
     {
-        $probe = PhpStanProbe::analyse(
+        $probe = PhpStanProbe::analyze(
             $this->tempDirectory,
             <<<'PHP'
             <?php

--- a/tests/Acceptance/PhpStanExtensionTest.php
+++ b/tests/Acceptance/PhpStanExtensionTest.php
@@ -16,7 +16,7 @@ final readonly class PhpStanExtensionTest
     #[Test]
     public function reflectedMatcherSignaturesAreEnforced(): void
     {
-        $probe = PhpStanProbe::analyse(
+        $probe = PhpStanProbe::analyze(
             $this->tempDirectory,
             <<<'PHP'
             <?php
@@ -56,7 +56,7 @@ final readonly class PhpStanExtensionTest
     #[Test]
     public function temporalMatcherSignaturesAreEnforced(): void
     {
-        $probe = PhpStanProbe::analyse(
+        $probe = PhpStanProbe::analyze(
             $this->tempDirectory,
             <<<'PHP'
             <?php

--- a/tests/Acceptance/PhpStanTestMethodRuleTest.php
+++ b/tests/Acceptance/PhpStanTestMethodRuleTest.php
@@ -16,7 +16,7 @@ final readonly class PhpStanTestMethodRuleTest
     #[Test]
     public function testMethodsMustBePublicNonStaticAndConcrete(): void
     {
-        $probe = PhpStanProbe::analyse(
+        $probe = PhpStanProbe::analyze(
             $this->tempDirectory,
             <<<'PHP'
             <?php

--- a/tests/Acceptance/PhpStanToThrowRuleTest.php
+++ b/tests/Acceptance/PhpStanToThrowRuleTest.php
@@ -16,7 +16,7 @@ final readonly class PhpStanToThrowRuleTest
     #[Test]
     public function patternAndExactMessageConstraintsAreMutuallyExclusive(): void
     {
-        $probe = PhpStanProbe::analyse(
+        $probe = PhpStanProbe::analyze(
             $this->tempDirectory,
             <<<'PHP'
             <?php

--- a/tests/Acceptance/ProseCheckTest.php
+++ b/tests/Acceptance/ProseCheckTest.php
@@ -19,6 +19,10 @@ final readonly class ProseCheckTest
     #[DataRow(['semicolon', 'The worker stops; the orchestrator continues.', 'The worker stops. The orchestrator continues.'], 'semicolon')]
     #[DataRow(['contraction', "The worker doesn't stop.", 'The worker does not stop.'], 'contraction')]
     #[DataRow(['british-spelling', 'The reporter uses a different colour.', 'The reporter uses a different color.'], 'British spelling')]
+    #[DataRow(['british-spelling', 'The runner favours one worker.', 'The runner favors one worker.'], 'British favour spelling')]
+    #[DataRow(['british-spelling', 'The runner honours a labelled test.', 'The runner honors a labeled test.'], 'British honor and label spelling')]
+    #[DataRow(['british-spelling', 'The driver normalises the data.', 'The driver normalizes the data.'], 'British normalize spelling')]
+    #[DataRow(['british-spelling', 'The runner parameterises tests.', 'The runner parameterizes tests.'], 'British parameterize spelling')]
     #[DataRow([
         'sentence-length',
         'The orchestrator collects every selected test class from the configured directories and sends one complete assignment to each available worker before the test run starts in parallel.',
@@ -34,16 +38,16 @@ final readonly class ProseCheckTest
         string $invalid,
         string $valid,
     ): void {
-        [$root, $baseline] = $this->workspace('blocking-' . $rule);
+        $root = $this->workspace('blocking-' . $rule);
         $this->write($root, 'sample.md', "# Sample\n\n" . $invalid . "\n");
 
-        $invalidResult = $this->run('check', $root, $baseline);
+        $invalidResult = $this->run('check', $root);
         Expect::that($invalidResult->exitCode)->because('blocking rules reject invalid prose and accept the valid counterpart')->toBe(1)
             ->and($invalidResult->output())->toContain($rule);
 
         $this->write($root, 'sample.md', "# Sample\n\n" . $valid . "\n");
 
-        $validResult = $this->run('check', $root, $baseline);
+        $validResult = $this->run('check', $root);
         Expect::that($validResult->exitCode)->because('blocking rules reject invalid prose and accept the valid counterpart')->toBe(0)
             ->and($validResult->output())->not()->toContain($rule);
     }
@@ -51,7 +55,7 @@ final readonly class ProseCheckTest
     #[Test]
     public function excludesMarkdownCodeAndLinks(): void
     {
-        [$root, $baseline] = $this->workspace('markdown-exclusions');
+        $root = $this->workspace('markdown-exclusions');
         $this->write(
             $root,
             'sample.md',
@@ -69,14 +73,14 @@ final readonly class ProseCheckTest
             MARKDOWN,
         );
 
-        $result = $this->run('check', $root, $baseline);
+        $result = $this->run('check', $root);
         Expect::that($result->exitCode)->because('excludes markdown code and links')->toBe(0);
     }
 
     #[Test]
     public function checksMarkdownHeadingsAndTables(): void
     {
-        [$root, $baseline] = $this->workspace('markdown-prose');
+        $root = $this->workspace('markdown-prose');
         $this->write(
             $root,
             'sample.md',
@@ -90,16 +94,16 @@ final readonly class ProseCheckTest
             MARKDOWN,
         );
 
-        $result = $this->run('check', $root, $baseline);
+        $result = $this->run('check', $root);
         Expect::that($result->exitCode)->because('checks markdown headings and tables')->toBe(1)
             ->and($result->output())->toContain('sample.md:1: british-spelling:')
             ->toContain('sample.md:5: contraction:');
     }
 
     #[Test]
-    public function checksWebsiteCopyAndUsesTheWebsiteShard(): void
+    public function checksWebsiteCopyAndExcludesCode(): void
     {
-        [$root, $baseline] = $this->workspace('website-copy');
+        $root = $this->workspace('website-copy');
         $this->write(
             $root,
             'website/src/pages/index.astro',
@@ -116,22 +120,58 @@ final readonly class ProseCheckTest
             ASTRO,
         );
 
-        $result = $this->run('check', $root, $baseline);
-        Expect::that($result->exitCode)->because('checks website copy and uses the website shard')->toBe(1)
+        $result = $this->run('check', $root);
+        Expect::that($result->exitCode)->because('checks website copy and excludes code')->toBe(1)
             ->and($result->output())->toContain('website/src/pages/index.astro:')
             ->toContain('british-spelling')
-            ->toContain('contraction');
-
-        Expect::that($this->run('baseline', $root, $baseline, '--create')->exitCode)->because('checks website copy and uses the website shard')->toBe(0);
-        $websiteBaseline = (string) \file_get_contents($baseline . '/website.json');
-        Expect::that($websiteBaseline)->because('checks website copy and uses the website shard')->toContain('website/src/pages/index.astro')
+            ->toContain('contraction')
             ->not()->toContain('codeSample');
+    }
+
+    #[Test]
+    public function excludesMultilineAstroExpressions(): void
+    {
+        $root = $this->workspace('website-expressions');
+        $this->write(
+            $root,
+            'website/src/layouts/DocsLayout.astro',
+            <<<'ASTRO'
+            <main>
+              {
+                headings.map((heading) => (
+                  <a href={`#${heading.slug}`}>{heading.text}</a>
+                ))
+              }
+              <p>The worker stops.</p>
+            </main>
+
+            ASTRO,
+        );
+
+        $result = $this->run('review', $root);
+        Expect::that($result->exitCode)->because('excludes multiline Astro expressions')->toBe(0)
+            ->and($result->output())->toBe('');
+    }
+
+    #[Test]
+    public function excludesRegisteredLiterals(): void
+    {
+        $root = $this->workspace('registered-literals');
+        $this->write(
+            $root,
+            'website/src/components/Version.astro',
+            "<span>dev-main</span>\n",
+        );
+
+        $result = $this->run('review', $root);
+        Expect::that($result->exitCode)->because('excludes registered literals')->toBe(0)
+            ->and($result->output())->toBe('');
     }
 
     #[Test]
     public function excludesPhpDocTagsAndMachineDirectivesButChecksNarrativeComments(): void
     {
-        [$root, $baseline] = $this->workspace('php-comments');
+        $root = $this->workspace('php-comments');
         $this->write(
             $root,
             'src/TagOnly.php',
@@ -149,7 +189,7 @@ final readonly class ProseCheckTest
             PHP,
         );
 
-        $excludedResult = $this->run('check', $root, $baseline);
+        $excludedResult = $this->run('check', $root);
         Expect::that($excludedResult->exitCode)->because('excludes PHPDoc tags and machine directives but checks narrative comments')->toBe(0);
 
         $this->write(
@@ -164,7 +204,7 @@ final readonly class ProseCheckTest
             PHP,
         );
 
-        $includedResult = $this->run('check', $root, $baseline);
+        $includedResult = $this->run('check', $root);
         Expect::that($includedResult->exitCode)->because('excludes PHPDoc tags and machine directives but checks narrative comments')->toBe(1)
             ->and($includedResult->output())->toContain('src/Narrative.php:3:')
             ->toContain('british-spelling')
@@ -174,7 +214,7 @@ final readonly class ProseCheckTest
     #[Test]
     public function joinsConsecutiveLineCommentsAndDoesNotCreateDelimiterText(): void
     {
-        [$root, $baseline] = $this->workspace('php-comment-groups');
+        $root = $this->workspace('php-comment-groups');
         $this->write(
             $root,
             'src/Comments.php',
@@ -194,7 +234,7 @@ final readonly class ProseCheckTest
             PHP,
         );
 
-        $result = $this->run('check', $root, $baseline);
+        $result = $this->run('check', $root);
         Expect::that($result->exitCode)->because('joins consecutive line comments and does not create delimiter text')->toBe(1)
             ->and($result->output())->toContain('paragraph-length')
             ->not()->toContain('valid description. /');
@@ -203,7 +243,7 @@ final readonly class ProseCheckTest
     #[Test]
     public function reviewReportsAdvisoriesWithoutFailure(): void
     {
-        [$root, $baseline] = $this->workspace('advisories');
+        $root = $this->workspace('advisories');
         $this->write(
             $root,
             'sample.md',
@@ -223,7 +263,7 @@ final readonly class ProseCheckTest
             MARKDOWN,
         );
 
-        $result = $this->run('review', $root, $baseline);
+        $result = $this->run('review', $root);
         Expect::that($result->exitCode)->because('review reports advisories without failure')->toBe(0)
             ->and($result->output())->toContain('procedural-sentence-length')
             ->toContain('passive-voice')
@@ -236,15 +276,15 @@ final readonly class ProseCheckTest
     #[Test]
     public function reportsLongInstructionsWithoutBlockingThem(): void
     {
-        [$root, $baseline] = $this->workspace('long-instruction');
+        $root = $this->workspace('long-instruction');
         $this->write(
             $root,
             'sample.md',
             'Configure each available worker with every selected test class from all project directories before the orchestrator starts the complete test run with parallel processes and reports.' . "\n",
         );
 
-        $checked = $this->run('check', $root, $baseline);
-        $reviewed = $this->run('review', $root, $baseline);
+        $checked = $this->run('check', $root);
+        $reviewed = $this->run('review', $root);
 
         Expect::that($checked->exitCode)->because('reports long instructions without blocking them')->toBe(0)
             ->and($reviewed->exitCode)->toBe(0)
@@ -254,14 +294,14 @@ final readonly class ProseCheckTest
     #[Test]
     public function doesNotReportApprovedNormativeTokensAsDiscouragedWords(): void
     {
-        [$root, $baseline] = $this->workspace('normative-tokens');
+        $root = $this->workspace('normative-tokens');
         $this->write(
             $root,
             'sample.md',
             "The worker MUST stop. The reporter SHOULD continue. The plugin MAY report the result.\n",
         );
 
-        $result = $this->run('review', $root, $baseline);
+        $result = $this->run('review', $root);
         Expect::that($result->exitCode)->because('does not report approved normative tokens as discouraged words')->toBe(0)
             ->and($result->output())->not()->toContain('discouraged-word');
     }
@@ -269,12 +309,12 @@ final readonly class ProseCheckTest
     #[Test]
     public function outputIsDeterministicAndSortedByPath(): void
     {
-        [$root, $baseline] = $this->workspace('deterministic-output');
+        $root = $this->workspace('deterministic-output');
         $this->write($root, 'z-last.md', "The worker doesn't stop.\n");
         $this->write($root, 'a-first.md', "The worker doesn't start.\n");
 
-        $first = $this->run('check', $root, $baseline);
-        $second = $this->run('check', $root, $baseline);
+        $first = $this->run('check', $root);
+        $second = $this->run('check', $root);
         $firstPosition = \strpos($first->output(), 'a-first.md:');
         $lastPosition = \strpos($first->output(), 'z-last.md:');
 
@@ -290,156 +330,56 @@ final readonly class ProseCheckTest
     #[Test]
     public function excludesSharedFixtureDirectories(): void
     {
-        [$root, $baseline] = $this->workspace('fixture-exclusion');
+        $root = $this->workspace('fixture-exclusion');
         $this->write(
             $root,
             'tests/Fixture/Invalid.php',
             "<?php\n\n// The worker doesn't use the configured colour; it stops.\n",
         );
 
-        $result = $this->run('check', $root, $baseline);
+        $result = $this->run('check', $root);
         Expect::that($result->exitCode)->because('excludes shared fixture directories')->toBe(0);
     }
 
     #[Test]
     public function excludesDependenciesAtAnyDirectoryDepth(): void
     {
-        [$root, $baseline] = $this->workspace('dependency-exclusion');
+        $root = $this->workspace('dependency-exclusion');
         $invalid = "The worker doesn't use the configured colour; it stops.\n";
         $this->write($root, 'vendor/package/README.md', $invalid);
         $this->write($root, 'website/node_modules/package/README.md', $invalid);
         $this->write($root, 'packages/example/vendor/package/README.md', $invalid);
         $this->write($root, 'packages/example/node_modules/package/README.md', $invalid);
 
-        $result = $this->run('check', $root, $baseline);
+        $result = $this->run('check', $root);
         Expect::that($result->exitCode)->because('excludes dependencies at any directory depth')->toBe(0);
     }
 
     #[Test]
-    public function createsAnInitialBaselineThatAllowsExistingFindings(): void
+    public function rejectsRemovedBaselineOptions(): void
     {
-        [$root, $baseline] = $this->workspace('baseline-create');
-        $this->write($root, 'sample.md', "The worker doesn't stop.\n");
+        $root = $this->workspace('removed-baseline');
+        $this->write($root, 'sample.md', "The worker stops.\n");
+        $result = Subprocess::run($root, [
+            \PHP_BINARY,
+            \dirname(__DIR__, 2) . '/tools/prose-check.php',
+            'check',
+            '--root=' . $root,
+            '--baseline-dir=' . $root . '/baseline',
+        ]);
 
-        $created = $this->run('baseline', $root, $baseline, '--create');
-        $checked = $this->run('check', $root, $baseline);
-        $matchedBaselineFiles = \glob($baseline . '/*');
-        $baselineFiles = $matchedBaselineFiles === false ? [] : $matchedBaselineFiles;
-
-        Expect::that($created->exitCode)->because('creates an initial baseline that allows existing findings')->toBe(0)
-            ->and($baselineFiles)->not()->toBeEmpty()
-            ->and($checked->exitCode)->toBe(0);
+        Expect::that($result->exitCode)->because('rejects removed baseline options')->toBe(1)
+            ->and($result->stderr)->toContain('Unknown prose-check option "--baseline-dir=');
     }
 
-    #[Test]
-    public function refusesToReplaceAnExistingBaseline(): void
-    {
-        [$root, $baseline] = $this->workspace('baseline-create-twice');
-        $this->write($root, 'sample.md', "The worker doesn't stop.\n");
-
-        $created = $this->run('baseline', $root, $baseline, '--create');
-        $repeated = $this->run('baseline', $root, $baseline, '--create');
-
-        Expect::that($created->exitCode)->because('refuses to replace an existing baseline')->toBe(0)
-            ->and($repeated->exitCode)->toBe(1)
-            ->and($repeated->output())->toContain('already exists');
-    }
-
-    #[Test]
-    public function newFindingsFailAgainstAnExistingBaseline(): void
-    {
-        [$root, $baseline] = $this->workspace('baseline-new');
-        $this->write($root, 'sample.md', "The worker doesn't stop.\n");
-        Expect::that($this->run('baseline', $root, $baseline, '--create')->exitCode)->because('new findings fail against an existing baseline')->toBe(0);
-
-        $this->write(
-            $root,
-            'sample.md',
-            "The worker doesn't stop.\n\nThe reporter uses a different colour.\n",
-        );
-
-        $result = $this->run('check', $root, $baseline);
-        Expect::that($result->exitCode)->because('new findings fail against an existing baseline')->toBe(1)
-            ->and(\strtolower($result->output()))->toContain('new')
-            ->and($result->output())->toContain('british-spelling');
-    }
-
-    #[Test]
-    public function staleFindingsFailUntilTheBaselineIsPruned(): void
-    {
-        [$root, $baseline] = $this->workspace('baseline-stale');
-        $this->write($root, 'sample.md', "The worker doesn't stop.\n");
-        Expect::that($this->run('baseline', $root, $baseline, '--create')->exitCode)->because('stale findings fail until the baseline is pruned')->toBe(0);
-
-        $this->write($root, 'sample.md', "The worker does not stop.\n");
-
-        $stale = $this->run('check', $root, $baseline);
-        $pruned = $this->run('baseline', $root, $baseline, '--prune');
-        $checked = $this->run('check', $root, $baseline);
-
-        Expect::that($stale->exitCode)->because('stale findings fail until the baseline is pruned')->toBe(1)
-            ->and(\strtolower($stale->output()))->toContain('stale')
-            ->and($pruned->exitCode)->toBe(0)
-            ->and($checked->exitCode)->toBe(0);
-    }
-
-    #[Test]
-    public function baselineFingerprintsIncludeDuplicateFindingCounts(): void
-    {
-        [$root, $baseline] = $this->workspace('baseline-duplicates');
-        $duplicate = "The worker doesn't stop.\n\nThe worker doesn't stop.\n";
-        $this->write($root, 'sample.md', $duplicate);
-        Expect::that($this->run('baseline', $root, $baseline, '--create')->exitCode)->because('baseline fingerprints include duplicate finding counts')->toBe(0);
-        $baselineJson = (string) \file_get_contents($baseline . '/root.json');
-        $expectedFingerprint = \hash(
-            'sha256',
-            "sample.md\0contraction\0the worker doesn't stop.\0" . '2',
-        );
-
-        $this->write($root, 'sample.md', "The worker doesn't stop.\n");
-
-        $result = $this->run('check', $root, $baseline);
-        Expect::that($baselineJson)->because('baseline fingerprints include duplicate finding counts')->toContain($expectedFingerprint)
-            ->toContain('"count": 2')
-            ->and($result->exitCode)->toBe(1)
-            ->and(\strtolower($result->output()))->toContain('stale');
-    }
-
-    #[Test]
-    public function pruneRefusesToAddNewFindings(): void
-    {
-        [$root, $baseline] = $this->workspace('baseline-prune-refusal');
-        $this->write($root, 'sample.md', "The worker doesn't stop.\n");
-        Expect::that($this->run('baseline', $root, $baseline, '--create')->exitCode)->because('prune refuses to add new findings')->toBe(0);
-        $before = $this->baselineContents($baseline);
-
-        $this->write(
-            $root,
-            'sample.md',
-            "The worker doesn't stop.\n\nThe reporter uses a different colour.\n",
-        );
-
-        $pruned = $this->run('baseline', $root, $baseline, '--prune');
-        $after = $this->baselineContents($baseline);
-        $checked = $this->run('check', $root, $baseline);
-
-        Expect::that($pruned->exitCode)->because('prune refuses to add new findings')->toBe(1)
-            ->and(\strtolower($pruned->output()))->toContain('new')
-            ->and($after)->toBe($before)
-            ->and($checked->exitCode)->toBe(1);
-    }
-
-    /**
-     * @return array{string, string}
-     */
-    private function workspace(string $name): array
+    private function workspace(string $name): string
     {
         $directory = $this->tempDirectory->subdirectory($name);
         $root = $directory . '/project';
 
         \mkdir($root);
 
-        return [$root, $directory . '/baseline'];
+        return $root;
     }
 
     private function write(string $root, string $relativePath, string $contents): void
@@ -454,39 +394,13 @@ final readonly class ProseCheckTest
         \file_put_contents($path, $contents);
     }
 
-    private function run(
-        string $command,
-        string $root,
-        string $baseline,
-        ?string $operation = null,
-    ): ProcessResult {
-        $arguments = [
+    private function run(string $command, string $root): ProcessResult
+    {
+        return Subprocess::run($root, [
             \PHP_BINARY,
             \dirname(__DIR__, 2) . '/tools/prose-check.php',
             $command,
-        ];
-
-        if ($operation !== null) {
-            $arguments[] = $operation;
-        }
-
-        $arguments[] = '--root=' . $root;
-        $arguments[] = '--baseline-dir=' . $baseline;
-
-        return Subprocess::run($root, $arguments);
-    }
-
-    private function baselineContents(string $baseline): string
-    {
-        $matchedFiles = \glob($baseline . '/*');
-        $files = $matchedFiles === false ? [] : $matchedFiles;
-        \sort($files);
-        $contents = '';
-
-        foreach ($files as $file) {
-            $contents .= \basename($file) . "\n" . \file_get_contents($file);
-        }
-
-        return $contents;
+            '--root=' . $root,
+        ]);
     }
 }

--- a/tests/Support/PhpStanProbe.php
+++ b/tests/Support/PhpStanProbe.php
@@ -20,7 +20,7 @@ final readonly class PhpStanProbe
     /**
      * @throws \RuntimeException when PHPStan cannot run or return a valid file report
      */
-    public static function analyse(
+    public static function analyze(
         TempDirectory $workspace,
         string $goodSource,
         string $badSource,

--- a/tests/Support/TerminalEmulator.php
+++ b/tests/Support/TerminalEmulator.php
@@ -6,7 +6,7 @@ namespace Greenlight\Tests\Support;
 
 /**
  * Supports carriage return, newline, CSI cursor-up, line and screen clear operations,
- * cursor visibility, and TtyReporter SGR sequences. Unless retainColour is
+ * cursor visibility, and TtyReporter SGR sequences. Unless retainColor is
  * true, it removes SGR codes. write() throws for other escape sequences.
  */
 final class TerminalEmulator
@@ -32,7 +32,7 @@ final class TerminalEmulator
     private bool $cursorHidden = false;
 
     public function __construct(
-        private readonly bool $retainColour = false,
+        private readonly bool $retainColor = false,
     ) {
         $this->cells[0] = [];
     }
@@ -109,7 +109,7 @@ final class TerminalEmulator
 
     private function applySgr(string $params): void
     {
-        if ($this->retainColour) {
+        if ($this->retainColor) {
             $this->pendingPrefix .= \sprintf("\x1b[%sm", $params);
         }
     }

--- a/tests/Unit/Cli/TerminalCapabilitiesTest.php
+++ b/tests/Unit/Cli/TerminalCapabilitiesTest.php
@@ -11,12 +11,12 @@ use Greenlight\Expect\Expect;
 final class TerminalCapabilitiesTest
 {
     #[Test]
-    public function aPlainTtyIsInteractiveWithColour(): void
+    public function aPlainTtyIsInteractiveWithColor(): void
     {
         $capabilities = TerminalCapabilities::detect(stdoutIsTty: true, env: [], noAnsiFlag: false);
 
         Expect::that($capabilities->interactive)->because('a plain TTY is interactive with color')->toBeTrue()
-            ->and($capabilities->colour)->toBeTrue();
+            ->and($capabilities->color)->toBeTrue();
     }
 
     #[Test]
@@ -25,7 +25,7 @@ final class TerminalCapabilitiesTest
         $capabilities = TerminalCapabilities::detect(stdoutIsTty: false, env: [], noAnsiFlag: false);
 
         Expect::that($capabilities->interactive)->because('non TTY is never interactive')->toBeFalse()
-            ->and($capabilities->colour)->toBeFalse();
+            ->and($capabilities->color)->toBeFalse();
     }
 
     #[Test]
@@ -34,7 +34,7 @@ final class TerminalCapabilitiesTest
         $capabilities = TerminalCapabilities::detect(stdoutIsTty: true, env: [], noAnsiFlag: true);
 
         Expect::that($capabilities->interactive)->because('the no ANSI flag forces non interactive')->toBeFalse()
-            ->and($capabilities->colour)->toBeFalse();
+            ->and($capabilities->color)->toBeFalse();
     }
 
     #[Test]
@@ -44,7 +44,7 @@ final class TerminalCapabilitiesTest
             $capabilities = TerminalCapabilities::detect(stdoutIsTty: true, env: ['CI' => $value], noAnsiFlag: false);
 
             Expect::that($capabilities->interactive)->toBeFalse()
-                ->and($capabilities->colour)->toBeFalse();
+                ->and($capabilities->color)->toBeFalse();
         }
     }
 
@@ -59,12 +59,12 @@ final class TerminalCapabilitiesTest
     }
 
     #[Test]
-    public function noColorStripsColourButKeepsInteractivity(): void
+    public function noColorStripsColorButKeepsInteractivity(): void
     {
         $capabilities = TerminalCapabilities::detect(stdoutIsTty: true, env: ['NO_COLOR' => '1'], noAnsiFlag: false);
 
         Expect::that($capabilities->interactive)->because('no color strips color but keeps interactivity')->toBeTrue()
-            ->and($capabilities->colour)->toBeFalse();
+            ->and($capabilities->color)->toBeFalse();
     }
 
     #[Test]
@@ -72,6 +72,6 @@ final class TerminalCapabilitiesTest
     {
         $capabilities = TerminalCapabilities::detect(stdoutIsTty: true, env: ['NO_COLOR' => ''], noAnsiFlag: false);
 
-        Expect::that($capabilities->colour)->because('an empty no color is ignored')->toBeTrue();
+        Expect::that($capabilities->color)->because('an empty no color is ignored')->toBeTrue();
     }
 }

--- a/tests/Unit/Coverage/HtmlExporterTest.php
+++ b/tests/Unit/Coverage/HtmlExporterTest.php
@@ -107,7 +107,7 @@ final class HtmlExporterTest
     }
 
     #[Test]
-    public function filePageColoursSourceLinesByCoverageStatus(): void
+    public function filePageColorsSourceLinesByCoverageStatus(): void
     {
         $fixture = (string) new \ReflectionClass(Adder::class)->getFileName();
         \assert($fixture !== '');

--- a/tests/Unit/Discovery/FilterTest.php
+++ b/tests/Unit/Discovery/FilterTest.php
@@ -149,10 +149,10 @@ final class FilterTest
         Expect::that($filter->acceptsId('Acme\\BravoTest::alpha[edge case]'))->because('ID wildcards match the whole ID including data set labels')->toBeTrue();
         Expect::that($filter->acceptsId('Acme\\BravoTest::beta'))->because('ID wildcards match the whole ID including data set labels')->toBeFalse();
 
-        $labelled = new Filter(includeIds: ['*[edge case]']);
+        $labeled = new Filter(includeIds: ['*[edge case]']);
 
-        Expect::that($labelled->acceptsId('Acme\\BravoTest::alpha[edge case]'))->because('ID wildcards match the whole ID including data set labels')->toBeTrue();
-        Expect::that($labelled->acceptsId('Acme\\BravoTest::alpha[other]'))->because('ID wildcards match the whole ID including data set labels')->toBeFalse();
+        Expect::that($labeled->acceptsId('Acme\\BravoTest::alpha[edge case]'))->because('ID wildcards match the whole ID including data set labels')->toBeTrue();
+        Expect::that($labeled->acceptsId('Acme\\BravoTest::alpha[other]'))->because('ID wildcards match the whole ID including data set labels')->toBeFalse();
     }
 
     #[Test]

--- a/tests/Unit/PhpStan/ExtensionMatcherDispatchTest.php
+++ b/tests/Unit/PhpStan/ExtensionMatcherDispatchTest.php
@@ -15,7 +15,7 @@ use Greenlight\Tests\Fixture\PhpStanExtension\DigestExtension;
 final class ExtensionMatcherDispatchTest
 {
     #[Test]
-    public function fixtureMatchersDispatchAndAnalyse(): void
+    public function fixtureMatchersDispatchAndAnalyze(): void
     {
         Expect::install([new DigestExtension()]);
 

--- a/tests/Unit/Reporting/AttachmentReporterTest.php
+++ b/tests/Unit/Reporting/AttachmentReporterTest.php
@@ -29,7 +29,7 @@ final class AttachmentReporterTest
     {
         foreach ([
             static fn(BufferOutput $output) => new PlainReporter($output),
-            static fn(BufferOutput $output) => new TtyReporter($output, colour: false, cursor: false),
+            static fn(BufferOutput $output) => new TtyReporter($output, color: false, cursor: false),
         ] as $factory) {
             $output = new BufferOutput();
             $reporter = $factory($output);
@@ -47,7 +47,7 @@ final class AttachmentReporterTest
     public function ttyReporterDoesNotRetainSuccessfulResultsUntilFinish(): void
     {
         $output = new BufferOutput();
-        $reporter = new TtyReporter($output, colour: false, cursor: false);
+        $reporter = new TtyReporter($output, color: false, cursor: false);
         $failed = $this->result();
         $result = new TestResult(
             $failed->id,

--- a/tests/Unit/Reporting/PluralTest.php
+++ b/tests/Unit/Reporting/PluralTest.php
@@ -11,7 +11,7 @@ use Greenlight\Reporting\Plural;
 final class PluralTest
 {
     #[Test]
-    public function countPluralisesRegularNouns(): void
+    public function countPluralizesRegularNouns(): void
     {
         Expect::that(Plural::count(1, 'test'))->because('count pluralizes regular nouns')->toBe('1 test')
             ->and(Plural::count(2, 'test'))->toBe('2 tests')

--- a/tests/Unit/Reporting/ProfileAggregatorTest.php
+++ b/tests/Unit/Reporting/ProfileAggregatorTest.php
@@ -21,7 +21,7 @@ use Greenlight\Reporting\Style;
 final class ProfileAggregatorTest
 {
     #[Test]
-    public function derivesUtilisationBootLatencyAndSpreadFromACannedStream(): void
+    public function derivesUtilizationBootLatencyAndSpreadFromACannedStream(): void
     {
         $aggregator = new ProfileAggregator();
 
@@ -76,7 +76,7 @@ final class ProfileAggregatorTest
     }
 
     #[Test]
-    public function utilisationBandsAndSlowDurationsColourWithAnsi(): void
+    public function utilizationBandsAndSlowDurationsColorWithAnsi(): void
     {
         $aggregator = new ProfileAggregator();
 
@@ -96,7 +96,7 @@ final class ProfileAggregatorTest
     }
 
     #[Test]
-    public function fullyBusyWorkersColourGreen(): void
+    public function fullyBusyWorkersColorGreen(): void
     {
         $aggregator = new ProfileAggregator();
 

--- a/tests/Unit/Reporting/RunHeaderTest.php
+++ b/tests/Unit/Reporting/RunHeaderTest.php
@@ -21,7 +21,7 @@ final class RunHeaderTest
     }
 
     #[Test]
-    public function coloursTheNameGreenAndTheSeedDim(): void
+    public function colorsTheNameGreenAndTheSeedDim(): void
     {
         $header = new RunHeader('0.4.0', 'greenlight.php', 123456, phpVersion: '8.3.1');
 

--- a/tests/Unit/Reporting/SlowTestsTest.php
+++ b/tests/Unit/Reporting/SlowTestsTest.php
@@ -59,7 +59,7 @@ final class SlowTestsTest
     }
 
     #[Test]
-    public function durationsAreColouredThroughTheStyle(): void
+    public function durationsAreColoredThroughTheStyle(): void
     {
         $slow = new SlowTests();
         $slow->record($this->finished('Acme\SlowTest::crawls', 1.5));

--- a/tests/Unit/Reporting/StyleTest.php
+++ b/tests/Unit/Reporting/StyleTest.php
@@ -11,7 +11,7 @@ use Greenlight\Reporting\Style;
 final class StyleTest
 {
     #[Test]
-    public function coloursApplyOnlyWithAnsi(): void
+    public function colorsApplyOnlyWithAnsi(): void
     {
         $ansi = new Style(ansi: true);
         $plain = new Style(ansi: false);
@@ -25,7 +25,7 @@ final class StyleTest
     }
 
     #[Test]
-    public function durationsColourBySeverity(): void
+    public function durationsColorBySeverity(): void
     {
         $ansi = new Style(ansi: true);
 

--- a/tests/Unit/Reporting/SummaryFormatTest.php
+++ b/tests/Unit/Reporting/SummaryFormatTest.php
@@ -86,7 +86,7 @@ final class SummaryFormatTest
     }
 
     #[Test]
-    public function leaksColourTheHeaderRedAndNothingWithoutLeaks(): void
+    public function leaksColorTheHeaderRedAndNothingWithoutLeaks(): void
     {
         $block = SummaryFormat::leaks([new TestId('App\AlphaTest', 'one')], new Style(ansi: true));
 
@@ -103,7 +103,7 @@ final class SummaryFormatTest
     }
 
     #[Test]
-    public function coverageSingularisesASingleExecutableLine(): void
+    public function coverageSingularizesASingleExecutableLine(): void
     {
         $line = SummaryFormat::coverage(100.0, 1, 1, new Style(ansi: false));
 
@@ -111,7 +111,7 @@ final class SummaryFormatTest
     }
 
     #[Test]
-    public function coverageColoursThePercentageGreen(): void
+    public function coverageColorsThePercentageGreen(): void
     {
         $line = SummaryFormat::coverage(88.3, 5283, 5983, new Style(ansi: true));
 

--- a/tests/Unit/Reporting/TerminalEmulatorTest.php
+++ b/tests/Unit/Reporting/TerminalEmulatorTest.php
@@ -56,7 +56,7 @@ final class TerminalEmulatorTest
     }
 
     #[Test]
-    public function sgrColourCodesAreStrippedByDefault(): void
+    public function sgrColorCodesAreStrippedByDefault(): void
     {
         $terminal = new TerminalEmulator();
         $terminal->write("\x1b[32mok\x1b[0m plain");
@@ -65,9 +65,9 @@ final class TerminalEmulatorTest
     }
 
     #[Test]
-    public function sgrColourCodesCanBeRetainedOnRequest(): void
+    public function sgrColorCodesCanBeRetainedOnRequest(): void
     {
-        $terminal = new TerminalEmulator(retainColour: true);
+        $terminal = new TerminalEmulator(retainColor: true);
         $terminal->write("\x1b[32mok\x1b[0m");
 
         Expect::that($terminal->screen())->because('SGR color codes can be retained on request')->toBe("\x1b[32mok\x1b[0m");

--- a/tests/Unit/Reporting/TtyReporterTest.php
+++ b/tests/Unit/Reporting/TtyReporterTest.php
@@ -27,7 +27,7 @@ final class TtyReporterTest
     public function interleavedClassesFinalizeInPlaceWithAnsi(): void
     {
         $output = new BufferOutput();
-        $reporter = new TtyReporter($output, colour: true, cursor: true, header: new RunHeader('dev-main', 'greenlight.php', 4242, phpVersion: '8.4.0'));
+        $reporter = new TtyReporter($output, color: true, cursor: true, header: new RunHeader('dev-main', 'greenlight.php', 4242, phpVersion: '8.4.0'));
 
         // Two classes are active at the same time, as with multiple workers.
         // Timestamps differ by at least 0.05 seconds. Thus, the redraw limit
@@ -59,7 +59,7 @@ final class TtyReporterTest
     public function withoutAnsiOnlyFinalizedLinesAreWritten(): void
     {
         $output = new BufferOutput();
-        $reporter = new TtyReporter($output, colour: false, cursor: false);
+        $reporter = new TtyReporter($output, color: false, cursor: false);
 
         $reporter->onEvent(new TestClassStarted('App\AlphaTest', 1.0));
         $reporter->onEvent(new TestFinished($this->result('App\AlphaTest', 'one', Outcome::Passed), 1.1));
@@ -78,7 +78,7 @@ final class TtyReporterTest
     public function zeroResultCategoriesAreOmittedFromTheSummary(): void
     {
         $output = new BufferOutput();
-        $reporter = new TtyReporter($output, colour: false, cursor: false);
+        $reporter = new TtyReporter($output, color: false, cursor: false);
 
         $reporter->onEvent(new TestClassStarted('App\AlphaTest', 1.0));
         $reporter->onEvent(new TestFinished($this->result('App\AlphaTest', 'one', Outcome::Passed), 1.1));
@@ -95,7 +95,7 @@ final class TtyReporterTest
     public function skippedTestsAreUnambiguousAndListedWithReasons(): void
     {
         $output = new BufferOutput();
-        $reporter = new TtyReporter($output, colour: false, cursor: false);
+        $reporter = new TtyReporter($output, color: false, cursor: false);
 
         $reporter->onEvent(new TestClassStarted('App\GammaTest', 1.0));
         $reporter->onEvent(new TestFinished($this->skipped('App\GammaTest', 'one', 'xdebug not loaded'), 1.1));
@@ -121,7 +121,7 @@ final class TtyReporterTest
     public function workersLineOmitsZeroRecycledAndDisappearsWhenNoneSpawned(): void
     {
         $spawned = new BufferOutput();
-        $reporter = new TtyReporter($spawned, colour: false, cursor: false);
+        $reporter = new TtyReporter($spawned, color: false, cursor: false);
         $reporter->onEvent(new WorkerSpawned('w-1', 101, 1.0));
         $reporter->onEvent(new RunFinished('run-1', new ResultSummary(passed: 1), 0.1, 1.3));
         $reporter->finish();
@@ -130,7 +130,7 @@ final class TtyReporterTest
             ->not()->toContain('recycled');
 
         $inProcess = new BufferOutput();
-        $reporter = new TtyReporter($inProcess, colour: false, cursor: false);
+        $reporter = new TtyReporter($inProcess, color: false, cursor: false);
         $reporter->onEvent(new RunFinished('run-1', new ResultSummary(passed: 1), 0.1, 1.3));
         $reporter->finish();
 
@@ -138,17 +138,17 @@ final class TtyReporterTest
     }
 
     #[Test]
-    public function slowDurationsAreColouredOnClassLines(): void
+    public function slowDurationsAreColoredOnClassLines(): void
     {
         $output = new BufferOutput();
-        $reporter = new TtyReporter($output, colour: true, cursor: true, verbose: true);
+        $reporter = new TtyReporter($output, color: true, cursor: true, verbose: true);
 
         $reporter->onEvent(new TestClassStarted('App\SlowTest', 1.0));
         $reporter->onEvent(new TestFinished($this->result('App\SlowTest', 'one', Outcome::Passed, 1.5), 1.1));
         $reporter->onEvent(new TestClassFinished('App\SlowTest', 1.2));
         $reporter->finish();
 
-        $terminal = new TerminalEmulator(retainColour: true);
+        $terminal = new TerminalEmulator(retainColor: true);
         $terminal->write($output->buffer());
 
         Expect::that($terminal->screen())->because('slow durations are colored on class lines')->toContain("(1 test, \x1b[33m1.500s\x1b[0m)");
@@ -158,14 +158,14 @@ final class TtyReporterTest
     public function verboseRestoresAPermanentLinePerClass(): void
     {
         $output = new BufferOutput();
-        $reporter = new TtyReporter($output, colour: true, cursor: true, verbose: true);
+        $reporter = new TtyReporter($output, color: true, cursor: true, verbose: true);
 
         $reporter->onEvent(new TestClassStarted('App\AlphaTest', 1.0));
         $reporter->onEvent(new TestFinished($this->result('App\AlphaTest', 'one', Outcome::Passed), 1.1));
         $reporter->onEvent(new TestClassFinished('App\AlphaTest', 1.2));
         $reporter->finish();
 
-        $terminal = new TerminalEmulator(retainColour: true);
+        $terminal = new TerminalEmulator(retainColor: true);
         $terminal->write($output->buffer());
 
         Expect::that($terminal->screen())->because('verbose restores a permanent line per class')->toContain("\x1b[32m✓\x1b[0m App\AlphaTest (1 test, 0.010s)");
@@ -175,7 +175,7 @@ final class TtyReporterTest
     public function aBlankLineSeparatesPermanentLinesFromTheLiveWindow(): void
     {
         $output = new BufferOutput();
-        $reporter = new TtyReporter($output, colour: false, cursor: true);
+        $reporter = new TtyReporter($output, color: false, cursor: true);
 
         $reporter->onEvent(new RunStarted('run-1', 2, 1, 1.0));
         $reporter->onEvent(new TestClassStarted('App\GammaTest', 1.0));
@@ -198,7 +198,7 @@ final class TtyReporterTest
     public function theFirstPermanentLineGetsAGapAndLaterOnesStack(): void
     {
         $output = new BufferOutput();
-        $reporter = new TtyReporter($output, colour: false, cursor: true, header: new RunHeader('dev-main', 'greenlight.php', null, phpVersion: '8.4.0'));
+        $reporter = new TtyReporter($output, color: false, cursor: true, header: new RunHeader('dev-main', 'greenlight.php', null, phpVersion: '8.4.0'));
 
         $reporter->onEvent(new RunStarted('run-1', 4, 1, 1.0));
         $reporter->onEvent(new TestClassStarted('App\GammaTest', 1.0));
@@ -222,11 +222,11 @@ final class TtyReporterTest
     }
 
     #[Test]
-    public function noColourKeepsTheLiveWindowWithoutColourCodes(): void
+    public function noColorKeepsTheLiveWindowWithoutColorCodes(): void
     {
         // In the NO_COLOR case, cursor control remains and color is absent.
         $output = new BufferOutput();
-        $reporter = new TtyReporter($output, colour: false, cursor: true);
+        $reporter = new TtyReporter($output, color: false, cursor: true);
 
         $reporter->onEvent(new RunStarted('run-1', 2, 1, 1.0));
         $reporter->onEvent(new TestClassStarted('App\AlphaTest', 1.0));
@@ -248,7 +248,7 @@ final class TtyReporterTest
         // On a non-TTY, --reporter=tty uses output that only adds new lines.
         // Unavailable live output MUST NOT hide information.
         $output = new BufferOutput();
-        $reporter = new TtyReporter($output, colour: false, cursor: false);
+        $reporter = new TtyReporter($output, color: false, cursor: false);
 
         $reporter->onEvent(new TestClassStarted('App\AlphaTest', 1.0));
         $reporter->onEvent(new TestFinished($this->result('App\AlphaTest', 'one', Outcome::Passed), 1.1));
@@ -263,13 +263,13 @@ final class TtyReporterTest
     public function theWindowShowsACounterAndInFlightClassesWithElapsedTime(): void
     {
         $output = new BufferOutput();
-        $reporter = new TtyReporter($output, colour: true, cursor: true);
+        $reporter = new TtyReporter($output, color: true, cursor: true);
 
         $reporter->onEvent(new RunStarted('run-1', 4, 2, 10.0));
         $reporter->onEvent(new TestClassStarted('App\AlphaTest', 10.0));
         $reporter->onEvent(new TestFinished($this->result('App\AlphaTest', 'one', Outcome::Failed), 11.5));
 
-        $terminal = new TerminalEmulator(retainColour: true);
+        $terminal = new TerminalEmulator(retainColor: true);
         $terminal->write($output->buffer());
 
         // The counter shows completed and planned tests with a red failure
@@ -288,7 +288,7 @@ final class TtyReporterTest
         $output = new BufferOutput();
         // Eight terminal rows limit the window to three lines. These lines are
         // the counter, one class, and the overflow.
-        $reporter = new TtyReporter($output, colour: false, cursor: true, terminalRows: 8);
+        $reporter = new TtyReporter($output, color: false, cursor: true, terminalRows: 8);
 
         $reporter->onEvent(new RunStarted('run-1', 9, 3, 1.0));
         $reporter->onEvent(new TestClassStarted('App\AlphaTest', 1.0));
@@ -318,7 +318,7 @@ final class TtyReporterTest
     public function tickAdvancesInFlightDurationsWithoutEvents(): void
     {
         $output = new BufferOutput();
-        $reporter = new TtyReporter($output, colour: false, cursor: true);
+        $reporter = new TtyReporter($output, color: false, cursor: true);
 
         $reporter->onEvent(new RunStarted('run-1', 1, 1, 1.0));
         $reporter->onEvent(new TestClassStarted('App\AlphaTest', 1.0));
@@ -335,7 +335,7 @@ final class TtyReporterTest
     public function tickWithoutCursorSupportWritesNothing(): void
     {
         $output = new BufferOutput();
-        $reporter = new TtyReporter($output, colour: false, cursor: false);
+        $reporter = new TtyReporter($output, color: false, cursor: false);
 
         $reporter->onEvent(new TestClassStarted('App\AlphaTest', 1.0));
         $reporter->tick(2.0);
@@ -347,7 +347,7 @@ final class TtyReporterTest
     public function tickWithNoClassesInFlightWritesNothing(): void
     {
         $output = new BufferOutput();
-        $reporter = new TtyReporter($output, colour: false, cursor: true);
+        $reporter = new TtyReporter($output, color: false, cursor: true);
 
         $reporter->onEvent(new RunStarted('run-1', 1, 1, 1.0));
         $reporter->tick(2.0);
@@ -359,7 +359,7 @@ final class TtyReporterTest
     public function redrawsInsideTheThrottleWindowAreSkipped(): void
     {
         $output = new BufferOutput();
-        $reporter = new TtyReporter($output, colour: false, cursor: true);
+        $reporter = new TtyReporter($output, color: false, cursor: true);
 
         $reporter->onEvent(new TestClassStarted('App\AlphaTest', 1.0));
         $before = $output->buffer();
@@ -377,7 +377,7 @@ final class TtyReporterTest
     public function repaintsRewriteLinesInPlaceWithoutBlankingTheWindow(): void
     {
         $output = new BufferOutput();
-        $reporter = new TtyReporter($output, colour: false, cursor: true);
+        $reporter = new TtyReporter($output, color: false, cursor: true);
 
         $reporter->onEvent(new TestClassStarted('App\AlphaTest', 1.0));
         $before = \strlen($output->buffer());
@@ -396,7 +396,7 @@ final class TtyReporterTest
     public function classFinalizationRepaintsInOneFrameWithoutBlanking(): void
     {
         $output = new BufferOutput();
-        $reporter = new TtyReporter($output, colour: false, cursor: true);
+        $reporter = new TtyReporter($output, color: false, cursor: true);
 
         $reporter->onEvent(new TestClassStarted('App\AlphaTest', 1.0));
         $reporter->onEvent(new TestClassStarted('App\BetaTest', 1.05));
@@ -417,7 +417,7 @@ final class TtyReporterTest
     public function theCursorIsHiddenWhileLiveAndRestoredAtFinish(): void
     {
         $output = new BufferOutput();
-        $reporter = new TtyReporter($output, colour: false, cursor: true);
+        $reporter = new TtyReporter($output, color: false, cursor: true);
 
         $reporter->onEvent(new TestClassStarted('App\AlphaTest', 1.0));
 
@@ -433,7 +433,7 @@ final class TtyReporterTest
     public function classFinalizationBypassesTheThrottle(): void
     {
         $output = new BufferOutput();
-        $reporter = new TtyReporter($output, colour: false, cursor: true);
+        $reporter = new TtyReporter($output, color: false, cursor: true);
 
         $reporter->onEvent(new TestClassStarted('App\AlphaTest', 1.0));
         $reporter->onEvent(new TestFinished($this->result('App\AlphaTest', 'one', Outcome::Failed), 1.01));

--- a/tests/Unit/Runner/ConditionEvaluationTest.php
+++ b/tests/Unit/Runner/ConditionEvaluationTest.php
@@ -18,7 +18,7 @@ use Greenlight\Tests\Support\CollectingEventSink;
 final class ConditionEvaluationTest
 {
     #[Test]
-    public function parameterisedConditionsSkipWithRenderedArgumentsAndRunWhenSatisfied(): void
+    public function parameterizedConditionsSkipWithRenderedArgumentsAndRunWhenSatisfied(): void
     {
         \putenv('GREENLIGHT_STDLIB_NOPE');
         [$summary, $results] = $this->runFixture('ConditionArguments');

--- a/tests/Unit/Support/SubprocessTest.php
+++ b/tests/Unit/Support/SubprocessTest.php
@@ -16,7 +16,7 @@ final readonly class SubprocessTest
     public function __construct(private TempDirectory $workspace) {}
 
     #[Test]
-    public function runCapturesTheResultAndHonoursItsExecutionContext(): void
+    public function runCapturesTheResultAndHonorsItsExecutionContext(): void
     {
         $result = Subprocess::run(
             $this->workspace->path(),

--- a/tests/Unit/Tools/RuntimeMessageTest.php
+++ b/tests/Unit/Tools/RuntimeMessageTest.php
@@ -102,10 +102,9 @@ final readonly class RuntimeMessageTest
     }
 
     #[Test]
-    public function proseCheckReportsTheNewExactDiagnostics(): void
+    public function proseCheckReportsExactDiagnosticsAndRejectsRemovedOptions(): void
     {
         $root = $this->tempDirectory->subdirectory('prose-check/project');
-        $baseline = $this->tempDirectory->path() . '/prose-check/baseline';
         \file_put_contents(
             $root . '/sample.md',
             "# Sample\n\n"
@@ -118,29 +117,24 @@ final readonly class RuntimeMessageTest
             $script,
             'check',
             '--root=' . $root,
-            '--baseline-dir=' . $baseline,
         ]);
 
         Expect::that($sentence->exitCode)->toBe(1)
             ->and($sentence->stdout)->toContain(
-                'sample.md:3: sentence-length: Write no more than 25 words in a descriptive sentence. Found 27 words. [new finding]',
+                'sample.md:3: sentence-length: Write no more than 25 words in a descriptive sentence. Found 27 words.',
             );
 
         \file_put_contents($root . '/sample.md', "# Sample\n\nThe worker stops.\n");
-        \mkdir($baseline);
-        \file_put_contents($baseline . '/root.json', '"invalid"');
-        $invalidBaseline = Subprocess::run($root, [
+        $removedOption = Subprocess::run($root, [
             \PHP_BINARY,
             $script,
             'check',
             '--root=' . $root,
-            '--baseline-dir=' . $baseline,
+            '--baseline-dir=' . $root . '/baseline',
         ]);
 
-        Expect::that($invalidBaseline->exitCode)->toBe(1)
-            ->and($invalidBaseline->stderr)->toContain(
-                \sprintf('Use an array in baseline file "%s/root.json".', $baseline),
-            );
+        Expect::that($removedOption->exitCode)->toBe(1)
+            ->and($removedOption->stderr)->toContain('Unknown prose-check option "--baseline-dir=');
     }
 
     #[Test]

--- a/tools/prose-check.php
+++ b/tools/prose-check.php
@@ -2,14 +2,6 @@
 
 declare(strict_types=1);
 
-const PROSE_BLOCKING_RULES = [
-    'semicolon',
-    'contraction',
-    'british-spelling',
-    'sentence-length',
-    'paragraph-length',
-];
-
 const PROSE_EXCLUDED_DIRECTORIES = [
     '.git',
     '.phpstan-api-stubs',
@@ -79,6 +71,16 @@ const PROSE_BRITISH_SPELLINGS = [
     'coloured',
     'colouring',
     'colours',
+    'favour',
+    'favoured',
+    'favouring',
+    'favourite',
+    'favourites',
+    'favours',
+    'honour',
+    'honoured',
+    'honouring',
+    'honours',
     'initialise',
     'initialised',
     'initialises',
@@ -87,10 +89,24 @@ const PROSE_BRITISH_SPELLINGS = [
     'licenced',
     'licences',
     'licencing',
+    'labelled',
+    'labelling',
+    'normalise',
+    'normalised',
+    'normalises',
+    'normalising',
     'optimise',
     'optimised',
     'optimises',
     'optimising',
+    'parameterise',
+    'parameterised',
+    'parameterises',
+    'parameterising',
+    'pluralise',
+    'pluralised',
+    'pluralises',
+    'pluralising',
     'prioritise',
     'prioritised',
     'prioritises',
@@ -103,6 +119,10 @@ const PROSE_BRITISH_SPELLINGS = [
     'serialised',
     'serialises',
     'serialising',
+    'singularise',
+    'singularised',
+    'singularises',
+    'singularising',
     'travelling',
     'utilisation',
 ];
@@ -121,17 +141,31 @@ const PROSE_DISCOURAGED_WORDS = [
     'using',
 ];
 
+const PROSE_REGISTERED_LITERALS = [
+    'dev-main',
+];
+
 const PROSE_ALLOWED_ING_WORDS = [
     'anything',
     'during',
     'everything',
+    'marketing',
+    'meaning',
     'missing',
     'nothing',
     'opening',
     'remaining',
+    'running',
+    'scheduling',
     'something',
+    'spelling',
+    'staging',
     'string',
+    'substring',
+    'testing',
+    'timing',
     'warning',
+    'writing',
 ];
 
 const PROSE_IMPERATIVE_VERBS = [
@@ -170,22 +204,16 @@ function proseFail(string $message): never
 /**
  * @param list<string> $arguments
  *
- * @return array{command: string, operation: ?string, root: string, baseline: string}
+ * @return array{command: string, root: string}
  */
 function proseArguments(array $arguments): array
 {
     \array_shift($arguments);
     $command = 'check';
-    $operation = null;
     $root = \dirname(__DIR__);
-    $baseline = null;
 
     if (isset($arguments[0]) && !\str_starts_with($arguments[0], '--')) {
         $command = \array_shift($arguments);
-    }
-
-    if ($command === 'baseline' && isset($arguments[0]) && \in_array($arguments[0], ['--create', '--prune'], true)) {
-        $operation = \array_shift($arguments);
     }
 
     foreach ($arguments as $argument) {
@@ -195,21 +223,11 @@ function proseArguments(array $arguments): array
             continue;
         }
 
-        if (\str_starts_with($argument, '--baseline-dir=')) {
-            $baseline = \substr($argument, \strlen('--baseline-dir='));
-
-            continue;
-        }
-
         \proseFail(\sprintf('Unknown prose-check option "%s".', $argument));
     }
 
-    if (!\in_array($command, ['check', 'review', 'baseline'], true)) {
+    if (!\in_array($command, ['check', 'review'], true)) {
         \proseFail(\sprintf('Unknown prose-check command "%s".', $command));
-    }
-
-    if ($command === 'baseline' && $operation === null) {
-        \proseFail('The baseline command requires --create or --prune.');
     }
 
     $resolvedRoot = \realpath($root);
@@ -220,9 +238,7 @@ function proseArguments(array $arguments): array
 
     return [
         'command' => $command,
-        'operation' => $operation,
         'root' => $resolvedRoot,
-        'baseline' => $baseline ?? $resolvedRoot . '/tools/prose-baseline',
     ];
 }
 
@@ -397,8 +413,17 @@ function proseCleanMarkdown(string $text): string
  */
 function proseAstroPassages(string $path, string $contents): array
 {
-    $contents = (string) \preg_replace('/\A---\R.*?\R---\R/s', '', $contents);
-    $contents = (string) \preg_replace('#<(?:script|style|code|pre)\b[^>]*>.*?</(?:script|style|code|pre)>#is', ' LITERAL ', $contents);
+    $contents = (string) \preg_replace_callback(
+        '/\A---\R.*?\R---\R/s',
+        static fn(array $matches): string => \str_repeat("\n", \substr_count($matches[0], "\n")),
+        $contents,
+    );
+    $contents = (string) \preg_replace_callback(
+        '#<(?:script|style|code|pre)\b[^>]*>.*?</(?:script|style|code|pre)>#is',
+        static fn(array $matches): string => ' LITERAL ' . \str_repeat("\n", \substr_count($matches[0], "\n")),
+        $contents,
+    );
+    $contents = \proseMaskAstroExpressions($contents);
     $lines = \preg_split('/\R/', $contents);
     $passages = [];
     $paragraph = [];
@@ -442,6 +467,70 @@ function proseAstroPassages(string $path, string $contents): array
     \proseFlushParagraph($passages, $paragraph, $paragraphLine, $path, false);
 
     return $passages;
+}
+
+function proseMaskAstroExpressions(string $contents): string
+{
+    $masked = '';
+    $depth = 0;
+    $quote = null;
+    $escaped = false;
+    $length = \strlen($contents);
+
+    for ($index = 0; $index < $length; ++$index) {
+        $character = $contents[$index];
+
+        if ($depth === 0) {
+            if ($character === '{') {
+                $depth = 1;
+                $masked .= ' ';
+
+                continue;
+            }
+
+            $masked .= $character;
+
+            continue;
+        }
+
+        if ($character === "\n" || $character === "\r") {
+            $masked .= $character;
+
+            continue;
+        }
+
+        $masked .= ' ';
+
+        if ($escaped) {
+            $escaped = false;
+
+            continue;
+        }
+
+        if ($quote !== null) {
+            if ($character === '\\') {
+                $escaped = true;
+            } elseif ($character === $quote) {
+                $quote = null;
+            }
+
+            continue;
+        }
+
+        if (\in_array($character, ["'", '"', '`'], true)) {
+            $quote = $character;
+
+            continue;
+        }
+
+        if ($character === '{') {
+            ++$depth;
+        } elseif ($character === '}') {
+            --$depth;
+        }
+    }
+
+    return $masked;
 }
 
 /**
@@ -569,7 +658,7 @@ function proseCommentTokens(string $contents): array
 function proseAnalyze(array $passage): array
 {
     $findings = [];
-    $text = $passage['text'];
+    $text = \proseWithoutRegisteredLiterals($passage['text']);
     $normalized = \proseNormalize($text);
 
     $add = static function (string $rule, string $severity, string $message) use (&$findings, $passage, $normalized): void {
@@ -674,6 +763,20 @@ function proseAnalyze(array $passage): array
     }
 
     return $findings;
+}
+
+function proseWithoutRegisteredLiterals(string $text): string
+{
+    $literals = \array_map(
+        static fn(string $literal): string => \preg_quote($literal, '/'),
+        PROSE_REGISTERED_LITERALS,
+    );
+
+    return (string) \preg_replace(
+        '/(?<![A-Za-z0-9])(?:' . \implode('|', $literals) . ')(?![A-Za-z0-9])/u',
+        ' LITERAL ',
+        $text,
+    );
 }
 
 /**
@@ -783,269 +886,6 @@ function proseFindings(string $root): array
 }
 
 /**
- * @param list<array{path: string, line: int, rule: string, severity: string, message: string, passage: string}> $findings
- *
- * @return array<string, array{fingerprint: string, path: string, rule: string, passage: string, count: int, line: int, message: string}>
- */
-function proseAggregate(array $findings): array
-{
-    $entries = [];
-
-    foreach ($findings as $finding) {
-        if ($finding['severity'] !== 'blocking') {
-            continue;
-        }
-
-        $identity = \proseFindingIdentity($finding['path'], $finding['rule'], $finding['passage']);
-
-        if (!isset($entries[$identity])) {
-            $entries[$identity] = [
-                'fingerprint' => '',
-                'path' => $finding['path'],
-                'rule' => $finding['rule'],
-                'passage' => $finding['passage'],
-                'count' => 0,
-                'line' => $finding['line'],
-                'message' => $finding['message'],
-            ];
-        }
-
-        ++$entries[$identity]['count'];
-    }
-
-    $fingerprinted = [];
-
-    foreach ($entries as $entry) {
-        $fingerprint = \hash(
-            'sha256',
-            $entry['path'] . "\0" . $entry['rule'] . "\0" . $entry['passage'] . "\0" . $entry['count'],
-        );
-        $entry['fingerprint'] = $fingerprint;
-        $fingerprinted[$fingerprint] = $entry;
-    }
-
-    \ksort($fingerprinted);
-
-    return $fingerprinted;
-}
-
-function proseFindingIdentity(string $path, string $rule, string $passage): string
-{
-    return \hash('sha256', $path . "\0" . $rule . "\0" . $passage);
-}
-
-function proseShard(string $path): string
-{
-    if (\str_starts_with($path, 'docs/architecture/')) {
-        return 'docs-architecture';
-    }
-
-    if (\str_starts_with($path, 'docs/')) {
-        return 'docs-guides';
-    }
-
-    if (\str_starts_with($path, 'website/')) {
-        return 'website';
-    }
-
-    if (\preg_match('#^src/([^/]+)/#', $path, $matches) === 1) {
-        return 'src-' . \strtolower($matches[1]);
-    }
-
-    if (\str_starts_with($path, 'tests/')) {
-        return 'tests';
-    }
-
-    if (\str_starts_with($path, 'tools/')) {
-        return 'tools';
-    }
-
-    return 'root';
-}
-
-/**
- * @return list<string>
- */
-function proseExpectedShards(string $root): array
-{
-    $shards = ['root', 'docs-guides', 'docs-architecture', 'website', 'tests', 'tools'];
-    $source = $root . '/src';
-
-    if (\is_dir($source)) {
-        foreach (new DirectoryIterator($source) as $entry) {
-            if ($entry->isDot() || !$entry->isDir()) {
-                continue;
-            }
-
-            $shards[] = 'src-' . \strtolower($entry->getFilename());
-        }
-    }
-
-    $shards = \array_values(\array_unique($shards));
-    \sort($shards);
-
-    return $shards;
-}
-
-/**
- * @param array<string, array{fingerprint: string, path: string, rule: string, passage: string, count: int, line: int, message: string}> $entries
- */
-function proseWriteBaseline(string $root, string $directory, array $entries): void
-{
-    if (!\is_dir($directory) && !\mkdir($directory, 0o777, true) && !\is_dir($directory)) {
-        \proseFail(\sprintf('Cannot create baseline directory "%s".', $directory));
-    }
-
-    $byShard = [];
-
-    foreach (\proseExpectedShards($root) as $shard) {
-        $byShard[$shard] = [];
-    }
-
-    foreach ($entries as $entry) {
-        $byShard[\proseShard($entry['path'])][] = [
-            'fingerprint' => $entry['fingerprint'],
-            'path' => $entry['path'],
-            'rule' => $entry['rule'],
-            'passage' => $entry['passage'],
-            'count' => $entry['count'],
-        ];
-    }
-
-    \ksort($byShard);
-
-    $existingFiles = \glob($directory . '/*.json');
-
-    foreach ($existingFiles === false ? [] : $existingFiles as $file) {
-        \unlink($file);
-    }
-
-    foreach ($byShard as $shard => $values) {
-        \usort(
-            $values,
-            static fn(array $left, array $right): int => [
-                $left['path'],
-                $left['rule'],
-                $left['passage'],
-            ] <=> [
-                $right['path'],
-                $right['rule'],
-                $right['passage'],
-            ],
-        );
-
-        $json = \json_encode($values, \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR);
-        \file_put_contents($directory . '/' . $shard . '.json', $json . "\n");
-    }
-}
-
-/**
- * @return array<string, array{fingerprint: string, path: string, rule: string, passage: string, count: int}>
- */
-function proseReadBaseline(string $directory): array
-{
-    $entries = [];
-
-    $baselineFiles = \glob($directory . '/*.json');
-
-    foreach ($baselineFiles === false ? [] : $baselineFiles as $file) {
-        $contents = \file_get_contents($file);
-
-        if (!\is_string($contents)) {
-            \proseFail(\sprintf('Cannot read baseline file "%s".', $file));
-        }
-
-        $values = \json_decode($contents, true, flags: \JSON_THROW_ON_ERROR);
-
-        if (!\is_array($values)) {
-            \proseFail(\sprintf('Use an array in baseline file "%s".', $file));
-        }
-
-        foreach ($values as $value) {
-            if (!\is_array($value) || !isset(
-                $value['fingerprint'],
-                $value['path'],
-                $value['rule'],
-                $value['passage'],
-                $value['count'],
-            )
-                || !\is_string($value['fingerprint'])
-                || !\is_string($value['path'])
-                || !\is_string($value['rule'])
-                || !\is_string($value['passage'])
-                || !\is_int($value['count'])
-            ) {
-                \proseFail(\sprintf('Baseline file "%s" contains an invalid entry.', $file));
-            }
-
-            $entries[$value['fingerprint']] = [
-                'fingerprint' => $value['fingerprint'],
-                'path' => $value['path'],
-                'rule' => $value['rule'],
-                'passage' => $value['passage'],
-                'count' => $value['count'],
-            ];
-        }
-    }
-
-    \ksort($entries);
-
-    return $entries;
-}
-
-/**
- * @param array<string, array{fingerprint: string, path: string, rule: string, passage: string, count: int, line: int, message: string}> $current
- * @param array<string, array{fingerprint: string, path: string, rule: string, passage: string, count: int}> $baseline
- *
- * @return array{
- *     new: list<array{fingerprint: string, path: string, rule: string, passage: string, count: int, line: int, message: string}>,
- *     stale: list<array{fingerprint: string, path: string, rule: string, passage: string, count: int}>
- * }
- */
-function proseCompareBaseline(array $current, array $baseline): array
-{
-    $new = [];
-    $stale = [];
-    $currentByIdentity = [];
-    $baselineByIdentity = [];
-
-    foreach ($current as $entry) {
-        $currentByIdentity[\proseFindingIdentity($entry['path'], $entry['rule'], $entry['passage'])] = $entry;
-    }
-
-    foreach ($baseline as $entry) {
-        $baselineByIdentity[\proseFindingIdentity($entry['path'], $entry['rule'], $entry['passage'])] = $entry;
-    }
-
-    foreach ($currentByIdentity as $identity => $entry) {
-        if (!isset($baselineByIdentity[$identity])) {
-            $new[] = $entry;
-
-            continue;
-        }
-
-        if ($entry['count'] > $baselineByIdentity[$identity]['count']) {
-            $new[] = $entry;
-        }
-
-        if ($entry['count'] < $baselineByIdentity[$identity]['count']) {
-            $stale[] = $baselineByIdentity[$identity];
-        }
-    }
-
-    foreach ($baselineByIdentity as $identity => $entry) {
-        if (!isset($currentByIdentity[$identity])) {
-            $stale[] = $entry;
-        }
-    }
-
-    \usort($new, static fn(array $left, array $right): int => [$left['path'], $left['rule']] <=> [$right['path'], $right['rule']]);
-    \usort($stale, static fn(array $left, array $right): int => [$left['path'], $left['rule']] <=> [$right['path'], $right['rule']]);
-
-    return ['new' => $new, 'stale' => $stale];
-}
-
-/**
  * @param array{path: string, line: int, rule: string, message: string, ...} $finding
  */
 function prosePrintFinding(array $finding, string $suffix = ''): void
@@ -1073,50 +913,13 @@ if ($options['command'] === 'review') {
     exit(0);
 }
 
-$current = \proseAggregate($findings);
+$hasBlockingFinding = false;
 
-if ($options['command'] === 'baseline' && $options['operation'] === '--create') {
-    $baselineFiles = \glob($options['baseline'] . '/*.json');
-
-    if ($baselineFiles !== false && $baselineFiles !== []) {
-        \proseFail('The prose baseline already exists.');
+foreach ($findings as $finding) {
+    if ($finding['severity'] === 'blocking') {
+        \prosePrintFinding($finding);
+        $hasBlockingFinding = true;
     }
-
-    \proseWriteBaseline($options['root'], $options['baseline'], $current);
-    echo \sprintf("Created prose baseline with %d finding groups.\n", \count($current));
-
-    exit(0);
 }
 
-$baseline = \proseReadBaseline($options['baseline']);
-$comparison = \proseCompareBaseline($current, $baseline);
-
-if ($options['command'] === 'baseline' && $options['operation'] === '--prune') {
-    if ($comparison['new'] !== []) {
-        foreach ($comparison['new'] as $finding) {
-            \prosePrintFinding($finding, ' [new finding]');
-        }
-
-        \proseFail('Baseline pruning refused new prose findings.');
-    }
-
-    \proseWriteBaseline($options['root'], $options['baseline'], $current);
-    echo \sprintf("Pruned prose baseline to %d finding groups.\n", \count($current));
-
-    exit(0);
-}
-
-foreach ($comparison['new'] as $finding) {
-    \prosePrintFinding($finding, ' [new finding]');
-}
-
-foreach ($comparison['stale'] as $finding) {
-    echo \sprintf(
-        '%s:1: %s: stale baseline finding for "%s"',
-        $finding['path'],
-        $finding['rule'],
-        $finding['passage'],
-    ) . "\n";
-}
-
-exit($comparison['new'] === [] && $comparison['stale'] === [] ? 0 : 1);
+exit($hasBlockingFinding ? 1 : 0);

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -66,7 +66,7 @@ final class PriceTest
         <h2>Tests stay plain PHP.</h2>
         <p>
           Use ordinary classes, native attributes, and typed expectations. Greenlight
-          finds each <code>#[Test]</code> method without a base class or naming rule.
+          finds each <code>#[Test]</code> method without a base class or method-name convention.
         </p>
         <a class="text-link" href={sitePath('docs/getting-started/')}>Write your first test</a>
       </div>
@@ -149,7 +149,7 @@ final class PriceTest
         <div>
           <dt><code>test*()</code></dt>
           <span aria-hidden="true">→</span>
-          <dd><code>#[Test]</code> on any public method</dd>
+          <dd><code>#[Test]</code> on a public method</dd>
         </div>
         <div>
           <dt><code>$this-&gt;assertSame()</code></dt>


### PR DESCRIPTION
## Summary

- Removes prose baseline generation, comparison, pruning, and shard support.
- Enforces zero blocking findings directly and leaves advisory review as a manual guardrail.
- Resolves the final documentation, PHPDoc, comment, and website advisory findings.
- Applies American English spelling to repository-owned identifiers and updates their call sites.
- Excludes multiline Astro expressions and registered exact literals from prose analysis.

## Continuation record

- Base commit: \`80e3725cf7c13aa8f9492f934e7435b1879727bf\`
- Result commit: \`009fdbc3104cf0768340bae4d19309b5570c614e\`
- Owned paths: final documentation and PHPDoc findings, prose-check implementation and tests, American-spelling identifier call sites, and website copy
- Blocking findings: 0 before, 0 after
- Advisory findings: 74 before, 0 after
- Terminology: registered marketing copy and substring; approved established noun forms for scheduling, staging, timing, testing, and related terms
- Checks: \`composer prose:check\`, \`composer prose:review\`, focused prose and runtime-message tests, \`composer static-analysis\`, \`composer tests\`, and \`make docs-check\`
- Next unclaimed shard: none

The prose baseline directory is absent. The checker rejects the removed baseline option. External names such as PHPStan\`s \`analyse\` command and \`Analyser\` namespace remain exact.