### PR TITLE
fix: close simplified English audit gaps

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 - Technical prose includes documentation, PHPDoc, comments, contributor material, accessibility text, diagnostics, CLI help, and human-readable output.
 - Use ASD-STE100 Issue 9 for technical prose.
 - Use uppercase `MUST`, `MUST NOT`, `SHOULD`, `SHOULD NOT`, and `MAY` as normative tokens.
-- Use STE clarity principles for promotional copy. The controlled vocabulary is optional for promotional copy.
+- Use STE clarity principles for marketing copy. The controlled vocabulary is optional for marketing copy.
 - Add focused unit or acceptance tests. Use `Greenlight\Expect`. Treat shared fixture directories as append-only.
 - Run focused tests with `php bin/greenlight run --filter=<test-id>`.
 - Before you complete PHP changes, run `composer static-analysis && composer tests`.

--- a/docs/architecture/conventions.md
+++ b/docs/architecture/conventions.md
@@ -69,7 +69,7 @@ from another throwable, preserve that text and its punctuation.
 An error message **MUST** enclose an interpolated identifier in double quotes:
 
 ```php
-'Config file "%s" does not exist.'
+'Configuration file "%s" does not exist.'
 ```
 
 The PHP string literal itself **SHOULD** stay single-quoted.

--- a/docs/architecture/technical-writing.md
+++ b/docs/architecture/technical-writing.md
@@ -12,8 +12,8 @@ This policy applies to repository-owned technical prose:
 * Command help, diagnostics, error messages, and reports
 * Package, schema, and configuration descriptions
 
-Promotional website text follows the clarity principles in this policy. It does
-not have to use the controlled vocabulary.
+Marketing copy follows the clarity principles in this policy. It does not have
+to use the controlled vocabulary.
 
 The prose checker finds mechanical errors and possible language problems. It
 does not certify compliance with ASD-STE100. A writer must also review the

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -103,7 +103,7 @@ Enum cases compare by identity.
 * `toStartWith(string $prefix)` checks that a string starts with the prefix.
 * `toEndWith(string $suffix)` checks that a string ends with the suffix.
 
-Matchers that consume a `Traversable` do not rewind it afterwards.
+Matchers that consume a `Traversable` do not rewind it after consumption.
 
 ### Numbers
 

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -930,7 +930,7 @@ final readonly class Application
         return $probed > 0 ? $probed : 24;
     }
 
-    /** Uses the loaded config so IDE and PHPStan signatures match. */
+    /** Uses the loaded configuration so IDE and PHPStan signatures match. */
     private function ideHelperCommand(ParsedArguments $arguments, string $workingDirectory): int
     {
         try {

--- a/src/Config/ConfigFileError.php
+++ b/src/Config/ConfigFileError.php
@@ -28,13 +28,13 @@ final class ConfigFileError extends \RuntimeException
 
     public static function notFound(string $path): self
     {
-        return new self(\sprintf('Config file "%s" does not exist.', $path));
+        return new self(\sprintf('Configuration file "%s" does not exist.', $path));
     }
 
     public static function didNotReturnBuilder(string $file, mixed $returned): self
     {
         return new self(\sprintf(
-            'Config file "%s" must return a %s instance, got %s. End the file with "return GreenlightConfig::create()->...;".',
+            'Configuration file "%s" must return a %s instance, got %s. End the file with "return GreenlightConfig::create()->...;".',
             $file,
             GreenlightConfig::class,
             \get_debug_type($returned),
@@ -44,7 +44,7 @@ final class ConfigFileError extends \RuntimeException
     public static function threw(string $file, \Throwable $cause): self
     {
         return new self(\sprintf(
-            'Config file "%s" threw %s: %s',
+            'Configuration file "%s" threw %s: %s',
             $file,
             $cause::class,
             $cause->getMessage(),

--- a/src/Reporting/RunHeader.php
+++ b/src/Reporting/RunHeader.php
@@ -20,8 +20,8 @@ final readonly class RunHeader
         $segments = ['PHP ' . $this->phpVersion];
 
         $segments[] = $this->configFile === null
-            ? $style->warn('config: (none)')
-            : 'config: ' . $this->configFile;
+            ? $style->warn('configuration: (none)')
+            : 'configuration: ' . $this->configFile;
 
         $workersSegment = 'workers: ' . $workers;
         $segments[] = $this->workerFallback ? $style->warn($workersSegment) : $workersSegment;

--- a/tests/Acceptance/ProseCheckTest.php
+++ b/tests/Acceptance/ProseCheckTest.php
@@ -23,6 +23,7 @@ final readonly class ProseCheckTest
     #[DataRow(['british-spelling', 'The runner honours a labelled test.', 'The runner honors a labeled test.'], 'British honor and label spelling')]
     #[DataRow(['british-spelling', 'The driver normalises the data.', 'The driver normalizes the data.'], 'British normalize spelling')]
     #[DataRow(['british-spelling', 'The runner parameterises tests.', 'The runner parameterizes tests.'], 'British parameterize spelling')]
+    #[DataRow(['british-spelling', 'The reporter deserialises the event.', 'The reporter deserializes the event.'], 'British deserialize spelling')]
     #[DataRow([
         'sentence-length',
         'The orchestrator collects every selected test class from the configured directories and sends one complete assignment to each available worker before the test run starts in parallel.',
@@ -353,6 +354,20 @@ final readonly class ProseCheckTest
 
         $result = $this->run('check', $root);
         Expect::that($result->exitCode)->because('excludes dependencies at any directory depth')->toBe(0);
+    }
+
+    #[Test]
+    public function excludesNestedClaudeWorktrees(): void
+    {
+        $root = $this->workspace('nested-worktree-exclusion');
+        $this->write(
+            $root,
+            '.claude/worktrees/example/README.md',
+            "The worker doesn't use the configured colour; it stops.\n",
+        );
+
+        $result = $this->run('check', $root);
+        Expect::that($result->exitCode)->because('excludes nested Claude worktrees')->toBe(0);
     }
 
     #[Test]

--- a/tests/Unit/Config/ConfigLoaderTest.php
+++ b/tests/Unit/Config/ConfigLoaderTest.php
@@ -84,7 +84,7 @@ final class ConfigLoaderTest
         }
 
         Fail::because(
-            'Expected ConfigLoader::loadFromDirectory() to wrap the config RuntimeException in ConfigFileError.',
+            'Expected ConfigLoader::loadFromDirectory() to wrap the configuration RuntimeException in ConfigFileError.',
         );
     }
 

--- a/tests/Unit/Reporting/JsonLinesReporterTest.php
+++ b/tests/Unit/Reporting/JsonLinesReporterTest.php
@@ -104,7 +104,7 @@ final class JsonLinesReporterTest
             #[\Override]
             public static function fromWire(array $payload): static
             {
-                throw new \LogicException('Not deserialisable.');
+                throw new \LogicException('Not deserializable.');
             }
         };
 

--- a/tests/Unit/Reporting/PlainReporterTest.php
+++ b/tests/Unit/Reporting/PlainReporterTest.php
@@ -56,7 +56,7 @@ final class PlainReporterTest
         CannedStream::feed(new PlainReporter($output, new RunHeader('0.4.0', 'greenlight.php', 7, phpVersion: '8.3.1')));
 
         Expect::that($output->buffer())->because('header line precedes the run line when provided')
-            ->toStartWith("Greenlight 0.4.0\nPHP 8.3.1 | config: greenlight.php | workers: 2 | seed: 7\nRun run-1: 6 tests, 2 workers\n");
+            ->toStartWith("Greenlight 0.4.0\nPHP 8.3.1 | configuration: greenlight.php | workers: 2 | seed: 7\nRun run-1: 6 tests, 2 workers\n");
     }
 
     #[Test]

--- a/tests/Unit/Reporting/RunHeaderTest.php
+++ b/tests/Unit/Reporting/RunHeaderTest.php
@@ -17,7 +17,7 @@ final class RunHeaderTest
         $header = new RunHeader('0.4.0', 'greenlight.php', 123456, phpVersion: '8.3.1');
 
         Expect::that($header->render(11, new Style(ansi: false)))->because('renders two plain lines when every field is present')
-            ->toBe("Greenlight 0.4.0\nPHP 8.3.1 | config: greenlight.php | workers: 11 | seed: 123456");
+            ->toBe("Greenlight 0.4.0\nPHP 8.3.1 | configuration: greenlight.php | workers: 11 | seed: 123456");
     }
 
     #[Test]
@@ -26,7 +26,7 @@ final class RunHeaderTest
         $header = new RunHeader('0.4.0', 'greenlight.php', 123456, phpVersion: '8.3.1');
 
         Expect::that($header->render(11, new Style(ansi: true)))->because('colors the name green and the seed dim')
-            ->toBe("\x1b[32mGreenlight\x1b[0m 0.4.0\nPHP 8.3.1 | config: greenlight.php | workers: 11 | \x1b[2mseed: 123456\x1b[0m");
+            ->toBe("\x1b[32mGreenlight\x1b[0m 0.4.0\nPHP 8.3.1 | configuration: greenlight.php | workers: 11 | \x1b[2mseed: 123456\x1b[0m");
     }
 
     #[Test]
@@ -35,7 +35,7 @@ final class RunHeaderTest
         $header = new RunHeader('dev-main', 'greenlight.php', null, phpVersion: '8.4.0');
 
         Expect::that($header->render(1, new Style(ansi: false)))->because('omits the seed when absent')
-            ->toBe("Greenlight dev-main\nPHP 8.4.0 | config: greenlight.php | workers: 1");
+            ->toBe("Greenlight dev-main\nPHP 8.4.0 | configuration: greenlight.php | workers: 1");
     }
 
     #[Test]
@@ -44,9 +44,9 @@ final class RunHeaderTest
         $header = new RunHeader('dev-main', null, null, phpVersion: '8.4.0');
 
         Expect::that($header->render(1, new Style(ansi: false)))->because('flags a missing configuration file')
-            ->toBe("Greenlight dev-main\nPHP 8.4.0 | config: (none) | workers: 1")
+            ->toBe("Greenlight dev-main\nPHP 8.4.0 | configuration: (none) | workers: 1")
             ->and($header->render(1, new Style(ansi: true)))
-            ->toContain("\x1b[33mconfig: (none)\x1b[0m");
+            ->toContain("\x1b[33mconfiguration: (none)\x1b[0m");
     }
 
     #[Test]
@@ -61,10 +61,10 @@ final class RunHeaderTest
     }
 
     #[Test]
-    public function phpVersionDefaultsToTheRuntime(): void
+    public function phpVersionDefaultsToCurrentPhpVersion(): void
     {
         $header = new RunHeader('dev-main');
 
-        Expect::that($header->render(2, new Style(ansi: false)))->because('PHP version defaults to the runtime')->toContain('PHP ' . \PHP_VERSION);
+        Expect::that($header->render(2, new Style(ansi: false)))->because('PHP version defaults to the current PHP version')->toContain('PHP ' . \PHP_VERSION);
     }
 }

--- a/tests/Unit/Reporting/TtyReporterTest.php
+++ b/tests/Unit/Reporting/TtyReporterTest.php
@@ -47,7 +47,7 @@ final class TtyReporterTest
         $screen = $terminal->screen();
 
         Expect::that($screen)->because('interleaved classes finalize in place with ANSI')->toContain('Greenlight dev-main')
-            ->toContain('PHP 8.4.0 | config: greenlight.php | workers: 2 | seed: 4242')
+            ->toContain('PHP 8.4.0 | configuration: greenlight.php | workers: 2 | seed: 4242')
             // Only the failed class has a permanent line. The passed class
             // changes only the count.
             ->not()->toContain('✓ App\AlphaTest')

--- a/tests/Unit/Support/AcceptanceProjectTest.php
+++ b/tests/Unit/Support/AcceptanceProjectTest.php
@@ -46,7 +46,7 @@ final readonly class AcceptanceProjectTest
 
         if (!$builder instanceof GreenlightConfig) {
             Fail::because(\sprintf(
-                'Expected generated config "%s" to return GreenlightConfig, got %s.',
+                'Expected generated configuration "%s" to return GreenlightConfig, got %s.',
                 $project->path('greenlight.php'),
                 \get_debug_type($builder),
             ));
@@ -76,7 +76,7 @@ final readonly class AcceptanceProjectTest
 
         if (!$builder instanceof GreenlightConfig) {
             Fail::because(\sprintf(
-                'Expected generated config "%s" to return GreenlightConfig, got %s.',
+                'Expected generated configuration "%s" to return GreenlightConfig, got %s.',
                 $project->path('greenlight.php'),
                 \get_debug_type($builder),
             ));

--- a/tools/prose-check.php
+++ b/tools/prose-check.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 const PROSE_EXCLUDED_DIRECTORIES = [
+    '.claude/worktrees',
     '.git',
     '.phpstan-api-stubs',
     'tests/Fixture',
@@ -71,6 +72,11 @@ const PROSE_BRITISH_SPELLINGS = [
     'coloured',
     'colouring',
     'colours',
+    'deserialisable',
+    'deserialisation',
+    'deserialised',
+    'deserialises',
+    'deserialising',
     'favour',
     'favoured',
     'favouring',

--- a/website/src/components/RunPreview.astro
+++ b/website/src/components/RunPreview.astro
@@ -10,7 +10,7 @@
   <div class="run-preview__body">
     <div class="run-preview__meta">
       <strong>Greenlight <span>dev-main</span></strong>
-      <code>PHP 8.4.14 · config: greenlight.php · workers: 11</code>
+      <code>PHP 8.4.14 · configuration: greenlight.php · workers: 11</code>
     </div>
 
     <div class="run-preview__progress">

--- a/website/src/components/TerminalOutput.astro
+++ b/website/src/components/TerminalOutput.astro
@@ -17,7 +17,7 @@ const lines: Part[][] = [
     { text: ' dev-main' },
   ],
   [
-    { text: 'PHP 8.4.14 | config: greenlight.php | workers: 11 | ' },
+    { text: 'PHP 8.4.14 | configuration: greenlight.php | workers: 11 | ' },
     { text: 'seed: 560647545', tone: 'muted' },
   ],
   [],


### PR DESCRIPTION
## Summary

- Exclude ignored nested Claude worktrees from repository prose scans.
- Add missing American deserialize variants to the spelling guardrail.
- Normalize marketing copy, configuration, and run time terminology across owned prose.
- Change the human-readable run header label from config to configuration. Machine fields and contracts do not change.

## Continuation record

- Base commit: cef0b72e616d49219b2924d8ee96a10edf85c697
- Result commit: f9f5770cd6ea5bdec5c62355a5cdd7f7529aa1d2
- Owned paths: prose checker and acceptance coverage, technical-writing policy, affected documentation, PHP diagnostics and PHPDoc, reporting output assertions, and website examples
- Blocking findings: 0 before integration, 0 after integration
- Advisory findings: residual audit findings resolved; none deferred
- Terminology decisions: use marketing copy, configuration in prose, run time as a noun, and American deserialize forms
- Checks run: focused prose and reporting tests; full static analysis; full test suite; documentation build and site validation; blocking and advisory prose scans; diff validation
- Next unclaimed shard: none

This PR completes the final manual pass after the baseline-free enforcement PRs merged.