### PR TITLE
fix: close remaining simplified English gaps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,11 +32,11 @@
     },
     "suggest": {
         "ext-pcov": "Collects line coverage quickly",
-        "fidry/cpu-core-counter": "Improves worker core detection for auto with cgroup limits and more platforms",
+        "fidry/cpu-core-counter": "Improves the 'auto' worker count on systems with cgroup limits and on more platforms",
         "phpstan/extension-installer": "Registers the bundled PHPStan extension automatically",
-        "phpstan/phpstan": "Type-checks extension matcher calls and data providers with the bundled extension.neon",
-        "rector/rector": "Converts PHPUnit test classes to Greenlight with the bundled PhpUnitToGreenlightRector rule",
-        "symfony/framework-bundle": "Enables container service injection into kernel-aware Symfony tests through the SymfonyPlugin bridge"
+        "phpstan/phpstan": "Type-checks extension matcher calls and data providers with the bundled 'extension.neon' file",
+        "rector/rector": "Converts PHPUnit test classes to Greenlight with the bundled 'PhpUnitToGreenlightRector' rule",
+        "symfony/framework-bundle": "Enables container service injection into kernel-aware Symfony tests through the 'SymfonyPlugin' bridge"
     },
     "autoload": {
         "psr-4": {

--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -233,9 +233,9 @@ PHPDoc:
 
 Namespace: `Greenlight\Attribute`
 
-Runs an unsuccessful test attempt again for the specified number of
-additional attempts. The optional throwable type limits the unsuccessful
-attempts that start another attempt.
+Starts the specified number of additional attempts after an unsuccessful
+test attempt. If `$onlyOn` specifies a throwable type, only a cause of this
+type starts another attempt.
 
 ```php
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS)]

--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -2,7 +2,7 @@
 
 # Integration API
 
-This reference lists public integration types for PHPStan, Rector, and Symfony.
+This reference lists public integration types for Rector and Symfony.
 
 These signatures are the public API.
 
@@ -21,7 +21,7 @@ final class PhpUnitToGreenlightRector extends AbstractRector implements Configur
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Rector/PhpUnitToGreenlightRector.php#L54)
 
-### `string`
+### `DROP_ASSERTION_MESSAGES`
 
 Configuration key: remove PHPUnit failure-message arguments. Without
 this option, a custom message rejects the class. Greenlight

--- a/docs/api.md
+++ b/docs/api.md
@@ -19,4 +19,4 @@ Use the task guides for workflows and examples. Use these pages for exact signat
 - [Fixtures and harness API](api-fixtures-harness.md) — This reference lists fixtures and harness service contracts.
 - [Plugin API](api-plugins.md) — This reference lists plugin capabilities and lifecycle callback contracts.
 - [Reporter API](api-reporting.md) — This reference lists reporter and output contracts.
-- [Integration API](api-integrations.md) — This reference lists public integration types for PHPStan, Rector, and Symfony.
+- [Integration API](api-integrations.md) — This reference lists public integration types for Rector and Symfony.

--- a/docs/architecture/technical-writing.md
+++ b/docs/architecture/technical-writing.md
@@ -19,10 +19,11 @@ The prose checker finds mechanical errors and possible language problems. It
 does not certify compliance with ASD-STE100. A writer must also review the
 meaning, vocabulary, grammar, and technical accuracy.
 
-The checker also examines structured text fields and PHP strings that resemble
-messages. It applies only mandatory rules to PHPDoc tag descriptions and these
-strings. Review all PHP strings manually because code literals can resemble
-prose.
+The checker also examines structured text fields, script strings, and PHP
+strings that resemble messages. It checks multiline PHPDoc tag descriptions
+and visible Markdown link labels. It applies only mandatory rules to PHPDoc tag
+descriptions and human-readable strings. Review all strings manually because
+code literals can resemble prose.
 
 ## Writing rules
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,7 @@ GreenlightConfig::create()
 
 Every builder method returns `$this`. Thus, you can chain method calls.
 
-### paths(array $tests): self
+### `paths(array $tests): self`
 
 Default: `['tests']`.
 
@@ -48,7 +48,7 @@ Sets the directories that Greenlight scans when you do not select a suite.
 
 Paths must be non-empty strings. The list itself must not be empty.
 
-### suite(string $name, callable $configurator): self
+### `suite(string $name, callable $configurator): self`
 
 Default: no suites.
 
@@ -68,7 +68,7 @@ A second declaration with the same suite name causes an error.
 * `in(string ...$paths): self` adds directories to the suite. Required.
 * `tag(string ...$tags): self` adds tags to the suite. Optional.
 
-### workers(int|string $count = 'auto', ?int $recycleAfterTests = null, string $recycleAboveMemory = '256M'): self
+### `workers(int|string $count = 'auto', ?int $recycleAfterTests = null, string $recycleAboveMemory = '256M'): self`
 
 Default: `'auto'` workers, a `256M` memory recycle limit, and no test-count
 recycle limit.
@@ -106,7 +106,7 @@ boot. The worker channel is idle during the boot. Use this limit for suites
 that collect per-process state that memory checks cannot detect. Examples
 include connections and file handles.
 
-### resourceLimit(string $name, int $limit = 1): self
+### `resourceLimit(string $name, int $limit = 1): self`
 
 Default: `1` for a resource used by `#[RequiresResource]`.
 
@@ -134,7 +134,7 @@ identifier. If a test needs one of several distinct instances, the application
 must allocate it. Use a channel instead when every worker can have its own
 instance.
 
-### coverage(callable $configurator): self
+### `coverage(callable $configurator): self`
 
 Default: coverage off.
 
@@ -182,7 +182,7 @@ Before export, the run adds these coverage files to the
 result. This collection operation does not fail the run. The configured include
 paths filter coverage from all processes.
 
-### watch(callable $configurator): self
+### `watch(callable $configurator): self`
 
 Default: 200 ms debounce.
 
@@ -200,7 +200,7 @@ of save operations starts only one run.
 ->watch(fn ($w) => $w->debounceMilliseconds(500))
 ```
 
-### failOnDeprecation(bool $enabled = true): self
+### `failOnDeprecation(bool $enabled = true): self`
 
 Default: off.
 
@@ -214,7 +214,7 @@ The worker applies this policy after retries and `afterTest()` subscribers.
 
 Also available as `--fail-on-deprecation`.
 
-### failOnNotice(bool $enabled = true): self
+### `failOnNotice(bool $enabled = true): self`
 
 Default: off.
 
@@ -240,7 +240,7 @@ The method is repeatable and patterns accumulate.
 
 Use this for dependency deprecations you cannot fix yet.
 
-### failOnRisky(bool $enabled = true): self
+### `failOnRisky(bool $enabled = true): self`
 
 Default: off.
 
@@ -258,7 +258,7 @@ Each `eventually()` or `consistently()` matcher counts once.
 
 Also available as `--fail-on-risky`.
 
-### plugins(Plugin ...$plugins): self
+### `plugins(Plugin ...$plugins): self`
 
 Default: none.
 
@@ -267,7 +267,7 @@ capability interfaces.
 
 The method is repeatable and instances accumulate.
 
-### artifacts(callable $configurator): self
+### `artifacts(callable $configurator): self`
 
 Default: output below `build/greenlight-artifacts`, with failure-only retention.
 
@@ -291,13 +291,13 @@ later. Greenlight releases run quota when it discards an attachment.
 
 See [test attachments](attachments.md) for the runtime API and security model.
 
-### failFast(bool $enabled = true): self
+### `failFast(bool $enabled = true): self`
 
 Default: off.
 
 Stops the run after the first failure.
 
-### randomizeOrder(?int $seed = null): self
+### `randomizeOrder(?int $seed = null): self`
 
 Default: declared order, no seed.
 
@@ -306,7 +306,7 @@ Randomizes class order.
 If `$seed` is `null`, Greenlight selects and prints a seed at run time. Use
 `--seed` with that value to reproduce the same order.
 
-### build(): Configuration
+### `build(): Configuration`
 
 The loader calls this method. User configuration does not call it.
 
@@ -375,7 +375,7 @@ This is the default command if you do not give a command.
 
 Prints each discovered test ID on a separate line. It then prints the count.
 
-### coverage:diff
+### `coverage:diff`
 
 Compares two coverage JSON exports.
 
@@ -433,15 +433,15 @@ For zsh, run `compinit` before you source the completion script.
 
 ## Options
 
-### --config=<path>
+### `--config=<path>`
 
 Uses this configuration file instead of `./greenlight.php`.
 
-### --workers=<n|auto>
+### `--workers=<n|auto>`
 
 Overrides the worker process count.
 
-### --resource-limit=<name>=<n>
+### `--resource-limit=<name>=<n>`
 
 Sets a resource limit for this run and overrides `greenlight.php`.
 
@@ -454,19 +454,19 @@ vendor/bin/greenlight run \
 Repeat the option to set limits for different resources. Use each name only one
 time.
 
-### --bail[=<n>]
+### `--bail[=<n>]`
 
 Stops after `<n>` failures.
 
 Bare `--bail` means `--bail=1`.
 
-### --group=<name>
+### `--group=<name>`
 
 Runs only tests in the given group.
 
 Repeatable.
 
-### --filter=<pattern>
+### `--filter=<pattern>`
 
 Runs only tests with a test ID that matches the pattern.
 
@@ -477,7 +477,7 @@ that contains `*` or `?` must match the complete test ID.
 
 Repeatable. Multiple filters form a union.
 
-### --test-id=<id>
+### `--test-id=<id>`
 
 Runs only the exact test ID. Unlike `--filter`, this option does not compare
 substrings or wildcard patterns.
@@ -493,13 +493,13 @@ greenlight run \
 Repeatable. Multiple exact test IDs and `--filter` patterns form a union.
 Exclusions have precedence.
 
-### --exclude-group=<name>
+### `--exclude-group=<name>`
 
 Excludes tests in the given group.
 
 Repeatable. Exclusions take precedence over `--group` and `--filter`.
 
-### --exclude-class=<pattern>
+### `--exclude-class=<pattern>`
 
 Excludes classes with names that match the pattern.
 
@@ -508,7 +508,7 @@ that contains `*` or `?` must match the complete class name.
 
 Repeatable.
 
-### --exclude-method=<pattern>
+### `--exclude-method=<pattern>`
 
 Excludes methods with names that match the pattern.
 
@@ -517,39 +517,39 @@ that contains `*` or `?` must match the complete method name.
 
 Repeatable.
 
-### --exclude-path=<prefix>
+### `--exclude-path=<prefix>`
 
 Excludes tests whose source file is below the path prefix.
 
 Greenlight resolves relative prefixes from the current directory. Repeatable.
 
-### --list-tests
+### `--list-tests`
 
 Prints the selected test IDs. It does not run them.
 
-### --list-groups
+### `--list-groups`
 
 Prints each selected group and its test count. It does not run tests.
 
-### --list-suites
+### `--list-suites`
 
 Prints the configured named suites. It does not discover or run tests.
 
-### --repeat=<n>
+### `--repeat=<n>`
 
 Runs the selected tests in `<n>` fresh iterations.
 
 The command exits with a nonzero code if an iteration fails. `--repeat=1` is
 equivalent to an ordinary run.
 
-### --repeat-until-failure
+### `--repeat-until-failure`
 
 Repeats fresh runs until an iteration fails.
 
 On its own, the command stops after 100 successful iterations. Use
 `--repeat=<n>` to set a different limit. Do not use it with `--watch`.
 
-### --shard=n/m
+### `--shard=n/m`
 
 Runs the nth of m disjoint slices of the plan.
 
@@ -564,7 +564,7 @@ into shards.
 Each shard enforces its own resource limits. If four shards each use
 `postgres=2`, up to eight tests can use PostgreSQL across the CI job.
 
-### --failed
+### `--failed`
 
 Reruns only tests that did not pass in the previous run.
 
@@ -579,14 +579,14 @@ to rerun and exits 0.
 When failure state exists, normal runs put previously failed classes first.
 `--seed` disables this order.
 
-### --seed=<n>
+### `--seed=<n>`
 
 Randomizes class order with this seed.
 
 Seeded runs do not use the timing-cache order. The seed determines the complete
 order.
 
-### --reporter=<name>
+### `--reporter=<name>`
 
 Selects the output format.
 
@@ -612,21 +612,21 @@ The `teamcity` reporter includes IDE navigation metadata: `php_qn://` location
 hints for click-to-source, plus a per-class `flowId` to keep parallel output
 separated in JetBrains tools.
 
-### --artifacts-dir=<path>
+### `--artifacts-dir=<path>`
 
 Overrides the configured artifact parent directory for this run. Greenlight
 creates a unique run directory below it and reports that path in human and
 machine-readable output.
 
-### --baseline=<path>
+### `--baseline=<path>`
 
 Sets the baseline coverage JSON file for `coverage:diff`.
 
-### --current=<path>
+### `--current=<path>`
 
 Sets the current coverage JSON file for `coverage:diff`.
 
-### --watch
+### `--watch`
 
 Reruns on file changes.
 
@@ -635,25 +635,25 @@ In watch mode:
 * Enter reruns everything.
 * `q` quits.
 
-### --detect-leaks
+### `--detect-leaks`
 
 Verifies that garbage collection removes each test instance after its test.
 
 A detected leak fails the run.
 
-### --fail-on-deprecation
+### `--fail-on-deprecation`
 
 Enables the deprecation policy for this run.
 
-### --fail-on-notice
+### `--fail-on-notice`
 
 Enables the notice policy for this run.
 
-### --fail-on-risky
+### `--fail-on-risky`
 
 Enables the risky-test policy for this run.
 
-### --profile
+### `--profile`
 
 Adds a run profile after the summary.
 
@@ -674,25 +674,25 @@ artifact later with:
 greenlight profile:report --input=<file>
 ```
 
-### --input=<path>
+### `--input=<path>`
 
 Sets the JSONL input file for `profile:report`.
 
-### --output=<path>
+### `--output=<path>`
 
 Changes the file written by `ide-helper`.
 
 Default: `_greenlight_ide_helper.php`.
 
-### --dry-run
+### `--dry-run`
 
 Prints the resolved configuration and does not run tests.
 
-### --verbose
+### `--verbose`
 
 In interactive output, prints a permanent line for every completed class.
 
-### --no-ansi
+### `--no-ansi`
 
 Disables colors and the live progress window. Output becomes plain and
 append-only.

--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -133,11 +133,11 @@ coverage attributes do not require `#[Test]`.
 
 ## Test constructor checks
 
-A concrete class that contains or inherits a test must have a public
-constructor. Each required constructor parameter must have one class or
-interface type. A scalar, untyped, union, intersection, or `object` parameter
-must have a default value. Greenlight can then resolve supported service types
-at run time.
+A concrete class that contains or inherits a test can omit its constructor. If
+the class declares a constructor, the constructor must be public. Each required
+constructor parameter must have one class or interface type. A parameter must
+have a default value if it has a scalar, union, intersection, or `object` type,
+or no type. Greenlight can then resolve supported service types at run time.
 
 Errors have identifiers under `greenlight.testConstructor.*` (`visibility`,
 `parameter`).

--- a/src/Attribute/Retry.php
+++ b/src/Attribute/Retry.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Greenlight\Attribute;
 
 /**
- * Runs an unsuccessful test attempt again for the specified number of
- * additional attempts. The optional throwable type limits the unsuccessful
- * attempts that start another attempt.
+ * Starts the specified number of additional attempts after an unsuccessful
+ * test attempt. If `$onlyOn` specifies a throwable type, only a cause of this
+ * type starts another attempt.
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS)]
 final readonly class Retry

--- a/src/PhpStan/AttributeArgumentRule.php
+++ b/src/PhpStan/AttributeArgumentRule.php
@@ -115,14 +115,14 @@ final class AttributeArgumentRule implements Rule
     private function checkSkipUnless(Attribute $attribute, Scope $scope): array
     {
         $errors = [];
-        $conditionArgument = 0;
+        $conditionArgumentNumber = 0;
 
         foreach ($attribute->args as $index => $argument) {
             if ($argument->name === null ? $index === 0 : $argument->name->toString() === 'condition') {
                 continue;
             }
 
-            ++$conditionArgument;
+            ++$conditionArgumentNumber;
             $type = $scope->getType($argument->value);
 
             if ($type->isNull()->yes() || $type->isScalar()->yes()) {
@@ -130,7 +130,7 @@ final class AttributeArgumentRule implements Rule
             }
 
             $errors[] = $this->error(
-                \sprintf('#[SkipUnless] argument %d must be a scalar or null.', $conditionArgument),
+                \sprintf('#[SkipUnless] argument %d must be a scalar or null.', $conditionArgumentNumber),
                 'skipUnless',
                 $argument->getStartLine(),
             );

--- a/src/PhpStan/DataProviderSignatureRule.php
+++ b/src/PhpStan/DataProviderSignatureRule.php
@@ -255,7 +255,7 @@ final readonly class DataProviderSignatureRule implements Rule
         if ($returnType->isIterable()->no()) {
             return [$this->error(
                 \sprintf(
-                    'Data provider %s::%s() must return an iterable of argument arrays, returns %s.',
+                    'Data provider %s::%s() must return an iterable of argument arrays. It returns %s.',
                     $providerClass->getDisplayName(),
                     $provider,
                     $returnType->describe(VerbosityLevel::typeOnly()),
@@ -278,7 +278,7 @@ final readonly class DataProviderSignatureRule implements Rule
         if ($rowType->isArray()->no()) {
             return [$this->error(
                 \sprintf(
-                    'Data provider %s::%s() must yield arrays of arguments, yields %s.',
+                    'Data provider %s::%s() must yield argument arrays. It yields %s.',
                     $providerClass->getDisplayName(),
                     $provider,
                     $rowType->describe(VerbosityLevel::typeOnly()),
@@ -373,12 +373,12 @@ final readonly class DataProviderSignatureRule implements Rule
             if ($parameter->getType()->accepts($valueType, true)->no()) {
                 $errors[] = $this->error(
                     \sprintf(
-                        '%s argument #%d of %s() expects %s, %s given.',
+                        '%s argument #%d for %s() has type %s, but the parameter requires %s.',
                         $source,
                         $position + 1,
                         $methodName,
-                        $parameter->getType()->describe(VerbosityLevel::typeOnly()),
                         $valueType->describe(VerbosityLevel::typeOnly()),
+                        $parameter->getType()->describe(VerbosityLevel::typeOnly()),
                     ),
                     'argument',
                     $line,

--- a/src/PhpStan/ExtensionMatcherSubjectRule.php
+++ b/src/PhpStan/ExtensionMatcherSubjectRule.php
@@ -83,7 +83,7 @@ final readonly class ExtensionMatcherSubjectRule implements Rule
     private function error(string $matcher, Type $accepted, Type $subject, int $line): IdentifierRuleError
     {
         return RuleErrorBuilder::message(\sprintf(
-            'Extension matcher %s() expects subject type %s, %s given.',
+            'Extension matcher %s() requires subject type %s, but the subject has type %s.',
             $matcher,
             $accepted->describe(VerbosityLevel::typeOnly()),
             $subject->describe(VerbosityLevel::typeOnly()),

--- a/src/PhpStan/SkipUnlessConditionRule.php
+++ b/src/PhpStan/SkipUnlessConditionRule.php
@@ -84,11 +84,12 @@ final readonly class SkipUnlessConditionRule implements Rule
         if ($actual < $required) {
             return [$this->error(
                 \sprintf(
-                    '%s constructor invoked with %d %s, %d required.',
-                    $classReflection->getDisplayName(),
+                    '#[SkipUnless] supplies %d argument%s to the %s constructor, but the constructor requires %d argument%s.',
                     $actual,
-                    $actual === 1 ? 'parameter' : 'parameters',
+                    $actual === 1 ? '' : 's',
+                    $classReflection->getDisplayName(),
                     $required,
+                    $required === 1 ? '' : 's',
                 ),
                 'arity',
                 $node->getStartLine(),
@@ -96,12 +97,16 @@ final readonly class SkipUnlessConditionRule implements Rule
         }
 
         if (!$variadic && $actual > \count($parameters)) {
+            $accepted = \count($parameters);
+
             return [$this->error(
                 \sprintf(
-                    '%s constructor invoked with %d parameters, %d accepted.',
-                    $classReflection->getDisplayName(),
+                    '#[SkipUnless] supplies %d argument%s to the %s constructor, but the constructor accepts %d argument%s.',
                     $actual,
-                    \count($parameters),
+                    $actual === 1 ? '' : 's',
+                    $classReflection->getDisplayName(),
+                    $accepted,
+                    $accepted === 1 ? '' : 's',
                 ),
                 'arity',
                 $node->getStartLine(),
@@ -120,12 +125,12 @@ final readonly class SkipUnlessConditionRule implements Rule
 
             $errors[] = $this->error(
                 \sprintf(
-                    'Parameter #%d $%s of class %s constructor expects %s, %s given.',
+                    '#[SkipUnless] argument #%d for %s constructor parameter $%s has type %s, but the parameter requires %s.',
                     $index + 1,
-                    $parameter->getName(),
                     $classReflection->getDisplayName(),
-                    $parameter->getType()->describe(VerbosityLevel::typeOnly()),
+                    $parameter->getName(),
                     $argumentType->describe(VerbosityLevel::typeOnly()),
+                    $parameter->getType()->describe(VerbosityLevel::typeOnly()),
                 ),
                 'argument',
                 $argument->getStartLine(),

--- a/src/PhpStan/TestConstructorRule.php
+++ b/src/PhpStan/TestConstructorRule.php
@@ -60,7 +60,7 @@ final class TestConstructorRule implements Rule
 
         if (!$constructor->isPublic()) {
             $errors[] = $this->error(
-                \sprintf('Test class %s cannot be instantiated because its constructor is not public.', $class->getDisplayName()),
+                \sprintf('Greenlight cannot instantiate test class %s because its constructor is not public.', $class->getDisplayName()),
                 'visibility',
                 $line,
             );
@@ -79,7 +79,7 @@ final class TestConstructorRule implements Rule
 
             $errors[] = $this->error(
                 \sprintf(
-                    'Constructor parameter $%s of test class %s cannot be resolved. '
+                    'Greenlight cannot resolve constructor parameter $%s of test class %s. '
                     . 'Use one class or interface type, or give the parameter a default value.',
                     $parameter->getName(),
                     $class->getDisplayName(),

--- a/tests/Acceptance/PhpStanDataProviderRuleTest.php
+++ b/tests/Acceptance/PhpStanDataProviderRuleTest.php
@@ -218,14 +218,14 @@ final readonly class PhpStanDataProviderRuleTest
             ->and(\count($probe->errors))->toBe(10)
             ->and($probe->messages())->toContain('Data provider doesNotExist() for missingProvider() does not exist')
             ->toContain('notStatic() must be public and static')
-            ->toContain('notIterable() must return an iterable of argument arrays, returns string')
-            ->toContain('scalarRows() must yield arrays of arguments, yields int')
-            ->toContain('Data provider stringRows() row argument #1 of typedRows() expects int, string given')
+            ->toContain('notIterable() must return an iterable of argument arrays. It returns string')
+            ->toContain('scalarRows() must yield argument arrays. It yields int')
+            ->toContain('Data provider stringRows() row argument #1 for typedRows() has type string, but the parameter requires int')
             ->toContain('requiredArgument() must not require arguments')
             ->toContain('SharedBadProviders::notStatic() must be public and static')
             ->toContain('SharedBadProviders::abstractProvider() must be concrete')
             ->toContain('#[DataRow] supplies 2 arguments, but tooManyInline() expects exactly 1')
-            ->toContain('#[DataRow] argument #1 of wrongInlineType() expects int, string given');
+            ->toContain('#[DataRow] argument #1 for wrongInlineType() has type string, but the parameter requires int');
     }
 
     #[Test]

--- a/tests/Acceptance/PhpStanExtensionTest.php
+++ b/tests/Acceptance/PhpStanExtensionTest.php
@@ -93,7 +93,7 @@ final readonly class PhpStanExtensionTest
         Expect::that($probe->exitCode)->because('matcher subject types follow fluent chains')->toBe(1)
             ->and($probe->goodPassed)->toBeTrue()
             ->and(\count($probe->errors))->toBe(2)
-            ->and($probe->messages())->toContain('expects subject type string, int given');
+            ->and($probe->messages())->toContain('requires subject type string, but the subject has type int');
     }
 
     #[Test]
@@ -193,6 +193,6 @@ final readonly class PhpStanExtensionTest
         Expect::that($probe->exitCode)->because('matcher subject types follow temporal chains')->toBe(1)
             ->and($probe->goodPassed)->toBeTrue()
             ->and(\count($probe->errors))->toBe(3)
-            ->and($probe->messages())->toContain('expects subject type string, int given');
+            ->and($probe->messages())->toContain('requires subject type string, but the subject has type int');
     }
 }

--- a/tests/Acceptance/PhpStanSkipUnlessConditionRuleTest.php
+++ b/tests/Acceptance/PhpStanSkipUnlessConditionRuleTest.php
@@ -82,7 +82,7 @@ final readonly class PhpStanSkipUnlessConditionRuleTest
         Expect::that($probe->exitCode)->because('skip-unless arguments must match the condition constructor')->toBe(1)
             ->and($probe->goodPassed)->toBeTrue()
             ->and(\count($probe->errors))->toBe(2)
-            ->and($probe->messages())->toContain('TwoArgumentsCondition constructor invoked with 1 parameter, 2 required')
-            ->toContain('Parameter #1 $value of class GreenlightSkipUnlessConditionProbe\IntegerCondition constructor expects int, string given');
+            ->and($probe->messages())->toContain('#[SkipUnless] supplies 1 argument to the GreenlightSkipUnlessConditionProbe\TwoArgumentsCondition constructor, but the constructor requires 2 arguments')
+            ->toContain('#[SkipUnless] argument #1 for GreenlightSkipUnlessConditionProbe\IntegerCondition constructor parameter $value has type string, but the parameter requires int');
     }
 }

--- a/tests/Acceptance/PhpStanTestConstructorRuleTest.php
+++ b/tests/Acceptance/PhpStanTestConstructorRuleTest.php
@@ -106,10 +106,10 @@ final readonly class PhpStanTestConstructorRuleTest
         Expect::that($probe->exitCode)->because('test constructors must have resolvable shapes')->toBe(1)
             ->and($probe->goodPassed)->toBeTrue()
             ->and(\count($probe->errors))->toBe(5)
-            ->and($probe->messages())->toContain('PrivateConstructorProbe cannot be instantiated because its constructor is not public')
-            ->toContain('Constructor parameter $scalar of test class GreenlightTestConstructorProbe\InvalidParametersProbe cannot be resolved')
-            ->toContain('Constructor parameter $union of test class GreenlightTestConstructorProbe\InvalidParametersProbe cannot be resolved')
-            ->toContain('Constructor parameter $object of test class GreenlightTestConstructorProbe\InvalidParametersProbe cannot be resolved')
-            ->toContain('Constructor parameter $value of test class GreenlightTestConstructorProbe\InvalidInheritedTestConstructorProbe cannot be resolved');
+            ->and($probe->messages())->toContain('Greenlight cannot instantiate test class GreenlightTestConstructorProbe\PrivateConstructorProbe because its constructor is not public')
+            ->toContain('Greenlight cannot resolve constructor parameter $scalar of test class GreenlightTestConstructorProbe\InvalidParametersProbe')
+            ->toContain('Greenlight cannot resolve constructor parameter $union of test class GreenlightTestConstructorProbe\InvalidParametersProbe')
+            ->toContain('Greenlight cannot resolve constructor parameter $object of test class GreenlightTestConstructorProbe\InvalidParametersProbe')
+            ->toContain('Greenlight cannot resolve constructor parameter $value of test class GreenlightTestConstructorProbe\InvalidInheritedTestConstructorProbe');
     }
 }

--- a/tests/Acceptance/ProseCheckTest.php
+++ b/tests/Acceptance/ProseCheckTest.php
@@ -18,18 +18,20 @@ final readonly class ProseCheckTest
     #[Test]
     #[DataRow(['semicolon', 'The worker stops; the orchestrator continues.', 'The worker stops. The orchestrator continues.'], 'semicolon')]
     #[DataRow(['contraction', "The worker doesn't stop.", 'The worker does not stop.'], 'contraction')]
+    #[DataRow(['contraction', 'The worker doesn’t stop.', 'The worker does not stop.'], 'Unicode contraction')]
     #[DataRow(['contraction', "Let's start the worker.", 'Start the worker.'], 'additional contraction')]
-    #[DataRow(['british-spelling', 'The reporter uses a different colour.', 'The reporter uses a different color.'], 'British spelling')]
-    #[DataRow(['british-spelling', 'The runner favours one worker.', 'The runner favors one worker.'], 'British favour spelling')]
-    #[DataRow(['british-spelling', 'The runner honours a labelled test.', 'The runner honors a labeled test.'], 'British honor and label spelling')]
-    #[DataRow(['british-spelling', 'The driver normalises the data.', 'The driver normalizes the data.'], 'British normalize spelling')]
-    #[DataRow(['british-spelling', 'The runner parameterises tests.', 'The runner parameterizes tests.'], 'British parameterize spelling')]
-    #[DataRow(['british-spelling', 'The reporter deserialises the event.', 'The reporter deserializes the event.'], 'British deserialize spelling')]
+    #[DataRow(['british-spelling', 'The reporter uses a different colour.', 'The reporter uses a different color.'], 'colour')]
+    #[DataRow(['british-spelling', 'The runner favours one worker.', 'The runner favors one worker.'], 'favour')]
+    #[DataRow(['british-spelling', 'The runner honours a labelled test.', 'The runner honors a labeled test.'], 'honour and labelled')]
+    #[DataRow(['british-spelling', 'The driver normalises the data.', 'The driver normalizes the data.'], 'normalise')]
+    #[DataRow(['british-spelling', 'The runner parameterises tests.', 'The runner parameterizes tests.'], 'parameterise')]
+    #[DataRow(['british-spelling', 'The reporter deserialises the event.', 'The reporter deserializes the event.'], 'deserialise')]
+    #[DataRow(['british-spelling', 'The worker fulfils the request.', 'The worker fulfills the request.'], 'fulfil')]
     #[DataRow([
         'british-spelling',
         'Organise the authorised customisation.',
         'Organize the authorized customization.',
-    ], 'additional British spellings')]
+    ], 'other spellings')]
     #[DataRow([
         'sentence-length',
         'The orchestrator collects every selected test class from the configured directories and sends one complete assignment to each available worker before the test run starts in parallel.',
@@ -71,7 +73,7 @@ final readonly class ProseCheckTest
 
             The value is `colour;` in this sample.
 
-            [colour;](https://example.com/colour)
+            [reference](https://example.com/colour)
 
             ```php
             $colour = 'value;';
@@ -82,6 +84,23 @@ final readonly class ProseCheckTest
 
         $result = $this->run('check', $root);
         Expect::that($result->exitCode)->because('excludes markdown code and links')->toBe(0);
+    }
+
+    #[Test]
+    public function checksMarkdownLinkLabelsButExcludesDestinations(): void
+    {
+        $root = $this->workspace('markdown-link-label');
+        $this->write(
+            $root,
+            'sample.md',
+            "[The guide doesn't use colour;](https://example.com/colour)\n",
+        );
+
+        $result = $this->run('check', $root);
+        Expect::that($result->exitCode)->because('checks visible Markdown link labels but excludes destinations')->toBe(1)
+            ->and($result->output())->toContain('sample.md:1: british-spelling:')
+            ->toContain('sample.md:1: contraction:')
+            ->toContain('sample.md:1: semicolon:');
     }
 
     #[Test]
@@ -133,12 +152,17 @@ final readonly class ProseCheckTest
             <<<'ASTRO'
             ---
             const codeSample = "The code doesn't use colour;";
+            const title = "The page doesn't use colour.";
             ---
 
             <main aria-label="The site uses colour">
               <p>The worker doesn't stop.</p>
               <code>The code doesn't use colour;</code>
             </main>
+
+            <script>
+              status.textContent = "The search doesn't use colour.";
+            </script>
 
             ASTRO,
         );
@@ -190,6 +214,50 @@ final readonly class ProseCheckTest
             ->toContain('.github/ISSUE_TEMPLATE/feature.yml:2: british-spelling:')
             ->toContain('.github/ISSUE_TEMPLATE/feature.yml:3: contraction:')
             ->toContain('website/src/lib/docs.ts:3: british-spelling:');
+    }
+
+    #[Test]
+    public function checksMultilineStructuredAndScriptProse(): void
+    {
+        $root = $this->workspace('multiline-structured-prose');
+        $this->write(
+            $root,
+            'composer.json',
+            <<<'JSON'
+            {"suggest": {
+              "vendor/package": "The package doesn't organise tests."
+            }}
+            JSON,
+        );
+        $this->write(
+            $root,
+            '.github/ISSUE_TEMPLATE/feature.yml',
+            <<<'YAML'
+            description: >-
+              The template doesn't use
+              colour;
+            YAML,
+        );
+        $this->write(
+            $root,
+            'website/scripts/status.mjs',
+            <<<'JS'
+            const labels = { unavailable: 'The service does not use colour.' };
+            throw new Error("The worker doesn't stop.");
+            status.textContent = 'The runner does not organise tests.';
+            JS,
+        );
+
+        $result = $this->run('check', $root);
+        Expect::that($result->exitCode)->because('checks multiline structured and script prose')->toBe(1)
+            ->and($result->output())->toContain('composer.json:2: contraction:')
+            ->toContain('composer.json:2: british-spelling:')
+            ->toContain('.github/ISSUE_TEMPLATE/feature.yml:1: contraction:')
+            ->toContain('.github/ISSUE_TEMPLATE/feature.yml:1: british-spelling:')
+            ->toContain('.github/ISSUE_TEMPLATE/feature.yml:1: semicolon:')
+            ->toContain('website/scripts/status.mjs:1: british-spelling:')
+            ->toContain('website/scripts/status.mjs:2: contraction:')
+            ->toContain('website/scripts/status.mjs:3: british-spelling:');
     }
 
     #[Test]
@@ -305,6 +373,72 @@ final readonly class ProseCheckTest
             ->toContain('src/Message.php:6: contraction:')
             ->toContain('src/Message.php:6: british-spelling:')
             ->toContain('src/Message.php:10: british-spelling:');
+    }
+
+    #[Test]
+    public function checksMultilinePhpDocAndInterpolatedPhpStrings(): void
+    {
+        $root = $this->workspace('php-multiline-prose');
+        $this->write(
+            $root,
+            'src/Message.php',
+            <<<'PHP'
+            <?php
+
+            final class Message
+            {
+                /**
+                 * @param string $value The reporter starts here and
+                 *   doesn't use colour;
+                 */
+                public function report(string $value, string $worker): string
+                {
+                    return "The $worker doesn't organise tests.";
+                }
+
+                public function document(): string
+                {
+                    return <<<TEXT
+                    The worker doesn't use colour;
+                    TEXT;
+                }
+            }
+
+            PHP,
+        );
+
+        $result = $this->run('check', $root);
+        Expect::that($result->exitCode)->because('checks multiline PHPDoc and interpolated PHP strings')->toBe(1)
+            ->and($result->output())->toContain('src/Message.php:6: semicolon:')
+            ->toContain('src/Message.php:6: contraction:')
+            ->toContain('src/Message.php:6: british-spelling:')
+            ->toContain('src/Message.php:11: contraction:')
+            ->toContain('src/Message.php:11: british-spelling:')
+            ->toContain('src/Message.php:16: semicolon:')
+            ->toContain('src/Message.php:16: contraction:')
+            ->toContain('src/Message.php:16: british-spelling:');
+    }
+
+    #[Test]
+    public function joinsWrappedMarkdownListItems(): void
+    {
+        $root = $this->workspace('markdown-list-continuation');
+        $this->write(
+            $root,
+            'sample.md',
+            <<<'MARKDOWN'
+            - The orchestrator collects every selected test class from all configured directories
+              and sends one complete assignment to every available worker before the test run begins across all active channels.
+
+            - One sentence. Two sentences. Three sentences.
+              Four sentences. Five sentences. Six sentences. Seven sentences.
+            MARKDOWN,
+        );
+
+        $result = $this->run('check', $root);
+        Expect::that($result->exitCode)->because('joins wrapped Markdown list items')->toBe(1)
+            ->and($result->output())->toContain('sample.md:1: sentence-length:')
+            ->toContain('sample.md:4: paragraph-length:');
     }
 
     #[Test]

--- a/tools/prose-check.php
+++ b/tools/prose-check.php
@@ -132,6 +132,10 @@ const PROSE_BRITISH_SPELLINGS = [
     'favourite',
     'favourites',
     'favours',
+    'fulfil',
+    'fulfilled',
+    'fulfilling',
+    'fulfils',
     'grey',
     'greys',
     'honour',
@@ -337,7 +341,7 @@ function proseFiles(string $root): array
             continue;
         }
 
-        if (!\in_array(\strtolower($file->getExtension()), ['astro', 'json', 'md', 'markdown', 'neon', 'php', 'ts', 'tsx', 'yaml', 'yml'], true)) {
+        if (!\in_array(\strtolower($file->getExtension()), ['astro', 'js', 'json', 'md', 'markdown', 'mjs', 'neon', 'php', 'ts', 'tsx', 'yaml', 'yml'], true)) {
             continue;
         }
 
@@ -387,7 +391,7 @@ function prosePassages(string $root, string $path): array
         return \proseAstroPassages($relative, $contents);
     }
 
-    if (\in_array($extension, ['json', 'neon', 'ts', 'tsx', 'yaml', 'yml'], true)) {
+    if (\in_array($extension, ['js', 'json', 'mjs', 'neon', 'ts', 'tsx', 'yaml', 'yml'], true)) {
         return \proseStructuredPassages($relative, $contents, $extension);
     }
 
@@ -401,36 +405,47 @@ function prosePassages(string $root, string $path): array
  */
 function proseStructuredPassages(string $path, string $contents, string $extension): array
 {
-    $passages = [];
-    $lines = \preg_split('/\R/', $contents);
+    if ($extension === 'json') {
+        return \proseJsonPassages($path, $contents);
+    }
 
-    foreach ($lines === false ? [] : $lines as $offset => $line) {
+    if (\in_array($extension, ['js', 'mjs', 'ts', 'tsx'], true)) {
+        return \proseScriptPassages($path, $contents);
+    }
+
+    $passages = [];
+    $splitLines = \preg_split('/\R/', $contents);
+    $lines = $splitLines === false ? [] : $splitLines;
+    $counter = \count($lines);
+
+    for ($offset = 0; $offset < $counter; ++$offset) {
+        $line = $lines[$offset];
         $lineNumber = $offset + 1;
         $text = null;
 
-        if ($extension === 'json' && \preg_match(
-            '/^\s*"(?:description|label|placeholder|title)"\s*:\s*"((?:\\\\.|[^"\\\\])*)"/',
-            $line,
-            $matches,
-        ) === 1) {
-            $decoded = \json_decode('"' . $matches[1] . '"', true);
-            $text = \is_string($decoded) ? $decoded : $matches[1];
-        } elseif (\in_array($extension, ['yaml', 'yml', 'neon'], true)) {
-            if (\preg_match('/^\s*(?:description|label|name|placeholder|title)\s*:\s*(.+?)\s*$/', $line, $matches) === 1) {
-                $text = \proseStructuredScalar($matches[1]);
-            } elseif (\preg_match('/^\s*#\s+(?!@)(.+)$/', $line, $matches) === 1) {
-                $text = $matches[1];
+        if (\preg_match('/^(\s*)(?:description|label|name|placeholder|title)\s*:\s*(.+?)\s*$/', $line, $matches) === 1) {
+            if (\in_array(\trim($matches[2]), ['|', '>', '|-', '>-'], true)) {
+                $indent = \strlen($matches[1]);
+                $block = [];
+
+                while (isset($lines[$offset + 1])) {
+                    $next = $lines[$offset + 1];
+                    $nextIndent = \strlen($next) - \strlen(\ltrim($next));
+
+                    if (\trim($next) !== '' && $nextIndent <= $indent) {
+                        break;
+                    }
+
+                    ++$offset;
+                    $block[] = \trim($next);
+                }
+
+                $text = \implode(' ', $block);
+            } else {
+                $text = \proseStructuredScalar($matches[2]);
             }
-        } elseif (\in_array($extension, ['ts', 'tsx'], true)) {
-            if (\preg_match(
-                '/\b(?:description|label|placeholder|title)\s*:\s*([\'"`])((?:\\\\.|(?!\1).)*)\1/',
-                $line,
-                $matches,
-            ) === 1) {
-                $text = \stripcslashes($matches[2]);
-            } elseif (\preg_match('/^\s*\/\/\s+(?!@)(.+)$/', $line, $matches) === 1) {
-                $text = $matches[1];
-            }
+        } elseif (\preg_match('/^\s*#\s+(?!@)(.+)$/', $line, $matches) === 1) {
+            $text = $matches[1];
         }
 
         if ($text === null || \preg_match('/[A-Za-z]/', $text) !== 1) {
@@ -445,6 +460,103 @@ function proseStructuredPassages(string $path, string $contents, string $extensi
     }
 
     return $passages;
+}
+
+/**
+ * @return list<array{path: string, line: int, text: string, advisory?: bool}>
+ */
+function proseJsonPassages(string $path, string $contents): array
+{
+    $passages = [];
+    $pattern = '/"(description|label|placeholder|title)"\s*:\s*"((?:\\\\.|[^"\\\\])*)"/s';
+
+    if (\preg_match_all($pattern, $contents, $matches, \PREG_OFFSET_CAPTURE) !== false) {
+        foreach ($matches[2] as $match) {
+            [$encoded, $offset] = $match;
+            $decoded = \json_decode('"' . $encoded . '"', true);
+            $text = \is_string($decoded) ? $decoded : $encoded;
+
+            if (\preg_match('/[A-Za-z]/', $text) !== 1) {
+                continue;
+            }
+
+            $passages[] = [
+                'path' => $path,
+                'line' => \proseLineAtOffset($contents, $offset),
+                'text' => \trim((string) \preg_replace('/\s+/', ' ', $text)),
+            ];
+        }
+    }
+
+    if (\preg_match('/"suggest"\s*:\s*\{(.*?)\}/s', $contents, $suggest, \PREG_OFFSET_CAPTURE) === 1) {
+        $body = $suggest[1][0];
+        $bodyOffset = $suggest[1][1];
+
+        if (\preg_match_all('/"[^"]+"\s*:\s*"((?:\\\\.|[^"\\\\])*)"/s', $body, $values, \PREG_OFFSET_CAPTURE) !== false) {
+            foreach ($values[1] as $match) {
+                [$encoded, $offset] = $match;
+                $decoded = \json_decode('"' . $encoded . '"', true);
+                $text = \is_string($decoded) ? $decoded : $encoded;
+
+                if (!\proseLooksLikeHumanString($text)) {
+                    continue;
+                }
+
+                $passages[] = [
+                    'path' => $path,
+                    'line' => \proseLineAtOffset($contents, $bodyOffset + $offset),
+                    'text' => $text,
+                ];
+            }
+        }
+    }
+
+    return $passages;
+}
+
+/**
+ * @return list<array{path: string, line: int, text: string, advisory?: bool}>
+ */
+function proseScriptPassages(string $path, string $contents): array
+{
+    $passages = [];
+
+    if (\preg_match_all('/^\s*\/\/\s+(?!@)(.+)$/m', $contents, $comments, \PREG_OFFSET_CAPTURE) !== false) {
+        foreach ($comments[1] as [$text, $offset]) {
+            $passages[] = ['path' => $path, 'line' => \proseLineAtOffset($contents, $offset), 'text' => $text];
+        }
+    }
+
+    if (\preg_match_all('/([\'"`])((?:\\\\.|(?!\1).)*)\1/s', $contents, $strings, \PREG_OFFSET_CAPTURE) !== false) {
+        foreach ($strings[2] as $index => [$encoded, $offset]) {
+            $matchOffset = $strings[0][$index][1];
+            $lineStart = \strrpos(\substr($contents, 0, $matchOffset), "\n");
+            $linePrefix = \substr($contents, $lineStart === false ? 0 : $lineStart + 1, $matchOffset - ($lineStart === false ? 0 : $lineStart + 1));
+
+            if (\preg_match('/\b(?:code|sample)\w*\s*=\s*$/i', $linePrefix) === 1) {
+                continue;
+            }
+
+            $text = \stripcslashes($encoded);
+
+            if (\preg_match('/\s/', $text) !== 1 || !\proseLooksLikeHumanString($text)) {
+                continue;
+            }
+
+            $passages[] = [
+                'path' => $path,
+                'line' => \proseLineAtOffset($contents, $offset),
+                'text' => \trim((string) \preg_replace('/\s+/', ' ', $text)),
+            ];
+        }
+    }
+
+    return $passages;
+}
+
+function proseLineAtOffset(string $contents, int $offset): int
+{
+    return \substr_count(\substr($contents, 0, $offset), "\n") + 1;
 }
 
 function proseStructuredScalar(string $value): ?string
@@ -477,6 +589,7 @@ function proseMarkdownPassages(string $path, string $contents): array
     $paragraph = [];
     $paragraphLine = 1;
     $inFence = false;
+    $listItemIndent = null;
     $lines = \preg_split('/\R/', $contents);
 
     foreach ($lines === false ? [] : $lines as $offset => $line) {
@@ -505,6 +618,7 @@ function proseMarkdownPassages(string $path, string $contents): array
 
         if ($isBoundary) {
             \proseFlushParagraph($passages, $paragraph, $paragraphLine, $path, true);
+            $listItemIndent = null;
 
             continue;
         }
@@ -514,6 +628,7 @@ function proseMarkdownPassages(string $path, string $contents): array
             $paragraphLine = $lineNumber;
             $paragraph[] = (string) \preg_replace('/^\s*#{1,6}\s+/', '', $line);
             \proseFlushParagraph($passages, $paragraph, $paragraphLine, $path, true);
+            $listItemIndent = null;
 
             continue;
         }
@@ -523,6 +638,7 @@ function proseMarkdownPassages(string $path, string $contents): array
             $paragraphLine = $lineNumber;
             $paragraph[] = \str_replace('|', ' ', \trim($line, " \t|"));
             \proseFlushParagraph($passages, $paragraph, $paragraphLine, $path, true);
+            $listItemIndent = null;
 
             continue;
         }
@@ -531,9 +647,23 @@ function proseMarkdownPassages(string $path, string $contents): array
             \proseFlushParagraph($passages, $paragraph, $paragraphLine, $path, true);
             $paragraphLine = $lineNumber;
             $paragraph[] = (string) \preg_replace('/^\s*(?:[-*+]|\d+[.)])\s+/', '', $line);
-            \proseFlushParagraph($passages, $paragraph, $paragraphLine, $path, true);
+            \preg_match('/^(\s*)/', $line, $indentMatch);
+            $listItemIndent = \strlen($indentMatch[1] ?? '') + 1;
 
             continue;
+        }
+
+        $indent = \strlen($line) - \strlen(\ltrim($line));
+
+        if ($listItemIndent !== null && $indent >= $listItemIndent) {
+            $paragraph[] = $trimmed;
+
+            continue;
+        }
+
+        if ($listItemIndent !== null) {
+            \proseFlushParagraph($passages, $paragraph, $paragraphLine, $path, true);
+            $listItemIndent = null;
         }
 
         if ($paragraph === []) {
@@ -551,7 +681,7 @@ function proseMarkdownPassages(string $path, string $contents): array
 function proseCleanMarkdown(string $text): string
 {
     $text = (string) \preg_replace('/!\[([^\]]*)]\([^)]*\)/', ' $1 ', $text);
-    $text = (string) \preg_replace('/\[[^\]]+]\([^)]*\)/', ' LITERAL ', $text);
+    $text = (string) \preg_replace('/\[([^\]]+)]\([^)]*\)/', ' $1 ', $text);
     $text = (string) \preg_replace('/`[^`]*`/', ' LITERAL ', $text);
     $text = (string) \preg_replace('/<https?:\/\/[^>]+>/', ' LITERAL ', $text);
     $text = (string) \preg_replace('/https?:\/\/\S+/', ' LITERAL ', $text);
@@ -566,6 +696,29 @@ function proseCleanMarkdown(string $text): string
  */
 function proseAstroPassages(string $path, string $contents): array
 {
+    $passages = [];
+
+    if (\preg_match('/\A---\R(.*?)\R---\R/s', $contents, $frontmatter, \PREG_OFFSET_CAPTURE) === 1) {
+        $frontmatterText = $frontmatter[1][0];
+        $frontmatterLine = \proseLineAtOffset($contents, $frontmatter[1][1]) - 1;
+
+        foreach (\proseScriptPassages($path, $frontmatterText) as $passage) {
+            $passage['line'] += $frontmatterLine;
+            $passages[] = $passage;
+        }
+    }
+
+    if (\preg_match_all('#<script\b[^>]*>(.*?)</script>#is', $contents, $scripts, \PREG_OFFSET_CAPTURE) !== false) {
+        foreach ($scripts[1] as [$script, $offset]) {
+            $scriptLine = \proseLineAtOffset($contents, $offset) - 1;
+
+            foreach (\proseScriptPassages($path, $script) as $passage) {
+                $passage['line'] += $scriptLine;
+                $passages[] = $passage;
+            }
+        }
+    }
+
     $contents = (string) \preg_replace_callback(
         '/\A---\R.*?\R---\R/s',
         static fn(array $matches): string => \str_repeat("\n", \substr_count($matches[0], "\n")),
@@ -578,7 +731,6 @@ function proseAstroPassages(string $path, string $contents): array
     );
     $contents = \proseMaskAstroExpressions($contents);
     $lines = \preg_split('/\R/', $contents);
-    $passages = [];
     $paragraph = [];
     $paragraphLine = 1;
 
@@ -732,6 +884,20 @@ function prosePhpPassages(string $path, string $contents): array
         $paragraph = [];
         $paragraphLine = $line;
         $inTag = false;
+        $tagDescription = null;
+        $tagLine = $line;
+        $flushTagDescription = static function (?string $tagDescription, int $tagLine) use (&$passages, $path): void {
+            if ($tagDescription === null) {
+                return;
+            }
+
+            $passages[] = [
+                'path' => $path,
+                'line' => $tagLine,
+                'text' => \trim((string) \preg_replace('/\s+/', ' ', $tagDescription)),
+                'advisory' => false,
+            ];
+        };
 
         foreach ($lines as $offset => $commentLine) {
             $clean = (string) \preg_replace('/^\s*(?:\/\*\*?|\/\/|#|\*(?!\/))\s?/', '', $commentLine);
@@ -740,6 +906,8 @@ function prosePhpPassages(string $path, string $contents): array
 
             if ($trimmed === '') {
                 \proseFlushParagraph($passages, $paragraph, $paragraphLine, $path, false);
+                $flushTagDescription($tagDescription, $tagLine);
+                $tagDescription = null;
                 $inTag = false;
 
                 continue;
@@ -747,16 +915,9 @@ function prosePhpPassages(string $path, string $contents): array
 
             if (\str_starts_with($trimmed, '@')) {
                 \proseFlushParagraph($passages, $paragraph, $paragraphLine, $path, false);
-                $description = \prosePhpDocTagDescription($trimmed);
-
-                if ($description !== null) {
-                    $passages[] = [
-                        'path' => $path,
-                        'line' => $line + $offset,
-                        'text' => $description,
-                        'advisory' => false,
-                    ];
-                }
+                $flushTagDescription($tagDescription, $tagLine);
+                $tagDescription = \prosePhpDocTagDescription($trimmed);
+                $tagLine = $line + $offset;
 
                 $inTag = true;
 
@@ -764,6 +925,10 @@ function prosePhpPassages(string $path, string $contents): array
             }
 
             if ($inTag) {
+                if ($tagDescription !== null) {
+                    $tagDescription .= ' ' . $trimmed;
+                }
+
                 continue;
             }
 
@@ -775,13 +940,17 @@ function prosePhpPassages(string $path, string $contents): array
         }
 
         \proseFlushParagraph($passages, $paragraph, $paragraphLine, $path, false);
+        $flushTagDescription($tagDescription, $tagLine);
     }
 
     if (
         $path !== 'tools/prose-check.php'
         && (\str_starts_with($path, 'src/') || \str_starts_with($path, 'tools/') || \str_starts_with($path, 'bin/'))
     ) {
-        $passages = [...$passages, ...\prosePhpStringPassages($path, $contents)];
+        $passages = [
+            ...$passages,
+            ...\prosePhpStringPassages($path, $contents),
+        ];
     }
 
     return $passages;
@@ -806,27 +975,97 @@ function prosePhpDocTagDescription(string $line): ?string
 function prosePhpStringPassages(string $path, string $contents): array
 {
     $passages = [];
+    $tokens = \token_get_all($contents);
+    $counter = \count($tokens);
 
-    foreach (\token_get_all($contents) as $token) {
-        if (!\is_array($token) || $token[0] !== \T_CONSTANT_ENCAPSED_STRING) {
+    for ($index = 0; $index < $counter; ++$index) {
+        $token = $tokens[$index];
+
+        if (\is_array($token) && $token[0] === \T_CONSTANT_ENCAPSED_STRING) {
+            \proseAddPhpStringPassage($passages, $path, $token[2], \proseDecodePhpString($token[1]));
+
             continue;
         }
 
-        $text = \proseDecodePhpString($token[1]);
+        $isHeredoc = \is_array($token) && $token[0] === \T_START_HEREDOC;
+        $isInterpolated = $token === '"';
 
-        if (!\proseLooksLikeHumanString($text)) {
+        if (!$isHeredoc && !$isInterpolated) {
             continue;
         }
 
-        $passages[] = [
-            'path' => $path,
-            'line' => $token[2],
-            'text' => $text,
-            'advisory' => false,
-        ];
+        $line = $isHeredoc ? $token[2] : \proseTokenLine($tokens, $index);
+        $text = '';
+
+        for (++$index; $index < \count($tokens); ++$index) {
+            $part = $tokens[$index];
+
+            if ($isHeredoc && \is_array($part) && $part[0] === \T_END_HEREDOC) {
+                break;
+            }
+
+            if ($isInterpolated && $part === '"') {
+                break;
+            }
+
+            if (\is_array($part) && $part[0] === \T_ENCAPSED_AND_WHITESPACE) {
+                $text .= $part[1];
+
+                continue;
+            }
+
+            if (\is_array($part) && \in_array($part[0], [\T_VARIABLE, \T_STRING_VARNAME], true)) {
+                $text .= ' LITERAL ';
+            }
+        }
+
+        \proseAddPhpStringPassage($passages, $path, $line, $text);
     }
 
     return $passages;
+}
+
+/**
+ * @param list<array{path: string, line: int, text: string, advisory: false}> $passages
+ */
+function proseAddPhpStringPassage(array &$passages, string $path, int $line, string $text): void
+{
+    if (
+        \str_contains($text, '<?php')
+        || \substr_count($text, ';') > 2
+        || \preg_match('/^\s*(?:if\b|public\b|private\b|protected\b|function\b|class\b|declare\b)/', $text) === 1
+    ) {
+        return;
+    }
+
+    $text = \trim((string) \preg_replace('/\s+/', ' ', $text));
+
+    if (!\proseLooksLikeHumanString($text)) {
+        return;
+    }
+
+    $passages[] = [
+        'path' => $path,
+        'line' => $line,
+        'text' => $text,
+        'advisory' => false,
+    ];
+}
+
+/**
+ * @param list<array{int, string, int}|string> $tokens
+ */
+function proseTokenLine(array $tokens, int $index): int
+{
+    for (; $index >= 0; --$index) {
+        $token = $tokens[$index];
+
+        if (\is_array($token)) {
+            return $token[2] + \substr_count($token[1], "\n");
+        }
+    }
+
+    return 1;
 }
 
 function proseDecodePhpString(string $literal): string
@@ -859,7 +1098,7 @@ function proseLooksLikeHumanString(string $text): bool
         return false;
     }
 
-    $withoutPlaceholders = (string) \preg_replace('/%(?:\d+\$)?[-+0-9.\']*[bcdeEfFgGosuxX]/', ' LITERAL ', $text);
+    $withoutPlaceholders = (string) \preg_replace('/%(?:\d+\$)?[-+0-9.\']*[bcdeEfFgGosuxX]/', ' X ', $text);
 
     return \preg_match('/\b[A-Za-z]{2,}\b.*\b[A-Za-z]{2,}\b/s', $withoutPlaceholders) === 1;
 }
@@ -906,7 +1145,8 @@ function proseCommentTokens(string $contents): array
 function proseAnalyze(array $passage): array
 {
     $findings = [];
-    $text = \proseWithoutQuotedLiterals(\proseWithoutRegisteredLiterals($passage['text']));
+    $text = \str_replace(["\u{2019}", "\u{02BC}"], "'", $passage['text']);
+    $text = \proseWithoutQuotedLiterals(\proseWithoutRegisteredLiterals($text));
     $normalized = \proseNormalize($text);
 
     $add = static function (string $rule, string $severity, string $message) use (&$findings, $passage, $normalized): void {

--- a/website/scripts/check-built-site.mjs
+++ b/website/scripts/check-built-site.mjs
@@ -50,7 +50,7 @@ const registeredOptions = new Set(
   [...application.matchAll(/new OptionSpec\('([^']+)'/g)].map((match) => match[1]),
 );
 const documentedOptions = new Set(
-  [...configurationReference.matchAll(/^### (?:-[A-Za-z], )?--([a-z][a-z-]*)(?:[=<[]|$)/gm)].map(
+  [...configurationReference.matchAll(/^### `?(?:-[A-Za-z], )?--([a-z][a-z-]*)(?:[=<[]|`|$)/gm)].map(
     (match) => match[1],
   ),
 );

--- a/website/scripts/generate-api-reference.mjs
+++ b/website/scripts/generate-api-reference.mjs
@@ -78,7 +78,7 @@ const sections = [
   {
     id: 'api-integrations',
     title: 'Integration API',
-    description: 'This reference lists public integration types for PHPStan, Rector, and Symfony.',
+    description: 'This reference lists public integration types for Rector and Symfony.',
     prefixes: ['Greenlight\\PhpStan\\', 'Greenlight\\Rector\\', 'Greenlight\\Symfony\\'],
   },
 ];
@@ -503,10 +503,17 @@ function memberName(tokens, kind) {
     return tokens.find((token) => token.kind === 'variable')?.value;
   }
 
-  const marker = kind === 'case' ? 'case' : 'const';
-  const markerIndex = tokens.findIndex((token) => token.value === marker);
+  if (kind === 'case') {
+    const markerIndex = tokens.findIndex((token) => token.value === 'case');
 
-  return tokens.slice(markerIndex + 1).find((token) => token.kind === 'word')?.value;
+    return tokens.slice(markerIndex + 1).find((token) => token.kind === 'word')?.value;
+  }
+
+  const markerIndex = tokens.findIndex((token) => token.value === 'const');
+  const equalsIndex = tokens.findIndex((token, index) => index > markerIndex && token.value === '=');
+  const declaration = tokens.slice(markerIndex + 1, equalsIndex === -1 ? undefined : equalsIndex);
+
+  return declaration.findLast((token) => token.kind === 'word')?.value;
 }
 
 function normalizeSignature(signature, baseIndent) {

--- a/website/src/components/RunPreview.astro
+++ b/website/src/components/RunPreview.astro
@@ -1,6 +1,6 @@
 <figure class="run-preview" aria-label="A typical Greenlight test run">
   <figcaption class="run-preview__bar">
-    <code><span aria-hidden="true">›</span> ./bin/greenlight</code>
+    <code><span aria-hidden="true">›</span> vendor/bin/greenlight</code>
     <span class="run-preview__state">
       <span aria-hidden="true"></span>
       Running

--- a/website/src/components/TerminalOutput.astro
+++ b/website/src/components/TerminalOutput.astro
@@ -9,7 +9,7 @@ interface Part {
 const lines: Part[][] = [
   [
     { text: '❯', tone: 'prompt' },
-    { text: ' ./bin/greenlight', tone: 'command' },
+    { text: ' vendor/bin/greenlight', tone: 'command' },
   ],
   [],
   [

--- a/website/src/lib/docs.ts
+++ b/website/src/lib/docs.ts
@@ -134,7 +134,7 @@ export const docSections = [
       {
         id: 'api-integrations',
         title: 'Integration API',
-        description: 'This reference lists public integration types for PHPStan, Rector, and Symfony.',
+        description: 'This reference lists public integration types for Rector and Symfony.',
       },
     ],
   },


### PR DESCRIPTION
## Summary

- Extend the prose guardrail to visible Markdown labels, wrapped lists, multiline PHPDoc, interpolated PHP strings, script copy, and multiline structured fields.
- Correct remaining PHPStan diagnostics, Retry documentation, configuration reference formatting, Composer suggestions, and installed command examples.
- Fix API reference generation for typed constants and integration metadata while retaining the code-identifier exemption and zero baselines.

## Observable wording

This changes human-readable PHPStan diagnostics. It preserves rule identifiers, public APIs, schemas, protocol fields, status tokens, and other machine contracts. Exact diagnostic assertions change with the messages.

## Continuation record

- Base commit: 653778b073bacabec77b2750c5c61b9bf13ac45b
- Result commit: 5e369de
- Owned paths: prose checker and acceptance coverage, PHPStan diagnostics and assertions, generated API documentation, configuration documentation, website command examples, and related policy text
- Blocking findings: 0 before, 0 after
- Advisory findings: 0 remaining
- Terminology: use argument for supplied values, parameter for declarations, and cause for the throwable that starts another retry attempt
- Checks run: composer prose:check, composer prose:review, make docs-check, composer static-analysis, composer tests, and focused prose and PHPStan acceptance tests
- Next unclaimed shard: none