### PR TITLE
fix: complete simplified English audit

### DIFF
--- a/bin/greenlight
+++ b/bin/greenlight
@@ -5,7 +5,7 @@ declare(strict_types=1);
 
 if (\PHP_VERSION_ID < 80400) {
     \fwrite(\STDERR, \sprintf(
-        "Greenlight requires PHP 8.4 or later; running under %s.\n",
+        "Greenlight requires PHP 8.4 or later. The current PHP version is %s.\n",
         \PHP_VERSION,
     ));
 

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     },
     "suggest": {
         "ext-pcov": "Collects line coverage quickly",
-        "fidry/cpu-core-counter": "Improves the 'auto' worker count on systems with cgroup limits and on more platforms",
+        "fidry/cpu-core-counter": "Improves the 'auto' worker count across platforms and on systems with cgroup limits",
         "phpstan/extension-installer": "Registers the bundled PHPStan extension automatically",
         "phpstan/phpstan": "Type-checks extension matcher calls and data providers with the bundled 'extension.neon' file",
         "rector/rector": "Converts PHPUnit test classes to Greenlight with the bundled 'PhpUnitToGreenlightRector' rule",

--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -10,14 +10,15 @@ These signatures are the public API.
 
 Namespace: `Greenlight\Attribute`
 
-Runs after a test, even if the test fails.
+Runs at the end of an attempt that has a test instance. It also runs when
+setup or the test method does not complete.
 
 ```php
 #[\Attribute(\Attribute::TARGET_METHOD)]
 final readonly class After
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/After.php#L9)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/After.php#L12)
 
 This type does not declare public members.
 
@@ -233,9 +234,9 @@ PHPDoc:
 
 Namespace: `Greenlight\Attribute`
 
-Starts the specified number of additional attempts after an unsuccessful
-test attempt. If `$onlyOn` specifies a throwable type, only a cause of this
-type starts another attempt.
+Starts up to `$times` additional attempts after an unsuccessful test attempt.
+If `$onlyOn` specifies a throwable type, Greenlight starts another attempt
+only when the cause has that type.
 
 ```php
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS)]

--- a/docs/api-expectations.md
+++ b/docs/api-expectations.md
@@ -50,15 +50,14 @@ Namespace: `Greenlight\Expect`
 
 Extension matchers are worker-local state. `install()` stores the configured
 `ExpectationExtension` list when the worker starts. Each chain from `that()`
-uses this list. A worker uses one thread, and the runner controls the
-install point. Thus, no code reads the static registry during a change.
-Before `install()` runs, `that()` uses no extensions.
+uses a snapshot of this list. The runner changes the list before test
+execution starts. Before `install()` runs, `that()` uses no extensions.
 
 ```php
 final class Expect
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expect.php#L14)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expect.php#L13)
 
 ### `that()`
 
@@ -72,7 +71,7 @@ PHPDoc:
 - `@param T $value`
 - `@return Expectation<T>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expect.php#L31)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expect.php#L30)
 
 ### `eventually()`
 
@@ -88,7 +87,7 @@ PHPDoc:
 - `@param callable(): T $probe`
 - `@return PendingEventually<T>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expect.php#L45)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expect.php#L44)
 
 ### `consistently()`
 
@@ -104,7 +103,7 @@ PHPDoc:
 - `@param callable(): T $probe`
 - `@return PendingConsistently<T>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expect.php#L65)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expect.php#L64)
 
 ## `Expectation`
 

--- a/docs/api-plugins.md
+++ b/docs/api-plugins.md
@@ -76,13 +76,13 @@ public function priority(): int;
 
 Namespace: `Greenlight\Plugin`
 
-A retry decider that a worker calls after each unsuccessful attempt.
+A worker calls a retry decider after each unsuccessful attempt.
 
-A yes result starts a new attempt with a new test instance in a new service
-scope.
+A `true` result starts a new attempt with a new test instance and a new
+service scope.
 
-`shouldRetry()` receives the metadata, result, and optional cause. It does not
-receive a context because the test instance no longer exists.
+`shouldRetry()` receives the metadata, result, attempt number, and optional
+cause. It does not receive `TestContext` because the attempt is complete.
 
 ```php
 interface RetryDecider extends Plugin

--- a/docs/architecture/compatibility.md
+++ b/docs/architecture/compatibility.md
@@ -105,8 +105,8 @@ access controls as logs and test evidence.
 
 The protocol version detects peer-version mismatches. Frame and payload
 decoders reject malformed protocol data. The protocol does not support
-independent upgrades. The orchestrator and worker always come from the same
-Greenlight installation.
+independent upgrades. The orchestrator and worker always use the same Greenlight
+installation.
 
 Protocol payloads can change without a public compatibility cycle. For each
 change, update both sides and their protocol tests together.

--- a/docs/architecture/technical-writing.md
+++ b/docs/architecture/technical-writing.md
@@ -19,11 +19,12 @@ The prose checker finds mechanical errors and possible language problems. It
 does not certify compliance with ASD-STE100. A writer must also review the
 meaning, vocabulary, grammar, and technical accuracy.
 
-The checker also examines structured text fields, script strings, and PHP
-strings that resemble messages. It checks multiline PHPDoc tag descriptions
-and visible Markdown link labels. It applies only mandatory rules to PHPDoc tag
-descriptions and human-readable strings. Review all strings manually because
-code literals can resemble prose.
+The checker also examines structured text fields, script strings and comments,
+and PHP strings that resemble messages. It examines extensionless PHP command
+entry points. It checks multiline PHPDoc tag descriptions, visible Markdown
+link labels, and website accessibility attributes. It applies only mandatory
+rules to PHPDoc tag descriptions and human-readable strings. Review all strings
+manually because code literals can resemble prose.
 
 ## Writing rules
 
@@ -160,7 +161,7 @@ and meaning. Use the singular form unless the context requires a plural.
 | result policy | Technical noun | A rule that can change a test result after execution |
 | retention | Technical noun | The rule that determines if Greenlight publishes an attachment |
 | retry decider | Technical noun | A plugin that determines if Greenlight starts another test attempt |
-| risky test | Technical noun | A passed test that verifies no expectations and does not opt out |
+| risky test | Technical noun | A passed test that verifies no expectations and has no `#[NoExpectations]` attribute |
 | run | Technical noun | One execution of a selected test suite |
 | run | Technical verb | To execute a command, test, or test suite |
 | run directory | Technical noun | The directory that contains published attachments for one run |

--- a/docs/architecture/worker-lifecycle.md
+++ b/docs/architecture/worker-lifecycle.md
@@ -260,4 +260,4 @@ A channel identifies a stable resource slot for one worker. The resource
 scheduler controls shared capacity but does not assign resource identity. A
 test can use both functions. For example, it can use a channel-specific
 database and a concurrency limit for a shared sandbox. For user guidance, see
-[external resources](../../README.md#external-resources).
+[channels and resource limits](../configuration.md#channels-and-resource-limits).

--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -76,7 +76,7 @@ return GreenlightConfig::create()
 Use `--artifacts-dir` to override it for one run:
 
 ```sh
-greenlight run --artifacts-dir=build/ci-evidence
+vendor/bin/greenlight run --artifacts-dir=build/ci-evidence
 ```
 
 Greenlight does not delete completed run directories. For local runs, remove

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -73,13 +73,10 @@ A second declaration with the same suite name causes an error.
 Default: `'auto'` workers, a `256M` memory recycle limit, and no test-count
 recycle limit.
 
-Workers pull one class at a time from the orchestrator queue. When a worker
-finishes a class, it takes the next one. Thus, a long batch for one worker does
-not make another worker idle.
-
-The orchestrator orders the queue by the class durations from the previous run.
-The longest classes go first. Classes that failed in that run go before other
-classes.
+A worker requests one class at a time. When the worker finishes that class, it
+requests the next class. Thus, a long class does not make another worker idle.
+The orchestrator gives first priority to classes that failed in the previous
+run. It orders the other classes by previous duration, longest first.
 
 Worker placement is load-dependent. The stable parts are:
 
@@ -251,8 +248,7 @@ teardown.
 The `tty` and `plain` reporters always list risky tests after the summary. The
 `failOnRisky()` method changes risky tests to failures.
 
-A test that intentionally has no expectations can opt out with
-`#[NoExpectations]`.
+Use `#[NoExpectations]` for a test that intentionally verifies no expectations.
 
 Each `eventually()` or `consistently()` matcher counts once.
 

--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -58,8 +58,8 @@ These checks apply when a plugin adds matchers through `ExpectationExtension`.
 See [plugins](plugins.md). Built-in matchers such as `toBe()` are real methods.
 Thus, PHPStan checks them without help from the extension.
 
-Custom matchers send calls through `__call` at run time. PHPStan does not
-usually check these calls. The extension loads your configuration files in the
+Custom matcher calls use `__call()` at run time. PHPStan cannot infer their
+signatures from `__call()`. The extension loads your configuration files in the
 same way as workers. It reflects each matcher closure and checks calls against
 the real signature.
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -225,11 +225,11 @@ parameters:
 PHPStan provides analysis. IDE completion needs a separate file because IDE
 indexers do not run PHPStan plugins.
 
-Run `greenlight ide-helper` to generate `_greenlight_ide_helper.php`. No process
-executes this file. It declares a duplicate expectation chain with `@method`
-annotations for each configured matcher. PhpStorm and Intelephense merge the
-duplicate declaration. Thus, configured matchers have their real signatures in
-IDE completion.
+Run `vendor/bin/greenlight ide-helper` to generate
+`_greenlight_ide_helper.php`. No process executes this file. It declares a
+duplicate expectation chain with `@method` annotations for each configured
+matcher. PhpStorm and Intelephense merge the duplicate declaration. Thus,
+configured matchers have their real signatures in IDE completion.
 
 Add the helper file to `.gitignore`. Regenerate it after a matcher change.
 

--- a/src/Attribute/After.php
+++ b/src/Attribute/After.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Greenlight\Attribute;
 
-/** Runs after a test, even if the test fails. */
+/**
+ * Runs at the end of an attempt that has a test instance. It also runs when
+ * setup or the test method does not complete.
+ */
 #[\Attribute(\Attribute::TARGET_METHOD)]
 final readonly class After {}

--- a/src/Attribute/Retry.php
+++ b/src/Attribute/Retry.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Greenlight\Attribute;
 
 /**
- * Starts the specified number of additional attempts after an unsuccessful
- * test attempt. If `$onlyOn` specifies a throwable type, only a cause of this
- * type starts another attempt.
+ * Starts up to `$times` additional attempts after an unsuccessful test attempt.
+ * If `$onlyOn` specifies a throwable type, Greenlight starts another attempt
+ * only when the cause has that type.
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS)]
 final readonly class Retry

--- a/src/Core/Result/ResultPolicy.php
+++ b/src/Core/Result/ResultPolicy.php
@@ -62,7 +62,7 @@ final readonly class ResultPolicy implements WireSerializable
 
             if ($offends) {
                 $details[] = new FailureDetail(\sprintf(
-                    'The %s policy failed this passed test: %s at %s:%d',
+                    'The %s policy changed this test from passed to failed: %s at %s:%d',
                     $diagnostic->severity->value,
                     $diagnostic->message,
                     $diagnostic->file,
@@ -77,7 +77,7 @@ final readonly class ResultPolicy implements WireSerializable
 
         if ($result->risky && $this->failOnRisky) {
             return $result->failedBy('fail-on-risky policy', [new FailureDetail(
-                'The fail-on-risky policy failed this passed test: it verified no expectations.',
+                'The fail-on-risky policy changed this test from passed to failed because it verified no expectations.',
             )]);
         }
 

--- a/src/Core/Test/ExpectationCounter.php
+++ b/src/Core/Test/ExpectationCounter.php
@@ -14,8 +14,8 @@ namespace Greenlight\Core\Test;
  * verification.
  *
  * The static counter supports the design. Harness service factories do not
- * receive a resolver. Each worker uses one thread. The executor controls the
- * reset and read operations.
+ * receive a resolver. Each worker runs one test attempt at a time. The executor
+ * controls the reset and read operations.
  *
  * @internal
  */

--- a/src/Doubles/MethodExpectation.php
+++ b/src/Doubles/MethodExpectation.php
@@ -13,7 +13,7 @@ use Greenlight\Expect\ValueRenderer;
  *
  * MockPlan::expects() creates this object. Its fluent plan methods are the
  * public interface. The call handler and verifier use the members marked
- * @internal.
+ * @internal
  *
  * Argument values compare with the same deep equality as Expect's toEqual().
  */

--- a/src/Expect/ArraySubset.php
+++ b/src/Expect/ArraySubset.php
@@ -11,9 +11,9 @@ final class ArraySubset
     private function __construct() {}
 
     /**
-     * Returns null when every subset key exists in the subject with an equal
-     * value (nested arrays match as subsets too), otherwise a description of
-     * the first difference, e.g. "missing key 'user.address.city'".
+     * Returns null when each subset key exists in the subject with an equal
+     * value. Nested arrays also match as subsets. Otherwise, it describes the
+     * first difference, for example, "missing key 'user.address.city'".
      *
      * @param array<array-key, mixed> $subset
      * @param array<array-key, mixed> $subject

--- a/src/Expect/Expect.php
+++ b/src/Expect/Expect.php
@@ -7,9 +7,8 @@ namespace Greenlight\Expect;
 /**
  * Extension matchers are worker-local state. `install()` stores the configured
  * `ExpectationExtension` list when the worker starts. Each chain from `that()`
- * uses this list. A worker uses one thread, and the runner controls the
- * install point. Thus, no code reads the static registry during a change.
- * Before `install()` runs, `that()` uses no extensions.
+ * uses a snapshot of this list. The runner changes the list before test
+ * execution starts. Before `install()` runs, `that()` uses no extensions.
  */
 final class Expect
 {

--- a/src/PhpStan/DataProviderSignatureRule.php
+++ b/src/PhpStan/DataProviderSignatureRule.php
@@ -267,7 +267,7 @@ final readonly class DataProviderSignatureRule implements Rule
 
         if ($returnType->isIterableAtLeastOnce()->no()) {
             return [$this->error(
-                \sprintf('Data provider %s::%s() must yield at least one argument array.', $providerClass->getDisplayName(), $provider),
+                \sprintf('Data provider %s::%s() must provide at least one argument array.', $providerClass->getDisplayName(), $provider),
                 'empty',
                 $line,
             )];
@@ -278,7 +278,7 @@ final readonly class DataProviderSignatureRule implements Rule
         if ($rowType->isArray()->no()) {
             return [$this->error(
                 \sprintf(
-                    'Data provider %s::%s() must yield argument arrays. It yields %s.',
+                    'Data provider %s::%s() must provide argument arrays. The iterable has value type %s.',
                     $providerClass->getDisplayName(),
                     $provider,
                     $rowType->describe(VerbosityLevel::typeOnly()),

--- a/src/PhpStan/TestAttributePlacementRule.php
+++ b/src/PhpStan/TestAttributePlacementRule.php
@@ -86,7 +86,7 @@ final class TestAttributePlacementRule implements Rule
 
         foreach ($attributes as [$attribute, $line]) {
             $errors[] = $this->error(\sprintf(
-                '#[%s] on %s has no effect because the method is not a #[Test].',
+                '#[%s] on %s has no effect because the method does not have #[Test].',
                 self::TEST_ATTRIBUTES[$attribute],
                 $method,
             ), $line);

--- a/src/Plugin/RetryDecider.php
+++ b/src/Plugin/RetryDecider.php
@@ -8,13 +8,13 @@ use Greenlight\Core\Result\TestResult;
 use Greenlight\Core\Test\TestMetadata;
 
 /**
- * A retry decider that a worker calls after each unsuccessful attempt.
+ * A worker calls a retry decider after each unsuccessful attempt.
  *
- * A yes result starts a new attempt with a new test instance in a new service
- * scope.
+ * A `true` result starts a new attempt with a new test instance and a new
+ * service scope.
  *
- * `shouldRetry()` receives the metadata, result, and optional cause. It does not
- * receive a context because the test instance no longer exists.
+ * `shouldRetry()` receives the metadata, result, attempt number, and optional
+ * cause. It does not receive `TestContext` because the attempt is complete.
  */
 interface RetryDecider extends Plugin
 {

--- a/src/Plugin/RetryPlugin.php
+++ b/src/Plugin/RetryPlugin.php
@@ -10,9 +10,9 @@ use Greenlight\Core\Test\TestMetadata;
 /**
  * Implements RetryDecider for the #[Retry] attribute.
  *
- * shouldRetry() returns yes while unused additional attempts remain. If the
+ * shouldRetry() returns true while additional attempts remain unused. If the
  * attribute specifies a throwable type, the cause must have that type. The
- * method returns no for a test without the attribute.
+ * method returns false if the test does not have the attribute.
  *
  * @internal
  */

--- a/src/Runner/Worker/TestExecutor.php
+++ b/src/Runner/Worker/TestExecutor.php
@@ -28,19 +28,25 @@ use Greenlight\Runner\Artifact\StagedAttachments;
 use Greenlight\Runner\Artifact\TestArtifactBudget;
 
 /**
- * Each test attempt has these operations:
+ * Each test attempt can have these operations, in this order:
  *
  * - Constructor injection
- * - beforeTest subscribers
- * - Before hooks in declaration order
+ * - `beforeTest()` subscribers
+ * - `Before` hooks
  * - The test method
- * - After hooks in reverse declaration order
+ * - `After` hooks
  * - Test-scope teardown
  * - Timeout enforcement
+ * - `afterTest()` subscribers
  *
- * After hooks always run. afterTest subscribers use the guard for the
- * transformation log in applyAfterSubscribers(). Greenlight removes each reference to the
- * test instance when the test attempt ends.
+ * `Before` hooks use declaration order. `After` hooks use reverse declaration
+ * order.
+ *
+ * An `After` hook runs if constructor injection created a test instance. It
+ * runs even when a previous test-body operation did not complete.
+ * `applyAfterSubscribers()` validates each outcome change against the
+ * transformation log. Greenlight removes each reference to the test instance
+ * when the attempt ends.
  *
  * @internal
  */
@@ -300,8 +306,9 @@ final readonly class TestExecutor
     }
 
     /**
-     * Runs afterTest subscribers with the guard for the transformation log.
- *
+     * Runs afterTest() subscribers and validates each outcome change against
+     * the transformation log.
+     *
      * A change without a new transformation-log entry has no source. This
      * condition causes a test error that identifies the plugin.
      *

--- a/src/Symfony/SymfonyBridgeError.php
+++ b/src/Symfony/SymfonyBridgeError.php
@@ -16,7 +16,7 @@ final class SymfonyBridgeError extends \RuntimeException
     {
         return new self(\sprintf(
             'The kernel started in the "%s" environment without the Symfony test container. '
-            . 'Container services cannot reach tests. Enable framework.test for this environment. '
+            . 'Tests cannot use container services. Enable framework.test for this environment. '
             . 'The standard FrameworkBundle test configuration usually uses APP_ENV=test. '
             . 'You can also configure SymfonyPlugin to use an environment that provides the test container.',
             $environment,

--- a/tests/Acceptance/PhpStanDataProviderRuleTest.php
+++ b/tests/Acceptance/PhpStanDataProviderRuleTest.php
@@ -219,7 +219,7 @@ final readonly class PhpStanDataProviderRuleTest
             ->and($probe->messages())->toContain('Data provider doesNotExist() for missingProvider() does not exist')
             ->toContain('notStatic() must be public and static')
             ->toContain('notIterable() must return an iterable of argument arrays. It returns string')
-            ->toContain('scalarRows() must yield argument arrays. It yields int')
+            ->toContain('scalarRows() must provide argument arrays. The iterable has value type int')
             ->toContain('Data provider stringRows() row argument #1 for typedRows() has type string, but the parameter requires int')
             ->toContain('requiredArgument() must not require arguments')
             ->toContain('SharedBadProviders::notStatic() must be public and static')
@@ -333,6 +333,6 @@ final readonly class PhpStanDataProviderRuleTest
             ->and($probe->messages())->toContain('#[DataRow] key "same" occurs more than once on duplicateLabels()')
             ->toContain('#[DataRow] key "#0" occurs more than once on duplicateGeneratedLabel()')
             ->toContain('invalidKeys() keys must be int or string. The provider returns keys of type bool')
-            ->toContain('empty() must yield at least one argument array');
+            ->toContain('empty() must provide at least one argument array');
     }
 }

--- a/tests/Acceptance/PolicyTest.php
+++ b/tests/Acceptance/PolicyTest.php
@@ -22,23 +22,23 @@ final readonly class PolicyTest
         // Without flags, all tests pass. Greenlight records deprecations but
         // does not make them fatal.
         $result = $this->run($project, '--filter=DiagnosticProbeTest');
-        Expect::that($result->exitCode)->because('deprecation and notice policies flip passed tests')->toBe(0)
+        Expect::that($result->exitCode)->because('deprecation and notice policies change passed tests to failed')->toBe(0)
             ->and($result->output())->toContain('3 tests, 3 passed')
         // Each test uses one matcher. The summary contains those expectations
         // after transfer from the worker.
             ->toContain('3 expectations');
         $result = $this->run($project, '--filter=DiagnosticProbeTest', '--fail-on-deprecation');
-        Expect::that($result->exitCode)->because('deprecation and notice policies flip passed tests')->toBe(1)
+        Expect::that($result->exitCode)->because('deprecation and notice policies change passed tests to failed')->toBe(1)
             ->and($result->output())->toContain('3 tests, 2 passed, 1 failed')
-            ->toContain('deprecation policy failed this passed test')
+            ->toContain('deprecation policy changed this test from passed to failed')
             ->toContain('old api is deprecated')
         // The result change MUST NOT remove verified expectations.
             ->toContain('3 expectations')
         // The deprecation in the allow list does not fail the test.
             ->toContain('PASS PolicyProbe\DiagnosticProbeTest::ignorableDeprecation');
         $result = $this->run($project, '--filter=DiagnosticProbeTest', '--fail-on-notice');
-        Expect::that($result->exitCode)->because('deprecation and notice policies flip passed tests')->toBe(1)
-            ->and($result->output())->toContain('notice policy failed this passed test')
+        Expect::that($result->exitCode)->because('deprecation and notice policies change passed tests to failed')->toBe(1)
+            ->and($result->output())->toContain('notice policy changed this test from passed to failed')
             ->toContain('a probe notice');
     }
 
@@ -61,7 +61,7 @@ final readonly class PolicyTest
         $result = $this->run($project, '--filter=RiskyProbeTest', '--fail-on-risky');
         Expect::that($result->exitCode)->because('risky tests warn by default and fail under the flag')->toBe(1)
             ->and($result->output())->toContain('3 tests, 2 passed, 1 failed')
-            ->toContain('fail-on-risky policy failed this passed test');
+            ->toContain('fail-on-risky policy changed this test from passed to failed');
     }
 
     private function run(AcceptanceProject $project, string ...$flags): ProcessResult

--- a/tests/Acceptance/ProseCheckTest.php
+++ b/tests/Acceptance/ProseCheckTest.php
@@ -20,6 +20,8 @@ final readonly class ProseCheckTest
     #[DataRow(['contraction', "The worker doesn't stop.", 'The worker does not stop.'], 'contraction')]
     #[DataRow(['contraction', 'The worker doesn’t stop.', 'The worker does not stop.'], 'Unicode contraction')]
     #[DataRow(['contraction', "Let's start the worker.", 'Start the worker.'], 'additional contraction')]
+    #[DataRow(['contraction', "Here's why that should've worked.", 'Here is why that should have worked.'], 'missing forms')]
+    #[DataRow(['contraction', "There'll be capacity, so that'll work.", 'There will be capacity, so that will work.'], 'future forms')]
     #[DataRow(['british-spelling', 'The reporter uses a different colour.', 'The reporter uses a different color.'], 'colour')]
     #[DataRow(['british-spelling', 'The runner favours one worker.', 'The runner favors one worker.'], 'favour')]
     #[DataRow(['british-spelling', 'The runner honours a labelled test.', 'The runner honors a labeled test.'], 'honour and labelled')]
@@ -176,6 +178,27 @@ final readonly class ProseCheckTest
     }
 
     #[Test]
+    public function checksAccessibilityAttributeForms(): void
+    {
+        $root = $this->workspace('accessibility-attributes');
+        $this->write(
+            $root,
+            'website/src/pages/index.astro',
+            <<<'ASTRO'
+            <main aria-label='The page does not stop;'>
+              <section aria-label={ready ? "The dialog doesn't stop." : 'The dialog stops.'}></section>
+            </main>
+
+            ASTRO,
+        );
+
+        $result = $this->run('check', $root);
+        Expect::that($result->exitCode)->because('checks static and expression accessibility attributes')->toBe(1)
+            ->and($result->output())->toContain('website/src/pages/index.astro:1: semicolon:')
+            ->toContain('website/src/pages/index.astro:2: contraction:');
+    }
+
+    #[Test]
     public function checksStructuredDescriptionsAndOwnedComments(): void
     {
         $root = $this->workspace('structured-prose');
@@ -261,6 +284,31 @@ final readonly class ProseCheckTest
     }
 
     #[Test]
+    public function checksScriptBlockComments(): void
+    {
+        $root = $this->workspace('script-block-comments');
+        $this->write(
+            $root,
+            'website/scripts/status.mjs',
+            <<<'JS'
+            const open = '/*';
+            const codeSample = "The code doesn't stop;";
+            const close = '*/';
+
+            /**
+             * The reporter does not stop;
+             * the worker continues.
+             */
+            JS,
+        );
+
+        $result = $this->run('check', $root);
+        Expect::that($result->exitCode)->because('checks script block comments')->toBe(1)
+            ->and($result->output())->toContain('website/scripts/status.mjs:6: semicolon:')
+            ->not()->toContain('website/scripts/status.mjs:2: contraction:');
+    }
+
+    #[Test]
     public function excludesMultilineAstroExpressions(): void
     {
         $root = $this->workspace('website-expressions');
@@ -298,6 +346,20 @@ final readonly class ProseCheckTest
         $result = $this->run('review', $root);
         Expect::that($result->exitCode)->because('excludes registered literals')->toBe(0)
             ->and($result->output())->toBe('');
+    }
+
+    #[Test]
+    public function excludesGeneratedAstroTypes(): void
+    {
+        $root = $this->workspace('generated-astro-types');
+        $this->write(
+            $root,
+            'website/.astro/content.d.ts',
+            "/** The generated declaration doesn't stop; */\n",
+        );
+
+        $result = $this->run('check', $root);
+        Expect::that($result->exitCode)->because('excludes generated Astro types')->toBe(0);
     }
 
     #[Test]
@@ -373,6 +435,57 @@ final readonly class ProseCheckTest
             ->toContain('src/Message.php:6: contraction:')
             ->toContain('src/Message.php:6: british-spelling:')
             ->toContain('src/Message.php:10: british-spelling:');
+    }
+
+    #[Test]
+    public function checksProseBearingPhpDocTags(): void
+    {
+        $root = $this->workspace('php-prose-tags');
+        $this->write(
+            $root,
+            'src/Message.php',
+            <<<'PHP'
+            <?php
+
+            final class Message
+            {
+                /**
+                 * @internal The reporter doesn't stop;
+                 */
+                public function report(): void {}
+
+                /**
+                 * @deprecated The worker starts here and
+                 *   doesn't continue;
+                 */
+                public function oldReport(): void {}
+            }
+
+            PHP,
+        );
+
+        $result = $this->run('check', $root);
+        Expect::that($result->exitCode)->because('checks prose-bearing PHPDoc tags')->toBe(1)
+            ->and($result->output())->toContain('src/Message.php:6: contraction:')
+            ->toContain('src/Message.php:6: semicolon:')
+            ->toContain('src/Message.php:11: contraction:')
+            ->toContain('src/Message.php:11: semicolon:');
+    }
+
+    #[Test]
+    public function checksTheExtensionlessPhpEntrypoint(): void
+    {
+        $root = $this->workspace('extensionless-php');
+        $this->write(
+            $root,
+            'bin/greenlight',
+            "<?php\n\n\\fwrite(\\STDERR, \"The runner doesn't stop;\");\n",
+        );
+
+        $result = $this->run('check', $root);
+        Expect::that($result->exitCode)->because('checks the extensionless PHP entry point')->toBe(1)
+            ->and($result->output())->toContain('bin/greenlight:3: contraction:')
+            ->toContain('bin/greenlight:3: semicolon:');
     }
 
     #[Test]

--- a/tools/prose-check.php
+++ b/tools/prose-check.php
@@ -7,6 +7,7 @@ const PROSE_EXCLUDED_DIRECTORIES = [
     '.git',
     '.phpstan-api-stubs',
     'tests/Fixture',
+    'website/.astro',
     'website/dist',
 ];
 
@@ -19,6 +20,7 @@ const PROSE_CONTRACTIONS = [
     "ain't",
     "aren't",
     "can't",
+    "could've",
     "couldn't",
     "couldn't've",
     "didn't",
@@ -30,6 +32,7 @@ const PROSE_CONTRACTIONS = [
     "he'd",
     "he'll",
     "he's",
+    "here's",
     "how'd",
     "how'll",
     "how's",
@@ -53,7 +56,11 @@ const PROSE_CONTRACTIONS = [
     "she's",
     "shouldn't",
     "shouldn't've",
+    "should've",
+    "that'll",
     "that's",
+    "there'd",
+    "there'll",
     "there's",
     "they'd",
     "they'll",
@@ -341,7 +348,10 @@ function proseFiles(string $root): array
             continue;
         }
 
-        if (!\in_array(\strtolower($file->getExtension()), ['astro', 'js', 'json', 'md', 'markdown', 'mjs', 'neon', 'php', 'ts', 'tsx', 'yaml', 'yml'], true)) {
+        if (
+            $relative !== 'bin/greenlight'
+            && !\in_array(\strtolower($file->getExtension()), ['astro', 'js', 'json', 'md', 'markdown', 'mjs', 'neon', 'php', 'ts', 'tsx', 'yaml', 'yml'], true)
+        ) {
             continue;
         }
 
@@ -383,7 +393,7 @@ function prosePassages(string $root, string $path): array
 
     $extension = \strtolower(\pathinfo($path, \PATHINFO_EXTENSION));
 
-    if ($extension === 'php') {
+    if ($extension === 'php' || $relative === 'bin/greenlight') {
         return \prosePhpPassages($relative, $contents);
     }
 
@@ -527,6 +537,30 @@ function proseScriptPassages(string $path, string $contents): array
         }
     }
 
+    foreach (\proseScriptBlockComments($contents) as [$comment, $commentOffset]) {
+        $lines = \preg_split('/\R/', $comment);
+        $paragraph = [];
+        $paragraphLine = \proseLineAtOffset($contents, $commentOffset);
+
+        foreach ($lines === false ? [] : $lines as $offset => $line) {
+            $text = \trim((string) \preg_replace('/^\s*\*\s?/', '', $line));
+
+            if ($text === '' || \str_starts_with($text, '@')) {
+                \proseFlushParagraph($passages, $paragraph, $paragraphLine, $path, true);
+
+                continue;
+            }
+
+            if ($paragraph === []) {
+                $paragraphLine = \proseLineAtOffset($contents, $commentOffset) + $offset;
+            }
+
+            $paragraph[] = $text;
+        }
+
+        \proseFlushParagraph($passages, $paragraph, $paragraphLine, $path, true);
+    }
+
     if (\preg_match_all('/([\'"`])((?:\\\\.|(?!\1).)*)\1/s', $contents, $strings, \PREG_OFFSET_CAPTURE) !== false) {
         foreach ($strings[2] as $index => [$encoded, $offset]) {
             $matchOffset = $strings[0][$index][1];
@@ -552,6 +586,63 @@ function proseScriptPassages(string $path, string $contents): array
     }
 
     return $passages;
+}
+
+/**
+ * @return list<array{string, int}>
+ */
+function proseScriptBlockComments(string $contents): array
+{
+    $comments = [];
+    $length = \strlen($contents);
+
+    for ($index = 0; $index < $length; ++$index) {
+        $character = $contents[$index];
+
+        if (\in_array($character, ["'", '"', '`'], true)) {
+            $quote = $character;
+
+            for (++$index; $index < $length; ++$index) {
+                if ($contents[$index] === '\\') {
+                    ++$index;
+
+                    continue;
+                }
+
+                if ($contents[$index] === $quote) {
+                    break;
+                }
+            }
+
+            continue;
+        }
+
+        if ($character !== '/' || $index + 1 >= $length) {
+            continue;
+        }
+
+        if ($contents[$index + 1] === '/') {
+            $newline = \strpos($contents, "\n", $index + 2);
+            $index = $newline === false ? $length : $newline;
+
+            continue;
+        }
+
+        if ($contents[$index + 1] !== '*') {
+            continue;
+        }
+
+        $end = \strpos($contents, '*/', $index + 2);
+
+        if ($end === false) {
+            break;
+        }
+
+        $comments[] = [\substr($contents, $index + 2, $end - $index - 2), $index + 2];
+        $index = $end + 1;
+    }
+
+    return $comments;
 }
 
 function proseLineAtOffset(string $contents, int $offset): int
@@ -729,6 +820,28 @@ function proseAstroPassages(string $path, string $contents): array
         static fn(array $matches): string => ' LITERAL ' . \str_repeat("\n", \substr_count($matches[0], "\n")),
         $contents,
     );
+
+    if (\preg_match_all('/\b(?:alt|aria-label|description|placeholder|title)\s*=\s*([\'"])(.*?)\1/is', $contents, $attributes, \PREG_OFFSET_CAPTURE) !== false) {
+        foreach ($attributes[2] as [$attributeText, $offset]) {
+            $passages[] = [
+                'path' => $path,
+                'line' => \proseLineAtOffset($contents, $offset),
+                'text' => \html_entity_decode($attributeText, \ENT_QUOTES | \ENT_HTML5),
+            ];
+        }
+    }
+
+    if (\preg_match_all('/\b(?:alt|aria-label|description|placeholder|title)\s*=\s*\{([^{}]*)\}/is', $contents, $attributes, \PREG_OFFSET_CAPTURE) !== false) {
+        foreach ($attributes[1] as [$expression, $offset]) {
+            $expressionLine = \proseLineAtOffset($contents, $offset) - 1;
+
+            foreach (\proseScriptPassages($path, $expression) as $passage) {
+                $passage['line'] += $expressionLine;
+                $passages[] = $passage;
+            }
+        }
+    }
+
     $contents = \proseMaskAstroExpressions($contents);
     $lines = \preg_split('/\R/', $contents);
     $paragraph = [];
@@ -736,18 +849,6 @@ function proseAstroPassages(string $path, string $contents): array
 
     foreach ($lines === false ? [] : $lines as $offset => $line) {
         $lineNumber = $offset + 1;
-
-        if (\preg_match_all('/\b(?:alt|aria-label|description|placeholder|title)="([^"]+)"/i', $line, $matches) !== false) {
-            foreach ($matches[1] as $attributeText) {
-                if (!\str_contains($attributeText, '{')) {
-                    $passages[] = [
-                        'path' => $path,
-                        'line' => $lineNumber,
-                        'text' => \html_entity_decode($attributeText, \ENT_QUOTES | \ENT_HTML5),
-                    ];
-                }
-            }
-        }
 
         $visible = (string) \preg_replace('/\{[^{}]*\}/', ' LITERAL ', $line);
         $visible = (string) \preg_replace('/<[^>]+>/', ' ', $visible);
@@ -964,6 +1065,10 @@ function prosePhpDocTagDescription(string $line): ?string
 
     if (\preg_match('/^@(return|throws|var)\s+\S+\s+(.+)$/', $line, $matches) === 1) {
         return $matches[2];
+    }
+
+    if (\preg_match('/^@(internal|deprecated)(?:\s+(.+))?$/', $line, $matches) === 1) {
+        return $matches[2] ?? '';
     }
 
     return null;


### PR DESCRIPTION
## Summary

- Close checker gaps for extensionless PHP entry points, script block comments, PHPDoc prose tags, Astro accessibility attributes, and additional contractions.
- Correct lifecycle, retry, policy, data-provider, Symfony, configuration, and integration prose.
- Regenerate the affected API reference pages.
- Keep code identifiers and machine contracts unchanged. The repository has no prose baselines.

## Observable wording changes

This PR changes the PHP version diagnostic, PHPStan data-provider diagnostics, policy failure details, and one Symfony bridge error. Exact assertions change with the messages. Schema keys, protocol fields, status tokens, and public APIs do not change.

## Continuation record

- Base commit: 07e1cff52071092c7a2467306fe9193a95365c79
- Result commit: 063ae44a309041366856207b298867c589732c7c
- Owned paths: checker and acceptance coverage, affected documentation and generated API pages, and focused PHPDoc and diagnostic files
- Blocking findings: 0 before, 0 after
- Advisory findings: 0 remaining
- Terminology: use attempt, test instance, worker-local snapshot, argument array, and TestContext precisely
- Checks run: composer prose:check; composer prose:review; make docs-check; composer static-analysis; composer tests
- Next unclaimed shard: none