### PR TITLE
fix: tighten simplified English coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 **A parallel-first test framework for PHP 8.4 and later.**
 
 Greenlight runs test classes in parallel by default and has zero runtime
-dependencies. An orchestrator discovers one suite and sends test classes to a
-pool of worker processes.
+dependencies. Greenlight discovers one suite and sends assignments to a pool of
+worker processes.
 
 [Read the documentation](https://ben-challis.github.io/greenlight/)
 
@@ -104,14 +104,15 @@ See the [start guide](docs/getting-started.md) for a complete example.
 
 ## Execution model
 
-The orchestrator discovers each test class once and creates an execution plan.
-Workers request test classes when they have capacity.
+Greenlight discovers each test class once and creates an execution plan.
+Workers request assignments when they have capacity.
 
 The orchestrator controls resource limits, worker replacement, event checks,
 and reports. It also stores test durations to improve the order of later runs.
 
-Greenlight schedules complete test classes. It preserves the method order in a
-class, but different workers can run different classes.
+Greenlight normally schedules complete test classes. It schedules each
+`#[Isolated]` test separately. It preserves the method order in a class, but
+different workers can run different classes.
 
 Use a channel to give each worker a separate external resource. Use
 `#[RequiresResource]` to limit concurrent access to a shared resource.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,5 +12,5 @@ Do not open a public issue for a security problem.
 Report the problem privately through GitHub Security Advisories in this
 repository. On the Security tab, select "Report a vulnerability".
 
-We will acknowledge your report as soon as possible. We will coordinate a fix
-or mitigation plan with you before public disclosure.
+We will acknowledge your report. We will coordinate a fix or mitigation plan
+with you before public disclosure.

--- a/docs/api-doubles.md
+++ b/docs/api-doubles.md
@@ -168,8 +168,8 @@ Namespace: `Greenlight\Doubles`
 
 Mocks are strict. A call without a planned expectation fails the test
 immediately. Each return value needs a configured result. Stubs cause an
-error for all interactions. Spies record calls to methods that return
-nothing.
+error for all interactions. Spies record calls to methods without a return
+value.
 
 A verification failure throws one `ExpectationFailed`. It contains one
 `FailureDetail` for each unmet expectation. Thus, the reporter shows it in

--- a/docs/api-results.md
+++ b/docs/api-results.md
@@ -104,8 +104,8 @@ public static function fromWire(array $payload): static
 
 Namespace: `Greenlight\Core\Result`
 
-Greenlight captures only notices, warnings, and deprecations. PHP handles
-other levels with its default process.
+Greenlight captures only notices, warnings, and deprecations. PHP uses its
+default behavior for all other error levels.
 
 ```php
 enum DiagnosticSeverity: string

--- a/docs/architecture/technical-writing.md
+++ b/docs/architecture/technical-writing.md
@@ -29,7 +29,7 @@ manually because code literals can resemble prose.
 ## Writing rules
 
 Use the official ASD-STE100 Issue 9 standard as the primary reference. Apply
-these rules to all new or materially changed technical prose:
+these rules to all repository-owned technical prose:
 
 * Use approved words with their approved meaning and part of speech.
 * Use the project terms in the technical-term register.
@@ -95,7 +95,7 @@ and meaning. Use the singular form unless the context requires a plural.
 | --- | --- | --- |
 | adapter | Technical noun | A component that connects Greenlight to an external tool or execution method |
 | artifact | Technical noun | A file or data item that a run produces |
-| assignment | Technical noun | A group of test classes that an orchestrator sends to a worker |
+| assignment | Technical noun | A scheduling unit that an orchestrator sends to a worker |
 | attachment | Technical noun | Evidence that belongs to one test result |
 | attempt | Technical noun | One execution of a test before Greenlight reports a result or starts a retry |
 | baseline diff | Technical noun | A comparison of current coverage with a saved coverage map |
@@ -189,7 +189,7 @@ and meaning. Use the singular form unless the context requires a plural.
 | temporal expectation | Technical noun | An expectation that observes probe values over time |
 | terminal emulator | Technical noun | Test support that models the terminal state after control sequences |
 | terminal result | Technical noun | The final result after all test and plugin changes |
-| test | Technical noun | One test method with one optional data set |
+| test | Technical noun | One invocation of a test method with one optional data set |
 | test class | Technical noun | A class that contains one or more test methods |
 | test container | Technical noun | A Symfony container that makes test services available |
 | test ID | Technical noun | The stable class, method, and optional data-set label for a test |

--- a/docs/architecture/worker-lifecycle.md
+++ b/docs/architecture/worker-lifecycle.md
@@ -119,9 +119,9 @@ suite success.
 
 ## Resource assignment
 
-Discovery stores `#[RequiresResource]` names in test metadata. It groups entries
-by class and combines the requirements from all entries in that class. The
-orchestrator treats an isolated entry as a separate unit.
+Discovery stores `#[RequiresResource]` names in test metadata. The orchestrator
+groups non-isolated entries by class and combines their requirements. It treats
+each isolated entry as a separate scheduling unit.
 
 Before it sends `assign`, the orchestrator claims one slot from each required
 resource in one atomic operation. A resource without a configured limit has one
@@ -151,8 +151,8 @@ separate resource counters. Different runs require an external lock or service
 for coordination.
 
 The orchestrator controls capacity, not resource identity. A limit of two
-permits two class assignments that require the resource at the same time. It
-does not tell either class which database, account, or sandbox to use.
+permits two assignments that require the resource at the same time. It does not
+tell either assignment which database, account, or sandbox to use.
 
 ## Worker exit
 

--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -42,7 +42,7 @@ temporary source file after `file()` returns. Later changes to a value or file
 do not change the attachment.
 
 Greenlight retains attachments when the attempt fails or has an error. This
-rule includes a successful attempt that result policy changes to another
+rule includes a successful attempt that a result policy changes to another
 outcome. To retain an attachment from a successful attempt, set its retention to
 `AttachmentRetention::Always`:
 
@@ -89,9 +89,9 @@ attempt number, retention policy, and published path. The metadata does not
 include the original source path or the attachment content.
 
 Attachment names are labels, not paths. They cannot contain directory
-separators, control characters, `.` or `..`. Repeated names within one attempt
-receive `-2`, `-3`, and later suffixes in their published filenames. Their
-logical names remain unchanged in the result metadata.
+separators or control characters. They cannot equal `.` or `..`. Repeated names
+within one attempt receive `-2`, `-3`, and later suffixes in their published
+filenames. Their logical names remain unchanged in the result metadata.
 
 Greenlight converts test IDs to slugs and hashes before it uses them in paths.
 

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -380,9 +380,11 @@ final class OrderRepositoryTest { ... }
 Class-level requirements apply to each method. Greenlight combines method-level
 requirements with them. Multiple occurrences of the same name have no effect.
 
-Greenlight assigns work by class, so it combines the requirements from every
-method and holds those resources until the class finishes. A requirement on one
-method can therefore reduce concurrency for other methods in the same class.
+Greenlight combines requirements from all non-isolated tests in a class and
+holds them until the class assignment finishes. Thus, a method requirement can
+reduce concurrency for other non-isolated tests in the class. Each isolated
+test has a separate assignment with its class-level and method-level
+requirements.
 
 Resources default to a limit of one. Use `resourceLimit()` in `greenlight.php`
 or `--resource-limit` to set a larger limit.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -107,8 +107,8 @@ include connections and file handles.
 
 Default: `1` for a resource used by `#[RequiresResource]`.
 
-Limits how many class assignments in one Greenlight run can use the named
-resource at once.
+Limits how many assignments in one Greenlight run can use the named resource at
+once.
 
 ```php
 return GreenlightConfig::create()
@@ -119,9 +119,9 @@ return GreenlightConfig::create()
 Limits must be positive. Names must match `[a-z0-9][a-z0-9._-]*`. Configure
 each name only one time.
 
-A class that requires several resources waits until all of them have capacity.
-Greenlight claims the slots together, so a class never starts with only part of
-its requirement.
+An assignment that requires several resources waits until all of them have
+capacity. Greenlight claims the slots together and sends the assignment only
+after all slots are available.
 
 The limit is an in-memory scheduler gate, not a distributed lock. Separate
 Greenlight processes, worktrees, and CI shards do not share capacity.
@@ -321,8 +321,8 @@ directories.
 
 Use a channel when each worker can have a separate resource. Use
 `#[RequiresResource]` when workers share a dependency with lower safe
-concurrency. A resource limit controls the number of classes that can run. It
-does not assign a resource instance to a class.
+concurrency. A resource limit controls the number of assignments that can run.
+It does not assign a resource instance to an assignment.
 
 Two concurrent tests do not share a channel. Channel numbers are from 1 through
 the worker count. The number of worker processes during the run does not change

--- a/docs/symfony.md
+++ b/docs/symfony.md
@@ -41,7 +41,7 @@ At boot, the bridge checks that the container supports the features it needs.
 The bridge reports a configuration error if the Symfony test container is not
 present. It also reports a configuration error if an active service reset has
 no `services_resetter`. The error message contains a correction. The bridge
-does not silently use weaker isolation.
+reports an error and does not use weaker isolation.
 
 ## Container services
 
@@ -157,10 +157,10 @@ return GreenlightConfig::create()
     ->resourceLimit('payments-sandbox', 2);
 ```
 
-The limit controls how many classes that require this resource can run. It does
-not choose a service instance, and it does not coordinate another Greenlight
-process or CI shard. See [configuration](configuration.md) for the complete
-resource rules.
+The limit controls how many assignments that require this resource can run. It
+does not choose a service instance, and it does not coordinate another
+Greenlight process or CI shard. See [configuration](configuration.md) for the
+complete resource rules.
 
 ## Doubles and the container
 

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -460,8 +460,8 @@ final readonly class Application
 
         if ($coverageSettings instanceof CoverageSettings) {
             // The worker-pool path collects orchestrator coverage unless this
-            // process inherits relay variables. A second driver period would
-            // close the inherited process period too early.
+            // process inherits relay variables. A second driver period closes
+            // the inherited process period too early.
             if ($workers !== 1 && $realBin !== false && !SubprocessCoverage::requested()) {
                 $orchestratorCollector = CoverageCollector::create($coverageSettings);
                 $orchestratorCollector?->start();

--- a/src/Cli/Watch/StatChangeDetector.php
+++ b/src/Cli/Watch/StatChangeDetector.php
@@ -11,7 +11,7 @@ namespace Greenlight\Cli\Watch;
  * directories. It reports a path when its fingerprint changes. It also
  * reports new and removed paths.
  *
- * The first poll creates the initial record and reports nothing.
+ * The first poll creates the initial record and reports no changes.
  *
  * @internal
  */

--- a/src/Config/ConfigFileError.php
+++ b/src/Config/ConfigFileError.php
@@ -20,7 +20,7 @@ final class ConfigFileError extends \RuntimeException
     public static function noneInDirectory(string $directory): self
     {
         return new self(\sprintf(
-            'No %s found in "%s". Create one that returns GreenlightConfig::create(), or point at one with --config=<path>.',
+            'No %s found in "%s". Create one that returns GreenlightConfig::create(). Alternatively, use --config=<path> to select a configuration file.',
             ConfigLoader::FILE_NAME,
             $directory,
         ));
@@ -34,10 +34,10 @@ final class ConfigFileError extends \RuntimeException
     public static function didNotReturnBuilder(string $file, mixed $returned): self
     {
         return new self(\sprintf(
-            'Configuration file "%s" must return a %s instance, got %s. End the file with "return GreenlightConfig::create()->...;".',
+            'Configuration file "%s" returned %s. It must return a %s instance. End the file with "return GreenlightConfig::create()->...;".',
             $file,
-            GreenlightConfig::class,
             \get_debug_type($returned),
+            GreenlightConfig::class,
         ));
     }
 

--- a/src/Core/ErrorTrap.php
+++ b/src/Core/ErrorTrap.php
@@ -7,8 +7,9 @@ namespace Greenlight\Core;
 /**
  * Runs one native operation. It does not send engine diagnostics to a host error handler.
  *
- * run() installs an error handler that records the last message and handles
- * it. It then invokes the operation and restores the previous handler.
+ * run() installs an error handler that records the last message and suppresses
+ * each diagnostic. It then invokes the operation and restores the previous
+ * handler.
  * The return value of the operation still identifies a failure. The recorded
  * message gives more information for an error that the caller raises.
  *

--- a/src/Core/Result/DiagnosticSeverity.php
+++ b/src/Core/Result/DiagnosticSeverity.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Greenlight\Core\Result;
 
 /**
- * Greenlight captures only notices, warnings, and deprecations. PHP handles
- * other levels with its default process.
+ * Greenlight captures only notices, warnings, and deprecations. PHP uses its
+ * default behavior for all other error levels.
  */
 enum DiagnosticSeverity: string
 {

--- a/src/Coverage/Driver/XdebugDriver.php
+++ b/src/Coverage/Driver/XdebugDriver.php
@@ -23,7 +23,7 @@ final class XdebugDriver implements CoverageDriver
     public function __construct()
     {
         if (!self::isAvailable()) {
-            throw CoverageError::driverUnavailable('xdebug', 'Enable the xdebug extension and include "coverage" in xdebug.mode or the XDEBUG_MODE environment variable.');
+            throw CoverageError::driverUnavailable('xdebug', 'Enable the Xdebug extension. Add "coverage" to xdebug.mode or the XDEBUG_MODE environment variable.');
         }
     }
 

--- a/src/Discovery/DiscoveryError.php
+++ b/src/Discovery/DiscoveryError.php
@@ -7,9 +7,9 @@ namespace Greenlight\Discovery;
 /**
  * Discovery raises this error when it cannot make plan entries from a test file.
  *
- * Discovery does not silently ignore a file that it cannot resolve. Each
- * failure type has a named constructor. Its message identifies the applicable
- * file, class, or method.
+ * Discovery reports each file that it cannot resolve. Each failure type has a
+ * named constructor. Its message identifies the applicable file, class, or
+ * method.
  *
  * @internal
  */

--- a/src/Doubles/Doubles.php
+++ b/src/Doubles/Doubles.php
@@ -13,8 +13,8 @@ use Greenlight\Harness\Disposable;
 /**
  * Mocks are strict. A call without a planned expectation fails the test
  * immediately. Each return value needs a configured result. Stubs cause an
- * error for all interactions. Spies record calls to methods that return
- * nothing.
+ * error for all interactions. Spies record calls to methods without a return
+ * value.
  *
  * A verification failure throws one `ExpectationFailed`. It contains one
  * `FailureDetail` for each unmet expectation. Thus, the reporter shows it in

--- a/src/Doubles/MethodExpectation.php
+++ b/src/Doubles/MethodExpectation.php
@@ -25,7 +25,7 @@ final class MethodExpectation
     public int $actualCalls = 0;
 
     /**
-     * @var list<mixed>|null A null value accepts any arguments.
+     * @var list<mixed>|null A null value accepts all argument lists.
      */
     private ?array $arguments = null;
 
@@ -310,7 +310,7 @@ final class MethodExpectation
     public function describeCall(ValueRenderer $renderer): string
     {
         if ($this->arguments === null) {
-            return $this->method . '(any arguments)';
+            return $this->method . '(all arguments)';
         }
 
         $parts = \array_map(

--- a/src/Expect/Equality.php
+++ b/src/Expect/Equality.php
@@ -35,8 +35,8 @@ final class Equality
         $canonical = \array_map(self::canonicalize(...), $value);
 
         if (\array_is_list($canonical)) {
-            // Compute each key one time for each element. A comparator would
-            // serialize both operands again for each comparison.
+            // Compute each key one time for each element. A comparator
+            // serializes both operands again for each comparison.
             $keys = \array_map(static fn(mixed $item): string => self::sortKey($item, []), $canonical);
             \array_multisort($keys, \SORT_ASC, \SORT_STRING, $canonical);
         }

--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -829,7 +829,7 @@ final class Expectation
                 $thrown::class,
                 $this->renderer->render($thrown->getMessage()),
             )
-            : 'a callable that threw nothing';
+            : 'a callable that did not throw';
 
         return $this->verify($matched, $description, $throwable, $actual);
     }

--- a/src/Rector/PhpUnitToGreenlightRector.php
+++ b/src/Rector/PhpUnitToGreenlightRector.php
@@ -359,7 +359,8 @@ final class PhpUnitToGreenlightRector extends AbstractRector implements Configur
 
         if ($hasTestAttribute) {
             // A #[Test] attribute on a static or non-public method is not a
-            // runnable PHPUnit test. A conversion would silently drop it.
+            // runnable PHPUnit test. Without this check, conversion drops the
+            // method without an error.
             return null;
         }
 
@@ -887,7 +888,7 @@ final class PhpUnitToGreenlightRector extends AbstractRector implements Configur
     /**
      * @param array<Arg|Node\VariadicPlaceholder> $args
      *
-     * @return list<Arg>|null null when any argument is named, unpacked, or a
+     * @return list<Arg>|null Null if an argument is named, unpacked, or a
      *                        first-class callable placeholder
      */
     private function positionalArgs(array $args): ?array

--- a/src/Runner/Orchestrator/Orchestrator.php
+++ b/src/Runner/Orchestrator/Orchestrator.php
@@ -341,8 +341,8 @@ final class Orchestrator
     /**
      * Returns live workers without a first assignment.
      *
-     * These workers will consume queued scheduling units. Thus, the
-     * orchestrator must not start more workers for the same scheduling units.
+     * The orchestrator assigns queued scheduling units to these workers. Thus,
+     * it does not start more workers for the same units.
      */
     private function unassignedActiveCount(): int
     {
@@ -687,8 +687,8 @@ final class Orchestrator
             }
 
             // pumpChannels already drained the channel, so the EOF state is
-            // current. Do not poll here. This code would discard a returned
-            // message.
+            // current. Do not poll here because another poll discards a
+            // returned message.
             if (!$handle->channel->isEof()) {
                 continue;
             }

--- a/src/Runner/PlanOrder.php
+++ b/src/Runner/PlanOrder.php
@@ -14,8 +14,8 @@ use Greenlight\Discovery\PlanEntry;
  *
  * Entry order within a class never changes.
  *
- * A run with a seed must not supply durations. An order from cached durations
- * would change the order that the seed reproduces.
+ * A run with a seed does not supply durations. Cached durations change the
+ * order that the seed reproduces.
  *
  * @internal
  */

--- a/src/Runner/SubprocessCoverage.php
+++ b/src/Runner/SubprocessCoverage.php
@@ -14,8 +14,8 @@ use Greenlight\Coverage\Export\JsonExporter;
  * not write an empty coverage map.
  *
  * Worker processes do not write coverage files. They send coverage through
- * the worker protocol. A second collection period would close the inherited
- * process period too early.
+ * the worker protocol. A second collection period closes the inherited process
+ * period too early.
  *
  * @internal
  */

--- a/src/Runner/Worker/LeakDetector.php
+++ b/src/Runner/Worker/LeakDetector.php
@@ -30,7 +30,7 @@ final class LeakDetector
     private array $watched = [];
 
     /**
-     * @return non-empty-string|null a warning when the environment makes leak reports untrustworthy
+     * @return non-empty-string|null A warning if the environment can cause incorrect leak reports
      */
     public static function environmentWarning(): ?string
     {
@@ -38,7 +38,7 @@ final class LeakDetector
             return null;
         }
 
-        return 'Warning: xdebug develop mode keeps caught exceptions alive, so leak detection will report false positives. Rerun with XDEBUG_MODE=off for a trustworthy signal.';
+        return 'Warning: Xdebug develop mode keeps caught exceptions in memory. Thus, leak detection reports false positives. Rerun with XDEBUG_MODE=off to get correct results.';
     }
 
     public function watch(TestId $id, object $instance): void

--- a/src/Runner/Worker/TestExecutor.php
+++ b/src/Runner/Worker/TestExecutor.php
@@ -447,8 +447,8 @@ final readonly class TestExecutor
             return $shortName;
         }
 
-        // Replace invalid UTF-8 to keep a skipped result. An encoder error
-        // would change the skip-reason conversion to a worker error.
+        // Replace invalid UTF-8 to keep a skipped result. Without replacement,
+        // an encoder error changes the skip-reason conversion to a worker error.
         $rendered = \array_map(
             static fn(bool|float|int|string|null $argument): string => (string) \json_encode($argument, \JSON_INVALID_UTF8_SUBSTITUTE),
             $arguments,

--- a/tests/Acceptance/ListingTest.php
+++ b/tests/Acceptance/ListingTest.php
@@ -20,8 +20,8 @@ final readonly class ListingTest
         $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'listing');
         $result = GreenlightCli::run($project->directory, ['run', '--list-tests']);
         $output = $result->stdoutLines();
-        Expect::that($result->exitCode)->because('list tests prints the selection in plan order without running')->toBe(0);
-        Expect::that($output)->because('list tests prints the selection in plan order without running')
+        Expect::that($result->exitCode)->because('--list-tests prints the selection in plan order and does not run tests')->toBe(0);
+        Expect::that($output)->because('--list-tests prints the selection in plan order and does not run tests')
             ->toContain('Greenlight\Tests\Fixture\DiscoveryBasic\AlphaTest::one')
             ->toContain('Greenlight\Tests\Fixture\DiscoveryBasic\CharlieTest::crawls')
             ->toContain('7 tests');
@@ -35,7 +35,7 @@ final readonly class ListingTest
                 $classes[] = $class;
             }
         }
-        Expect::that($classes)->because('list tests prints the selection in plan order without running')->toBe(\array_values(\array_unique($classes)));
+        Expect::that($classes)->because('--list-tests prints the selection in plan order and does not run tests')->toBe(\array_values(\array_unique($classes)));
     }
 
     #[Test]

--- a/tests/Acceptance/ParallelRunTest.php
+++ b/tests/Acceptance/ParallelRunTest.php
@@ -131,16 +131,16 @@ final readonly class ParallelRunTest
         if (!\extension_loaded('xdebug')) {
             // Xdebug develop mode causes the warning. The test cannot create
             // this environment property without the extension.
-            throw new SkipTest('xdebug is not loaded');
+            throw new SkipTest('Xdebug is not loaded');
         }
 
         $develop = $this->runIn('LeakConfig', ['run', '--detect-leaks', '--workers=2'], ['XDEBUG_MODE' => 'develop']);
 
-        Expect::that($develop->output())->because('leak detection warns when Xdebug develop mode is active')->toContain('xdebug develop mode');
+        Expect::that($develop->output())->because('leak detection warns when Xdebug develop mode is active')->toContain('Xdebug develop mode');
 
         $off = $this->runIn('LeakConfig', ['run', '--detect-leaks', '--workers=2'], ['XDEBUG_MODE' => 'off']);
 
-        Expect::that($off->output())->because('leak detection warns when Xdebug develop mode is active')->not()->toContain('xdebug develop mode');
+        Expect::that($off->output())->because('leak detection warns when Xdebug develop mode is active')->not()->toContain('Xdebug develop mode');
     }
 
     #[Test]

--- a/tests/Acceptance/PhpStanExtensionTest.php
+++ b/tests/Acceptance/PhpStanExtensionTest.php
@@ -90,7 +90,7 @@ final readonly class PhpStanExtensionTest
             PHP,
         );
 
-        Expect::that($probe->exitCode)->because('matcher subject types follow fluent chains')->toBe(1)
+        Expect::that($probe->exitCode)->because('fluent chains preserve matcher subject types')->toBe(1)
             ->and($probe->goodPassed)->toBeTrue()
             ->and(\count($probe->errors))->toBe(2)
             ->and($probe->messages())->toContain('requires subject type string, but the subject has type int');
@@ -190,7 +190,7 @@ final readonly class PhpStanExtensionTest
             PHP,
         );
 
-        Expect::that($probe->exitCode)->because('matcher subject types follow temporal chains')->toBe(1)
+        Expect::that($probe->exitCode)->because('temporal chains preserve matcher subject types')->toBe(1)
             ->and($probe->goodPassed)->toBeTrue()
             ->and(\count($probe->errors))->toBe(3)
             ->and($probe->messages())->toContain('requires subject type string, but the subject has type int');

--- a/tests/Acceptance/ProseCheckTest.php
+++ b/tests/Acceptance/ProseCheckTest.php
@@ -74,6 +74,7 @@ final readonly class ProseCheckTest
             # Exclusions
 
             The value is `colour;` in this sample.
+            The other value is ``colour; `sample` `` in this sample.
 
             [reference](https://example.com/colour)
 
@@ -86,6 +87,34 @@ final readonly class ProseCheckTest
 
         $result = $this->run('check', $root);
         Expect::that($result->exitCode)->because('excludes markdown code and links')->toBe(0);
+    }
+
+    #[Test]
+    public function closesMarkdownFencesOnlyWithTheOpeningMarker(): void
+    {
+        $root = $this->workspace('markdown-fence-marker');
+        $this->write(
+            $root,
+            'sample.md',
+            <<<'MARKDOWN'
+            # Fence marker
+
+            ```php
+            $colour = 'value;';
+            ~~~
+            $colour = 'other;';
+            ```
+
+            The reporter doesn't stop;
+
+            MARKDOWN,
+        );
+
+        $result = $this->run('check', $root);
+        Expect::that($result->exitCode)->because('closes Markdown fences only with the opening marker')->toBe(1)
+            ->and($result->output())->toContain('sample.md:9: contraction:')
+            ->toContain('sample.md:9: semicolon:')
+            ->not()->toContain('sample.md:6:');
     }
 
     #[Test]
@@ -309,6 +338,32 @@ final readonly class ProseCheckTest
     }
 
     #[Test]
+    public function joinsScriptLineCommentParagraphs(): void
+    {
+        $root = $this->workspace('script-line-comments');
+        $this->write(
+            $root,
+            'website/scripts/status.mjs',
+            <<<'JS'
+            const template = `
+            // The template doesn't stop;
+            `;
+
+            // The orchestrator collects every selected test class from all configured directories and
+            // sends one complete assignment to every available worker before the test run begins across all active channels.
+            //
+            // One sentence. Two sentences. Three sentences. Four sentences. Five sentences. Six sentences. Seven sentences.
+            JS,
+        );
+
+        $result = $this->run('check', $root);
+        Expect::that($result->exitCode)->because('joins script line-comment paragraphs')->toBe(1)
+            ->and($result->output())->toContain('website/scripts/status.mjs:5: sentence-length:')
+            ->toContain('website/scripts/status.mjs:8: paragraph-length:')
+            ->not()->toContain('website/scripts/status.mjs:2: contraction:');
+    }
+
+    #[Test]
     public function excludesMultilineAstroExpressions(): void
     {
         $root = $this->workspace('website-expressions');
@@ -419,8 +474,10 @@ final readonly class ProseCheckTest
             {
                 /**
                  * @param string $value The reporter doesn't use colour;
+                 * @param int<1, max>|null $limit The worker doesn't use colour;
+                 * @return array{value: string, label: string} The method doesn't use colour;
                  */
-                public function report(string $value): string
+                public function report(string $value, ?int $limit): string
                 {
                     return 'The worker does not organise the data.';
                 }
@@ -434,7 +491,11 @@ final readonly class ProseCheckTest
             ->and($result->output())->toContain('src/Message.php:6: semicolon:')
             ->toContain('src/Message.php:6: contraction:')
             ->toContain('src/Message.php:6: british-spelling:')
-            ->toContain('src/Message.php:10: british-spelling:');
+            ->toContain('src/Message.php:7: contraction:')
+            ->toContain('src/Message.php:7: british-spelling:')
+            ->toContain('src/Message.php:8: contraction:')
+            ->toContain('src/Message.php:8: british-spelling:')
+            ->toContain('src/Message.php:12: british-spelling:');
     }
 
     #[Test]
@@ -725,7 +786,7 @@ final readonly class ProseCheckTest
         $this->write($root, 'packages/example/node_modules/package/README.md', $invalid);
 
         $result = $this->run('check', $root);
-        Expect::that($result->exitCode)->because('excludes dependencies at any directory depth')->toBe(0);
+        Expect::that($result->exitCode)->because('excludes dependencies at all directory depths')->toBe(0);
     }
 
     #[Test]

--- a/tests/Acceptance/ResourceSchedulingTest.php
+++ b/tests/Acceptance/ResourceSchedulingTest.php
@@ -121,9 +121,9 @@ final readonly class ResourceSchedulingTest
             ['RESOURCE_CRASH_MARKER' => $marker],
         );
 
-        Expect::that($result->exitCode)->because('a crashed worker releases its lease for waiting work')->toBe(1);
-        Expect::that($result->output())->because('a crashed worker releases its lease for waiting work')->toContain('2 tests, 1 passed, 1 errored');
-        Expect::that((string) \file_get_contents($marker))->because('a crashed worker releases its lease for waiting work')->toBe('ran');
+        Expect::that($result->exitCode)->because('a crashed worker releases its lease for queued work')->toBe(1);
+        Expect::that($result->output())->because('a crashed worker releases its lease for queued work')->toContain('2 tests, 1 passed, 1 errored');
+        Expect::that((string) \file_get_contents($marker))->because('a crashed worker releases its lease for queued work')->toBe('ran');
     }
 
     private function concurrencyProject(): AcceptanceProject

--- a/tests/Acceptance/SequentialFallbackTest.php
+++ b/tests/Acceptance/SequentialFallbackTest.php
@@ -25,7 +25,7 @@ final readonly class SequentialFallbackTest
             ['run', '--workers=4', '--reporter=plain'],
             phpArguments: ['-d', 'disable_functions=proc_open'],
         );
-        Expect::that($result->exitCode)->because('disabled proc open falls back to in process')->toBe(0)
+        Expect::that($result->exitCode)->because('the runner uses in-process execution when PHP disables proc_open')->toBe(0)
             ->and($result->output())->toContain('7 tests, 7 passed')
             ->not()->toContain('proc_open');
     }

--- a/tests/Acceptance/SymfonyRunTest.php
+++ b/tests/Acceptance/SymfonyRunTest.php
@@ -126,8 +126,8 @@ final readonly class SymfonyRunTest
                 #[Test]
                 public function statefulServicesResetBetweenTests(): void
                 {
-                    // Without the services_resetter hook the shared counter
-                    // would still hold the previous test's visit.
+                    // Without the services_resetter hook, the shared counter
+                    // still contains the previous test's visit.
                     $this->counter->record();
 
                     Expect::that($this->counter->count())->toBe(1);

--- a/tests/Support/AcceptanceProject.php
+++ b/tests/Support/AcceptanceProject.php
@@ -16,8 +16,8 @@ final readonly class AcceptanceProject
     }
 
     /**
-     * Uses the shared DiscoveryBasic directory. A copy of its PSR-4 classes
-     * would make the autoloader load them from the original path.
+     * Uses the shared DiscoveryBasic directory. Do not copy its PSR-4 classes
+     * because the autoloader loads copies from the original path.
      */
     public static function createWithDiscoveryBasicTests(TempDirectory $workspace, string $name): self
     {

--- a/tests/Unit/Artifact/AttachmentsTest.php
+++ b/tests/Unit/Artifact/AttachmentsTest.php
@@ -137,9 +137,9 @@ final readonly class AttachmentsTest
         $budget = new TestArtifactBudget();
         $attachments = $store->forAttempt($id, 1, $budget);
 
-        Expect::that(static fn() => $attachments->text('../secret', 'x'))->because('unsafe names symlinks and limits fail loudly')
+        Expect::that(static fn() => $attachments->text('../secret', 'x'))->because('invalid names, symbolic links, and exceeded limits cause errors')
             ->toThrow(AttachmentError::class);
-        Expect::that(static fn() => $attachments->bytes('large.bin', '12345'))->because('unsafe names symlinks and limits fail loudly')
+        Expect::that(static fn() => $attachments->bytes('large.bin', '12345'))->because('invalid names, symbolic links, and exceeded limits cause errors')
             ->toThrow(
                 AttachmentError::class,
                 message: 'Attachment size 5 exceeds the limit of 4 bytes.',
@@ -147,19 +147,19 @@ final readonly class AttachmentsTest
 
         $attachments->text('one.txt', '1234');
 
-        Expect::that(static fn() => $attachments->text('two.txt', 'x'))->because('unsafe names symlinks and limits fail loudly')
+        Expect::that(static fn() => $attachments->text('two.txt', 'x'))->because('invalid names, symbolic links, and exceeded limits cause errors')
             ->toThrow(
                 AttachmentError::class,
                 message: 'This test has reached the limit of 1 attachments.',
             );
         $retry = $store->forAttempt($id, 2, $budget);
-        Expect::that(static fn() => $retry->text('retry.txt', 'x'))->because('unsafe names symlinks and limits fail loudly')
+        Expect::that(static fn() => $retry->text('retry.txt', 'x'))->because('invalid names, symbolic links, and exceeded limits cause errors')
             ->toThrow(
                 AttachmentError::class,
                 message: 'This test has reached the limit of 1 attachments.',
             );
         $runLimited = $store->forAttempt(new TestId('Example\EvidenceTest', 'run-limit'), 1, new TestArtifactBudget());
-        Expect::that(static fn() => $runLimited->text('other.txt', 'x'))->because('unsafe names symlinks and limits fail loudly')
+        Expect::that(static fn() => $runLimited->text('other.txt', 'x'))->because('invalid names, symbolic links, and exceeded limits cause errors')
             ->toThrow(
                 AttachmentError::class,
                 message: 'This run has reached the limit of 1 attachments.',
@@ -171,7 +171,7 @@ final readonly class AttachmentsTest
         \symlink($source, $link);
         $other = $store->forAttempt(new TestId('Example\EvidenceTest', 'symlink'), 1, new TestArtifactBudget());
 
-        Expect::that(static fn() => $other->file('link.txt', $link))->because('unsafe names symlinks and limits fail loudly')
+        Expect::that(static fn() => $other->file('link.txt', $link))->because('invalid names, symbolic links, and exceeded limits cause errors')
             ->toThrow(
                 AttachmentError::class,
                 message: \sprintf(

--- a/tests/Unit/Capture/CapturedOutputTest.php
+++ b/tests/Unit/Capture/CapturedOutputTest.php
@@ -46,7 +46,7 @@ final class CapturedOutputTest
 
         $restored = CapturedOutput::fromWire(JsonWire::roundTrip($original->toWire()));
 
-        Expect::that($restored->stdout)->because('binary bytes are scrubbed on the way to the wire')->toMatch('//u')
+        Expect::that($restored->stdout)->because('wire serialization replaces invalid bytes')->toMatch('//u')
             ->toContain('stdout with')
             ->toContain('1')
             ->and(\preg_match('//u', $restored->diagnostics[0]->message))->toBe(1)
@@ -59,7 +59,7 @@ final class CapturedOutputTest
     {
         $restored = CapturedOutput::fromWire(JsonWire::roundTrip(new CapturedOutput('')->toWire()));
 
-        Expect::that($restored->stdout)->because('an empty capture round trips')->toBe('')
+        Expect::that($restored->stdout)->because('wire serialization preserves an empty capture')->toBe('')
             ->and($restored->diagnostics)->toBe([])
             ->and($restored->stdoutTruncated)->toBeFalse()
             ->and($restored->diagnosticsTruncated)->toBeFalse();

--- a/tests/Unit/Capture/OutputCaptureTest.php
+++ b/tests/Unit/Capture/OutputCaptureTest.php
@@ -228,7 +228,7 @@ final class OutputCaptureTest
     #[Test]
     public function stoppingWithoutStartingThrows(): void
     {
-        Expect::that(static fn(): mixed => new OutputCapture()->stop())->because('stopping without starting throws')
+        Expect::that(static fn(): mixed => new OutputCapture()->stop())->because('stop() without start() throws')
             ->toThrow(CaptureError::class, '/not active.*start\(\)/');
     }
 

--- a/tests/Unit/Cli/PrecedenceMatrixTest.php
+++ b/tests/Unit/Cli/PrecedenceMatrixTest.php
@@ -129,9 +129,9 @@ final class PrecedenceMatrixTest
             ->paths(['tests/Only'])
             ->workers(recycleAfterTests: 42, recycleAboveMemory: '64M'), cli: new CliOverrides(workers: WorkerCount::auto(), stopAfterFailures: 1, groups: ['g'], seed: 1));
 
-        Expect::that($resolved->paths)->because('settings without flags always come from the configuration file')->toBe(['tests/Only']);
-        Expect::that($resolved->recycleAfterTests)->because('settings without flags always come from the configuration file')->toBe(42);
-        Expect::that($resolved->recycleAboveMemoryBytes)->because('settings without flags always come from the configuration file')->toBe(67108864);
+        Expect::that($resolved->paths)->because('settings without flags use the configuration file')->toBe(['tests/Only']);
+        Expect::that($resolved->recycleAfterTests)->because('settings without flags use the configuration file')->toBe(42);
+        Expect::that($resolved->recycleAboveMemoryBytes)->because('settings without flags use the configuration file')->toBe(67108864);
     }
 
     /**

--- a/tests/Unit/Condition/ConditionsTest.php
+++ b/tests/Unit/Condition/ConditionsTest.php
@@ -70,7 +70,7 @@ final class ConditionsTest
     #[Test]
     public function phpVersionAtLeastComparesAgainstTheRunningVersion(): void
     {
-        Expect::that(new PhpVersionAtLeast('8.0')->isSatisfied())->because('PHP version at least compares against the running version')->toBeTrue()
+        Expect::that(new PhpVersionAtLeast('8.0')->isSatisfied())->because('PHP version at least compares against the current PHP version')->toBeTrue()
             ->and(new PhpVersionAtLeast(\PHP_VERSION)->isSatisfied())->toBeTrue()
             ->and(new PhpVersionAtLeast('99.0')->isSatisfied())->toBeFalse();
     }
@@ -78,7 +78,7 @@ final class ConditionsTest
     #[Test]
     public function phpVersionLessThanComparesAgainstTheRunningVersion(): void
     {
-        Expect::that(new PhpVersionLessThan('99.0')->isSatisfied())->because('PHP version less than compares against the running version')->toBeTrue()
+        Expect::that(new PhpVersionLessThan('99.0')->isSatisfied())->because('PHP version less than compares against the current PHP version')->toBeTrue()
             ->and(new PhpVersionLessThan('8.0')->isSatisfied())->toBeFalse()
             ->and(new PhpVersionLessThan(\PHP_VERSION)->isSatisfied())->toBeFalse();
     }

--- a/tests/Unit/Config/ConfigLoaderTest.php
+++ b/tests/Unit/Config/ConfigLoaderTest.php
@@ -60,7 +60,7 @@ final class ConfigLoaderTest
             new ConfigLoader()->loadFromDirectory(self::fixtureDir('WrongReturn'));
         } catch (ConfigFileError $error) {
             Expect::that($error->getMessage())->toContain('must return a Greenlight\Config\GreenlightConfig instance');
-            Expect::that($error->getMessage())->toContain('got string');
+            Expect::that($error->getMessage())->toContain('returned string');
 
             return;
         }

--- a/tests/Unit/Core/TestMetadataTest.php
+++ b/tests/Unit/Core/TestMetadataTest.php
@@ -138,13 +138,13 @@ final class TestMetadataTest
 
         Expect::that(
             static fn(): TestMetadata => TestMetadata::fromWire($payload),
-        )->because('missing optional keys fail loudly')->toThrow(InvalidWirePayload::class);
+        )->because('missing optional keys cause an error')->toThrow(InvalidWirePayload::class);
 
         $payload = new TestMetadata('App\FooTest', 'bar')->toWire();
         unset($payload['timeoutSeconds']);
 
         Expect::that(
             static fn(): TestMetadata => TestMetadata::fromWire($payload),
-        )->because('missing optional keys fail loudly')->toThrow(InvalidWirePayload::class);
+        )->because('missing optional keys cause an error')->toThrow(InvalidWirePayload::class);
     }
 }

--- a/tests/Unit/Core/Utf8Test.php
+++ b/tests/Unit/Core/Utf8Test.php
@@ -15,9 +15,9 @@ final class Utf8Test
     #[Test]
     public function validUtf8PassesThroughUntouched(): void
     {
-        Expect::that(Utf8::scrub('plain'))->because('valid utf8 passes through untouched')->toBe('plain');
-        Expect::that(Utf8::scrub('naïve ✓'))->because('valid utf8 passes through untouched')->toBe('naïve ✓');
-        Expect::that(Utf8::scrub(''))->because('valid utf8 passes through untouched')->toBe('');
+        Expect::that(Utf8::scrub('plain'))->because('valid UTF-8 remains unchanged')->toBe('plain');
+        Expect::that(Utf8::scrub('naïve ✓'))->because('valid UTF-8 remains unchanged')->toBe('naïve ✓');
+        Expect::that(Utf8::scrub(''))->because('valid UTF-8 remains unchanged')->toBe('');
     }
 
     #[Test]

--- a/tests/Unit/Coverage/HtmlExporterTest.php
+++ b/tests/Unit/Coverage/HtmlExporterTest.php
@@ -148,7 +148,7 @@ final class HtmlExporterTest
 
         $page = new HtmlExporter()->export($map)[HtmlExporter::pageName('/no/such/file.php')];
 
-        Expect::that($page)->because('unreadable source falls back to line numbers only')->toContain('class="cov"')
+        Expect::that($page)->because('unreadable source shows only line numbers')->toContain('class="cov"')
             ->toContain('class="unc"')
             ->toContain('<span class="num">5</span>');
     }

--- a/tests/Unit/Coverage/IgnoreFilterTest.php
+++ b/tests/Unit/Coverage/IgnoreFilterTest.php
@@ -74,7 +74,7 @@ final class IgnoreFilterTest
         $filtered = new IgnoreFilter()->apply($map);
         $file = $filtered->files()['/nonexistent/plain.php'];
 
-        Expect::that($file->coveredLines)->because('files without markers pass through unchanged')->toBe([1, 2])
+        Expect::that($file->coveredLines)->because('files without markers remain unchanged')->toBe([1, 2])
             ->and($file->uncoveredLines)->toBe([3]);
     }
 

--- a/tests/Unit/Coverage/JsonExporterTest.php
+++ b/tests/Unit/Coverage/JsonExporterTest.php
@@ -58,7 +58,7 @@ final class JsonExporterTest
 
         $restored = JsonExporter::import(new JsonExporter()->export($map)[JsonExporter::FILE_NAME]);
 
-        Expect::that($restored->toWire())->because('import round trips an exported document')->toBe($map->toWire());
+        Expect::that($restored->toWire())->because('import restores the exported coverage map')->toBe($map->toWire());
     }
 
     #[Test]

--- a/tests/Unit/Discovery/ExecutionPlanTest.php
+++ b/tests/Unit/Discovery/ExecutionPlanTest.php
@@ -93,13 +93,13 @@ final class ExecutionPlanTest
 
         Expect::that(
             static fn(): ExecutionPlan => ExecutionPlan::fromWire($payload),
-        )->because('missing wire keys fail loudly')->toThrow(InvalidWirePayload::class);
+        )->because('missing wire keys cause an error')->toThrow(InvalidWirePayload::class);
 
         $payload = new ExecutionPlan([self::entry('App\FooTest', 'a')])->toWire();
         unset($payload['entries']);
 
         Expect::that(
             static fn(): ExecutionPlan => ExecutionPlan::fromWire($payload),
-        )->because('missing wire keys fail loudly')->toThrow(InvalidWirePayload::class);
+        )->because('missing wire keys cause an error')->toThrow(InvalidWirePayload::class);
     }
 }

--- a/tests/Unit/Discovery/Psr4ViolationTest.php
+++ b/tests/Unit/Discovery/Psr4ViolationTest.php
@@ -48,7 +48,7 @@ final class Psr4ViolationTest
     {
         $message = $this->discoveryErrorMessage('DiscoveryNoClass');
 
-        Expect::that($message)->because('file without any declaration produces a typed error')->toContain('does not declare a class');
-        Expect::that($message)->because('file without any declaration produces a typed error')->toContain('NothingHereTest.php');
+        Expect::that($message)->because('a file without a declaration produces a typed error')->toContain('does not declare a class');
+        Expect::that($message)->because('a file without a declaration produces a typed error')->toContain('NothingHereTest.php');
     }
 }

--- a/tests/Unit/Discovery/TestDiscovererTest.php
+++ b/tests/Unit/Discovery/TestDiscovererTest.php
@@ -134,7 +134,7 @@ final class TestDiscovererTest
 
         Expect::that(
             static fn(): ExecutionPlan => new TestDiscoverer()->discover([$directory]),
-        )->because('unknown directory fails loudly')->toThrow(
+        )->because('an unknown directory causes an error')->toThrow(
             DiscoveryError::class,
             message: \sprintf('Discovery directory "%s" is missing or is not a directory.', $directory),
         );

--- a/tests/Unit/Doubles/AnswersTest.php
+++ b/tests/Unit/Doubles/AnswersTest.php
@@ -63,7 +63,7 @@ final class AnswersTest
             $plan->expects('add')->once()->andReturnsUsing(static fn(int $a, int $b): int => $a + $b);
         });
 
-        Expect::that($calculator->add(19, 23))->because('and() returns using receives the call arguments')->toBe(42);
+        Expect::that($calculator->add(19, 23))->because('andReturnsUsing() receives the call arguments')->toBe(42);
 
         $doubles->dispose();
     }

--- a/tests/Unit/Doubles/MockTest.php
+++ b/tests/Unit/Doubles/MockTest.php
@@ -47,7 +47,7 @@ final class MockTest
                 'Calls to Greenlight\Tests\Fixture\Doubles\Calculator::add(): 1 time. '
                 . 'The expectation requires exactly 2 times.',
             )
-                ->and($detail->expected)->toBe('add(any arguments) exactly 2 times')
+                ->and($detail->expected)->toBe('add(all arguments) exactly 2 times')
                 ->and($detail->actual)->toBe('add(1, 2)');
 
             return;
@@ -135,7 +135,7 @@ final class MockTest
             $plan->expects('add')->with(MockPlan::any(), 7)->times(2)->andReturns(7);
         });
 
-        Expect::that($calculator->add(1, 7))->because('the any matcher accepts every value in its position')->toBe(7)
+        Expect::that($calculator->add(1, 7))->because('any() accepts each value at its position')->toBe(7)
             ->and($calculator->add(999, 7))->toBe(7);
 
         $doubles->dispose();
@@ -161,7 +161,7 @@ final class MockTest
 
         // Greenlight keeps the call failure. Thus, verification reports it
         // again.
-        Expect::that(static fn() => $doubles->dispose())->because('never means any call fails immediately')
+        Expect::that(static fn() => $doubles->dispose())->because('never() causes each call to fail immediately')
             ->toThrow(ExpectationFailed::class, '/unexpected call/');
     }
 

--- a/tests/Unit/Doubles/StubTest.php
+++ b/tests/Unit/Doubles/StubTest.php
@@ -30,7 +30,7 @@ final class StubTest
         $doubles = new Doubles();
         $stub = $doubles->stub(Stubbable::class);
 
-        Expect::that(static fn(): string => $stub->name())->because('any call is an authoring error')
+        Expect::that(static fn(): string => $stub->name())->because('each call is an authoring error')
             ->toThrow(DoublesError::class, '/Stubs only satisfy a type/');
 
         $doubles->dispose();

--- a/tests/Unit/Expect/BecauseTest.php
+++ b/tests/Unit/Expect/BecauseTest.php
@@ -25,7 +25,7 @@ final class BecauseTest
     #[Test]
     public function becauseDoesNotChangeAPassingMatcher(): void
     {
-        Expect::that(true)->because('a passing matcher consumes the reason silently')->toBeTrue();
+        Expect::that(true)->because('a passing matcher consumes the reason without reporting it')->toBeTrue();
     }
 
     #[Test]
@@ -46,12 +46,12 @@ final class BecauseTest
         $notFirst = FailureProbe::detailOf(
             static fn() => Expect::that(1)->not()->because('the id must change')->toBe(1),
         );
-        Expect::that($notFirst->message)->because('because() combines with negation in any order')->toBe($expected);
+        Expect::that($notFirst->message)->because('because() combines with negation in both orders')->toBe($expected);
 
         $becauseFirst = FailureProbe::detailOf(
             static fn() => Expect::that(1)->because('the id must change')->not()->toBe(1),
         );
-        Expect::that($becauseFirst->message)->because('because() combines with negation in any order')->toBe($expected);
+        Expect::that($becauseFirst->message)->because('because() combines with negation in both orders')->toBe($expected);
     }
 
     #[Test]

--- a/tests/Unit/Expect/StringMatchersTest.php
+++ b/tests/Unit/Expect/StringMatchersTest.php
@@ -139,7 +139,7 @@ final class StringMatchersTest
     #[Test]
     public function toHaveLengthFallsBackToBytesForInvalidUtf8(): void
     {
-        Expect::that("\xC3\x28")->because('toHaveLength() falls back to bytes for invalid utf8')->toHaveLength(2);
+        Expect::that("\xC3\x28")->because('toHaveLength() counts bytes for invalid UTF-8')->toHaveLength(2);
     }
 
     #[Test]

--- a/tests/Unit/Expect/ToThrowTest.php
+++ b/tests/Unit/Expect/ToThrowTest.php
@@ -37,9 +37,9 @@ final class ToThrowTest
             static fn() => Expect::that(static fn(): int => 1)->toThrow(\DomainException::class),
         );
 
-        Expect::that($detail->message)->because('toThrow() fails when nothing is thrown')->toBe('Expected a callable that threw nothing to throw DomainException.');
-        Expect::that($detail->expected)->because('toThrow() fails when nothing is thrown')->toBe('DomainException');
-        Expect::that($detail->actual)->because('toThrow() fails when nothing is thrown')->toBe('a callable that threw nothing');
+        Expect::that($detail->message)->because('toThrow() fails when the callable does not throw')->toBe('Expected a callable that did not throw to throw DomainException.');
+        Expect::that($detail->expected)->because('toThrow() fails when the callable does not throw')->toBe('DomainException');
+        Expect::that($detail->actual)->because('toThrow() fails when the callable does not throw')->toBe('a callable that did not throw');
     }
 
     #[Test]
@@ -86,7 +86,7 @@ final class ToThrowTest
     #[Test]
     public function notToThrowPassesWhenNothingIsThrown(): void
     {
-        Expect::that(static fn(): int => 1)->because('not()->toThrow() passes when nothing is thrown')->not()->toThrow(\DomainException::class);
+        Expect::that(static fn(): int => 1)->because('not()->toThrow() passes when the callable does not throw')->not()->toThrow(\DomainException::class);
     }
 
     #[Test]

--- a/tests/Unit/Expect/ValueRendererTest.php
+++ b/tests/Unit/Expect/ValueRendererTest.php
@@ -99,8 +99,8 @@ final class ValueRendererTest
         $renderer = new ValueRenderer();
         $stream = \fopen('php://memory', 'r');
 
-        Expect::that($renderer->render(static fn(): int => 1))->because('falls back to debug type for unrenderable values')->toBe('Closure (unrendered)');
-        Expect::that($renderer->render($stream))->because('falls back to debug type for unrenderable values')->toBe('resource (stream) (unrendered)');
+        Expect::that($renderer->render(static fn(): int => 1))->because('the renderer uses the debug type for unrenderable values')->toBe('Closure (unrendered)');
+        Expect::that($renderer->render($stream))->because('the renderer uses the debug type for unrenderable values')->toBe('resource (stream) (unrendered)');
 
         if (\is_resource($stream)) {
             \fclose($stream);
@@ -112,8 +112,8 @@ final class ValueRendererTest
     {
         $rendered = new ValueRenderer()->render("bad \xB1\x31 bytes");
 
-        Expect::that($rendered)->because('scrubs invalid utf8')->toMatch('//u');
-        Expect::that($rendered)->because('scrubs invalid utf8')->toContain('bad');
+        Expect::that($rendered)->because('scrubs invalid UTF-8')->toMatch('//u');
+        Expect::that($rendered)->because('scrubs invalid UTF-8')->toContain('bad');
     }
 }
 

--- a/tests/Unit/Fixture/TempDirectoryTest.php
+++ b/tests/Unit/Fixture/TempDirectoryTest.php
@@ -13,8 +13,8 @@ final class TempDirectoryTest
     #[Test]
     public function nothingExistsOnDiskBeforeFirstUse(): void
     {
-        // path() is the only method that accesses the disk. If construction
-        // created a directory, disposal could try to remove it and throw.
+        // path() is the only method that accesses the disk. Construction does
+        // not create a directory for disposal.
         $directory = new TempDirectory();
 
         Expect::that(static function () use ($directory): void {

--- a/tests/Unit/Harness/HarnessScopesTest.php
+++ b/tests/Unit/Harness/HarnessScopesTest.php
@@ -122,7 +122,7 @@ final class HarnessScopesTest
 
         Expect::that(static function () use ($scopes): void {
             $scopes->resolve(\ArrayObject::class, 'test');
-        })->because('a resolver answering with the wrong type fails loudly')->toThrow(UnresolvableService::class, matching: '/is not that type/');
+        })->because('a resolver that returns the wrong type causes an error')->toThrow(UnresolvableService::class, matching: '/is not that type/');
     }
 
     #[Test]

--- a/tests/Unit/PhpStan/MatcherMapTest.php
+++ b/tests/Unit/PhpStan/MatcherMapTest.php
@@ -38,7 +38,7 @@ final class MatcherMapTest
     {
         $map = MatcherMap::fromConfigFiles([self::CONFIG, self::CONFIG]);
 
-        Expect::that($map->has('toHaveDigestLength'))->because('identical declarations across files union silently')->toBeTrue();
+        Expect::that($map->has('toHaveDigestLength'))->because('identical declarations from multiple files merge without an error')->toBeTrue();
     }
 
     #[Test]

--- a/tests/Unit/Runner/Orchestrator/ChannelAllocatorTest.php
+++ b/tests/Unit/Runner/Orchestrator/ChannelAllocatorTest.php
@@ -43,7 +43,7 @@ final readonly class ChannelAllocatorTest
 
         Expect::that(static function () use ($allocator): void {
             $allocator->allocate();
-        })->because('never hands out more than the bound')->toThrow(\LogicException::class, matching: '/channels are in use/');
+        })->because('does not allocate more channels than the limit')->toThrow(\LogicException::class, matching: '/channels are in use/');
     }
 
     #[Test]
@@ -74,6 +74,6 @@ final readonly class ChannelAllocatorTest
 
         Expect::that(static function () use ($allocator): void {
             $allocator->release(1);
-        })->because('releasing an unallocated channel fails loudly')->toThrow(\LogicException::class, matching: '/not allocated/');
+        })->because('releasing an unallocated channel causes an error')->toThrow(\LogicException::class, matching: '/not allocated/');
     }
 }

--- a/tests/Unit/Symfony/SymfonyPluginTest.php
+++ b/tests/Unit/Symfony/SymfonyPluginTest.php
@@ -78,7 +78,7 @@ final class SymfonyPluginTest
 
         Expect::that(static function () use ($plugin): void {
             $plugin->resolve(Greeter::class, [new Service('fixture.missing')]);
-        })->because('an unknown explicit ID fails loudly')->toThrow(SymfonyBridgeError::class, matching: '/no service "fixture\.missing".*Check the service ID/s');
+        })->because('an unknown explicit ID causes an error')->toThrow(SymfonyBridgeError::class, matching: '/no service "fixture\.missing".*Check the service ID/s');
     }
 
     #[Test]
@@ -88,15 +88,15 @@ final class SymfonyPluginTest
 
         Expect::that(static function () use ($plugin): void {
             $plugin->resolve(VisitCounter::class, [new Service('fixture.named_greeter')]);
-        })->because('an explicit ID of the wrong type fails loudly')->toThrow(SymfonyBridgeError::class, matching: '/has type .* The parameter requires type/');
+        })->because('an explicit ID of the wrong type causes an error')->toThrow(SymfonyBridgeError::class, matching: '/has type .* The parameter requires type/');
     }
 
     #[Test]
     public function aKernelWithoutTheTestContainerFailsAtBoot(): void
     {
         // The prod environment compiles without framework.test. Boot validation
-        // rejects it before service resolution can silently use a less strict
-        // path.
+        // rejects it before service resolution uses a less strict path without
+        // an error.
         $plugin = new SymfonyPlugin(FixtureKernel::class, env: 'prod', debug: true);
 
         Expect::that(static function () use ($plugin): void {
@@ -182,7 +182,7 @@ final class SymfonyPluginTest
 
         Expect::that(static function () use ($plugin): void {
             $plugin->resolve(Greeter::class, []);
-        })->because('a class that is not a kernel fails loudly')->toThrow(SymfonyBridgeError::class, matching: '/does not implement/');
+        })->because('a class that is not a kernel causes an error')->toThrow(SymfonyBridgeError::class, matching: '/does not implement/');
     }
 
     #[Test]

--- a/tests/Unit/Tools/RuntimeMessageTest.php
+++ b/tests/Unit/Tools/RuntimeMessageTest.php
@@ -27,13 +27,13 @@ final readonly class RuntimeMessageTest
         Expect::that($result->exitCode)->toBe(1)
             ->and($result->stderr)->toContain(
                 \sprintf(
-                    'Coverage export not found at %s/build/coverage/coverage.json. Run `composer tests:coverage` first.',
+                    'Greenlight did not find the coverage export at %s/build/coverage/coverage.json. Run `composer tests:coverage` first.',
                     (string) \realpath($root),
                 ),
             )
             ->and((string) \file_get_contents($summary))->toBe(
                 "## Code coverage\n\n"
-                . "**Coverage unavailable.** The coverage run did not produce an export.\n\n",
+                . "**Coverage unavailable.** Greenlight did not produce the coverage export.\n\n",
             );
     }
 

--- a/tools/coverage-gate.php
+++ b/tools/coverage-gate.php
@@ -16,9 +16,9 @@ $summaryFile = \getenv('GITHUB_STEP_SUMMARY');
 $summaryFile = \is_string($summaryFile) && $summaryFile !== '' ? $summaryFile : null;
 
 if (!\is_file($exportFile)) {
-    \appendGithubSummary($summaryFile, \unavailableSummary('The coverage run did not produce an export.'));
+    \appendGithubSummary($summaryFile, \unavailableSummary('Greenlight did not produce the coverage export.'));
     \fwrite(\STDERR, \sprintf(
-        "Coverage export not found at %s. Run `composer tests:coverage` first.\n",
+        "Greenlight did not find the coverage export at %s. Run `composer tests:coverage` first.\n",
         $exportFile,
     ));
     exit(1);
@@ -27,8 +27,8 @@ if (!\is_file($exportFile)) {
 $json = \file_get_contents($exportFile);
 
 if ($json === false) {
-    \appendGithubSummary($summaryFile, \unavailableSummary('The coverage export could not be read.'));
-    \fwrite(\STDERR, \sprintf("Failed to read coverage export at %s.\n", $exportFile));
+    \appendGithubSummary($summaryFile, \unavailableSummary('Greenlight did not read the coverage export.'));
+    \fwrite(\STDERR, \sprintf("Greenlight did not read the coverage export at %s.\n", $exportFile));
     exit(1);
 }
 

--- a/tools/memory-gate.php
+++ b/tools/memory-gate.php
@@ -109,8 +109,9 @@ final class MemoryProbe implements TestLifecycleSubscriber
 
         if ($this->count === $this->warmupTests || $this->count === $this->totalTests) {
             gc_collect_cycles();
-            // Real allocation, not reserved allocator chunks: chunk reservation
-            // moves in 2 MiB steps and would mask or fake a leak slope.
+            // Real allocation, not reserved allocator chunks. Chunk
+            // reservation moves in 2 MiB steps. It can hide a leak slope or
+            // create a false one.
             $this->samples[(string) $this->count] = memory_get_usage();
             file_put_contents($this->samplesFile, json_encode($this->samples));
         }
@@ -154,7 +155,7 @@ $config = \file_get_contents($workDir . '/greenlight.php');
 $config = \str_replace(['{WARMUP}', '{TOTAL}'], [(string) WARMUP_TESTS, (string) $totalTests], (string) $config);
 \file_put_contents($workDir . '/greenlight.php', $config);
 
-echo \sprintf("Running %d generated tests in one worker...\n", $totalTests);
+echo \sprintf("Greenlight runs %d generated tests in one worker...\n", $totalTests);
 
 $command = \sprintf(
     'cd %s && %s %s run --reporter=plain 2>&1 | tail -4',
@@ -189,7 +190,7 @@ if (\is_array($samples)) {
 }
 
 if ($baseline === null || $final === null) {
-    \fwrite(\STDERR, "Sampling points are missing from the probe output.\n");
+    \fwrite(\STDERR, "The probe output does not contain all sample points.\n");
     $cleanup();
     exit(1);
 }
@@ -209,7 +210,7 @@ echo \sprintf(
 $cleanup();
 
 if ($drift > MAX_DRIFT_BYTES) {
-    \fwrite(\STDERR, "FLAT-MEMORY GATE FAILED: the framework leaks across a long run.\n");
+    \fwrite(\STDERR, "FLAT-MEMORY GATE FAILED: Greenlight leaks memory during a long run.\n");
     exit(1);
 }
 

--- a/tools/prose-check.php
+++ b/tools/prose-check.php
@@ -530,14 +530,38 @@ function proseJsonPassages(string $path, string $contents): array
 function proseScriptPassages(string $path, string $contents): array
 {
     $passages = [];
+    $lineParagraph = [];
+    $lineParagraphLine = 1;
+    $lastLine = null;
 
-    if (\preg_match_all('/^\s*\/\/\s+(?!@)(.+)$/m', $contents, $comments, \PREG_OFFSET_CAPTURE) !== false) {
-        foreach ($comments[1] as [$text, $offset]) {
-            $passages[] = ['path' => $path, 'line' => \proseLineAtOffset($contents, $offset), 'text' => $text];
+    foreach (\proseScriptComments($contents) as [$type, $comment, $commentOffset]) {
+        if ($type === 'line') {
+            $line = \proseLineAtOffset($contents, $commentOffset);
+            $text = \trim($comment);
+
+            if ($text === '' || \str_starts_with($text, '@')) {
+                \proseFlushParagraph($passages, $lineParagraph, $lineParagraphLine, $path, true);
+                $lastLine = null;
+
+                continue;
+            }
+
+            if ($lastLine !== null && $line !== $lastLine + 1) {
+                \proseFlushParagraph($passages, $lineParagraph, $lineParagraphLine, $path, true);
+            }
+
+            if ($lineParagraph === []) {
+                $lineParagraphLine = $line;
+            }
+
+            $lineParagraph[] = $text;
+            $lastLine = $line;
+
+            continue;
         }
-    }
 
-    foreach (\proseScriptBlockComments($contents) as [$comment, $commentOffset]) {
+        \proseFlushParagraph($passages, $lineParagraph, $lineParagraphLine, $path, true);
+        $lastLine = null;
         $lines = \preg_split('/\R/', $comment);
         $paragraph = [];
         $paragraphLine = \proseLineAtOffset($contents, $commentOffset);
@@ -560,6 +584,8 @@ function proseScriptPassages(string $path, string $contents): array
 
         \proseFlushParagraph($passages, $paragraph, $paragraphLine, $path, true);
     }
+
+    \proseFlushParagraph($passages, $lineParagraph, $lineParagraphLine, $path, true);
 
     if (\preg_match_all('/([\'"`])((?:\\\\.|(?!\1).)*)\1/s', $contents, $strings, \PREG_OFFSET_CAPTURE) !== false) {
         foreach ($strings[2] as $index => [$encoded, $offset]) {
@@ -589,9 +615,9 @@ function proseScriptPassages(string $path, string $contents): array
 }
 
 /**
- * @return list<array{string, int}>
+ * @return list<array{string, string, int}>
  */
-function proseScriptBlockComments(string $contents): array
+function proseScriptComments(string $contents): array
 {
     $comments = [];
     $length = \strlen($contents);
@@ -623,7 +649,9 @@ function proseScriptBlockComments(string $contents): array
 
         if ($contents[$index + 1] === '/') {
             $newline = \strpos($contents, "\n", $index + 2);
-            $index = $newline === false ? $length : $newline;
+            $end = $newline === false ? $length : $newline;
+            $comments[] = ['line', \substr($contents, $index + 2, $end - $index - 2), $index + 2];
+            $index = $end;
 
             continue;
         }
@@ -638,7 +666,7 @@ function proseScriptBlockComments(string $contents): array
             break;
         }
 
-        $comments[] = [\substr($contents, $index + 2, $end - $index - 2), $index + 2];
+        $comments[] = ['block', \substr($contents, $index + 2, $end - $index - 2), $index + 2];
         $index = $end + 1;
     }
 
@@ -679,21 +707,32 @@ function proseMarkdownPassages(string $path, string $contents): array
     $passages = [];
     $paragraph = [];
     $paragraphLine = 1;
-    $inFence = false;
+    $fenceMarker = null;
+    $fenceLength = 0;
     $listItemIndent = null;
     $lines = \preg_split('/\R/', $contents);
 
     foreach ($lines === false ? [] : $lines as $offset => $line) {
         $lineNumber = $offset + 1;
 
-        if (\preg_match('/^\s*(```|~~~)/', $line) === 1) {
+        if ($fenceMarker === null && \preg_match('/^\s*(`{3,}|~{3,})/', $line, $fence) === 1) {
             \proseFlushParagraph($passages, $paragraph, $paragraphLine, $path, true);
-            $inFence = !$inFence;
+            $fenceMarker = $fence[1][0];
+            $fenceLength = \strlen($fence[1]);
 
             continue;
         }
 
-        if ($inFence) {
+        if ($fenceMarker !== null) {
+            if (
+                \preg_match('/^\s*(`+|~+)\s*$/', $line, $fence) === 1
+                && $fence[1][0] === $fenceMarker
+                && \strlen($fence[1]) >= $fenceLength
+            ) {
+                $fenceMarker = null;
+                $fenceLength = 0;
+            }
+
             continue;
         }
 
@@ -773,13 +812,63 @@ function proseCleanMarkdown(string $text): string
 {
     $text = (string) \preg_replace('/!\[([^\]]*)]\([^)]*\)/', ' $1 ', $text);
     $text = (string) \preg_replace('/\[([^\]]+)]\([^)]*\)/', ' $1 ', $text);
-    $text = (string) \preg_replace('/`[^`]*`/', ' LITERAL ', $text);
+    $text = \proseMaskMarkdownCodeSpans($text);
     $text = (string) \preg_replace('/<https?:\/\/[^>]+>/', ' LITERAL ', $text);
     $text = (string) \preg_replace('/https?:\/\/\S+/', ' LITERAL ', $text);
     $text = (string) \preg_replace('/[*_]{1,3}/', '', $text);
     $text = (string) \preg_replace('/\s+/', ' ', $text);
 
     return \trim($text);
+}
+
+function proseMaskMarkdownCodeSpans(string $text): string
+{
+    $masked = '';
+    $length = \strlen($text);
+
+    for ($index = 0; $index < $length; ++$index) {
+        if ($text[$index] !== '`') {
+            $masked .= $text[$index];
+
+            continue;
+        }
+
+        $runLength = 1;
+
+        while ($index + $runLength < $length && $text[$index + $runLength] === '`') {
+            ++$runLength;
+        }
+
+        $delimiter = \str_repeat('`', $runLength);
+        $searchOffset = $index + $runLength;
+        $closing = false;
+
+        while (($candidate = \strpos($text, $delimiter, $searchOffset)) !== false) {
+            $beforeIsBacktick = $candidate > 0 && $text[$candidate - 1] === '`';
+            $after = $candidate + $runLength;
+            $afterIsBacktick = $after < $length && $text[$after] === '`';
+
+            if (!$beforeIsBacktick && !$afterIsBacktick) {
+                $closing = $candidate;
+
+                break;
+            }
+
+            $searchOffset = $candidate + 1;
+        }
+
+        if ($closing === false) {
+            $masked .= $delimiter;
+            $index += $runLength - 1;
+
+            continue;
+        }
+
+        $masked .= ' LITERAL ';
+        $index = $closing + $runLength - 1;
+    }
+
+    return $masked;
 }
 
 /**
@@ -1059,16 +1148,145 @@ function prosePhpPassages(string $path, string $contents): array
 
 function prosePhpDocTagDescription(string $line): ?string
 {
-    if (\preg_match('/^@param(?:-out)?\s+\S+\s+\$\S+\s+(.+)$/', $line, $matches) === 1) {
-        return $matches[1];
+    if (\preg_match('/^@param(?:-out)?\s+(.+)$/', $line, $matches) === 1) {
+        return \prosePhpDocParamDescription($matches[1]);
     }
 
-    if (\preg_match('/^@(return|throws|var)\s+\S+\s+(.+)$/', $line, $matches) === 1) {
-        return $matches[2];
+    if (\preg_match('/^@(return|throws|var)\s+(.+)$/', $line, $matches) === 1) {
+        return \prosePhpDocTypeDescription($matches[2]);
     }
 
     if (\preg_match('/^@(internal|deprecated)(?:\s+(.+))?$/', $line, $matches) === 1) {
         return $matches[2] ?? '';
+    }
+
+    return null;
+}
+
+function prosePhpDocParamDescription(string $value): ?string
+{
+    $depth = 0;
+    $quote = null;
+    $length = \strlen($value);
+
+    for ($index = 0; $index < $length; ++$index) {
+        $character = $value[$index];
+
+        if ($quote !== null) {
+            if ($character === '\\') {
+                ++$index;
+            } elseif ($character === $quote) {
+                $quote = null;
+            }
+
+            continue;
+        }
+
+        if ($character === "'" || $character === '"') {
+            $quote = $character;
+
+            continue;
+        }
+
+        if (\str_contains('<{[(', $character)) {
+            ++$depth;
+
+            continue;
+        }
+
+        if (\str_contains('>}])', $character)) {
+            $depth = \max(0, $depth - 1);
+
+            continue;
+        }
+
+        if (
+            $character !== '$'
+            || $depth !== 0
+            || ($index > 0 && !\ctype_space($value[$index - 1]))
+        ) {
+            continue;
+        }
+
+        $descriptionOffset = $index;
+
+        while ($descriptionOffset < $length && !\ctype_space($value[$descriptionOffset])) {
+            ++$descriptionOffset;
+        }
+
+        $description = \trim(\substr($value, $descriptionOffset));
+
+        return $description === '' ? null : $description;
+    }
+
+    return null;
+}
+
+function prosePhpDocTypeDescription(string $value): ?string
+{
+    $depth = 0;
+    $quote = null;
+    $length = \strlen($value);
+
+    for ($index = 0; $index < $length; ++$index) {
+        $character = $value[$index];
+
+        if ($quote !== null) {
+            if ($character === '\\') {
+                ++$index;
+            } elseif ($character === $quote) {
+                $quote = null;
+            }
+
+            continue;
+        }
+
+        if ($character === "'" || $character === '"') {
+            $quote = $character;
+
+            continue;
+        }
+
+        if (\str_contains('<{[(', $character)) {
+            ++$depth;
+
+            continue;
+        }
+
+        if (\str_contains('>}])', $character)) {
+            $depth = \max(0, $depth - 1);
+
+            continue;
+        }
+
+        if (!\ctype_space($character) || $depth !== 0) {
+            continue;
+        }
+
+        $next = $index;
+
+        while ($next < $length && \ctype_space($value[$next])) {
+            ++$next;
+        }
+
+        if ($next >= $length) {
+            return null;
+        }
+
+        $previous = $index - 1;
+
+        while ($previous >= 0 && \ctype_space($value[$previous])) {
+            --$previous;
+        }
+
+        if (
+            ($previous >= 0 && \str_contains('|&', $value[$previous]))
+            || \str_contains('|&', $value[$next])
+        ) {
+            continue;
+        }
+
+        return \trim(\substr($value, $next));
     }
 
     return null;

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -94,7 +94,7 @@ final class PriceTest
           <span>02</span>
           <div>
             <h3>Keep every worker busy</h3>
-            <p>Free workers take the next class. Greenlight starts known slow classes and previously failed classes early.</p>
+            <p>The orchestrator assigns one scheduling unit to each available worker. Greenlight starts known slow classes and previously failed classes early.</p>
           </div>
         </li>
         <li>
@@ -115,7 +115,7 @@ final class PriceTest
           <p><strong>Crashed worker</strong><span>The orchestrator returns the rest of the assignment to the queue and starts a replacement worker.</span></p>
           <p><strong>Hung test</strong><span>A hard timeout stops the worker. A replacement worker continues the suite.</span></p>
           <p><strong>External resources</strong><span>Use channels to select separate resources for each worker. Resource limits restrict concurrent access to shared dependencies.</span></p>
-          <p><strong>Missed mock call</strong><span>At teardown, strict doubles verify interactions and report unmet expectations.</span></p>
+          <p><strong>Missed mock call</strong><span>When the test ends, Greenlight verifies strict doubles and reports unmet expectations.</span></p>
         </div>
       </div>
       <div class="terminal-window" aria-label="Example Greenlight terminal output">


### PR DESCRIPTION
## Summary

- Close checker gaps for grouped script comments, Markdown fence markers, multi-backtick code spans, and PHPDoc types that contain spaces.
- Correct assignment, isolated-test, resource-limit, and attachment-name documentation.
- Simplify remaining PHPDoc, comments, diagnostics, tool output, and test reasons. Regenerate the affected API reference pages.
- Keep code identifiers and machine contracts unchanged. No prose baselines remain.

## Observable wording changes

- Update configuration errors, Xdebug guidance, leak warnings, expectation output, double argument descriptions, and coverage and memory gate messages.
- Update exact-output assertions with each message change.

## Continuation

- Base commit: da5e35b
- Result commit: 7f1faf26d7091d2906ae24f3198a8fddb2a42b75
- Owned paths: prose checker and tests, published documentation, selected PHPDoc and comments, human-readable diagnostics, and matching assertions
- Blocking findings: 0 before, 0 after
- Advisory findings: 0 remaining
- Terminology: assignment means one scheduling unit; test means one method invocation with an optional data set
- Checks run: composer prose:check, composer prose:review, make docs-check, composer static-analysis, composer tests
- Next unclaimed shard: none