### PR TITLE
test: cover coverage collector lifecycle

### DIFF
--- a/src/Runner/CoverageCollector.php
+++ b/src/Runner/CoverageCollector.php
@@ -28,16 +28,20 @@ final readonly class CoverageCollector
 
     /**
      * @param \Closure(string): void|null $unavailable receives the reason when no driver can collect
+     * @param DriverSelector|null $selector The selector to use. Null selects the configured built-in drivers.
      */
-    public static function create(CoverageSettings $settings, ?\Closure $unavailable = null): ?self
-    {
+    public static function create(
+        CoverageSettings $settings,
+        ?\Closure $unavailable = null,
+        ?DriverSelector $selector = null,
+    ): ?self {
         $candidates = match ($settings->driver) {
             'pcov' => [PcovDriver::class],
             'xdebug' => [XdebugDriver::class],
             default => [PcovDriver::class, XdebugDriver::class],
         };
 
-        $selection = new DriverSelector($candidates)->select();
+        $selection = ($selector ?? new DriverSelector($candidates))->select();
         $driver = $selection->driver;
 
         if (!$driver instanceof CoverageDriver) {

--- a/tests/Fixture/Coverage/RecordingFakeDriver.php
+++ b/tests/Fixture/Coverage/RecordingFakeDriver.php
@@ -6,8 +6,9 @@ namespace Greenlight\Tests\Fixture\Coverage;
 
 use Greenlight\Coverage\Driver\CoverageDriver;
 use Greenlight\Coverage\RawCoverage;
+use Greenlight\Doubles\Fake;
 
-final class RecordingFakeDriver implements CoverageDriver
+final class RecordingFakeDriver implements CoverageDriver, Fake
 {
     private static bool $started = false;
 

--- a/tests/Fixture/Coverage/RecordingFakeDriver.php
+++ b/tests/Fixture/Coverage/RecordingFakeDriver.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Coverage;
+
+use Greenlight\Coverage\Driver\CoverageDriver;
+use Greenlight\Coverage\RawCoverage;
+
+final class RecordingFakeDriver implements CoverageDriver
+{
+    private static bool $started = false;
+
+    #[\Override]
+    public static function isAvailable(): bool
+    {
+        return true;
+    }
+
+    #[\Override]
+    public function start(): void
+    {
+        self::$started = true;
+    }
+
+    #[\Override]
+    public function stop(): RawCoverage
+    {
+        self::$started = false;
+
+        return new RawCoverage([
+            '/project/src/Included.php' => [
+                10 => 1,
+                11 => -1,
+                12 => -2,
+            ],
+            '/project/tests/Excluded.php' => [
+                20 => 1,
+            ],
+        ]);
+    }
+
+    public static function started(): bool
+    {
+        return self::$started;
+    }
+}

--- a/tests/Unit/Runner/CoverageCollectorTest.php
+++ b/tests/Unit/Runner/CoverageCollectorTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\Driver\DriverSelector;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Runner\CoverageCollector;
+use Greenlight\Runner\CoverageSettings;
+use Greenlight\Tests\Fixture\Coverage\RecordingFakeDriver;
+use Greenlight\Tests\Fixture\Coverage\UnavailableFakeDriver;
+
+final class CoverageCollectorTest
+{
+    #[Test]
+    public function startsStopsAndFiltersTheSelectedDriver(): void
+    {
+        $collector = CoverageCollector::create(
+            new CoverageSettings(['/project/src']),
+            selector: new DriverSelector([RecordingFakeDriver::class]),
+        );
+
+        if (!$collector instanceof CoverageCollector) {
+            Fail::because('Expected the available driver to create a coverage collector.');
+        }
+
+        $collector->start();
+
+        Expect::that(RecordingFakeDriver::started())
+            ->because('the collector starts the selected driver')
+            ->toBeTrue();
+
+        $files = $collector->stop()->files();
+
+        Expect::that(RecordingFakeDriver::started())
+            ->because('the collector stops the selected driver')
+            ->toBeFalse()
+            ->and(\array_keys($files))
+            ->because('the collector filters raw coverage to the included paths')
+            ->toBe(['/project/src/Included.php'])
+            ->and($files['/project/src/Included.php']->coveredLines)->toBe([10])
+            ->and($files['/project/src/Included.php']->uncoveredLines)->toBe([11]);
+    }
+
+    #[Test]
+    public function unavailableSelectionReturnsNullAndSendsTheReason(): void
+    {
+        $reason = null;
+        $collector = CoverageCollector::create(
+            new CoverageSettings([]),
+            static function (string $message) use (&$reason): void {
+                $reason = $message;
+            },
+            new DriverSelector([UnavailableFakeDriver::class]),
+        );
+
+        Expect::that($collector)
+            ->because('an unavailable driver does not create a collector')
+            ->toBeNull()
+            ->and($reason)->toBe(
+                'No coverage driver is available. Greenlight tried UnavailableFakeDriver. Install pcov or enable Xdebug coverage mode. '
+                . 'Set xdebug.mode to "coverage", or set the XDEBUG_MODE environment variable.',
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Allow the collector to use an injected driver selector while keeping built-in selection as the default.
- Verify start and stop delegation, raw coverage conversion, path filtering, and unavailable-driver diagnostics.
- Increase `CoverageCollector` line coverage from 11.11% to 88.89% and total line coverage from 84.53% to 84.70%.