### PR TITLE
test: cover unavailable attachment guards

### DIFF
--- a/tests/Unit/Artifact/UnavailableAttachmentsTest.php
+++ b/tests/Unit/Artifact/UnavailableAttachmentsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Core\Artifact\UnavailableAttachments;
+use Greenlight\Expect\Expect;
+
+final class UnavailableAttachmentsTest
+{
+    #[Test]
+    public function everyAttachmentTypeFailsOutsideAnActiveAttempt(): void
+    {
+        $attachments = new UnavailableAttachments();
+        $calls = [
+            'value' => static fn() => $attachments->value('state', ['ready' => true]),
+            'text' => static fn() => $attachments->text('log', 'Ready.'),
+            'bytes' => static fn() => $attachments->bytes('image', "\x89PNG"),
+            'file' => static fn() => $attachments->file('report', '/tmp/report.txt'),
+        ];
+
+        foreach ($calls as $type => $call) {
+            Expect::that($call)
+                ->because(\sprintf('%s attachments are unavailable outside an active attempt', $type))
+                ->toThrow(
+                    AttachmentError::class,
+                    message: 'Attachments are not available outside an active test attempt.',
+                );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Verify every attachment API rejects calls outside an active test attempt.
- Check the exact typed error and diagnostic for values, text, bytes, and files.
- Increase `UnavailableAttachments` line coverage from 33.33% to 100%.