### PR TITLE
test: identify in-memory test fakes

### DIFF
--- a/tests/Fixture/Coverage/AvailableFakeDriver.php
+++ b/tests/Fixture/Coverage/AvailableFakeDriver.php
@@ -6,8 +6,9 @@ namespace Greenlight\Tests\Fixture\Coverage;
 
 use Greenlight\Coverage\Driver\CoverageDriver;
 use Greenlight\Coverage\RawCoverage;
+use Greenlight\Doubles\Fake;
 
-final class AvailableFakeDriver implements CoverageDriver
+final class AvailableFakeDriver implements CoverageDriver, Fake
 {
     #[\Override]
     public static function isAvailable(): bool

--- a/tests/Fixture/Coverage/UnavailableFakeDriver.php
+++ b/tests/Fixture/Coverage/UnavailableFakeDriver.php
@@ -6,8 +6,9 @@ namespace Greenlight\Tests\Fixture\Coverage;
 
 use Greenlight\Coverage\Driver\CoverageDriver;
 use Greenlight\Coverage\RawCoverage;
+use Greenlight\Doubles\Fake;
 
-final class UnavailableFakeDriver implements CoverageDriver
+final class UnavailableFakeDriver implements CoverageDriver, Fake
 {
     #[\Override]
     public static function isAvailable(): bool

--- a/tests/Support/CollectingEventSink.php
+++ b/tests/Support/CollectingEventSink.php
@@ -7,9 +7,10 @@ namespace Greenlight\Tests\Support;
 use Greenlight\Core\Event\Event;
 use Greenlight\Core\Event\TestFinished;
 use Greenlight\Core\Result\TestResult;
+use Greenlight\Doubles\Fake;
 use Greenlight\Runner\Worker\EventSink;
 
-final class CollectingEventSink implements EventSink
+final class CollectingEventSink implements EventSink, Fake
 {
     /**
      * @var list<Event>

--- a/tests/Unit/Cli/WatchTest.php
+++ b/tests/Unit/Cli/WatchTest.php
@@ -11,6 +11,7 @@ use Greenlight\Cli\Watch\KeyInput;
 use Greenlight\Cli\Watch\StatChangeDetector;
 use Greenlight\Cli\Watch\WatchClock;
 use Greenlight\Cli\Watch\WatchLoop;
+use Greenlight\Doubles\Fake;
 use Greenlight\Expect\Expect;
 
 final class WatchTest
@@ -79,7 +80,7 @@ final class WatchTest
     public function loopDebouncesBurstsForcesOnEnterAndQuitsOnQ(): void
     {
         // Each scripted tick increases virtual time by 0.1 seconds.
-        $clock = new class implements WatchClock {
+        $clock = new class implements WatchClock, Fake {
             public float $time = 0.0;
 
             #[\Override]

--- a/tests/Unit/Expect/TemporalExpectationTest.php
+++ b/tests/Unit/Expect/TemporalExpectationTest.php
@@ -6,6 +6,7 @@ namespace Greenlight\Tests\Unit\Expect;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Test\ExpectationCounter;
+use Greenlight\Doubles\Fake;
 use Greenlight\Expect\EventuallyExpectation;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Expectation;
@@ -513,7 +514,7 @@ final class TemporalExpectationTest
     }
 }
 
-final class FakePollingClock implements PollingClock
+final class FakePollingClock implements PollingClock, Fake
 {
     public float $time = 0.0;
 

--- a/tests/Unit/Reporting/BufferOutput.php
+++ b/tests/Unit/Reporting/BufferOutput.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Reporting;
 
+use Greenlight\Doubles\Fake;
 use Greenlight\Reporting\Output\Output;
 
-final class BufferOutput implements Output
+final class BufferOutput implements Output, Fake
 {
     private string $buffer = '';
 


### PR DESCRIPTION
## Summary

- Mark existing in-memory coverage drivers, clocks, output, and event sink implementations with \`Greenlight\Doubles\Fake\`.
- Keep scripted stubs, recording spies, lifecycle probes, and plain contract fixtures unmarked.
- Follow up the equivalent \`RecordingFakeDriver\` correction in #119.