### PR TITLE
test: isolate PHPStan probe caches

### DIFF
--- a/tests/Support/PhpStanProbe.php
+++ b/tests/Support/PhpStanProbe.php
@@ -46,6 +46,11 @@ final readonly class PhpStanProbe
                 $goodFile,
                 $badFile,
             ],
+            [
+                'TEMP' => $probeDirectory,
+                'TMP' => $probeDirectory,
+                'TMPDIR' => $probeDirectory,
+            ],
         );
 
         try {


### PR DESCRIPTION
Isolate each PHPStan acceptance probe temporary directory.

PHPStan 2.2.6 introduced additional cached and native worker state. Concurrent probe processes previously shared the system PHPStan cache. This shared state made matcherSubjectTypesFollowFluentChains intermittently lose diagnostics under randomized CI schedules. Set TEMP, TMP, and TMPDIR to the probe workspace so each analysis has isolated container and result caches.