### PR TITLE
test: cover double type rendering

### DIFF
--- a/tests/Fixture/Doubles/TypeRenderingChild.php
+++ b/tests/Fixture/Doubles/TypeRenderingChild.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+abstract class TypeRenderingChild extends TypeRenderingParent
+{
+    abstract public function nullable(?string $value): void;
+
+    abstract public function named(TypeRenderingParent $value): void;
+
+    abstract public function acceptsSelf(self $value): void;
+
+    abstract public function acceptsParent(parent $value): void;
+
+    abstract public function returnsStatic(): static;
+
+    abstract public function intersection(TypeRenderingLeft&TypeRenderingRight $value): void;
+
+    abstract public function unionWithIntersection((TypeRenderingLeft&TypeRenderingRight)|string|null $value): void;
+}

--- a/tests/Fixture/Doubles/TypeRenderingLeft.php
+++ b/tests/Fixture/Doubles/TypeRenderingLeft.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+interface TypeRenderingLeft {}

--- a/tests/Fixture/Doubles/TypeRenderingParent.php
+++ b/tests/Fixture/Doubles/TypeRenderingParent.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+class TypeRenderingParent {}

--- a/tests/Fixture/Doubles/TypeRenderingRight.php
+++ b/tests/Fixture/Doubles/TypeRenderingRight.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+interface TypeRenderingRight {}

--- a/tests/Unit/Doubles/TypeRendererTest.php
+++ b/tests/Unit/Doubles/TypeRendererTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\TypeRenderer;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Tests\Fixture\Doubles\TypeRenderingChild;
+use Greenlight\Tests\Fixture\Doubles\TypeRenderingLeft;
+use Greenlight\Tests\Fixture\Doubles\TypeRenderingParent;
+use Greenlight\Tests\Fixture\Doubles\TypeRenderingRight;
+
+final class TypeRendererTest
+{
+    #[Test]
+    #[DataSet('supportedTypes')]
+    public function supportedReflectedTypesRenderAsPhpSource(string $method, ?int $parameter, string $expected): void
+    {
+        $reflection = new \ReflectionMethod(TypeRenderingChild::class, $method);
+        $type = $parameter === null
+            ? $reflection->getReturnType()
+            : $reflection->getParameters()[$parameter]->getType();
+
+        if (!$type instanceof \ReflectionType) {
+            Fail::because(\sprintf('Expected %s() to have the requested reflected type.', $method));
+        }
+
+        Expect::that(TypeRenderer::render($type, $reflection->getDeclaringClass()))
+            ->because('the reflected type renders as valid PHP source')
+            ->toBe($expected);
+    }
+
+    /**
+     * @return iterable<string, array{string, int|null, string}>
+     */
+    public static function supportedTypes(): iterable
+    {
+        yield 'nullable built-in' => ['nullable', 0, '?string'];
+
+        yield 'named class' => ['named', 0, '\\' . TypeRenderingParent::class];
+
+        yield 'self' => ['acceptsSelf', 0, '\\' . TypeRenderingChild::class];
+
+        yield 'parent' => ['acceptsParent', 0, '\\' . TypeRenderingParent::class];
+
+        yield 'static' => ['returnsStatic', null, 'static'];
+
+        yield 'intersection' => [
+            'intersection',
+            0,
+            '\\' . TypeRenderingLeft::class . '&\\' . TypeRenderingRight::class,
+        ];
+
+        yield 'union with intersection' => [
+            'unionWithIntersection',
+            0,
+            '(\\' . TypeRenderingLeft::class . '&\\' . TypeRenderingRight::class . ')|string|null',
+        ];
+    }
+}


### PR DESCRIPTION
Covers proxy signature rendering for nullable and named types, self and parent resolution, late-static return types, intersections, and unions containing intersections. Each reflected shape is an independently labelled Greenlight data-set case.