### PR TITLE
test: cover mock planning boundaries

### DIFF
--- a/tests/Fixture/Doubles/PlanningBoundaries.php
+++ b/tests/Fixture/Doubles/PlanningBoundaries.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+class PlanningBoundaries
+{
+    public static function staticMethod(): void {}
+
+    protected function protectedMethod(): void {}
+
+    final public function finalMethod(): void {}
+}

--- a/tests/Unit/Doubles/BoundaryTest.php
+++ b/tests/Unit/Doubles/BoundaryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Doubles;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Doubles\Doubles;
 use Greenlight\Doubles\DoublesError;
@@ -11,6 +12,7 @@ use Greenlight\Doubles\MockPlan;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\Doubles\Calculator;
 use Greenlight\Tests\Fixture\Doubles\FinalService;
+use Greenlight\Tests\Fixture\Doubles\PlanningBoundaries;
 use Greenlight\Tests\Fixture\Doubles\ReadonlyService;
 use Greenlight\Tests\Fixture\Doubles\Suit;
 
@@ -55,5 +57,45 @@ final class BoundaryTest
         Expect::that(static fn(): object => $doubles->mock(Calculator::class, static function (MockPlan $plan): void {
             $plan->expects('subtract');
         }))->because('planning a missing method is an authoring error')->toThrow(DoublesError::class, '/has no method subtract\(\)/');
+    }
+
+    /**
+     * @param non-empty-string $method
+     */
+    #[Test]
+    #[DataSet('unplannableMethods')]
+    public function planningAnUnplannableMethodIsAnAuthoringError(string $method, string $message): void
+    {
+        $doubles = new Doubles();
+
+        Expect::that(static fn(): object => $doubles->mock(
+            PlanningBoundaries::class,
+            static function (MockPlan $plan) use ($method): void {
+                $plan->expects($method);
+            },
+        ))
+            ->because('planning an unplannable method is an authoring error')
+            ->toThrow(DoublesError::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string, string}>
+     */
+    public static function unplannableMethods(): iterable
+    {
+        yield 'static' => [
+            'staticMethod',
+            PlanningBoundaries::class . '::staticMethod() is static. Doubles cannot intercept static methods.',
+        ];
+
+        yield 'non-public' => [
+            'protectedMethod',
+            PlanningBoundaries::class . '::protectedMethod() is not public. Doubles cannot plan it.',
+        ];
+
+        yield 'final' => [
+            'finalMethod',
+            PlanningBoundaries::class . '::finalMethod() is final. Doubles cannot intercept it. Use an interface instead.',
+        ];
     }
 }


### PR DESCRIPTION
Covers exact authoring errors when a mock plan targets static, non-public, or final methods. The three labelled cases use one dedicated PSR-4 fixture and exercise validation through the public Doubles factory.