### PR TITLE
test: isolate PSR-4 fixtures

### DIFF
--- a/tests/Fixture/Doubles/StaticMethodFixture.php
+++ b/tests/Fixture/Doubles/StaticMethodFixture.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+interface StaticMethodFixture
+{
+    public static function lookup(): string;
+}

--- a/tests/Fixture/Expect/CanonicalNode.php
+++ b/tests/Fixture/Expect/CanonicalNode.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Expect;
+
+final class CanonicalNode
+{
+    public ?CanonicalNode $next = null;
+
+    public function __construct(public readonly string $name) {}
+}

--- a/tests/Fixture/Expect/Credentials.php
+++ b/tests/Fixture/Expect/Credentials.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Expect;
+
+final class Credentials
+{
+    public function __construct(
+        public string $user,
+        private readonly string $password,
+    ) {}
+
+    public function password(): string
+    {
+        return $this->password;
+    }
+}

--- a/tests/Fixture/Expect/EvenNumbersExtension.php
+++ b/tests/Fixture/Expect/EvenNumbersExtension.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Expect;
+
+use Greenlight\Expect\ExpectationExtension;
+
+final class EvenNumbersExtension implements ExpectationExtension
+{
+    #[\Override]
+    public function matchers(): array
+    {
+        return [
+            'toBeEven' => static fn(mixed $subject): bool => \is_int($subject) && $subject % 2 === 0,
+        ];
+    }
+}

--- a/tests/Fixture/Expect/FakePollingClock.php
+++ b/tests/Fixture/Expect/FakePollingClock.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Expect;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Expect\PollingClock;
+
+final class FakePollingClock implements PollingClock, Fake
+{
+    public float $time = 0.0;
+
+    /**
+     * @var list<float>
+     */
+    public array $sleeps = [];
+
+    #[\Override]
+    public function now(): float
+    {
+        return $this->time;
+    }
+
+    #[\Override]
+    public function sleep(float $seconds): void
+    {
+        $this->sleeps[] = $seconds;
+        $this->time += $seconds;
+    }
+}

--- a/tests/Fixture/Expect/Holder.php
+++ b/tests/Fixture/Expect/Holder.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Expect;
+
+final class Holder
+{
+    public function __construct(public ?Holder $inner) {}
+}

--- a/tests/Fixture/Expect/LateInit.php
+++ b/tests/Fixture/Expect/LateInit.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Expect;
+
+final class LateInit
+{
+    public string $value;
+
+    public function init(): void
+    {
+        $this->value = 'set';
+    }
+}

--- a/tests/Fixture/Expect/Node.php
+++ b/tests/Fixture/Expect/Node.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Expect;
+
+final class Node
+{
+    public ?Node $next = null;
+}

--- a/tests/Fixture/Expect/Point.php
+++ b/tests/Fixture/Expect/Point.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Expect;
+
+final class Point
+{
+    public function __construct(
+        public int $x,
+        private readonly int $y,
+    ) {}
+
+    public function y(): int
+    {
+        return $this->y;
+    }
+}

--- a/tests/Fixture/Expect/PositiveNumbersExtension.php
+++ b/tests/Fixture/Expect/PositiveNumbersExtension.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Expect;
+
+use Greenlight\Expect\ExpectationExtension;
+
+final class PositiveNumbersExtension implements ExpectationExtension
+{
+    #[\Override]
+    public function matchers(): array
+    {
+        return [
+            'toBePositive' => static fn(mixed $subject): bool => \is_int($subject) && $subject > 0,
+        ];
+    }
+}

--- a/tests/Fixture/Expect/Signal.php
+++ b/tests/Fixture/Expect/Signal.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Expect;
+
+enum Signal
+{
+    case Green;
+}

--- a/tests/Fixture/Expect/Suit.php
+++ b/tests/Fixture/Expect/Suit.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Expect;
+
+enum Suit
+{
+    case Hearts;
+    case Spades;
+}

--- a/tests/Fixture/Expect/TransientProbeFailure.php
+++ b/tests/Fixture/Expect/TransientProbeFailure.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Expect;
+
+/**
+ * Represents a temporary probe failure that a temporal expectation can retry.
+ *
+ * @internal
+ */
+final class TransientProbeFailure extends \RuntimeException {}

--- a/tests/Fixture/Runner/UnsupportedConstructorProbe.php
+++ b/tests/Fixture/Runner/UnsupportedConstructorProbe.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Runner;
+
+final readonly class UnsupportedConstructorProbe
+{
+    public function __construct(public string $value) {}
+
+    public function neverRuns(): never
+    {
+        throw new \LogicException('The unsupported-constructor probe MUST NOT run.');
+    }
+}

--- a/tests/Fixture/Runner/Worker/ClassContextDataProbe.php
+++ b/tests/Fixture/Runner/Worker/ClassContextDataProbe.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Runner\Worker;
+
+final class ClassContextDataProbe
+{
+    public function accepts(): never
+    {
+        throw new \LogicException('The class-context probe MUST NOT run.');
+    }
+
+    /**
+     * @return iterable<string, string>
+     */
+    public static function scalarRows(): iterable
+    {
+        yield 'bad' => 'not an argument array';
+    }
+}

--- a/tests/Unit/Doubles/ProxyGenerationTest.php
+++ b/tests/Unit/Doubles/ProxyGenerationTest.php
@@ -14,6 +14,7 @@ use Greenlight\Tests\Fixture\Doubles\CacheBeta;
 use Greenlight\Tests\Fixture\Doubles\Calculator;
 use Greenlight\Tests\Fixture\Doubles\Clock;
 use Greenlight\Tests\Fixture\Doubles\ProxyFileProbe;
+use Greenlight\Tests\Fixture\Doubles\StaticMethodFixture;
 use Greenlight\Tests\Fixture\Doubles\Wide;
 
 final class ProxyGenerationTest
@@ -158,7 +159,7 @@ final class ProxyGenerationTest
         Expect::that(static fn(): string => $proxyClass::lookup())
             ->toThrow(
                 DoublesError::class,
-                message: 'Greenlight\Tests\Unit\Doubles\StaticMethodFixture::lookup() is static. '
+                message: StaticMethodFixture::class . '::lookup() is static. '
                     . 'Doubles cannot intercept static methods.',
             );
 
@@ -189,9 +190,4 @@ final class ProxyGenerationTest
 
         @\rmdir($directory);
     }
-}
-
-interface StaticMethodFixture
-{
-    public static function lookup(): string;
 }

--- a/tests/Unit/Expect/CanonicalizingTest.php
+++ b/tests/Unit/Expect/CanonicalizingTest.php
@@ -6,6 +6,7 @@ namespace Greenlight\Tests\Unit\Expect;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Expect\CanonicalNode;
 
 final class CanonicalizingTest
 {
@@ -106,11 +107,4 @@ final class CanonicalizingTest
             \fclose($secondStream);
         }
     }
-}
-
-final class CanonicalNode
-{
-    public ?CanonicalNode $next = null;
-
-    public function __construct(public readonly string $name) {}
 }

--- a/tests/Unit/Expect/ExpectTest.php
+++ b/tests/Unit/Expect/ExpectTest.php
@@ -6,9 +6,9 @@ namespace Greenlight\Tests\Unit\Expect;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\ExpectationExtension;
 use Greenlight\Expect\ExpectationFailed;
 use Greenlight\Expect\Fail;
+use Greenlight\Tests\Fixture\Expect\EvenNumbersExtension;
 
 final class ExpectTest
 {
@@ -81,16 +81,5 @@ final class ExpectTest
 
         Expect::that(static fn() => Expect::that(4)->__call('toBeEven', []))->because('chains created before an install keep their extensions')
             ->toThrow(\BadMethodCallException::class);
-    }
-}
-
-final class EvenNumbersExtension implements ExpectationExtension
-{
-    #[\Override]
-    public function matchers(): array
-    {
-        return [
-            'toBeEven' => static fn(mixed $subject): bool => \is_int($subject) && $subject % 2 === 0,
-        ];
     }
 }

--- a/tests/Unit/Expect/TemporalExpectationTest.php
+++ b/tests/Unit/Expect/TemporalExpectationTest.php
@@ -6,16 +6,16 @@ namespace Greenlight\Tests\Unit\Expect;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Test\ExpectationCounter;
-use Greenlight\Doubles\Fake;
 use Greenlight\Expect\EventuallyExpectation;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Expectation;
-use Greenlight\Expect\ExpectationExtension;
 use Greenlight\Expect\ExpectationFailed;
 use Greenlight\Expect\ExpectationRuntime;
 use Greenlight\Expect\PendingEventually;
-use Greenlight\Expect\PollingClock;
 use Greenlight\Expect\TemporalExpectation;
+use Greenlight\Tests\Fixture\Expect\FakePollingClock;
+use Greenlight\Tests\Fixture\Expect\PositiveNumbersExtension;
+use Greenlight\Tests\Fixture\Expect\TransientProbeFailure;
 
 final class TemporalExpectationTest
 {
@@ -511,41 +511,5 @@ final class TemporalExpectationTest
         \ksort($signatures);
 
         return $signatures;
-    }
-}
-
-final class FakePollingClock implements PollingClock, Fake
-{
-    public float $time = 0.0;
-
-    /**
-     * @var list<float>
-     */
-    public array $sleeps = [];
-
-    #[\Override]
-    public function now(): float
-    {
-        return $this->time;
-    }
-
-    #[\Override]
-    public function sleep(float $seconds): void
-    {
-        $this->sleeps[] = $seconds;
-        $this->time += $seconds;
-    }
-}
-
-final class TransientProbeFailure extends \RuntimeException {}
-
-final class PositiveNumbersExtension implements ExpectationExtension
-{
-    #[\Override]
-    public function matchers(): array
-    {
-        return [
-            'toBePositive' => static fn(mixed $subject): bool => \is_int($subject) && $subject > 0,
-        ];
     }
 }

--- a/tests/Unit/Expect/ToBeAndToEqualTest.php
+++ b/tests/Unit/Expect/ToBeAndToEqualTest.php
@@ -6,6 +6,9 @@ namespace Greenlight\Tests\Unit\Expect;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Expect\Node;
+use Greenlight\Tests\Fixture\Expect\Point;
+use Greenlight\Tests\Fixture\Expect\Suit;
 
 final class ToBeAndToEqualTest
 {
@@ -125,28 +128,4 @@ final class ToBeAndToEqualTest
         Expect::that($detail->expected)->because('toEqual() failure renders both sides')->toBe("['a' => 2]");
         Expect::that($detail->actual)->because('toEqual() failure renders both sides')->toBe("['a' => 1]");
     }
-}
-
-final class Point
-{
-    public function __construct(
-        public int $x,
-        private readonly int $y,
-    ) {}
-
-    public function y(): int
-    {
-        return $this->y;
-    }
-}
-
-enum Suit
-{
-    case Hearts;
-    case Spades;
-}
-
-final class Node
-{
-    public ?Node $next = null;
 }

--- a/tests/Unit/Expect/ValueRendererTest.php
+++ b/tests/Unit/Expect/ValueRendererTest.php
@@ -7,6 +7,10 @@ namespace Greenlight\Tests\Unit\Expect;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\ValueRenderer;
+use Greenlight\Tests\Fixture\Expect\Credentials;
+use Greenlight\Tests\Fixture\Expect\Holder;
+use Greenlight\Tests\Fixture\Expect\LateInit;
+use Greenlight\Tests\Fixture\Expect\Signal;
 
 final class ValueRendererTest
 {
@@ -115,37 +119,4 @@ final class ValueRendererTest
         Expect::that($rendered)->because('scrubs invalid UTF-8')->toMatch('//u');
         Expect::that($rendered)->because('scrubs invalid UTF-8')->toContain('bad');
     }
-}
-
-enum Signal
-{
-    case Green;
-}
-
-final class Credentials
-{
-    public function __construct(
-        public string $user,
-        private readonly string $password,
-    ) {}
-
-    public function password(): string
-    {
-        return $this->password;
-    }
-}
-
-final class LateInit
-{
-    public string $value;
-
-    public function init(): void
-    {
-        $this->value = 'set';
-    }
-}
-
-final class Holder
-{
-    public function __construct(public ?Holder $inner) {}
 }

--- a/tests/Unit/Runner/Worker/ClassContextTest.php
+++ b/tests/Unit/Runner/Worker/ClassContextTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Unit\Runner\Worker;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\Worker\ClassContext;
+use Greenlight\Tests\Fixture\Runner\Worker\ClassContextDataProbe;
 
 final class ClassContextTest
 {
@@ -52,21 +53,5 @@ final class ClassContextTest
                     ClassContextDataProbe::class,
                 ),
             );
-    }
-}
-
-final class ClassContextDataProbe
-{
-    public function accepts(): never
-    {
-        throw new \LogicException('The class-context probe MUST NOT run.');
-    }
-
-    /**
-     * @return iterable<string, string>
-     */
-    public static function scalarRows(): iterable
-    {
-        yield 'bad' => 'not an argument array';
     }
 }

--- a/tests/Unit/Runner/WorkerTest.php
+++ b/tests/Unit/Runner/WorkerTest.php
@@ -32,6 +32,7 @@ use Greenlight\Tests\Fixture\Lifecycle\Services\ServiceProbe;
 use Greenlight\Tests\Fixture\Lifecycle\TemporalRetry\TemporalRetryTest;
 use Greenlight\Tests\Fixture\Lifecycle\TraceLog;
 use Greenlight\Tests\Fixture\Lifecycle\VerifyOnDispose\VerifyingProbe;
+use Greenlight\Tests\Fixture\Runner\UnsupportedConstructorProbe;
 use Greenlight\Tests\Support\CollectingEventSink;
 
 final class WorkerTest
@@ -399,15 +400,5 @@ final class WorkerTest
         return new HarnessRegistry([
             new ServiceDefinition(InjectedProbe::class, Scope::PerTest, static fn(): InjectedProbe => new InjectedProbe()),
         ]);
-    }
-}
-
-final readonly class UnsupportedConstructorProbe
-{
-    public function __construct(public string $value) {}
-
-    public function neverRuns(): never
-    {
-        throw new \LogicException('The unsupported-constructor probe MUST NOT run.');
     }
 }


### PR DESCRIPTION
## Summary

- Move 15 reusable helper declarations from eight unit test files into dedicated PSR-4 fixture files.
- Import each helper explicitly and derive the static-method diagnostic expectation from its fixture class name.
- Keep shared fixture directories append-only.

## Intentional exceptions

- DiscoveryClassNameMismatch and DiscoveryPsr4Violation remain incorrect because those suites assert typed discovery errors.
- The RectorMigration PHPUnit stub bundles remain multi-declaration external inputs because each file models one source package for migration.
- The MutationPrototype project remains in its own namespace because it models a nested external project.