### PR TITLE
test: cover unknown matcher lookup

### DIFF
--- a/tests/Unit/PhpStan/MatcherMapTest.php
+++ b/tests/Unit/PhpStan/MatcherMapTest.php
@@ -48,4 +48,17 @@ final class MatcherMapTest
             static fn(): MatcherMap => MatcherMap::fromConfigFiles([self::CONFIG, self::CONFLICTING_CONFIG]),
         )->because('conflicting signatures are refused')->toThrow(MatcherMapError::class);
     }
+
+    #[Test]
+    public function anUnknownMatcherNameFailsLoudly(): void
+    {
+        $map = MatcherMap::fromConfigFiles([]);
+
+        Expect::that(static fn(): array => $map->parameters('toBeMissing'))
+            ->because('an unknown matcher name fails loudly')
+            ->toThrow(
+                \LogicException::class,
+                message: 'No extension matcher named "toBeMissing" is known.',
+            );
+    }
 }


### PR DESCRIPTION
Covers the matcher-map fail-fast path used by PHPStan and IDE-helper consumers. The test verifies that an unknown extension matcher name produces the deliberate diagnostic instead of an incidental reflection or array error.