### PR TITLE
test: cover matcher type rendering

### DIFF
--- a/tests/Fixture/PhpStan/MatcherTypeShapes.php
+++ b/tests/Fixture/PhpStan/MatcherTypeShapes.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\PhpStan;
+
+final class MatcherTypeShapes
+{
+    /**
+     * @param mixed $subject
+     */
+    public function untyped($subject): void {}
+
+    public function union(string|int $subject): void {}
+
+    /**
+     * @param \Countable&\Iterator<int, mixed> $subject
+     */
+    public function intersection(\Countable&\Iterator $subject): void {}
+}

--- a/tests/Unit/PhpStan/MatcherMapTest.php
+++ b/tests/Unit/PhpStan/MatcherMapTest.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\PhpStan;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\PhpStan\MatcherMap;
 use Greenlight\PhpStan\MatcherMapError;
+use Greenlight\Tests\Fixture\PhpStan\MatcherTypeShapes;
 
 final class MatcherMapTest
 {
@@ -60,5 +62,26 @@ final class MatcherMapTest
                 \LogicException::class,
                 message: 'No extension matcher named "toBeMissing" is known.',
             );
+    }
+
+    #[Test]
+    #[DataSet('matcherTypes')]
+    public function matcherTypesRenderForGeneratedSignatures(string $method, string $expected): void
+    {
+        $parameter = new \ReflectionMethod(MatcherTypeShapes::class, $method)->getParameters()[0];
+
+        Expect::that(MatcherMap::typeName($parameter->getType()))
+            ->because('matcher types render for generated signatures')
+            ->toBe($expected);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function matcherTypes(): iterable
+    {
+        yield 'untyped' => ['untyped', 'mixed'];
+        yield 'union' => ['union', 'string|int'];
+        yield 'intersection' => ['intersection', 'Countable&Iterator'];
     }
 }


### PR DESCRIPTION
Covers the union, intersection, and untyped reflection branches used to generate PHPStan matcher signatures. Labelled data-set cases use a dedicated PSR-4 reflection fixture, including precise iterator generics for static analysis.