### PR TITLE
test: cover proxy handler collisions

### DIFF
--- a/tests/Fixture/Doubles/HandlerCollision.php
+++ b/tests/Fixture/Doubles/HandlerCollision.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+interface HandlerCollision
+{
+    public function __greenlightAttachHandler(): void;
+}

--- a/tests/Unit/Doubles/BoundaryTest.php
+++ b/tests/Unit/Doubles/BoundaryTest.php
@@ -12,6 +12,7 @@ use Greenlight\Doubles\MockPlan;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\Doubles\Calculator;
 use Greenlight\Tests\Fixture\Doubles\FinalService;
+use Greenlight\Tests\Fixture\Doubles\HandlerCollision;
 use Greenlight\Tests\Fixture\Doubles\PlanningBoundaries;
 use Greenlight\Tests\Fixture\Doubles\ReadonlyService;
 use Greenlight\Tests\Fixture\Doubles\Suit;
@@ -46,6 +47,20 @@ final class BoundaryTest
                 DoublesError::class,
                 message: 'Greenlight\Tests\Fixture\Doubles\Suit is an enum. '
                     . 'Doubles does not support enums. Use an interface that the enum implements.',
+            );
+    }
+
+    #[Test]
+    public function theProxyHandlerMethodCannotBeDeclaredByTheDoubledType(): void
+    {
+        $doubles = new Doubles();
+
+        Expect::that(static fn(): object => $doubles->mock(HandlerCollision::class))
+            ->because('the proxy handler method cannot be declared by the doubled type')
+            ->toThrow(
+                DoublesError::class,
+                message: HandlerCollision::class . ' declares __greenlightAttachHandler(). '
+                    . 'This method conflicts with the proxy handler method.',
             );
     }
 


### PR DESCRIPTION
Covers proxy generation when the doubled type declares Greenlight’s reserved handler-attachment method. The test uses a dedicated PSR-4 interface fixture and verifies the exact authoring diagnostic.