### PR TITLE
test: cover incomplete worker profiles

### DIFF
--- a/tests/Unit/Reporting/WorkerProfileTest.php
+++ b/tests/Unit/Reporting/WorkerProfileTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\WorkerProfile;
+
+final class WorkerProfileTest
+{
+    #[Test]
+    public function incompleteTimingDataDoesNotInventMetrics(): void
+    {
+        $profile = new WorkerProfile();
+
+        Expect::that($profile->bootLatency())
+            ->because('incomplete timing data does not invent metrics')
+            ->toBeNull()
+            ->and($profile->window())
+            ->toBe(0.0)
+            ->and($profile->utilizationPercent())
+            ->toBeNull();
+    }
+}


### PR DESCRIPTION
Covers worker-profile metrics before a complete timing window exists. The test verifies that partial event data produces no boot latency, a zero window, and no utilization percentage instead of invented metrics.