### PR TITLE
test: cover invalid provider keys

### DIFF
--- a/tests/Fixture/DiscoveryDataSets/InvalidKeyProvider.php
+++ b/tests/Fixture/DiscoveryDataSets/InvalidKeyProvider.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\DiscoveryDataSets;
+
+final class InvalidKeyProvider
+{
+    /**
+     * @return iterable<mixed, array{string}>
+     */
+    public static function rows(): iterable
+    {
+        yield true => ['value'];
+    }
+}

--- a/tests/Unit/Discovery/DataSetExpansionTest.php
+++ b/tests/Unit/Discovery/DataSetExpansionTest.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Discovery;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Discovery\DataSetExpander;
 use Greenlight\Discovery\DiscoveryError;
 use Greenlight\Discovery\ExecutionPlan;
 use Greenlight\Discovery\PlanEntry;
 use Greenlight\Discovery\TestDiscoverer;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
+use Greenlight\Tests\Fixture\DiscoveryDataSets\InvalidKeyProvider;
+use Greenlight\Tests\Fixture\DiscoveryDataSets\ProviderKeysTest;
 
 final class DataSetExpansionTest
 {
@@ -77,6 +80,26 @@ final class DataSetExpansionTest
         ];
 
         Expect::that($this->keysFor($plan, 'withAwkwardKeys'))->because('non printable and empty keys become stable hash prefixes')->toBe($expected);
+    }
+
+    #[Test]
+    public function providerKeysMustBeStringsOrIntegers(): void
+    {
+        $expander = new DataSetExpander();
+
+        Expect::that(static fn(): array => $expander->rowsFor(
+            new \ReflectionClass(ProviderKeysTest::class),
+            'withStringKeys',
+            'rows',
+            5.0,
+            InvalidKeyProvider::class,
+        ))
+            ->because('provider keys must be strings or integers')
+            ->toThrow(
+                DiscoveryError::class,
+                message: 'Data-set provider ' . InvalidKeyProvider::class . '::rows() '
+                    . 'produced a key of type bool. Use string or integer keys.',
+            );
     }
 
     #[Test]


### PR DESCRIPTION
Covers data-set providers that yield keys other than strings or integers. The test uses a dedicated PSR-4 provider fixture and verifies the exact discovery diagnostic for a boolean key.