### PR TITLE
test: cover provider iteration failures

### DIFF
--- a/tests/Fixture/DiscoveryProviderIterationThrows/ThrowingIterationTest.php
+++ b/tests/Fixture/DiscoveryProviderIterationThrows/ThrowingIterationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\DiscoveryProviderIterationThrows;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+
+final class ThrowingIterationTest
+{
+    #[Test]
+    #[DataSet('rows')]
+    public function receivesAValue(string $value): void
+    {
+        echo $value;
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function rows(): iterable
+    {
+        yield 'first' => ['value'];
+
+        throw new \RuntimeException('iteration exploded');
+    }
+}

--- a/tests/Unit/Discovery/DataSetExpansionTest.php
+++ b/tests/Unit/Discovery/DataSetExpansionTest.php
@@ -127,6 +127,18 @@ final class DataSetExpansionTest
     }
 
     #[Test]
+    public function providerThatThrowsDuringIterationFailsDiscoveryWithTheCause(): void
+    {
+        $message = $this->discoveryErrorMessage('DiscoveryProviderIterationThrows');
+
+        Expect::that($message)
+            ->because('provider that throws during iteration fails discovery with the cause')
+            ->toContain('iteration exploded')
+            ->and($message)
+            ->toContain('rows');
+    }
+
+    #[Test]
     public function slowProviderExceedsTheConfiguredBudget(): void
     {
         $message = $this->discoveryErrorMessage('DiscoveryProviderSlow', 0.005);


### PR DESCRIPTION
Covers data-set providers that begin iteration successfully and then throw. The discovery test verifies that iteration-time failures retain the provider name and original cause.