### PR TITLE
test: cover invalid runtime conditions

### DIFF
--- a/tests/Unit/Runner/ConditionEvaluationTest.php
+++ b/tests/Unit/Runner/ConditionEvaluationTest.php
@@ -4,15 +4,22 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Runner;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Condition;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\ResultSummary;
 use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Discovery\ExecutionPlan;
+use Greenlight\Discovery\PlanEntry;
 use Greenlight\Discovery\TestDiscoverer;
 use Greenlight\Expect\Expect;
 use Greenlight\Harness\HarnessRegistry;
 use Greenlight\Plugin\PluginRegistry;
 use Greenlight\Runner\Worker\Worker;
+use Greenlight\Tests\Fixture\Lifecycle\ConditionArguments\ConditionArgumentsTest;
 use Greenlight\Tests\Support\CollectingEventSink;
 
 final class ConditionEvaluationTest
@@ -35,6 +42,59 @@ final class ConditionEvaluationTest
             ->and($byMethod['skipsWhenTheVariableDiffers']->skipReason)
             ->toBe('Condition EnvironmentVariableEquals("GREENLIGHT_STDLIB_NOPE", "yes") is not satisfied.')
             ->and($byMethod['runsWhenTheVersionIsSatisfied']->outcome)->toBe(Outcome::Passed);
+    }
+
+    /**
+     * @param non-empty-string $conditionClass
+     * @param non-empty-string $message
+     */
+    #[Test]
+    #[DataSet('invalidConditions')]
+    public function invalidRuntimeConditionMetadataErrorsTheTest(string $conditionClass, string $message): void
+    {
+        $id = new TestId(ConditionArgumentsTest::class, 'runsWhenTheVersionIsSatisfied');
+        $plan = new ExecutionPlan([
+            new PlanEntry(
+                $id,
+                new TestMetadata(
+                    $id->class,
+                    $id->method,
+                    skipUnlessCondition: $conditionClass,
+                ),
+            ),
+        ]);
+        $sink = new CollectingEventSink();
+
+        new Worker(new HarnessRegistry(), PluginRegistry::forWorker([]))
+            ->run($plan, $sink);
+
+        $result = $sink->results()[0];
+
+        Expect::that($result->outcome)
+            ->because('invalid runtime condition metadata errors the test')
+            ->toBe(Outcome::Errored)
+            ->and($result->error?->message)
+            ->toBe($message);
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string, non-empty-string}>
+     */
+    public static function invalidConditions(): iterable
+    {
+        yield 'missing class' => [
+            'Example\MissingCondition',
+            'Condition class "Example\MissingCondition" does not exist.',
+        ];
+
+        yield 'wrong interface' => [
+            \stdClass::class,
+            \sprintf(
+                'Condition class "%s" does not implement %s.',
+                \stdClass::class,
+                Condition::class,
+            ),
+        ];
     }
 
     /**


### PR DESCRIPTION
Covers invalid skip-condition metadata that reaches a worker despite discovery-time validation. Data-set cases verify exact errored-test diagnostics for a missing condition class and a class that does not implement the condition contract.