### PR TITLE
refactor: decode plan entries at the cache boundary

### DIFF
--- a/src/Discovery/DiscoveryCache.php
+++ b/src/Discovery/DiscoveryCache.php
@@ -7,7 +7,6 @@ namespace Greenlight\Discovery;
 use Greenlight\Core\AtomicFile;
 use Greenlight\Core\AtomicFileError;
 use Greenlight\Core\ErrorTrap;
-use Greenlight\Core\Wire\InvalidWirePayload;
 
 /**
  * Stores one discovery cache entry for each file. The path, mtime, size, and
@@ -86,14 +85,9 @@ final class DiscoveryCache
             }
         }
 
-        $entries = [];
+        $entries = $cached->planEntries();
 
-        try {
-            foreach ($cached->entries as $payload) {
-                $entries[] = PlanEntry::fromWire($payload);
-            }
-        } catch (\InvalidArgumentException|InvalidWirePayload) {
-            // Treat a cache payload that cannot decode as a cache miss.
+        if ($entries === null) {
             return null;
         }
 

--- a/src/Discovery/DiscoveryCacheEntry.php
+++ b/src/Discovery/DiscoveryCacheEntry.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Greenlight\Discovery;
 
+use Greenlight\Core\Wire\InvalidWirePayload;
+
 /**
  * fromDecoded() examines input JSON. It returns null if a part has an
  * incorrect form. Thus, discovery parses the file again after a corrupt cache
@@ -75,6 +77,26 @@ final readonly class DiscoveryCacheEntry implements \JsonSerializable
         }
 
         return new self($decoded['mtime'], $decoded['size'], $payloads, $dependencies);
+    }
+
+    /**
+     * Returns null if a stored plan entry cannot decode.
+     *
+     * @return list<PlanEntry>|null
+     */
+    public function planEntries(): ?array
+    {
+        $entries = [];
+
+        try {
+            foreach ($this->entries as $payload) {
+                $entries[] = PlanEntry::fromWire($payload);
+            }
+        } catch (\InvalidArgumentException|InvalidWirePayload) {
+            return null;
+        }
+
+        return $entries;
     }
 
     /**

--- a/tests/Unit/Discovery/DiscoveryCacheEntryTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheEntryTest.php
@@ -47,6 +47,16 @@ final class DiscoveryCacheEntryTest
             ->toBeNull();
     }
 
+    #[Test]
+    public function anUndecodablePlanEntryBecomesACacheMiss(): void
+    {
+        $entry = new DiscoveryCacheEntry(100, 200, [[]]);
+
+        Expect::that($entry->planEntries())
+            ->because('an undecodable plan entry MUST become a cache miss')
+            ->toBeNull();
+    }
+
     /**
      * @return iterable<string, array{array<mixed>}>
      */

--- a/tests/Unit/Discovery/DiscoveryCacheTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheTest.php
@@ -68,47 +68,6 @@ final class DiscoveryCacheTest
     }
 
     #[Test]
-    public function corruptDecodedEntriesAreReparsedInsteadOfFailingDiscovery(): void
-    {
-        $className = 'CorruptEntryProbeTest';
-        $directory = $this->writeFixture($className);
-        $testFile = $directory . '/' . $className . '.php';
-        $cacheFile = $this->cacheFile($directory);
-
-        \spl_autoload_register(static function (string $class) use ($directory, $className): void {
-            if ($class === 'GreenlightDiscoCache\\' . $className) {
-                require_once $directory . '/' . $className . '.php';
-            }
-        });
-
-        try {
-            new TestDiscoverer()->discover([$directory], cache: DiscoveryCache::forDirectories([$directory]));
-
-            $decoded = \json_decode((string) \file_get_contents($cacheFile), true, 32, \JSON_THROW_ON_ERROR);
-            \assert(\is_array($decoded) && \is_array($decoded['files']));
-            $cachedPath = (string) \array_key_first($decoded['files']);
-            $cachedFile = $decoded['files'][$cachedPath] ?? null;
-            \assert(\is_array($cachedFile) && \is_array($cachedFile['entries']));
-            $cachedFile['entries'] = [[]];
-            $decoded['files'][$cachedPath] = $cachedFile;
-            \file_put_contents($cacheFile, \json_encode($decoded, \JSON_THROW_ON_ERROR));
-
-            $recovered = new TestDiscoverer()->discover(
-                [$directory],
-                cache: DiscoveryCache::forDirectories([$directory]),
-            );
-
-            Expect::that($recovered->count())
-                ->because('a corrupt decoded entry MUST become a cache miss')
-                ->toBe(2);
-        } finally {
-            @\unlink($cacheFile);
-            @\unlink($testFile);
-            @\rmdir($directory);
-        }
-    }
-
-    #[Test]
     public function externalProviderFileChangesInvalidateTestEntries(): void
     {
         $directory = \sys_get_temp_dir() . '/greenlight-disco-' . \bin2hex(\random_bytes(6));


### PR DESCRIPTION
Replaces the merged cache-corruption test workaround with a typed boundary on DiscoveryCacheEntry. Invalid stored plan entries now become cache misses without native assertions, temporary discovery fixtures, or direct cache JSON mutation.