### PR TITLE
test: cover closed socket channels

### DIFF
--- a/tests/Unit/Runner/Protocol/SocketChannelTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelTest.php
@@ -6,6 +6,7 @@ namespace Greenlight\Tests\Unit\Runner\Protocol;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
 use Greenlight\Runner\Protocol\Messages\Drain;
 use Greenlight\Runner\Protocol\ProtocolError;
 use Greenlight\Runner\Protocol\SocketChannel;
@@ -15,9 +16,7 @@ final class SocketChannelTest
     #[Test]
     public function anExternallyClosedStreamEndsPollingAndRejectsWrites(): void
     {
-        $pair = \stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
-        \assert(\is_array($pair));
-        [$stream, $peer] = $pair;
+        [$stream, $peer] = $this->socketPair();
         $channel = new SocketChannel($stream);
 
         try {
@@ -40,5 +39,19 @@ final class SocketChannelTest
             $channel->close();
             \fclose($peer);
         }
+    }
+
+    /**
+     * @return array{resource, resource}
+     */
+    private function socketPair(): array
+    {
+        $pair = \stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+
+        if ($pair === false || \count($pair) !== 2 || !isset($pair[0], $pair[1])) {
+            Fail::because('Expected stream_socket_pair() to create a connected socket pair.');
+        }
+
+        return [$pair[0], $pair[1]];
     }
 }

--- a/tests/Unit/Runner/Protocol/SocketChannelTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Protocol;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\Protocol\Messages\Drain;
+use Greenlight\Runner\Protocol\ProtocolError;
+use Greenlight\Runner\Protocol\SocketChannel;
+
+final class SocketChannelTest
+{
+    #[Test]
+    public function anExternallyClosedStreamEndsPollingAndRejectsWrites(): void
+    {
+        $pair = \stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+        \assert(\is_array($pair));
+        [$stream, $peer] = $pair;
+        $channel = new SocketChannel($stream);
+
+        try {
+            \fclose($stream);
+
+            Expect::that($channel->poll())
+                ->because('polling an externally closed stream reaches EOF')
+                ->toBeNull()
+                ->and($channel->isEof())
+                ->toBeTrue()
+                ->and($channel->poll())
+                ->toBeNull();
+
+            Expect::that(static function () use ($channel): void {
+                $channel->send(new Drain());
+            })
+                ->because('a closed channel MUST reject writes')
+                ->toThrow(ProtocolError::class, message: 'Malformed frame: the channel is closed.');
+        } finally {
+            $channel->close();
+            \fclose($peer);
+        }
+    }
+}


### PR DESCRIPTION
Covers a channel whose underlying socket is closed outside the channel. The test verifies that polling records EOF, repeated polls remain inert, and subsequent writes fail with the closed-channel protocol diagnostic.