### PR TITLE
test: cover bounded throwable traces

### DIFF
--- a/tests/Unit/Core/ThrowableDetailTest.php
+++ b/tests/Unit/Core/ThrowableDetailTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\ThrowableDetail;
+use Greenlight\Expect\Expect;
+
+final class ThrowableDetailTest
+{
+    #[Test]
+    public function deepTracesAreBoundedWithATruncationMarker(): void
+    {
+        try {
+            $this->throwAtDepth(40);
+        } catch (\RuntimeException $threw) {
+            $detail = ThrowableDetail::fromThrowable($threw);
+
+            Expect::that($detail->stackFrames)
+                ->because('deep throwable traces are bounded with a truncation marker')
+                ->toHaveCount(33)
+                ->and($detail->stackFrames[32])
+                ->toBe('... (trace truncated)');
+        }
+    }
+
+    private function throwAtDepth(int $remaining): never
+    {
+        if ($remaining === 0) {
+            throw new \RuntimeException('bottom');
+        }
+
+        $this->throwAtDepth($remaining - 1);
+    }
+}

--- a/tests/Unit/Core/ThrowableDetailTest.php
+++ b/tests/Unit/Core/ThrowableDetailTest.php
@@ -7,26 +7,35 @@ namespace Greenlight\Tests\Unit\Core;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Result\ThrowableDetail;
 use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
 
 final class ThrowableDetailTest
 {
     #[Test]
     public function deepTracesAreBoundedWithATruncationMarker(): void
     {
+        $threw = null;
+
         try {
             $this->throwAtDepth(40);
-        } catch (\RuntimeException $threw) {
-            $detail = ThrowableDetail::fromThrowable($threw);
-
-            Expect::that($detail->stackFrames)
-                ->because('deep throwable traces are bounded with a truncation marker')
-                ->toHaveCount(33)
-                ->and($detail->stackFrames[32])
-                ->toBe('... (trace truncated)');
+        } catch (\RuntimeException $exception) {
+            $threw = $exception;
         }
+
+        if (!$threw instanceof \RuntimeException) {
+            Fail::because('Expected the recursive helper to throw.');
+        }
+
+        $detail = ThrowableDetail::fromThrowable($threw);
+
+        Expect::that($detail->stackFrames)
+            ->because('deep throwable traces are bounded with a truncation marker')
+            ->toHaveCount(33)
+            ->and($detail->stackFrames[32])
+            ->toBe('... (trace truncated)');
     }
 
-    private function throwAtDepth(int $remaining): never
+    private function throwAtDepth(int $remaining): void
     {
         if ($remaining === 0) {
             throw new \RuntimeException('bottom');

--- a/tests/Unit/Core/ThrowableDetailTest.php
+++ b/tests/Unit/Core/ThrowableDetailTest.php
@@ -14,16 +14,26 @@ final class ThrowableDetailTest
     #[Test]
     public function deepTracesAreBoundedWithATruncationMarker(): void
     {
-        $threw = null;
+        $capture = new class {
+            public ?\RuntimeException $exception = null;
+        };
 
-        try {
-            $this->throwAtDepth(40);
-        } catch (\RuntimeException $exception) {
-            $threw = $exception;
-        }
+        Expect::that(function () use ($capture): void {
+            try {
+                $this->throwAtDepth(40);
+            } catch (\RuntimeException $exception) {
+                $capture->exception = $exception;
+
+                throw $exception;
+            }
+        })
+            ->because('the recursive helper MUST throw at its terminal depth')
+            ->toThrow(\RuntimeException::class, message: 'bottom');
+
+        $threw = $capture->exception;
 
         if (!$threw instanceof \RuntimeException) {
-            Fail::because('Expected the recursive helper to throw.');
+            Fail::because('Expected to capture the recursive helper exception.');
         }
 
         $detail = ThrowableDetail::fromThrowable($threw);


### PR DESCRIPTION
Covers throwable traces deeper than the wire payload limit. The test verifies that Greenlight retains exactly 32 frames and appends the stable truncation marker.