### PR TITLE
test: cover invalid test method discovery

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -13,6 +13,7 @@ parameters:
     excludePaths:
         analyse:
             - tests/Fixture/DiscoveryAttributeArgumentsInvalid
+            - tests/Fixture/DiscoveryInvalidMethods
             - tests/Fixture/DiscoveryResourceInvalid
     greenlight:
         configFiles:

--- a/tests/Fixture/DiscoveryInvalidMethods/AbstractMethodTest.php
+++ b/tests/Fixture/DiscoveryInvalidMethods/AbstractMethodTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\DiscoveryInvalidMethods;
+
+use Greenlight\Attribute\Test;
+
+abstract class AbstractMethodTest
+{
+    #[Test]
+    abstract public function invalid(): void;
+}

--- a/tests/Fixture/DiscoveryInvalidMethods/NonPublicMethodTest.php
+++ b/tests/Fixture/DiscoveryInvalidMethods/NonPublicMethodTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\DiscoveryInvalidMethods;
+
+use Greenlight\Attribute\Test;
+
+final class NonPublicMethodTest
+{
+    #[Test]
+    private function invalid(): void {}
+}

--- a/tests/Fixture/DiscoveryInvalidMethods/StaticMethodTest.php
+++ b/tests/Fixture/DiscoveryInvalidMethods/StaticMethodTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\DiscoveryInvalidMethods;
+
+use Greenlight\Attribute\Test;
+
+final class StaticMethodTest
+{
+    #[Test]
+    public static function invalid(): void {}
+}

--- a/tests/Unit/Discovery/MetadataFactoryTest.php
+++ b/tests/Unit/Discovery/MetadataFactoryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\DiscoveryError;
+use Greenlight\Discovery\MetadataFactory;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\DiscoveryInvalidMethods\AbstractMethodTest;
+use Greenlight\Tests\Fixture\DiscoveryInvalidMethods\NonPublicMethodTest;
+use Greenlight\Tests\Fixture\DiscoveryInvalidMethods\StaticMethodTest;
+
+final class MetadataFactoryTest
+{
+    /**
+     * @param class-string $class
+     */
+    #[Test]
+    #[DataSet('invalidMethods')]
+    public function rejectsTestMethodsThatCannotRun(string $class, string $reason): void
+    {
+        Expect::that(
+            static fn(): array => new MetadataFactory()->forClass(new \ReflectionClass($class)),
+        )
+            ->because('discovery MUST reject a test method that cannot run')
+            ->toThrow(
+                DiscoveryError::class,
+                message: \sprintf(
+                    'Greenlight cannot run test method %s::invalid() because %s.',
+                    $class,
+                    $reason,
+                ),
+            );
+    }
+
+    /**
+     * @return iterable<string, array{class-string, non-empty-string}>
+     */
+    public static function invalidMethods(): iterable
+    {
+        yield 'non-public' => [NonPublicMethodTest::class, 'it is not public'];
+
+        yield 'static' => [StaticMethodTest::class, 'it is static'];
+
+        yield 'abstract' => [AbstractMethodTest::class, 'it is abstract'];
+    }
+}


### PR DESCRIPTION
Covers MetadataFactory runtime guards for non-public, static, and abstract test methods. The cases use PSR-4 fixtures and one data set to verify each exact discovery error.