### PR TITLE
test: cover plan plugin output

### DIFF
--- a/tests/Fixture/Plugins/NamedFakePlugin.php
+++ b/tests/Fixture/Plugins/NamedFakePlugin.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Plugins;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Plugin\Plugin;
+
+final class NamedFakePlugin implements Fake, Plugin {}

--- a/tests/Unit/Cli/PlanFormatterTest.php
+++ b/tests/Unit/Cli/PlanFormatterTest.php
@@ -9,10 +9,12 @@ use Greenlight\Cli\PlanFormatter;
 use Greenlight\Config\Configuration;
 use Greenlight\Config\CoverageConfiguration;
 use Greenlight\Config\CoverageExport;
+use Greenlight\Config\GreenlightConfig;
 use Greenlight\Config\WatchConfiguration;
 use Greenlight\Config\WorkerCount;
 use Greenlight\Core\Result\ResultPolicy;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Plugins\NamedFakePlugin;
 
 final class PlanFormatterTest
 {
@@ -58,5 +60,22 @@ final class PlanFormatterTest
 
                 PLAN,
         );
+    }
+
+    #[Test]
+    public function formatsRuntimeSeedSelectionAndPluginClasses(): void
+    {
+        $configuration = GreenlightConfig::create()
+            ->randomizeOrder()
+            ->plugins(new NamedFakePlugin())
+            ->build();
+
+        $formatted = PlanFormatter::format($configuration, '/project/greenlight.php');
+
+        Expect::that($formatted)
+            ->because('the plan names runtime seed selection and configured plugins')
+            ->toContain('  order: random (seed chosen at run time)')
+            ->and($formatted)
+            ->toContain('  plugins: ' . NamedFakePlugin::class);
     }
 }


### PR DESCRIPTION
Covers run-plan output for random order without a fixed seed and configured plugin classes. The named plugin substitute implements Fake so Greenlight can identify its test-only role.