### PR TITLE
test: cover in-process run subscribers

### DIFF
--- a/tests/Fixture/Plugins/RecordingRunSubscriber.php
+++ b/tests/Fixture/Plugins/RecordingRunSubscriber.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Plugins;
+
+use Greenlight\Core\Event\Event;
+use Greenlight\Doubles\Fake;
+use Greenlight\Plugin\RunLifecycleSubscriber;
+
+final class RecordingRunSubscriber implements RunLifecycleSubscriber, Fake
+{
+    /**
+     * @var list<Event>
+     */
+    public private(set) array $events = [];
+
+    #[\Override]
+    public function onRunEvent(Event $event): void
+    {
+        $this->events[] = $event;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function sequence(): array
+    {
+        return \array_map(
+            static fn(Event $event): string => new \ReflectionClass($event)->getShortName(),
+            $this->events,
+        );
+    }
+}

--- a/tests/Unit/Runner/InProcessRunnerTest.php
+++ b/tests/Unit/Runner/InProcessRunnerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\InProcessRunner;
+use Greenlight\Tests\Fixture\Plugins\RecordingRunSubscriber;
+use Greenlight\Tests\Support\CollectingEventSink;
+
+final readonly class InProcessRunnerTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function runSubscribersObserveTheCompleteInProcessEventStream(): void
+    {
+        $subscriber = new RecordingRunSubscriber();
+        $configuration = GreenlightConfig::create()->plugins($subscriber)->build();
+        $sink = new CollectingEventSink();
+        $fixtureDirectory = \dirname(__DIR__, 2) . '/Fixture/DiscoveryBasic';
+
+        $result = new InProcessRunner($this->tempDirectory->path())->run(
+            $configuration,
+            [$fixtureDirectory],
+            $sink,
+        );
+
+        Expect::that($subscriber->events)
+            ->because('run subscribers observe the same event stream as the configured sink')
+            ->toBe($sink->events);
+
+        Expect::that($subscriber->sequence())
+            ->because('the subscriber observes both run boundaries')
+            ->toContain('RunStarted')
+            ->toContain('RunFinished')
+            ->and($result->summary->passed)
+            ->toBe(7);
+    }
+}


### PR DESCRIPTION
Covers orchestrator-side run lifecycle subscribers in the in-process runner. A Greenlight fake records the event stream and verifies that subscribers observe the same complete run boundaries and test events as the configured sink.