### PR TITLE
test: cover unfiltered coverage collection

### DIFF
--- a/tests/Unit/Runner/CoverageCollectorTest.php
+++ b/tests/Unit/Runner/CoverageCollectorTest.php
@@ -65,4 +65,27 @@ final class CoverageCollectorTest
                 . 'Set xdebug.mode to "coverage", or set the XDEBUG_MODE environment variable.',
             );
     }
+
+    #[Test]
+    public function emptyIncludePathsKeepCoverageFromEveryFile(): void
+    {
+        $collector = CoverageCollector::create(
+            new CoverageSettings([]),
+            selector: new DriverSelector([RecordingFakeDriver::class]),
+        );
+
+        if (!$collector instanceof CoverageCollector) {
+            Fail::because('Expected the available driver to create a coverage collector.');
+        }
+
+        $collector->start();
+        $files = $collector->stop()->files();
+
+        Expect::that(\array_keys($files))
+            ->because('empty coverage include paths MUST retain every collected file')
+            ->toBe([
+                '/project/src/Included.php',
+                '/project/tests/Excluded.php',
+            ]);
+    }
 }


### PR DESCRIPTION
Covers the CoverageCollector boundary where no include paths are configured. The test uses the existing fake driver and verifies that coverage from every collected file survives the unfiltered path.