### PR TITLE
test: cover plugin capability ordering

### DIFF
--- a/tests/Fixture/Plugins/FakeCapabilityPlugin.php
+++ b/tests/Fixture/Plugins/FakeCapabilityPlugin.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Plugins;
+
+use Greenlight\Core\Event\Event;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Doubles\Fake;
+use Greenlight\Harness\ServiceResolver;
+use Greenlight\Plugin\RetryDecider;
+use Greenlight\Plugin\RunLifecycleSubscriber;
+use Greenlight\Plugin\TestContext;
+use Greenlight\Plugin\TestLifecycleSubscriber;
+
+class FakeCapabilityPlugin implements Fake, RetryDecider, RunLifecycleSubscriber, ServiceResolver, TestLifecycleSubscriber
+{
+    #[\Override]
+    public function shouldRetry(TestMetadata $metadata, TestResult $result, int $attempt, ?\Throwable $cause): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public function onRunEvent(Event $event): void {}
+
+    #[\Override]
+    public function resolve(string $type, array $attributes): ?object
+    {
+        return null;
+    }
+
+    #[\Override]
+    public function beforeTest(TestContext $context): void {}
+
+    #[\Override]
+    public function afterTest(TestContext $context, TestResult $result): TestResult
+    {
+        return $result;
+    }
+}

--- a/tests/Fixture/Plugins/PrioritizedFakeCapabilityPlugin.php
+++ b/tests/Fixture/Plugins/PrioritizedFakeCapabilityPlugin.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Plugins;
+
+use Greenlight\Plugin\Prioritized;
+
+final class PrioritizedFakeCapabilityPlugin extends FakeCapabilityPlugin implements Prioritized
+{
+    public function __construct(private readonly int $priority) {}
+
+    #[\Override]
+    public function priority(): int
+    {
+        return $this->priority;
+    }
+}

--- a/tests/Unit/Plugin/PluginRegistryTest.php
+++ b/tests/Unit/Plugin/PluginRegistryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Plugin;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Plugin\PluginRegistry;
+use Greenlight\Tests\Fixture\Plugins\FakeCapabilityPlugin;
+use Greenlight\Tests\Fixture\Plugins\NamedFakePlugin;
+use Greenlight\Tests\Fixture\Plugins\PrioritizedFakeCapabilityPlugin;
+
+final class PluginRegistryTest
+{
+    #[Test]
+    public function capabilityAccessorsFilterPluginsAndKeepStablePriorityOrder(): void
+    {
+        $late = new PrioritizedFakeCapabilityPlugin(10);
+        $prioritizedDefault = new PrioritizedFakeCapabilityPlugin(0);
+        $unrelated = new NamedFakePlugin();
+        $default = new FakeCapabilityPlugin();
+        $early = new PrioritizedFakeCapabilityPlugin(-10);
+        $registry = new PluginRegistry([$late, $prioritizedDefault, $unrelated, $default, $early]);
+        $expected = [$early, $prioritizedDefault, $default, $late];
+
+        Expect::that($registry->testSubscribers())
+            ->because('capability accessors filter plugins and keep stable priority order')
+            ->toBe($expected)
+            ->and($registry->retryDeciders())->toBe($expected)
+            ->and($registry->runSubscribers())->toBe($expected)
+            ->and($registry->serviceResolvers())->toBe($expected)
+            ->and($registry->ofType(NamedFakePlugin::class))->toBe([$unrelated]);
+    }
+}


### PR DESCRIPTION
Adds direct PluginRegistry contract coverage for capability filtering, priority ordering, and stable registration order across equal priorities. Adds reusable Fake-marked plugins that expose the worker and orchestrator capabilities under test.