### PR TITLE
test: cover equals matcher diagnostics

### DIFF
--- a/tests/Unit/Doubles/ArgumentMatchingTest.php
+++ b/tests/Unit/Doubles/ArgumentMatchingTest.php
@@ -118,6 +118,14 @@ final class ArgumentMatchingTest
     }
 
     #[Test]
+    public function equalsDiagnosticsRenderTheExpectedValue(): void
+    {
+        Expect::that(Argument::equals(['a' => [1, 2]])->describe())
+            ->because('equals() diagnostics render the expected value')
+            ->toBe("equals(['a' => [1, 2]])");
+    }
+
+    #[Test]
     public function bareValuesAndMatchersMixInOneWith(): void
     {
         $doubles = new Doubles();


### PR DESCRIPTION
Covers the public equals() matcher description used in mock failure diagnostics. The test verifies nested expected values use Greenlight’s standard value rendering.