### PR TITLE
test: cover missing XMLWriter diagnostic

### DIFF
--- a/tests/Unit/Reporting/ReportingErrorTest.php
+++ b/tests/Unit/Reporting/ReportingErrorTest.php
@@ -26,4 +26,12 @@ final class ReportingErrorTest
                 self::class,
             ));
     }
+
+    #[Test]
+    public function reportsTheMissingXmlWriterExtensionExactly(): void
+    {
+        Expect::that(ReportingError::xmlUnavailable()->getMessage())
+            ->because('JUnit output names the required PHP extension')
+            ->toBe('The XMLWriter extension is required for JUnit output. Enable ext-xmlwriter.');
+    }
 }


### PR DESCRIPTION
Covers the exact user-facing diagnostic emitted when JUnit output is requested without XMLWriter. The assertion protects both the required extension name and the action needed to enable it.