### PR TITLE
test: cover empty filter overrides

### DIFF
--- a/tests/Unit/Cli/CliOverridesTest.php
+++ b/tests/Unit/Cli/CliOverridesTest.php
@@ -99,6 +99,16 @@ final class CliOverridesTest
     }
 
     #[Test]
+    public function emptyFilterPatternsAreRejectedExactly(): void
+    {
+        Expect::that(static function (): void {
+            CliOverrides::fromArguments(new ParsedArguments(null, ['filter' => ['']]));
+        })
+            ->because('an empty filter cannot select tests')
+            ->toThrow(CliError::class, message: '--filter requires a pattern.');
+    }
+
+    #[Test]
     public function workersAutoIsKeptAsTheAutoMarker(): void
     {
         $overrides = CliOverrides::fromArguments(new ParsedArguments(null, ['workers' => ['auto']]));


### PR DESCRIPTION
Covers empty --filter validation in the CLI override layer. The assertion protects the exact user-facing guidance through the public argument conversion path.