### PR TITLE
test: cover duplicate inline data rows

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -12,6 +12,7 @@ parameters:
         - tools
     excludePaths:
         analyse:
+            - tests/Fixture/DataRowsDuplicateInline
             - tests/Fixture/DiscoveryAttributeArgumentsInvalid
             - tests/Fixture/DiscoveryInvalidMethods
             - tests/Fixture/DiscoveryResourceInvalid

--- a/tests/Fixture/DataRowsDuplicateInline/DuplicateInlineRowKeyTest.php
+++ b/tests/Fixture/DataRowsDuplicateInline/DuplicateInlineRowKeyTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\DataRowsDuplicateInline;
+
+use Greenlight\Attribute\DataRow;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Fail;
+
+final class DuplicateInlineRowKeyTest
+{
+    #[Test]
+    #[DataRow([1], label: 'twice')]
+    #[DataRow([2], label: 'twice')]
+    public function probe(int $value): void
+    {
+        if ($value < 0) {
+            Fail::because(\sprintf(
+                'Expected the duplicate-inline-row fixture value to be non-negative, got %d.',
+                $value,
+            ));
+        }
+    }
+}

--- a/tests/Unit/Discovery/DataRowTest.php
+++ b/tests/Unit/Discovery/DataRowTest.php
@@ -12,6 +12,7 @@ use Greenlight\Discovery\TestDiscoverer;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\DataRows\InlineRowsTest;
 use Greenlight\Tests\Fixture\DataRowsConflict\DuplicateRowKeyTest;
+use Greenlight\Tests\Fixture\DataRowsDuplicateInline\DuplicateInlineRowKeyTest;
 
 final class DataRowTest
 {
@@ -46,6 +47,22 @@ final class DataRowTest
         Expect::that(
             static fn(): array => new DataSetExpander()->rowsFor($reflection, 'probe', 'rows', 5.0),
         )->because('duplicate keys between inline and provider are refused')->toThrow(DiscoveryError::class, '/twice/');
+    }
+
+    #[Test]
+    public function duplicateInlineKeysAreRefused(): void
+    {
+        $reflection = new \ReflectionClass(DuplicateInlineRowKeyTest::class);
+
+        Expect::that(
+            static fn(): array => new DataSetExpander()->rowsFor($reflection, 'probe', null, 5.0),
+        )
+            ->because('duplicate inline data-row keys are refused')
+            ->toThrow(
+                DiscoveryError::class,
+                message: 'Data sets for Greenlight\Tests\Fixture\DataRowsDuplicateInline\DuplicateInlineRowKeyTest::probe() '
+                    . 'contain key "twice" more than once. Use each key only once for the test method.',
+            );
     }
 
     #[Test]


### PR DESCRIPTION
Covers the runtime rejection of duplicate keys across inline DataRow attributes, complementing the existing inline/provider collision test. The deliberately invalid PSR-4 fixture is isolated from the normal PHPStan project scan.