### PR TITLE
test: cover captor diagnostics

### DIFF
--- a/tests/Unit/Doubles/ArgumentMatchingTest.php
+++ b/tests/Unit/Doubles/ArgumentMatchingTest.php
@@ -156,6 +156,14 @@ final class ArgumentMatchingTest
     }
 
     #[Test]
+    public function captorDiagnosticsNameTheConstraint(): void
+    {
+        Expect::that(Argument::captor()->describe())
+            ->because('captor diagnostics identify the argument constraint')
+            ->toBe('captor()');
+    }
+
+    #[Test]
     public function captureArgumentRecordsEveryMatchedCall(): void
     {
         $doubles = new Doubles();


### PR DESCRIPTION
Covers the public argument captor description used in mock failure diagnostics. The assertion protects the concise captor() constraint name.