### PR TITLE
test: cover any matcher diagnostics

### DIFF
--- a/tests/Unit/Doubles/ArgumentMatchingTest.php
+++ b/tests/Unit/Doubles/ArgumentMatchingTest.php
@@ -131,6 +131,14 @@ final class ArgumentMatchingTest
     }
 
     #[Test]
+    public function anyDiagnosticsNameTheConstraint(): void
+    {
+        Expect::that(Argument::any()->describe())
+            ->because('any() diagnostics identify the argument constraint')
+            ->toBe('any()');
+    }
+
+    #[Test]
     public function aCaptorInWithCollectsValuesInCallOrder(): void
     {
         $doubles = new Doubles();


### PR DESCRIPTION
Covers the public any() matcher description used in mock failure diagnostics. The assertion protects the concise argument-constraint name.