### PR TITLE
test: cover parallel run subscribers

### DIFF
--- a/tests/Unit/Runner/ParallelRunnerTest.php
+++ b/tests/Unit/Runner/ParallelRunnerTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\ParallelRunner;
+use Greenlight\Tests\Fixture\Plugins\RecordingRunSubscriber;
+use Greenlight\Tests\Support\CollectingEventSink;
+
+final readonly class ParallelRunnerTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function runSubscribersObserveTheCompleteParallelEventStream(): void
+    {
+        $subscriber = new RecordingRunSubscriber();
+        $configuration = GreenlightConfig::create()->plugins($subscriber)->build();
+        $sink = new CollectingEventSink();
+        $root = \dirname(__DIR__, 3);
+        $fixtureDirectory = \dirname(__DIR__, 2) . '/Fixture/DiscoveryBasic';
+
+        $result = new ParallelRunner(
+            [\PHP_BINARY, $root . '/bin/greenlight'],
+            $this->tempDirectory->path(),
+        )->run(
+            $configuration,
+            [$fixtureDirectory],
+            $sink,
+            workerCount: 2,
+        );
+
+        Expect::that($subscriber->events)
+            ->because('parallel run subscribers observe the configured sink event stream')
+            ->toBe($sink->events);
+
+        Expect::that($subscriber->sequence())
+            ->because('the parallel subscriber observes both run boundaries')
+            ->toContain('RunStarted')
+            ->toContain('RunFinished')
+            ->and($result->summary->passed)
+            ->toBe(7);
+    }
+}


### PR DESCRIPTION
Covers orchestrator-side run subscribers in the parallel runner. The test verifies subscribers observe the exact configured sink event stream, including both run boundaries, while the worker pool completes the discovered plan.