### PR TITLE
test: cover non-class discovery candidates

### DIFF
--- a/docs/api-fixtures-harness.md
+++ b/docs/api-fixtures-harness.md
@@ -75,8 +75,9 @@ public function subdirectory(string $name): string
 PHPDoc:
 
 - `@param string $name A relative path of plain segments. The path can contain separators but cannot contain traversal segments.`
+- `@return non-empty-string`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L42)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L44)
 
 ### `dispose()`
 
@@ -85,7 +86,7 @@ PHPDoc:
 public function dispose(): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L67)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L69)
 
 ## `Disposable`
 

--- a/src/Fixture/TempDirectory.php
+++ b/src/Fixture/TempDirectory.php
@@ -38,6 +38,8 @@ final class TempDirectory implements Disposable
     /**
      * @param string $name A relative path of plain segments. The path can
      *   contain separators but cannot contain traversal segments.
+     *
+     * @return non-empty-string
      */
     public function subdirectory(string $name): string
     {

--- a/tests/Unit/Discovery/TestDiscovererNonClassTest.php
+++ b/tests/Unit/Discovery/TestDiscovererNonClassTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\TestDiscoverer;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class TestDiscovererNonClassTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    #[DataSet('nonClassDeclarations')]
+    public function nonClassDeclarationsWithMatchingFileNamesAreIgnored(string $kind): void
+    {
+        $directory = $this->tempDirectory->subdirectory($kind);
+        $file = $directory . '/IgnoredTest.php';
+        \file_put_contents($file, \sprintf(
+            "<?php\n\ndeclare(strict_types=1);\n\n%s IgnoredTest {}\n",
+            $kind,
+        ));
+        $discoverer = new TestDiscoverer();
+
+        Expect::that($discoverer->testFiles([$directory]))
+            ->because('a matching non-class declaration is a test-file candidate')
+            ->toBe([$file]);
+        Expect::that($discoverer->discover([$directory])->count())
+            ->because('a matching non-class declaration MUST be ignored')
+            ->toBe(0);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function nonClassDeclarations(): iterable
+    {
+        yield 'interface' => ['interface'];
+
+        yield 'trait' => ['trait'];
+
+        yield 'enum' => ['enum'];
+    }
+}


### PR DESCRIPTION
Covers interfaces, traits, and enums whose names match the Test.php discovery convention. The test verifies that these files are scanned as candidates and then ignored without a discovery error. It also records the existing non-empty return contract of TempDirectory::subdirectory() so tests can pass generated paths to typed discovery APIs.