### PR TITLE
test: cover assign coverage path normalization

### DIFF
--- a/tests/Unit/Runner/Protocol/ProtocolTest.php
+++ b/tests/Unit/Runner/Protocol/ProtocolTest.php
@@ -123,6 +123,21 @@ final class ProtocolTest
     }
 
     #[Test]
+    public function assignDropsEmptyCoverageIncludePathsFromTheWire(): void
+    {
+        $payload = new Assign(
+            new ExecutionPlan([]),
+            coverageInclude: ['/app/src'],
+        )->toWire();
+        $payload['coverageInclude'] = ['', '/app/src', ''];
+        $assign = Assign::fromWire($payload);
+
+        Expect::that($assign->coverageInclude)
+            ->because('workers receive only non-empty coverage include paths')
+            ->toBe(['/app/src']);
+    }
+
+    #[Test]
     public function oversizedFramesAreRejectedOnBothSides(): void
     {
         $codec = new JsonFrameCodec(maxFrameBytes: 64);


### PR DESCRIPTION
Covers worker assignment decoding when a legacy wire payload contains empty coverage include paths. The test verifies Greenlight keeps valid paths and drops empty entries at the protocol boundary.