### PR TITLE
test: cover discovery class location mismatch

### DIFF
--- a/tests/Unit/Discovery/TestDiscovererLoadedClassTest.php
+++ b/tests/Unit/Discovery/TestDiscovererLoadedClassTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\DiscoveryError;
+use Greenlight\Discovery\ExecutionPlan;
+use Greenlight\Discovery\TestDiscoverer;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class TestDiscovererLoadedClassTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function aClassLoadedFromAnotherFileFailsWithBothPaths(): void
+    {
+        $root = $this->tempDirectory->path();
+        $expectedDirectory = $root . '/scanned';
+        $actualDirectory = $root . '/autoloaded';
+        \mkdir($expectedDirectory);
+        \mkdir($actualDirectory);
+        $expectedFile = $expectedDirectory . '/ShadowedTest.php';
+        $actualFile = $actualDirectory . '/ShadowedTest.php';
+        $class = 'GreenlightDiscoveryShadow\ShadowedTest';
+        $source = <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace GreenlightDiscoveryShadow;
+
+            final class ShadowedTest {}
+            PHP;
+        \file_put_contents($expectedFile, $source);
+        \file_put_contents($actualFile, $source);
+
+        $loader = static function (string $candidate) use ($class, $actualFile): void {
+            if ($candidate === $class) {
+                require_once $actualFile;
+            }
+        };
+        \spl_autoload_register($loader);
+
+        try {
+            Expect::that(
+                static fn(): ExecutionPlan => new TestDiscoverer()->discover([$expectedDirectory]),
+            )->because('discovery MUST reject a class that the autoloader loaded from another file')->toThrow(
+                DiscoveryError::class,
+                message: \sprintf(
+                    'The autoloader loaded class "%s" from "%s". It expected the class in "%s". Only one file can declare a class.',
+                    $class,
+                    $actualFile,
+                    $expectedFile,
+                ),
+            );
+        } finally {
+            \spl_autoload_unregister($loader);
+        }
+    }
+}


### PR DESCRIPTION
Covers discovery when an autoloader resolves the expected class name from a different file. The test uses isolated temporary source files and verifies that the typed error identifies both the scanned path and the path that supplied the class, without adding a PSR-4 violation to the fixture tree.