### PR TITLE
test: cover in-process shard execution

### DIFF
--- a/tests/Unit/Runner/InProcessRunnerTest.php
+++ b/tests/Unit/Runner/InProcessRunnerTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Cli\CliOverrides;
+use Greenlight\Cli\ConfigurationResolver;
 use Greenlight\Config\GreenlightConfig;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -40,5 +42,40 @@ final readonly class InProcessRunnerTest
             ->toContain('RunFinished')
             ->and($result->summary->passed)
             ->toBe(7);
+    }
+
+    #[Test]
+    public function inProcessShardsPartitionTheDiscoveredSuite(): void
+    {
+        $configuration = GreenlightConfig::create()->build();
+        $fixtureDirectory = \dirname(__DIR__, 2) . '/Fixture/DiscoveryBasic';
+        $ids = [];
+        $plannedTests = 0;
+
+        foreach ([1, 2] as $index) {
+            $sink = new CollectingEventSink();
+            $shard = ConfigurationResolver::resolve(
+                $configuration,
+                new CliOverrides(shard: [$index, 2]),
+            );
+            $result = new InProcessRunner($this->tempDirectory->path())->run(
+                $shard,
+                [$fixtureDirectory],
+                $sink,
+            );
+            $plannedTests += $result->plannedTests;
+
+            foreach ($sink->results() as $testResult) {
+                $ids[] = (string) $testResult->id;
+            }
+        }
+
+        Expect::that($plannedTests)
+            ->because('both in-process shards reconstitute the discovered suite')
+            ->toBe(7)
+            ->and($ids)
+            ->toHaveCount(7)
+            ->and(\array_values(\array_unique($ids)))
+            ->toHaveCount(7);
     }
 }


### PR DESCRIPTION
Covers shard application at the in-process runner boundary. The test executes both halves of a discovered suite and verifies their combined plans contain every test exactly once.