### PR TITLE
test: cover in-process sharding

### DIFF
--- a/tests/Unit/Runner/InProcessRunnerTest.php
+++ b/tests/Unit/Runner/InProcessRunnerTest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Cli\CliOverrides;
+use Greenlight\Cli\ConfigurationResolver;
 use Greenlight\Config\GreenlightConfig;
+use Greenlight\Core\Result\TestResult;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Runner\InProcessRunner;
@@ -40,5 +43,54 @@ final readonly class InProcessRunnerTest
             ->toContain('RunFinished')
             ->and($result->summary->passed)
             ->toBe(7);
+    }
+
+    #[Test]
+    public function shardsPartitionAnInProcessRunWithoutLossOrDuplication(): void
+    {
+        $runner = new InProcessRunner($this->tempDirectory->path());
+        $base = GreenlightConfig::create()->build();
+        $fixtureDirectory = \dirname(__DIR__, 2) . '/Fixture/DiscoveryBasic';
+        $completeSink = new CollectingEventSink();
+
+        $runner->run($base, [$fixtureDirectory], $completeSink);
+        $completeIds = $this->resultIds($completeSink);
+        $shardedIds = [];
+
+        for ($index = 1; $index <= 3; ++$index) {
+            $sink = new CollectingEventSink();
+            $configuration = ConfigurationResolver::resolve(
+                $base,
+                new CliOverrides(shard: [$index, 3]),
+            );
+            $result = $runner->run($configuration, [$fixtureDirectory], $sink);
+            $ids = $this->resultIds($sink);
+
+            Expect::that($result->plannedTests)
+                ->because('each in-process shard reports the number of tests it executes')
+                ->toBe(\count($ids))
+                ->and($result->summary->total())
+                ->toBe(\count($ids));
+
+            $shardedIds = [...$shardedIds, ...$ids];
+        }
+
+        \sort($completeIds);
+        \sort($shardedIds);
+
+        Expect::that($shardedIds)
+            ->because('all in-process shards reconstitute the complete run exactly once')
+            ->toBe($completeIds);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function resultIds(CollectingEventSink $sink): array
+    {
+        return \array_map(
+            static fn(TestResult $result): string => (string) $result->id,
+            $sink->results(),
+        );
     }
 }


### PR DESCRIPTION
Covers sharding in the in-process runner rather than only list and parallel execution paths. The test runs every shard, verifies each reported count, and confirms that their combined test IDs reconstitute the complete run exactly once.