### PR TITLE
test: cover extensionless attachment collisions

### DIFF
--- a/tests/Unit/Artifact/StagedAttachmentNamingTest.php
+++ b/tests/Unit/Artifact/StagedAttachmentNamingTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\Artifact\StagedAttachment;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\ArtifactStore;
+use Greenlight\Runner\Artifact\TestArtifactBudget;
+
+final readonly class StagedAttachmentNamingTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function duplicateExtensionlessNamesGainANumericSuffix(): void
+    {
+        $root = $this->tempDirectory->subdirectory('extensionless-names');
+        $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-1');
+
+        try {
+            $attachments = $store->forAttempt(
+                new TestId('Example\EvidenceTest', 'captures'),
+                1,
+                new TestArtifactBudget(),
+            );
+            $attachments->text('evidence', 'first');
+            $attachments->text('evidence', 'second');
+            $names = \array_map(
+                static fn(StagedAttachment $attachment): string => \basename($attachment->storageKey),
+                $attachments->seal(),
+            );
+
+            Expect::that($names)
+                ->because('duplicate extensionless attachment names MUST remain distinct')
+                ->toBe(['01-evidence', '02-evidence-2']);
+        } finally {
+            $store->cleanup();
+        }
+    }
+}


### PR DESCRIPTION
Covers storage-key generation when one test stages the same extensionless attachment name twice. The focused test verifies that Greenlight preserves both attachments by adding the numeric suffix after the whole name, producing evidence and evidence-2.