### PR TITLE
test: cover trait double boundary

### DIFF
--- a/tests/Fixture/Doubles/ReusableBehavior.php
+++ b/tests/Fixture/Doubles/ReusableBehavior.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+trait ReusableBehavior
+{
+    public function act(): void {}
+}

--- a/tests/Fixture/Doubles/ReusableBehaviorConsumer.php
+++ b/tests/Fixture/Doubles/ReusableBehaviorConsumer.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+final class ReusableBehaviorConsumer
+{
+    use ReusableBehavior;
+}

--- a/tests/Unit/Doubles/BoundaryTest.php
+++ b/tests/Unit/Doubles/BoundaryTest.php
@@ -15,6 +15,7 @@ use Greenlight\Tests\Fixture\Doubles\FinalService;
 use Greenlight\Tests\Fixture\Doubles\HandlerCollision;
 use Greenlight\Tests\Fixture\Doubles\PlanningBoundaries;
 use Greenlight\Tests\Fixture\Doubles\ReadonlyService;
+use Greenlight\Tests\Fixture\Doubles\ReusableBehavior;
 use Greenlight\Tests\Fixture\Doubles\Suit;
 
 final class BoundaryTest
@@ -47,6 +48,21 @@ final class BoundaryTest
                 DoublesError::class,
                 message: 'Greenlight\Tests\Fixture\Doubles\Suit is an enum. '
                     . 'Doubles does not support enums. Use an interface that the enum implements.',
+            );
+    }
+
+    #[Test]
+    public function traitsCannotBeDoubled(): void
+    {
+        $doubles = new Doubles();
+
+        Expect::that(static fn(): object => $doubles->mock(ReusableBehavior::class))
+            ->because('a trait cannot supply an object type for a generated proxy')
+            ->toThrow(
+                DoublesError::class,
+                message: ReusableBehavior::class . ' is a trait. '
+                    . 'Doubles cannot create a proxy for a trait. '
+                    . 'Use a class or interface that uses it.',
             );
     }
 


### PR DESCRIPTION
Covers the runtime boundary that rejects traits as double targets. The fixture uses a separate PSR-4 consumer so PHPStan analyzes the trait in a real class context, while the assertion verifies Greenlight’s exact actionable diagnostic.