### PR TITLE
test: cover closed worker handles

### DIFF
--- a/tests/Unit/Runner/Orchestrator/WorkerHandleTest.php
+++ b/tests/Unit/Runner/Orchestrator/WorkerHandleTest.php
@@ -16,6 +16,24 @@ use Greenlight\Runner\Orchestrator\WorkerHandle;
 final class WorkerHandleTest
 {
     #[Test]
+    public function aClosedProcessHandleIsNotRunning(): void
+    {
+        $process = $this->stream();
+        \fclose($process);
+        $handle = new WorkerHandle(
+            'worker-1',
+            1,
+            $process,
+            $this->stream(),
+            $this->stream(),
+        );
+
+        Expect::that($handle->isRunning())
+            ->because('a closed worker process handle cannot be running')
+            ->toBeFalse();
+    }
+
+    #[Test]
     public function unfinishedReturnsOnlyEntriesEligibleForCrashReassignment(): void
     {
         $handle = $this->handle();


### PR DESCRIPTION
Covers the worker lifecycle boundary after a process handle closes. The test verifies isRunning() returns false without passing a closed handle to proc_get_status().