### PR TITLE
test: cover explicit attachment retention wire value

### DIFF
--- a/tests/Unit/Core/AttachmentWireTest.php
+++ b/tests/Unit/Core/AttachmentWireTest.php
@@ -6,12 +6,37 @@ namespace Greenlight\Tests\Unit\Core;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Artifact\Attachment;
+use Greenlight\Core\Artifact\AttachmentKind;
 use Greenlight\Core\Artifact\AttachmentRetention;
 use Greenlight\Core\Artifact\StagedAttachment;
 use Greenlight\Expect\Expect;
 
 final class AttachmentWireTest
 {
+    #[Test]
+    public function explicitRetentionSurvivesTheWireRoundTrip(): void
+    {
+        $attachment = new Attachment(
+            name: 'response.json',
+            kind: AttachmentKind::Value,
+            mediaType: 'application/json',
+            sizeBytes: 2,
+            sha256: \str_repeat('a', 64),
+            attempt: 1,
+            path: 'build/artifacts/response.json',
+            retention: AttachmentRetention::Always,
+        );
+
+        $payload = $attachment->toWire();
+        $decoded = Attachment::fromWire($payload);
+
+        Expect::that($payload['retention'])
+            ->because('explicit attachment retention survives the wire round-trip')
+            ->toBe(AttachmentRetention::Always->value)
+            ->and($decoded)
+            ->toEqual($attachment);
+    }
+
     #[Test]
     public function payloadsWithoutRetentionUseTheBackwardCompatibleDefault(): void
     {


### PR DESCRIPTION
Adds focused wire coverage for explicit attachment retention. Verifies the serialized enum value and that decoding reconstructs the attachment unchanged, complementing the existing backward-compatible omission case.