### PR TITLE
test: cover optional constructor defaults

### DIFF
--- a/tests/Fixture/Runner/OptionalConstructorProbe.php
+++ b/tests/Fixture/Runner/OptionalConstructorProbe.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Runner;
+
+use Greenlight\Expect\Expect;
+
+final readonly class OptionalConstructorProbe
+{
+    public function __construct(private string $value = 'declared default') {}
+
+    public function usesDeclaredDefault(): void
+    {
+        Expect::that($this->value)
+            ->because('the worker uses optional built-in constructor defaults')
+            ->toBe('declared default');
+    }
+}

--- a/tests/Unit/Runner/WorkerTest.php
+++ b/tests/Unit/Runner/WorkerTest.php
@@ -32,6 +32,7 @@ use Greenlight\Tests\Fixture\Lifecycle\Services\ServiceProbe;
 use Greenlight\Tests\Fixture\Lifecycle\TemporalRetry\TemporalRetryTest;
 use Greenlight\Tests\Fixture\Lifecycle\TraceLog;
 use Greenlight\Tests\Fixture\Lifecycle\VerifyOnDispose\VerifyingProbe;
+use Greenlight\Tests\Fixture\Runner\OptionalConstructorProbe;
 use Greenlight\Tests\Fixture\Runner\UnsupportedConstructorProbe;
 use Greenlight\Tests\Support\CollectingEventSink;
 
@@ -152,6 +153,26 @@ final class WorkerTest
 
         Expect::that($results[0]->outcome)->because('unknown constructor dependencies error the test naming the type')->toBe(Outcome::Errored)
             ->and($results[0]->error?->message)->toContain('SplStack');
+    }
+
+    #[Test]
+    public function optionalBuiltInConstructorParametersUseTheirDefaults(): void
+    {
+        $id = new TestId(OptionalConstructorProbe::class, 'usesDeclaredDefault');
+        $plan = new ExecutionPlan([
+            new PlanEntry($id, new TestMetadata($id->class, $id->method)),
+        ]);
+        $sink = new CollectingEventSink();
+
+        new Worker($this->registry())->run($plan, $sink);
+
+        $result = $sink->results()[0];
+
+        Expect::that($result->outcome)
+            ->because('optional built-in constructor parameters use their defaults')
+            ->toBe(Outcome::Passed)
+            ->and($result->expectations)
+            ->toBe(1);
     }
 
     #[Test]


### PR DESCRIPTION
Adds a PSR-4 worker fixture with an optional built-in constructor parameter. The focused Worker test proves TestExecutor supplies its declared default and the fixture runs with a verified expectation.