### PR TITLE
test: cover profile report validation

### DIFF
--- a/tests/Acceptance/CommandErrorsTest.php
+++ b/tests/Acceptance/CommandErrorsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Acceptance;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Test\SkipTest;
 use Greenlight\Expect\Expect;
@@ -42,6 +43,59 @@ final readonly class CommandErrorsTest
         Expect::that($result->exitCode)->because('profile report with a missing input file fails cleanly')->toBe(1)
             ->and($result->output())->toContain('Greenlight could not read')
             ->toContain('nowhere.jsonl');
+    }
+
+    #[Test]
+    #[DataSet('invalidProfileStreams')]
+    public function profileReportRejectsInvalidEventStreams(
+        string $projectName,
+        string $stream,
+        string $message,
+    ): void {
+        $project = AcceptanceProject::create($this->tempDirectory, $projectName);
+        $project->writeFile('profile.jsonl', $stream);
+
+        $result = GreenlightCli::run($project->directory, [
+            'profile:report',
+            '--input=profile.jsonl',
+            '--no-ansi',
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('an invalid profile stream fails cleanly')
+            ->toBe(1)
+            ->and($result->output())
+            ->toContain($message);
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string, non-empty-string, non-empty-string}>
+     */
+    public static function invalidProfileStreams(): iterable
+    {
+        yield 'invalid JSON' => [
+            'profile-invalid-json',
+            '{',
+            'A line is not valid JSON.',
+        ];
+
+        yield 'invalid envelope' => [
+            'profile-invalid-envelope',
+            '{"event":7,"data":[]}',
+            'A line does not contain an event envelope.',
+        ];
+
+        yield 'invalid known event payload' => [
+            'profile-invalid-payload',
+            '{"event":"run-started","data":[]}',
+            'Greenlight could not decode a "run-started" event:',
+        ];
+
+        yield 'no finished run' => [
+            'profile-no-finished-run',
+            '{"event":"future-event","data":[]}',
+            'The stream has no finished run to profile.',
+        ];
     }
 
     #[Test]


### PR DESCRIPTION
Covers profile:report rejection of malformed JSON, invalid envelopes, malformed known events, and streams without a finished run. Each acceptance case verifies the command fails with its specific actionable diagnostic.