### PR TITLE
test: cover throwing condition evaluation

### DIFF
--- a/tests/Fixture/Condition/ThrowingCondition.php
+++ b/tests/Fixture/Condition/ThrowingCondition.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Condition;
+
+use Greenlight\Core\Condition;
+use Greenlight\Doubles\Fake;
+
+final class ThrowingCondition implements Condition, Fake
+{
+    #[\Override]
+    public function isSatisfied(): bool
+    {
+        throw new \RuntimeException('condition evaluation failed');
+    }
+}

--- a/tests/Unit/Runner/ConditionEvaluationTest.php
+++ b/tests/Unit/Runner/ConditionEvaluationTest.php
@@ -19,6 +19,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Harness\HarnessRegistry;
 use Greenlight\Plugin\PluginRegistry;
 use Greenlight\Runner\Worker\Worker;
+use Greenlight\Tests\Fixture\Condition\ThrowingCondition;
 use Greenlight\Tests\Fixture\Lifecycle\ConditionArguments\ConditionArgumentsTest;
 use Greenlight\Tests\Support\CollectingEventSink;
 
@@ -94,6 +95,11 @@ final class ConditionEvaluationTest
                 \stdClass::class,
                 Condition::class,
             ),
+        ];
+
+        yield 'throws while evaluating' => [
+            ThrowingCondition::class,
+            'condition evaluation failed',
         ];
     }
 


### PR DESCRIPTION
Covers runtime failures from a valid SkipUnless condition implementation. The PSR-4 fixture implements Fake, and the worker assertion verifies the original condition error becomes the test’s typed error result.