### PR TITLE
test: cover per-test disposal errors

### DIFF
--- a/tests/Fixture/Lifecycle/PerTestDisposeFails/FailingPerTestDisposal.php
+++ b/tests/Fixture/Lifecycle/PerTestDisposeFails/FailingPerTestDisposal.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Lifecycle\PerTestDisposeFails;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Harness\Disposable;
+
+final class FailingPerTestDisposal implements Disposable, Fake
+{
+    public function touch(): void {}
+
+    #[\Override]
+    public function dispose(): never
+    {
+        throw new \RuntimeException('per-test disposal broke');
+    }
+}

--- a/tests/Fixture/Lifecycle/PerTestDisposeFails/PerTestDisposeFailsTest.php
+++ b/tests/Fixture/Lifecycle/PerTestDisposeFails/PerTestDisposeFailsTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Lifecycle\PerTestDisposeFails;
+
+use Greenlight\Attribute\Test;
+
+final readonly class PerTestDisposeFailsTest
+{
+    public function __construct(private FailingPerTestDisposal $probe) {}
+
+    #[Test]
+    public function passesBeforeDisposal(): void
+    {
+        $this->probe->touch();
+    }
+}

--- a/tests/Unit/Runner/WorkerTest.php
+++ b/tests/Unit/Runner/WorkerTest.php
@@ -26,6 +26,7 @@ use Greenlight\Runner\Worker\WorkerBudget;
 use Greenlight\Tests\Fixture\LeakSuite\LeakyTest;
 use Greenlight\Tests\Fixture\Lifecycle\DisposeFails\FailingDisposalProbe;
 use Greenlight\Tests\Fixture\Lifecycle\Injection\InjectedProbe;
+use Greenlight\Tests\Fixture\Lifecycle\PerTestDisposeFails\FailingPerTestDisposal;
 use Greenlight\Tests\Fixture\Lifecycle\Retries\RetriesTest;
 use Greenlight\Tests\Fixture\Lifecycle\RetryFilter\RetryFilterTest;
 use Greenlight\Tests\Fixture\Lifecycle\Services\ServiceProbe;
@@ -254,6 +255,25 @@ final class WorkerTest
         Expect::that($results[0]->outcome)->because('class scope teardown failure is attributed to the last test')->toBe(Outcome::Passed)
             ->and($results[1]->outcome)->toBe(Outcome::Errored)
             ->and($results[1]->error?->message)->toBe('disposal broke');
+    }
+
+    #[Test]
+    public function perTestScopeTeardownFailureErrorsTheCurrentTest(): void
+    {
+        $registry = $this->registry();
+        $registry->register(new ServiceDefinition(
+            FailingPerTestDisposal::class,
+            Scope::PerTest,
+            static fn(): FailingPerTestDisposal => new FailingPerTestDisposal(),
+        ));
+
+        [, $results] = $this->runFixture('PerTestDisposeFails', $registry);
+
+        Expect::that($results[0]->outcome)
+            ->because('a per-test teardown failure is attributed to the current test')
+            ->toBe(Outcome::Errored)
+            ->and($results[0]->error?->message)
+            ->toBe('per-test disposal broke');
     }
 
     #[Test]


### PR DESCRIPTION
Covers attribution of a per-test service disposal failure to the current passing test. The new PSR-4 service fixture implements Fake, and the worker assertion verifies the failure becomes the test’s exact error result.