### PR TITLE
test: cover built-in CPU probing

### DIFF
--- a/tests/Unit/Runner/CpuCoresTest.php
+++ b/tests/Unit/Runner/CpuCoresTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\Subprocess;
+
+final class CpuCoresTest
+{
+    #[Test]
+    public function countUsesTheBuiltInProbeWithoutTheOptionalPackage(): void
+    {
+        $root = \dirname(__DIR__, 3);
+        $result = Subprocess::run($root, [
+            \PHP_BINARY,
+            '-n',
+            '-r',
+            <<<'PHP'
+            $source = $argv[1];
+
+            spl_autoload_register(static function (string $class) use ($source): void {
+                $prefix = 'Greenlight\\';
+
+                if (!str_starts_with($class, $prefix)) {
+                    return;
+                }
+
+                $path = $source . '/' . str_replace('\\', '/', substr($class, strlen($prefix))) . '.php';
+
+                if (is_file($path)) {
+                    require $path;
+                }
+            });
+
+            if (class_exists(\Fidry\CpuCoreCounter\CpuCoreCounter::class)) {
+                exit(2);
+            }
+
+            echo \Greenlight\Runner\CpuCores::count();
+            PHP,
+            $root . '/src',
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('the built-in CPU probe runs without the optional package')
+            ->toBe(0)
+            ->and($result->stdout)
+            ->because('the built-in CPU probe returns a positive integer')
+            ->toMatch('/^[1-9]\d*$/D');
+    }
+}


### PR DESCRIPTION
Covers the zero-runtime-dependency path for automatic worker sizing. The test starts an isolated PHP process with no configuration or Composer autoloader, confirms the optional CPU counter package is unavailable, and verifies that Greenlight’s built-in probe still returns a positive integer across Linux and Darwin.