### PR TITLE
test: cover worker control channel endings

### DIFF
--- a/tests/Unit/Runner/Worker/WorkerProcessTest.php
+++ b/tests/Unit/Runner/Worker/WorkerProcessTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Runner\Worker;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Attribute\Timeout;
 use Greenlight\Expect\Expect;
@@ -17,6 +18,40 @@ final class WorkerProcessTest
     #[Timeout(5.0)]
     public function itKeepsPollingAfterAnIdleReceiveTimesOut(): void
     {
+        [$workerExit, $serverExit] = $this->runScenario('idle-then-drain');
+
+        Expect::that($workerExit)->toBe(0)
+            ->and($serverExit)->toBe(0);
+    }
+
+    #[Test]
+    #[Timeout(5.0)]
+    #[DataSet('cleanControlChannelEndings')]
+    public function controlChannelEndingsStopTheWorkerCleanly(string $scenario): void
+    {
+        [$workerExit, $serverExit] = $this->runScenario($scenario);
+
+        Expect::that($workerExit)
+            ->because('a control-channel ending MUST stop the worker cleanly')
+            ->toBe(0)
+            ->and($serverExit)
+            ->toBe(0);
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function cleanControlChannelEndings(): iterable
+    {
+        yield 'orchestrator disconnect' => ['eof'];
+        yield 'unexpected message followed by drain' => ['unexpected-then-drain'];
+    }
+
+    /**
+     * @return array{int, int}
+     */
+    private function runScenario(string $scenario): array
+    {
         $root = \dirname(__DIR__, 4);
         $server = Subprocess::start($root, [
             \PHP_BINARY,
@@ -24,6 +59,7 @@ final class WorkerProcessTest
             <<<'PHP'
             require $argv[1];
 
+            $scenario = $argv[2];
             $socketPath = '/tmp/greenlight-worker-' . bin2hex(random_bytes(6)) . '.sock';
             register_shutdown_function(static fn() => @unlink($socketPath));
             $address = 'unix://' . $socketPath;
@@ -48,10 +84,23 @@ final class WorkerProcessTest
                 exit(4);
             }
 
-            usleep(100_000);
+            if ($scenario === 'eof') {
+                $channel->close();
+                exit(0);
+            }
+
+            if ($scenario === 'unexpected-then-drain') {
+                $channel->send(new Greenlight\Runner\Protocol\Messages\Hello('unexpected', 'token', 1));
+            } elseif ($scenario === 'idle-then-drain') {
+                usleep(100_000);
+            } else {
+                exit(5);
+            }
+
             $channel->send(new Greenlight\Runner\Protocol\Messages\Drain());
             PHP,
             $root . '/vendor/autoload.php',
+            $scenario,
         ]);
 
         try {
@@ -61,11 +110,10 @@ final class WorkerProcessTest
                 Fail::because('Worker protocol server did not publish its address.');
             }
 
-            $exitCode = new WorkerProcess(0.01)->run($address, 'worker-under-test', 'token');
+            $workerExit = new WorkerProcess(0.01)->run($address, 'worker-under-test', 'token');
             $serverResult = $server->wait(2.0);
 
-            Expect::that($exitCode)->toBe(0)
-                ->and($serverResult->exitCode)->toBe(0);
+            return [$workerExit, $serverResult->exitCode];
         } finally {
             $server->terminate();
         }


### PR DESCRIPTION
Cover clean worker shutdown when the orchestrator disconnects and when an unexpected control message precedes a drain request. The shared protocol-server helper also keeps the existing idle-polling scenario focused.