### PR TITLE
test: cover PCOV availability

### DIFF
--- a/tests/Unit/Coverage/PcovDriverTest.php
+++ b/tests/Unit/Coverage/PcovDriverTest.php
@@ -5,11 +5,37 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Coverage;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Coverage\CoverageError;
 use Greenlight\Coverage\Driver\PcovDriver;
 use Greenlight\Expect\Expect;
 
 final class PcovDriverTest
 {
+    #[Test]
+    public function availabilityMatchesTheExtensionAndMissingDriverIsActionable(): void
+    {
+        $available = \extension_loaded('pcov');
+
+        Expect::that(PcovDriver::isAvailable())
+            ->because('PCOV availability matches the loaded extension')
+            ->toBe($available);
+
+        if ($available) {
+            Expect::that(new PcovDriver())
+                ->because('an available PCOV extension permits driver construction')
+                ->toBeInstanceOf(PcovDriver::class);
+
+            return;
+        }
+
+        Expect::that(static fn(): PcovDriver => new PcovDriver())
+            ->because('a missing PCOV extension gives exact installation guidance')
+            ->toThrow(
+                CoverageError::class,
+                message: 'Coverage driver "pcov" is not available. Install and enable the pcov extension.',
+            );
+    }
+
     #[Test]
     public function reportsInvalidCollectionStateExactly(): void
     {


### PR DESCRIPTION
Covers PCOV driver availability and unavailable-driver construction. The environment-adaptive test always verifies that Greenlight agrees with PHP’s loaded-extension state and, when PCOV is absent, verifies the exact installation guidance.