### PR TITLE
test: cover one-shot leak reporting

### DIFF
--- a/tests/Unit/Runner/Worker/LeakDetectorTest.php
+++ b/tests/Unit/Runner/Worker/LeakDetectorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Worker;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\Worker\LeakDetector;
+
+final class LeakDetectorTest
+{
+    #[Test]
+    public function sweepDropsCollectedInstancesAndReportsRetainedInstancesOnce(): void
+    {
+        $detector = new LeakDetector();
+        $retainedId = new TestId('Example\RetainedTest', 'retainsItself');
+        $collectedId = new TestId('Example\CollectedTest', 'releasesItself');
+        $retained = new \stdClass();
+        $collected = new \stdClass();
+
+        $detector->watch($retainedId, $retained);
+        $detector->watch($collectedId, $collected);
+        unset($collected);
+
+        Expect::that($detector->sweep())
+            ->because('a sweep MUST report only instances that remain alive')
+            ->toBe([$retainedId])
+            ->and($detector->sweep())
+            ->because('a leak MUST be reported one time')
+            ->toBe([]);
+    }
+}


### PR DESCRIPTION
Cover the leak detector contract directly. The test verifies collected instances are dropped, retained instances are reported, and a later sweep does not report the same leak again.