### PR TITLE
test: cover Xdebug availability

### DIFF
--- a/tests/Unit/Coverage/XdebugDriverTest.php
+++ b/tests/Unit/Coverage/XdebugDriverTest.php
@@ -6,6 +6,7 @@ namespace Greenlight\Tests\Unit\Coverage;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Test\SkipTest;
+use Greenlight\Coverage\CoverageError;
 use Greenlight\Coverage\CoverageMap;
 use Greenlight\Coverage\Driver\XdebugDriver;
 use Greenlight\Coverage\PathFilter;
@@ -14,6 +15,33 @@ use Greenlight\Tests\Fixture\Coverage\Adder;
 
 final class XdebugDriverTest
 {
+    #[Test]
+    public function availabilityMatchesTheActiveModesAndMissingCoverageModeIsActionable(): void
+    {
+        $available = \extension_loaded('xdebug')
+            && \in_array('coverage', $this->activeXdebugModes(), true);
+
+        Expect::that(XdebugDriver::isAvailable())
+            ->because('Xdebug availability matches the active extension modes')
+            ->toBe($available);
+
+        if ($available) {
+            Expect::that(new XdebugDriver())
+                ->because('an active Xdebug coverage mode permits driver construction')
+                ->toBeInstanceOf(XdebugDriver::class);
+
+            return;
+        }
+
+        Expect::that(static fn(): XdebugDriver => new XdebugDriver())
+            ->because('an inactive Xdebug coverage mode gives exact configuration guidance')
+            ->toThrow(
+                CoverageError::class,
+                message: 'Coverage driver "xdebug" is not available. Enable the Xdebug extension. '
+                . 'Add "coverage" to xdebug.mode or the XDEBUG_MODE environment variable.',
+            );
+    }
+
     #[Test]
     public function reportsInvalidCollectionStateExactly(): void
     {
@@ -61,5 +89,25 @@ final class XdebugDriverTest
 
         Expect::that($file->coveredLines)->because('collects real line coverage over the fixture')->toContain(Adder::ADD_RETURN_LINE)
             ->and($file->uncoveredLines)->not()->toContain(Adder::ADD_RETURN_LINE);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function activeXdebugModes(): array
+    {
+        if (\function_exists('xdebug_info')) {
+            $modes = \xdebug_info('mode');
+
+            if (\is_array($modes)) {
+                return \array_values(\array_filter($modes, \is_string(...)));
+            }
+        }
+
+        $ini = \ini_get('xdebug.mode');
+
+        return \is_string($ini) && $ini !== ''
+            ? \array_map(\trim(...), \explode(',', $ini))
+            : [];
     }
 }


### PR DESCRIPTION
Covers Xdebug driver availability and construction across active modes. The environment-adaptive test always verifies that Greenlight agrees with the active extension modes, constructs the driver when coverage is active, and otherwise verifies the exact configuration guidance.