### PR TITLE
test: cover missing doubles working directory

### DIFF
--- a/tests/Unit/Doubles/DoublesWorkingDirectoryTest.php
+++ b/tests/Unit/Doubles/DoublesWorkingDirectoryTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\DoublesError;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class DoublesWorkingDirectoryTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function missingWorkingDirectoryGivesExactGuidance(): void
+    {
+        $original = \getcwd();
+
+        if (!\is_string($original)) {
+            Fail::because('Expected the test process to start in a working directory.');
+        }
+
+        $deleted = $this->tempDirectory->subdirectory('deleted-working-directory');
+
+        try {
+            Expect::that(\chdir($deleted))
+                ->because('the test enters its temporary directory')
+                ->toBeTrue();
+            Expect::that(\rmdir($deleted))
+                ->because('the current temporary directory can be removed')
+                ->toBeTrue();
+            Expect::that(static fn(): Doubles => new Doubles())
+                ->because('the default proxy directory needs a current working directory')
+                ->toThrow(
+                    DoublesError::class,
+                    message: 'Doubles could not resolve the working directory. Pass a proxy directory explicitly.',
+                );
+        } finally {
+            \chdir($original);
+        }
+    }
+}


### PR DESCRIPTION
Adds focused coverage for constructing Doubles after its current working directory disappears. The test keeps the mutation inside TempDirectory, restores the original directory, and locks the public recovery guidance to its exact diagnostic.