### PR TITLE
test: cover unknown double types

### DIFF
--- a/tests/Unit/Doubles/UnknownDoubleTypeTest.php
+++ b/tests/Unit/Doubles/UnknownDoubleTypeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\DoublesError;
+use Greenlight\Expect\Expect;
+
+final class UnknownDoubleTypeTest
+{
+    #[Test]
+    public function unknownTypesGiveExactGuidance(): void
+    {
+        $doubles = new Doubles();
+        $mock = new \ReflectionMethod(Doubles::class, 'mock');
+
+        Expect::that(static fn(): mixed => $mock->invoke($doubles, 'Example\MissingContract'))
+            ->because('a double needs a loadable class or interface')
+            ->toThrow(
+                DoublesError::class,
+                message: 'Doubles cannot load Example\MissingContract as a class or interface.',
+            );
+    }
+}


### PR DESCRIPTION
Adds focused coverage for Doubles::mock() receiving a class or interface name that cannot be loaded. The test uses the public method through reflection so it can exercise runtime validation without weakening the production class-string contract, and it locks the recovery guidance to its exact diagnostic.