### PR TITLE
test: cover lazy Laravel before hook

### DIFF
--- a/tests/Unit/Laravel/LaravelPluginTest.php
+++ b/tests/Unit/Laravel/LaravelPluginTest.php
@@ -105,6 +105,23 @@ final class LaravelPluginTest
     }
 
     #[Test]
+    public function beforeTestPreservesLazyApplicationBoot(): void
+    {
+        $factoryCalled = false;
+        $plugin = new LaravelPlugin(static function () use (&$factoryCalled): Application {
+            $factoryCalled = true;
+
+            Fail::because('LaravelPlugin::beforeTest() MUST NOT boot the application.');
+        });
+
+        $plugin->beforeTest($this->context());
+
+        Expect::that($factoryCalled)
+            ->because('the application remains lazy during beforeTest()')
+            ->toBeFalse();
+    }
+
+    #[Test]
     public function anUnknownExplicitIdFailsLoudly(): void
     {
         $plugin = $this->plugin();


### PR DESCRIPTION
Adds focused coverage for LaravelPlugin::beforeTest(). The public lifecycle callback now has a regression test proving it does not invoke the application factory, preserving lazy framework boot until a service is needed.