### PR TITLE
test: cover lazy Symfony before hook

### DIFF
--- a/tests/Unit/Symfony/SymfonyPluginTest.php
+++ b/tests/Unit/Symfony/SymfonyPluginTest.php
@@ -207,6 +207,23 @@ final class SymfonyPluginTest
     }
 
     #[Test]
+    public function beforeTestPreservesLazyKernelBoot(): void
+    {
+        $factoryCalled = false;
+        $plugin = new SymfonyPlugin(static function () use (&$factoryCalled): KernelInterface {
+            $factoryCalled = true;
+
+            Fail::because('SymfonyPlugin::beforeTest() MUST NOT boot the kernel.');
+        });
+
+        $plugin->beforeTest($this->context());
+
+        Expect::that($factoryCalled)
+            ->because('the kernel remains lazy during beforeTest()')
+            ->toBeFalse();
+    }
+
+    #[Test]
     public function afterTestWithoutABootedKernelIsANoOp(): void
     {
         $booted = false;


### PR DESCRIPTION
Adds focused coverage for SymfonyPlugin::beforeTest(). The public lifecycle callback now has a regression test that proves it does not invoke the kernel factory, which preserves lazy framework boot until a service is needed.