### PR TITLE
test: cover PHPUnit attribute mappings

### DIFF
--- a/tests/Unit/Rector/PhpUnitAttributesTest.php
+++ b/tests/Unit/Rector/PhpUnitAttributesTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Rector;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Group;
+use Greenlight\Attribute\Isolated;
+use Greenlight\Attribute\NoExpectations;
+use Greenlight\Attribute\Test;
+use Greenlight\Condition\ExtensionLoaded;
+use Greenlight\Condition\OperatingSystemFamily;
+use Greenlight\Expect\Expect;
+use Greenlight\Rector\PhpUnitAttributes;
+
+final class PhpUnitAttributesTest
+{
+    #[Test]
+    public function conversionTablesDescribeTheSupportedPhpUnitAttributesExactly(): void
+    {
+        Expect::that(PhpUnitAttributes::RENAMES)
+            ->because('the Rector MUST preserve the supported PHPUnit attribute semantics')
+            ->toBe([
+                'DataProvider' => DataSet::class,
+                'Group' => Group::class,
+                'Ticket' => Group::class,
+                'RunInSeparateProcess' => Isolated::class,
+                'RunTestsInSeparateProcesses' => Isolated::class,
+                'DoesNotPerformAssertions' => NoExpectations::class,
+            ])
+            ->and(PhpUnitAttributes::SIZE_GROUPS)
+            ->toBe([
+                'Small' => 'small',
+                'Medium' => 'medium',
+                'Large' => 'large',
+            ])
+            ->and(PhpUnitAttributes::SKIP_UNLESS_CONDITIONS)
+            ->toBe([
+                'RequiresPhpExtension' => ExtensionLoaded::class,
+                'RequiresOperatingSystemFamily' => OperatingSystemFamily::class,
+            ])
+            ->and(PhpUnitAttributes::STRUCTURAL)
+            ->toBe(['Test', 'Before', 'After'])
+            ->and(PhpUnitAttributes::TEST_WITH)
+            ->toBe('TestWith');
+    }
+
+    #[Test]
+    public function onlyInertPhpUnitAttributesAreDropped(): void
+    {
+        Expect::that(PhpUnitAttributes::DROPS)
+            ->because('the Rector MUST drop only PHPUnit metadata without Greenlight runtime behavior')
+            ->toBe([
+                'CoversClass',
+                'CoversFunction',
+                'CoversMethod',
+                'CoversNothing',
+                'CoversTrait',
+                'UsesClass',
+                'UsesFunction',
+                'UsesMethod',
+                'UsesTrait',
+                'TestDox',
+                'DisableReturnValueGenerationForTestDoubles',
+            ]);
+    }
+}


### PR DESCRIPTION
Pin the Rector attribute conversion tables that define supported PHPUnit migration behavior. The focused tests cover renames, size groups, requirements, structural attributes, TestWith handling, and the exact inert metadata drop list.