### PR TITLE
test: cover matcher map provider caching

### DIFF
--- a/tests/Unit/PhpStan/MatcherMapProviderTest.php
+++ b/tests/Unit/PhpStan/MatcherMapProviderTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\PhpStan;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\PhpStan\MatcherMapProvider;
+
+final class MatcherMapProviderTest
+{
+    #[Test]
+    public function oneMatcherMapIsSharedAcrossEveryConsumer(): void
+    {
+        $provider = new MatcherMapProvider([]);
+        $first = $provider->get();
+
+        Expect::that($provider->get())
+            ->because('PHPStan extensions MUST share one lazily loaded matcher map')
+            ->toBe($first)
+            ->and($first->names())
+            ->toBe([]);
+    }
+}


### PR DESCRIPTION
Cover the shared matcher-map provider through its public API. The focused test verifies that all PHPStan extension consumers receive the same lazily loaded map instead of reloading configuration.