### PR TITLE
test: cover native PHPStan matcher types

### DIFF
--- a/tests/Acceptance/PhpStanExtensionTest.php
+++ b/tests/Acceptance/PhpStanExtensionTest.php
@@ -54,6 +54,57 @@ final readonly class PhpStanExtensionTest
     }
 
     #[Test]
+    public function nativeMatcherTypesKeepNullableUnionAndIntersectionShapes(): void
+    {
+        $root = \dirname(__DIR__, 2);
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Expect\Expect;
+            use Greenlight\Tests\Fixture\PhpStanNativeType\SerializableString;
+
+            function greenlightGoodNativeTypeProbe(): void
+            {
+                Expect::that(null)->toAcceptNullableDateTime();
+                Expect::that(new DateTimeImmutable())->toAcceptNullableDateTime();
+                Expect::that(1)->toAcceptIntegerOrString();
+                Expect::that('one')->toAcceptIntegerOrString();
+                Expect::that(new SerializableString())->toAcceptSerializableString();
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Expect\Expect;
+
+            function greenlightBadNativeTypeProbe(): void
+            {
+                Expect::that(1)->toAcceptNullableDateTime();
+                Expect::that([])->toAcceptIntegerOrString();
+                Expect::that(new stdClass())->toAcceptSerializableString();
+            }
+            PHP,
+            $root . '/tests/Fixture/PhpStanNativeType/probe.neon',
+        );
+
+        Expect::that($probe->exitCode)
+            ->because('native matcher types keep nullable union and intersection shapes')
+            ->toBe(1)
+            ->and($probe->goodPassed)->toBeTrue()
+            ->and($probe->errors)->toBe([
+                'Extension matcher toAcceptNullableDateTime() requires subject type DateTimeInterface|null, but the subject has type int.',
+                'Extension matcher toAcceptIntegerOrString() requires subject type int|string, but the subject has type array.',
+                'Extension matcher toAcceptSerializableString() requires subject type JsonSerializable&Stringable, but the subject has type stdClass.',
+            ]);
+    }
+
+    #[Test]
     public function matcherSubjectTypesFollowFluentChains(): void
     {
         $probe = PhpStanProbe::analyze(

--- a/tests/Fixture/PhpStanNativeType/NativeTypeExtension.php
+++ b/tests/Fixture/PhpStanNativeType/NativeTypeExtension.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\PhpStanNativeType;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Expect\ExpectationExtension;
+
+final class NativeTypeExtension implements ExpectationExtension, Fake
+{
+    #[\Override]
+    public function matchers(): array
+    {
+        return [
+            'toAcceptNullableDateTime' => static fn(?\DateTimeInterface $subject): bool => true,
+            'toAcceptIntegerOrString' => static fn(int|string $subject): bool => true,
+            'toAcceptSerializableString' => static fn(\JsonSerializable&\Stringable $subject): bool => true,
+        ];
+    }
+}

--- a/tests/Fixture/PhpStanNativeType/SerializableString.php
+++ b/tests/Fixture/PhpStanNativeType/SerializableString.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\PhpStanNativeType;
+
+use Greenlight\Doubles\Fake;
+
+final class SerializableString implements \JsonSerializable, \Stringable, Fake
+{
+    #[\Override]
+    public function jsonSerialize(): string
+    {
+        return (string) $this;
+    }
+
+    #[\Override]
+    public function __toString(): string
+    {
+        return '';
+    }
+}

--- a/tests/Fixture/PhpStanNativeType/greenlight.php
+++ b/tests/Fixture/PhpStanNativeType/greenlight.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Tests\Fixture\PhpStanNativeType\NativeTypeExtension;
+
+return GreenlightConfig::create()
+    ->paths([__DIR__ . '/../DiscoveryBasic'])
+    ->plugins(new NativeTypeExtension());

--- a/tests/Fixture/PhpStanNativeType/probe.neon
+++ b/tests/Fixture/PhpStanNativeType/probe.neon
@@ -1,0 +1,8 @@
+includes:
+    - ../../../extension.neon
+
+parameters:
+    level: max
+    greenlight:
+        configFiles:
+            - tests/Fixture/PhpStanNativeType/greenlight.php

--- a/tests/Support/PhpStanProbe.php
+++ b/tests/Support/PhpStanProbe.php
@@ -24,8 +24,10 @@ final readonly class PhpStanProbe
         TempDirectory $workspace,
         string $goodSource,
         string $badSource,
+        ?string $configFile = null,
     ): self {
         $root = \dirname(__DIR__, 2);
+        $configFile ??= $root . '/tests/Fixture/PhpStanExtension/probe.neon';
         $probeDirectory = $workspace->subdirectory('phpstan-probe');
         $goodFile = $probeDirectory . '/GoodProbe.php';
         $badFile = $probeDirectory . '/BadProbe.php';
@@ -42,7 +44,7 @@ final readonly class PhpStanProbe
                 '--no-progress',
                 '--error-format=json',
                 '-c',
-                $root . '/tests/Fixture/PhpStanExtension/probe.neon',
+                $configFile,
                 $goodFile,
                 $badFile,
             ],


### PR DESCRIPTION
Adds a supported PHPStan CLI integration fixture for extension matchers with nullable object, union, and intersection subject types. The acceptance probe verifies valid subjects and exact diagnostics for incompatible subjects without relying on PHPStan internal APIs.