### PR TITLE
test: cover repeated suite configuration

### DIFF
--- a/tests/Unit/Config/SuiteBuilderTest.php
+++ b/tests/Unit/Config/SuiteBuilderTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Config;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\SuiteBuilder;
+use Greenlight\Expect\Expect;
+
+final class SuiteBuilderTest
+{
+    #[Test]
+    public function repeatedCallsAccumulatePathsAndTagsInDeclarationOrder(): void
+    {
+        $suite = new SuiteBuilder('integration')
+            ->in('tests/Integration')
+            ->in('tests/Browser', 'tests/Smoke')
+            ->tag('io')
+            ->tag('slow', 'external')
+            ->toConfiguration();
+
+        Expect::that($suite->paths)
+            ->because('repeated in() calls append each path')
+            ->toBe(['tests/Integration', 'tests/Browser', 'tests/Smoke']);
+        Expect::that($suite->tags)
+            ->because('repeated tag() calls append each tag')
+            ->toBe(['io', 'slow', 'external']);
+    }
+}


### PR DESCRIPTION
Adds focused coverage for repeated SuiteBuilder calls. The test locks in that in() and tag() append every supplied value and preserve declaration order across separate fluent calls.