### PR TITLE
test: cover signal handler fallback

### DIFF
--- a/src/Cli/SignalHandlers.php
+++ b/src/Cli/SignalHandlers.php
@@ -21,21 +21,25 @@ final class SignalHandlers
     /** @codeCoverageIgnore */
     private function __construct() {}
 
-    public static function install(GracefulShutdown $shutdown): void
-    {
-        if (!\function_exists('pcntl_signal') || !\function_exists('pcntl_async_signals')) {
+    public static function install(
+        GracefulShutdown $shutdown,
+        ?SignalOperations $operations = null,
+    ): void {
+        $operations ??= new SystemSignalOperations();
+
+        if (!$operations->available()) {
             return;
         }
 
-        \pcntl_async_signals(true);
+        $operations->enableAsync();
 
-        $handler = static function (int $signal) use ($shutdown): void {
+        $handler = static function (int $signal) use ($shutdown, $operations): void {
             $shutdown->request($signal);
-            \pcntl_signal(\SIGINT, \SIG_DFL);
-            \pcntl_signal(\SIGTERM, \SIG_DFL);
+            $operations->register(\SIGINT, \SIG_DFL);
+            $operations->register(\SIGTERM, \SIG_DFL);
         };
 
-        \pcntl_signal(\SIGINT, $handler);
-        \pcntl_signal(\SIGTERM, $handler);
+        $operations->register(\SIGINT, $handler);
+        $operations->register(\SIGTERM, $handler);
     }
 }

--- a/src/Cli/SignalOperations.php
+++ b/src/Cli/SignalOperations.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli;
+
+/**
+ * Provides process signal operations to SignalHandlers.
+ *
+ * @internal
+ */
+interface SignalOperations
+{
+    public function available(): bool;
+
+    public function enableAsync(): void;
+
+    public function register(int $signal, callable|int $handler): void;
+}

--- a/src/Cli/SystemSignalOperations.php
+++ b/src/Cli/SystemSignalOperations.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli;
+
+/** @internal */
+final readonly class SystemSignalOperations implements SignalOperations
+{
+    #[\Override]
+    public function available(): bool
+    {
+        return \function_exists('pcntl_signal') && \function_exists('pcntl_async_signals');
+    }
+
+    #[\Override]
+    public function enableAsync(): void
+    {
+        \pcntl_async_signals(true);
+    }
+
+    #[\Override]
+    public function register(int $signal, callable|int $handler): void
+    {
+        \pcntl_signal($signal, $handler);
+    }
+}

--- a/tests/Fixture/Cli/RecordingSignalOperations.php
+++ b/tests/Fixture/Cli/RecordingSignalOperations.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Cli;
+
+use Greenlight\Cli\SignalOperations;
+use Greenlight\Doubles\Fake;
+
+final class RecordingSignalOperations implements SignalOperations, Fake
+{
+    public bool $asyncEnabled = false;
+
+    /**
+     * @var list<array{signal: int, handler: callable|int}>
+     */
+    public array $registrations = [];
+
+    public function __construct(private readonly bool $available) {}
+
+    #[\Override]
+    public function available(): bool
+    {
+        return $this->available;
+    }
+
+    #[\Override]
+    public function enableAsync(): void
+    {
+        $this->asyncEnabled = true;
+    }
+
+    #[\Override]
+    public function register(int $signal, callable|int $handler): void
+    {
+        $this->registrations[] = [
+            'signal' => $signal,
+            'handler' => $handler,
+        ];
+    }
+}

--- a/tests/Unit/Cli/SignalHandlersTest.php
+++ b/tests/Unit/Cli/SignalHandlersTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\SignalHandlers;
+use Greenlight\Core\GracefulShutdown;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Tests\Fixture\Cli\RecordingSignalOperations;
+
+final class SignalHandlersTest
+{
+    #[Test]
+    public function unavailableSignalOperationsAreAStrictNoOp(): void
+    {
+        $operations = new RecordingSignalOperations(available: false);
+        $shutdown = new GracefulShutdown();
+
+        SignalHandlers::install($shutdown, $operations);
+
+        Expect::that($operations->asyncEnabled)
+            ->because('unavailable signal operations do not enable asynchronous signals')
+            ->toBeFalse()
+            ->and($operations->registrations)
+            ->because('unavailable signal operations do not register handlers')
+            ->toBe([])
+            ->and($shutdown->requested())->toBeFalse();
+    }
+
+    #[Test]
+    public function theFirstSignalRequestsShutdownAndRestoresDefaultHandlers(): void
+    {
+        $operations = new RecordingSignalOperations(available: true);
+        $shutdown = new GracefulShutdown();
+
+        SignalHandlers::install($shutdown, $operations);
+
+        Expect::that($operations->asyncEnabled)
+            ->because('available signal operations enable asynchronous signals')
+            ->toBeTrue()
+            ->and(\array_column($operations->registrations, 'signal'))
+            ->because('SIGINT and SIGTERM handlers are registered')
+            ->toBe([\SIGINT, \SIGTERM]);
+
+        $handler = $operations->registrations[0]['handler'] ?? null;
+
+        if (!\is_callable($handler)) {
+            Fail::because('Expected SignalHandlers to register a callable for SIGINT.');
+        }
+
+        $handler(\SIGTERM);
+
+        Expect::that($shutdown->requested())
+            ->because('the first signal requests graceful shutdown')
+            ->toBeTrue()
+            ->and($shutdown->exitCode())->toBe(128 + \SIGTERM)
+            ->and($operations->registrations[2] ?? null)
+            ->because('the first signal restores the default SIGINT handler')
+            ->toBe(['signal' => \SIGINT, 'handler' => \SIG_DFL])
+            ->and($operations->registrations[3] ?? null)
+            ->because('the first signal restores the default SIGTERM handler')
+            ->toBe(['signal' => \SIGTERM, 'handler' => \SIG_DFL]);
+    }
+}


### PR DESCRIPTION
Introduces a small internal signal-operations boundary so SignalHandlers can be verified without changing real process handlers. The focused tests prove missing PCNTL is a strict no-op and that an available handler requests graceful shutdown before resetting SIGINT and SIGTERM to their defaults. The recording fixture follows PSR-4 and implements Fake.