### PR TITLE
test: cover active error handler preservation

### DIFF
--- a/tests/Unit/Capture/OutputCaptureTest.php
+++ b/tests/Unit/Capture/OutputCaptureTest.php
@@ -121,6 +121,34 @@ final class OutputCaptureTest
     }
 
     #[Test]
+    public function stopPreservesAnErrorHandlerInstalledDuringCapture(): void
+    {
+        $baselineHandler = self::activeErrorHandler();
+        $messages = [];
+        $capture = new OutputCapture();
+        $capture->start();
+
+        \set_error_handler(
+            static function (int $severity, string $message) use (&$messages): bool {
+                $messages[] = [$severity, $message];
+
+                return true;
+            },
+        );
+
+        try {
+            $capture->stop();
+            \trigger_error('after capture', \E_USER_NOTICE);
+
+            Expect::that($messages)
+                ->because('stop preserves an error handler installed during capture')
+                ->toBe([[\E_USER_NOTICE, 'after capture']]);
+        } finally {
+            self::restoreErrorHandler($baselineHandler);
+        }
+    }
+
+    #[Test]
     public function truncationKeepsTheHeadAndSetsTheFlag(): void
     {
         $capture = new OutputCapture(maxStdoutBytes: 8);
@@ -258,5 +286,27 @@ final class OutputCaptureTest
     {
         Expect::that(static fn(): OutputCapture => new OutputCapture(maxDiagnostics: 0))->because('a nonpositive diagnostics bound is rejected')
             ->toThrow(\InvalidArgumentException::class, '/at least 1 entry/');
+    }
+
+    private static function activeErrorHandler(): ?callable
+    {
+        $probe = static fn(): bool => false;
+        $active = \set_error_handler($probe);
+        \restore_error_handler();
+
+        return $active;
+    }
+
+    private static function restoreErrorHandler(?callable $baseline): void
+    {
+        for ($attempt = 0; $attempt < 4; ++$attempt) {
+            if (self::activeErrorHandler() === $baseline) {
+                return;
+            }
+
+            \restore_error_handler();
+        }
+
+        throw new \RuntimeException('Failed to restore the test error-handler stack.');
     }
 }

--- a/tests/Unit/Capture/OutputCaptureTest.php
+++ b/tests/Unit/Capture/OutputCaptureTest.php
@@ -123,7 +123,7 @@ final class OutputCaptureTest
     #[Test]
     public function stopPreservesAnErrorHandlerInstalledDuringCapture(): void
     {
-        $baselineHandler = self::activeErrorHandler();
+        $baselineHandler = $this->activeErrorHandler();
         $messages = [];
         $capture = new OutputCapture();
         $capture->start();
@@ -144,7 +144,7 @@ final class OutputCaptureTest
                 ->because('stop preserves an error handler installed during capture')
                 ->toBe([[\E_USER_NOTICE, 'after capture']]);
         } finally {
-            self::restoreErrorHandler($baselineHandler);
+            $this->restoreErrorHandler($baselineHandler);
         }
     }
 
@@ -288,7 +288,7 @@ final class OutputCaptureTest
             ->toThrow(\InvalidArgumentException::class, '/at least 1 entry/');
     }
 
-    private static function activeErrorHandler(): ?callable
+    private function activeErrorHandler(): ?callable
     {
         $probe = static fn(): bool => false;
         $active = \set_error_handler($probe);
@@ -297,10 +297,10 @@ final class OutputCaptureTest
         return $active;
     }
 
-    private static function restoreErrorHandler(?callable $baseline): void
+    private function restoreErrorHandler(?callable $baseline): void
     {
         for ($attempt = 0; $attempt < 4; ++$attempt) {
-            if (self::activeErrorHandler() === $baseline) {
+            if ($this->activeErrorHandler() === $baseline) {
                 return;
             }
 


### PR DESCRIPTION
Adds focused coverage for OutputCapture’s documented error-handler ownership boundary. The test installs a user handler during capture, proves stop() leaves it active, and restores the nested handler stack to its original baseline in a finally block.