### PR TITLE
fix: reject truncated frames at peer EOF

### DIFF
--- a/src/Runner/Protocol/FrameBuffer.php
+++ b/src/Runner/Protocol/FrameBuffer.php
@@ -24,6 +24,11 @@ final class FrameBuffer
         $this->buffer .= $bytes;
     }
 
+    public function hasPendingBytes(): bool
+    {
+        return $this->buffer !== '';
+    }
+
     /**
      * @return non-empty-string|null the next complete frame body, or null when more bytes are needed
      *

--- a/src/Runner/Protocol/SocketChannel.php
+++ b/src/Runner/Protocol/SocketChannel.php
@@ -128,6 +128,10 @@ final class SocketChannel
         }
 
         if ($this->eof) {
+            if ($this->buffer->hasPendingBytes()) {
+                throw ProtocolError::malformedFrame('peer closed the connection with an incomplete frame');
+            }
+
             return null;
         }
 
@@ -158,6 +162,10 @@ final class SocketChannel
         $body = $this->buffer->next();
 
         if ($body === null) {
+            if ($this->eof && $this->buffer->hasPendingBytes()) {
+                throw ProtocolError::malformedFrame('peer closed the connection with an incomplete frame');
+            }
+
             return null;
         }
 

--- a/tests/Unit/Runner/Protocol/SocketChannelTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelTest.php
@@ -14,6 +14,35 @@ use Greenlight\Runner\Protocol\SocketChannel;
 final class SocketChannelTest
 {
     #[Test]
+    public function peerEofRejectsAnIncompleteFrame(): void
+    {
+        [$stream, $peer] = $this->socketPair();
+        $channel = new SocketChannel($stream);
+
+        try {
+            \fwrite($peer, \pack('N', 10) . 'abc');
+            \fclose($peer);
+
+            Expect::that($channel->poll())
+                ->because('the first poll reads the incomplete frame')
+                ->toBeNull();
+
+            Expect::that(static fn(): mixed => $channel->poll())
+                ->because('peer EOF MUST reject an incomplete frame')
+                ->toThrow(
+                    ProtocolError::class,
+                    message: 'Malformed frame: peer closed the connection with an incomplete frame.',
+                );
+        } finally {
+            $channel->close();
+
+            if (\is_resource($peer)) {
+                \fclose($peer);
+            }
+        }
+    }
+
+    #[Test]
     public function anExternallyClosedStreamEndsPollingAndRejectsWrites(): void
     {
         [$stream, $peer] = $this->socketPair();


### PR DESCRIPTION
## Summary

- reject a partial protocol frame when the peer closes the socket
- preserve clean EOF and complete buffered-frame behavior
- cover the truncated-frame boundary with a deterministic socket-pair regression test