### PR TITLE
test: cover watch debounce configuration

### DIFF
--- a/tests/Unit/Config/WatchBuilderTest.php
+++ b/tests/Unit/Config/WatchBuilderTest.php
@@ -12,6 +12,20 @@ use Greenlight\Expect\Expect;
 final class WatchBuilderTest
 {
     #[Test]
+    public function buildsTheDefaultAndConfiguredDebounce(): void
+    {
+        $default = new WatchBuilder()->toConfiguration();
+        $configured = new WatchBuilder()->debounceMilliseconds(750)->toConfiguration();
+
+        Expect::that($default->debounceMilliseconds)
+            ->because('watch mode MUST have a stable default debounce')
+            ->toBe(200)
+            ->and($configured->debounceMilliseconds)
+            ->because('the configured debounce MUST reach watch mode')
+            ->toBe(750);
+    }
+
+    #[Test]
     public function theDebounceMustBePositive(): void
     {
         foreach ([0, -1] as $milliseconds) {


### PR DESCRIPTION
Covers both the stable default watch debounce and propagation of an explicitly configured debounce into WatchConfiguration.