### PR TITLE
test: cover object default proxy rejection

### DIFF
--- a/tests/Fixture/Doubles/ObjectDefault.php
+++ b/tests/Fixture/Doubles/ObjectDefault.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+interface ObjectDefault
+{
+    public function run(\stdClass $value = new \stdClass()): void;
+}

--- a/tests/Unit/Doubles/ObjectDefaultTest.php
+++ b/tests/Unit/Doubles/ObjectDefaultTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\DoublesError;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Fixture\Doubles\ObjectDefault;
+
+final readonly class ObjectDefaultTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function objectDefaultsAreRejectedBeforeGeneratingAnInvalidProxy(): void
+    {
+        $doubles = new Doubles($this->tempDirectory->path() . '/proxies');
+
+        try {
+            Expect::that(static fn(): object => $doubles->stub(ObjectDefault::class))
+                ->because('an object default cannot be reproduced in generated proxy source')
+                ->toThrow(
+                    DoublesError::class,
+                    message: 'Doubles cannot reproduce the object default of parameter $value from '
+                        . ObjectDefault::class
+                        . '::run() in a proxy. Use an interface without object defaults instead.',
+                );
+        } finally {
+            $doubles->dispose();
+        }
+    }
+}


### PR DESCRIPTION
Adds focused coverage for the proxy generator’s object-default safety boundary. A PSR-4 contract fixture uses a constructor expression as a parameter default, and the test verifies that Greenlight rejects it with the exact actionable diagnostic before emitting unusable proxy source.