### PR TITLE
test: cover stalled polling clocks

### DIFF
--- a/tests/Fixture/Expect/StalledPollingClock.php
+++ b/tests/Fixture/Expect/StalledPollingClock.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Expect;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Expect\PollingClock;
+
+final class StalledPollingClock implements PollingClock, Fake
+{
+    #[\Override]
+    public function now(): float
+    {
+        return 0.0;
+    }
+
+    #[\Override]
+    public function sleep(float $seconds): void {}
+}

--- a/tests/Unit/Expect/PollingClockStallTest.php
+++ b/tests/Unit/Expect/PollingClockStallTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\ExpectationRuntime;
+use Greenlight\Tests\Fixture\Expect\StalledPollingClock;
+
+final class PollingClockStallTest
+{
+    #[Test]
+    public function aStalledClockCannotCauseAnUnlimitedWait(): void
+    {
+        Expect::that(static function (): void {
+            ExpectationRuntime::withClock(
+                new StalledPollingClock(),
+                static fn() => Expect::eventually(static fn(): string => 'pending')
+                    ->pollEvery(0.010)
+                    ->within(0.100)
+                    ->toBe('ready'),
+            );
+        })
+            ->because('a stalled polling clock MUST fail instead of waiting without a limit')
+            ->toThrow(
+                \LogicException::class,
+                message: 'The polling clock did not advance during sleep.',
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- add a test fake whose monotonic time cannot advance
- verify that temporal polling fails with the exact diagnostic instead of waiting without a limit
- keep the regression independent of wall-clock timing