### PR TITLE
test: cover temporary clock restoration

### DIFF
--- a/tests/Unit/Expect/ExpectationRuntimeTest.php
+++ b/tests/Unit/Expect/ExpectationRuntimeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\ExpectationRuntime;
+use Greenlight\Tests\Fixture\Expect\FakePollingClock;
+
+final class ExpectationRuntimeTest
+{
+    #[Test]
+    public function nestedClockIsRestoredAfterTheOperationThrows(): void
+    {
+        $baseline = ExpectationRuntime::clock();
+        $outer = new FakePollingClock();
+        $inner = new FakePollingClock();
+        $expected = new \RuntimeException('clock operation failed');
+
+        [$thrown, $afterInner] = ExpectationRuntime::withClock(
+            $outer,
+            static function () use ($inner, $expected): array {
+                $thrown = null;
+
+                try {
+                    ExpectationRuntime::withClock(
+                        $inner,
+                        static fn(): never => throw $expected,
+                    );
+                } catch (\RuntimeException $caught) {
+                    $thrown = $caught;
+                }
+
+                return [$thrown, ExpectationRuntime::clock()];
+            },
+        );
+
+        Expect::that($thrown)
+            ->because('withClock propagates the operation exception')
+            ->toBe($expected)
+            ->and($afterInner)
+            ->toBe($outer)
+            ->and(ExpectationRuntime::clock())
+            ->toBe($baseline);
+    }
+}


### PR DESCRIPTION
Adds focused coverage for ExpectationRuntime’s temporary clock ownership. The test nests two fake clocks, forces the inner operation to throw, verifies the same exception propagates, and proves both nested and baseline clocks are restored.