### PR TITLE
test: cover failed scope disposal cleanup

### DIFF
--- a/tests/Fixture/Harness/FailingDisposable.php
+++ b/tests/Fixture/Harness/FailingDisposable.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Harness;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Harness\Disposable;
+
+final class FailingDisposable implements Disposable, Fake
+{
+    private static int $disposals = 0;
+
+    public function initialize(): void {}
+
+    #[\Override]
+    public function dispose(): void
+    {
+        ++self::$disposals;
+
+        throw new \RuntimeException('disposal broke');
+    }
+
+    public static function reset(): void
+    {
+        self::$disposals = 0;
+    }
+
+    public static function disposals(): int
+    {
+        return self::$disposals;
+    }
+}

--- a/tests/Unit/Harness/ScopeContainerTest.php
+++ b/tests/Unit/Harness/ScopeContainerTest.php
@@ -10,6 +10,7 @@ use Greenlight\Expect\Fail;
 use Greenlight\Harness\Scope;
 use Greenlight\Harness\ScopeContainer;
 use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Tests\Fixture\Harness\FailingDisposable;
 use Greenlight\Tests\Fixture\Lifecycle\DisposeFails\FailingDisposalProbe;
 use Greenlight\Tests\Fixture\Lifecycle\Services\ServiceProbe;
 use Greenlight\Tests\Fixture\Lifecycle\TraceLog;
@@ -93,5 +94,41 @@ final class ScopeContainerTest
 
         Expect::that($failures)->because('disposal failures are collected not thrown')->toHaveCount(1)
             ->and($failures[0]->getMessage())->toBe('disposal broke');
+    }
+
+    #[Test]
+    public function aFailedDisposalIsNotRetried(): void
+    {
+        FailingDisposable::reset();
+
+        $container = new ScopeContainer();
+        $definition = new ServiceDefinition(
+            FailingDisposable::class,
+            Scope::PerTest,
+            static fn(): FailingDisposable => new FailingDisposable(),
+        );
+        $service = $container->get($definition);
+
+        if (!$service instanceof FailingDisposable) {
+            Fail::because(\sprintf(
+                'Expected ScopeContainer::get() to return FailingDisposable, got %s.',
+                \get_debug_type($service),
+            ));
+        }
+
+        $service->initialize();
+        $first = $container->dispose();
+        $second = $container->dispose();
+
+        Expect::that($first)
+            ->because('the first disposal reports the service failure')
+            ->toHaveCount(1)
+            ->and($first[0]->getMessage())
+            ->toBe('disposal broke')
+            ->and($second)
+            ->because('a failed disposal MUST still leave the scope empty')
+            ->toBe([])
+            ->and(FailingDisposable::disposals())
+            ->toBe(1);
     }
 }


### PR DESCRIPTION
Covers the scope lifecycle guarantee that a disposal failure is reported once and still clears the owned service. The PSR-4 test substitute implements Fake and records disposal attempts.