### PR TITLE
test: cover negative polling sleep

### DIFF
--- a/tests/Unit/Expect/SystemPollingClockTest.php
+++ b/tests/Unit/Expect/SystemPollingClockTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\SystemPollingClock;
+
+final class SystemPollingClockTest
+{
+    #[Test]
+    public function negativeSleepReturnsControlToTheCaller(): void
+    {
+        $reachedAfterSleep = false;
+
+        new SystemPollingClock()->sleep(-0.001);
+        $reachedAfterSleep = true;
+
+        Expect::that($reachedAfterSleep)
+            ->because('a negative sleep returns before calling usleep')
+            ->toBeTrue();
+    }
+}


### PR DESCRIPTION
Adds focused coverage for SystemPollingClock’s negative-delay guard. The test calls sleep() with a negative duration and verifies control reaches a post-call sentinel, protecting elapsed temporal deadlines from surfacing a ValueError from usleep().