### PR TITLE
test: cover parsed argument values

### DIFF
--- a/tests/Unit/Cli/ParsedArgumentsTest.php
+++ b/tests/Unit/Cli/ParsedArgumentsTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\ParsedArguments;
+use Greenlight\Expect\Expect;
+
+final class ParsedArgumentsTest
+{
+    #[Test]
+    public function valueReturnsTheLastRecordedOptionValue(): void
+    {
+        $arguments = new ParsedArguments('run', [
+            'group' => ['first', 'last'],
+        ]);
+
+        Expect::that($arguments->value('group'))
+            ->because('a singular lookup uses the last repeated option value')
+            ->toBe('last');
+    }
+
+    #[Test]
+    public function valuesRemoveMissingValuesWithoutChangingOrder(): void
+    {
+        $arguments = new ParsedArguments(null, [
+            'option' => ['first', null, 'last'],
+            'flag' => [null],
+        ]);
+
+        Expect::that($arguments->values('option'))
+            ->because('repeatable values retain input order and omit absent values')
+            ->toBe(['first', 'last'])
+            ->and($arguments->has('flag'))
+            ->because('a flag with no value is still present')
+            ->toBeTrue()
+            ->and($arguments->value('flag'))
+            ->toBeNull()
+            ->and($arguments->has('missing'))
+            ->toBeFalse();
+    }
+}


### PR DESCRIPTION
Covers ParsedArguments directly: singular lookup uses the last recorded value, repeated values preserve input order while omitting missing values, and valueless flags remain distinguishable from absent options.