### PR TITLE
test: cover watch mode without shell exec

### DIFF
--- a/tests/Acceptance/WatchModeTest.php
+++ b/tests/Acceptance/WatchModeTest.php
@@ -47,6 +47,34 @@ final readonly class WatchModeTest
         }
     }
 
+    #[Test]
+    public function watchStartsAndQuitsWhenShellExecIsDisabled(): void
+    {
+        $project = $this->writeProject();
+        $process = GreenlightCli::start(
+            $project->directory,
+            ['run', '--watch', '--reporter=plain'],
+            phpArguments: ['-d', 'disable_functions=shell_exec'],
+        );
+
+        try {
+            $output = $process->readStdoutUntil('Waiting for changes', 20.0);
+
+            Expect::that($output)
+                ->because('watch mode starts when PHP disables shell_exec')
+                ->toContain('1 test, 1 passed');
+
+            $process->write('q');
+            $result = $process->wait(10.0);
+
+            Expect::that($result->exitCode)
+                ->because('watch mode exits cleanly when PHP disables shell_exec')
+                ->toBe(0);
+        } finally {
+            $process->terminate();
+        }
+    }
+
     private function writeProject(): AcceptanceProject
     {
         $project = AcceptanceProject::create($this->tempDirectory, 'watch');


### PR DESCRIPTION
Adds focused acceptance coverage for watch mode when PHP disables shell_exec. The test proves the initial run completes and the watch loop exits cleanly on q without requiring terminal mode shell commands.