### PR TITLE
test: cover worker connection failures

### DIFF
--- a/tests/Unit/Runner/Worker/WorkerProcessTest.php
+++ b/tests/Unit/Runner/Worker/WorkerProcessTest.php
@@ -15,6 +15,36 @@ use Greenlight\Tests\Support\Subprocess;
 final class WorkerProcessTest
 {
     #[Test]
+    public function connectionFailureNamesTheExactAddress(): void
+    {
+        $root = \dirname(__DIR__, 4);
+        $address = 'unix://' . \sys_get_temp_dir()
+            . '/greenlight-missing-worker-' . \bin2hex(\random_bytes(6)) . '.sock';
+
+        $result = Subprocess::run($root, [
+            \PHP_BINARY,
+            '-r',
+            <<<'PHP'
+            require $argv[1];
+
+            exit(new Greenlight\Runner\Worker\WorkerProcess()->run(
+                $argv[2],
+                'worker-under-test',
+                'token',
+            ));
+            PHP,
+            $root . '/vendor/autoload.php',
+            $address,
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('a worker connection failure MUST fail startup')
+            ->toBe(1)
+            ->and($result->stderr)
+            ->toContain('The worker did not connect to ' . $address . ':');
+    }
+
+    #[Test]
     #[Timeout(5.0)]
     public function itKeepsPollingAfterAnIdleReceiveTimesOut(): void
     {


### PR DESCRIPTION
## Summary

- connect a worker process to a unique missing Unix socket
- verify that worker startup fails
- verify that the diagnostic identifies the exact socket address