### PR TITLE
test: cover corrupt artifact recovery metadata

### DIFF
--- a/tests/Unit/Artifact/AttachmentsTest.php
+++ b/tests/Unit/Artifact/AttachmentsTest.php
@@ -454,6 +454,30 @@ final readonly class AttachmentsTest
     }
 
     #[Test]
+    public function corruptRecoveryMetadataDoesNotHideCompletedEvidence(): void
+    {
+        $root = $this->tempDirectory->subdirectory('corrupt-recovery');
+        $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-corrupt');
+        $id = new TestId('Example\EvidenceTest', 'crashes');
+        $attachments = $store->forAttempt($id, 1, new TestArtifactBudget());
+        $attachments->text('completed.txt', 'complete before crash');
+        $testDirectory = $store->session()->stagingDirectory . '/' . ArtifactStore::testDirectory($id);
+        \file_put_contents($testDirectory . '/broken.meta.json', '{"name":');
+
+        $recovered = $store->recover(new TestResult($id, Outcome::Errored, 0.0, 0));
+
+        Expect::that($recovered->attachments)
+            ->because('corrupt recovery metadata MUST NOT hide completed evidence')
+            ->toHaveCount(1)
+            ->and($recovered->attachments[0]->name)
+            ->toBe('completed.txt')
+            ->and(\is_file($recovered->attachments[0]->path))
+            ->toBeTrue();
+
+        $store->cleanup();
+    }
+
+    #[Test]
     public function crashRecoveryRestoresTheLatestAttemptWithoutAnAttachment(): void
     {
         $root = $this->tempDirectory->subdirectory('attempt-recovery');


### PR DESCRIPTION
Covers crash recovery when a test staging directory contains both completed evidence and a corrupt sidecar. Recovery skips the corrupt metadata and still publishes the valid attachment.