### PR TITLE
test: cover artifact output symlink safety

### DIFF
--- a/tests/Unit/Artifact/ArtifactOutputSafetyTest.php
+++ b/tests/Unit/Artifact/ArtifactOutputSafetyTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\ArtifactStore;
+use Greenlight\Runner\Artifact\TestArtifactBudget;
+
+final readonly class ArtifactOutputSafetyTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function outputDirectorySymlinksCannotRedirectPublication(): void
+    {
+        $root = $this->tempDirectory->subdirectory('output-symlink');
+        $outside = $this->tempDirectory->subdirectory('outside-output');
+        $store = ArtifactStore::open(
+            new ArtifactConfiguration($root . '/published'),
+            $root,
+            'run-1',
+        );
+        $id = new TestId('Example\EvidenceTest', 'publishesEvidence');
+        $attachments = $store->forAttempt($id, 1, new TestArtifactBudget());
+        $attachments->text('evidence.txt', 'body');
+        $staged = $attachments->seal()[0];
+        $firstSegment = \explode('/', $staged->storageKey)[0];
+        \mkdir($store->publicDirectory(), 0o777, true);
+        \symlink($outside, $store->publicDirectory() . '/' . $firstSegment);
+
+        try {
+            Expect::that(static fn(): TestResult => $store->publish(new TestResult(
+                $id,
+                Outcome::Failed,
+                0.1,
+                0,
+                attachments: [$staged],
+            )))
+                ->because('artifact publication MUST NOT follow output directory symbolic links')
+                ->toThrow(
+                    AttachmentError::class,
+                    message: 'Attachment output directory contains a symbolic link.',
+                )
+                ->and(\glob($outside . '/*'))
+                ->because('a rejected publication MUST NOT write outside its output directory')
+                ->toBe([])
+                ->and(\is_file($store->session()->stagingDirectory . '/' . $staged->storageKey))
+                ->because('rejected evidence remains available for recovery')
+                ->toBeTrue();
+        } finally {
+            $store->cleanup();
+        }
+    }
+}

--- a/tests/Unit/Artifact/ArtifactOutputSafetyTest.php
+++ b/tests/Unit/Artifact/ArtifactOutputSafetyTest.php
@@ -24,6 +24,7 @@ final readonly class ArtifactOutputSafetyTest
     {
         $root = $this->tempDirectory->subdirectory('output-symlink');
         $outside = $this->tempDirectory->subdirectory('outside-output');
+        \mkdir($root . '/published');
         $store = ArtifactStore::open(
             new ArtifactConfiguration($root . '/published'),
             $root,


### PR DESCRIPTION
Covers publication when an output path segment is a symbolic link. Greenlight rejects the redirect, writes nothing outside the artifact directory, and keeps the staged evidence available for recovery.