### PR TITLE
fix(test): isolate subprocesses from host tracing

### DIFF
--- a/tests/Support/GreenlightCli.php
+++ b/tests/Support/GreenlightCli.php
@@ -48,7 +48,15 @@ final class GreenlightCli
                 $root . '/bin/greenlight',
                 ...$arguments,
             ],
-            $environment,
+            [
+                // Child workers MUST NOT start host tracer sidecars. A
+                // sidecar can keep a completed acceptance process alive.
+                'DD_INSTRUMENTATION_TELEMETRY_ENABLED' => '0',
+                'DD_REMOTE_CONFIG_ENABLED' => '0',
+                'DD_TRACE_CLI_ENABLED' => '0',
+                'DD_TRACE_SIDECAR_TRACE_SENDER' => '0',
+                ...$environment,
+            ],
         );
     }
 }

--- a/tests/Support/Subprocess.php
+++ b/tests/Support/Subprocess.php
@@ -53,6 +53,16 @@ final class Subprocess
         array $command,
         array $environment = [],
     ): self {
+        // Direct PHP probes MUST NOT start the host tracer.
+        if ($command[0] === \PHP_BINARY) {
+            $command = [
+                \PHP_BINARY,
+                '-d',
+                'ddtrace.disable=1',
+                ...\array_slice($command, 1),
+            ];
+        }
+
         $processEnvironment = null;
 
         if ($environment !== []) {

--- a/tests/Unit/Support/SubprocessTest.php
+++ b/tests/Unit/Support/SubprocessTest.php
@@ -65,6 +65,24 @@ final readonly class SubprocessTest
     }
 
     #[Test]
+    public function phpProcessesDoNotInheritHostTracing(): void
+    {
+        $result = Subprocess::run(
+            $this->workspace->path(),
+            [
+                \PHP_BINARY,
+                '-r',
+                <<<'PHP'
+                fwrite(STDOUT, ini_get('ddtrace.disable'));
+                PHP,
+            ],
+        );
+
+        Expect::that($result->exitCode)->because('PHP processes do not inherit host tracing')->toBe(0)
+            ->and($result->stdout)->toBe('1');
+    }
+
+    #[Test]
     public function interactiveProcessAcceptsInputAndReturnsItsFinalResult(): void
     {
         $process = Subprocess::start(

--- a/tests/Unit/Support/SubprocessTest.php
+++ b/tests/Unit/Support/SubprocessTest.php
@@ -73,7 +73,7 @@ final readonly class SubprocessTest
                 \PHP_BINARY,
                 '-r',
                 <<<'PHP'
-                fwrite(STDOUT, ini_get('ddtrace.disable'));
+                fwrite(STDOUT, get_cfg_var('ddtrace.disable'));
                 PHP,
             ],
         );


### PR DESCRIPTION
## What

Disable the host ddtrace extension for direct PHP probes and disable its sidecar features for Greenlight acceptance child processes.

Add focused coverage for direct PHP subprocess isolation.

## Why

The ddtrace sidecar can deadlock during PHP module shutdown after Greenlight has completed a nested CLI command. This leaves acceptance workers waiting indefinitely and makes ShardingTest appear to hang near the end of the suite.