### PR TITLE
test: cover changing attachment sources

### DIFF
--- a/tests/Fixture/Artifact/ChangingFileStream.php
+++ b/tests/Fixture/Artifact/ChangingFileStream.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Artifact;
+
+use Greenlight\Doubles\Fake;
+
+/**
+ * Simulates a regular file whose modification time changes after it is read.
+ */
+final class ChangingFileStream implements Fake
+{
+    public mixed $context;
+
+    private const string CONTENT = 'evidence';
+
+    private int $offset = 0;
+
+    private int $statCalls = 0;
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        $this->offset = 0;
+        $this->statCalls = 0;
+
+        return $mode === 'rb';
+    }
+
+    public function stream_read(int $count): string
+    {
+        $chunk = \substr(self::CONTENT, $this->offset, $count);
+        $this->offset += \strlen($chunk);
+
+        return $chunk;
+    }
+
+    public function stream_eof(): bool
+    {
+        return $this->offset >= \strlen(self::CONTENT);
+    }
+
+    /**
+     * @return array{mode: int, size: int, mtime: int}
+     */
+    public function stream_stat(): array
+    {
+        return self::stat(++$this->statCalls);
+    }
+
+    /**
+     * @return array{mode: int, size: int, mtime: int}
+     */
+    public function url_stat(string $path, int $flags): array
+    {
+        return self::stat(0);
+    }
+
+    /**
+     * @return array{mode: int, size: int, mtime: int}
+     */
+    private static function stat(int $mtime): array
+    {
+        return [
+            'mode' => 0100600,
+            'size' => \strlen(self::CONTENT),
+            'mtime' => $mtime,
+        ];
+    }
+}

--- a/tests/Unit/Artifact/ArtifactSourceMutationTest.php
+++ b/tests/Unit/Artifact/ArtifactSourceMutationTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\ArtifactStore;
+use Greenlight\Runner\Artifact\TestArtifactBudget;
+use Greenlight\Tests\Fixture\Artifact\ChangingFileStream;
+
+final readonly class ArtifactSourceMutationTest
+{
+    private const string SCHEME = 'greenlight-changing-file';
+
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function aSourceThatChangesDuringCopyIsRejectedAndReleased(): void
+    {
+        if (!\stream_wrapper_register(self::SCHEME, ChangingFileStream::class)) {
+            throw new \RuntimeException('Greenlight did not register the changing-file stream.');
+        }
+
+        $store = null;
+
+        try {
+            $root = $this->tempDirectory->subdirectory('source-mutation');
+            $configuration = new ArtifactConfiguration(
+                $root,
+                maxRunAttachments: 1,
+            );
+            $store = ArtifactStore::open($configuration, $root, 'run-source-mutation');
+            $attachments = $store->forAttempt(
+                new TestId('Example\EvidenceTest', 'rejectsChangingSource'),
+                1,
+                new TestArtifactBudget(),
+            );
+            $source = self::SCHEME . '://evidence';
+
+            Expect::that(static fn() => $attachments->file('evidence.txt', $source))
+                ->because('a file attachment source must stay unchanged while Greenlight copies it')
+                ->toThrow(
+                    AttachmentError::class,
+                    message: \sprintf(
+                        'Attachment source "%s" changed while it was being copied.',
+                        $source,
+                    ),
+                );
+
+            $attachments->text('replacement.txt', 'replacement');
+
+            Expect::that($attachments->collected())
+                ->because('a rejected source releases its run quota')
+                ->toHaveCount(1)
+                ->and($attachments->collected()[0]->name)
+                ->toBe('replacement.txt');
+        } finally {
+            $store?->cleanup();
+            \stream_wrapper_unregister(self::SCHEME);
+        }
+    }
+}


### PR DESCRIPTION
Adds a deterministic Fake stream source whose modification time changes after copying. The focused test verifies the exact mutation diagnostic, rollback of staged data, and release of run attachment quota without relying on timing.