### PR TITLE
test: cover optional CPU counter

### DIFF
--- a/tests/Fixture/Runner/FakeCpuCoreCounter.php
+++ b/tests/Fixture/Runner/FakeCpuCoreCounter.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Runner;
+
+use Greenlight\Doubles\Fake;
+
+final class FakeCpuCoreCounter implements Fake
+{
+    public static bool $notFound = false;
+
+    public static int $calls = 0;
+
+    public function getCount(): int
+    {
+        ++self::$calls;
+
+        if (self::$notFound) {
+            throw new FakeNumberOfCpuCoreNotFound();
+        }
+
+        return 7;
+    }
+}

--- a/tests/Fixture/Runner/FakeNumberOfCpuCoreNotFound.php
+++ b/tests/Fixture/Runner/FakeNumberOfCpuCoreNotFound.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Runner;
+
+use Greenlight\Doubles\Fake;
+
+final class FakeNumberOfCpuCoreNotFound extends \RuntimeException implements Fake {}

--- a/tests/Unit/Runner/CpuCoresTest.php
+++ b/tests/Unit/Runner/CpuCoresTest.php
@@ -6,10 +6,37 @@ namespace Greenlight\Tests\Unit\Runner;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\ProcessResult;
 use Greenlight\Tests\Support\Subprocess;
 
 final class CpuCoresTest
 {
+    #[Test]
+    public function countUsesTheOptionalCpuCounterWhenItIsAvailable(): void
+    {
+        $result = $this->runWithFakeOptionalCounter(notFound: false);
+
+        Expect::that($result->exitCode)
+            ->because('the optional CPU counter runs successfully')
+            ->toBe(0)
+            ->and($result->stdout)
+            ->because('the optional CPU counter supplies the exact worker count once')
+            ->toBe('7:1');
+    }
+
+    #[Test]
+    public function countFallsBackWhenTheOptionalCpuCounterCannotFindACount(): void
+    {
+        $result = $this->runWithFakeOptionalCounter(notFound: true);
+
+        Expect::that($result->exitCode)
+            ->because('the typed not-found error falls through to the built-in probe')
+            ->toBe(0)
+            ->and($result->stdout)
+            ->because('the built-in probe returns a positive count after one optional attempt')
+            ->toMatch('/^[1-9]\d*:1$/D');
+    }
+
     #[Test]
     public function countUsesTheBuiltInProbeWithoutTheOptionalPackage(): void
     {
@@ -50,5 +77,35 @@ final class CpuCoresTest
             ->and($result->stdout)
             ->because('the built-in CPU probe returns a positive integer')
             ->toMatch('/^[1-9]\d*$/D');
+    }
+
+    private function runWithFakeOptionalCounter(bool $notFound): ProcessResult
+    {
+        $root = \dirname(__DIR__, 3);
+
+        return Subprocess::run($root, [
+            \PHP_BINARY,
+            '-r',
+            <<<'PHP'
+            require $argv[1];
+
+            class_alias(
+                \Greenlight\Tests\Fixture\Runner\FakeNumberOfCpuCoreNotFound::class,
+                \Fidry\CpuCoreCounter\NumberOfCpuCoreNotFound::class,
+            );
+            class_alias(
+                \Greenlight\Tests\Fixture\Runner\FakeCpuCoreCounter::class,
+                \Fidry\CpuCoreCounter\CpuCoreCounter::class,
+            );
+
+            \Greenlight\Tests\Fixture\Runner\FakeCpuCoreCounter::$notFound = $argv[2] === 'not-found';
+
+            $count = \Greenlight\Runner\CpuCores::count();
+
+            echo $count . ':' . \Greenlight\Tests\Fixture\Runner\FakeCpuCoreCounter::$calls;
+            PHP,
+            $root . '/vendor/autoload.php',
+            $notFound ? 'not-found' : 'available',
+        ]);
     }
 }


### PR DESCRIPTION
Adds isolated coverage for the optional Fidry CPU-counter boundary. PSR-4 fake types verify that an available counter supplies the exact worker count and that its typed not-found exception falls through to Greenlight’s built-in positive probe.