### PR TITLE
fix(test): compare canonical generated coverage paths

### DIFF
--- a/tests/Acceptance/GeneratedCoveragePathTest.php
+++ b/tests/Acceptance/GeneratedCoveragePathTest.php
@@ -35,6 +35,12 @@ final readonly class GeneratedCoveragePathTest
             ->because('coverage MUST collect source generated during the run')
             ->toBe(0);
 
+        $generatedPath = \realpath($generatedDirectory . '/RuntimeSource.php');
+
+        if ($generatedPath === false) {
+            Fail::because('Expected the generated source file to exist after the run.');
+        }
+
         $json = \file_get_contents($project->path('coverage.json'));
 
         if ($json === false) {
@@ -46,7 +52,7 @@ final readonly class GeneratedCoveragePathTest
         $generatedFile = null;
 
         foreach ($decoded['files'] as $file => $lines) {
-            if ($file === $generatedDirectory . '/RuntimeSource.php') {
+            if ($file === $generatedPath) {
                 $generatedFile = $lines;
             }
         }


### PR DESCRIPTION
## Summary

- resolve the generated source path after the acceptance run creates it
- compare the canonical source path with canonical coverage export keys
- preserve the exact generated-file and covered-line assertions