### PR TITLE
test: canonicalize missing config path

### DIFF
--- a/tests/Acceptance/CliTest.php
+++ b/tests/Acceptance/CliTest.php
@@ -140,13 +140,14 @@ final readonly class CliTest
     public function listTestsWithMissingConfigFailsWithTheExactPath(): void
     {
         $project = AcceptanceProject::create($this->tempDirectory, 'list-tests-missing-config');
+        $projectDirectory = (string) \realpath($project->directory);
         $result = GreenlightCli::run($project->directory, ['list-tests', '--config=missing.php']);
 
         Expect::that($result->exitCode)
             ->because('list tests reports an explicitly missing configuration')
             ->toBe(1)
             ->and($result->output())
-            ->toContain('Configuration file "' . $project->path('missing.php') . '" does not exist.');
+            ->toContain('Configuration file "' . $projectDirectory . '/missing.php" does not exist.');
     }
 
     #[Test]


### PR DESCRIPTION
Canonicalize the temporary acceptance project directory before asserting the explicit missing configuration diagnostic. This keeps the expected path aligned with CLI path resolution on macOS, where /var resolves to /private/var.