### PR TITLE
test: cover untyped double returns

### DIFF
--- a/tests/Fixture/Doubles/UntypedAction.php
+++ b/tests/Fixture/Doubles/UntypedAction.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+interface UntypedAction
+{
+    /** @return mixed */
+    public function perform(string $value);
+}

--- a/tests/Unit/Doubles/UntypedReturnTest.php
+++ b/tests/Unit/Doubles/UntypedReturnTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\MockPlan;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Doubles\UntypedAction;
+
+final class UntypedReturnTest
+{
+    #[Test]
+    public function aPlannedUntypedMethodNeedsNoConfiguredReturnValue(): void
+    {
+        $doubles = new Doubles();
+        $action = $doubles->mock(
+            UntypedAction::class,
+            static function (MockPlan $plan): void {
+                $plan
+                    ->expects('perform')
+                    ->with('value')
+                    ->once();
+            },
+        );
+
+        $result = $action->perform('value');
+
+        Expect::that($result)
+            ->because('an untyped collaborator method can complete without a configured value')
+            ->toBeNull();
+
+        $doubles->dispose();
+    }
+}


### PR DESCRIPTION
Covers legacy collaborator methods without declared return types. A planned mock call now verifies that no configured return value is required and the generated proxy completes with null.