### PR TITLE
test: restore static analysis

### DIFF
--- a/tests/Unit/Discovery/Psr4ViolationTest.php
+++ b/tests/Unit/Discovery/Psr4ViolationTest.php
@@ -74,11 +74,6 @@ final readonly class Psr4ViolationTest
     public function incompleteClassDeclarationsProduceATypedDiscoveryError(): void
     {
         $directory = $this->tempDirectory->subdirectory('incomplete-declaration');
-
-        if ($directory === '') {
-            Fail::because('Expected the incomplete class fixture directory to be non-empty.');
-        }
-
         $file = $directory . '/IncompleteTest.php';
         \file_put_contents($file, "<?php\n\nclass");
         $resolvedFile = \realpath($file);


### PR DESCRIPTION
Removes a redundant impossible guard that broke PHPStan after TempDirectory gained a non-empty-string contract.