### PR TITLE
test: cover TTY worker recycling summary

### DIFF
--- a/tests/Unit/Reporting/TtyReporterTest.php
+++ b/tests/Unit/Reporting/TtyReporterTest.php
@@ -5,11 +5,13 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Reporting;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\RecycleReason;
 use Greenlight\Core\Event\RunFinished;
 use Greenlight\Core\Event\RunStarted;
 use Greenlight\Core\Event\TestClassFinished;
 use Greenlight\Core\Event\TestClassStarted;
 use Greenlight\Core\Event\TestFinished;
+use Greenlight\Core\Event\WorkerRecycled;
 use Greenlight\Core\Event\WorkerSpawned;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\ResultSummary;
@@ -167,6 +169,21 @@ final class TtyReporterTest
         $reporter->finish();
 
         Expect::that($inProcess->buffer())->because('workers line omits zero recycled and disappears when none spawned')->not()->toContain('Workers:');
+    }
+
+    #[Test]
+    public function workersLineIncludesTheRecycledCount(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new TtyReporter($output, color: false, cursor: false);
+        $reporter->onEvent(new WorkerSpawned('w-1', 101, 1.0));
+        $reporter->onEvent(new WorkerRecycled('w-1', RecycleReason::Memory, 1.1));
+        $reporter->onEvent(new RunFinished('run-1', new ResultSummary(passed: 1), 0.1, 1.2));
+        $reporter->finish();
+
+        Expect::that($output->buffer())
+            ->because('the TTY summary reports worker recycling')
+            ->toContain("Workers: 1 spawned, 1 recycled\n");
     }
 
     #[Test]


### PR DESCRIPTION
Covers non-zero worker recycling in the TTY summary. The reporter now has an exact assertion for spawned and recycled worker counts.