### PR TITLE
test: cover repeated incomplete frame polling

### DIFF
--- a/tests/Unit/Runner/Protocol/SocketChannelTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelTest.php
@@ -84,6 +84,13 @@ final class SocketChannelTest
                     ProtocolError::class,
                     message: 'Malformed frame: peer closed the connection with an incomplete frame.',
                 );
+
+            Expect::that(static fn(): mixed => $channel->poll())
+                ->because('an incomplete frame MUST remain invalid after it is reported')
+                ->toThrow(
+                    ProtocolError::class,
+                    message: 'Malformed frame: peer closed the connection with an incomplete frame.',
+                );
         } finally {
             $channel->close();
 


### PR DESCRIPTION
Covers repeated reads after a peer closes with an incomplete protocol frame. Every subsequent poll must continue to reject the retained truncated frame with the exact protocol error.