### PR TITLE
test: cover invalid artifact output paths

### DIFF
--- a/tests/Unit/Artifact/ArtifactOutputSafetyTest.php
+++ b/tests/Unit/Artifact/ArtifactOutputSafetyTest.php
@@ -20,6 +20,23 @@ final readonly class ArtifactOutputSafetyTest
     public function __construct(private TempDirectory $tempDirectory) {}
 
     #[Test]
+    public function outputDirectoriesRejectNullBytesBeforeFilesystemUse(): void
+    {
+        $workingDirectory = $this->tempDirectory->subdirectory('invalid-output');
+
+        Expect::that(static fn(): ArtifactStore => ArtifactStore::open(
+            new ArtifactConfiguration("published\0outside"),
+            $workingDirectory,
+            'run-1',
+        ))
+            ->because('an attachment output directory MUST be a valid filesystem path')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Attachment output directory is invalid.',
+            );
+    }
+
+    #[Test]
     public function outputDirectorySymlinksCannotRedirectPublication(): void
     {
         $root = $this->tempDirectory->subdirectory('output-symlink');

--- a/tests/Unit/Discovery/Psr4ViolationTest.php
+++ b/tests/Unit/Discovery/Psr4ViolationTest.php
@@ -75,10 +75,6 @@ final readonly class Psr4ViolationTest
     {
         $directory = $this->tempDirectory->subdirectory('incomplete-declaration');
 
-        if ($directory === '') {
-            Fail::because('Expected the incomplete class fixture directory to be non-empty.');
-        }
-
         $file = $directory . '/IncompleteTest.php';
         \file_put_contents($file, "<?php\n\nclass");
         $resolvedFile = \realpath($file);


### PR DESCRIPTION
Covers the attachment output boundary for paths containing null bytes. Artifact storage now has an exact regression assertion that rejects the path before any filesystem operation.