### PR TITLE
test: reject unsafe artifact quota paths

### DIFF
--- a/tests/Unit/Artifact/ArtifactQuotaTest.php
+++ b/tests/Unit/Artifact/ArtifactQuotaTest.php
@@ -19,6 +19,38 @@ final readonly class ArtifactQuotaTest
     public function __construct(private TempDirectory $tempDirectory) {}
 
     #[Test]
+    public function aQuotaSymlinkCannotRedirectSharedAccounting(): void
+    {
+        $root = $this->tempDirectory->subdirectory('quota-symlink');
+        $staging = $root . '/staging';
+        $outside = $root . '/outside-quota';
+        \mkdir($staging);
+        \file_put_contents($outside, 'untouched');
+        \symlink($outside, $staging . '/.quota');
+        $store = ArtifactStore::fromSession(
+            new ArtifactSession($staging, $root . '/published/run-1'),
+            new ArtifactConfiguration($root . '/published'),
+        );
+        $attachments = $store->forAttempt(
+            new TestId('Example\EvidenceTest', 'recordsEvidence'),
+            1,
+            new TestArtifactBudget(),
+        );
+
+        Expect::that(static function () use ($attachments): void {
+            $attachments->text('evidence.txt', 'body');
+        })
+            ->because('shared quota accounting MUST NOT follow symbolic links')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Attachment quota path is unsafe.',
+            )
+            ->and((string) \file_get_contents($outside))
+            ->because('a rejected quota path MUST NOT change its target')
+            ->toBe('untouched');
+    }
+
+    #[Test]
     public function corruptRunQuotaMetadataFailsBeforeStaging(): void
     {
         $root = $this->tempDirectory->subdirectory('corrupt-run-quota');


### PR DESCRIPTION
Covers shared attachment quota metadata at a symbolic-link path. Artifact staging MUST reject the unsafe path before opening it and leave the link target unchanged.