### PR TITLE
test: cover empty plugin registry

### DIFF
--- a/tests/Unit/Plugin/PluginRegistryTest.php
+++ b/tests/Unit/Plugin/PluginRegistryTest.php
@@ -14,6 +14,24 @@ use Greenlight\Tests\Fixture\Plugins\PrioritizedFakeCapabilityPlugin;
 final class PluginRegistryTest
 {
     #[Test]
+    public function emptyRegistryExposesNoCapabilitiesOrHarnessServices(): void
+    {
+        $registry = PluginRegistry::none();
+
+        Expect::that($registry->testSubscribers())
+            ->because('an empty registry MUST expose no plugin capabilities or harness services')
+            ->toBe([])
+            ->and($registry->retryDeciders())
+            ->toBe([])
+            ->and($registry->runSubscribers())
+            ->toBe([])
+            ->and($registry->harnessServices())
+            ->toBe([])
+            ->and($registry->serviceResolvers())
+            ->toBe([]);
+    }
+
+    #[Test]
     public function capabilityAccessorsFilterPluginsAndKeepStablePriorityOrder(): void
     {
         $late = new PrioritizedFakeCapabilityPlugin(10);


### PR DESCRIPTION
Covers the empty plugin-registry factory contract. Verifies that it exposes no lifecycle capabilities, harness services, or service resolvers.