### PR TITLE
fix: preserve colliding staging files

### DIFF
--- a/src/Runner/Artifact/ArtifactStore.php
+++ b/src/Runner/Artifact/ArtifactStore.php
@@ -125,6 +125,7 @@ final class ArtifactStore
         $this->reserve($size);
         $path = null;
         $part = null;
+        $stagingFileCreated = false;
 
         try {
             $path = $this->preparePath($storageKey);
@@ -134,6 +135,8 @@ final class ArtifactStore
             if ($stream === false) {
                 throw AttachmentError::storage('Greenlight did not create the attachment staging file');
             }
+
+            $stagingFileCreated = true;
 
             try {
                 $this->writeFully($stream, $bytes);
@@ -162,7 +165,10 @@ final class ArtifactStore
 
             return $attachment;
         } catch (\Throwable $error) {
-            $this->rollbackStagedAttachment($storageKey, $path, $part);
+            if ($stagingFileCreated) {
+                $this->rollbackStagedAttachment($storageKey, $path, $part);
+            }
+
             $this->release($size);
 
             throw $error;
@@ -200,6 +206,7 @@ final class ArtifactStore
             $this->reserve($size);
             $path = null;
             $part = null;
+            $stagingFileCreated = false;
 
             try {
                 $path = $this->preparePath($storageKey);
@@ -210,6 +217,7 @@ final class ArtifactStore
                     throw AttachmentError::storage('Greenlight did not create the attachment staging file');
                 }
 
+                $stagingFileCreated = true;
                 $hash = \hash_init('sha256');
                 $copied = 0;
 
@@ -266,7 +274,10 @@ final class ArtifactStore
 
                 return $attachment;
             } catch (\Throwable $error) {
-                $this->rollbackStagedAttachment($storageKey, $path, $part);
+                if ($stagingFileCreated) {
+                    $this->rollbackStagedAttachment($storageKey, $path, $part);
+                }
+
                 $this->release($size);
 
                 throw $error;

--- a/tests/Unit/Artifact/ArtifactStagingCollisionTest.php
+++ b/tests/Unit/Artifact/ArtifactStagingCollisionTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Core\Artifact\AttachmentKind;
+use Greenlight\Core\Artifact\AttachmentRetention;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\ArtifactSession;
+use Greenlight\Runner\Artifact\ArtifactStore;
+
+final readonly class ArtifactStagingCollisionTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function fileStagingCollisionPreservesTheExistingPartAndReleasesQuota(): void
+    {
+        $root = $this->tempDirectory->subdirectory('file-staging-collision');
+        $source = $root . '/source.txt';
+        \file_put_contents($source, 'evidence');
+        [$store, $configuration, $part] = $this->store($root);
+
+        Expect::that(static fn() => $store->stageFile(
+            $source,
+            'evidence.txt',
+            'Example-EvidenceTest/attempt-1/01-evidence.txt',
+            'text/plain',
+            1,
+            AttachmentRetention::OnFailure,
+            $configuration,
+        ))
+            ->because('a staging collision MUST reject the file attachment')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Greenlight did not create the attachment staging file.',
+            )
+            ->and((string) \file_get_contents($part))
+            ->because('a rejected file attachment MUST NOT delete the existing staging part')
+            ->toBe('occupied');
+
+        \unlink($part);
+        $staged = $store->stageFile(
+            $source,
+            'evidence.txt',
+            'Example-EvidenceTest/attempt-1/01-evidence.txt',
+            'text/plain',
+            1,
+            AttachmentRetention::OnFailure,
+            $configuration,
+        );
+
+        Expect::that($staged->name)
+            ->because('a rejected file attachment MUST release its run quota')
+            ->toBe('evidence.txt');
+    }
+
+    #[Test]
+    public function byteStagingCollisionPreservesTheExistingPartAndReleasesQuota(): void
+    {
+        $root = $this->tempDirectory->subdirectory('byte-staging-collision');
+        [$store, $configuration, $part] = $this->store($root);
+
+        Expect::that(static fn() => $store->stageBytes(
+            'evidence',
+            'evidence.txt',
+            'Example-EvidenceTest/attempt-1/01-evidence.txt',
+            'text/plain',
+            AttachmentKind::Text,
+            1,
+            AttachmentRetention::OnFailure,
+            $configuration,
+        ))
+            ->because('a staging collision MUST reject the byte attachment')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Greenlight did not create the attachment staging file.',
+            )
+            ->and((string) \file_get_contents($part))
+            ->because('a rejected byte attachment MUST NOT delete the existing staging part')
+            ->toBe('occupied');
+
+        \unlink($part);
+        $staged = $store->stageBytes(
+            'evidence',
+            'evidence.txt',
+            'Example-EvidenceTest/attempt-1/01-evidence.txt',
+            'text/plain',
+            AttachmentKind::Text,
+            1,
+            AttachmentRetention::OnFailure,
+            $configuration,
+        );
+
+        Expect::that($staged->name)
+            ->because('a rejected byte attachment MUST release its run quota')
+            ->toBe('evidence.txt');
+    }
+
+    /**
+     * @return array{ArtifactStore, ArtifactConfiguration, non-empty-string}
+     */
+    private function store(string $root): array
+    {
+        $staging = $root . '/staging';
+        $storageKey = 'Example-EvidenceTest/attempt-1/01-evidence.txt';
+        $part = $staging . '/' . $storageKey . '.part';
+        \mkdir(\dirname($part), 0o777, true);
+        \file_put_contents($part, 'occupied');
+        $configuration = new ArtifactConfiguration(
+            $root . '/published',
+            maxRunAttachments: 1,
+        );
+        $store = ArtifactStore::fromSession(
+            new ArtifactSession($staging, $root . '/published/run-1'),
+            $configuration,
+        );
+
+        return [$store, $configuration, $part];
+    }
+}


### PR DESCRIPTION
Covers exclusive-create collisions for file and byte attachments. A rejected staging attempt MUST release its run quota without deleting the pre-existing `.part` file that caused the collision.