### PR TITLE
test: cover missing profile report input

### DIFF
--- a/tests/Acceptance/CommandErrorsTest.php
+++ b/tests/Acceptance/CommandErrorsTest.php
@@ -36,6 +36,18 @@ final readonly class CommandErrorsTest
     }
 
     #[Test]
+    public function profileReportWithoutInputIsAUsageError(): void
+    {
+        $result = GreenlightCli::run(\dirname(__DIR__, 2), ['profile:report']);
+
+        Expect::that($result->exitCode)
+            ->because('profile report without input is a usage error')
+            ->toBe(64)
+            ->and($result->stderr)
+            ->toBe('profile:report requires --input=<path to a JSONL stream>.');
+    }
+
+    #[Test]
     public function profileReportWithAMissingInputFileFailsCleanly(): void
     {
         $project = AcceptanceProject::create($this->tempDirectory, 'command-errors');


### PR DESCRIPTION
Add an exact acceptance assertion for profile:report without its required input path. The command must return a usage exit and name the required option before it attempts to read an event stream.