### PR TITLE
test: cover list discovery failures

### DIFF
--- a/tests/Acceptance/ListingTest.php
+++ b/tests/Acceptance/ListingTest.php
@@ -48,6 +48,34 @@ final readonly class ListingTest
     }
 
     #[Test]
+    public function listTestsReportsDiscoveryFailures(): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'listing-discovery-error');
+        $testFile = $project->path('tests/NoClassTest.php');
+        $project->writeFile('tests/NoClassTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace ListingDiscoveryError;
+
+            function helper(): void {}
+            PHP);
+        $project->configureWithTestFiles(['tests/NoClassTest.php']);
+
+        $result = GreenlightCli::run($project->directory, ['run', '--list-tests', '--no-ansi']);
+
+        Expect::that($result->exitCode)
+            ->because('list tests MUST report discovery failures')
+            ->toBe(1)
+            ->and($result->stderr)
+            ->toBe(\sprintf(
+                'greenlight: Test file "%s" does not declare a class, interface, trait, or enum.',
+                $testFile,
+            ));
+    }
+
+    #[Test]
     public function listTestsComposesWithExcludeGroup(): void
     {
         $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'listing');


### PR DESCRIPTION
Add an acceptance project whose configured test file has no class declaration. Assert that run --list-tests returns a failure and prints the exact discovery diagnostic instead of silently producing a partial list.