### PR TITLE
test: cover run discovery failures

### DIFF
--- a/tests/Acceptance/RunDiscoveryErrorTest.php
+++ b/tests/Acceptance/RunDiscoveryErrorTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\GreenlightCli;
+
+final readonly class RunDiscoveryErrorTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function runReportsDiscoveryFailuresCleanly(): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'run-discovery-error');
+        $fixture = \dirname(__DIR__) . '/Fixture/DiscoveryProviderMissing';
+        $project->writeFile('greenlight.php', \sprintf(
+            <<<'PHP'
+                <?php
+
+                declare(strict_types=1);
+
+                use Greenlight\Config\GreenlightConfig;
+
+                return GreenlightConfig::create()
+                    ->paths([%s])
+                    ->workers(1);
+
+                PHP,
+            \var_export($fixture, true),
+        ));
+
+        $result = GreenlightCli::run($project->directory, ['run', '--no-ansi']);
+
+        Expect::that($result->exitCode)
+            ->because('a discovery failure MUST stop the run cleanly')
+            ->toBe(1)
+            ->and($result->stderr)
+            ->toContain('MissingProviderTest::needsData() references data-set provider')
+            ->toContain('MissingProviderTest::doesNotExist(), but the provider does not exist.');
+    }
+}


### PR DESCRIPTION
Covers discovery errors through the normal run command. The acceptance test confirms that a missing data provider stops the run with exit code 1 and prints the actionable discovery diagnostic.