### PR TITLE
test: cover temp directory root cleanup failures

### DIFF
--- a/docs/api-fixtures-harness.md
+++ b/docs/api-fixtures-harness.md
@@ -64,7 +64,7 @@ final class TempDirectory implements Disposable
 public function path(): string
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L19)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L21)
 
 ### `subdirectory()`
 
@@ -77,7 +77,7 @@ PHPDoc:
 - `@param string $name A relative path of plain segments. The path can contain separators but cannot contain traversal segments.`
 - `@return non-empty-string`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L47)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L49)
 
 ### `dispose()`
 
@@ -86,7 +86,7 @@ PHPDoc:
 public function dispose(): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L72)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L74)
 
 ## `Disposable`
 

--- a/src/Fixture/TempDirectory.php
+++ b/src/Fixture/TempDirectory.php
@@ -16,10 +16,12 @@ final class TempDirectory implements Disposable
 {
     private ?string $path = null;
 
+    public function __construct(private readonly ?string $temporaryRoot = null) {}
+
     public function path(): string
     {
         if ($this->path === null) {
-            $systemTemporaryRoot = \sys_get_temp_dir();
+            $systemTemporaryRoot = $this->temporaryRoot ?? \sys_get_temp_dir();
             $resolvedTemporaryRoot = \realpath($systemTemporaryRoot);
             $temporaryRoot = $resolvedTemporaryRoot === false ? $systemTemporaryRoot : $resolvedTemporaryRoot;
             $path = $temporaryRoot . '/greenlight-' . \bin2hex(\random_bytes(8));

--- a/tests/Unit/Fixture/TempDirectoryTest.php
+++ b/tests/Unit/Fixture/TempDirectoryTest.php
@@ -235,6 +235,40 @@ final class TempDirectoryTest
     }
 
     #[Test]
+    public function disposeReportsItsRootWhenTheRootCannotBeRemoved(): void
+    {
+        $owner = new TempDirectory();
+        $temporaryRoot = $owner->subdirectory('blocked-root');
+        $directory = new TempDirectory($temporaryRoot);
+        $path = $directory->path();
+        \chmod($temporaryRoot, 0o500);
+        \clearstatcache(true, $temporaryRoot);
+
+        try {
+            if (\is_writable($temporaryRoot)) {
+                throw new SkipTest('The filesystem does not enforce directory write permissions.');
+            }
+
+            Expect::that(static function () use ($directory): void {
+                $directory->dispose();
+            })
+                ->because('fixture cleanup MUST report a root that it cannot remove')
+                ->toThrow(
+                    \RuntimeException::class,
+                    message: \sprintf(
+                        'Failed to remove temp directory "%s": rmdir(%s): Permission denied.',
+                        $path,
+                        $path,
+                    ),
+                );
+        } finally {
+            \chmod($temporaryRoot, 0o700);
+            $directory->dispose();
+            $owner->dispose();
+        }
+    }
+
+    #[Test]
     public function disposeRemovesASymbolicLinkWithoutChangingItsTarget(): void
     {
         $directory = new TempDirectory();


### PR DESCRIPTION
Let TempDirectory accept an optional temporary root so cleanup failures can be exercised directly without a subprocess or timing dependency. Cover the final root-removal failure with an exact toThrow assertion and restore permissions before fixture cleanup.