### PR TITLE
test: remove subprocess exit timing race

### DIFF
--- a/tests/Support/Subprocess.php
+++ b/tests/Support/Subprocess.php
@@ -131,6 +131,16 @@ final class Subprocess
     public function readStdoutUntil(string $needle, float $timeoutSeconds): string
     {
         $offset = \strlen($this->stdout);
+
+        if ($this->finished) {
+            throw new \RuntimeException(\sprintf(
+                "Process exited before stdout contained '%s'. Stdout:\n%s\nStderr:\n%s",
+                $needle,
+                $this->stdout,
+                $this->stderr,
+            ));
+        }
+
         $deadline = \microtime(true) + $timeoutSeconds;
 
         while (\microtime(true) < $deadline) {

--- a/tests/Unit/Support/SubprocessTest.php
+++ b/tests/Unit/Support/SubprocessTest.php
@@ -98,7 +98,7 @@ final readonly class SubprocessTest
     }
 
     #[Test]
-    public function readStdoutUntilStopsWaitingWhenTheProcessExits(): void
+    public function readStdoutUntilReportsAProcessThatAlreadyExited(): void
     {
         $process = Subprocess::start(
             $this->workspace->path(),
@@ -106,6 +106,11 @@ final readonly class SubprocessTest
         );
 
         try {
+            $result = $process->complete();
+
+            Expect::that($result->exitCode)->toBe(9)
+                ->and($result->stderr)->toBe('failed');
+
             Expect::that(static fn(): string => $process->readStdoutUntil('ready', 2.0))
                 ->toThrow(\RuntimeException::class, '/Process exited before stdout contained/');
         } finally {


### PR DESCRIPTION
The Subprocess exit test required a newly spawned PHP process to finish inside a fixed two-second window. Under parallel suite load, process startup could consume that complete window and report a timeout instead of the intended exit diagnostic.\n\nTeach the test helper to report its buffered terminal state after complete() closes the process. Complete the child before asserting that readStdoutUntil() reports the exit, so scheduling speed no longer determines the result.