### PR TITLE
test: exercise corrupt discovery cache fallback

### DIFF
--- a/tests/Unit/Discovery/DiscoveryCacheTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheTest.php
@@ -122,7 +122,12 @@ final class DiscoveryCacheTest
     {
         $className = 'WireProbe' . \bin2hex(\random_bytes(6)) . 'Test';
         $directory = $this->writeFixture($className);
-        $source = $directory . '/' . $className . '.php';
+        $source = \realpath($directory . '/' . $className . '.php');
+
+        if (!\is_string($source)) {
+            Fail::because('Expected the discovery fixture to have a canonical path.');
+        }
+
         $cacheFile = $this->cacheFile($directory);
         $loader = static function (string $class) use ($directory, $className): void {
             if ($class === 'GreenlightDiscoCache\\' . $className) {


### PR DESCRIPTION
Canonicalizes the fixture file key planted in the discovery cache. This makes the existing test exercise the corrupt-plan fallback and replacement path on systems where the temporary directory resolves through a symlink.