### PR TITLE
test: cover unencodable discovery cache metadata

### DIFF
--- a/tests/Unit/Discovery/DiscoveryCachePersistenceTest.php
+++ b/tests/Unit/Discovery/DiscoveryCachePersistenceTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Discovery\DiscoveryCache;
+use Greenlight\Discovery\PlanEntry;
+use Greenlight\Expect\Expect;
+
+final readonly class DiscoveryCachePersistenceTest
+{
+    #[Test]
+    public function unencodableMetadataDoesNotWriteACache(): void
+    {
+        $directory = \sys_get_temp_dir() . '/greenlight-unencodable-cache-' . \bin2hex(\random_bytes(6));
+        $source = $directory . '/InvalidUtf8Test.php';
+        $cacheFile = $this->cacheFile($directory);
+        \mkdir($directory, 0o777, true);
+        \file_put_contents($source, '<?php');
+
+        $id = new TestId('Example\InvalidUtf8Test', 'runs');
+        $entry = new PlanEntry(
+            $id,
+            new TestMetadata($id->class, $id->method, groups: ["invalid \xFF"]),
+        );
+        $cache = DiscoveryCache::forDirectories([$directory]);
+        $cache->store($source, [$entry]);
+
+        try {
+            Expect::that($cache->persist())
+                ->because('unencodable metadata MUST make cache persistence fail safely')
+                ->toBeFalse()
+                ->and(\is_file($cacheFile))
+                ->because('a failed cache encoding MUST not write a cache file')
+                ->toBeFalse();
+        } finally {
+            @\unlink($cacheFile);
+            @\unlink($source);
+            @\rmdir($directory);
+        }
+    }
+
+    /**
+     * @param non-empty-string $directory
+     */
+    private function cacheFile(string $directory): string
+    {
+        return \sprintf(
+            '%s/greenlight-discovery-%s.json',
+            \rtrim(\sys_get_temp_dir(), '/'),
+            \substr(\sha1($directory), 0, 12),
+        );
+    }
+}


### PR DESCRIPTION
Cover the cache persistence recovery path when a valid plan entry contains metadata that JSON cannot encode. The focused test verifies that persistence returns false and leaves no cache file behind.