### PR TITLE
test: cover LINES terminal height override

### DIFF
--- a/tests/Unit/Cli/ApplicationTerminalRowsTest.php
+++ b/tests/Unit/Cli/ApplicationTerminalRowsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\Application;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\EnvironmentSandbox;
+
+final readonly class ApplicationTerminalRowsTest
+{
+    public function __construct(private EnvironmentSandbox $environment) {}
+
+    #[Test]
+    public function linesEnvironmentVariableSetsTerminalRows(): void
+    {
+        $this->environment->set('LINES', '37');
+
+        $application = new \ReflectionClass(Application::class)->newInstanceWithoutConstructor();
+        $rows = new \ReflectionMethod(Application::class, 'terminalRows')->invoke($application);
+
+        Expect::that($rows)
+            ->because('a positive LINES value MUST set the reporter terminal height')
+            ->toBe(37);
+    }
+}


### PR DESCRIPTION
Cover the positive LINES environment override used to size the TTY reporter window. The focused test isolates process environment changes and verifies the exact terminal height selected by the application.