### PR TITLE
test: cover orchestrator TCP socket fallback

### DIFF
--- a/src/Runner/Orchestrator/Orchestrator.php
+++ b/src/Runner/Orchestrator/Orchestrator.php
@@ -183,7 +183,7 @@ final class Orchestrator
         $this->spawnBudget = \count($plan->entries) + $workerCount * 8 + 16;
 
         $token = \bin2hex(\random_bytes(16));
-        [$server, $address, $socketPath] = $this->listen();
+        $server = ServerSocket::listen();
 
         try {
             while (true) {
@@ -191,13 +191,13 @@ final class Orchestrator
                     $this->drainAll();
                 }
 
-                $this->spawnUpTo($workerCount, $address, $token, $sink);
+                $this->spawnUpTo($workerCount, $server->address, $token, $sink);
 
                 if ($this->finished()) {
                     break;
                 }
 
-                $this->tick($server, $token, $sink);
+                $this->tick($server->stream(), $token, $sink);
                 $this->ticker?->tick(\microtime(true));
             }
         } finally {
@@ -205,53 +205,10 @@ final class Orchestrator
                 $handle->terminate();
             }
 
-            ErrorTrap::run(static function () use ($server, $socketPath): void {
-                \fclose($server);
-
-                if ($socketPath !== null) {
-                    \unlink($socketPath);
-                    \rmdir(\dirname($socketPath));
-                }
-            });
+            $server->close();
         }
 
         return $this->summary;
-    }
-
-    /**
-     * @return array{resource, non-empty-string, non-empty-string|null} server, address, unix socket path when used
-     */
-    private function listen(): array
-    {
-        // Put Unix sockets in the temporary directory. sun_path has a limit of
-        // approximately 100 bytes, and long project paths can exceed it.
-        $socketPath = \rtrim(\sys_get_temp_dir(), '/') . '/greenlight-' . \bin2hex(\random_bytes(6)) . '/orchestrator.sock';
-
-        $server = ErrorTrap::run(static function () use ($socketPath) {
-            \mkdir(\dirname($socketPath), 0o700, true);
-
-            return \stream_socket_server('unix://' . $socketPath, $errorCode, $errorMessage);
-        });
-
-        if (\is_resource($server)) {
-            return [$server, 'unix://' . $socketPath, $socketPath];
-        }
-
-        $server = ErrorTrap::run(static function () use (&$errorCode, &$errorMessage) {
-            return \stream_socket_server('tcp://127.0.0.1:0', $errorCode, $errorMessage);
-        });
-
-        if (!\is_resource($server)) {
-            throw ProtocolError::malformedFrame('Greenlight did not open an orchestrator socket: ' . $errorMessage);
-        }
-
-        $name = \stream_socket_get_name($server, false);
-
-        if ($name === false || $name === '') {
-            throw ProtocolError::malformedFrame('Greenlight did not resolve the orchestrator socket address');
-        }
-
-        return [$server, 'tcp://' . $name, null];
     }
 
     /**

--- a/src/Runner/Orchestrator/ServerSocket.php
+++ b/src/Runner/Orchestrator/ServerSocket.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Runner\Orchestrator;
+
+use Greenlight\Core\ErrorTrap;
+use Greenlight\Runner\Protocol\ProtocolError;
+
+/**
+ * Opens the orchestrator listener and owns its cleanup.
+ *
+ * @internal
+ */
+final class ServerSocket
+{
+    /**
+     * @param resource $stream
+     * @param non-empty-string $address
+     */
+    private function __construct(
+        private $stream,
+        public readonly string $address,
+        private readonly ?string $unixPath,
+    ) {}
+
+    public static function listen(?string $temporaryDirectory = null): self
+    {
+        $temporaryDirectory ??= \sys_get_temp_dir();
+        $socketPath = \rtrim($temporaryDirectory, '/')
+            . '/greenlight-' . \bin2hex(\random_bytes(6)) . '/orchestrator.sock';
+
+        $server = ErrorTrap::run(static function () use ($socketPath) {
+            \mkdir(\dirname($socketPath), 0o700, true);
+
+            return \stream_socket_server('unix://' . $socketPath, $errorCode, $errorMessage);
+        });
+
+        if (\is_resource($server)) {
+            return new self($server, 'unix://' . $socketPath, $socketPath);
+        }
+
+        $server = ErrorTrap::run(static function () use (&$errorCode, &$errorMessage) {
+            return \stream_socket_server('tcp://127.0.0.1:0', $errorCode, $errorMessage);
+        });
+
+        if (!\is_resource($server)) {
+            throw ProtocolError::malformedFrame(
+                'Greenlight did not open an orchestrator socket: ' . $errorMessage,
+            );
+        }
+
+        $name = \stream_socket_get_name($server, false);
+
+        if ($name === false || $name === '') {
+            throw ProtocolError::malformedFrame(
+                'Greenlight did not resolve the orchestrator socket address',
+            );
+        }
+
+        return new self($server, 'tcp://' . $name, null);
+    }
+
+    /**
+     * @return resource
+     */
+    public function stream()
+    {
+        return $this->stream;
+    }
+
+    public function close(): void
+    {
+        ErrorTrap::run(function (): void {
+            \fclose($this->stream);
+
+            if ($this->unixPath !== null) {
+                \unlink($this->unixPath);
+                \rmdir(\dirname($this->unixPath));
+            }
+        });
+    }
+}

--- a/tests/Unit/Runner/Orchestrator/ServerSocketTest.php
+++ b/tests/Unit/Runner/Orchestrator/ServerSocketTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Orchestrator;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Runner\Orchestrator\ServerSocket;
+
+final class ServerSocketTest
+{
+    #[Test]
+    public function tcpFallbackListensWhenTheUnixSocketCannotOpen(): void
+    {
+        $temporaryDirectory = \is_dir('/tmp') ? '/tmp' : \sys_get_temp_dir();
+        $blocked = \tempnam($temporaryDirectory, 'greenlight-socket-');
+        $socket = null;
+
+        try {
+            if (!\is_string($blocked)) {
+                Fail::because('Could not create the blocked socket directory fixture.');
+            }
+
+            $socket = ServerSocket::listen($blocked);
+
+            Expect::that($socket->address)
+                ->because('the orchestrator MUST use TCP when its Unix socket cannot open')
+                ->toStartWith('tcp://127.0.0.1:')
+                ->and(\is_resource($socket->stream()))
+                ->toBeTrue();
+        } finally {
+            $socket?->close();
+
+            if (\is_string($blocked)) {
+                \unlink($blocked);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Extract the orchestrator listener into an internal socket owner so its fallback policy can be exercised directly. Add deterministic coverage that blocks Unix socket creation and verifies the live TCP listener used instead.