### PR TITLE
test: cover orchestrator worker spawn budget

### DIFF
--- a/src/Runner/Orchestrator/Orchestrator.php
+++ b/src/Runner/Orchestrator/Orchestrator.php
@@ -96,10 +96,6 @@ final class Orchestrator
 
     private bool $retryWaitingWorkers = false;
 
-    private int $spawnedCount = 0;
-
-    private int $spawnBudget = 0;
-
     private ?ChannelAllocator $channels = null;
 
     /**
@@ -177,10 +173,7 @@ final class Orchestrator
             return $this->summary;
         }
 
-        // Worker replacement and crash containment can start replacement
-        // processes. Permit only a small number for each planned test. A
-        // larger number indicates a replacement loop and must fail the run.
-        $this->spawnBudget = \count($plan->entries) + $workerCount * 8 + 16;
+        $spawnBudget = new WorkerSpawnBudget(\count($plan->entries), $workerCount);
 
         $token = \bin2hex(\random_bytes(16));
         [$server, $address, $socketPath] = $this->listen();
@@ -191,7 +184,7 @@ final class Orchestrator
                     $this->drainAll();
                 }
 
-                $this->spawnUpTo($workerCount, $address, $token, $sink);
+                $this->spawnUpTo($workerCount, $address, $token, $sink, $spawnBudget);
 
                 if ($this->finished()) {
                     break;
@@ -259,15 +252,20 @@ final class Orchestrator
      * @param non-empty-string $address
      * @param non-empty-string $token
      */
-    private function spawnUpTo(int $workerCount, string $address, string $token, EventSink $sink): void
-    {
+    private function spawnUpTo(
+        int $workerCount,
+        string $address,
+        string $token,
+        EventSink $sink,
+        WorkerSpawnBudget $spawnBudget,
+    ): void {
         // Isolated and reused workers use the same worker pool. The active
         // count below limits live workers to the worker count. Thus, the
         // allocator has a channel for each possible live worker.
         $channels = $this->channels ??= new ChannelAllocator($workerCount);
 
         while (!$this->draining && $this->pendingUnits() > $this->unassignedActiveCount() && $this->activeCount() < $workerCount) {
-            $workerId = 'w-' . ++$this->spawnedCount;
+            $workerId = $spawnBudget->nextWorkerId();
 
             $command = [...$this->workerCommand, '__worker', $address, $workerId, $token];
             $descriptors = [
@@ -275,14 +273,6 @@ final class Orchestrator
                 1 => ['pipe', 'w'],
                 2 => ['pipe', 'w'],
             ];
-
-            if ($this->spawnedCount > $this->spawnBudget) {
-                throw ProtocolError::malformedFrame(\sprintf(
-                    'Greenlight started %d workers for this execution plan. '
-                    . 'This count indicates a worker replacement loop',
-                    $this->spawnedCount,
-                ));
-            }
 
             $channelNumber = $channels->allocate();
             // The env parameter of proc_open replaces the complete

--- a/src/Runner/Orchestrator/WorkerSpawnBudget.php
+++ b/src/Runner/Orchestrator/WorkerSpawnBudget.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Runner\Orchestrator;
+
+use Greenlight\Runner\Protocol\ProtocolError;
+
+/**
+ * Allocates worker IDs and stops replacement loops.
+ *
+ * @internal
+ */
+final class WorkerSpawnBudget
+{
+    private int $spawned = 0;
+
+    private readonly int $limit;
+
+    /**
+     * @param non-negative-int $plannedTests
+     * @param positive-int $workerCount
+     */
+    public function __construct(int $plannedTests, int $workerCount)
+    {
+        // Worker replacement and crash containment can start replacement
+        // processes. Permit only a small number for each planned test.
+        $this->limit = $plannedTests + $workerCount * 8 + 16;
+    }
+
+    /**
+     * @return non-empty-string
+     */
+    public function nextWorkerId(): string
+    {
+        ++$this->spawned;
+
+        if ($this->spawned > $this->limit) {
+            throw ProtocolError::malformedFrame(\sprintf(
+                'Greenlight started %d workers for this execution plan. '
+                . 'This count indicates a worker replacement loop',
+                $this->spawned,
+            ));
+        }
+
+        return 'w-' . $this->spawned;
+    }
+}

--- a/tests/Unit/Runner/Orchestrator/WorkerSpawnBudgetTest.php
+++ b/tests/Unit/Runner/Orchestrator/WorkerSpawnBudgetTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Orchestrator;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\Orchestrator\WorkerSpawnBudget;
+use Greenlight\Runner\Protocol\ProtocolError;
+
+final readonly class WorkerSpawnBudgetTest
+{
+    #[Test]
+    public function workerIdsStopAtTheReplacementBudget(): void
+    {
+        $budget = new WorkerSpawnBudget(plannedTests: 1, workerCount: 1);
+
+        Expect::that($budget->nextWorkerId())
+            ->because('worker IDs start at one')
+            ->toBe('w-1');
+
+        $last = '';
+
+        for ($worker = 2; $worker <= 25; ++$worker) {
+            $last = $budget->nextWorkerId();
+        }
+
+        Expect::that($last)
+            ->because('the replacement budget permits the final bounded worker')
+            ->toBe('w-25')
+            ->and($budget->nextWorkerId(...))
+            ->because('the replacement budget MUST stop a worker loop')
+            ->toThrow(
+                ProtocolError::class,
+                message: 'Malformed frame: Greenlight started 26 workers for this execution plan. '
+                    . 'This count indicates a worker replacement loop.',
+            );
+    }
+}


### PR DESCRIPTION
Extract worker ID allocation and replacement-loop enforcement from process startup into a focused policy module. Cover its boundary synchronously so the guard is verified without spawning 26 replacement processes.