### PR TITLE
test: cover stalled attachment writes

### DIFF
--- a/src/Runner/Artifact/ArtifactStore.php
+++ b/src/Runner/Artifact/ArtifactStore.php
@@ -139,7 +139,7 @@ final class ArtifactStore
             $stagingFileCreated = true;
 
             try {
-                $this->writeFully($stream, $bytes);
+                StreamWriter::writeFully($stream, $bytes);
             } finally {
                 \fclose($stream);
             }
@@ -235,7 +235,7 @@ final class ArtifactStore
 
                         $copied += \strlen($chunk);
                         \hash_update($hash, $chunk);
-                        $this->writeFully($destination, $chunk);
+                        StreamWriter::writeFully($destination, $chunk);
                     }
                 } finally {
                     \fclose($destination);
@@ -475,25 +475,6 @@ final class ArtifactStore
                 $size,
                 $configuration->maxAttachmentBytes,
             ));
-        }
-    }
-
-    /**
-     * @param resource $stream
-     */
-    private function writeFully($stream, string $bytes): void
-    {
-        $offset = 0;
-        $length = \strlen($bytes);
-
-        while ($offset < $length) {
-            $written = \fwrite($stream, \substr($bytes, $offset));
-
-            if ($written === false || $written === 0) {
-                throw AttachmentError::storage('Failed to write the complete attachment');
-            }
-
-            $offset += $written;
         }
     }
 
@@ -743,7 +724,7 @@ final class ArtifactStore
                 }
 
                 if ($chunk !== '') {
-                    $this->writeFully($destination, $chunk);
+                    StreamWriter::writeFully($destination, $chunk);
                 }
             }
 

--- a/src/Runner/Artifact/StreamWriter.php
+++ b/src/Runner/Artifact/StreamWriter.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Runner\Artifact;
+
+use Greenlight\Core\Artifact\AttachmentError;
+
+/**
+ * Writes complete byte strings to streams.
+ *
+ * @internal
+ */
+final class StreamWriter
+{
+    /**
+     * @param resource $stream
+     */
+    public static function writeFully($stream, string $bytes): void
+    {
+        $offset = 0;
+        $length = \strlen($bytes);
+
+        while ($offset < $length) {
+            $written = \fwrite($stream, \substr($bytes, $offset));
+
+            if ($written === false || $written === 0) {
+                throw AttachmentError::storage('Failed to write the complete attachment');
+            }
+
+            $offset += $written;
+        }
+    }
+
+    private function __construct() {}
+}

--- a/src/Runner/Artifact/StreamWriter.php
+++ b/src/Runner/Artifact/StreamWriter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Runner\Artifact;
 
+use Greenlight\Attribute\CoverageIgnore;
 use Greenlight\Core\Artifact\AttachmentError;
 
 /**
@@ -32,5 +33,6 @@ final class StreamWriter
         }
     }
 
+    #[CoverageIgnore]
     private function __construct() {}
 }

--- a/tests/Fixture/Artifact/ZeroWriteStream.php
+++ b/tests/Fixture/Artifact/ZeroWriteStream.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Artifact;
+
+use Greenlight\Doubles\Fake;
+
+/**
+ * Simulates an open stream that cannot make progress on a write.
+ */
+final class ZeroWriteStream implements Fake
+{
+    public mixed $context;
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        return true;
+    }
+
+    public function stream_write(string $data): int
+    {
+        return 0;
+    }
+}

--- a/tests/Unit/Artifact/ArtifactStreamWriteFailureTest.php
+++ b/tests/Unit/Artifact/ArtifactStreamWriteFailureTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Runner\Artifact\StreamWriter;
+use Greenlight\Tests\Fixture\Artifact\ZeroWriteStream;
+
+final class ArtifactStreamWriteFailureTest
+{
+    private const string SCHEME = 'greenlight-zero-write';
+
+    #[Test]
+    public function aZeroByteWriteFailsInsteadOfLooping(): void
+    {
+        if (!\stream_wrapper_register(self::SCHEME, ZeroWriteStream::class)) {
+            Fail::because('The test could not register the zero-write stream.');
+        }
+
+        $stream = \fopen(self::SCHEME . '://attachment', 'wb');
+
+        if ($stream === false) {
+            \stream_wrapper_unregister(self::SCHEME);
+            Fail::because('The test could not open the zero-write stream.');
+        }
+
+        try {
+            Expect::that(static fn() => StreamWriter::writeFully($stream, 'evidence'))
+                ->because('a write without progress MUST fail instead of looping')
+                ->toThrow(
+                    AttachmentError::class,
+                    message: 'Failed to write the complete attachment.',
+                );
+        } finally {
+            \fclose($stream);
+            \stream_wrapper_unregister(self::SCHEME);
+        }
+    }
+}


### PR DESCRIPTION
Cover an attachment output stream that accepts no bytes. The Fake stream deterministically returns a zero-byte write, and the focused test verifies that Greenlight reports the exact storage failure instead of looping indefinitely.