### PR TITLE
fix(artifacts): preserve metadata blockers on rollback

### DIFF
--- a/src/Runner/Artifact/ArtifactStore.php
+++ b/src/Runner/Artifact/ArtifactStore.php
@@ -694,11 +694,12 @@ final class ArtifactStore
         ?string $path,
         ?string $part,
     ): void {
+        // writeMetadata() removes its temporary file when it fails. A final
+        // metadata path that remains belongs to an earlier operation.
         foreach ([
             $part,
             $path,
             $this->metadataPath($storageKey) . '.part',
-            $this->metadataPath($storageKey),
         ] as $candidate) {
             if ($candidate !== null) {
                 $this->removeFile($candidate, 'incomplete attachment staging data');

--- a/tests/Unit/Artifact/ArtifactMetadataCollisionTest.php
+++ b/tests/Unit/Artifact/ArtifactMetadataCollisionTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Core\Artifact\AttachmentKind;
+use Greenlight\Core\Artifact\AttachmentRetention;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\ArtifactSession;
+use Greenlight\Runner\Artifact\ArtifactStore;
+
+final readonly class ArtifactMetadataCollisionTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function metadataCollisionPreservesTheBlockerAndReleasesQuota(): void
+    {
+        $root = $this->tempDirectory->subdirectory('metadata-collision');
+        $staging = $root . '/staging';
+        $storageKey = 'Example-EvidenceTest/attempt-1/01-evidence.txt';
+        $metadata = $staging . '/' . $storageKey . '.meta.json';
+        \mkdir($metadata, 0o777, true);
+        $configuration = new ArtifactConfiguration(
+            $root . '/published',
+            maxRunAttachments: 1,
+        );
+        $store = ArtifactStore::fromSession(
+            new ArtifactSession($staging, $root . '/published/run-1'),
+            $configuration,
+        );
+
+        Expect::that(static fn() => $store->stageBytes(
+            'evidence',
+            'evidence.txt',
+            $storageKey,
+            'text/plain',
+            AttachmentKind::Text,
+            1,
+            AttachmentRetention::OnFailure,
+            $configuration,
+        ))
+            ->because('a metadata collision MUST report its primary finalization failure')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Failed to finalize attachment recovery metadata.',
+            )
+            ->and(\is_dir($metadata))
+            ->because('rollback MUST preserve pre-existing metadata blockers')
+            ->toBeTrue()
+            ->and(\file_exists($staging . '/' . $storageKey))
+            ->because('rollback MUST remove attachment content without completed metadata')
+            ->toBeFalse();
+
+        \rmdir($metadata);
+        $staged = $store->stageBytes(
+            'replacement',
+            'replacement.txt',
+            $storageKey,
+            'text/plain',
+            AttachmentKind::Text,
+            1,
+            AttachmentRetention::OnFailure,
+            $configuration,
+        );
+
+        Expect::that($staged->name)
+            ->because('a metadata failure MUST release its run quota')
+            ->toBe('replacement.txt');
+    }
+}


### PR DESCRIPTION
Cover attachment metadata finalization failure through a pre-existing metadata-path blocker. Keep caller-owned metadata paths intact, preserve the primary finalization error, remove incomplete content, and release quota for a successful retry.