### PR TITLE
test: cover assignment send recovery

### DIFF
--- a/tests/Fixture/Runner/Orchestrator/DisconnectBeforeAssignmentWorker.php
+++ b/tests/Fixture/Runner/Orchestrator/DisconnectBeforeAssignmentWorker.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Runner\Orchestrator;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Runner\Protocol\Messages\Hello;
+use Greenlight\Runner\Protocol\SocketChannel;
+use Greenlight\Runner\Worker\WorkerProcess;
+
+final readonly class DisconnectBeforeAssignmentWorker implements Fake
+{
+    /**
+     * @param non-empty-string $address
+     * @param non-empty-string $workerId
+     * @param non-empty-string $token
+     */
+    public static function run(string $address, string $workerId, string $token): int
+    {
+        if ($workerId !== 'w-1') {
+            return new WorkerProcess()->run($address, $workerId, $token);
+        }
+
+        $stream = \stream_socket_client($address);
+
+        if (!\is_resource($stream)) {
+            return 2;
+        }
+
+        $channel = new SocketChannel($stream);
+        $pid = \getmypid();
+        $channel->send(new Hello($workerId, $token, $pid === false ? 1 : \max(1, $pid)));
+        \stream_socket_shutdown($stream, \STREAM_SHUT_RDWR);
+        $channel->close();
+
+        return 0;
+    }
+}

--- a/tests/Unit/Runner/Orchestrator/OrchestratorTest.php
+++ b/tests/Unit/Runner/Orchestrator/OrchestratorTest.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Attribute\Timeout;
 use Greenlight\Core\Event\RecycleReason;
+use Greenlight\Core\Event\TestClassStarted;
 use Greenlight\Core\Event\WorkerRecycled;
 use Greenlight\Core\Result\ResultSummary;
 use Greenlight\Core\Test\TestId;
@@ -23,6 +24,7 @@ use Greenlight\Tests\Fixture\Lifecycle\Bail\AaTest;
 use Greenlight\Tests\Fixture\Lifecycle\Bail\BbTest;
 use Greenlight\Tests\Fixture\ResourceScheduling\SlowResourceTest;
 use Greenlight\Tests\Fixture\ResourceScheduling\WaitingResourceTest;
+use Greenlight\Tests\Fixture\Runner\Orchestrator\DisconnectBeforeAssignmentWorker;
 use Greenlight\Tests\Support\CollectingEventSink;
 
 final class OrchestratorTest
@@ -88,6 +90,39 @@ final class OrchestratorTest
             ->and($results)->toHaveCount(1)
             ->and((string) $results[0]->id)
             ->toBe(CleanTest::class . '::passesAndIsCollectable');
+    }
+
+    #[Test]
+    #[Timeout(30.0)]
+    public function aWorkerThatDisconnectsBeforeAssignmentIsReplaced(): void
+    {
+        $root = \dirname(__DIR__, 4);
+        $bootstrap = \sprintf(
+            'require %s; exit(%s::run($argv[2], $argv[3], $argv[4]));',
+            \var_export($root . '/vendor/autoload.php', true),
+            DisconnectBeforeAssignmentWorker::class,
+        );
+        $orchestrator = new Orchestrator(
+            workerCommand: [\PHP_BINARY, '-r', $bootstrap],
+            workingDirectory: $root,
+        );
+        $sink = new CollectingEventSink();
+
+        $summary = $orchestrator->run($this->passingPlan(), $sink, 1);
+        $workers = [];
+
+        foreach ($sink->events as $event) {
+            if ($event instanceof TestClassStarted) {
+                $workers[] = $event->workerId;
+            }
+        }
+
+        Expect::that($summary->passed)
+            ->because('a replacement worker MUST complete the undelivered assignment')
+            ->toBe(1)
+            ->and($workers)
+            ->because('the disconnected worker MUST NOT start the test class')
+            ->toBe(['w-2']);
     }
 
     #[Test]


### PR DESCRIPTION
Add a protocol-aware fake worker that authenticates and then closes its socket before assignment delivery. Verify that the orchestrator requeues the untouched assignment and that a real replacement worker completes it.