### PR TITLE
test: cover attachment copy open failures

### DIFF
--- a/src/Runner/Artifact/ArtifactStore.php
+++ b/src/Runner/Artifact/ArtifactStore.php
@@ -349,7 +349,7 @@ final class ArtifactStore
             }
 
             try {
-                $this->copyFile($source, $part);
+                FileCopier::copy($source, $part);
 
                 if (\filesize($part) !== $attachment->sizeBytes || \hash_file('sha256', $part) !== $attachment->sha256) {
                     throw AttachmentError::storage('Published attachment content does not match its metadata');
@@ -696,45 +696,6 @@ final class ArtifactStore
 
         if (!\unlink($path)) {
             throw AttachmentError::storage('Greenlight did not remove ' . $description);
-        }
-    }
-
-    private function copyFile(string $sourcePath, string $destinationPath): void
-    {
-        $source = \fopen($sourcePath, 'rb');
-        $destination = \fopen($destinationPath, 'xb');
-
-        if ($source === false || $destination === false) {
-            if (\is_resource($source)) {
-                \fclose($source);
-            }
-
-            if (\is_resource($destination)) {
-                \fclose($destination);
-            }
-
-            throw AttachmentError::storage('Failed to copy attachment into its output directory');
-        }
-
-        try {
-            while (!\feof($source)) {
-                $chunk = \fread($source, self::COPY_CHUNK_BYTES);
-
-                if ($chunk === false) {
-                    throw AttachmentError::storage('Failed to read attachment staging content');
-                }
-
-                if ($chunk !== '') {
-                    StreamWriter::writeFully($destination, $chunk);
-                }
-            }
-
-            if (!\fflush($destination)) {
-                throw AttachmentError::storage('Failed to flush the published attachment');
-            }
-        } finally {
-            \fclose($destination);
-            \fclose($source);
         }
     }
 

--- a/src/Runner/Artifact/FileCopier.php
+++ b/src/Runner/Artifact/FileCopier.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Runner\Artifact;
+
+use Greenlight\Attribute\CoverageIgnore;
+use Greenlight\Core\Artifact\AttachmentError;
+
+/**
+ * Copies attachment files into their output directory.
+ *
+ * @internal
+ */
+final class FileCopier
+{
+    private const int COPY_CHUNK_BYTES = 1024 * 1024;
+
+    public static function copy(string $sourcePath, string $destinationPath): void
+    {
+        $source = \fopen($sourcePath, 'rb');
+        $destination = \fopen($destinationPath, 'xb');
+
+        if ($source === false || $destination === false) {
+            if (\is_resource($source)) {
+                \fclose($source);
+            }
+
+            if (\is_resource($destination)) {
+                \fclose($destination);
+            }
+
+            throw AttachmentError::storage('Failed to copy attachment into its output directory');
+        }
+
+        try {
+            while (!\feof($source)) {
+                $chunk = \fread($source, self::COPY_CHUNK_BYTES);
+
+                if ($chunk === false) {
+                    throw AttachmentError::storage('Failed to read attachment staging content');
+                }
+
+                if ($chunk !== '') {
+                    StreamWriter::writeFully($destination, $chunk);
+                }
+            }
+
+            if (!\fflush($destination)) {
+                throw AttachmentError::storage('Failed to flush the published attachment');
+            }
+        } finally {
+            \fclose($destination);
+            \fclose($source);
+        }
+    }
+
+    #[CoverageIgnore]
+    private function __construct() {}
+}

--- a/tests/Fixture/Artifact/TrackedOpenStream.php
+++ b/tests/Fixture/Artifact/TrackedOpenStream.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Artifact;
+
+use Greenlight\Doubles\Fake;
+
+final class TrackedOpenStream implements Fake
+{
+    public mixed $context;
+
+    private static int $closedStreams = 0;
+
+    public static function reset(): void
+    {
+        self::$closedStreams = 0;
+    }
+
+    public static function closedStreams(): int
+    {
+        return self::$closedStreams;
+    }
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        return true;
+    }
+
+    public function stream_close(): void
+    {
+        ++self::$closedStreams;
+    }
+}

--- a/tests/Unit/Artifact/ArtifactCopyOpenFailureTest.php
+++ b/tests/Unit/Artifact/ArtifactCopyOpenFailureTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\FileCopier;
+use Greenlight\Tests\Fixture\Artifact\TrackedOpenStream;
+
+final readonly class ArtifactCopyOpenFailureTest
+{
+    private const string SCHEME = 'greenlight-tracked-open';
+
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function copyOpenFailuresCloseTheOtherStream(): void
+    {
+        if (!\stream_wrapper_register(self::SCHEME, TrackedOpenStream::class)) {
+            Fail::because('The test could not register the tracked-open stream.');
+        }
+
+        $root = $this->tempDirectory->subdirectory('copy-open-failures');
+
+        try {
+            TrackedOpenStream::reset();
+
+            Expect::that(static fn() => FileCopier::copy(
+                $root . '/missing-source.txt',
+                self::SCHEME . '://destination',
+            ))
+                ->because('a missing source MUST fail the attachment copy')
+                ->toThrow(
+                    AttachmentError::class,
+                    message: 'Failed to copy attachment into its output directory.',
+                );
+
+            Expect::that(TrackedOpenStream::closedStreams())
+                ->because('a source open failure MUST close the destination stream')
+                ->toBe(1);
+
+            TrackedOpenStream::reset();
+
+            Expect::that(static fn() => FileCopier::copy(
+                self::SCHEME . '://source',
+                $root . '/missing/destination.txt',
+            ))
+                ->because('an unavailable destination MUST fail the attachment copy')
+                ->toThrow(
+                    AttachmentError::class,
+                    message: 'Failed to copy attachment into its output directory.',
+                );
+
+            Expect::that(TrackedOpenStream::closedStreams())
+                ->because('a destination open failure MUST close the source stream')
+                ->toBe(1);
+        } finally {
+            \stream_wrapper_unregister(self::SCHEME);
+        }
+    }
+}


### PR DESCRIPTION
Extract attachment publication copying into an internal file copier so its failure paths can be tested without reflection. Cover source and destination open failures, including closure of the stream that opened successfully.