### PR TITLE
test: cover unavailable proxy defaults

### DIFF
--- a/tests/Unit/Doubles/ProxyGenerationTest.php
+++ b/tests/Unit/Doubles/ProxyGenerationTest.php
@@ -160,6 +160,24 @@ final class ProxyGenerationTest
     }
 
     #[Test]
+    public function unavailableInternalDefaultsAreRejectedBeforeProxyGeneration(): void
+    {
+        $doubles = new Doubles();
+
+        try {
+            Expect::that(static fn(): object => $doubles->stub(\ReflectionClass::class))
+                ->because('an unavailable internal default cannot produce a valid proxy signature')
+                ->toThrow(
+                    DoublesError::class,
+                    message: 'Doubles cannot reproduce the default value of parameter $default '
+                        . 'from ReflectionClass::getStaticPropertyValue() in a proxy.',
+                );
+        } finally {
+            $doubles->dispose();
+        }
+    }
+
+    #[Test]
     public function wideSignaturesRoundTripThroughTheProxy(): void
     {
         $doubles = new Doubles();


### PR DESCRIPTION
Exercise proxy generation for an internal optional parameter whose default value Reflection cannot reproduce. Verify that Doubles rejects the signature with exact guidance before writing an invalid proxy class.