### PR TITLE
test: cover intermittent attachment reads

### DIFF
--- a/tests/Fixture/Artifact/IntermittentFileStream.php
+++ b/tests/Fixture/Artifact/IntermittentFileStream.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Artifact;
+
+use Greenlight\Doubles\Fake;
+
+/**
+ * Simulates a regular file that returns no bytes before it reaches EOF.
+ */
+final class IntermittentFileStream implements Fake
+{
+    public mixed $context;
+
+    private const string CONTENT = 'evidence';
+
+    private int $offset = 0;
+
+    private bool $paused = false;
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        $this->offset = 0;
+        $this->paused = false;
+
+        return $mode === 'rb';
+    }
+
+    public function stream_read(int $count): string
+    {
+        if (!$this->paused) {
+            $this->paused = true;
+
+            return '';
+        }
+
+        $chunk = \substr(self::CONTENT, $this->offset, $count);
+        $this->offset += \strlen($chunk);
+
+        return $chunk;
+    }
+
+    public function stream_eof(): bool
+    {
+        return $this->offset >= \strlen(self::CONTENT);
+    }
+
+    /**
+     * @return array{mode: int, size: int, mtime: int}
+     */
+    public function stream_stat(): array
+    {
+        return self::stat();
+    }
+
+    /**
+     * @return array{mode: int, size: int, mtime: int}
+     */
+    public function url_stat(string $path, int $flags): array
+    {
+        return self::stat();
+    }
+
+    /**
+     * @return array{mode: int, size: int, mtime: int}
+     */
+    private static function stat(): array
+    {
+        return [
+            'mode' => 0100600,
+            'size' => \strlen(self::CONTENT),
+            'mtime' => 1,
+        ];
+    }
+}

--- a/tests/Unit/Artifact/ArtifactIntermittentReadTest.php
+++ b/tests/Unit/Artifact/ArtifactIntermittentReadTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\ArtifactStore;
+use Greenlight\Runner\Artifact\TestArtifactBudget;
+use Greenlight\Tests\Fixture\Artifact\IntermittentFileStream;
+
+final readonly class ArtifactIntermittentReadTest
+{
+    private const string SCHEME = 'greenlight-intermittent-file';
+
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function anEmptyReadBeforeEofDoesNotTruncateTheAttachment(): void
+    {
+        if (!\stream_wrapper_register(self::SCHEME, IntermittentFileStream::class)) {
+            Fail::because('The test could not register the intermittent-file stream.');
+        }
+
+        $store = null;
+
+        try {
+            $root = $this->tempDirectory->subdirectory('intermittent-file');
+            $configuration = new ArtifactConfiguration($root);
+            $store = ArtifactStore::open($configuration, $root, 'run-intermittent-file');
+            $attachments = $store->forAttempt(
+                new TestId('Example\EvidenceTest', 'keepsReading'),
+                1,
+                new TestArtifactBudget(),
+            );
+
+            $attachments->file('evidence.txt', self::SCHEME . '://evidence');
+            $attachment = $attachments->collected()[0];
+
+            Expect::that([$attachment->sizeBytes, $attachment->sha256])
+                ->because('an empty read before EOF MUST NOT truncate an attachment')
+                ->toBe([8, \hash('sha256', 'evidence')]);
+        } finally {
+            $store?->cleanup();
+            \stream_wrapper_unregister(self::SCHEME);
+        }
+    }
+}


### PR DESCRIPTION
Cover a readable attachment source that temporarily returns no bytes before EOF. Verify the public attachment API keeps reading and preserves the complete size and digest.