### PR TITLE
test: cover attachment copy flush failures

### DIFF
--- a/src/Runner/Artifact/ArtifactStore.php
+++ b/src/Runner/Artifact/ArtifactStore.php
@@ -349,7 +349,7 @@ final class ArtifactStore
             }
 
             try {
-                $this->copyFile($source, $part);
+                FileCopier::copy($source, $part);
 
                 if (\filesize($part) !== $attachment->sizeBytes || \hash_file('sha256', $part) !== $attachment->sha256) {
                     throw AttachmentError::storage('Published attachment content does not match its metadata');
@@ -696,45 +696,6 @@ final class ArtifactStore
 
         if (!\unlink($path)) {
             throw AttachmentError::storage('Greenlight did not remove ' . $description);
-        }
-    }
-
-    private function copyFile(string $sourcePath, string $destinationPath): void
-    {
-        $source = \fopen($sourcePath, 'rb');
-        $destination = \fopen($destinationPath, 'xb');
-
-        if ($source === false || $destination === false) {
-            if (\is_resource($source)) {
-                \fclose($source);
-            }
-
-            if (\is_resource($destination)) {
-                \fclose($destination);
-            }
-
-            throw AttachmentError::storage('Failed to copy attachment into its output directory');
-        }
-
-        try {
-            while (!\feof($source)) {
-                $chunk = \fread($source, self::COPY_CHUNK_BYTES);
-
-                if ($chunk === false) {
-                    throw AttachmentError::storage('Failed to read attachment staging content');
-                }
-
-                if ($chunk !== '') {
-                    StreamWriter::writeFully($destination, $chunk);
-                }
-            }
-
-            if (!\fflush($destination)) {
-                throw AttachmentError::storage('Failed to flush the published attachment');
-            }
-        } finally {
-            \fclose($destination);
-            \fclose($source);
         }
     }
 

--- a/src/Runner/Artifact/FileCopier.php
+++ b/src/Runner/Artifact/FileCopier.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Runner\Artifact;
+
+use Greenlight\Attribute\CoverageIgnore;
+use Greenlight\Core\Artifact\AttachmentError;
+
+/**
+ * Copies attachment files into their output directory.
+ *
+ * @internal
+ */
+final class FileCopier
+{
+    private const int COPY_CHUNK_BYTES = 1024 * 1024;
+
+    public static function copy(string $sourcePath, string $destinationPath): void
+    {
+        $source = \fopen($sourcePath, 'rb');
+        $destination = \fopen($destinationPath, 'xb');
+
+        if ($source === false || $destination === false) {
+            if (\is_resource($source)) {
+                \fclose($source);
+            }
+
+            if (\is_resource($destination)) {
+                \fclose($destination);
+            }
+
+            throw AttachmentError::storage('Failed to copy attachment into its output directory');
+        }
+
+        try {
+            while (!\feof($source)) {
+                $chunk = \fread($source, self::COPY_CHUNK_BYTES);
+
+                if ($chunk === false) {
+                    throw AttachmentError::storage('Failed to read attachment staging content');
+                }
+
+                if ($chunk !== '') {
+                    StreamWriter::writeFully($destination, $chunk);
+                }
+            }
+
+            if (!\fflush($destination)) {
+                throw AttachmentError::storage('Failed to flush the published attachment');
+            }
+        } finally {
+            \fclose($destination);
+            \fclose($source);
+        }
+    }
+
+    #[CoverageIgnore]
+    private function __construct() {}
+}

--- a/tests/Fixture/Artifact/TrackedOpenStream.php
+++ b/tests/Fixture/Artifact/TrackedOpenStream.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Artifact;
+
+use Greenlight\Doubles\Fake;
+
+final class TrackedOpenStream implements Fake
+{
+    public mixed $context;
+
+    private static int $closedStreams = 0;
+
+    public static function reset(): void
+    {
+        self::$closedStreams = 0;
+    }
+
+    public static function closedStreams(): int
+    {
+        return self::$closedStreams;
+    }
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        return true;
+    }
+
+    public function stream_close(): void
+    {
+        ++self::$closedStreams;
+    }
+}

--- a/tests/Fixture/Artifact/UnflushableStream.php
+++ b/tests/Fixture/Artifact/UnflushableStream.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Artifact;
+
+use Greenlight\Doubles\Fake;
+
+final class UnflushableStream implements Fake
+{
+    public mixed $context;
+
+    private static int $closedStreams = 0;
+
+    public static function reset(): void
+    {
+        self::$closedStreams = 0;
+    }
+
+    public static function closedStreams(): int
+    {
+        return self::$closedStreams;
+    }
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        return true;
+    }
+
+    public function stream_write(string $data): int
+    {
+        return \strlen($data);
+    }
+
+    public function stream_flush(): bool
+    {
+        return false;
+    }
+
+    public function stream_close(): void
+    {
+        ++self::$closedStreams;
+    }
+}

--- a/tests/Fixture/Artifact/UnreadableCopySourceStream.php
+++ b/tests/Fixture/Artifact/UnreadableCopySourceStream.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Artifact;
+
+use Greenlight\Doubles\Fake;
+
+final class UnreadableCopySourceStream implements Fake
+{
+    public mixed $context;
+
+    private static int $closedStreams = 0;
+
+    public static function reset(): void
+    {
+        self::$closedStreams = 0;
+    }
+
+    public static function closedStreams(): int
+    {
+        return self::$closedStreams;
+    }
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        return true;
+    }
+
+    public function stream_read(int $count): false
+    {
+        return false;
+    }
+
+    public function stream_eof(): bool
+    {
+        return false;
+    }
+
+    public function stream_close(): void
+    {
+        ++self::$closedStreams;
+    }
+}

--- a/tests/Unit/Artifact/ArtifactCopyFlushFailureTest.php
+++ b/tests/Unit/Artifact/ArtifactCopyFlushFailureTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\FileCopier;
+use Greenlight\Tests\Fixture\Artifact\UnflushableStream;
+
+final readonly class ArtifactCopyFlushFailureTest
+{
+    private const string SCHEME = 'greenlight-unflushable';
+
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function aFlushFailureRejectsTheCopyAndClosesTheDestination(): void
+    {
+        if (!\stream_wrapper_register(self::SCHEME, UnflushableStream::class)) {
+            Fail::because('The test could not register the unflushable stream.');
+        }
+
+        try {
+            $source = $this->tempDirectory->path() . '/copy-flush-source.txt';
+
+            if (\file_put_contents($source, 'evidence') === false) {
+                Fail::because('The test could not write its attachment source.');
+            }
+
+            UnflushableStream::reset();
+
+            Expect::that(static fn() => FileCopier::copy(
+                $source,
+                self::SCHEME . '://destination',
+            ))
+                ->because('an unflushed attachment copy MUST fail')
+                ->toThrow(
+                    AttachmentError::class,
+                    message: 'Failed to flush the published attachment.',
+                )
+                ->and(UnflushableStream::closedStreams())
+                ->because('a flush failure MUST close the destination stream')
+                ->toBe(1);
+        } finally {
+            \stream_wrapper_unregister(self::SCHEME);
+        }
+    }
+}

--- a/tests/Unit/Artifact/ArtifactCopyOpenFailureTest.php
+++ b/tests/Unit/Artifact/ArtifactCopyOpenFailureTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\FileCopier;
+use Greenlight\Tests\Fixture\Artifact\TrackedOpenStream;
+
+final readonly class ArtifactCopyOpenFailureTest
+{
+    private const string SCHEME = 'greenlight-tracked-open';
+
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function copyOpenFailuresCloseTheOtherStream(): void
+    {
+        if (!\stream_wrapper_register(self::SCHEME, TrackedOpenStream::class)) {
+            Fail::because('The test could not register the tracked-open stream.');
+        }
+
+        $root = $this->tempDirectory->subdirectory('copy-open-failures');
+
+        try {
+            TrackedOpenStream::reset();
+
+            Expect::that(static fn() => FileCopier::copy(
+                $root . '/missing-source.txt',
+                self::SCHEME . '://destination',
+            ))
+                ->because('a missing source MUST fail the attachment copy')
+                ->toThrow(
+                    AttachmentError::class,
+                    message: 'Failed to copy attachment into its output directory.',
+                );
+
+            Expect::that(TrackedOpenStream::closedStreams())
+                ->because('a source open failure MUST close the destination stream')
+                ->toBe(1);
+
+            TrackedOpenStream::reset();
+
+            Expect::that(static fn() => FileCopier::copy(
+                self::SCHEME . '://source',
+                $root . '/missing/destination.txt',
+            ))
+                ->because('an unavailable destination MUST fail the attachment copy')
+                ->toThrow(
+                    AttachmentError::class,
+                    message: 'Failed to copy attachment into its output directory.',
+                );
+
+            Expect::that(TrackedOpenStream::closedStreams())
+                ->because('a destination open failure MUST close the source stream')
+                ->toBe(1);
+        } finally {
+            \stream_wrapper_unregister(self::SCHEME);
+        }
+    }
+}

--- a/tests/Unit/Artifact/ArtifactCopyReadFailureTest.php
+++ b/tests/Unit/Artifact/ArtifactCopyReadFailureTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\FileCopier;
+use Greenlight\Tests\Fixture\Artifact\UnreadableCopySourceStream;
+
+final readonly class ArtifactCopyReadFailureTest
+{
+    private const string SCHEME = 'greenlight-unreadable-copy-source';
+
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function aReadFailureRejectsTheCopyAndClosesTheSource(): void
+    {
+        if (!\stream_wrapper_register(self::SCHEME, UnreadableCopySourceStream::class)) {
+            Fail::because('The test could not register the unreadable copy-source stream.');
+        }
+
+        try {
+            UnreadableCopySourceStream::reset();
+            $destination = $this->tempDirectory->path() . '/destination.txt';
+
+            Expect::that(static fn() => FileCopier::copy(
+                self::SCHEME . '://source',
+                $destination,
+            ))
+                ->because('an unreadable attachment source MUST fail its copy')
+                ->toThrow(
+                    AttachmentError::class,
+                    message: 'Failed to read attachment staging content.',
+                )
+                ->and(UnreadableCopySourceStream::closedStreams())
+                ->because('a read failure MUST close the source stream')
+                ->toBe(1);
+        } finally {
+            \stream_wrapper_unregister(self::SCHEME);
+        }
+    }
+}


### PR DESCRIPTION
Cover a destination stream that accepts the complete attachment but cannot flush it. Verify the internal file-copy seam reports the exact storage error and closes the destination stream.