### PR TITLE
test: cover attachment copy read failures

### DIFF
--- a/tests/Fixture/Artifact/UnreadableCopySourceStream.php
+++ b/tests/Fixture/Artifact/UnreadableCopySourceStream.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Artifact;
+
+use Greenlight\Doubles\Fake;
+
+final class UnreadableCopySourceStream implements Fake
+{
+    public mixed $context;
+
+    private static int $closedStreams = 0;
+
+    public static function reset(): void
+    {
+        self::$closedStreams = 0;
+    }
+
+    public static function closedStreams(): int
+    {
+        return self::$closedStreams;
+    }
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        return true;
+    }
+
+    public function stream_read(int $count): false
+    {
+        return false;
+    }
+
+    public function stream_eof(): bool
+    {
+        return false;
+    }
+
+    public function stream_close(): void
+    {
+        ++self::$closedStreams;
+    }
+}

--- a/tests/Unit/Artifact/ArtifactCopyReadFailureTest.php
+++ b/tests/Unit/Artifact/ArtifactCopyReadFailureTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\FileCopier;
+use Greenlight\Tests\Fixture\Artifact\UnreadableCopySourceStream;
+
+final readonly class ArtifactCopyReadFailureTest
+{
+    private const string SCHEME = 'greenlight-unreadable-copy-source';
+
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function aReadFailureRejectsTheCopyAndClosesTheSource(): void
+    {
+        if (!\stream_wrapper_register(self::SCHEME, UnreadableCopySourceStream::class)) {
+            Fail::because('The test could not register the unreadable copy-source stream.');
+        }
+
+        try {
+            UnreadableCopySourceStream::reset();
+            $destination = $this->tempDirectory->path() . '/destination.txt';
+
+            Expect::that(static fn() => FileCopier::copy(
+                self::SCHEME . '://source',
+                $destination,
+            ))
+                ->because('an unreadable attachment source MUST fail its copy')
+                ->toThrow(
+                    AttachmentError::class,
+                    message: 'Failed to read attachment staging content.',
+                )
+                ->and(UnreadableCopySourceStream::closedStreams())
+                ->because('a read failure MUST close the source stream')
+                ->toBe(1);
+        } finally {
+            \stream_wrapper_unregister(self::SCHEME);
+        }
+    }
+}


### PR DESCRIPTION
Cover a source stream that becomes unreadable during attachment publication. Verify the internal file-copy seam reports the exact storage error and closes the source stream.