### PR TITLE
fix(protocol): handle unsupported receive streams

### DIFF
--- a/src/Runner/Protocol/SocketChannel.php
+++ b/src/Runner/Protocol/SocketChannel.php
@@ -102,9 +102,13 @@ final class SocketChannel
             $except = null;
             $microseconds = (int) \min($left * 1_000_000, 200_000);
 
-            $ready = ErrorTrap::run(
-                static fn(): int|false => \stream_select($read, $write, $except, 0, \max(1, $microseconds)),
-            );
+            try {
+                $ready = ErrorTrap::run(
+                    static fn(): int|false => \stream_select($read, $write, $except, 0, \max(1, $microseconds)),
+                );
+            } catch (\ValueError) {
+                return null;
+            }
 
             if ($ready === false) {
                 return null;

--- a/tests/Fixture/Runner/Protocol/UnselectableStream.php
+++ b/tests/Fixture/Runner/Protocol/UnselectableStream.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Runner\Protocol;
+
+use Greenlight\Doubles\Fake;
+
+final class UnselectableStream implements Fake
+{
+    public mixed $context;
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        return true;
+    }
+
+    public function stream_read(int $count): string
+    {
+        return '';
+    }
+
+    public function stream_eof(): bool
+    {
+        return false;
+    }
+
+    public function stream_set_option(
+        int $option,
+        int $argumentOne,
+        ?int $argumentTwo,
+    ): bool {
+        return true;
+    }
+}

--- a/tests/Unit/Runner/Protocol/SocketChannelTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelTest.php
@@ -10,9 +10,12 @@ use Greenlight\Expect\Fail;
 use Greenlight\Runner\Protocol\Messages\Drain;
 use Greenlight\Runner\Protocol\ProtocolError;
 use Greenlight\Runner\Protocol\SocketChannel;
+use Greenlight\Tests\Fixture\Runner\Protocol\UnselectableStream;
 
 final class SocketChannelTest
 {
+    private const string UNSELECTABLE_SCHEME = 'greenlight-unselectable';
+
     #[Test]
     public function receiveTimeoutLeavesTheChannelOpenForLaterMessages(): void
     {
@@ -125,6 +128,35 @@ final class SocketChannelTest
         } finally {
             $channel->close();
             \fclose($peer);
+        }
+    }
+
+    #[Test]
+    public function aSelectFailureEndsTheReceiveWithoutClosingTheChannel(): void
+    {
+        if (!\stream_wrapper_register(self::UNSELECTABLE_SCHEME, UnselectableStream::class)) {
+            Fail::because('The test could not register the unselectable stream.');
+        }
+
+        $stream = \fopen(self::UNSELECTABLE_SCHEME . '://channel', 'r+');
+
+        if ($stream === false) {
+            \stream_wrapper_unregister(self::UNSELECTABLE_SCHEME);
+            Fail::because('The test could not open the unselectable stream.');
+        }
+
+        $channel = new SocketChannel($stream);
+
+        try {
+            Expect::that($channel->receive(1.0))
+                ->because('a stream-select failure MUST end the receive wait')
+                ->toBeNull()
+                ->and($channel->isEof())
+                ->because('a stream-select failure MUST NOT mark the channel as EOF')
+                ->toBeFalse();
+        } finally {
+            $channel->close();
+            \stream_wrapper_unregister(self::UNSELECTABLE_SCHEME);
         }
     }
 


### PR DESCRIPTION
Treat a stream-select ValueError as a failed receive wait, consistent with its existing false return handling. Cover the behavior through SocketChannel::receive() with an unselectable Fake stream and verify the channel remains open.