### PR TITLE
fix(runner): deduplicate priority classes

### DIFF
--- a/src/Runner/PlanOrder.php
+++ b/src/Runner/PlanOrder.php
@@ -41,18 +41,22 @@ final class PlanOrder
         }
 
         $order = [];
+        $prioritized = [];
 
         foreach ($priorityClasses as $class) {
-            if (isset($byClass[$class])) {
-                $order[] = $class;
+            if (!isset($byClass[$class]) || isset($prioritized[$class])) {
+                continue;
             }
+
+            $order[] = $class;
+            $prioritized[$class] = true;
         }
 
         $known = [];
         $unknown = [];
 
         foreach (\array_keys($byClass) as $class) {
-            if (\in_array($class, $order, true)) {
+            if (isset($prioritized[$class])) {
                 continue;
             }
 

--- a/tests/Unit/Runner/PlanOrderTest.php
+++ b/tests/Unit/Runner/PlanOrderTest.php
@@ -39,6 +39,20 @@ final class PlanOrderTest
     }
 
     #[Test]
+    public function duplicatePriorityClassesDoNotDuplicateTests(): void
+    {
+        $plan = $this->plan(['Acme\A', 'Acme\B']);
+
+        $ordered = PlanOrder::schedule($plan, ['Acme\B', 'Acme\B', 'Acme\Missing', 'Acme\B'], []);
+
+        Expect::that($this->classes($ordered))
+            ->because('priority inputs MUST preserve each planned test exactly once')
+            ->toBe(['Acme\B', 'Acme\A'])
+            ->and($ordered->count())
+            ->toBe(2);
+    }
+
+    #[Test]
     public function withNothingRecordedThePlanIsUntouched(): void
     {
         $plan = $this->plan(['Acme\B', 'Acme\A']);


### PR DESCRIPTION
Keep the execution plan stable when persisted or plugin-supplied priority classes contain duplicates. Record prioritized classes in a set, preserve their first-seen order, and verify that every planned test remains present exactly once.