### PR TITLE
fix(discovery): reject duplicate plan IDs

### DIFF
--- a/src/Discovery/ExecutionPlan.php
+++ b/src/Discovery/ExecutionPlan.php
@@ -23,7 +23,7 @@ final readonly class ExecutionPlan implements WireSerializable, \Countable
     /**
      * @param list<PlanEntry> $entries
      *
-     * @throws \InvalidArgumentException when entries are not grouped by class
+     * @throws \InvalidArgumentException when entries are not grouped by class or contain duplicate test IDs
      */
     public function __construct(array $entries, public ?int $seed = null)
     {
@@ -46,6 +46,21 @@ final readonly class ExecutionPlan implements WireSerializable, \Countable
 
             $seen[$class] = true;
             $current = $class;
+        }
+
+        $ids = [];
+
+        foreach ($entries as $entry) {
+            $id = (string) $entry->id;
+
+            if (isset($ids[$id])) {
+                throw new \InvalidArgumentException(\sprintf(
+                    'Execution plan test ID "%s" occurs more than once.',
+                    $id,
+                ));
+            }
+
+            $ids[$id] = true;
         }
 
         $this->entries = $entries;
@@ -104,7 +119,7 @@ final readonly class ExecutionPlan implements WireSerializable, \Countable
     }
 
     /**
-     * @throws \InvalidArgumentException when entries are not grouped by class
+     * @throws \InvalidArgumentException when entries are not grouped by class or contain duplicate test IDs
      */
     #[\Override]
     public static function fromWire(array $payload): static

--- a/tests/Unit/Discovery/ExecutionPlanTest.php
+++ b/tests/Unit/Discovery/ExecutionPlanTest.php
@@ -70,6 +70,26 @@ final class ExecutionPlanTest
     }
 
     #[Test]
+    public function rejectsDuplicateTestIdsFromConstructionAndTheWire(): void
+    {
+        $entry = self::entry('App\FooTest', 'a', 'first');
+        $message = 'Execution plan test ID "App\FooTest::a[first]" occurs more than once.';
+
+        Expect::that(static fn(): ExecutionPlan => new ExecutionPlan([$entry, $entry]))
+            ->because('an execution plan MUST contain each test ID exactly once')
+            ->toThrow(\InvalidArgumentException::class, message: $message);
+
+        $payload = [
+            'seed' => null,
+            'entries' => [$entry->toWire(), $entry->toWire()],
+        ];
+
+        Expect::that(static fn(): ExecutionPlan => ExecutionPlan::fromWire($payload))
+            ->because('wire decoding MUST reject duplicate test IDs')
+            ->toThrow(\InvalidArgumentException::class, message: $message);
+    }
+
+    #[Test]
     public function survivesTheWire(): void
     {
         $plan = new ExecutionPlan([


### PR DESCRIPTION
Reject execution plans that contain the same test ID more than once, before a worker can execute the test twice. Cover both direct construction and wire decoding with the exact invariant error.