### PR TITLE
fix(coverage): fail when relay directory cannot be created

### DIFF
--- a/src/Coverage/CoverageError.php
+++ b/src/Coverage/CoverageError.php
@@ -21,4 +21,13 @@ final class CoverageError extends \RuntimeException
     {
         return new self(\sprintf('Coverage JSON document is invalid: %s', $reason));
     }
+
+    public static function sharedDirectoryCreationFailed(string $directory, ?string $cause): self
+    {
+        return new self(\sprintf(
+            'Failed to create shared coverage directory "%s"%s.',
+            $directory,
+            $cause === null ? '' : ': ' . $cause,
+        ));
+    }
 }

--- a/src/Runner/SharedCoverageDirectory.php
+++ b/src/Runner/SharedCoverageDirectory.php
@@ -26,7 +26,10 @@ final readonly class SharedCoverageDirectory
     public static function open(CoverageSettings $settings): self
     {
         $directory = \rtrim(\sys_get_temp_dir(), '/') . '/greenlight-coverage-' . \bin2hex(\random_bytes(6));
-        ErrorTrap::run(static fn(): bool => \mkdir($directory, 0o700, true));
+
+        if (!ErrorTrap::run(static fn(): bool => \mkdir($directory, 0o700, true), $warning)) {
+            throw CoverageError::sharedDirectoryCreationFailed($directory, $warning);
+        }
 
         $previousDirectory = \getenv(SubprocessCoverage::DIRECTORY_ENV);
         $previousInclude = \getenv(SubprocessCoverage::INCLUDE_ENV);

--- a/tests/Unit/Runner/SubprocessCoverageTest.php
+++ b/tests/Unit/Runner/SubprocessCoverageTest.php
@@ -19,6 +19,7 @@ use Greenlight\Runner\SubprocessCoverage;
 use Greenlight\Tests\Fixture\Coverage\AvailableFakeDriver;
 use Greenlight\Tests\Fixture\Coverage\RecordingFakeDriver;
 use Greenlight\Tests\Fixture\Coverage\UnavailableFakeDriver;
+use Greenlight\Tests\Support\Subprocess;
 
 final readonly class SubprocessCoverageTest
 {
@@ -49,6 +50,67 @@ final readonly class SubprocessCoverageTest
         } finally {
             $sandbox->dispose();
         }
+    }
+
+    #[Test]
+    public function openRejectsABlockedSystemTempDirectory(): void
+    {
+        $blocker = $this->tempDirectory->path() . '/not-a-directory';
+
+        Expect::that(\file_put_contents($blocker, 'blocked'))
+            ->because('the test setup MUST create the blocking file')
+            ->toBe(7);
+
+        $root = \dirname(__DIR__, 3);
+        $result = Subprocess::run($root, [
+            \PHP_BINARY,
+            '-n',
+            '-d',
+            'sys_temp_dir=' . $blocker,
+            '-r',
+            <<<'PHP'
+            $source = $argv[1];
+
+            spl_autoload_register(static function (string $class) use ($source): void {
+                $prefix = 'Greenlight\\';
+
+                if (!str_starts_with($class, $prefix)) {
+                    return;
+                }
+
+                $path = $source . '/' . str_replace('\\', '/', substr($class, strlen($prefix))) . '.php';
+
+                if (is_file($path)) {
+                    require $path;
+                }
+            });
+
+            $blocker = $argv[2];
+            $message = '/^Failed to create shared coverage directory "'
+                . preg_quote($blocker, '/')
+                . '\/greenlight-coverage-[0-9a-f]{12}": mkdir\(\): Not a directory\.$/D';
+
+            \Greenlight\Expect\Expect::that(
+                static fn(): \Greenlight\Runner\SharedCoverageDirectory =>
+                    \Greenlight\Runner\SharedCoverageDirectory::open(new \Greenlight\Runner\CoverageSettings([])),
+            )
+                ->because('coverage setup MUST reject a blocked system temp directory')
+                ->toThrow(\Greenlight\Coverage\CoverageError::class, matching: $message);
+
+            fwrite(STDOUT, 'matched');
+            PHP,
+            $root . '/src',
+            $blocker,
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('coverage setup MUST fail before it exports a nonexistent relay directory')
+            ->toBe(0)
+            ->and($result->stdout)
+            ->because('the child MUST emit success only after the exact coverage error matches')
+            ->toBe('matched')
+            ->and($result->stderr)
+            ->toBe('');
     }
 
     #[Test]


### PR DESCRIPTION
Fail coverage setup before exporting a nonexistent subprocess relay path. Preserve the attempted directory and native mkdir cause, with a subprocess regression that uses a blocking system-temp file and cannot pass when no exception is raised.