### PR TITLE
test: cover retry throwable filter boundaries

### DIFF
--- a/tests/Unit/Plugin/RetryPluginTest.php
+++ b/tests/Unit/Plugin/RetryPluginTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Plugin;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Expect\Expect;
+use Greenlight\Plugin\RetryPlugin;
+
+final class RetryPluginTest
+{
+    /**
+     * @param positive-int|null $times
+     * @param class-string<\Throwable>|null $onlyOn
+     * @param positive-int $attempt
+     */
+    #[Test]
+    #[DataSet('retryDecisions')]
+    public function throwableFiltersAndAttemptLimitsControlRetries(
+        ?int $times,
+        ?string $onlyOn,
+        int $attempt,
+        ?\Throwable $cause,
+        bool $expected,
+    ): void {
+        $plugin = new RetryPlugin();
+        $result = new TestResult(
+            new TestId('Example\RetryTest', 'retries'),
+            Outcome::Errored,
+            0.1,
+            0,
+        );
+        $filtered = new TestMetadata(
+            'Example\RetryTest',
+            'retries',
+            retryTimes: $times,
+            retryOnlyOn: $onlyOn,
+        );
+
+        Expect::that($plugin->shouldRetry(
+            $filtered,
+            $result,
+            $attempt,
+            $cause,
+        ))
+            ->because('retry decisions MUST honor throwable filters and attempt limits')
+            ->toBe($expected);
+    }
+
+    /**
+     * @return iterable<string, array{
+     *     positive-int|null,
+     *     class-string<\Throwable>|null,
+     *     positive-int,
+     *     \Throwable|null,
+     *     bool
+     * }>
+     */
+    public static function retryDecisions(): iterable
+    {
+        yield 'matching throwable before limit' => [
+            2,
+            \DomainException::class,
+            1,
+            new \DomainException('retry'),
+            true,
+        ];
+
+        yield 'matching throwable at limit' => [
+            2,
+            \DomainException::class,
+            2,
+            new \DomainException('last retry'),
+            true,
+        ];
+
+        yield 'matching throwable after limit' => [
+            2,
+            \DomainException::class,
+            3,
+            new \DomainException('exhausted'),
+            false,
+        ];
+
+        yield 'non-matching throwable' => [
+            2,
+            \DomainException::class,
+            1,
+            new \RuntimeException('wrong type'),
+            false,
+        ];
+
+        yield 'missing cause with throwable filter' => [
+            2,
+            \DomainException::class,
+            1,
+            null,
+            false,
+        ];
+
+        yield 'no retry metadata' => [
+            null,
+            null,
+            1,
+            new \DomainException('ignored'),
+            false,
+        ];
+    }
+}


### PR DESCRIPTION
Cover RetryPlugin decisions directly across matching and non-matching throwable filters, a missing cause, the inclusive final retry, exhaustion, and absent retry metadata.