### PR TITLE
fix(core): reject invalid metadata timeouts

### DIFF
--- a/docs/api-test-contracts.md
+++ b/docs/api-test-contracts.md
@@ -260,7 +260,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L101)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L105)
 
 ### `fromWire()`
 
@@ -269,7 +269,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L123)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L127)
 
 ## `InvalidWirePayload`
 

--- a/src/Core/Test/TestMetadata.php
+++ b/src/Core/Test/TestMetadata.php
@@ -61,6 +61,10 @@ final readonly class TestMetadata implements WireSerializable
         array $resources = [],
         public ?string $dataSetProviderClass = null,
     ) {
+        if (!self::isValidTimeout($timeoutSeconds)) {
+            throw new \InvalidArgumentException('Timeout seconds must be finite and greater than zero.');
+        }
+
         $validated = [];
 
         foreach ($groups as $group) {
@@ -140,6 +144,15 @@ final readonly class TestMetadata implements WireSerializable
             : null;
         $retryTimes = Wire::nullableInt($payload, 'retryTimes');
         $timeoutSeconds = Wire::nullableFloat($payload, 'timeoutSeconds');
+
+        if (!self::isValidTimeout($timeoutSeconds)) {
+            throw InvalidWirePayload::wrongType(
+                'timeoutSeconds',
+                'a finite float greater than zero or null',
+                $timeoutSeconds,
+            );
+        }
+
         $skipUnlessArguments = self::skipUnlessArgumentsFromWire($payload);
         $resources = \array_key_exists('resources', $payload) ? Wire::listOfStrings($payload, 'resources') : [];
 
@@ -166,6 +179,11 @@ final readonly class TestMetadata implements WireSerializable
             $resources,
             $dataSetProviderClass === '' ? null : $dataSetProviderClass,
         );
+    }
+
+    private static function isValidTimeout(?float $seconds): bool
+    {
+        return $seconds === null || (\is_finite($seconds) && $seconds > 0.0);
     }
 
     /**

--- a/tests/Unit/Core/TestMetadataWireTest.php
+++ b/tests/Unit/Core/TestMetadataWireTest.php
@@ -66,10 +66,12 @@ final class TestMetadataWireTest
                 'checksValue',
                 timeoutSeconds: $seconds,
             ),
-        )->because('invalid timeouts are rejected by direct construction')->toThrow(
-            \InvalidArgumentException::class,
-            message: 'Timeout seconds must be finite and greater than zero.',
-        );
+        )
+            ->because('invalid timeouts are rejected by direct construction')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Timeout seconds must be finite and greater than zero.',
+            );
 
         $payload = new TestMetadata('App\ExampleTest', 'checksValue')->toWire();
         $payload['timeoutSeconds'] = $seconds;

--- a/tests/Unit/Core/TestMetadataWireTest.php
+++ b/tests/Unit/Core/TestMetadataWireTest.php
@@ -56,6 +56,32 @@ final class TestMetadataWireTest
             );
     }
 
+    #[Test]
+    #[DataSet('invalidTimeouts')]
+    public function invalidTimeoutsAreRejectedOnBothSides(float $seconds): void
+    {
+        Expect::that(
+            static fn(): TestMetadata => new TestMetadata(
+                'App\ExampleTest',
+                'checksValue',
+                timeoutSeconds: $seconds,
+            ),
+        )->because('invalid timeouts are rejected by direct construction')->toThrow(
+            \InvalidArgumentException::class,
+            message: 'Timeout seconds must be finite and greater than zero.',
+        );
+
+        $payload = new TestMetadata('App\ExampleTest', 'checksValue')->toWire();
+        $payload['timeoutSeconds'] = $seconds;
+
+        Expect::that(static fn(): TestMetadata => TestMetadata::fromWire($payload))
+            ->because('invalid timeouts are rejected as wire protocol errors')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "timeoutSeconds" must be a finite float greater than zero or null, got float.',
+            );
+    }
+
     /**
      * @return iterable<string, array{non-empty-string, mixed}>
      */
@@ -77,5 +103,16 @@ final class TestMetadataWireTest
         yield 'data-set provider' => ['dataSetProvider', '', null];
         yield 'data-set provider class' => ['dataSetProviderClass', '', null];
         yield 'retry count' => ['retryTimes', 0, 1];
+    }
+
+    /**
+     * @return iterable<string, array{float}>
+     */
+    public static function invalidTimeouts(): iterable
+    {
+        yield 'zero' => [0.0];
+        yield 'negative' => [-0.5];
+        yield 'positive infinity' => [\INF];
+        yield 'not a number' => [\NAN];
     }
 }


### PR DESCRIPTION
Keeps the timeout invariant consistent across attributes, direct metadata construction, and decoded worker payloads. Invalid wire values now remain typed protocol errors instead of reaching execution with impossible deadlines.