### PR TITLE
fix(protocol): reject unknown worker recycle reasons

### DIFF
--- a/src/Runner/Protocol/Messages/Done.php
+++ b/src/Runner/Protocol/Messages/Done.php
@@ -58,15 +58,16 @@ final readonly class Done implements Message
     public static function fromWire(array $payload): static
     {
         $coverage = Wire::nullableMap($payload, 'coverage');
+        $reason = Wire::nullableString($payload, 'wantsRecycle');
 
         return new self(
             ResultSummary::fromWire(Wire::map($payload, 'summary')),
             \max(0, Wire::int($payload, 'peakMemoryBytes')),
             $coverage === null ? null : CoverageMap::fromWire($coverage),
             \array_map(TestId::fromWire(...), Wire::listOfMaps($payload, 'leaks')),
-            ($reason = Wire::nullableString($payload, 'wantsRecycle')) === null || $reason === ''
+            $reason === null || $reason === ''
                 ? null
-                : RecycleReason::from($reason),
+                : Wire::enum($payload, 'wantsRecycle', RecycleReason::class),
         );
     }
 }

--- a/tests/Unit/Runner/Protocol/WorkerMessageWireTest.php
+++ b/tests/Unit/Runner/Protocol/WorkerMessageWireTest.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Core\Event\RecycleReason;
 use Greenlight\Core\Result\ResultSummary;
 use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Wire\InvalidWirePayload;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\Protocol\Messages\AttemptStarted;
 use Greenlight\Runner\Protocol\Messages\Done;
@@ -69,5 +70,19 @@ final class WorkerMessageWireTest
             ->because('valid Done fields MUST survive decoding')
             ->toBe(2048)
             ->and($withRecycle->wantsRecycle)->toBe(RecycleReason::TestCount);
+    }
+
+    #[Test]
+    public function doneRejectsAnUnknownRecycleReasonAsAProtocolError(): void
+    {
+        $payload = new Done(new ResultSummary(), 2048)->toWire();
+        $payload['wantsRecycle'] = 'unknown';
+
+        Expect::that(static fn(): Done => Done::fromWire($payload))
+            ->because('unknown worker recycle reasons MUST be protocol errors')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "wantsRecycle" must be a Greenlight\Core\Event\RecycleReason value, got string.',
+            );
     }
 }


### PR DESCRIPTION
Routes the optional worker recycle reason through Greenlight’s enum wire reader. Unknown values now produce an `InvalidWirePayload` with the offending field instead of leaking a `ValueError` from enum construction.