### PR TITLE
test: verify reverse scope disposal order

### DIFF
--- a/tests/Fixture/Lifecycle/Services/SecondaryServiceProbe.php
+++ b/tests/Fixture/Lifecycle/Services/SecondaryServiceProbe.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Lifecycle\Services;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Harness\Disposable;
+use Greenlight\Tests\Fixture\Lifecycle\TraceLog;
+
+final class SecondaryServiceProbe implements Disposable, Fake
+{
+    private readonly string $name;
+
+    public function __construct()
+    {
+        $this->name = 'secondary';
+        TraceLog::add($this->name . ':created');
+    }
+
+    public function touch(): void
+    {
+        TraceLog::add($this->name . ':touched');
+    }
+
+    #[\Override]
+    public function dispose(): void
+    {
+        TraceLog::add($this->name . ':disposed');
+    }
+}

--- a/tests/Fixture/Lifecycle/Services/ServiceProbe.php
+++ b/tests/Fixture/Lifecycle/Services/ServiceProbe.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Fixture\Lifecycle\Services;
 
+use Greenlight\Doubles\Fake;
 use Greenlight\Harness\Disposable;
 use Greenlight\Tests\Fixture\Lifecycle\TraceLog;
 
-final class ServiceProbe implements Disposable
+final class ServiceProbe implements Disposable, Fake
 {
     private static int $instances = 0;
 

--- a/tests/Unit/Harness/ScopeContainerTest.php
+++ b/tests/Unit/Harness/ScopeContainerTest.php
@@ -12,6 +12,7 @@ use Greenlight\Harness\ScopeContainer;
 use Greenlight\Harness\ServiceDefinition;
 use Greenlight\Tests\Fixture\Harness\FailingDisposable;
 use Greenlight\Tests\Fixture\Lifecycle\DisposeFails\FailingDisposalProbe;
+use Greenlight\Tests\Fixture\Lifecycle\Services\SecondaryServiceProbe;
 use Greenlight\Tests\Fixture\Lifecycle\Services\ServiceProbe;
 use Greenlight\Tests\Fixture\Lifecycle\TraceLog;
 
@@ -51,23 +52,45 @@ final class ScopeContainerTest
         TraceLog::drain();
 
         $container = new ScopeContainer();
-        $probeDefinition = new ServiceDefinition(ServiceProbe::class, Scope::PerTest, static fn(): ServiceProbe => new ServiceProbe());
-        $otherDefinition = new ServiceDefinition(\ArrayObject::class, Scope::PerTest, static fn(): \ArrayObject => new \ArrayObject());
+        $probeDefinition = new ServiceDefinition(
+            ServiceProbe::class,
+            Scope::PerTest,
+            static fn(): ServiceProbe => new ServiceProbe(),
+        );
+        $secondaryDefinition = new ServiceDefinition(
+            SecondaryServiceProbe::class,
+            Scope::PerTest,
+            static fn(): SecondaryServiceProbe => new SecondaryServiceProbe(),
+        );
 
         $probe = $container->get($probeDefinition);
-        $container->get($otherDefinition);
+        $secondary = $container->get($secondaryDefinition);
 
-        if (!$probe instanceof ServiceProbe) {
-            Fail::because(\sprintf(
-                'Expected ScopeContainer::get() to return ServiceProbe, got %s.',
-                \get_debug_type($probe),
-            ));
+        if (!$probe instanceof ServiceProbe || !$secondary instanceof SecondaryServiceProbe) {
+            Fail::because('Expected ScopeContainer::get() to return both disposable service probes.');
         }
 
         $probe->touch();
-        $container->dispose();
+        $secondary->touch();
+        $firstFailures = $container->dispose();
+        $secondFailures = $container->dispose();
 
-        Expect::that(TraceLog::drain())->because('touched services dispose in reverse creation order')->toBe(['probe1:created', 'probe1:touched', 'probe1:disposed']);
+        Expect::that($firstFailures)
+            ->because('disposing touched services succeeds')
+            ->toBe([])
+            ->and($secondFailures)
+            ->because('a disposed scope does not dispose its services twice')
+            ->toBe([])
+            ->and(TraceLog::drain())
+            ->because('touched services dispose in reverse creation order')
+            ->toBe([
+                'probe1:created',
+                'probe1:touched',
+                'secondary:created',
+                'secondary:touched',
+                'secondary:disposed',
+                'probe1:disposed',
+            ]);
     }
 
     #[Test]


### PR DESCRIPTION
Strengthens the scope-container lifecycle test with two initialized disposable fake services. The assertion now distinguishes LIFO from FIFO disposal and confirms that closing an already-disposed scope does not dispose either service twice.