### PR TITLE
test: cover cleanup after hook failures

### DIFF
--- a/tests/Fixture/Lifecycle/AfterFailureContinues/AfterFailureContinuesTest.php
+++ b/tests/Fixture/Lifecycle/AfterFailureContinues/AfterFailureContinuesTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Lifecycle\AfterFailureContinues;
+
+use Greenlight\Attribute\After;
+use Greenlight\Attribute\Test;
+use Greenlight\Tests\Fixture\Lifecycle\TraceLog;
+
+final class AfterFailureContinuesTest
+{
+    #[Test]
+    public function passesUntilTeardown(): void
+    {
+        TraceLog::add('test');
+    }
+
+    #[After]
+    public function finalCleanup(): void
+    {
+        TraceLog::add('final cleanup');
+    }
+
+    #[After]
+    public function failingCleanup(): never
+    {
+        TraceLog::add('failing cleanup');
+
+        throw new \RuntimeException('after broke');
+    }
+}

--- a/tests/Unit/Runner/WorkerTest.php
+++ b/tests/Unit/Runner/WorkerTest.php
@@ -71,6 +71,22 @@ final class WorkerTest
     }
 
     #[Test]
+    public function afterHooksContinueAfterACleanupFailure(): void
+    {
+        TraceLog::drain();
+        [, $results] = $this->runFixture('AfterFailureContinues');
+
+        Expect::that(TraceLog::drain())
+            ->because('later cleanup MUST run after an earlier after-hook throws')
+            ->toBe(['test', 'failing cleanup', 'final cleanup'])
+            ->and($results[0]->outcome)
+            ->toBe(Outcome::Errored)
+            ->and($results[0]->error?->message)
+            ->because('the first teardown error MUST remain primary')
+            ->toBe('after broke');
+    }
+
+    #[Test]
     public function retriesUntilPassingAndRecordsAttempts(): void
     {
         RetriesTest::$attempts = 0;


### PR DESCRIPTION
Cover a teardown stack whose first executed after-hook throws. Verify later cleanup still runs in reverse declaration order and the original teardown error remains the public test result error.