### PR TITLE
fix(fixtures): reject invalid environment names

### DIFF
--- a/docs/api-fixtures-harness.md
+++ b/docs/api-fixtures-harness.md
@@ -25,7 +25,11 @@ final class EnvironmentSandbox implements Disposable
 public function set(string $name, string $value): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/EnvironmentSandbox.php#L20)
+PHPDoc:
+
+- `@throws \InvalidArgumentException If $name is empty or contains "=" or a null byte.`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/EnvironmentSandbox.php#L23)
 
 ### `unset()`
 
@@ -33,7 +37,11 @@ public function set(string $name, string $value): void
 public function unset(string $name): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/EnvironmentSandbox.php#L29)
+PHPDoc:
+
+- `@throws \InvalidArgumentException If $name is empty or contains "=" or a null byte.`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/EnvironmentSandbox.php#L36)
 
 ### `dispose()`
 
@@ -42,7 +50,7 @@ public function unset(string $name): void
 public function dispose(): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/EnvironmentSandbox.php#L37)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/EnvironmentSandbox.php#L45)
 
 ## `TempDirectory`
 

--- a/src/Fixture/EnvironmentSandbox.php
+++ b/src/Fixture/EnvironmentSandbox.php
@@ -17,8 +17,12 @@ final class EnvironmentSandbox implements Disposable
      */
     private array $originals = [];
 
+    /**
+     * @throws \InvalidArgumentException If $name is empty or contains "=" or a null byte.
+     */
     public function set(string $name, string $value): void
     {
+        $this->validateName($name);
         $this->record($name);
 
         \putenv($name . '=' . $value);
@@ -26,8 +30,12 @@ final class EnvironmentSandbox implements Disposable
         $_SERVER[$name] = $value;
     }
 
+    /**
+     * @throws \InvalidArgumentException If $name is empty or contains "=" or a null byte.
+     */
     public function unset(string $name): void
     {
+        $this->validateName($name);
         $this->record($name);
 
         \putenv($name);
@@ -47,5 +55,14 @@ final class EnvironmentSandbox implements Disposable
     private function record(string $name): void
     {
         $this->originals[$name] ??= EnvironmentBackup::capture($name);
+    }
+
+    private function validateName(string $name): void
+    {
+        if ($name === '' || \str_contains($name, '=') || \str_contains($name, "\0")) {
+            throw new \InvalidArgumentException(
+                'Environment variable names cannot be empty or contain "=" or a null byte.',
+            );
+        }
     }
 }

--- a/tests/Unit/Fixture/EnvironmentSandboxTest.php
+++ b/tests/Unit/Fixture/EnvironmentSandboxTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Fixture;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\EnvironmentSandbox;
@@ -147,6 +148,66 @@ final class EnvironmentSandboxTest
             \putenv($name);
             unset($_ENV[$name], $_SERVER[$name]);
         }
+    }
+
+    #[Test]
+    #[DataSet('invalidNames')]
+    public function setRejectsInvalidNamesWithoutChangingTheEnvironment(string $name): void
+    {
+        $processBefore = \getenv();
+        $envBefore = $_ENV;
+        $serverBefore = $_SERVER;
+        $sandbox = new EnvironmentSandbox();
+
+        Expect::that(static fn() => $sandbox->set($name, 'value'))
+            ->because('set rejects invalid names before it changes the environment')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Environment variable names cannot be empty or contain "=" or a null byte.',
+            );
+
+        Expect::that(\getenv())
+            ->because('set rejects invalid names before it changes the environment')
+            ->toBe($processBefore)
+            ->and($_ENV)
+            ->toBe($envBefore)
+            ->and($_SERVER)
+            ->toBe($serverBefore);
+    }
+
+    #[Test]
+    #[DataSet('invalidNames')]
+    public function unsetRejectsInvalidNamesWithoutChangingTheEnvironment(string $name): void
+    {
+        $processBefore = \getenv();
+        $envBefore = $_ENV;
+        $serverBefore = $_SERVER;
+        $sandbox = new EnvironmentSandbox();
+
+        Expect::that(static fn() => $sandbox->unset($name))
+            ->because('unset rejects invalid names before it changes the environment')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Environment variable names cannot be empty or contain "=" or a null byte.',
+            );
+
+        Expect::that(\getenv())
+            ->because('unset rejects invalid names before it changes the environment')
+            ->toBe($processBefore)
+            ->and($_ENV)
+            ->toBe($envBefore)
+            ->and($_SERVER)
+            ->toBe($serverBefore);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function invalidNames(): iterable
+    {
+        yield 'empty name' => [''];
+        yield 'equals sign' => ['GREENLIGHT_INVALID=NAME'];
+        yield 'null byte' => ["GREENLIGHT_INVALID\0NAME"];
     }
 
     /** Tells the analyzer that the superglobal offset remains variable after a change. */


### PR DESCRIPTION
EnvironmentSandbox currently accepts names that PHP cannot represent consistently. A name that contains an equals sign updates a different process variable from the keys written to `$_ENV` and `$_SERVER`. Empty names and null bytes also reach lower-level PHP failures.

Validate names before capture or mutation, preserve all three environment channels when validation fails, and document the exception contract.
