### PR TITLE
fix(cli): reject integer overflow

### DIFF
--- a/src/Cli/CliOverrides.php
+++ b/src/Cli/CliOverrides.php
@@ -103,11 +103,16 @@ final readonly class CliOverrides
                 throw CliError::malformedShard($raw);
             }
 
-            $index = (int) $matches[1];
-            $count = (int) $matches[2];
+            $index = self::decimalInt($matches[1]);
+            $count = self::decimalInt($matches[2]);
 
-            if ($count < 1 || $index < 1 || $index > $count) {
-                throw CliError::shardOutOfRange($raw, $count);
+            if ($index === null
+                || $count === null
+                || $count < 1
+                || $index < 1
+                || $index > $count
+            ) {
+                throw CliError::shardOutOfRange($raw, $count ?? 0);
             }
 
             $shard = [$index, $count];
@@ -166,13 +171,9 @@ final readonly class CliOverrides
         if ($arguments->has('seed')) {
             $raw = $arguments->value('seed') ?? '';
 
-            if (\preg_match('/^\d+$/', $raw) !== 1) {
-                throw CliError::invalidSeed($raw);
-            }
+            $parsed = self::decimalInt($raw);
 
-            $parsed = (int) $raw;
-
-            if ($parsed < 0) {
+            if ($parsed === null) {
                 throw CliError::invalidSeed($raw);
             }
 
@@ -226,12 +227,38 @@ final readonly class CliOverrides
      */
     private static function positiveInt(string $raw, string $flag): int
     {
-        $value = \preg_match('/^\d+$/', $raw) === 1 ? (int) $raw : 0;
+        $value = self::decimalInt($raw);
 
-        if ($value < 1) {
+        if ($value === null || $value < 1) {
             throw CliError::notAPositiveInteger($flag, $raw);
         }
 
         return $value;
+    }
+
+    /**
+     * @return int<0, max>|null
+     */
+    private static function decimalInt(string $raw): ?int
+    {
+        if (\preg_match('/^\d+$/', $raw) !== 1) {
+            return null;
+        }
+
+        $normalized = \ltrim($raw, '0');
+
+        if ($normalized === '') {
+            return 0;
+        }
+
+        $maximum = (string) \PHP_INT_MAX;
+
+        if (\strlen($normalized) > \strlen($maximum)
+            || (\strlen($normalized) === \strlen($maximum) && \strcmp($normalized, $maximum) > 0)
+        ) {
+            return null;
+        }
+
+        return \max(0, (int) $normalized);
     }
 }

--- a/src/Cli/CliOverrides.php
+++ b/src/Cli/CliOverrides.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Cli;
 
 use Greenlight\Config\WorkerCount;
+use Greenlight\Core\DecimalInteger;
 use Greenlight\Core\Test\ResourceName;
 
 /**
@@ -103,8 +104,8 @@ final readonly class CliOverrides
                 throw CliError::malformedShard($raw);
             }
 
-            $index = self::decimalInt($matches[1]);
-            $count = self::decimalInt($matches[2]);
+            $index = DecimalInteger::parse($matches[1]);
+            $count = DecimalInteger::parse($matches[2]);
 
             if ($index === null
                 || $count === null
@@ -171,7 +172,7 @@ final readonly class CliOverrides
         if ($arguments->has('seed')) {
             $raw = $arguments->value('seed') ?? '';
 
-            $parsed = self::decimalInt($raw);
+            $parsed = DecimalInteger::parse($raw);
 
             if ($parsed === null) {
                 throw CliError::invalidSeed($raw);
@@ -227,38 +228,12 @@ final readonly class CliOverrides
      */
     private static function positiveInt(string $raw, string $flag): int
     {
-        $value = self::decimalInt($raw);
+        $value = DecimalInteger::parse($raw);
 
         if ($value === null || $value < 1) {
             throw CliError::notAPositiveInteger($flag, $raw);
         }
 
         return $value;
-    }
-
-    /**
-     * @return int<0, max>|null
-     */
-    private static function decimalInt(string $raw): ?int
-    {
-        if (\preg_match('/^\d+$/', $raw) !== 1) {
-            return null;
-        }
-
-        $normalized = \ltrim($raw, '0');
-
-        if ($normalized === '') {
-            return 0;
-        }
-
-        $maximum = (string) \PHP_INT_MAX;
-
-        if (\strlen($normalized) > \strlen($maximum)
-            || (\strlen($normalized) === \strlen($maximum) && \strcmp($normalized, $maximum) > 0)
-        ) {
-            return null;
-        }
-
-        return \max(0, (int) $normalized);
     }
 }

--- a/src/Config/MemorySize.php
+++ b/src/Config/MemorySize.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Greenlight\Config;
 
+use Greenlight\Core\DecimalInteger;
+
 /**
  * Converts memory-size text to bytes.
  *
@@ -35,7 +37,14 @@ final class MemorySize
             ));
         }
 
-        $number = (int) $matches[1];
+        $number = DecimalInteger::parse($matches[1]);
+
+        if ($number === null) {
+            throw new InvalidConfiguration(\sprintf(
+                'Invalid memory size "%s". The value does not fit in an integer byte count.',
+                $value,
+            ));
+        }
 
         if ($number < 1) {
             throw new InvalidConfiguration(\sprintf(

--- a/src/Core/DecimalInteger.php
+++ b/src/Core/DecimalInteger.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Core;
+
+/**
+ * Parses nonnegative decimal text without integer overflow.
+ *
+ * @internal
+ */
+final class DecimalInteger
+{
+    /** @codeCoverageIgnore */
+    private function __construct() {}
+
+    /**
+     * @return int<0, max>|null
+     */
+    public static function parse(string $raw): ?int
+    {
+        if (\preg_match('/^\d+$/', $raw) !== 1) {
+            return null;
+        }
+
+        $normalized = \ltrim($raw, '0');
+
+        if ($normalized === '') {
+            return 0;
+        }
+
+        $maximum = (string) \PHP_INT_MAX;
+
+        if (\strlen($normalized) > \strlen($maximum)
+            || (\strlen($normalized) === \strlen($maximum) && \strcmp($normalized, $maximum) > 0)
+        ) {
+            return null;
+        }
+
+        return \max(0, (int) $normalized);
+    }
+}

--- a/tests/Unit/Cli/CliOverridesTest.php
+++ b/tests/Unit/Cli/CliOverridesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Cli;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Cli\CliError;
 use Greenlight\Cli\CliOverrides;
@@ -146,6 +147,66 @@ final class CliOverridesTest
         }
 
         Fail::because('Expected CliOverrides::fromArguments() to reject zero-shard specification "1/0".');
+    }
+
+    /**
+     * @param array<string, list<string|null>> $options
+     */
+    #[Test]
+    #[DataSet('integerOverflows')]
+    public function rejectsIntegerValuesOutsideThePlatformRange(array $options, string $message): void
+    {
+        Expect::that(static fn(): CliOverrides => CliOverrides::fromArguments(
+            new ParsedArguments(null, $options),
+        ))
+            ->because('CLI integers MUST fit the platform integer range')
+            ->toThrow(CliError::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{array<string, list<string|null>>, non-empty-string}>
+     */
+    public static function integerOverflows(): iterable
+    {
+        $overflow = \PHP_INT_MAX . '0';
+
+        yield 'workers' => [
+            ['workers' => [$overflow]],
+            \sprintf('--workers requires a positive integer. Received "%s".', $overflow),
+        ];
+
+        yield 'bail' => [
+            ['bail' => [$overflow]],
+            \sprintf('--bail requires a positive integer. Received "%s".', $overflow),
+        ];
+
+        yield 'repeat' => [
+            ['repeat' => [$overflow]],
+            \sprintf('--repeat requires a positive integer. Received "%s".', $overflow),
+        ];
+
+        yield 'resource limit' => [
+            ['resource-limit' => ['postgres=' . $overflow]],
+            \sprintf('--resource-limit requires a positive integer. Received "%s".', $overflow),
+        ];
+
+        yield 'seed' => [
+            ['seed' => [$overflow]],
+            \sprintf('--seed requires a nonnegative integer. Received "%s".', $overflow),
+        ];
+
+        yield 'shard index' => [
+            ['shard' => [$overflow . '/4']],
+            \sprintf(
+                '--shard requires 1 <= n <= m. Received "%s/4". Valid n values for 4 shards are 1 through 4.',
+                $overflow,
+            ),
+        ];
+
+        yield 'shard count' => [
+            ['shard' => ['1/' . $overflow]],
+            \sprintf('--shard requires 1 <= n <= m. Received "1/%s".', $overflow),
+        ];
     }
 
     #[Test]

--- a/tests/Unit/Config/MemorySizeTest.php
+++ b/tests/Unit/Config/MemorySizeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Config;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\InvalidConfiguration;
 use Greenlight\Config\MemorySize;
@@ -43,18 +44,34 @@ final class MemorySizeTest
     }
 
     #[Test]
-    public function rejectsSizesThatOverflowTheIntegerByteCount(): void
+    #[DataSet('overflowingSizes')]
+    public function rejectsSizesThatOverflowTheIntegerByteCount(string $input): void
     {
-        $input = \PHP_INT_MAX . 'G';
-
         Expect::that(static function () use ($input): void {
             MemorySize::parseToBytes($input);
         })
             ->because('the parsed byte count MUST fit in a platform integer')
             ->toThrow(
                 InvalidConfiguration::class,
-                '/The value does not fit in an integer byte count\./',
+                message: \sprintf(
+                    'Invalid memory size "%s". The value does not fit in an integer byte count.',
+                    $input,
+                ),
             );
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function overflowingSizes(): iterable
+    {
+        yield 'plain bytes exceed the platform integer range' => [
+            \PHP_INT_MAX . '0',
+        ];
+
+        yield 'suffix multiplication exceeds the platform integer range' => [
+            \intdiv(\PHP_INT_MAX, 1024) + 1 . 'K',
+        ];
     }
 
     #[Test]


### PR DESCRIPTION
Reject decimal CLI and memory-size integers that exceed the platform integer range before casting them. Route workers, bail, repeat, resource limits, seeds, both shard components, and memory-size parsing through one range-aware parser while preserving their existing option-specific diagnostics. Also retain the multiplication overflow check for K, M, and G suffixes.