### PR TITLE
fix(discovery): reset global bracketed namespaces

### DIFF
--- a/src/Discovery/ClassFileParser.php
+++ b/src/Discovery/ClassFileParser.php
@@ -42,10 +42,9 @@ final class ClassFileParser
 
             if ($token->is(\T_NAMESPACE)) {
                 $name = self::nextSignificant($tokens, $i);
-
-                if ($name instanceof \PhpToken && $name->is([\T_NAME_QUALIFIED, \T_STRING])) {
-                    $namespace = $name->text;
-                }
+                $namespace = $name instanceof \PhpToken && $name->is([\T_NAME_QUALIFIED, \T_STRING])
+                    ? $name->text
+                    : '';
 
                 continue;
             }

--- a/tests/Unit/Discovery/ClassFileParserTest.php
+++ b/tests/Unit/Discovery/ClassFileParserTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\ClassDeclaration;
+use Greenlight\Discovery\ClassFileParser;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class ClassFileParserTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function aGlobalBracketedNamespaceClearsThePreviousNamespace(): void
+    {
+        $file = $this->tempDirectory->path() . '/Declarations.php';
+        \file_put_contents($file, <<<'PHP'
+            <?php
+
+            namespace Example\Named {
+                final class NamedTest {}
+            }
+
+            namespace {
+                final class GlobalTest {}
+            }
+            PHP);
+
+        $declarations = \array_map(
+            static fn(ClassDeclaration $declaration): array => [
+                $declaration->fqcn(),
+                $declaration->kind,
+            ],
+            ClassFileParser::declarationsIn($file),
+        );
+
+        Expect::that($declarations)
+            ->because('a global bracketed namespace clears the previous namespace')
+            ->toBe([
+                ['Example\Named\NamedTest', 'class'],
+                ['GlobalTest', 'class'],
+            ]);
+    }
+}


### PR DESCRIPTION
ClassFileParser retains the previous namespace when it encounters a valid global bracketed namespace. Declarations inside the global block then receive the wrong fully qualified class name, and discovery can fail.

Reset the parser namespace for a nameless namespace declaration. Cover a named bracketed declaration followed by a global declaration from real PHP source.
