### PR TITLE
fix(core): reject empty skip reasons

### DIFF
--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -284,17 +284,29 @@ final readonly class Skip
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Skip.php#L8)
 
-### `__construct()`
+### `$reason`
 
 ```php
-public function __construct(public string $reason)
+public string $reason;
 ```
 
 PHPDoc:
 
-- `@param non-empty-string $reason`
+- `@var non-empty-string`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Skip.php#L13)
+
+### `__construct()`
+
+```php
+public function __construct(string $reason)
+```
+
+PHPDoc:
+
+- `@throws \InvalidArgumentException If $reason is empty.`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Skip.php#L18)
 
 ## `SkipUnless`
 

--- a/docs/api-test-contracts.md
+++ b/docs/api-test-contracts.md
@@ -45,19 +45,29 @@ final class SkipTest extends \Exception
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/SkipTest.php#L13)
 
-### `__construct()`
+### `$reason`
 
 ```php
-public function __construct(
-    public readonly string $reason,
-)
+public readonly string $reason;
 ```
 
 PHPDoc:
 
-- `@param non-empty-string $reason`
+- `@var non-empty-string`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/SkipTest.php#L18)
+
+### `__construct()`
+
+```php
+public function __construct(string $reason)
+```
+
+PHPDoc:
+
+- `@throws \InvalidArgumentException If $reason is empty.`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/SkipTest.php#L23)
 
 ## `TestChannel`
 

--- a/src/Attribute/Skip.php
+++ b/src/Attribute/Skip.php
@@ -8,7 +8,19 @@ namespace Greenlight\Attribute;
 final readonly class Skip
 {
     /**
-     * @param non-empty-string $reason
+     * @var non-empty-string
      */
-    public function __construct(public string $reason) {}
+    public string $reason;
+
+    /**
+     * @throws \InvalidArgumentException If $reason is empty.
+     */
+    public function __construct(string $reason)
+    {
+        if ($reason === '') {
+            throw new \InvalidArgumentException('Skip reasons cannot be empty.');
+        }
+
+        $this->reason = $reason;
+    }
 }

--- a/src/Core/Test/SkipTest.php
+++ b/src/Core/Test/SkipTest.php
@@ -13,11 +13,20 @@ namespace Greenlight\Core\Test;
 final class SkipTest extends \Exception
 {
     /**
-     * @param non-empty-string $reason
+     * @var non-empty-string
      */
-    public function __construct(
-        public readonly string $reason,
-    ) {
+    public readonly string $reason;
+
+    /**
+     * @throws \InvalidArgumentException If $reason is empty.
+     */
+    public function __construct(string $reason)
+    {
+        if ($reason === '') {
+            throw new \InvalidArgumentException('Skip reasons cannot be empty.');
+        }
+
+        $this->reason = $reason;
         parent::__construct($reason);
     }
 }

--- a/tests/Unit/Attribute/AttributeContractTest.php
+++ b/tests/Unit/Attribute/AttributeContractTest.php
@@ -23,6 +23,14 @@ use Greenlight\Expect\Expect;
 final class AttributeContractTest
 {
     #[Test]
+    public function skipRejectsAnEmptyReason(): void
+    {
+        Expect::that(static fn(): Skip => new Skip(''))
+            ->because('skip reasons cannot be empty')
+            ->toThrow(\InvalidArgumentException::class, message: 'Skip reasons cannot be empty.');
+    }
+
+    #[Test]
     public function methodOnlyAttributesTargetMethods(): void
     {
         foreach ([Test::class, Before::class, After::class, DataSet::class, NoExpectations::class] as $attribute) {

--- a/tests/Unit/Core/SkipTestTest.php
+++ b/tests/Unit/Core/SkipTestTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\SkipTest;
+use Greenlight\Expect\Expect;
+
+final class SkipTestTest
+{
+    #[Test]
+    public function anEmptyReasonIsRejected(): void
+    {
+        Expect::that(static fn(): SkipTest => new SkipTest(''))
+            ->because('skip reasons cannot be empty')
+            ->toThrow(\InvalidArgumentException::class, message: 'Skip reasons cannot be empty.');
+    }
+}


### PR DESCRIPTION
The public skip attribute and runtime skip signal both declare a non-empty reason, but neither enforces that contract. An empty value can therefore produce an unexplained skipped result.

Reject an empty reason at both public entry points, preserve the narrowed public property types, and document the exception behavior.
