### PR TITLE
test(expect): cover empty explicit failure reasons

### DIFF
--- a/tests/Unit/Expect/FailTest.php
+++ b/tests/Unit/Expect/FailTest.php
@@ -36,6 +36,18 @@ final class FailTest
     }
 
     #[Test]
+    public function anEmptyReasonUsesAClearFallback(): void
+    {
+        $detail = FailureProbe::detailOf(
+            static fn() => Fail::because(''),
+        );
+
+        Expect::that($detail->message)
+            ->because('an explicit failure always has a reason')
+            ->toBe('The test failed without a reason.');
+    }
+
+    #[Test]
     public function failureLocationPointsAtTheCallSite(): void
     {
         $line = __LINE__ + 1;

--- a/tests/Unit/Expect/FailTest.php
+++ b/tests/Unit/Expect/FailTest.php
@@ -15,12 +15,12 @@ final class FailTest
     #[Test]
     public function throwsWithTheGivenReason(): void
     {
-        try {
-            Fail::because('The required value was not found.');
-        } catch (ExpectationFailed $failure) {
-            Expect::that($failure->getMessage())
-                ->toStartWith('The required value was not found. (at ');
-        }
+        Expect::that(static fn() => Fail::because('The required value was not found.'))
+            ->because('an explicit failure MUST throw with its reason and call site')
+            ->toThrow(
+                ExpectationFailed::class,
+                matching: '/^The required value was not found\. \(at .+:\d+\)$/',
+            );
     }
 
     #[Test]


### PR DESCRIPTION
Fail::because() deliberately substitutes a clear diagnostic when its caller supplies an empty reason, but no test protects that branch.

Cover the structured failure detail and its exact fallback message.
