### PR TITLE
test(core): cover legacy wire payload defaults

### DIFF
--- a/tests/Unit/Core/EventsTest.php
+++ b/tests/Unit/Core/EventsTest.php
@@ -58,6 +58,35 @@ final class EventsTest
     }
 
     #[Test]
+    public function legacyEventPayloadsDefaultNewOptionalFields(): void
+    {
+        $started = TestClassStarted::fromWire([
+            'class' => 'App\FooTest',
+            'occurredAt' => 1_780_000_000.1,
+        ]);
+        $finished = TestClassFinished::fromWire([
+            'class' => 'App\FooTest',
+            'occurredAt' => 1_780_000_000.2,
+        ]);
+        $run = RunStarted::fromWire([
+            'runId' => 'run-1',
+            'plannedTests' => 1,
+            'workers' => 1,
+            'occurredAt' => 1_780_000_000.0,
+        ]);
+
+        Expect::that($started->workerId)
+            ->because('legacy class-started events have no worker attribution')
+            ->toBe('')
+            ->and($finished->workerId)
+            ->because('legacy class-finished events have no worker attribution')
+            ->toBe('')
+            ->and($run->artifactsDirectory)
+            ->because('legacy run-started events have no artifacts directory')
+            ->toBeNull();
+    }
+
+    #[Test]
     public function runFinishedCarriesSummarySemantics(): void
     {
         $summary = new ResultSummary()

--- a/tests/Unit/Runner/Protocol/ProtocolTest.php
+++ b/tests/Unit/Runner/Protocol/ProtocolTest.php
@@ -138,6 +138,22 @@ final class ProtocolTest
     }
 
     #[Test]
+    public function legacyAssignmentPayloadsDefaultArtifactFields(): void
+    {
+        $payload = new Assign(new ExecutionPlan([]))->toWire();
+        unset($payload['artifactSession'], $payload['artifactConfiguration']);
+
+        $assign = Assign::fromWire($payload);
+
+        Expect::that($assign->artifactSession)
+            ->because('legacy assignments have no artifact session')
+            ->toBeNull()
+            ->and($assign->artifactConfiguration)
+            ->because('legacy assignments have no artifact configuration')
+            ->toBeNull();
+    }
+
+    #[Test]
     public function oversizedFramesAreRejectedOnBothSides(): void
     {
         $codec = new JsonFrameCodec(maxFrameBytes: 64);


### PR DESCRIPTION
Protects backward-compatible decoding for event and worker-assignment payloads created before newer optional fields were added.