### PR TITLE
test: cover CLI option ordering

### DIFF
--- a/tests/Unit/Cli/ArgumentParserTest.php
+++ b/tests/Unit/Cli/ArgumentParserTest.php
@@ -43,6 +43,27 @@ final class ArgumentParserTest
     }
 
     #[Test]
+    public function optionsCanSurroundTheCommandWithoutChangingTheirMeaning(): void
+    {
+        $parsed = self::parser()->parse([
+            '--workers=4',
+            'run',
+            '--group=slow',
+            '--seed=123',
+        ]);
+
+        Expect::that($parsed->command)
+            ->because('option position MUST NOT change the selected command')
+            ->toBe('run')
+            ->and($parsed->value('workers'))
+            ->toBe('4')
+            ->and($parsed->values('group'))
+            ->toBe(['slow'])
+            ->and($parsed->value('seed'))
+            ->toBe('123');
+    }
+
+    #[Test]
     public function shortAliasesMapToTheirLongOptions(): void
     {
         Expect::that(self::parser()->parse(['-h'])->has('help'))->because('short aliases map to their long options')->toBeTrue();


### PR DESCRIPTION
Cover command-line options placed on both sides of the command word. Verify option position does not change command selection or parsed option values.