### PR TITLE
fix(config): validate variadic inputs before mutation

### DIFF
--- a/src/Config/CoverageBuilder.php
+++ b/src/Config/CoverageBuilder.php
@@ -31,9 +31,9 @@ final class CoverageBuilder
             if ($path === '') {
                 throw new InvalidConfiguration('Coverage include paths cannot be empty.');
             }
-
-            $this->includePaths[] = $path;
         }
+
+        \array_push($this->includePaths, ...\array_values($paths));
 
         return $this;
     }

--- a/src/Config/GreenlightConfig.php
+++ b/src/Config/GreenlightConfig.php
@@ -270,9 +270,9 @@ final class GreenlightConfig
             if ($pattern === '') {
                 throw new InvalidConfiguration('ignoreDeprecationsMatching() patterns cannot be empty.');
             }
-
-            $this->ignoreDeprecations[] = $pattern;
         }
+
+        \array_push($this->ignoreDeprecations, ...\array_values($patterns));
 
         return $this;
     }

--- a/src/Config/SuiteBuilder.php
+++ b/src/Config/SuiteBuilder.php
@@ -31,9 +31,9 @@ final class SuiteBuilder
             if ($path === '') {
                 throw new InvalidConfiguration(\sprintf('Suite "%s" was given an empty path.', $this->name));
             }
-
-            $this->paths[] = $path;
         }
+
+        \array_push($this->paths, ...\array_values($paths));
 
         return $this;
     }
@@ -47,9 +47,9 @@ final class SuiteBuilder
             if ($tag === '') {
                 throw new InvalidConfiguration(\sprintf('Suite "%s" was given an empty tag.', $this->name));
             }
-
-            $this->tags[] = $tag;
         }
+
+        \array_push($this->tags, ...\array_values($tags));
 
         return $this;
     }

--- a/tests/Unit/Config/CoverageBuilderTest.php
+++ b/tests/Unit/Config/CoverageBuilderTest.php
@@ -25,6 +25,23 @@ final class CoverageBuilderTest
     }
 
     #[Test]
+    public function aRejectedIncludeCallDoesNotRetainEarlierPaths(): void
+    {
+        $builder = new CoverageBuilder()->include('src/Base');
+
+        Expect::that(static fn(): CoverageBuilder => $builder->include('src/Partial', ''))
+            ->because('a rejected include list does not partially change coverage')
+            ->toThrow(
+                InvalidConfiguration::class,
+                message: 'Coverage include paths cannot be empty.',
+            );
+
+        Expect::that($builder->toConfiguration()->includePaths)
+            ->because('a rejected include call retains only prior paths')
+            ->toBe(['src/Base']);
+    }
+
+    #[Test]
     public function anEmptyDriverNameIsRejected(): void
     {
         Expect::that(static function (): void {

--- a/tests/Unit/Config/ResultPolicyConfigurationTest.php
+++ b/tests/Unit/Config/ResultPolicyConfigurationTest.php
@@ -112,6 +112,26 @@ final class ResultPolicyConfigurationTest
             );
     }
 
+    #[Test]
+    public function rejectedIgnorePatternsDoNotRetainEarlierArguments(): void
+    {
+        $config = GreenlightConfig::create()
+            ->ignoreDeprecationsMatching('existing');
+
+        Expect::that(
+            static fn(): GreenlightConfig => $config->ignoreDeprecationsMatching('partial', ''),
+        )
+            ->because('a rejected pattern list does not partially change the policy')
+            ->toThrow(
+                InvalidConfiguration::class,
+                message: 'ignoreDeprecationsMatching() patterns cannot be empty.',
+            );
+
+        Expect::that($config->build()->policy->ignoreDeprecations)
+            ->because('a rejected pattern call retains only prior patterns')
+            ->toBe(['existing']);
+    }
+
     /**
      * @return iterable<string, array{list<string>}>
      */

--- a/tests/Unit/Config/SuiteBuilderTest.php
+++ b/tests/Unit/Config/SuiteBuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Config;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Config\InvalidConfiguration;
 use Greenlight\Config\SuiteBuilder;
 use Greenlight\Expect\Expect;
 
@@ -26,5 +27,34 @@ final class SuiteBuilderTest
         Expect::that($suite->tags)
             ->because('repeated tag() calls append each tag')
             ->toBe(['io', 'slow', 'external']);
+    }
+
+    #[Test]
+    public function rejectedCallsDoNotRetainEarlierArguments(): void
+    {
+        $builder = new SuiteBuilder('integration')
+            ->in('tests/Base')
+            ->tag('base');
+
+        Expect::that(static fn(): SuiteBuilder => $builder->in('tests/Partial', ''))
+            ->because('a rejected path list does not partially change the suite')
+            ->toThrow(
+                InvalidConfiguration::class,
+                message: 'Suite "integration" was given an empty path.',
+            );
+        Expect::that(static fn(): SuiteBuilder => $builder->tag('partial', ''))
+            ->because('a rejected tag list does not partially change the suite')
+            ->toThrow(
+                InvalidConfiguration::class,
+                message: 'Suite "integration" was given an empty tag.',
+            );
+
+        $suite = $builder->toConfiguration();
+
+        Expect::that($suite->paths)
+            ->because('rejected calls do not retain earlier arguments')
+            ->toBe(['tests/Base'])
+            ->and($suite->tags)
+            ->toBe(['base']);
     }
 }


### PR DESCRIPTION
Four configuration methods validate variadic arguments while appending them. If a later path, tag, or pattern is empty, the call throws after it has already retained earlier arguments.

Validate each complete argument list before mutation. Cover suite paths, suite tags, coverage include paths, and ignored deprecation patterns. Each rejected call now leaves the prior configuration unchanged.
