### PR TITLE
fix(cli): ignore invalid cached durations

### DIFF
--- a/src/Cli/RunState.php
+++ b/src/Cli/RunState.php
@@ -98,9 +98,17 @@ final readonly class RunState
         $durations = [];
 
         foreach ($decoded['classSeconds'] as $class => $seconds) {
-            if (\is_string($class) && $class !== '' && (\is_float($seconds) || \is_int($seconds))) {
-                $durations[$class] = (float) $seconds;
+            if (!\is_string($class) || $class === '' || (!\is_float($seconds) && !\is_int($seconds))) {
+                continue;
             }
+
+            $seconds = (float) $seconds;
+
+            if (!\is_finite($seconds) || $seconds < 0.0) {
+                continue;
+            }
+
+            $durations[$class] = $seconds;
         }
 
         return $durations;

--- a/tests/Unit/Cli/RunStateTest.php
+++ b/tests/Unit/Cli/RunStateTest.php
@@ -48,6 +48,36 @@ final class RunStateTest
     }
 
     #[Test]
+    public function invalidCachedClassDurationsAreIgnored(): void
+    {
+        $directory = '/fake/project-' . \bin2hex(\random_bytes(6));
+        $file = $this->stateFileFor($directory);
+        \file_put_contents($file, <<<'JSON'
+            {
+                "classSeconds": {
+                    "Acme\\ValidTest": 1.25,
+                    "Acme\\ZeroDurationTest": 0,
+                    "Acme\\NegativeTest": -1,
+                    "Acme\\OverflowTest": 1e400,
+                    "Acme\\StringTest": "2.5",
+                    "": 3
+                }
+            }
+            JSON);
+
+        try {
+            Expect::that(RunState::forWorkingDirectory($directory)->classSeconds())
+                ->because('cached durations MUST be finite, non-negative numbers for named classes')
+                ->toBe([
+                    'Acme\ValidTest' => 1.25,
+                    'Acme\ZeroDurationTest' => 0.0,
+                ]);
+        } finally {
+            @\unlink($file);
+        }
+    }
+
+    #[Test]
     public function corruptStateReadsAsAbsent(): void
     {
         $directory = '/fake/project-' . \bin2hex(\random_bytes(6));


### PR DESCRIPTION
Run state is advisory input to longest-first scheduling. A persisted JSON document can contain negative durations or an overflowing number that PHP decodes as infinity.

Keep only finite, non-negative numeric durations at the run-state boundary. Valid entries in a mixed state document remain available to scheduling.
