### PR TITLE
fix(core): reject non-finite wire floats

### DIFF
--- a/src/Core/Result/TestResult.php
+++ b/src/Core/Result/TestResult.php
@@ -49,8 +49,8 @@ final readonly class TestResult implements WireSerializable
         public int $expectations = 0,
         public array $attachments = [],
     ) {
-        if ($durationSeconds < 0.0) {
-            throw new \InvalidArgumentException('Duration cannot be negative.');
+        if (!\is_finite($durationSeconds) || $durationSeconds < 0.0) {
+            throw new \InvalidArgumentException('Duration must be finite and zero or more.');
         }
 
         if ($attempts < 1) {

--- a/src/Core/Wire/Wire.php
+++ b/src/Core/Wire/Wire.php
@@ -10,8 +10,8 @@ namespace Greenlight\Core\Wire;
  * Each reader throws InvalidWirePayload with the applicable key. Thus, its
  * message identifies the protocol error.
  *
- * A float reader accepts integer values because JSON does not preserve the
- * difference.
+ * A float reader accepts finite integer and float values. It accepts integers
+ * because JSON does not preserve the difference between the numeric types.
  *
  * @internal
  */
@@ -100,11 +100,11 @@ final class Wire
         }
 
         if (\is_int($value)) {
-            return (float) $value;
+            $value = (float) $value;
         }
 
-        if (!\is_float($value)) {
-            throw InvalidWirePayload::wrongType($key, 'a float or null', $value);
+        if (!\is_float($value) || !\is_finite($value)) {
+            throw InvalidWirePayload::wrongType($key, 'a finite float or null', $value);
         }
 
         return $value;
@@ -136,11 +136,11 @@ final class Wire
         $value = self::require($payload, $key);
 
         if (\is_int($value)) {
-            return (float) $value;
+            $value = (float) $value;
         }
 
-        if (!\is_float($value)) {
-            throw InvalidWirePayload::wrongType($key, 'a float', $value);
+        if (!\is_float($value) || !\is_finite($value)) {
+            throw InvalidWirePayload::wrongType($key, 'a finite float', $value);
         }
 
         return $value;

--- a/tests/Unit/Core/TestResultTest.php
+++ b/tests/Unit/Core/TestResultTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Core;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Artifact\Attachment;
 use Greenlight\Core\Artifact\AttachmentKind;
@@ -103,14 +104,29 @@ final class TestResultTest
     }
 
     #[Test]
-    public function rejectsInvalidConstruction(): void
+    public function rejectsInvalidAttemptCounts(): void
     {
         $id = new TestId('App\FooTest', 'bar');
 
-        Expect::that(static fn(): TestResult => new TestResult($id, Outcome::Passed, -0.1, 0))->because('rejects invalid construction')
+        Expect::that(static fn(): TestResult => new TestResult($id, Outcome::Passed, 0.1, 0, 0))
+            ->because('attempt counts MUST start at one')
             ->toThrow(\InvalidArgumentException::class);
-        Expect::that(static fn(): TestResult => new TestResult($id, Outcome::Passed, 0.1, 0, 0))->because('rejects invalid construction')
-            ->toThrow(\InvalidArgumentException::class);
+    }
+
+    #[Test]
+    #[DataSet('invalidDurations')]
+    public function rejectsInvalidDurations(float $duration): void
+    {
+        $id = new TestId('App\FooTest', 'bar');
+
+        Expect::that(
+            static fn(): TestResult => new TestResult($id, Outcome::Passed, $duration, 0),
+        )
+            ->because('result durations MUST be finite and non-negative')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Duration must be finite and zero or more.',
+            );
     }
 
     #[Test]
@@ -120,5 +136,16 @@ final class TestResultTest
         Expect::that(Outcome::Skipped->isSuccessful())->because('outcome success uses the required semantics')->toBeTrue();
         Expect::that(Outcome::Failed->isSuccessful())->because('outcome success uses the required semantics')->toBeFalse();
         Expect::that(Outcome::Errored->isSuccessful())->because('outcome success uses the required semantics')->toBeFalse();
+    }
+
+    /**
+     * @return iterable<string, array{float}>
+     */
+    public static function invalidDurations(): iterable
+    {
+        yield 'negative' => [-0.1];
+        yield 'positive infinity' => [\INF];
+        yield 'negative infinity' => [-\INF];
+        yield 'not a number' => [\NAN];
     }
 }

--- a/tests/Unit/Core/WireTest.php
+++ b/tests/Unit/Core/WireTest.php
@@ -95,6 +95,26 @@ final class WireTest
     }
 
     #[Test]
+    #[DataSet('nonFiniteFloats')]
+    public function floatReadersRejectNonFiniteValues(float $value): void
+    {
+        $payload = ['durationSeconds' => $value];
+
+        Expect::that(static fn(): float => Wire::float($payload, 'durationSeconds'))
+            ->because('protocol floats MUST be finite')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "durationSeconds" must be a finite float, got float.',
+            )
+            ->and(static fn(): ?float => Wire::nullableFloat($payload, 'durationSeconds'))
+            ->because('nullable protocol floats MUST reject non-finite values')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "durationSeconds" must be a finite float or null, got float.',
+            );
+    }
+
+    #[Test]
     #[DataSet('invalidReaderCases')]
     public function typedReadersRejectInvalidFields(string $reader, string $expected): void
     {
@@ -130,10 +150,22 @@ final class WireTest
         yield 'string' => ['string', 'a string'];
         yield 'nullable string' => ['nullableString', 'a string or null'];
         yield 'nullable integer' => ['nullableInt', 'an integer or null'];
-        yield 'nullable float' => ['nullableFloat', 'a float or null'];
+        yield 'nullable float' => ['nullableFloat', 'a finite float or null'];
         yield 'boolean' => ['bool', 'a boolean'];
         yield 'map' => ['map', 'a map'];
         yield 'nullable map' => ['nullableMap', 'a map'];
         yield 'list of maps' => ['listOfMaps', 'a list of maps'];
+    }
+
+    /**
+     * @return iterable<string, array{float}>
+     */
+    public static function nonFiniteFloats(): iterable
+    {
+        yield 'JSON exponent overflow' => [
+            \json_decode('1e400', flags: \JSON_THROW_ON_ERROR),
+        ];
+        yield 'negative infinity' => [-\INF];
+        yield 'not a number' => [\NAN];
     }
 }

--- a/tests/Unit/Core/WireTest.php
+++ b/tests/Unit/Core/WireTest.php
@@ -69,18 +69,18 @@ final class WireTest
     #[Test]
     public function failuresNameTheOffendingKey(): void
     {
-        try {
-            Wire::string([], 'runId');
-        } catch (InvalidWirePayload $e) {
-            Expect::that($e->getMessage())->toContain('runId');
-        }
-
-        try {
-            Wire::int(['count' => 'many'], 'count');
-        } catch (InvalidWirePayload $e) {
-            Expect::that($e->getMessage())->toContain('count');
-            Expect::that($e->getMessage())->toContain('string');
-        }
+        Expect::that(static fn(): string => Wire::string([], 'runId'))
+            ->because('a missing field MUST name its wire key')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload is missing the "runId" key.',
+            );
+        Expect::that(static fn(): int => Wire::int(['count' => 'many'], 'count'))
+            ->because('an invalid field MUST name its wire key and actual type')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "count" must be an integer, got string.',
+            );
     }
 
     #[Test]


### PR DESCRIPTION
JSON decoding accepts exponent overflow as infinity. Reject non-finite values in both float wire readers so malformed payloads cannot poison event timestamps, result durations, or nullable numeric fields. Enforce the same invariant when TestResult values are created so Greenlight cannot emit an unencodable duration. Cover JSON exponent overflow, infinities, and not-a-number values at both boundaries.