### PR TITLE
test: identify remaining fixture fakes

### DIFF
--- a/tests/Fixture/DiscoveryAttributes/AlwaysFalse.php
+++ b/tests/Fixture/DiscoveryAttributes/AlwaysFalse.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Fixture\DiscoveryAttributes;
 
 use Greenlight\Core\Condition;
+use Greenlight\Doubles\Fake;
 
-final class AlwaysFalse implements Condition
+final class AlwaysFalse implements Condition, Fake
 {
     #[\Override]
     public function isSatisfied(): bool

--- a/tests/Fixture/DiscoveryAttributes/AlwaysTrue.php
+++ b/tests/Fixture/DiscoveryAttributes/AlwaysTrue.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Fixture\DiscoveryAttributes;
 
 use Greenlight\Core\Condition;
+use Greenlight\Doubles\Fake;
 
-final class AlwaysTrue implements Condition
+final class AlwaysTrue implements Condition, Fake
 {
     #[\Override]
     public function isSatisfied(): bool

--- a/tests/Fixture/Expect/EvenNumbersExtension.php
+++ b/tests/Fixture/Expect/EvenNumbersExtension.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Fixture\Expect;
 
+use Greenlight\Doubles\Fake;
 use Greenlight\Expect\ExpectationExtension;
 
-final class EvenNumbersExtension implements ExpectationExtension
+final class EvenNumbersExtension implements ExpectationExtension, Fake
 {
     #[\Override]
     public function matchers(): array

--- a/tests/Fixture/Expect/PositiveNumbersExtension.php
+++ b/tests/Fixture/Expect/PositiveNumbersExtension.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Fixture\Expect;
 
+use Greenlight\Doubles\Fake;
 use Greenlight\Expect\ExpectationExtension;
 
-final class PositiveNumbersExtension implements ExpectationExtension
+final class PositiveNumbersExtension implements ExpectationExtension, Fake
 {
     #[\Override]
     public function matchers(): array

--- a/tests/Fixture/Laravel/ThrowingKernel.php
+++ b/tests/Fixture/Laravel/ThrowingKernel.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Fixture\Laravel;
 
+use Greenlight\Doubles\Fake;
 use Illuminate\Contracts\Console\Kernel;
 
 /**
  * Throws when the bridge starts the console kernel.
  */
-final class ThrowingKernel implements Kernel
+final class ThrowingKernel implements Kernel, Fake
 {
     #[\Override]
     public function bootstrap(): void

--- a/tests/Fixture/Lifecycle/DisposeFails/FailingDisposalProbe.php
+++ b/tests/Fixture/Lifecycle/DisposeFails/FailingDisposalProbe.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Fixture\Lifecycle\DisposeFails;
 
+use Greenlight\Doubles\Fake;
 use Greenlight\Harness\Disposable;
 
-final class FailingDisposalProbe implements Disposable
+final class FailingDisposalProbe implements Disposable, Fake
 {
     public function touch(): void {}
 

--- a/tests/Fixture/Lifecycle/Services/ServiceProbe.php
+++ b/tests/Fixture/Lifecycle/Services/ServiceProbe.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Fixture\Lifecycle\Services;
 
+use Greenlight\Doubles\Fake;
 use Greenlight\Harness\Disposable;
 use Greenlight\Tests\Fixture\Lifecycle\TraceLog;
 
-final class ServiceProbe implements Disposable
+final class ServiceProbe implements Disposable, Fake
 {
     private static int $instances = 0;
 

--- a/tests/Fixture/Lifecycle/Services/ServiceProbe.php
+++ b/tests/Fixture/Lifecycle/Services/ServiceProbe.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Fixture\Lifecycle\Services;
 
-use Greenlight\Doubles\Fake;
 use Greenlight\Harness\Disposable;
 use Greenlight\Tests\Fixture\Lifecycle\TraceLog;
 
-final class ServiceProbe implements Disposable, Fake
+final class ServiceProbe implements Disposable
 {
     private static int $instances = 0;
 

--- a/tests/Fixture/Lifecycle/Skips/AlwaysCondition.php
+++ b/tests/Fixture/Lifecycle/Skips/AlwaysCondition.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Fixture\Lifecycle\Skips;
 
 use Greenlight\Core\Condition;
+use Greenlight\Doubles\Fake;
 
-final class AlwaysCondition implements Condition
+final class AlwaysCondition implements Condition, Fake
 {
     #[\Override]
     public function isSatisfied(): bool

--- a/tests/Fixture/Lifecycle/Skips/NeverCondition.php
+++ b/tests/Fixture/Lifecycle/Skips/NeverCondition.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Fixture\Lifecycle\Skips;
 
 use Greenlight\Core\Condition;
+use Greenlight\Doubles\Fake;
 
-final class NeverCondition implements Condition
+final class NeverCondition implements Condition, Fake
 {
     #[\Override]
     public function isSatisfied(): bool

--- a/tests/Fixture/Lifecycle/VerifyOnDispose/VerifyingProbe.php
+++ b/tests/Fixture/Lifecycle/VerifyOnDispose/VerifyingProbe.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Fixture\Lifecycle\VerifyOnDispose;
 
+use Greenlight\Doubles\Fake;
 use Greenlight\Expect\Expect;
 use Greenlight\Harness\Disposable;
 
-final class VerifyingProbe implements Disposable
+final class VerifyingProbe implements Disposable, Fake
 {
     public int $touches = 0;
 

--- a/tests/Fixture/PhpStanExtension/DigestExtension.php
+++ b/tests/Fixture/PhpStanExtension/DigestExtension.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Fixture\PhpStanExtension;
 
+use Greenlight\Doubles\Fake;
 use Greenlight\Expect\ExpectationExtension;
 
-final class DigestExtension implements ExpectationExtension
+final class DigestExtension implements ExpectationExtension, Fake
 {
     #[\Override]
     public function matchers(): array

--- a/tests/Fixture/PhpStanExtensionConflict/ConflictingDigestExtension.php
+++ b/tests/Fixture/PhpStanExtensionConflict/ConflictingDigestExtension.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Fixture\PhpStanExtensionConflict;
 
+use Greenlight\Doubles\Fake;
 use Greenlight\Expect\ExpectationExtension;
 
-final class ConflictingDigestExtension implements ExpectationExtension
+final class ConflictingDigestExtension implements ExpectationExtension, Fake
 {
     #[\Override]
     public function matchers(): array

--- a/tests/Fixture/Plugins/EvenNumbersExtension.php
+++ b/tests/Fixture/Plugins/EvenNumbersExtension.php
@@ -4,9 +4,10 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Fixture\Plugins;
 
+use Greenlight\Doubles\Fake;
 use Greenlight\Expect\ExpectationExtension;
 
-final readonly class EvenNumbersExtension implements ExpectationExtension
+final readonly class EvenNumbersExtension implements ExpectationExtension, Fake
 {
     #[\Override]
     public function matchers(): array

--- a/tests/Fixture/Plugins/ProbeProvider.php
+++ b/tests/Fixture/Plugins/ProbeProvider.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Fixture\Plugins;
 
+use Greenlight\Doubles\Fake;
 use Greenlight\Harness\Scope;
 use Greenlight\Harness\ServiceDefinition;
 use Greenlight\Plugin\HarnessProvider;
 use Greenlight\Tests\Fixture\Lifecycle\Services\ServiceProbe;
 
-final readonly class ProbeProvider implements HarnessProvider
+final readonly class ProbeProvider implements HarnessProvider, Fake
 {
     #[\Override]
     public function services(): array

--- a/tests/Fixture/Plugins/QuarantinePlugin.php
+++ b/tests/Fixture/Plugins/QuarantinePlugin.php
@@ -6,10 +6,11 @@ namespace Greenlight\Tests\Fixture\Plugins;
 
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
+use Greenlight\Doubles\Fake;
 use Greenlight\Plugin\TestContext;
 use Greenlight\Plugin\TestLifecycleSubscriber;
 
-final readonly class QuarantinePlugin implements TestLifecycleSubscriber
+final readonly class QuarantinePlugin implements TestLifecycleSubscriber, Fake
 {
     #[\Override]
     public function beforeTest(TestContext $context): void {}

--- a/tests/Fixture/Symfony/BareKernel.php
+++ b/tests/Fixture/Symfony/BareKernel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Fixture\Symfony;
 
+use Greenlight\Doubles\Fake;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -17,7 +18,7 @@ use Symfony\Component\HttpKernel\KernelInterface;
  * withTestContainer() omits services_resetter; withoutTestContainer() also
  * omits the test container.
  */
-final class BareKernel implements KernelInterface
+final class BareKernel implements KernelInterface, Fake
 {
     private function __construct(private readonly Container $container) {}
 

--- a/tests/Unit/Doubles/FakeFixtureTest.php
+++ b/tests/Unit/Doubles/FakeFixtureTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Doubles;
 
 use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\SkipUnless;
 use Greenlight\Attribute\Test;
+use Greenlight\Condition\ClassAvailable;
 use Greenlight\Doubles\Fake;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\DiscoveryAttributes\AlwaysFalse;
@@ -14,7 +16,6 @@ use Greenlight\Tests\Fixture\Expect\EvenNumbersExtension as ExpectEvenNumbersExt
 use Greenlight\Tests\Fixture\Expect\PositiveNumbersExtension;
 use Greenlight\Tests\Fixture\Laravel\ThrowingKernel;
 use Greenlight\Tests\Fixture\Lifecycle\DisposeFails\FailingDisposalProbe;
-use Greenlight\Tests\Fixture\Lifecycle\Services\ServiceProbe;
 use Greenlight\Tests\Fixture\Lifecycle\Skips\AlwaysCondition;
 use Greenlight\Tests\Fixture\Lifecycle\Skips\NeverCondition;
 use Greenlight\Tests\Fixture\Lifecycle\VerifyOnDispose\VerifyingProbe;
@@ -24,6 +25,7 @@ use Greenlight\Tests\Fixture\Plugins\EvenNumbersExtension as PluginEvenNumbersEx
 use Greenlight\Tests\Fixture\Plugins\ProbeProvider;
 use Greenlight\Tests\Fixture\Plugins\QuarantinePlugin;
 use Greenlight\Tests\Fixture\Symfony\BareKernel;
+use Illuminate\Foundation\Application as LaravelApplication;
 
 final class FakeFixtureTest
 {
@@ -34,8 +36,18 @@ final class FakeFixtureTest
     #[DataSet('manualInMemoryFixtures')]
     public function manualInMemoryFixturesIdentifyThemselvesAsFakes(string $fixture): void
     {
-        Expect::that(\is_a($fixture, Fake::class, true))
+        Expect::that(\is_subclass_of($fixture, Fake::class))
             ->because('a manual in-memory fixture MUST identify itself as a fake')
+            ->toBeTrue();
+    }
+
+    #[Test]
+    #[SkipUnless(ClassAvailable::class, LaravelApplication::class)]
+    #[DataSet('optionalLaravelFixtures')]
+    public function optionalLaravelFixturesIdentifyThemselvesAsFakes(string $fixture): void
+    {
+        Expect::that(\is_subclass_of($fixture, Fake::class))
+            ->because('the optional Laravel fixture MUST identify itself as a fake')
             ->toBeTrue();
     }
 
@@ -48,9 +60,7 @@ final class FakeFixtureTest
         yield AlwaysTrue::class => [AlwaysTrue::class];
         yield ExpectEvenNumbersExtension::class => [ExpectEvenNumbersExtension::class];
         yield PositiveNumbersExtension::class => [PositiveNumbersExtension::class];
-        yield ThrowingKernel::class => [ThrowingKernel::class];
         yield FailingDisposalProbe::class => [FailingDisposalProbe::class];
-        yield ServiceProbe::class => [ServiceProbe::class];
         yield AlwaysCondition::class => [AlwaysCondition::class];
         yield NeverCondition::class => [NeverCondition::class];
         yield VerifyingProbe::class => [VerifyingProbe::class];
@@ -60,5 +70,13 @@ final class FakeFixtureTest
         yield ProbeProvider::class => [ProbeProvider::class];
         yield QuarantinePlugin::class => [QuarantinePlugin::class];
         yield BareKernel::class => [BareKernel::class];
+    }
+
+    /**
+     * @return iterable<string, array{class-string}>
+     */
+    public static function optionalLaravelFixtures(): iterable
+    {
+        yield ThrowingKernel::class => [ThrowingKernel::class];
     }
 }

--- a/tests/Unit/Doubles/FakeFixtureTest.php
+++ b/tests/Unit/Doubles/FakeFixtureTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Fake;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\DiscoveryAttributes\AlwaysFalse;
+use Greenlight\Tests\Fixture\DiscoveryAttributes\AlwaysTrue;
+use Greenlight\Tests\Fixture\Expect\EvenNumbersExtension as ExpectEvenNumbersExtension;
+use Greenlight\Tests\Fixture\Expect\PositiveNumbersExtension;
+use Greenlight\Tests\Fixture\Laravel\ThrowingKernel;
+use Greenlight\Tests\Fixture\Lifecycle\DisposeFails\FailingDisposalProbe;
+use Greenlight\Tests\Fixture\Lifecycle\Services\ServiceProbe;
+use Greenlight\Tests\Fixture\Lifecycle\Skips\AlwaysCondition;
+use Greenlight\Tests\Fixture\Lifecycle\Skips\NeverCondition;
+use Greenlight\Tests\Fixture\Lifecycle\VerifyOnDispose\VerifyingProbe;
+use Greenlight\Tests\Fixture\PhpStanExtension\DigestExtension;
+use Greenlight\Tests\Fixture\PhpStanExtensionConflict\ConflictingDigestExtension;
+use Greenlight\Tests\Fixture\Plugins\EvenNumbersExtension as PluginEvenNumbersExtension;
+use Greenlight\Tests\Fixture\Plugins\ProbeProvider;
+use Greenlight\Tests\Fixture\Plugins\QuarantinePlugin;
+use Greenlight\Tests\Fixture\Symfony\BareKernel;
+
+final class FakeFixtureTest
+{
+    /**
+     * @param class-string $fixture
+     */
+    #[Test]
+    #[DataSet('manualInMemoryFixtures')]
+    public function manualInMemoryFixturesIdentifyThemselvesAsFakes(string $fixture): void
+    {
+        Expect::that(\is_a($fixture, Fake::class, true))
+            ->because('a manual in-memory fixture MUST identify itself as a fake')
+            ->toBeTrue();
+    }
+
+    /**
+     * @return iterable<string, array{class-string}>
+     */
+    public static function manualInMemoryFixtures(): iterable
+    {
+        yield AlwaysFalse::class => [AlwaysFalse::class];
+        yield AlwaysTrue::class => [AlwaysTrue::class];
+        yield ExpectEvenNumbersExtension::class => [ExpectEvenNumbersExtension::class];
+        yield PositiveNumbersExtension::class => [PositiveNumbersExtension::class];
+        yield ThrowingKernel::class => [ThrowingKernel::class];
+        yield FailingDisposalProbe::class => [FailingDisposalProbe::class];
+        yield ServiceProbe::class => [ServiceProbe::class];
+        yield AlwaysCondition::class => [AlwaysCondition::class];
+        yield NeverCondition::class => [NeverCondition::class];
+        yield VerifyingProbe::class => [VerifyingProbe::class];
+        yield DigestExtension::class => [DigestExtension::class];
+        yield ConflictingDigestExtension::class => [ConflictingDigestExtension::class];
+        yield PluginEvenNumbersExtension::class => [PluginEvenNumbersExtension::class];
+        yield ProbeProvider::class => [ProbeProvider::class];
+        yield QuarantinePlugin::class => [QuarantinePlugin::class];
+        yield BareKernel::class => [BareKernel::class];
+    }
+}


### PR DESCRIPTION
Mark older manual in-memory fixture implementations with Greenlight\Doubles\Fake. Cover condition stubs, expectation and plugin collaborators, lifecycle probes, and hand-rolled framework kernels with an explicit marker contract. Keep application services and ordinary data, configuration, and filesystem fixtures unmarked.