### PR TITLE
fix(discovery): reject invalid provider budgets

### DIFF
--- a/src/Discovery/TestDiscoverer.php
+++ b/src/Discovery/TestDiscoverer.php
@@ -26,8 +26,8 @@ final readonly class TestDiscoverer
     public function __construct(
         private float $providerTimeBudgetSeconds = 5.0,
     ) {
-        if ($providerTimeBudgetSeconds <= 0.0) {
-            throw new \InvalidArgumentException('Set the provider time budget to a value greater than zero seconds.');
+        if (!\is_finite($providerTimeBudgetSeconds) || $providerTimeBudgetSeconds <= 0.0) {
+            throw new \InvalidArgumentException('Provider time budget seconds must be finite and greater than zero.');
         }
 
         $this->metadataFactory = new MetadataFactory();

--- a/tests/Unit/Discovery/TestDiscovererTest.php
+++ b/tests/Unit/Discovery/TestDiscovererTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Discovery;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Discovery\DiscoveryError;
 use Greenlight\Discovery\ExecutionPlan;
@@ -36,14 +37,27 @@ final class TestDiscovererTest
     }
 
     #[Test]
-    public function rejectsANonpositiveProviderTimeBudgetWithExactGuidance(): void
+    #[DataSet('invalidProviderTimeBudgets')]
+    public function rejectsAnInvalidProviderTimeBudgetWithExactGuidance(float $budgetSeconds): void
     {
         Expect::that(
-            static fn(): TestDiscoverer => new TestDiscoverer(0.0),
+            static fn(): TestDiscoverer => new TestDiscoverer($budgetSeconds),
         )->toThrow(
             \InvalidArgumentException::class,
-            message: 'Set the provider time budget to a value greater than zero seconds.',
+            message: 'Provider time budget seconds must be finite and greater than zero.',
         );
+    }
+
+    /**
+     * @return iterable<string, array{float}>
+     */
+    public static function invalidProviderTimeBudgets(): iterable
+    {
+        yield 'zero' => [0.0];
+        yield 'negative' => [-1.0];
+        yield 'positive infinity' => [\INF];
+        yield 'negative infinity' => [-\INF];
+        yield 'not a number' => [\NAN];
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- reject non-finite and non-positive data-provider time budgets at construction
- cover zero, negative, infinity, and NaN inputs with one dataset