### PR TITLE
fix(attributes): reject empty data row labels

### DIFF
--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -68,21 +68,33 @@ final readonly class DataRow
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataRow.php#L15)
 
+### `$label`
+
+```php
+public ?string $label;
+```
+
+PHPDoc:
+
+- `@var non-empty-string|null`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataRow.php#L20)
+
 ### `__construct()`
 
 ```php
 public function __construct(
     public array $arguments,
-    public ?string $label = null,
+    ?string $label = null,
 )
 ```
 
 PHPDoc:
 
 - `@param array<mixed> $arguments`
-- `@param non-empty-string|null $label`
+- `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataRow.php#L21)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataRow.php#L27)
 
 ## `DataSet`
 

--- a/src/Attribute/DataRow.php
+++ b/src/Attribute/DataRow.php
@@ -15,11 +15,23 @@ namespace Greenlight\Attribute;
 final readonly class DataRow
 {
     /**
+     * @var non-empty-string|null
+     */
+    public ?string $label;
+
+    /**
      * @param array<mixed> $arguments
-     * @param non-empty-string|null $label
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct(
         public array $arguments,
-        public ?string $label = null,
-    ) {}
+        ?string $label = null,
+    ) {
+        if ($label === '') {
+            throw new \InvalidArgumentException('Data row label must not be empty.');
+        }
+
+        $this->label = $label;
+    }
 }

--- a/src/Discovery/DataSetExpander.php
+++ b/src/Discovery/DataSetExpander.php
@@ -69,7 +69,12 @@ final readonly class DataSetExpander
         $position = 0;
 
         foreach ($class->getMethod($testMethod)->getAttributes(DataRow::class) as $attribute) {
-            $row = $attribute->newInstance();
+            try {
+                $row = $attribute->newInstance();
+            } catch (\Throwable $e) {
+                throw DiscoveryError::invalidAttribute($className . '::' . $testMethod . '()', $e);
+            }
+
             $key = $row->label ?? \sprintf('#%d', $position);
 
             if (\array_key_exists($key, $rows)) {

--- a/tests/Fixture/DataRowsInvalid/EmptyDataRowLabelTest.php
+++ b/tests/Fixture/DataRowsInvalid/EmptyDataRowLabelTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\DataRowsInvalid;
+
+use Greenlight\Attribute\DataRow;
+use Greenlight\Attribute\Test;
+
+final class EmptyDataRowLabelTest
+{
+    #[Test]
+    #[DataRow([], label: '')]
+    public function neverDiscovered(): void {}
+}

--- a/tests/Unit/Discovery/DataRowTest.php
+++ b/tests/Unit/Discovery/DataRowTest.php
@@ -13,6 +13,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\DataRows\InlineRowsTest;
 use Greenlight\Tests\Fixture\DataRowsConflict\DuplicateRowKeyTest;
 use Greenlight\Tests\Fixture\DataRowsDuplicateInline\DuplicateInlineRowKeyTest;
+use Greenlight\Tests\Fixture\DataRowsInvalid\EmptyDataRowLabelTest;
 use Greenlight\Tests\Fixture\DataRowsZeroLabel\ZeroLabelRowTest;
 
 final class DataRowTest
@@ -77,6 +78,29 @@ final class DataRowTest
                 DiscoveryError::class,
                 message: 'Data sets for Greenlight\Tests\Fixture\DataRowsDuplicateInline\DuplicateInlineRowKeyTest::probe() '
                     . 'contain key "twice" more than once. Use each key only once for the test method.',
+            );
+    }
+
+    #[Test]
+    public function anEmptyInlineLabelIsReportedAsAnInvalidAttribute(): void
+    {
+        $class = EmptyDataRowLabelTest::class;
+
+        Expect::that(
+            static fn(): array => new DataSetExpander()->rowsFor(
+                new \ReflectionClass($class),
+                'neverDiscovered',
+                null,
+                5.0,
+            ),
+        )
+            ->because('an empty inline label cannot create an ambiguous data-set ID')
+            ->toThrow(
+                DiscoveryError::class,
+                message: \sprintf(
+                    'Attribute on %s::neverDiscovered() is invalid: Data row label must not be empty.',
+                    $class,
+                ),
             );
     }
 


### PR DESCRIPTION
Data row labels become keys in test IDs. An empty explicit label previously produced an ambiguous `method[]` ID.

Reject empty labels at the attribute boundary. Discovery wraps the invalid attribute with the test method location and preserves the original cause.
