### PR TITLE
fix(protocol): reject invalid frame limits

### DIFF
--- a/src/Runner/Protocol/FrameBuffer.php
+++ b/src/Runner/Protocol/FrameBuffer.php
@@ -17,7 +17,22 @@ final class FrameBuffer
 {
     private string $buffer = '';
 
-    public function __construct(private readonly int $maxFrameBytes = JsonFrameCodec::DEFAULT_MAX_FRAME_BYTES) {}
+    /**
+     * @var positive-int
+     */
+    private readonly int $maxFrameBytes;
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(int $maxFrameBytes = JsonFrameCodec::DEFAULT_MAX_FRAME_BYTES)
+    {
+        if ($maxFrameBytes < 1) {
+            throw new \InvalidArgumentException('Maximum frame size must be greater than zero.');
+        }
+
+        $this->maxFrameBytes = $maxFrameBytes;
+    }
 
     public function feed(string $bytes): void
     {

--- a/src/Runner/Protocol/JsonFrameCodec.php
+++ b/src/Runner/Protocol/JsonFrameCodec.php
@@ -17,7 +17,22 @@ final readonly class JsonFrameCodec implements FrameCodec
 {
     public const int DEFAULT_MAX_FRAME_BYTES = 8 * 1024 * 1024;
 
-    public function __construct(public int $maxFrameBytes = self::DEFAULT_MAX_FRAME_BYTES) {}
+    /**
+     * @var positive-int
+     */
+    public int $maxFrameBytes;
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(int $maxFrameBytes = self::DEFAULT_MAX_FRAME_BYTES)
+    {
+        if ($maxFrameBytes < 1) {
+            throw new \InvalidArgumentException('Maximum frame size must be greater than zero.');
+        }
+
+        $this->maxFrameBytes = $maxFrameBytes;
+    }
 
     #[\Override]
     public function encode(array $envelope): string

--- a/tests/Unit/Runner/Protocol/FrameLimitTest.php
+++ b/tests/Unit/Runner/Protocol/FrameLimitTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Protocol;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\Protocol\FrameBuffer;
+use Greenlight\Runner\Protocol\JsonFrameCodec;
+
+final readonly class FrameLimitTest
+{
+    #[Test]
+    #[DataSet('invalidLimits')]
+    public function frameLimitsMustBePositive(int $limit): void
+    {
+        Expect::that(static fn(): JsonFrameCodec => new JsonFrameCodec($limit))
+            ->because('the encoder MUST reject a frame limit that cannot contain a frame')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Maximum frame size must be greater than zero.',
+            );
+
+        Expect::that(static fn(): FrameBuffer => new FrameBuffer($limit))
+            ->because('the decoder MUST reject a frame limit that cannot contain a frame')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Maximum frame size must be greater than zero.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function invalidLimits(): iterable
+    {
+        yield 'zero' => [0];
+        yield 'negative' => [-1];
+    }
+}


### PR DESCRIPTION
The frame encoder and decoder accepted zero or negative byte limits. Every valid frame then failed with a misleading oversized-frame error.

Require a positive limit when each protocol component is constructed. Keep the positive-size invariant on the stored properties.
