### PR TITLE
fix(attributes): reject empty group names

### DIFF
--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -150,17 +150,29 @@ final readonly class Group
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Group.php#L8)
 
-### `__construct()`
+### `$name`
 
 ```php
-public function __construct(public string $name)
+public string $name;
 ```
 
 PHPDoc:
 
-- `@param non-empty-string $name`
+- `@var non-empty-string`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Group.php#L13)
+
+### `__construct()`
+
+```php
+public function __construct(string $name)
+```
+
+PHPDoc:
+
+- `@throws \InvalidArgumentException`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Group.php#L18)
 
 ## `Isolated`
 

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -15,6 +15,7 @@ parameters:
         analyse:
             - tests/Fixture/DataRowsDuplicateInline
             - tests/Fixture/DiscoveryAttributeArgumentsInvalid
+            - tests/Fixture/DiscoveryGroupInvalid
             - tests/Fixture/DiscoveryInvalidMethods
             - tests/Fixture/DiscoveryResourceInvalid
     greenlight:

--- a/src/Attribute/Group.php
+++ b/src/Attribute/Group.php
@@ -8,7 +8,19 @@ namespace Greenlight\Attribute;
 final readonly class Group
 {
     /**
-     * @param non-empty-string $name
+     * @var non-empty-string
      */
-    public function __construct(public string $name) {}
+    public string $name;
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(string $name)
+    {
+        if ($name === '') {
+            throw new \InvalidArgumentException('Group names cannot be empty.');
+        }
+
+        $this->name = $name;
+    }
 }

--- a/tests/Fixture/DiscoveryGroupInvalid/EmptyGroupTest.php
+++ b/tests/Fixture/DiscoveryGroupInvalid/EmptyGroupTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\DiscoveryGroupInvalid;
+
+use Greenlight\Attribute\Group;
+use Greenlight\Attribute\Test;
+
+final class EmptyGroupTest
+{
+    #[Test]
+    #[Group('')]
+    public function neverDiscovered(): void {}
+}

--- a/tests/Unit/Discovery/AttributeMergeTest.php
+++ b/tests/Unit/Discovery/AttributeMergeTest.php
@@ -9,6 +9,7 @@ use Greenlight\Condition\EnvironmentVariableEquals;
 use Greenlight\Condition\PhpVersionAtLeast;
 use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\DiscoveryError;
+use Greenlight\Discovery\ExecutionPlan;
 use Greenlight\Discovery\TestDiscoverer;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
@@ -17,6 +18,7 @@ use Greenlight\Tests\Fixture\DiscoveryAttributes\AlwaysFalse;
 use Greenlight\Tests\Fixture\DiscoveryAttributes\AlwaysTrue;
 use Greenlight\Tests\Fixture\DiscoveryAttributes\MergedTest;
 use Greenlight\Tests\Fixture\DiscoveryAttributes\PlainTest;
+use Greenlight\Tests\Fixture\DiscoveryGroupInvalid\EmptyGroupTest;
 
 final class AttributeMergeTest
 {
@@ -137,6 +139,24 @@ final class AttributeMergeTest
         }
 
         Fail::because('Expected discovery to reject an invalid resource name.');
+    }
+
+    #[Test]
+    public function anEmptyGroupNameIsReportedAsAnInvalidAttribute(): void
+    {
+        $dir = \dirname(__DIR__, 2) . '/Fixture/DiscoveryGroupInvalid';
+
+        Expect::that(
+            static fn(): ExecutionPlan => new TestDiscoverer()->discover([$dir]),
+        )
+            ->because('an empty group name cannot enter the execution plan')
+            ->toThrow(
+                DiscoveryError::class,
+                message: \sprintf(
+                    'Attribute on %s::neverDiscovered() is invalid: Group names cannot be empty.',
+                    EmptyGroupTest::class,
+                ),
+            );
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- reject empty #[Group] names at attribute construction
- report invalid group attributes as location-aware discovery errors
- cover the public discovery path with a dedicated PSR-4 fixture