### PR TITLE
fix(reporting): complete partial stream writes

### DIFF
--- a/src/Reporting/Output/StreamOutput.php
+++ b/src/Reporting/Output/StreamOutput.php
@@ -24,8 +24,14 @@ final class StreamOutput implements Output
     #[\Override]
     public function write(string $text): void
     {
-        if (\fwrite($this->stream, $text) === false) {
-            throw ReportingError::writeFailed();
+        while ($text !== '') {
+            $written = \fwrite($this->stream, $text);
+
+            if ($written === false || $written === 0) {
+                throw ReportingError::writeFailed();
+            }
+
+            $text = \substr($text, $written);
         }
     }
 }

--- a/tests/Fixture/Reporting/PartialWriteStream.php
+++ b/tests/Fixture/Reporting/PartialWriteStream.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Reporting;
+
+use Greenlight\Doubles\Fake;
+
+/**
+ * Accepts at most three bytes from each write, or simulates a stalled stream.
+ */
+final class PartialWriteStream implements Fake
+{
+    public mixed $context;
+
+    private static string $contents = '';
+
+    private bool $stalled = false;
+
+    public static function contents(): string
+    {
+        return self::$contents;
+    }
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        self::$contents = '';
+        $this->stalled = \str_ends_with($path, '/stalled');
+
+        return $mode === 'wb';
+    }
+
+    public function stream_write(string $data): int
+    {
+        if ($this->stalled) {
+            return 0;
+        }
+
+        $chunk = \substr($data, 0, 3);
+        self::$contents .= $chunk;
+
+        return \strlen($chunk);
+    }
+}

--- a/tests/Unit/Reporting/StreamOutputTest.php
+++ b/tests/Unit/Reporting/StreamOutputTest.php
@@ -8,9 +8,12 @@ use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Reporting\Output\StreamOutput;
 use Greenlight\Reporting\ReportingError;
+use Greenlight\Tests\Fixture\Reporting\PartialWriteStream;
 
 final class StreamOutputTest
 {
+    private const string PARTIAL_WRITE_SCHEME = 'greenlight-partial-write';
+
     #[Test]
     public function writesAccumulateOnTheStream(): void
     {
@@ -54,5 +57,62 @@ final class StreamOutputTest
         } finally {
             \fclose($stream);
         }
+    }
+
+    #[Test]
+    public function partialWritesAreRetriedUntilTheReporterTextIsComplete(): void
+    {
+        $stream = $this->openPartialWriteStream('partial');
+
+        try {
+            new StreamOutput($stream)->write('complete reporter output');
+
+            Expect::that(PartialWriteStream::contents())
+                ->because('a short stream write MUST NOT truncate reporter output')
+                ->toBe('complete reporter output');
+        } finally {
+            \fclose($stream);
+            \stream_wrapper_unregister(self::PARTIAL_WRITE_SCHEME);
+        }
+    }
+
+    #[Test]
+    public function aStalledPartialWriteBecomesAReportingError(): void
+    {
+        $stream = $this->openPartialWriteStream('stalled');
+
+        try {
+            $output = new StreamOutput($stream);
+
+            Expect::that(static fn() => $output->write('cannot make progress'))
+                ->because('a zero-byte write MUST stop instead of retrying without a limit')
+                ->toThrow(
+                    ReportingError::class,
+                    message: 'Greenlight did not write reporter output to the stream.',
+                );
+        } finally {
+            \fclose($stream);
+            \stream_wrapper_unregister(self::PARTIAL_WRITE_SCHEME);
+        }
+    }
+
+    /**
+     * @return resource
+     */
+    private function openPartialWriteStream(string $path)
+    {
+        if (!\stream_wrapper_register(self::PARTIAL_WRITE_SCHEME, PartialWriteStream::class)) {
+            throw new \RuntimeException('Greenlight did not register the partial-write stream.');
+        }
+
+        $stream = \fopen(self::PARTIAL_WRITE_SCHEME . '://' . $path, 'wb');
+
+        if ($stream === false) {
+            \stream_wrapper_unregister(self::PARTIAL_WRITE_SCHEME);
+
+            throw new \RuntimeException('Greenlight did not open the partial-write stream.');
+        }
+
+        return $stream;
     }
 }


### PR DESCRIPTION
Reporter output could be truncated when a stream accepted only part of a write. A zero-byte write also needs a bounded failure instead of an unlimited retry.

Continue writing until all reporter text reaches the stream. Preserve the existing reporting error when the stream fails or stops making progress.
