### PR TITLE
fix(core): reject empty failure details

### DIFF
--- a/docs/api-results.md
+++ b/docs/api-results.md
@@ -162,11 +162,23 @@ final readonly class FailureDetail implements WireSerializable
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/FailureDetail.php#L14)
 
+### `$message`
+
+```php
+public string $message;
+```
+
+PHPDoc:
+
+- `@var non-empty-string`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/FailureDetail.php#L19)
+
 ### `__construct()`
 
 ```php
 public function __construct(
-    public string $message,
+    string $message,
     public ?string $expected = null,
     public ?string $actual = null,
     public ?SourceLocation $location = null,
@@ -175,9 +187,9 @@ public function __construct(
 
 PHPDoc:
 
-- `@param non-empty-string $message`
+- `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/FailureDetail.php#L19)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/FailureDetail.php#L24)
 
 ### `toWire()`
 
@@ -186,7 +198,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/FailureDetail.php#L26)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/FailureDetail.php#L37)
 
 ### `fromWire()`
 
@@ -195,7 +207,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/FailureDetail.php#L37)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/FailureDetail.php#L48)
 
 ## `Outcome`
 

--- a/src/Core/Result/FailureDetail.php
+++ b/src/Core/Result/FailureDetail.php
@@ -14,14 +14,25 @@ use Greenlight\Core\Wire\WireSerializable;
 final readonly class FailureDetail implements WireSerializable
 {
     /**
-     * @param non-empty-string $message
+     * @var non-empty-string
+     */
+    public string $message;
+
+    /**
+     * @throws \InvalidArgumentException
      */
     public function __construct(
-        public string $message,
+        string $message,
         public ?string $expected = null,
         public ?string $actual = null,
         public ?SourceLocation $location = null,
-    ) {}
+    ) {
+        if ($message === '') {
+            throw new \InvalidArgumentException('Failure detail message must not be empty.');
+        }
+
+        $this->message = $message;
+    }
 
     #[\Override]
     public function toWire(): array

--- a/tests/Unit/Core/FailureDetailTest.php
+++ b/tests/Unit/Core/FailureDetailTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\FailureDetail;
+use Greenlight\Expect\Expect;
+
+final readonly class FailureDetailTest
+{
+    #[Test]
+    public function rejectsAnEmptyMessage(): void
+    {
+        Expect::that(static fn(): FailureDetail => new FailureDetail(''))
+            ->because('a failure detail MUST explain the failure')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Failure detail message must not be empty.',
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- reject empty FailureDetail messages at construction
- preserve the non-empty public message contract
- cover the invalid boundary with an exact exception assertion