### PR TITLE
fix(core): reject empty transformation sources

### DIFF
--- a/docs/api-results.md
+++ b/docs/api-results.md
@@ -262,11 +262,23 @@ final readonly class OutcomeTransformation implements WireSerializable
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/OutcomeTransformation.php#L11)
 
+### `$transformedBy`
+
+```php
+public string $transformedBy;
+```
+
+PHPDoc:
+
+- `@var non-empty-string`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/OutcomeTransformation.php#L16)
+
 ### `__construct()`
 
 ```php
 public function __construct(
-    public string $transformedBy,
+    string $transformedBy,
     public Outcome $from,
     public Outcome $to,
 )
@@ -274,9 +286,9 @@ public function __construct(
 
 PHPDoc:
 
-- `@param non-empty-string $transformedBy`
+- `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/OutcomeTransformation.php#L16)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/OutcomeTransformation.php#L21)
 
 ### `toWire()`
 
@@ -285,7 +297,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/OutcomeTransformation.php#L22)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/OutcomeTransformation.php#L33)
 
 ### `fromWire()`
 
@@ -294,7 +306,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/OutcomeTransformation.php#L32)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/OutcomeTransformation.php#L43)
 
 ## `ResultSummary`
 

--- a/src/Core/Result/OutcomeTransformation.php
+++ b/src/Core/Result/OutcomeTransformation.php
@@ -11,13 +11,24 @@ use Greenlight\Core\Wire\WireSerializable;
 final readonly class OutcomeTransformation implements WireSerializable
 {
     /**
-     * @param non-empty-string $transformedBy
+     * @var non-empty-string
+     */
+    public string $transformedBy;
+
+    /**
+     * @throws \InvalidArgumentException
      */
     public function __construct(
-        public string $transformedBy,
+        string $transformedBy,
         public Outcome $from,
         public Outcome $to,
-    ) {}
+    ) {
+        if ($transformedBy === '') {
+            throw new \InvalidArgumentException('Outcome transformation source must not be empty.');
+        }
+
+        $this->transformedBy = $transformedBy;
+    }
 
     #[\Override]
     public function toWire(): array

--- a/tests/Unit/Core/OutcomeTransformationTest.php
+++ b/tests/Unit/Core/OutcomeTransformationTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\OutcomeTransformation;
+use Greenlight\Expect\Expect;
+
+final readonly class OutcomeTransformationTest
+{
+    #[Test]
+    public function rejectsAnEmptySource(): void
+    {
+        Expect::that(
+            static fn(): OutcomeTransformation => new OutcomeTransformation(
+                '',
+                Outcome::Failed,
+                Outcome::Skipped,
+            ),
+        )
+            ->because('an outcome transformation MUST identify its source')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Outcome transformation source must not be empty.',
+            );
+    }
+}


### PR DESCRIPTION
Reject empty transformation source names at construction time. This preserves the documented non-empty invariant and prevents locally created transformations from producing wire payloads that cannot be decoded.\n\nAdds focused coverage for the invalid boundary and refreshes the generated result API reference.