### PR TITLE
fix(runner): reject invalid plan shards

### DIFF
--- a/src/Runner/PlanShard.php
+++ b/src/Runner/PlanShard.php
@@ -26,11 +26,24 @@ final class PlanShard
     private function __construct() {}
 
     /**
-     * @param positive-int $index 1-based shard number
-     * @param positive-int $count total shards
+     * @param int $index 1-based shard number
+     * @param int $count total shards
+     *
+     * @throws \InvalidArgumentException
      */
     public static function select(ExecutionPlan $plan, int $index, int $count): ExecutionPlan
     {
+        if ($count < 1) {
+            throw new \InvalidArgumentException('The shard count must be at least 1.');
+        }
+
+        if ($index < 1 || $index > $count) {
+            throw new \InvalidArgumentException(\sprintf(
+                'The shard index must be between 1 and %d.',
+                $count,
+            ));
+        }
+
         if ($count === 1) {
             return $plan;
         }

--- a/tests/Unit/Runner/PlanShardTest.php
+++ b/tests/Unit/Runner/PlanShardTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner;
 
 use Greenlight\Attribute\DataRow;
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Core\Test\TestMetadata;
@@ -68,6 +69,31 @@ final class PlanShardTest
         $plan = $this->plan(5);
 
         Expect::that(PlanShard::select($plan, 1, 1))->because('one shard is the whole plan')->toBe($plan);
+    }
+
+    #[Test]
+    #[DataSet('invalidShards')]
+    public function invalidShardsAreRejected(int $index, int $count, string $message): void
+    {
+        $plan = $this->plan(1);
+
+        Expect::that(static function () use ($plan, $index, $count): void {
+            PlanShard::select($plan, $index, $count);
+        })
+            ->because('invalid shard coordinates MUST NOT select an execution plan')
+            ->toThrow(\InvalidArgumentException::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{int, int, string}>
+     */
+    public static function invalidShards(): iterable
+    {
+        yield 'zero count' => [1, 0, 'The shard count must be at least 1.'];
+        yield 'negative count' => [1, -1, 'The shard count must be at least 1.'];
+        yield 'zero index' => [0, 2, 'The shard index must be between 1 and 2.'];
+        yield 'negative index' => [-1, 2, 'The shard index must be between 1 and 2.'];
+        yield 'index above count' => [3, 2, 'The shard index must be between 1 and 2.'];
     }
 
     private function plan(int $classes): ExecutionPlan


### PR DESCRIPTION
Rejects non-positive shard counts and shard indexes outside the configured range at the plan-selection boundary. This replaces division-by-zero and silently empty-plan outcomes with focused diagnostics, covered by one dataset.