### PR TITLE
fix(integrations): reject empty service identifiers

### DIFF
--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -79,17 +79,29 @@ final readonly class Service
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/Service.php#L12)
 
-### `__construct()`
+### `$id`
 
 ```php
-public function __construct(public string $id)
+public string $id;
 ```
 
 PHPDoc:
 
-- `@param non-empty-string $id`
+- `@var non-empty-string`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/Service.php#L17)
+
+### `__construct()`
+
+```php
+public function __construct(string $id)
+```
+
+PHPDoc:
+
+- `@throws \InvalidArgumentException`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/Service.php#L22)
 
 ## `PhpUnitToGreenlightRector`
 
@@ -172,17 +184,29 @@ final readonly class Service
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/Service.php#L12)
 
-### `__construct()`
+### `$id`
 
 ```php
-public function __construct(public string $id)
+public string $id;
 ```
 
 PHPDoc:
 
-- `@param non-empty-string $id`
+- `@var non-empty-string`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/Service.php#L17)
+
+### `__construct()`
+
+```php
+public function __construct(string $id)
+```
+
+PHPDoc:
+
+- `@throws \InvalidArgumentException`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/Service.php#L22)
 
 ## `SymfonyPlugin`
 

--- a/src/Laravel/Service.php
+++ b/src/Laravel/Service.php
@@ -12,7 +12,19 @@ namespace Greenlight\Laravel;
 final readonly class Service
 {
     /**
-     * @param non-empty-string $id
+     * @var non-empty-string
      */
-    public function __construct(public string $id) {}
+    public string $id;
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(string $id)
+    {
+        if ($id === '') {
+            throw new \InvalidArgumentException('Service identifier must not be empty.');
+        }
+
+        $this->id = $id;
+    }
 }

--- a/src/Symfony/Service.php
+++ b/src/Symfony/Service.php
@@ -12,7 +12,19 @@ namespace Greenlight\Symfony;
 final readonly class Service
 {
     /**
-     * @param non-empty-string $id
+     * @var non-empty-string
      */
-    public function __construct(public string $id) {}
+    public string $id;
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(string $id)
+    {
+        if ($id === '') {
+            throw new \InvalidArgumentException('Service identifier must not be empty.');
+        }
+
+        $this->id = $id;
+    }
 }

--- a/tests/Unit/ServiceAttributeTest.php
+++ b/tests/Unit/ServiceAttributeTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Laravel\Service as LaravelService;
+use Greenlight\Symfony\Service as SymfonyService;
+
+final readonly class ServiceAttributeTest
+{
+    /**
+     * @param class-string<LaravelService|SymfonyService> $attribute
+     */
+    #[Test]
+    #[DataSet('serviceAttributes')]
+    public function rejectsAnEmptyServiceIdentifier(string $attribute): void
+    {
+        Expect::that(static fn(): object => new $attribute(''))
+            ->because('a service attribute MUST identify a container service')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Service identifier must not be empty.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{class-string<LaravelService|SymfonyService>}>
+     */
+    public static function serviceAttributes(): iterable
+    {
+        yield 'Laravel' => [LaravelService::class];
+        yield 'Symfony' => [SymfonyService::class];
+    }
+}


### PR DESCRIPTION
Reject empty container service identifiers in the Laravel and Symfony service attributes. This enforces their documented non-empty contract before either integration asks a container to resolve an unusable identifier.\n\nAdds shared dataset coverage for both integration attributes and refreshes the generated integration API reference.