### PR TITLE
fix(core): reject invalid source locations

### DIFF
--- a/docs/api-results.md
+++ b/docs/api-results.md
@@ -384,18 +384,41 @@ final readonly class SourceLocation implements WireSerializable, \Stringable
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/SourceLocation.php#L10)
 
-### `__construct()`
+### `$file`
 
 ```php
-public function __construct(public string $file, public int $line)
+public string $file;
 ```
 
 PHPDoc:
 
-- `@param non-empty-string $file`
-- `@param positive-int $line`
+- `@var non-empty-string`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/SourceLocation.php#L16)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/SourceLocation.php#L15)
+
+### `$line`
+
+```php
+public int $line;
+```
+
+PHPDoc:
+
+- `@var positive-int`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/SourceLocation.php#L20)
+
+### `__construct()`
+
+```php
+public function __construct(string $file, int $line)
+```
+
+PHPDoc:
+
+- `@throws \InvalidArgumentException`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/SourceLocation.php#L25)
 
 ### `__toString()`
 
@@ -404,7 +427,7 @@ PHPDoc:
 public function __toString(): string
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/SourceLocation.php#L18)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/SourceLocation.php#L39)
 
 ### `toWire()`
 
@@ -413,7 +436,7 @@ public function __toString(): string
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/SourceLocation.php#L24)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/SourceLocation.php#L45)
 
 ### `fromWire()`
 
@@ -422,7 +445,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/SourceLocation.php#L33)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/SourceLocation.php#L54)
 
 ## `TestResult`
 

--- a/src/Core/Result/SourceLocation.php
+++ b/src/Core/Result/SourceLocation.php
@@ -10,10 +10,31 @@ use Greenlight\Core\Wire\WireSerializable;
 final readonly class SourceLocation implements WireSerializable, \Stringable
 {
     /**
-     * @param non-empty-string $file
-     * @param positive-int $line
+     * @var non-empty-string
      */
-    public function __construct(public string $file, public int $line) {}
+    public string $file;
+
+    /**
+     * @var positive-int
+     */
+    public int $line;
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(string $file, int $line)
+    {
+        if ($file === '') {
+            throw new \InvalidArgumentException('Source location file must not be empty.');
+        }
+
+        if ($line < 1) {
+            throw new \InvalidArgumentException('Source location line must be at least 1.');
+        }
+
+        $this->file = $file;
+        $this->line = $line;
+    }
 
     #[\Override]
     public function __toString(): string

--- a/tests/Unit/Core/SourceLocationTest.php
+++ b/tests/Unit/Core/SourceLocationTest.php
@@ -51,4 +51,23 @@ final class SourceLocationTest
         yield 'zero' => [0];
         yield 'negative' => [-10];
     }
+
+    #[Test]
+    #[DataSet('invalidLocations')]
+    public function rejectsInvalidConstruction(string $file, int $line, string $message): void
+    {
+        Expect::that(static fn(): SourceLocation => new SourceLocation($file, $line))
+            ->because('source locations MUST identify a file and a positive line')
+            ->toThrow(\InvalidArgumentException::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{string, int, non-empty-string}>
+     */
+    public static function invalidLocations(): iterable
+    {
+        yield 'empty file' => ['', 1, 'Source location file must not be empty.'];
+        yield 'zero line' => ['/project/tests/PaymentTest.php', 0, 'Source location line must be at least 1.'];
+        yield 'negative line' => ['/project/tests/PaymentTest.php', -10, 'Source location line must be at least 1.'];
+    }
 }


### PR DESCRIPTION
Reject empty source file names and non-positive line numbers when a source location is constructed. This enforces the documented diagnostic invariant while the wire decoder continues to normalize legacy non-positive line values.\n\nAdds dataset coverage for each invalid constructor boundary and refreshes the generated result API reference.