### PR TITLE
fix(core): reject invalid test identities

### DIFF
--- a/docs/api-test-contracts.md
+++ b/docs/api-test-contracts.md
@@ -135,22 +135,45 @@ final readonly class TestId implements WireSerializable, \Stringable
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L13)
 
+### `$class`
+
+```php
+public string $class;
+```
+
+PHPDoc:
+
+- `@var non-empty-string`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L18)
+
+### `$method`
+
+```php
+public string $method;
+```
+
+PHPDoc:
+
+- `@var non-empty-string`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L23)
+
 ### `__construct()`
 
 ```php
 public function __construct(
-    public string $class,
-    public string $method,
+    string $class,
+    string $method,
     public ?string $dataSetKey = null,
 )
 ```
 
 PHPDoc:
 
-- `@param non-empty-string $class`
-- `@param non-empty-string $method`
+- `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L19)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L28)
 
 ### `equals()`
 
@@ -158,7 +181,7 @@ PHPDoc:
 public function equals(self $other): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L25)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L45)
 
 ### `__toString()`
 
@@ -167,7 +190,7 @@ public function equals(self $other): bool
 public function __toString(): string
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L32)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L52)
 
 ### `toWire()`
 
@@ -176,7 +199,7 @@ public function __toString(): string
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L42)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L62)
 
 ### `fromWire()`
 
@@ -185,7 +208,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L52)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L72)
 
 ## `TestMetadata`
 

--- a/docs/api-test-contracts.md
+++ b/docs/api-test-contracts.md
@@ -223,6 +223,30 @@ final readonly class TestMetadata implements WireSerializable
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L15)
 
+### `$class`
+
+```php
+public string $class;
+```
+
+PHPDoc:
+
+- `@var non-empty-string`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L20)
+
+### `$method`
+
+```php
+public string $method;
+```
+
+PHPDoc:
+
+- `@var non-empty-string`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L25)
+
 ### `$groups`
 
 ```php
@@ -233,7 +257,7 @@ PHPDoc:
 
 - `@var list<non-empty-string>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L20)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L30)
 
 ### `$skipUnlessArguments`
 
@@ -245,7 +269,7 @@ PHPDoc:
 
 - `@var list<scalar|null>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L25)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L35)
 
 ### `$resources`
 
@@ -257,14 +281,14 @@ PHPDoc:
 
 - `@var list<non-empty-string>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L30)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L40)
 
 ### `__construct()`
 
 ```php
 public function __construct(
-    public string $class,
-    public string $method,
+    string $class,
+    string $method,
     array $groups = [],
     public ?string $skipReason = null,
     public ?string $skipUnlessCondition = null,
@@ -283,8 +307,6 @@ public function __construct(
 
 PHPDoc:
 
-- `@param non-empty-string $class`
-- `@param non-empty-string $method`
 - `@param list<string> $groups`
 - `@param non-empty-string|null $skipReason`
 - `@param non-empty-string|null $skipUnlessCondition`
@@ -296,7 +318,7 @@ PHPDoc:
 - `@param non-empty-string|null $dataSetProviderClass`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L47)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L55)
 
 ### `toWire()`
 
@@ -305,7 +327,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L105)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L124)
 
 ### `fromWire()`
 
@@ -314,7 +336,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L127)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L146)
 
 ## `InvalidWirePayload`
 

--- a/src/Core/Test/TestId.php
+++ b/src/Core/Test/TestId.php
@@ -13,14 +13,34 @@ use Greenlight\Core\Wire\WireSerializable;
 final readonly class TestId implements WireSerializable, \Stringable
 {
     /**
-     * @param non-empty-string $class
-     * @param non-empty-string $method
+     * @var non-empty-string
+     */
+    public string $class;
+
+    /**
+     * @var non-empty-string
+     */
+    public string $method;
+
+    /**
+     * @throws \InvalidArgumentException
      */
     public function __construct(
-        public string $class,
-        public string $method,
+        string $class,
+        string $method,
         public ?string $dataSetKey = null,
-    ) {}
+    ) {
+        if ($class === '') {
+            throw new \InvalidArgumentException('Test ID class must not be empty.');
+        }
+
+        if ($method === '') {
+            throw new \InvalidArgumentException('Test ID method must not be empty.');
+        }
+
+        $this->class = $class;
+        $this->method = $method;
+    }
 
     public function equals(self $other): bool
     {

--- a/src/Core/Test/TestMetadata.php
+++ b/src/Core/Test/TestMetadata.php
@@ -15,6 +15,16 @@ use Greenlight\Core\Wire\WireSerializable;
 final readonly class TestMetadata implements WireSerializable
 {
     /**
+     * @var non-empty-string
+     */
+    public string $class;
+
+    /**
+     * @var non-empty-string
+     */
+    public string $method;
+
+    /**
      * @var list<non-empty-string>
      */
     public array $groups;
@@ -30,8 +40,6 @@ final readonly class TestMetadata implements WireSerializable
     public array $resources;
 
     /**
-     * @param non-empty-string $class
-     * @param non-empty-string $method
      * @param list<string> $groups
      * @param non-empty-string|null $skipReason
      * @param non-empty-string|null $skipUnlessCondition
@@ -45,8 +53,8 @@ final readonly class TestMetadata implements WireSerializable
      * @throws \InvalidArgumentException
      */
     public function __construct(
-        public string $class,
-        public string $method,
+        string $class,
+        string $method,
         array $groups = [],
         public ?string $skipReason = null,
         public ?string $skipUnlessCondition = null,
@@ -61,6 +69,17 @@ final readonly class TestMetadata implements WireSerializable
         array $resources = [],
         public ?string $dataSetProviderClass = null,
     ) {
+        if ($class === '') {
+            throw new \InvalidArgumentException('Test metadata class must not be empty.');
+        }
+
+        if ($method === '') {
+            throw new \InvalidArgumentException('Test metadata method must not be empty.');
+        }
+
+        $this->class = $class;
+        $this->method = $method;
+
         if (!self::isValidTimeout($timeoutSeconds)) {
             throw new \InvalidArgumentException('Timeout seconds must be finite and greater than zero.');
         }

--- a/tests/Unit/Core/TestIdTest.php
+++ b/tests/Unit/Core/TestIdTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Core;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Core\Wire\InvalidWirePayload;
@@ -52,5 +53,23 @@ final class TestIdTest
         Expect::that(
             static fn(): TestId => TestId::fromWire(['class' => 'App\FooTest', 'method' => 'bar', 'dataSetKey' => 42]),
         )->because('rejects invalid wire payloads')->toThrow(InvalidWirePayload::class);
+    }
+
+    #[Test]
+    #[DataSet('invalidIdentifiers')]
+    public function rejectsInvalidConstruction(string $class, string $method, string $message): void
+    {
+        Expect::that(static fn(): TestId => new TestId($class, $method))
+            ->because('a test ID MUST identify a class and method')
+            ->toThrow(\InvalidArgumentException::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{string, string, non-empty-string}>
+     */
+    public static function invalidIdentifiers(): iterable
+    {
+        yield 'empty class' => ['', 'bar', 'Test ID class must not be empty.'];
+        yield 'empty method' => ['App\FooTest', '', 'Test ID method must not be empty.'];
     }
 }

--- a/tests/Unit/Core/TestMetadataTest.php
+++ b/tests/Unit/Core/TestMetadataTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Core;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Core\Wire\InvalidWirePayload;
@@ -146,5 +147,23 @@ final class TestMetadataTest
         Expect::that(
             static fn(): TestMetadata => TestMetadata::fromWire($payload),
         )->because('missing optional keys cause an error')->toThrow(InvalidWirePayload::class);
+    }
+
+    #[Test]
+    #[DataSet('invalidIdentifiers')]
+    public function rejectsInvalidIdentifiers(string $class, string $method, string $message): void
+    {
+        Expect::that(static fn(): TestMetadata => new TestMetadata($class, $method))
+            ->because('test metadata MUST identify a class and method')
+            ->toThrow(\InvalidArgumentException::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{string, string, non-empty-string}>
+     */
+    public static function invalidIdentifiers(): iterable
+    {
+        yield 'empty class' => ['', 'bar', 'Test metadata class must not be empty.'];
+        yield 'empty method' => ['App\FooTest', '', 'Test metadata method must not be empty.'];
     }
 }

--- a/tests/Unit/Core/TestMetadataWireTest.php
+++ b/tests/Unit/Core/TestMetadataWireTest.php
@@ -58,7 +58,7 @@ final class TestMetadataWireTest
 
     #[Test]
     #[DataSet('invalidTimeouts')]
-    public function invalidTimeoutsAreRejectedOnBothSides(float $seconds): void
+    public function invalidTimeoutsAreRejectedOnBothSides(float $seconds, string $wireMessage): void
     {
         Expect::that(
             static fn(): TestMetadata => new TestMetadata(
@@ -80,7 +80,7 @@ final class TestMetadataWireTest
             ->because('invalid timeouts are rejected as wire protocol errors')
             ->toThrow(
                 InvalidWirePayload::class,
-                message: 'Wire payload key "timeoutSeconds" must be a finite float greater than zero or null, got float.',
+                message: $wireMessage,
             );
     }
 
@@ -109,13 +109,16 @@ final class TestMetadataWireTest
     }
 
     /**
-     * @return iterable<string, array{float}>
+     * @return iterable<string, array{float, non-empty-string}>
      */
     public static function invalidTimeouts(): iterable
     {
-        yield 'zero' => [0.0];
-        yield 'negative' => [-0.5];
-        yield 'positive infinity' => [\INF];
-        yield 'not a number' => [\NAN];
+        $positive = 'Wire payload key "timeoutSeconds" must be a finite float greater than zero or null, got float.';
+        $finite = 'Wire payload key "timeoutSeconds" must be a finite float or null, got float.';
+
+        yield 'zero' => [0.0, $positive];
+        yield 'negative' => [-0.5, $positive];
+        yield 'positive infinity' => [\INF, $finite];
+        yield 'not a number' => [\NAN, $finite];
     }
 }


### PR DESCRIPTION
Reject test IDs and test metadata with an empty class or method at construction time. This closes the shared identity boundary before invalid values can enter execution plans, assignment messages, rerun selection, or timing state.\n\nAdds exact dataset coverage for both identity representations and refreshes the generated test-contract API reference.