### PR TITLE
fix(runner): reject invalid channel bounds

### DIFF
--- a/src/Runner/Orchestrator/ChannelAllocator.php
+++ b/src/Runner/Orchestrator/ChannelAllocator.php
@@ -18,9 +18,14 @@ final class ChannelAllocator
     private array $inUse = [];
 
     /**
-     * @param positive-int $bound
+     * @throws \InvalidArgumentException
      */
-    public function __construct(private readonly int $bound) {}
+    public function __construct(private readonly int $bound)
+    {
+        if ($bound < 1) {
+            throw new \InvalidArgumentException('The channel bound must be at least 1.');
+        }
+    }
 
     /**
      * @return positive-int

--- a/tests/Unit/Runner/Orchestrator/ChannelAllocatorTest.php
+++ b/tests/Unit/Runner/Orchestrator/ChannelAllocatorTest.php
@@ -4,12 +4,34 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Runner\Orchestrator;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\Orchestrator\ChannelAllocator;
 
 final readonly class ChannelAllocatorTest
 {
+    #[Test]
+    #[DataSet('invalidBounds')]
+    public function rejectsInvalidBounds(int $bound): void
+    {
+        Expect::that(static fn(): ChannelAllocator => new ChannelAllocator($bound))
+            ->because('a channel allocator MUST have at least one channel')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'The channel bound must be at least 1.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function invalidBounds(): iterable
+    {
+        yield 'zero' => [0];
+        yield 'negative' => [-1];
+    }
+
     #[Test]
     public function allocatesTheLowestFreeChannelFirst(): void
     {


### PR DESCRIPTION
Rejects zero and negative worker-channel capacity at allocator construction. This prevents malformed capacity from surfacing later as a misleading channel-exhaustion lifecycle error, with exact diagnostics covered by one dataset.