### PR TITLE
fix(core): reject invalid throwable details

### DIFF
--- a/docs/api-results.md
+++ b/docs/api-results.md
@@ -526,26 +526,60 @@ final readonly class ThrowableDetail implements WireSerializable
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ThrowableDetail.php#L12)
 
+### `$class`
+
+```php
+public string $class;
+```
+
+PHPDoc:
+
+- `@var non-empty-string`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ThrowableDetail.php#L19)
+
+### `$file`
+
+```php
+public string $file;
+```
+
+PHPDoc:
+
+- `@var non-empty-string`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ThrowableDetail.php#L24)
+
+### `$line`
+
+```php
+public int $line;
+```
+
+PHPDoc:
+
+- `@var positive-int`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ThrowableDetail.php#L29)
+
 ### `__construct()`
 
 ```php
 public function __construct(
-    public string $class,
+    string $class,
     public string $message,
-    public string $file,
-    public int $line,
+    string $file,
+    int $line,
     public array $stackFrames = [],
 )
 ```
 
 PHPDoc:
 
-- `@param non-empty-string $class`
-- `@param non-empty-string $file`
-- `@param positive-int $line`
 - `@param list<string> $stackFrames`
+- `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ThrowableDetail.php#L22)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ThrowableDetail.php#L36)
 
 ### `fromThrowable()`
 
@@ -553,7 +587,7 @@ PHPDoc:
 public static function fromThrowable(\Throwable $throwable): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ThrowableDetail.php#L30)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ThrowableDetail.php#L60)
 
 ### `toWire()`
 
@@ -562,7 +596,7 @@ public static function fromThrowable(\Throwable $throwable): self
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ThrowableDetail.php#L64)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ThrowableDetail.php#L94)
 
 ### `fromWire()`
 
@@ -571,4 +605,4 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ThrowableDetail.php#L76)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ThrowableDetail.php#L106)

--- a/src/Core/Result/ThrowableDetail.php
+++ b/src/Core/Result/ThrowableDetail.php
@@ -14,18 +14,48 @@ final readonly class ThrowableDetail implements WireSerializable
     private const int MAX_STACK_FRAMES = 32;
 
     /**
-     * @param non-empty-string $class
-     * @param non-empty-string $file
-     * @param positive-int $line
+     * @var non-empty-string
+     */
+    public string $class;
+
+    /**
+     * @var non-empty-string
+     */
+    public string $file;
+
+    /**
+     * @var positive-int
+     */
+    public int $line;
+
+    /**
      * @param list<string> $stackFrames
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct(
-        public string $class,
+        string $class,
         public string $message,
-        public string $file,
-        public int $line,
+        string $file,
+        int $line,
         public array $stackFrames = [],
-    ) {}
+    ) {
+        if ($class === '') {
+            throw new \InvalidArgumentException('Throwable detail class must not be empty.');
+        }
+
+        if ($file === '') {
+            throw new \InvalidArgumentException('Throwable detail file must not be empty.');
+        }
+
+        if ($line < 1) {
+            throw new \InvalidArgumentException('Throwable detail line must be at least 1.');
+        }
+
+        $this->class = $class;
+        $this->file = $file;
+        $this->line = $line;
+    }
 
     public static function fromThrowable(\Throwable $throwable): self
     {

--- a/tests/Unit/Core/ThrowableDetailTest.php
+++ b/tests/Unit/Core/ThrowableDetailTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Core;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Result\ThrowableDetail;
+use Greenlight\Doubles\Fake;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 
@@ -14,7 +16,7 @@ final class ThrowableDetailTest
     #[Test]
     public function deepTracesAreBoundedWithATruncationMarker(): void
     {
-        $capture = new class {
+        $capture = new class implements Fake {
             public ?\RuntimeException $exception = null;
         };
 
@@ -43,6 +45,43 @@ final class ThrowableDetailTest
             ->toHaveCount(33)
             ->and($detail->stackFrames[32])
             ->toBe('... (trace truncated)');
+    }
+
+    #[Test]
+    #[DataSet('invalidDetails')]
+    public function rejectsInvalidConstruction(string $class, string $file, int $line, string $message): void
+    {
+        Expect::that(
+            static fn(): ThrowableDetail => new ThrowableDetail(
+                $class,
+                'message',
+                $file,
+                $line,
+            ),
+        )
+            ->because('a throwable detail MUST identify its type and source location')
+            ->toThrow(\InvalidArgumentException::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{string, string, int, non-empty-string}>
+     */
+    public static function invalidDetails(): iterable
+    {
+        yield 'empty class' => ['', '/project/tests/PaymentTest.php', 1, 'Throwable detail class must not be empty.'];
+        yield 'empty file' => [\RuntimeException::class, '', 1, 'Throwable detail file must not be empty.'];
+        yield 'zero line' => [
+            \RuntimeException::class,
+            '/project/tests/PaymentTest.php',
+            0,
+            'Throwable detail line must be at least 1.',
+        ];
+        yield 'negative line' => [
+            \RuntimeException::class,
+            '/project/tests/PaymentTest.php',
+            -10,
+            'Throwable detail line must be at least 1.',
+        ];
     }
 
     private function throwAtDepth(int $remaining): void


### PR DESCRIPTION
Reject throwable details with an empty type, empty source file, or non-positive line at construction time. This enforces the documented diagnostic contract while tolerant throwable and wire factories continue to normalize legacy inputs.\n\nAdds exact dataset coverage for each invalid boundary, marks the test capture double as a Fake, and refreshes the generated result API reference.