### PR TITLE
fix(core): reject empty test identities

### DIFF
--- a/docs/api-test-contracts.md
+++ b/docs/api-test-contracts.md
@@ -113,22 +113,45 @@ final readonly class TestId implements WireSerializable, \Stringable
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L13)
 
+### `$class`
+
+```php
+public string $class;
+```
+
+PHPDoc:
+
+- `@var non-empty-string`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L16)
+
+### `$method`
+
+```php
+public string $method;
+```
+
+PHPDoc:
+
+- `@var non-empty-string`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L19)
+
 ### `__construct()`
 
 ```php
 public function __construct(
-    public string $class,
-    public string $method,
+    string $class,
+    string $method,
     public ?string $dataSetKey = null,
 )
 ```
 
 PHPDoc:
 
-- `@param non-empty-string $class`
-- `@param non-empty-string $method`
+- `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L19)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L22)
 
 ### `equals()`
 
@@ -136,7 +159,7 @@ PHPDoc:
 public function equals(self $other): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L25)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L39)
 
 ### `__toString()`
 
@@ -145,7 +168,7 @@ public function equals(self $other): bool
 public function __toString(): string
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L32)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L46)
 
 ### `toWire()`
 
@@ -154,7 +177,7 @@ public function __toString(): string
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L42)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L56)
 
 ### `fromWire()`
 
@@ -163,7 +186,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L52)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L66)
 
 ## `TestMetadata`
 

--- a/src/Core/Test/TestId.php
+++ b/src/Core/Test/TestId.php
@@ -12,15 +12,29 @@ use Greenlight\Core\Wire\WireSerializable;
  */
 final readonly class TestId implements WireSerializable, \Stringable
 {
-    /**
-     * @param non-empty-string $class
-     * @param non-empty-string $method
-     */
+    /** @var non-empty-string */
+    public string $class;
+
+    /** @var non-empty-string */
+    public string $method;
+
+    /** @throws \InvalidArgumentException */
     public function __construct(
-        public string $class,
-        public string $method,
+        string $class,
+        string $method,
         public ?string $dataSetKey = null,
-    ) {}
+    ) {
+        if ($class === '') {
+            throw new \InvalidArgumentException('Test class name cannot be empty.');
+        }
+
+        if ($method === '') {
+            throw new \InvalidArgumentException('Test method name cannot be empty.');
+        }
+
+        $this->class = $class;
+        $this->method = $method;
+    }
 
     public function equals(self $other): bool
     {

--- a/tests/Unit/Core/TestIdTest.php
+++ b/tests/Unit/Core/TestIdTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Core;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Core\Wire\InvalidWirePayload;
@@ -12,6 +13,27 @@ use Greenlight\Tests\Support\JsonWire;
 
 final class TestIdTest
 {
+    #[Test]
+    #[DataSet('emptyIdentityComponents')]
+    public function rejectsEmptyLocalIdentityComponents(
+        string $class,
+        string $method,
+        string $message,
+    ): void {
+        Expect::that(static fn(): TestId => new TestId($class, $method))
+            ->because('a local test identity MUST satisfy the same non-empty contract as its wire form')
+            ->toThrow(\InvalidArgumentException::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{string, string, non-empty-string}>
+     */
+    public static function emptyIdentityComponents(): iterable
+    {
+        yield 'class' => ['', 'runs', 'Test class name cannot be empty.'];
+        yield 'method' => ['App\\ProbeTest', '', 'Test method name cannot be empty.'];
+    }
+
     #[Test]
     public function rendersWithAndWithoutDataSetKey(): void
     {


### PR DESCRIPTION
Reject empty class and method components when callers construct a TestId locally. This enforces the same documented non-empty invariant as wire decoding, preserves refined property types for static analysis, and refreshes the generated test-contract API reference.