### PR TITLE
fix(doubles): reject blank argument types

### DIFF
--- a/docs/api-doubles.md
+++ b/docs/api-doubles.md
@@ -35,11 +35,7 @@ It also accepts values when `get_debug_type()` returns `$type`.
 public static function type(string $type): ArgumentMatcher
 ```
 
-PHPDoc:
-
-- `@param non-empty-string $type`
-
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L26)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L24)
 
 ### `predicate()`
 
@@ -50,7 +46,7 @@ The description identifies the constraint in failure messages.
 public static function predicate(\Closure $predicate, string $description = 'predicate'): ArgumentMatcher
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L35)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L33)
 
 ### `equals()`
 
@@ -61,7 +57,7 @@ This form states the comparison explicitly.
 public static function equals(mixed $value): ArgumentMatcher
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L44)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L42)
 
 ### `captor()`
 
@@ -72,7 +68,7 @@ selects the related expectation for the call.
 public static function captor(): ArgumentCaptor
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L53)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L51)
 
 ## `ArgumentCaptor`
 

--- a/src/Doubles/Argument.php
+++ b/src/Doubles/Argument.php
@@ -20,8 +20,6 @@ final class Argument
     /**
      * This matcher accepts instances of the specified class or interface.
      * It also accepts values when `get_debug_type()` returns `$type`.
-     *
-     * @param non-empty-string $type
      */
     public static function type(string $type): ArgumentMatcher
     {

--- a/src/Doubles/DoublesError.php
+++ b/src/Doubles/DoublesError.php
@@ -213,4 +213,9 @@ final class DoublesError extends \LogicException
     {
         return new self(\sprintf('captureArgument(%d) requires a position of zero or more.', $position));
     }
+
+    public static function invalidArgumentType(): self
+    {
+        return new self('Argument::type() requires a type name that contains a non-space character.');
+    }
 }

--- a/src/Doubles/TypeMatcher.php
+++ b/src/Doubles/TypeMatcher.php
@@ -7,10 +7,12 @@ namespace Greenlight\Doubles;
 /** @internal */
 final readonly class TypeMatcher implements ArgumentMatcher
 {
-    /**
-     * @param non-empty-string $type
-     */
-    public function __construct(private string $type) {}
+    public function __construct(private string $type)
+    {
+        if (\trim($type) === '') {
+            throw DoublesError::invalidArgumentType();
+        }
+    }
 
     public function matches(mixed $value): bool
     {

--- a/tests/Unit/Doubles/ArgumentMatchingTest.php
+++ b/tests/Unit/Doubles/ArgumentMatchingTest.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Doubles\Argument;
 use Greenlight\Doubles\ArgumentCaptor;
+use Greenlight\Doubles\ArgumentMatcher;
 use Greenlight\Doubles\Doubles;
 use Greenlight\Doubles\DoublesError;
 use Greenlight\Doubles\MockPlan;
@@ -96,6 +97,27 @@ final class ArgumentMatchingTest
         }
 
         Fail::because("Expected record('not an int') to fail its type(int) argument matcher.");
+    }
+
+    #[Test]
+    #[DataSet('invalidArgumentTypes')]
+    public function typeMatchersRejectMissingTypeNames(string $type): void
+    {
+        Expect::that(static fn(): ArgumentMatcher => Argument::type($type))
+            ->because('argument type matchers MUST identify a type')
+            ->toThrow(
+                DoublesError::class,
+                message: 'Argument::type() requires a type name that contains a non-space character.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function invalidArgumentTypes(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'spaces' => ['   '];
     }
 
     #[Test]


### PR DESCRIPTION
Rejects empty and whitespace-only names when constructing an argument type matcher. This turns an otherwise impossible-to-match constraint into an immediate doubles authoring error, covered by one exact-message dataset.