### PR TITLE
test: cover late HTML source read failures

### DIFF
--- a/tests/Fixture/Coverage/UnreadableAfterStatStream.php
+++ b/tests/Fixture/Coverage/UnreadableAfterStatStream.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Coverage;
+
+use Greenlight\Doubles\Fake;
+
+/**
+ * Simulates a regular file that becomes unreadable after a successful stat.
+ */
+final class UnreadableAfterStatStream implements Fake
+{
+    public mixed $context;
+
+    /**
+     * @return array{mode: int}
+     */
+    public function url_stat(string $path, int $flags): array
+    {
+        return ['mode' => 0100444];
+    }
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        return false;
+    }
+}

--- a/tests/Unit/Coverage/HtmlExporterSourceFailureTest.php
+++ b/tests/Unit/Coverage/HtmlExporterSourceFailureTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\ErrorTrap;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Coverage\Export\HtmlExporter;
+use Greenlight\Coverage\FileCoverage;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Coverage\UnreadableAfterStatStream;
+
+final readonly class HtmlExporterSourceFailureTest
+{
+    private const string SCHEME = 'greenlight-unreadable-after-stat';
+
+    #[Test]
+    public function sourceReadFailureFallsBackToLineNumbersOnly(): void
+    {
+        if (!\stream_wrapper_register(self::SCHEME, UnreadableAfterStatStream::class)) {
+            throw new \RuntimeException('Greenlight did not register the unreadable source stream.');
+        }
+
+        try {
+            $path = self::SCHEME . '://Source.php';
+            $map = new CoverageMap([
+                new FileCoverage($path, [2], [4]),
+            ]);
+
+            Expect::that(\is_file($path) && \is_readable($path))
+                ->because('the source passes the exporter readability checks')
+                ->toBeTrue();
+
+            $pages = ErrorTrap::run(
+                static fn(): array => new HtmlExporter()->export($map),
+                $warning,
+            );
+            $page = $pages[HtmlExporter::pageName($path)];
+
+            Expect::that($warning)
+                ->because('the source becomes unreadable when the exporter opens it')
+                ->not()->toBeNull()
+                ->and($page)
+                ->because('a late read failure shows only coverage line numbers')
+                ->toContain('<span class="cov"><span class="num">2</span></span>')
+                ->toContain('<span class="unc"><span class="num">4</span></span>');
+        } finally {
+            \stream_wrapper_unregister(self::SCHEME);
+        }
+    }
+}

--- a/tests/Unit/Coverage/HtmlExporterSourceFailureTest.php
+++ b/tests/Unit/Coverage/HtmlExporterSourceFailureTest.php
@@ -39,9 +39,10 @@ final readonly class HtmlExporterSourceFailureTest
             );
             $page = $pages[HtmlExporter::pageName($path)];
 
-            Expect::that($warning)
+            Expect::that($warning ?? '')
                 ->because('the source becomes unreadable when the exporter opens it')
-                ->not()->toBeNull()
+                ->toContain('file_get_contents(' . $path . ')')
+                ->toContain('Failed to open stream')
                 ->and($page)
                 ->because('a late read failure shows only coverage line numbers')
                 ->toContain('<span class="cov"><span class="num">2</span></span>')


### PR DESCRIPTION
Add a stream-wrapper fake that passes file metadata checks but rejects the subsequent source read. Cover the HTML exporter fallback that preserves covered and uncovered line numbers when a source becomes unreadable after validation.