### PR TITLE
fix(coverage): reject empty file paths

### DIFF
--- a/src/Coverage/FileCoverage.php
+++ b/src/Coverage/FileCoverage.php
@@ -14,6 +14,11 @@ namespace Greenlight\Coverage;
 final readonly class FileCoverage
 {
     /**
+     * @var non-empty-string
+     */
+    public string $file;
+
+    /**
      * @var list<positive-int>
      */
     public array $coveredLines;
@@ -24,15 +29,19 @@ final readonly class FileCoverage
     public array $uncoveredLines;
 
     /**
-     * @param non-empty-string $file
      * @param list<int> $coveredLines
      * @param list<int> $uncoveredLines
      */
     public function __construct(
-        public string $file,
+        string $file,
         array $coveredLines,
         array $uncoveredLines,
     ) {
+        if ($file === '') {
+            throw new \InvalidArgumentException('Use a non-empty coverage file path.');
+        }
+
+        $this->file = $file;
         $covered = $this->normalizeLines($coveredLines);
         $coveredSet = \array_fill_keys($covered, true);
         $uncovered = [];

--- a/tests/Unit/Coverage/FileCoverageTest.php
+++ b/tests/Unit/Coverage/FileCoverageTest.php
@@ -11,6 +11,17 @@ use Greenlight\Expect\Expect;
 final class FileCoverageTest
 {
     #[Test]
+    public function emptyFilePathsAreRejected(): void
+    {
+        Expect::that(static fn(): FileCoverage => new FileCoverage('', [], []))
+            ->because('coverage entries MUST identify a file')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Use a non-empty coverage file path.',
+            );
+    }
+
+    #[Test]
     public function lineListsAreSortedAndDeduplicated(): void
     {
         $file = new FileCoverage('/src/A.php', [9, 3, 3, 5], [12, 7, 12]);


### PR DESCRIPTION
Reject empty file identifiers at the FileCoverage boundary so coverage maps cannot contain entries that violate the documented non-empty path invariant.

Add a focused exact-message regression test through the public constructor.