### PR TITLE
fix(worker): reject invalid recycle budgets

### DIFF
--- a/src/Runner/Worker/WorkerBudget.php
+++ b/src/Runner/Worker/WorkerBudget.php
@@ -7,14 +7,30 @@ namespace Greenlight\Runner\Worker;
 /** @internal */
 final readonly class WorkerBudget
 {
+    /** @var positive-int|null */
+    public ?int $maxTests;
+
+    /** @var positive-int|null */
+    public ?int $maxMemoryBytes;
+
     /**
-     * @param positive-int|null $maxTests
-     * @param positive-int|null $maxMemoryBytes
+     * @throws \InvalidArgumentException
      */
     public function __construct(
-        public ?int $maxTests = null,
-        public ?int $maxMemoryBytes = null,
-    ) {}
+        ?int $maxTests = null,
+        ?int $maxMemoryBytes = null,
+    ) {
+        if ($maxTests !== null && $maxTests < 1) {
+            throw new \InvalidArgumentException('The worker test budget must be at least 1.');
+        }
+
+        if ($maxMemoryBytes !== null && $maxMemoryBytes < 1) {
+            throw new \InvalidArgumentException('The worker memory budget must be at least 1 byte.');
+        }
+
+        $this->maxTests = $maxTests;
+        $this->maxMemoryBytes = $maxMemoryBytes;
+    }
 
     public function exhaustedByCount(int $executed): bool
     {

--- a/tests/Unit/Runner/Worker/WorkerBudgetTest.php
+++ b/tests/Unit/Runner/Worker/WorkerBudgetTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Worker;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\Worker\WorkerBudget;
+
+final readonly class WorkerBudgetTest
+{
+    #[Test]
+    #[DataSet('invalidBudgets')]
+    public function rejectsInvalidBudgets(?int $maxTests, ?int $maxMemoryBytes, string $message): void
+    {
+        Expect::that(static fn(): WorkerBudget => new WorkerBudget($maxTests, $maxMemoryBytes))
+            ->because('worker recycle budgets MUST be positive when set')
+            ->toThrow(\InvalidArgumentException::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{?int, ?int, string}>
+     */
+    public static function invalidBudgets(): iterable
+    {
+        yield 'zero test budget' => [0, null, 'The worker test budget must be at least 1.'];
+        yield 'negative test budget' => [-1, null, 'The worker test budget must be at least 1.'];
+        yield 'zero memory budget' => [null, 0, 'The worker memory budget must be at least 1 byte.'];
+        yield 'negative memory budget' => [null, -1, 'The worker memory budget must be at least 1 byte.'];
+    }
+}


### PR DESCRIPTION
Rejects zero and negative test-count or memory recycle budgets when a worker budget is constructed. This prevents malformed limits from making a worker immediately appear exhausted, with exact diagnostics covered by one dataset.