### PR TITLE
fix(coverage): allow root include directories

### DIFF
--- a/src/Coverage/PathFilter.php
+++ b/src/Coverage/PathFilter.php
@@ -27,12 +27,11 @@ final readonly class PathFilter
         $prefixes = [];
 
         foreach ($includeDirectories as $directory) {
-            $trimmed = \rtrim($directory, '/');
-
-            if ($trimmed === '') {
+            if ($directory === '') {
                 throw new \InvalidArgumentException('Use nonempty paths for coverage include directories.');
             }
 
+            $trimmed = \rtrim($directory, '/');
             $prefixes[] = $trimmed . '/';
         }
 

--- a/tests/Unit/Coverage/PathFilterTest.php
+++ b/tests/Unit/Coverage/PathFilterTest.php
@@ -36,6 +36,18 @@ final class PathFilterTest
     }
 
     #[Test]
+    public function filesystemRootIsAValidIncludeDirectory(): void
+    {
+        $filter = new PathFilter(['/']);
+
+        Expect::that($filter->accepts('/project/src/A.php'))
+            ->because('the filesystem root MUST remain a valid coverage include directory')
+            ->toBeTrue()
+            ->and($filter->accepts('relative.php'))
+            ->toBeFalse();
+    }
+
+    #[Test]
     public function emptyDirectoryEntriesAreRejected(): void
     {
         Expect::that(static fn(): PathFilter => new PathFilter(['']))->because('empty directory entries are rejected')


### PR DESCRIPTION
Keeps the filesystem root as a valid coverage include prefix instead of treating it as an empty path after slash normalization. Empty configured paths remain rejected, and focused coverage verifies both absolute and relative matching under the root filter.