### PR TITLE
test: cover unknown attachment sizes

### DIFF
--- a/tests/Fixture/Artifact/UnknownSizeFileStream.php
+++ b/tests/Fixture/Artifact/UnknownSizeFileStream.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Artifact;
+
+use Greenlight\Doubles\Fake;
+
+/**
+ * Simulates a regular file whose size cannot be determined.
+ */
+final class UnknownSizeFileStream implements Fake
+{
+    public mixed $context;
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        return $mode === 'rb';
+    }
+
+    /**
+     * @return array{mode: int, size: int}
+     */
+    public function stream_stat(): array
+    {
+        return self::stat();
+    }
+
+    /**
+     * @return array{mode: int, size: int}
+     */
+    public function url_stat(string $path, int $flags): array
+    {
+        return self::stat();
+    }
+
+    /**
+     * @return array{mode: int, size: int}
+     */
+    private static function stat(): array
+    {
+        return [
+            'mode' => 0100400,
+            'size' => -1,
+        ];
+    }
+}

--- a/tests/Unit/Artifact/ArtifactUnknownSizeTest.php
+++ b/tests/Unit/Artifact/ArtifactUnknownSizeTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\ArtifactStore;
+use Greenlight\Runner\Artifact\TestArtifactBudget;
+use Greenlight\Tests\Fixture\Artifact\UnknownSizeFileStream;
+
+final readonly class ArtifactUnknownSizeTest
+{
+    private const string SCHEME = 'greenlight-unknown-size';
+
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function aSourceWithAnUnknownSizeIsRejected(): void
+    {
+        if (!\stream_wrapper_register(self::SCHEME, UnknownSizeFileStream::class)) {
+            throw new \RuntimeException('Greenlight did not register the unknown-size stream.');
+        }
+
+        $store = null;
+
+        try {
+            $root = $this->tempDirectory->subdirectory('unknown-size');
+            $configuration = new ArtifactConfiguration($root);
+            $store = ArtifactStore::open($configuration, $root, 'run-unknown-size');
+            $attachments = $store->forAttempt(
+                new TestId('Example\EvidenceTest', 'rejectsUnknownSize'),
+                1,
+                new TestArtifactBudget(),
+            );
+
+            Expect::that(static fn() => $attachments->file(
+                'evidence.txt',
+                self::SCHEME . '://evidence',
+            ))
+                ->because('an attachment source MUST report a nonnegative size')
+                ->toThrow(
+                    AttachmentError::class,
+                    message: 'Attachment size could not be determined.',
+                );
+        } finally {
+            $store?->cleanup();
+            \stream_wrapper_unregister(self::SCHEME);
+        }
+    }
+}


### PR DESCRIPTION
Add a stream-wrapper fake that reports a regular file with an unknown size. Cover the high-level attachment path that rejects the source before reserving quota or reading content.