### PR TITLE
fix(coverage): reject invalid file deltas

### DIFF
--- a/src/Coverage/Diff/FileDelta.php
+++ b/src/Coverage/Diff/FileDelta.php
@@ -16,15 +16,40 @@ namespace Greenlight\Coverage\Diff;
 final readonly class FileDelta
 {
     /**
-     * @param non-empty-string $file
-     * @param list<positive-int> $newlyUncoveredLines
+     * @var non-empty-string
+     */
+    public string $file;
+
+    /**
+     * @var list<positive-int>
+     */
+    public array $newlyUncoveredLines;
+
+    /**
+     * @param list<int> $newlyUncoveredLines
      */
     public function __construct(
-        public string $file,
+        string $file,
         public ?float $baselinePercentage,
         public ?float $currentPercentage,
-        public array $newlyUncoveredLines,
-    ) {}
+        array $newlyUncoveredLines,
+    ) {
+        if ($file === '') {
+            throw new \InvalidArgumentException('Use a non-empty coverage delta file path.');
+        }
+
+        foreach ($newlyUncoveredLines as $line) {
+            if ($line < 1) {
+                throw new \InvalidArgumentException(\sprintf(
+                    'Use positive newly uncovered line numbers. Actual value: %d.',
+                    $line,
+                ));
+            }
+        }
+
+        $this->file = $file;
+        $this->newlyUncoveredLines = $newlyUncoveredLines;
+    }
 
     public function delta(): float
     {

--- a/tests/Unit/Coverage/FileDeltaTest.php
+++ b/tests/Unit/Coverage/FileDeltaTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\Diff\FileDelta;
+use Greenlight\Expect\Expect;
+
+final readonly class FileDeltaTest
+{
+    /**
+     * @param list<int> $newlyUncoveredLines
+     */
+    #[Test]
+    #[DataSet('invalidDeltas')]
+    public function invalidDeltaIdentitiesAreRejected(
+        string $file,
+        array $newlyUncoveredLines,
+        string $message,
+    ): void {
+        Expect::that(static fn(): FileDelta => new FileDelta(
+            $file,
+            100.0,
+            50.0,
+            $newlyUncoveredLines,
+        ))
+            ->because('coverage deltas MUST identify a file and positive source lines')
+            ->toThrow(\InvalidArgumentException::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{string, list<int>, string}>
+     */
+    public static function invalidDeltas(): iterable
+    {
+        yield 'empty file' => [
+            '',
+            [1],
+            'Use a non-empty coverage delta file path.',
+        ];
+        yield 'zero line' => [
+            '/src/A.php',
+            [0],
+            'Use positive newly uncovered line numbers. Actual value: 0.',
+        ];
+        yield 'negative line' => [
+            '/src/A.php',
+            [-1],
+            'Use positive newly uncovered line numbers. Actual value: -1.',
+        ];
+    }
+}


### PR DESCRIPTION
Enforce FileDelta’s documented identity invariants at construction time. Empty file paths and non-positive newly uncovered line numbers now fail with exact diagnostics.

Preserve refined non-empty and positive property types after validation, with focused dataset coverage for each invalid boundary.