### PR TITLE
fix(events): reject invalid run boundaries

### DIFF
--- a/docs/api-events.md
+++ b/docs/api-events.md
@@ -72,11 +72,23 @@ final readonly class RunFinished implements Event
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L10)
 
+### `$runId`
+
+```php
+public string $runId;
+```
+
+PHPDoc:
+
+- `@var non-empty-string`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L15)
+
 ### `__construct()`
 
 ```php
 public function __construct(
-    public string $runId,
+    string $runId,
     public ResultSummary $summary,
     public float $durationSeconds,
     public float $occurredAt,
@@ -85,9 +97,9 @@ public function __construct(
 
 PHPDoc:
 
-- `@param non-empty-string $runId`
+- `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L15)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L20)
 
 ### `toWire()`
 
@@ -96,7 +108,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L22)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L37)
 
 ### `fromWire()`
 
@@ -105,7 +117,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L33)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L48)
 
 ## `RunStarted`
 
@@ -117,13 +129,49 @@ final readonly class RunStarted implements Event
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunStarted.php#L9)
 
+### `$runId`
+
+```php
+public string $runId;
+```
+
+PHPDoc:
+
+- `@var non-empty-string`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunStarted.php#L14)
+
+### `$plannedTests`
+
+```php
+public int $plannedTests;
+```
+
+PHPDoc:
+
+- `@var non-negative-int`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunStarted.php#L19)
+
+### `$workers`
+
+```php
+public int $workers;
+```
+
+PHPDoc:
+
+- `@var positive-int`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunStarted.php#L24)
+
 ### `__construct()`
 
 ```php
 public function __construct(
-    public string $runId,
-    public int $plannedTests,
-    public int $workers,
+    string $runId,
+    int $plannedTests,
+    int $workers,
     public float $occurredAt,
     public ?string $artifactsDirectory = null,
 )
@@ -131,11 +179,9 @@ public function __construct(
 
 PHPDoc:
 
-- `@param non-empty-string $runId`
-- `@param non-negative-int $plannedTests`
-- `@param positive-int $workers`
+- `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunStarted.php#L16)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunStarted.php#L29)
 
 ### `toWire()`
 
@@ -144,7 +190,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunStarted.php#L24)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunStarted.php#L59)
 
 ### `fromWire()`
 
@@ -153,7 +199,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunStarted.php#L36)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunStarted.php#L71)
 
 ## `SuiteFinished`
 

--- a/src/Core/Event/RunFinished.php
+++ b/src/Core/Event/RunFinished.php
@@ -10,14 +10,29 @@ use Greenlight\Core\Wire\Wire;
 final readonly class RunFinished implements Event
 {
     /**
-     * @param non-empty-string $runId
+     * @var non-empty-string
+     */
+    public string $runId;
+
+    /**
+     * @throws \InvalidArgumentException
      */
     public function __construct(
-        public string $runId,
+        string $runId,
         public ResultSummary $summary,
         public float $durationSeconds,
         public float $occurredAt,
-    ) {}
+    ) {
+        if ($runId === '') {
+            throw new \InvalidArgumentException('RunFinished requires a non-empty run ID.');
+        }
+
+        if ($durationSeconds < 0.0) {
+            throw new \InvalidArgumentException('RunFinished duration cannot be negative.');
+        }
+
+        $this->runId = $runId;
+    }
 
     #[\Override]
     public function toWire(): array

--- a/src/Core/Event/RunStarted.php
+++ b/src/Core/Event/RunStarted.php
@@ -9,17 +9,52 @@ use Greenlight\Core\Wire\Wire;
 final readonly class RunStarted implements Event
 {
     /**
-     * @param non-empty-string $runId
-     * @param non-negative-int $plannedTests
-     * @param positive-int $workers
+     * @var non-empty-string
+     */
+    public string $runId;
+
+    /**
+     * @var non-negative-int
+     */
+    public int $plannedTests;
+
+    /**
+     * @var positive-int
+     */
+    public int $workers;
+
+    /**
+     * @throws \InvalidArgumentException
      */
     public function __construct(
-        public string $runId,
-        public int $plannedTests,
-        public int $workers,
+        string $runId,
+        int $plannedTests,
+        int $workers,
         public float $occurredAt,
         public ?string $artifactsDirectory = null,
-    ) {}
+    ) {
+        if ($runId === '') {
+            throw new \InvalidArgumentException('RunStarted requires a non-empty run ID.');
+        }
+
+        if ($plannedTests < 0) {
+            throw new \InvalidArgumentException(\sprintf(
+                'RunStarted requires a non-negative planned test count. Actual value: %d.',
+                $plannedTests,
+            ));
+        }
+
+        if ($workers < 1) {
+            throw new \InvalidArgumentException(\sprintf(
+                'RunStarted requires at least one worker. Actual value: %d.',
+                $workers,
+            ));
+        }
+
+        $this->runId = $runId;
+        $this->plannedTests = $plannedTests;
+        $this->workers = $workers;
+    }
 
     #[\Override]
     public function toWire(): array

--- a/tests/Unit/Core/RunEventValidationTest.php
+++ b/tests/Unit/Core/RunEventValidationTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\RunFinished;
+use Greenlight\Core\Event\RunStarted;
+use Greenlight\Core\Result\ResultSummary;
+use Greenlight\Expect\Expect;
+
+final readonly class RunEventValidationTest
+{
+    #[Test]
+    #[DataSet('invalidRunStarts')]
+    public function runStartRejectsInvalidIdentityAndCounts(
+        string $runId,
+        int $plannedTests,
+        int $workers,
+        string $message,
+    ): void {
+        Expect::that(static fn(): RunStarted => new RunStarted(
+            $runId,
+            $plannedTests,
+            $workers,
+            1.0,
+        ))
+            ->because('a run start MUST identify a run and use valid counts')
+            ->toThrow(\InvalidArgumentException::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{string, int, int, string}>
+     */
+    public static function invalidRunStarts(): iterable
+    {
+        yield 'empty run ID' => [
+            '',
+            0,
+            1,
+            'RunStarted requires a non-empty run ID.',
+        ];
+        yield 'negative planned tests' => [
+            'run-1',
+            -1,
+            1,
+            'RunStarted requires a non-negative planned test count. Actual value: -1.',
+        ];
+        yield 'zero workers' => [
+            'run-1',
+            0,
+            0,
+            'RunStarted requires at least one worker. Actual value: 0.',
+        ];
+        yield 'negative workers' => [
+            'run-1',
+            0,
+            -1,
+            'RunStarted requires at least one worker. Actual value: -1.',
+        ];
+    }
+
+    #[Test]
+    #[DataSet('invalidRunFinishes')]
+    public function runFinishRejectsInvalidIdentityAndDuration(
+        string $runId,
+        float $durationSeconds,
+        string $message,
+    ): void {
+        Expect::that(static fn(): RunFinished => new RunFinished(
+            $runId,
+            new ResultSummary(),
+            $durationSeconds,
+            1.0,
+        ))
+            ->because('a run finish MUST identify a run and use a non-negative duration')
+            ->toThrow(\InvalidArgumentException::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{string, float, string}>
+     */
+    public static function invalidRunFinishes(): iterable
+    {
+        yield 'empty run ID' => [
+            '',
+            0.0,
+            'RunFinished requires a non-empty run ID.',
+        ];
+        yield 'negative duration' => [
+            'run-1',
+            -0.1,
+            'RunFinished duration cannot be negative.',
+        ];
+    }
+}


### PR DESCRIPTION
Enforce the documented RunStarted and RunFinished construction invariants before invalid event state reaches reporters or plugins. Run IDs must be non-empty, planned-test and worker counts must be valid, and finished durations cannot be negative.

Preserve refined public property types after validation, add exact-message dataset coverage, and regenerate the event API reference.