### PR TITLE
fix(artifacts): reject invalid sessions

### DIFF
--- a/src/Runner/Artifact/ArtifactSession.php
+++ b/src/Runner/Artifact/ArtifactSession.php
@@ -15,13 +15,33 @@ use Greenlight\Core\Wire\WireSerializable;
 final readonly class ArtifactSession implements WireSerializable
 {
     /**
-     * @param non-empty-string $stagingDirectory
-     * @param non-empty-string $publicDirectory
+     * @var non-empty-string
+     */
+    public string $stagingDirectory;
+
+    /**
+     * @var non-empty-string
+     */
+    public string $publicDirectory;
+
+    /**
+     * @throws \InvalidArgumentException
      */
     public function __construct(
-        public string $stagingDirectory,
-        public string $publicDirectory,
-    ) {}
+        string $stagingDirectory,
+        string $publicDirectory,
+    ) {
+        if ($stagingDirectory === '') {
+            throw new \InvalidArgumentException('Artifact staging directory must not be empty.');
+        }
+
+        if ($publicDirectory === '') {
+            throw new \InvalidArgumentException('Artifact public directory must not be empty.');
+        }
+
+        $this->stagingDirectory = $stagingDirectory;
+        $this->publicDirectory = $publicDirectory;
+    }
 
     #[\Override]
     public function toWire(): array

--- a/tests/Unit/Artifact/ArtifactSessionTest.php
+++ b/tests/Unit/Artifact/ArtifactSessionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\Artifact\ArtifactSession;
+
+final readonly class ArtifactSessionTest
+{
+    #[Test]
+    #[DataSet('invalidDirectories')]
+    public function artifactSessionsRejectMissingDirectories(
+        string $stagingDirectory,
+        string $publicDirectory,
+        string $message,
+    ): void {
+        Expect::that(static fn(): ArtifactSession => new ArtifactSession(
+            $stagingDirectory,
+            $publicDirectory,
+        ))
+            ->because('an artifact session MUST identify both storage directories')
+            ->toThrow(\InvalidArgumentException::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{string, string, string}>
+     */
+    public static function invalidDirectories(): iterable
+    {
+        yield 'empty staging directory' => [
+            '',
+            '/project/build/artifacts/run-1',
+            'Artifact staging directory must not be empty.',
+        ];
+        yield 'empty public directory' => [
+            '/project/.greenlight/staging/run-1',
+            '',
+            'Artifact public directory must not be empty.',
+        ];
+    }
+}


### PR DESCRIPTION
Reject artifact sessions that omit either the private staging directory or the public output directory. This protects the orchestrator-to-worker boundary before invalid paths reach artifact storage.

Preserve both non-empty property contracts after validation and cover each boundary with an exact-message dataset.