### PR TITLE
fix(coverage): scrub invalid JSON paths

### DIFF
--- a/src/Coverage/Export/JsonExporter.php
+++ b/src/Coverage/Export/JsonExporter.php
@@ -42,7 +42,10 @@ final readonly class JsonExporter implements CoverageExporter
             ],
         ];
 
-        return [self::FILE_NAME => \json_encode($document, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES) . "\n"];
+        return [self::FILE_NAME => \json_encode(
+            $document,
+            \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES | \JSON_INVALID_UTF8_SUBSTITUTE,
+        ) . "\n"];
     }
 
     /**

--- a/tests/Unit/Coverage/JsonExporterTest.php
+++ b/tests/Unit/Coverage/JsonExporterTest.php
@@ -49,6 +49,22 @@ final class JsonExporterTest
     }
 
     #[Test]
+    public function exportScrubsInvalidUtf8FilePaths(): void
+    {
+        $map = new CoverageMap([
+            new FileCoverage("/src/\xB1.php", [1], []),
+        ]);
+
+        $json = new JsonExporter()->export($map)[JsonExporter::FILE_NAME];
+        $decoded = \json_decode($json, true, 512, \JSON_THROW_ON_ERROR);
+        \assert(\is_array($decoded) && \is_array($decoded['files']));
+
+        Expect::that(\array_keys($decoded['files']))
+            ->because('coverage JSON MUST remain valid for file-system paths with invalid UTF-8')
+            ->toBe(["/src/\u{FFFD}.php"]);
+    }
+
+    #[Test]
     public function importRoundTripsAnExportedDocument(): void
     {
         $map = new CoverageMap([


### PR DESCRIPTION
Keep JSON coverage export valid when a filesystem path contains bytes that are not valid UTF-8. Substitute the Unicode replacement character, consistent with Greenlight’s other machine-readable outputs, and cover the regression.