### PR TITLE
test(artifacts): cover publishing event boundary

### DIFF
--- a/tests/Unit/Artifact/PublishingEventSinkTest.php
+++ b/tests/Unit/Artifact/PublishingEventSinkTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\Event\RunStarted;
+use Greenlight\Core\Event\TestFinished;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\ArtifactStore;
+use Greenlight\Runner\Artifact\PublishingEventSink;
+use Greenlight\Runner\Artifact\TestArtifactBudget;
+use Greenlight\Tests\Support\CollectingEventSink;
+
+final readonly class PublishingEventSinkTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function completedTestsPublishAttachmentsBeforeTheyReachTheInnerSink(): void
+    {
+        $root = $this->tempDirectory->subdirectory('publishing-sink');
+        $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-publishing-sink');
+        $inner = new CollectingEventSink();
+        $sink = new PublishingEventSink($store, $inner);
+        $id = new TestId('Example\EvidenceTest', 'fails');
+        $attempt = $store->forAttempt($id, 1, new TestArtifactBudget());
+        $attempt->text('evidence.txt', 'published evidence');
+        $result = new TestResult(
+            $id,
+            Outcome::Failed,
+            0.1,
+            0,
+            attachments: $attempt->seal(),
+        );
+        $started = new RunStarted('run-publishing-sink', 1, 1, 10.0);
+
+        try {
+            $sink->emit($started);
+            $sink->emit(new TestFinished($result, 11.0));
+
+            Expect::that($inner->sequence())
+                ->because('the publishing sink MUST preserve event order')
+                ->toBe(['RunStarted', 'TestFinished'])
+                ->and($inner->events[0])
+                ->because('events without test results MUST pass through unchanged')
+                ->toBe($started);
+
+            $finished = $inner->events[1];
+
+            if (!$finished instanceof TestFinished) {
+                Fail::because('Expected the second event to be TestFinished.');
+            }
+
+            $publishedPath = $finished->result->attachments[0]->path;
+
+            Expect::that($finished->result)
+                ->because('a completed event MUST replace its staged result with the published result')
+                ->not()
+                ->toBe($result)
+                ->and($finished->occurredAt)
+                ->because('publishing MUST preserve the event timestamp')
+                ->toBe(11.0)
+                ->and($finished->result->attachments)
+                ->because('the inner sink MUST receive published attachment metadata')
+                ->toHaveCount(1)
+                ->and($finished->result->attachments[0]->path)
+                ->toContain('run-publishing-sink')
+                ->and((string) \file_get_contents(
+                    \str_starts_with($publishedPath, '/') ? $publishedPath : $root . '/' . $publishedPath,
+                ))
+                ->toBe('published evidence');
+        } finally {
+            $store->cleanup();
+        }
+    }
+}


### PR DESCRIPTION
Adds focused coverage for the coordinator event sink that publishes staged evidence. The test verifies ordinary events retain identity and order, while completed-test events reach the inner sink with published metadata, preserved timestamps, and readable attachment content.