### PR TITLE
fix(coverage): scrub invalid XML paths

### DIFF
--- a/src/Coverage/Export/CloverExporter.php
+++ b/src/Coverage/Export/CloverExporter.php
@@ -73,6 +73,6 @@ final readonly class CloverExporter implements CoverageExporter
 
     private function xml(string $value): string
     {
-        return \htmlspecialchars($value, \ENT_XML1 | \ENT_QUOTES, 'UTF-8');
+        return \htmlspecialchars($value, \ENT_XML1 | \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
     }
 }

--- a/src/Coverage/Export/CoberturaExporter.php
+++ b/src/Coverage/Export/CoberturaExporter.php
@@ -92,6 +92,6 @@ final readonly class CoberturaExporter implements CoverageExporter
 
     private function xml(string $value): string
     {
-        return \htmlspecialchars($value, \ENT_XML1 | \ENT_QUOTES, 'UTF-8');
+        return \htmlspecialchars($value, \ENT_XML1 | \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
     }
 }

--- a/tests/Unit/Coverage/XmlExporterInvalidUtf8PathTest.php
+++ b/tests/Unit/Coverage/XmlExporterInvalidUtf8PathTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Coverage\Export\CloverExporter;
+use Greenlight\Coverage\Export\CoberturaExporter;
+use Greenlight\Coverage\FileCoverage;
+use Greenlight\Expect\Expect;
+
+final readonly class XmlExporterInvalidUtf8PathTest
+{
+    #[Test]
+    public function invalidUtf8FilePathsAreScrubbed(): void
+    {
+        $map = new CoverageMap([
+            new FileCoverage("/src/\xB1.php", [1], []),
+        ]);
+
+        $clover = new \SimpleXMLElement(
+            new CloverExporter()->export($map)[CloverExporter::FILE_NAME],
+        );
+        $cloverFiles = $clover->xpath('/coverage/project/file');
+        Expect::that($cloverFiles)
+            ->because('the Clover document MUST contain exactly one file')
+            ->toHaveCount(1);
+        \assert(\is_array($cloverFiles) && isset($cloverFiles[0]));
+
+        $cobertura = new \SimpleXMLElement(
+            new CoberturaExporter()->export($map)[CoberturaExporter::FILE_NAME],
+        );
+        $coberturaClasses = $cobertura->xpath('/coverage/packages/package/classes/class');
+        Expect::that($coberturaClasses)
+            ->because('the Cobertura document MUST contain exactly one class')
+            ->toHaveCount(1);
+        \assert(\is_array($coberturaClasses) && isset($coberturaClasses[0]));
+
+        Expect::that((string) $cloverFiles[0]['name'])
+            ->because('Clover MUST scrub invalid UTF-8 in file-system paths')
+            ->toBe("/src/\u{FFFD}.php")
+            ->and((string) $coberturaClasses[0]['filename'])
+            ->because('Cobertura MUST scrub invalid UTF-8 in file-system paths')
+            ->toBe("src/\u{FFFD}.php");
+    }
+}


### PR DESCRIPTION
Preserve file identity in Clover and Cobertura exports when a filesystem path contains invalid UTF-8. Enable XML substitution instead of silently emitting empty path attributes, and cover both parsed formats.