### PR TITLE
fix(protocol): reject invalid worker introductions

### DIFF
--- a/src/Runner/Protocol/Messages/Hello.php
+++ b/src/Runner/Protocol/Messages/Hello.php
@@ -16,15 +16,47 @@ use Greenlight\Runner\Protocol\Message;
 final readonly class Hello implements Message
 {
     /**
-     * @param non-empty-string $workerId
-     * @param non-empty-string $token
-     * @param positive-int $pid
+     * @var non-empty-string
+     */
+    public string $workerId;
+
+    /**
+     * @var non-empty-string
+     */
+    public string $token;
+
+    /**
+     * @var positive-int
+     */
+    public int $pid;
+
+    /**
+     * @throws \InvalidArgumentException when a value does not identify a worker
      */
     public function __construct(
-        public string $workerId,
-        public string $token,
-        public int $pid,
-    ) {}
+        string $workerId,
+        string $token,
+        int $pid,
+    ) {
+        if ($workerId === '') {
+            throw new \InvalidArgumentException('Hello messages require a nonempty worker ID.');
+        }
+
+        if ($token === '') {
+            throw new \InvalidArgumentException('Hello messages require a nonempty authentication token.');
+        }
+
+        if ($pid < 1) {
+            throw new \InvalidArgumentException(\sprintf(
+                'Hello messages require a positive process ID. Actual value: %d.',
+                $pid,
+            ));
+        }
+
+        $this->workerId = $workerId;
+        $this->token = $token;
+        $this->pid = $pid;
+    }
 
     #[\Override]
     public static function tag(): string

--- a/tests/Unit/Runner/Protocol/HelloTest.php
+++ b/tests/Unit/Runner/Protocol/HelloTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Protocol;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\Protocol\Messages\Hello;
+
+final class HelloTest
+{
+    #[Test]
+    #[DataSet('invalidWorkerIntroductions')]
+    public function invalidWorkerIntroductionsAreRejected(
+        string $workerId,
+        string $token,
+        int $pid,
+        string $message,
+    ): void {
+        Expect::that(static fn(): Hello => new Hello($workerId, $token, $pid))
+            ->because('worker introductions MUST identify an authenticated operating-system process')
+            ->toThrow(\InvalidArgumentException::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{string, string, int, string}>
+     */
+    public static function invalidWorkerIntroductions(): iterable
+    {
+        yield 'empty worker ID' => [
+            '',
+            'token',
+            1,
+            'Hello messages require a nonempty worker ID.',
+        ];
+        yield 'empty authentication token' => [
+            'worker-1',
+            '',
+            1,
+            'Hello messages require a nonempty authentication token.',
+        ];
+        yield 'zero process ID' => [
+            'worker-1',
+            'token',
+            0,
+            'Hello messages require a positive process ID. Actual value: 0.',
+        ];
+        yield 'negative process ID' => [
+            'worker-1',
+            'token',
+            -7,
+            'Hello messages require a positive process ID. Actual value: -7.',
+        ];
+    }
+}


### PR DESCRIPTION
The Hello message advertises nonempty worker identity and authentication fields plus a positive process ID, but direct construction did not enforce those invariants. Enforce the protocol boundary at construction and cover every invalid value with an exact-message dataset.