### PR TITLE
fix(coverage): scrub invalid HTML paths

### DIFF
--- a/src/Coverage/Export/HtmlExporter.php
+++ b/src/Coverage/Export/HtmlExporter.php
@@ -299,6 +299,6 @@ final readonly class HtmlExporter implements CoverageExporter
 
     private function html(string $value): string
     {
-        return \htmlspecialchars($value, \ENT_QUOTES, 'UTF-8');
+        return \htmlspecialchars($value, \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
     }
 }

--- a/tests/Unit/Coverage/HtmlExporterInvalidUtf8PathTest.php
+++ b/tests/Unit/Coverage/HtmlExporterInvalidUtf8PathTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Coverage\Export\HtmlExporter;
+use Greenlight\Coverage\FileCoverage;
+use Greenlight\Expect\Expect;
+
+final readonly class HtmlExporterInvalidUtf8PathTest
+{
+    #[Test]
+    public function invalidUtf8FilePathsAreScrubbed(): void
+    {
+        $path = "/src/\xB1.php";
+        $pages = new HtmlExporter()->export(new CoverageMap([
+            new FileCoverage($path, [1], []),
+        ]));
+
+        $index = $pages[HtmlExporter::INDEX_FILE_NAME];
+        $file = $pages[HtmlExporter::pageName($path)];
+        $scrubbed = "/src/\u{FFFD}.php";
+
+        Expect::that($index)
+            ->because('the HTML index MUST scrub invalid UTF-8 in file-system paths')
+            ->toContain($scrubbed)
+            ->toMatch('//u')
+            ->and($file)
+            ->because('the HTML file page MUST scrub invalid UTF-8 in its title')
+            ->toContain('<h1>' . $scrubbed . '</h1>')
+            ->toMatch('//u');
+    }
+}


### PR DESCRIPTION
Preserve file identity in HTML coverage reports when a filesystem path contains invalid UTF-8. Substitute the Unicode replacement character instead of erasing the path, and cover both the index and file page.