### PR TITLE
test(cli): cover reporter event delivery

### DIFF
--- a/tests/Unit/Cli/ReporterSinkTest.php
+++ b/tests/Unit/Cli/ReporterSinkTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\ReporterSink;
+use Greenlight\Core\Event\Event;
+use Greenlight\Core\Event\SuiteStarted;
+use Greenlight\Doubles\Fake;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\Reporter;
+use Greenlight\Reporting\ReportingError;
+
+final class ReporterSinkTest
+{
+    #[Test]
+    public function eventsReachTheReporterWithoutReplacement(): void
+    {
+        $reporter = new class implements Reporter, Fake {
+            public ?Event $received = null;
+
+            #[\Override]
+            public function onEvent(Event $event): void
+            {
+                $this->received = $event;
+            }
+
+            #[\Override]
+            public function finish(): void {}
+        };
+        $event = new SuiteStarted('unit', 1.0);
+
+        new ReporterSink($reporter)->emit($event);
+
+        Expect::that($reporter->received)
+            ->because('the reporter sink MUST preserve event identity')
+            ->toBe($event);
+    }
+
+    #[Test]
+    public function reporterFailuresPropagateToTheEmitter(): void
+    {
+        $reporter = new class implements Reporter, Fake {
+            #[\Override]
+            public function onEvent(Event $event): never
+            {
+                throw ReportingError::writeFailed();
+            }
+
+            #[\Override]
+            public function finish(): void {}
+        };
+        $sink = new ReporterSink($reporter);
+
+        Expect::that(static function () use ($sink): void {
+            $sink->emit(new SuiteStarted('unit', 1.0));
+        })
+            ->because('a reporter failure MUST stop event delivery')
+            ->toThrow(
+                ReportingError::class,
+                message: 'Greenlight did not write reporter output to the stream.',
+            );
+    }
+}


### PR DESCRIPTION
Adds focused coverage for the CLI adapter between runner events and reporters. The tests verify that event identity is preserved and that reporting failures propagate to stop delivery instead of being swallowed.