### PR TITLE
test(artifacts): cover value encoding errors

### DIFF
--- a/tests/Unit/Artifact/AttachmentsTest.php
+++ b/tests/Unit/Artifact/AttachmentsTest.php
@@ -172,6 +172,22 @@ final readonly class AttachmentsTest
             },
             'Attachment value cannot be encoded as JSON: Recursion detected.',
         ];
+
+        yield 'invalid UTF-8 JSON value' => [
+            static fn(StagedAttachments $attachments) => $attachments->value(
+                'invalid-utf8.json',
+                "\xB1",
+            ),
+            'Attachment value cannot be encoded as JSON: Malformed UTF-8 characters, possibly incorrectly encoded.',
+        ];
+
+        yield 'nonfinite JSON value' => [
+            static fn(StagedAttachments $attachments) => $attachments->value(
+                'nonfinite.json',
+                \INF,
+            ),
+            'Attachment value cannot be encoded as JSON: Inf and NaN cannot be JSON encoded.',
+        ];
     }
 
     #[Test]


### PR DESCRIPTION
Cover the typed attachment errors for two JSON value boundaries beyond recursive data: invalid UTF-8 strings and non-finite numbers. Assert the exact actionable diagnostics for both inputs.