### PR TITLE
fix(protocol): reject invalid attempt messages

### DIFF
--- a/src/Runner/Protocol/Messages/AttemptStarted.php
+++ b/src/Runner/Protocol/Messages/AttemptStarted.php
@@ -19,12 +19,26 @@ use Greenlight\Runner\Protocol\Message;
 final readonly class AttemptStarted implements Message
 {
     /**
-     * @param positive-int $attempt
+     * @var positive-int
+     */
+    public int $attempt;
+
+    /**
+     * @throws \InvalidArgumentException when the attempt number is not positive
      */
     public function __construct(
         public TestId $id,
-        public int $attempt,
-    ) {}
+        int $attempt,
+    ) {
+        if ($attempt < 1) {
+            throw new \InvalidArgumentException(\sprintf(
+                'Attempt numbers MUST be positive. Actual value: %d.',
+                $attempt,
+            ));
+        }
+
+        $this->attempt = $attempt;
+    }
 
     #[\Override]
     public static function tag(): string

--- a/tests/Unit/Runner/Protocol/AttemptStartedTest.php
+++ b/tests/Unit/Runner/Protocol/AttemptStartedTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Protocol;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\Protocol\Messages\AttemptStarted;
+
+final class AttemptStartedTest
+{
+    #[Test]
+    #[DataSet('nonPositiveAttempts')]
+    public function directMessagesRejectNonPositiveAttempts(int $attempt): void
+    {
+        $id = new TestId('Example\RetryTest', 'retries');
+
+        Expect::that(static fn(): AttemptStarted => new AttemptStarted($id, $attempt))
+            ->because('attempt-started messages MUST identify a positive attempt number')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: \sprintf('Attempt numbers MUST be positive. Actual value: %d.', $attempt),
+            );
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function nonPositiveAttempts(): iterable
+    {
+        yield 'zero' => [0];
+        yield 'negative' => [-4];
+    }
+}


### PR DESCRIPTION
AttemptStarted advertises a positive attempt number, but direct construction accepted zero and negative values while wire decoding normalized them. Enforce the same protocol invariant at construction and cover both invalid boundaries with exact diagnostics.