### PR TITLE
test(artifacts): cover source read failures

### DIFF
--- a/tests/Fixture/Artifact/FailingFileReadStream.php
+++ b/tests/Fixture/Artifact/FailingFileReadStream.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Artifact;
+
+use Greenlight\Doubles\Fake;
+
+/**
+ * Simulates a regular file that fails when its contents are read.
+ */
+final class FailingFileReadStream implements Fake
+{
+    public mixed $context;
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        return $mode === 'rb';
+    }
+
+    public function stream_read(int $count): false
+    {
+        return false;
+    }
+
+    public function stream_eof(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @return array{mode: int, size: int, mtime: int}
+     */
+    public function stream_stat(): array
+    {
+        return self::stat();
+    }
+
+    /**
+     * @return array{mode: int, size: int, mtime: int}
+     */
+    public function url_stat(string $path, int $flags): array
+    {
+        return self::stat();
+    }
+
+    /**
+     * @return array{mode: int, size: int, mtime: int}
+     */
+    private static function stat(): array
+    {
+        return [
+            'mode' => 0100600,
+            'size' => 8,
+            'mtime' => 1,
+        ];
+    }
+}

--- a/tests/Unit/Artifact/ArtifactSourceMutationTest.php
+++ b/tests/Unit/Artifact/ArtifactSourceMutationTest.php
@@ -13,10 +13,13 @@ use Greenlight\Fixture\TempDirectory;
 use Greenlight\Runner\Artifact\ArtifactStore;
 use Greenlight\Runner\Artifact\TestArtifactBudget;
 use Greenlight\Tests\Fixture\Artifact\ChangingFileStream;
+use Greenlight\Tests\Fixture\Artifact\FailingFileReadStream;
 
 final readonly class ArtifactSourceMutationTest
 {
     private const string SCHEME = 'greenlight-changing-file';
+
+    private const string FAILING_READ_SCHEME = 'greenlight-failing-file-read';
 
     public function __construct(private TempDirectory $tempDirectory) {}
 
@@ -63,6 +66,64 @@ final readonly class ArtifactSourceMutationTest
         } finally {
             $store?->cleanup();
             \stream_wrapper_unregister(self::SCHEME);
+        }
+    }
+
+    #[Test]
+    public function aSourceThatFailsDuringCopyIsRejectedAndReleased(): void
+    {
+        if (!\stream_wrapper_register(self::FAILING_READ_SCHEME, FailingFileReadStream::class)) {
+            throw new \RuntimeException('Greenlight did not register the failing-file-read stream.');
+        }
+
+        $store = null;
+
+        try {
+            $root = $this->tempDirectory->subdirectory('source-read-failure');
+            $configuration = new ArtifactConfiguration(
+                $root,
+                maxRunAttachments: 1,
+            );
+            $store = ArtifactStore::open($configuration, $root, 'run-source-read-failure');
+            $id = new TestId('Example\EvidenceTest', 'rejectsUnreadableSource');
+            $attachments = $store->forAttempt(
+                $id,
+                1,
+                new TestArtifactBudget(),
+            );
+            $source = self::FAILING_READ_SCHEME . '://evidence';
+
+            Expect::that(static fn() => $attachments->file('evidence.txt', $source))
+                ->because('a file attachment read failure MUST reject the incomplete copy')
+                ->toThrow(
+                    AttachmentError::class,
+                    message: \sprintf('Attachment source "%s" could not be read.', $source),
+                );
+
+            $failedPath = $store->session()->stagingDirectory
+                . '/' . ArtifactStore::testDirectory($id)
+                . '/attempt-1/01-evidence.txt';
+
+            Expect::that(\file_exists($failedPath))
+                ->because('a failed source read MUST remove the incomplete staging file')
+                ->toBeFalse()
+                ->and(\file_exists($failedPath . '.part'))
+                ->because('a failed source read MUST remove the partial staging file')
+                ->toBeFalse()
+                ->and(\file_exists($failedPath . '.meta.json'))
+                ->because('a failed source read MUST not leave recovery metadata')
+                ->toBeFalse();
+
+            $attachments->text('replacement.txt', 'replacement');
+
+            Expect::that($attachments->collected())
+                ->because('a failed source read MUST release its run quota')
+                ->toHaveCount(1)
+                ->and($attachments->collected()[0]->name)
+                ->toBe('replacement.txt');
+        } finally {
+            $store?->cleanup();
+            \stream_wrapper_unregister(self::FAILING_READ_SCHEME);
         }
     }
 }


### PR DESCRIPTION
Cover a file attachment source that passes initial validation but fails during copying. Verify that Greenlight reports the exact source error, removes the incomplete staging data, and releases the reserved run quota for a later attachment.