### PR TITLE
fix(coverage): require unavailability reasons

### DIFF
--- a/src/Coverage/Driver/DriverSelection.php
+++ b/src/Coverage/Driver/DriverSelection.php
@@ -19,10 +19,14 @@ final readonly class DriverSelection
     }
 
     /**
-     * @param non-empty-string $reason
+     * @throws \InvalidArgumentException when the reason is empty
      */
     public static function unavailable(string $reason): self
     {
+        if ($reason === '') {
+            throw new \InvalidArgumentException('Coverage unavailability requires a nonempty reason.');
+        }
+
         return new self(null, $reason);
     }
 }

--- a/tests/Unit/Coverage/DriverSelectionTest.php
+++ b/tests/Unit/Coverage/DriverSelectionTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\Driver\DriverSelection;
+use Greenlight\Expect\Expect;
+
+final readonly class DriverSelectionTest
+{
+    #[Test]
+    public function unavailableSelectionsRequireAReason(): void
+    {
+        Expect::that(static fn(): DriverSelection => DriverSelection::unavailable(''))
+            ->because('coverage unavailability MUST explain why no driver was selected')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Coverage unavailability requires a nonempty reason.',
+            );
+    }
+}


### PR DESCRIPTION
An unavailable driver selection could carry an empty reason even though downstream reporting depends on that explanation. Enforce the factory invariant and cover the exact failure so coverage cannot disappear without diagnostics.