### PR TITLE
test(worker): cover data provider caching

### DIFF
--- a/tests/Fixture/Runner/Worker/CachedDataSetProbe.php
+++ b/tests/Fixture/Runner/Worker/CachedDataSetProbe.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Runner\Worker;
+
+final class CachedDataSetProbe
+{
+    public static int $providerCalls = 0;
+
+    public function accepts(): never
+    {
+        throw new \LogicException('The cached data-set probe MUST NOT run.');
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function rows(): iterable
+    {
+        ++self::$providerCalls;
+
+        yield 'first' => ['alpha'];
+        yield 'second' => ['beta'];
+    }
+}

--- a/tests/Unit/Runner/Worker/ClassContextTest.php
+++ b/tests/Unit/Runner/Worker/ClassContextTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Unit\Runner\Worker;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\Worker\ClassContext;
+use Greenlight\Tests\Fixture\Runner\Worker\CachedDataSetProbe;
 use Greenlight\Tests\Fixture\Runner\Worker\ClassContextDataProbe;
 
 final class ClassContextTest
@@ -53,5 +54,25 @@ final class ClassContextTest
                     ClassContextDataProbe::class,
                 ),
             );
+    }
+
+    #[Test]
+    public function dataProvidersRunOncePerClassContext(): void
+    {
+        CachedDataSetProbe::$providerCalls = 0;
+        $context = ClassContext::for(CachedDataSetProbe::class);
+
+        $first = $context->argumentsFor('rows', null, 'accepts', 'first');
+        $second = $context->argumentsFor('rows', null, 'accepts', 'second');
+
+        Expect::that($first)
+            ->because('the class context MUST return the first cached data row')
+            ->toBe(['alpha'])
+            ->and($second)
+            ->because('the class context MUST return another row from the same cache')
+            ->toBe(['beta'])
+            ->and(CachedDataSetProbe::$providerCalls)
+            ->because('the class context MUST evaluate its data provider only once')
+            ->toBe(1);
     }
 }


### PR DESCRIPTION
ClassContext promises to evaluate a data provider once for each class context, but its tests covered only failure paths. Add an isolated provider probe and prove that separate data-set keys reuse the same expanded provider result.