### PR TITLE
test(discovery): cover cache encoding failures

### DIFF
--- a/tests/Fixture/Filesystem/StatableFileStream.php
+++ b/tests/Fixture/Filesystem/StatableFileStream.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Filesystem;
+
+use Greenlight\Doubles\Fake;
+
+/**
+ * Simulates file metadata for paths that the host filesystem cannot create.
+ */
+final class StatableFileStream implements Fake
+{
+    public mixed $context;
+
+    /**
+     * @return array{mode: int, size: int, mtime: int}
+     */
+    public function url_stat(string $path, int $flags): array
+    {
+        return [
+            'mode' => 0100600,
+            'size' => 1,
+            'mtime' => 1,
+        ];
+    }
+}

--- a/tests/Unit/Discovery/DiscoveryCacheTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheTest.php
@@ -10,9 +10,12 @@ use Greenlight\Discovery\DiscoveryCache;
 use Greenlight\Discovery\TestDiscoverer;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
+use Greenlight\Tests\Fixture\Filesystem\StatableFileStream;
 
 final class DiscoveryCacheTest
 {
+    private const string STATABLE_FILE_SCHEME = 'greenlight-statable-file';
+
     #[Test]
     public function hitsServeFromCacheAndAnyChangeInvalidates(): void
     {
@@ -381,6 +384,33 @@ final class DiscoveryCacheTest
                 ->because('a vanished source MUST not create an empty cache document')
                 ->toBeFalse();
         } finally {
+            @\unlink($cacheFile);
+        }
+    }
+
+    #[Test]
+    public function anUnencodableSourcePathDisablesPersistenceCleanly(): void
+    {
+        $directory = \sys_get_temp_dir() . '/greenlight-binary-path-' . \bin2hex(\random_bytes(6));
+        $source = self::STATABLE_FILE_SCHEME . "://Invalid-\xFF-Test.php";
+        $cacheFile = $this->cacheFile($directory);
+        if (!\stream_wrapper_register(self::STATABLE_FILE_SCHEME, StatableFileStream::class)) {
+            Fail::because('Expected to register the statable-file stream.');
+        }
+
+        $cache = DiscoveryCache::forDirectories([$directory]);
+
+        try {
+            $cache->store($source, []);
+
+            Expect::that($cache->persist())
+                ->because('an unencodable source path MUST disable advisory cache persistence cleanly')
+                ->toBeFalse()
+                ->and(\is_file($cacheFile))
+                ->because('failed cache encoding MUST not leave a cache document')
+                ->toBeFalse();
+        } finally {
+            \stream_wrapper_unregister(self::STATABLE_FILE_SCHEME);
             @\unlink($cacheFile);
         }
     }


### PR DESCRIPTION
Cover advisory discovery-cache persistence when a source path cannot be represented in JSON. Verify that persistence returns false without leaving a cache document, using a statable filesystem fake for paths that the host filesystem cannot create.