### PR TITLE
fix(cli): reject invalid option specifications

### DIFF
--- a/src/Cli/OptionSpec.php
+++ b/src/Cli/OptionSpec.php
@@ -8,13 +8,36 @@ namespace Greenlight\Cli;
 final readonly class OptionSpec
 {
     /**
-     * @param non-empty-string $name
-     * @param non-empty-string|null $short
+     * @var non-empty-string
+     */
+    public string $name;
+
+    /**
+     * @var non-empty-string|null
+     */
+    public ?string $short;
+
+    /**
+     * @throws \InvalidArgumentException when the option name or short alias is invalid
      */
     public function __construct(
-        public string $name,
+        string $name,
         public OptionValue $value = OptionValue::None,
         public bool $repeatable = false,
-        public ?string $short = null,
-    ) {}
+        ?string $short = null,
+    ) {
+        if ($name === '') {
+            throw new \InvalidArgumentException('Option names cannot be empty.');
+        }
+
+        if ($short !== null && \preg_match('/^[A-Za-z]$/D', $short) !== 1) {
+            throw new \InvalidArgumentException(\sprintf(
+                'Short option alias "%s" MUST be one ASCII letter.',
+                $short,
+            ));
+        }
+
+        $this->name = $name;
+        $this->short = $short;
+    }
 }

--- a/tests/Unit/Cli/OptionSpecTest.php
+++ b/tests/Unit/Cli/OptionSpecTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\OptionSpec;
+use Greenlight\Expect\Expect;
+
+final readonly class OptionSpecTest
+{
+    #[Test]
+    #[DataSet('invalidDefinitions')]
+    public function invalidOptionDefinitionsAreRejected(
+        string $name,
+        ?string $short,
+        string $message,
+    ): void {
+        Expect::that(static fn(): OptionSpec => new OptionSpec($name, short: $short))
+            ->because('the argument parser MUST receive unambiguous option definitions')
+            ->toThrow(\InvalidArgumentException::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{string, ?string, string}>
+     */
+    public static function invalidDefinitions(): iterable
+    {
+        yield 'empty long name' => [
+            '',
+            null,
+            'Option names cannot be empty.',
+        ];
+        yield 'empty short alias' => [
+            'help',
+            '',
+            'Short option alias "" MUST be one ASCII letter.',
+        ];
+        yield 'multi-letter short alias' => [
+            'help',
+            'help',
+            'Short option alias "help" MUST be one ASCII letter.',
+        ];
+        yield 'numeric short alias' => [
+            'workers',
+            '1',
+            'Short option alias "1" MUST be one ASCII letter.',
+        ];
+    }
+}


### PR DESCRIPTION
ArgumentParser assumes every option has a nonempty long name and every short alias is one letter, but OptionSpec did not enforce either contract. Reject ambiguous definitions at construction and cover empty, multi-letter, and numeric aliases with exact diagnostics.