### PR TITLE
fix(attributes): reject empty data providers

### DIFF
--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -134,10 +134,9 @@ public function __construct(string $provider, ?string $method = null)
 
 PHPDoc:
 
-- `@param non-empty-string $provider`
-- `@param non-empty-string|null $method`
+- `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataSet.php#L32)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataSet.php#L31)
 
 ## `Group`
 

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -85,6 +85,8 @@ With one argument, references a public static provider method on the test
 class. With two arguments, the first argument is a provider class. The second
 argument is its public static method:
 
+Provider class and method names MUST NOT be empty.
+
 ```php
 #[DataSet('currencies')]
 ```

--- a/src/Attribute/DataSet.php
+++ b/src/Attribute/DataSet.php
@@ -26,11 +26,22 @@ final readonly class DataSet
      * arguments, it names the provider class and `$method` names the provider
      * method.
      *
-     * @param non-empty-string $provider
-     * @param non-empty-string|null $method
+     * @throws \InvalidArgumentException
      */
     public function __construct(string $provider, ?string $method = null)
     {
+        if ($provider === '') {
+            throw new \InvalidArgumentException(
+                $method === null
+                    ? 'Data set provider MUST NOT be empty.'
+                    : 'Data set provider class MUST NOT be empty.',
+            );
+        }
+
+        if ($method === '') {
+            throw new \InvalidArgumentException('Data set provider method MUST NOT be empty.');
+        }
+
         $this->provider = $method ?? $provider;
         $this->providerClass = $method === null ? null : $provider;
     }

--- a/tests/Unit/Attribute/DataSetTest.php
+++ b/tests/Unit/Attribute/DataSetTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Attribute;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+
+final class DataSetTest
+{
+    #[Test]
+    #[DataSet('emptyProviderIdentifiers')]
+    public function emptyProviderIdentifiersAreRejected(
+        string $provider,
+        ?string $method,
+        string $message,
+    ): void {
+        Expect::that(
+            static fn(): DataSet => new DataSet($provider, $method),
+        )
+            ->because('data set provider identifiers MUST be non-empty')
+            ->toThrow(\InvalidArgumentException::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{string, string|null, non-empty-string}>
+     */
+    public static function emptyProviderIdentifiers(): iterable
+    {
+        yield 'local provider' => [
+            '',
+            null,
+            'Data set provider MUST NOT be empty.',
+        ];
+
+        yield 'external provider class' => [
+            '',
+            'rows',
+            'Data set provider class MUST NOT be empty.',
+        ];
+
+        yield 'external provider method' => [
+            self::class,
+            '',
+            'Data set provider method MUST NOT be empty.',
+        ];
+    }
+}


### PR DESCRIPTION
Rejects empty local provider names, external provider classes, and external provider methods at the DataSet attribute boundary. This keeps the runtime contract aligned with the refined public properties and gives each invalid form an exact diagnostic.