### PR TITLE
test(artifacts): cover transient empty reads

### DIFF
--- a/tests/Fixture/Artifact/IntermittentFileReadStream.php
+++ b/tests/Fixture/Artifact/IntermittentFileReadStream.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Artifact;
+
+use Greenlight\Doubles\Fake;
+
+/**
+ * Simulates a regular file that returns no bytes for its first read.
+ */
+final class IntermittentFileReadStream implements Fake
+{
+    public mixed $context;
+
+    private const string CONTENT = 'evidence';
+
+    private int $offset = 0;
+
+    private int $reads = 0;
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        $this->offset = 0;
+        $this->reads = 0;
+
+        return $mode === 'rb';
+    }
+
+    public function stream_read(int $count): string
+    {
+        if ($this->reads++ === 0) {
+            return '';
+        }
+
+        $chunk = \substr(self::CONTENT, $this->offset, $count);
+        $this->offset += \strlen($chunk);
+
+        return $chunk;
+    }
+
+    public function stream_eof(): bool
+    {
+        return $this->offset >= \strlen(self::CONTENT);
+    }
+
+    /**
+     * @return array{mode: int, size: int, mtime: int}
+     */
+    public function stream_stat(): array
+    {
+        return self::stat();
+    }
+
+    /**
+     * @return array{mode: int, size: int, mtime: int}
+     */
+    public function url_stat(string $path, int $flags): array
+    {
+        return self::stat();
+    }
+
+    /**
+     * @return array{mode: int, size: int, mtime: int}
+     */
+    private static function stat(): array
+    {
+        return [
+            'mode' => 0100600,
+            'size' => \strlen(self::CONTENT),
+            'mtime' => 1,
+        ];
+    }
+}

--- a/tests/Unit/Artifact/ArtifactIntermittentReadTest.php
+++ b/tests/Unit/Artifact/ArtifactIntermittentReadTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\ArtifactStore;
+use Greenlight\Runner\Artifact\TestArtifactBudget;
+use Greenlight\Tests\Fixture\Artifact\IntermittentFileReadStream;
+
+final readonly class ArtifactIntermittentReadTest
+{
+    private const string SCHEME = 'greenlight-intermittent-file-read';
+
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function anEmptyReadBeforeContentDoesNotTruncateTheAttachment(): void
+    {
+        if (!\stream_wrapper_register(self::SCHEME, IntermittentFileReadStream::class)) {
+            throw new \RuntimeException('Greenlight did not register the intermittent-file-read stream.');
+        }
+
+        $store = null;
+
+        try {
+            $root = $this->tempDirectory->subdirectory('source-intermittent-read');
+            $store = ArtifactStore::open(
+                new ArtifactConfiguration($root),
+                $root,
+                'run-source-intermittent-read',
+            );
+            $attachments = $store->forAttempt(
+                new TestId('Example\EvidenceTest', 'copiesAfterEmptyRead'),
+                1,
+                new TestArtifactBudget(),
+            );
+
+            $attachments->file('evidence.txt', self::SCHEME . '://evidence', 'text/plain');
+            $collected = $attachments->collected();
+
+            Expect::that($collected)
+                ->because('the intermittent source MUST produce one staged attachment')
+                ->toHaveCount(1);
+
+            $attachment = $collected[0];
+            $stagedPath = $store->session()->stagingDirectory . '/' . $attachment->storageKey;
+
+            Expect::that(\file_get_contents($stagedPath))
+                ->because('a transient empty source read MUST not truncate the staged attachment')
+                ->toBe('evidence')
+                ->and($attachment->sizeBytes)
+                ->toBe(8)
+                ->and($attachment->sha256)
+                ->toBe(\hash('sha256', 'evidence'));
+        } finally {
+            $store?->cleanup();
+            \stream_wrapper_unregister(self::SCHEME);
+        }
+    }
+}


### PR DESCRIPTION
Cover file attachment streams that return no bytes before later content. Verify that Greenlight continues reading and preserves the exact staged bytes, size, and digest instead of truncating the attachment.