### PR TITLE
fix(attributes): reject invalid retry filters

### DIFF
--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -257,21 +257,32 @@ PHPDoc:
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Retry.php#L18)
 
+### `$onlyOn`
+
+```php
+public ?string $onlyOn;
+```
+
+PHPDoc:
+
+- `@var class-string<\Throwable>|null`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Retry.php#L23)
+
 ### `__construct()`
 
 ```php
 public function __construct(
     int $times,
-    public ?string $onlyOn = null,
+    ?string $onlyOn = null,
 )
 ```
 
 PHPDoc:
 
-- `@param class-string<\Throwable>|null $onlyOn`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Retry.php#L25)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Retry.php#L28)
 
 ## `Skip`
 

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -307,9 +307,9 @@ int $times
 
 Retries a failed test up to `$times` additional attempts.
 
-`$times` must be at least 1.
+`$times` MUST be at least 1.
 
-When you supply `$onlyOn`, it must be a throwable class-string. Greenlight
+When you supply `$onlyOn`, it MUST be a throwable class-string. Greenlight
 retries only failures with that throwable type. It does not retry other
 failures.
 

--- a/src/Attribute/Retry.php
+++ b/src/Attribute/Retry.php
@@ -18,18 +18,26 @@ final readonly class Retry
     public int $times;
 
     /**
-     * @param class-string<\Throwable>|null $onlyOn
-     *
+     * @var class-string<\Throwable>|null
+     */
+    public ?string $onlyOn;
+
+    /**
      * @throws \InvalidArgumentException
      */
     public function __construct(
         int $times,
-        public ?string $onlyOn = null,
+        ?string $onlyOn = null,
     ) {
         if ($times < 1) {
             throw new \InvalidArgumentException('Retry times must be at least 1.');
         }
 
+        if ($onlyOn !== null && !\is_a($onlyOn, \Throwable::class, true)) {
+            throw new \InvalidArgumentException('Retry onlyOn MUST name a Throwable type.');
+        }
+
         $this->times = $times;
+        $this->onlyOn = $onlyOn;
     }
 }

--- a/tests/Unit/Attribute/RetryTest.php
+++ b/tests/Unit/Attribute/RetryTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Attribute;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Retry;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+
+final class RetryTest
+{
+    #[Test]
+    #[DataSet('invalidThrowableTypes')]
+    public function invalidThrowableTypesAreRejected(string $onlyOn): void
+    {
+        Expect::that(
+            static fn(): Retry => new Retry(1, onlyOn: $onlyOn),
+        )
+            ->because('a retry filter MUST name a Throwable type')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Retry onlyOn MUST name a Throwable type.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function invalidThrowableTypes(): iterable
+    {
+        yield 'empty' => [''];
+
+        yield 'non-throwable class' => [\stdClass::class];
+
+        yield 'unknown class' => ['Example\MissingThrowable'];
+    }
+}


### PR DESCRIPTION
Validates Retry onlyOn values at the public attribute boundary so invalid or unavailable non-Throwable types cannot silently disable retries. The constructor preserves the refined class-string property after validation and reports one exact diagnostic for every invalid form.