### PR TITLE
fix(cli): reject conflicting option definitions

### DIFF
--- a/src/Cli/ArgumentParser.php
+++ b/src/Cli/ArgumentParser.php
@@ -26,13 +26,29 @@ final class ArgumentParser
 
     /**
      * @param list<OptionSpec> $specs
+     *
+     * @throws \InvalidArgumentException when option names or aliases conflict
      */
     public function __construct(array $specs)
     {
         foreach ($specs as $spec) {
+            if (isset($this->byName[$spec->name])) {
+                throw new \InvalidArgumentException(\sprintf(
+                    'Option "--%s" is defined more than once.',
+                    $spec->name,
+                ));
+            }
+
             $this->byName[$spec->name] = $spec;
 
             if ($spec->short !== null) {
+                if (isset($this->byShort[$spec->short])) {
+                    throw new \InvalidArgumentException(\sprintf(
+                        'Short option "-%s" is assigned to more than one option.',
+                        $spec->short,
+                    ));
+                }
+
                 $this->byShort[$spec->short] = $spec;
             }
         }

--- a/tests/Unit/Cli/ArgumentParserDefinitionTest.php
+++ b/tests/Unit/Cli/ArgumentParserDefinitionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\ArgumentParser;
+use Greenlight\Cli\OptionSpec;
+use Greenlight\Expect\Expect;
+
+final readonly class ArgumentParserDefinitionTest
+{
+    /**
+     * @param list<OptionSpec> $specs
+     */
+    #[Test]
+    #[DataSet('conflictingDefinitions')]
+    public function conflictingOptionDefinitionsAreRejected(array $specs, string $message): void
+    {
+        Expect::that(static fn(): ArgumentParser => new ArgumentParser($specs))
+            ->because('option maps MUST NOT silently replace conflicting definitions')
+            ->toThrow(\InvalidArgumentException::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{list<OptionSpec>, string}>
+     */
+    public static function conflictingDefinitions(): iterable
+    {
+        yield 'duplicate long name' => [
+            [
+                new OptionSpec('help', short: 'h'),
+                new OptionSpec('help', short: 'H'),
+            ],
+            'Option "--help" is defined more than once.',
+        ];
+        yield 'duplicate short alias' => [
+            [
+                new OptionSpec('help', short: 'h'),
+                new OptionSpec('host', short: 'h'),
+            ],
+            'Short option "-h" is assigned to more than one option.',
+        ];
+    }
+}


### PR DESCRIPTION
ArgumentParser silently replaced earlier entries when its specification list repeated a long name or short alias. Reject both conflicts at construction and cover the exact diagnostics with a focused dataset.