### PR TITLE
fix(attributes): reject invalid skip conditions

### DIFF
--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -310,6 +310,18 @@ final readonly class SkipUnless
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/SkipUnless.php#L14)
 
+### `$condition`
+
+```php
+public string $condition;
+```
+
+PHPDoc:
+
+- `@var class-string<Condition>`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/SkipUnless.php#L19)
+
 ### `$arguments`
 
 ```php
@@ -320,22 +332,22 @@ PHPDoc:
 
 - `@var list<mixed>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/SkipUnless.php#L19)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/SkipUnless.php#L24)
 
 ### `__construct()`
 
 ```php
 public function __construct(
-    public string $condition,
+    string $condition,
     mixed ...$arguments,
 )
 ```
 
 PHPDoc:
 
-- `@param class-string<Condition> $condition`
+- `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/SkipUnless.php#L24)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/SkipUnless.php#L29)
 
 ## `Test`
 

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -239,14 +239,15 @@ string $condition
 mixed ...$arguments
 ```
 
-`$condition` must be a class-string for `Greenlight\Core\Condition`.
+`$condition` MUST name an instantiable class that implements
+`Greenlight\Core\Condition`.
 
 Skips the test if the condition is false.
 
 Greenlight passes the remaining attribute arguments to the condition
-constructor. Arguments must be scalars or null because Greenlight sends them to
+constructor. Arguments MUST be scalars or null because Greenlight sends them to
 parallel workers. Another argument type causes a discovery error. The
-constructor must only store the arguments. The `isSatisfied()` method must
+constructor MUST only store the arguments. The `isSatisfied()` method MUST
 evaluate the condition without side effects:
 
 ```php

--- a/src/Attribute/SkipUnless.php
+++ b/src/Attribute/SkipUnless.php
@@ -14,17 +14,37 @@ use Greenlight\Core\Condition;
 final readonly class SkipUnless
 {
     /**
+     * @var class-string<Condition>
+     */
+    public string $condition;
+
+    /**
      * @var list<mixed>
      */
     public array $arguments;
 
     /**
-     * @param class-string<Condition> $condition
+     * @throws \InvalidArgumentException
      */
     public function __construct(
-        public string $condition,
+        string $condition,
         mixed ...$arguments,
     ) {
+        if (!\is_a($condition, Condition::class, true)) {
+            throw new \InvalidArgumentException(
+                'SkipUnless condition MUST name an instantiable Condition class.',
+            );
+        }
+
+        $reflection = new \ReflectionClass($condition);
+
+        if (!$reflection->isInstantiable()) {
+            throw new \InvalidArgumentException(
+                'SkipUnless condition MUST name an instantiable Condition class.',
+            );
+        }
+
+        $this->condition = $condition;
         $this->arguments = \array_values($arguments);
     }
 }

--- a/tests/Unit/Attribute/SkipUnlessTest.php
+++ b/tests/Unit/Attribute/SkipUnlessTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Attribute;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\SkipUnless;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Condition;
+use Greenlight\Expect\Expect;
+
+final class SkipUnlessTest
+{
+    #[Test]
+    #[DataSet('invalidConditionClasses')]
+    public function invalidConditionClassesAreRejected(string $condition): void
+    {
+        Expect::that(
+            static fn(): SkipUnless => new SkipUnless($condition),
+        )
+            ->because('a skip condition MUST name an instantiable Condition class')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'SkipUnless condition MUST name an instantiable Condition class.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function invalidConditionClasses(): iterable
+    {
+        yield 'empty' => [''];
+
+        yield 'non-condition class' => [\stdClass::class];
+
+        yield 'unknown class' => ['Example\MissingCondition'];
+
+        yield 'condition interface' => [Condition::class];
+    }
+}


### PR DESCRIPTION
Validates SkipUnless condition types at the public attribute boundary. Missing classes, unrelated classes, and non-instantiable Condition types now fail with one exact diagnostic before discovery can hand them to a worker, while the worker keeps its defensive wire validation.