### PR TITLE
fix(core): reject negative result counts

### DIFF
--- a/docs/api-results.md
+++ b/docs/api-results.md
@@ -308,25 +308,70 @@ final readonly class ResultSummary implements WireSerializable
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ResultSummary.php#L11)
 
+### `$passed`
+
+```php
+public int $passed;
+```
+
+PHPDoc:
+
+- `@var non-negative-int`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ResultSummary.php#L16)
+
+### `$failed`
+
+```php
+public int $failed;
+```
+
+PHPDoc:
+
+- `@var non-negative-int`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ResultSummary.php#L21)
+
+### `$errored`
+
+```php
+public int $errored;
+```
+
+PHPDoc:
+
+- `@var non-negative-int`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ResultSummary.php#L26)
+
+### `$skipped`
+
+```php
+public int $skipped;
+```
+
+PHPDoc:
+
+- `@var non-negative-int`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ResultSummary.php#L31)
+
 ### `__construct()`
 
 ```php
 public function __construct(
-    public int $passed = 0,
-    public int $failed = 0,
-    public int $errored = 0,
-    public int $skipped = 0,
+    int $passed = 0,
+    int $failed = 0,
+    int $errored = 0,
+    int $skipped = 0,
 )
 ```
 
 PHPDoc:
 
-- `@param non-negative-int $passed`
-- `@param non-negative-int $failed`
-- `@param non-negative-int $errored`
-- `@param non-negative-int $skipped`
+- `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ResultSummary.php#L19)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ResultSummary.php#L36)
 
 ### `add()`
 
@@ -334,7 +379,7 @@ PHPDoc:
 public function add(Outcome $outcome): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ResultSummary.php#L26)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ResultSummary.php#L64)
 
 ### `total()`
 
@@ -346,7 +391,7 @@ PHPDoc:
 
 - `@return non-negative-int`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ResultSummary.php#L39)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ResultSummary.php#L77)
 
 ### `isSuccessful()`
 
@@ -354,7 +399,7 @@ PHPDoc:
 public function isSuccessful(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ResultSummary.php#L44)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ResultSummary.php#L82)
 
 ### `toWire()`
 
@@ -363,7 +408,7 @@ public function isSuccessful(): bool
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ResultSummary.php#L49)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ResultSummary.php#L87)
 
 ### `fromWire()`
 
@@ -372,7 +417,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ResultSummary.php#L60)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ResultSummary.php#L98)
 
 ## `SourceLocation`
 

--- a/src/Core/Result/ResultSummary.php
+++ b/src/Core/Result/ResultSummary.php
@@ -11,17 +11,55 @@ use Greenlight\Core\Wire\WireSerializable;
 final readonly class ResultSummary implements WireSerializable
 {
     /**
-     * @param non-negative-int $passed
-     * @param non-negative-int $failed
-     * @param non-negative-int $errored
-     * @param non-negative-int $skipped
+     * @var non-negative-int
+     */
+    public int $passed;
+
+    /**
+     * @var non-negative-int
+     */
+    public int $failed;
+
+    /**
+     * @var non-negative-int
+     */
+    public int $errored;
+
+    /**
+     * @var non-negative-int
+     */
+    public int $skipped;
+
+    /**
+     * @throws \InvalidArgumentException
      */
     public function __construct(
-        public int $passed = 0,
-        public int $failed = 0,
-        public int $errored = 0,
-        public int $skipped = 0,
-    ) {}
+        int $passed = 0,
+        int $failed = 0,
+        int $errored = 0,
+        int $skipped = 0,
+    ) {
+        if ($passed < 0) {
+            throw new \InvalidArgumentException('Result summary passed count MUST NOT be negative.');
+        }
+
+        if ($failed < 0) {
+            throw new \InvalidArgumentException('Result summary failed count MUST NOT be negative.');
+        }
+
+        if ($errored < 0) {
+            throw new \InvalidArgumentException('Result summary errored count MUST NOT be negative.');
+        }
+
+        if ($skipped < 0) {
+            throw new \InvalidArgumentException('Result summary skipped count MUST NOT be negative.');
+        }
+
+        $this->passed = $passed;
+        $this->failed = $failed;
+        $this->errored = $errored;
+        $this->skipped = $skipped;
+    }
 
     public function add(Outcome $outcome): self
     {

--- a/tests/Unit/Core/ResultSummaryTest.php
+++ b/tests/Unit/Core/ResultSummaryTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\ResultSummary;
+use Greenlight\Expect\Expect;
+
+final class ResultSummaryTest
+{
+    #[Test]
+    #[DataSet('negativeCounts')]
+    public function negativeCountsAreRejected(string $field, string $message): void
+    {
+        $counts = [
+            'passed' => 0,
+            'failed' => 0,
+            'errored' => 0,
+            'skipped' => 0,
+        ];
+        $counts[$field] = -1;
+
+        Expect::that(
+            static fn(): ResultSummary => new ResultSummary(
+                $counts['passed'],
+                $counts['failed'],
+                $counts['errored'],
+                $counts['skipped'],
+            ),
+        )
+            ->because('result summary counts MUST NOT be negative')
+            ->toThrow(\InvalidArgumentException::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string, non-empty-string}>
+     */
+    public static function negativeCounts(): iterable
+    {
+        foreach (['passed', 'failed', 'errored', 'skipped'] as $field) {
+            yield $field => [
+                $field,
+                \sprintf('Result summary %s count MUST NOT be negative.', $field),
+            ];
+        }
+    }
+}


### PR DESCRIPTION
Enforces the non-negative ResultSummary contract during direct construction for every outcome count. Wire decoding keeps its existing normalization behavior, while invalid in-process values now fail with field-specific diagnostics.