### PR TITLE
fix(core): reject invalid captured diagnostics

### DIFF
--- a/docs/api-results.md
+++ b/docs/api-results.md
@@ -21,12 +21,24 @@ final readonly class CapturedOutput implements WireSerializable
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/CapturedOutput.php#L17)
 
+### `$diagnostics`
+
+```php
+public array $diagnostics;
+```
+
+PHPDoc:
+
+- `@var list<Diagnostic>`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/CapturedOutput.php#L22)
+
 ### `__construct()`
 
 ```php
 public function __construct(
     public string $stdout,
-    public array $diagnostics = [],
+    array $diagnostics = [],
     public bool $stdoutTruncated = false,
     public bool $diagnosticsTruncated = false,
 )
@@ -34,9 +46,10 @@ public function __construct(
 
 PHPDoc:
 
-- `@param list<Diagnostic> $diagnostics`
+- `@param array<mixed> $diagnostics`
+- `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/CapturedOutput.php#L22)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/CapturedOutput.php#L29)
 
 ### `toWire()`
 
@@ -45,7 +58,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/CapturedOutput.php#L29)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/CapturedOutput.php#L50)
 
 ### `fromWire()`
 
@@ -54,7 +67,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/CapturedOutput.php#L43)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/CapturedOutput.php#L64)
 
 ## `Diagnostic`
 

--- a/src/Core/Result/CapturedOutput.php
+++ b/src/Core/Result/CapturedOutput.php
@@ -17,14 +17,35 @@ use Greenlight\Core\Wire\WireSerializable;
 final readonly class CapturedOutput implements WireSerializable
 {
     /**
-     * @param list<Diagnostic> $diagnostics
+     * @var list<Diagnostic>
+     */
+    public array $diagnostics;
+
+    /**
+     * @param array<mixed> $diagnostics
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct(
         public string $stdout,
-        public array $diagnostics = [],
+        array $diagnostics = [],
         public bool $stdoutTruncated = false,
         public bool $diagnosticsTruncated = false,
-    ) {}
+    ) {
+        $validatedDiagnostics = [];
+
+        foreach ($diagnostics as $index => $diagnostic) {
+            if ($index !== \count($validatedDiagnostics) || !$diagnostic instanceof Diagnostic) {
+                throw new \InvalidArgumentException(
+                    'Captured output diagnostics MUST be a list of Diagnostic instances.',
+                );
+            }
+
+            $validatedDiagnostics[] = $diagnostic;
+        }
+
+        $this->diagnostics = $validatedDiagnostics;
+    }
 
     #[\Override]
     public function toWire(): array

--- a/tests/Unit/Core/CapturedOutputValidationTest.php
+++ b/tests/Unit/Core/CapturedOutputValidationTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\CapturedOutput;
+use Greenlight\Core\Result\Diagnostic;
+use Greenlight\Core\Result\DiagnosticSeverity;
+use Greenlight\Expect\Expect;
+
+final class CapturedOutputValidationTest
+{
+    /**
+     * @param array<mixed> $diagnostics
+     */
+    #[Test]
+    #[DataSet('invalidDiagnostics')]
+    public function invalidDiagnosticsAreRejected(array $diagnostics): void
+    {
+        Expect::that(static fn(): CapturedOutput => new CapturedOutput('', $diagnostics))
+            ->because('captured output diagnostics MUST be a list of Diagnostic instances')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Captured output diagnostics MUST be a list of Diagnostic instances.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{array<mixed>}>
+     */
+    public static function invalidDiagnostics(): iterable
+    {
+        yield 'associative diagnostics' => [[
+            'warning' => new Diagnostic(DiagnosticSeverity::Warning, 'warning', 'Test.php', 1),
+        ]];
+        yield 'wrong item type' => [['warning']];
+    }
+}


### PR DESCRIPTION
Validates CapturedOutput diagnostics during direct construction so malformed item types and associative keys cannot survive until serialization or change the wire list shape. The public property keeps its refined list<Diagnostic> contract after validation.