### PR TITLE
fix(core): reject invalid ignore patterns

### DIFF
--- a/src/Core/Result/ResultPolicy.php
+++ b/src/Core/Result/ResultPolicy.php
@@ -31,14 +31,35 @@ use Greenlight\Core\Wire\WireSerializable;
 final readonly class ResultPolicy implements WireSerializable
 {
     /**
-     * @param list<non-empty-string> $ignoreDeprecations
+     * @var list<non-empty-string>
+     */
+    public array $ignoreDeprecations;
+
+    /**
+     * @param array<mixed> $ignoreDeprecations
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct(
         public bool $failOnDeprecation = false,
         public bool $failOnNotice = false,
-        public array $ignoreDeprecations = [],
+        array $ignoreDeprecations = [],
         public bool $failOnRisky = false,
-    ) {}
+    ) {
+        $validatedPatterns = [];
+
+        foreach ($ignoreDeprecations as $index => $pattern) {
+            if ($index !== \count($validatedPatterns) || !\is_string($pattern) || $pattern === '') {
+                throw new \InvalidArgumentException(
+                    'Deprecation ignore patterns MUST be a list of non-empty strings.',
+                );
+            }
+
+            $validatedPatterns[] = $pattern;
+        }
+
+        $this->ignoreDeprecations = $validatedPatterns;
+    }
 
     public function isNoOp(): bool
     {

--- a/tests/Unit/Core/ResultPolicyValidationTest.php
+++ b/tests/Unit/Core/ResultPolicyValidationTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\ResultPolicy;
+use Greenlight\Expect\Expect;
+
+final class ResultPolicyValidationTest
+{
+    /**
+     * @param array<mixed> $ignoreDeprecations
+     */
+    #[Test]
+    #[DataSet('invalidPatterns')]
+    public function invalidIgnorePatternsAreRejected(array $ignoreDeprecations): void
+    {
+        Expect::that(static fn(): ResultPolicy => new ResultPolicy(
+            ignoreDeprecations: $ignoreDeprecations,
+        ))
+            ->because('deprecation ignore patterns MUST be a list of non-empty strings')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Deprecation ignore patterns MUST be a list of non-empty strings.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{array<mixed>}>
+     */
+    public static function invalidPatterns(): iterable
+    {
+        yield 'associative patterns' => [['legacy' => 'legacy']];
+        yield 'empty pattern' => [['']];
+        yield 'wrong item type' => [[42]];
+    }
+}


### PR DESCRIPTION
Validates deprecation ignore patterns during direct ResultPolicy construction. Associative keys, empty patterns, and non-string items now fail at the boundary instead of changing the wire shape or causing a late wildcard-matching type error.