### PR TITLE
fix(core): reject invalid diagnostic lines

### DIFF
--- a/docs/api-results.md
+++ b/docs/api-results.md
@@ -62,12 +62,25 @@ Namespace: `Greenlight\Core\Result`
 
 Greenlight converts the message and file to valid UTF-8 before the
 diagnostic crosses the wire. These values originate in user code.
+The line number MUST be greater than zero.
 
 ```php
 final readonly class Diagnostic implements WireSerializable
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/Diagnostic.php#L15)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/Diagnostic.php#L16)
+
+### `$line`
+
+```php
+public int $line;
+```
+
+PHPDoc:
+
+- `@var positive-int`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/Diagnostic.php#L21)
 
 ### `__construct()`
 
@@ -76,11 +89,15 @@ public function __construct(
     public DiagnosticSeverity $severity,
     public string $message,
     public string $file,
-    public int $line,
+    int $line,
 )
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/Diagnostic.php#L17)
+PHPDoc:
+
+- `@throws \InvalidArgumentException`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/Diagnostic.php#L26)
 
 ### `toWire()`
 
@@ -89,7 +106,7 @@ public function __construct(
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/Diagnostic.php#L24)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/Diagnostic.php#L39)
 
 ### `fromWire()`
 
@@ -98,7 +115,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/Diagnostic.php#L35)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/Diagnostic.php#L50)
 
 ## `DiagnosticSeverity`
 

--- a/src/Core/Result/Diagnostic.php
+++ b/src/Core/Result/Diagnostic.php
@@ -11,15 +11,30 @@ use Greenlight\Core\Wire\WireSerializable;
 /**
  * Greenlight converts the message and file to valid UTF-8 before the
  * diagnostic crosses the wire. These values originate in user code.
+ * The line number MUST be greater than zero.
  */
 final readonly class Diagnostic implements WireSerializable
 {
+    /**
+     * @var positive-int
+     */
+    public int $line;
+
+    /**
+     * @throws \InvalidArgumentException
+     */
     public function __construct(
         public DiagnosticSeverity $severity,
         public string $message,
         public string $file,
-        public int $line,
-    ) {}
+        int $line,
+    ) {
+        if ($line < 1) {
+            throw new \InvalidArgumentException('Diagnostic line MUST be greater than zero.');
+        }
+
+        $this->line = $line;
+    }
 
     #[\Override]
     public function toWire(): array
@@ -39,7 +54,7 @@ final readonly class Diagnostic implements WireSerializable
             Wire::enum($payload, 'severity', DiagnosticSeverity::class),
             Wire::string($payload, 'message'),
             Wire::string($payload, 'file'),
-            Wire::int($payload, 'line'),
+            \max(1, Wire::int($payload, 'line')),
         );
     }
 }

--- a/tests/Unit/Core/DiagnosticValidationTest.php
+++ b/tests/Unit/Core/DiagnosticValidationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\Diagnostic;
+use Greenlight\Core\Result\DiagnosticSeverity;
+use Greenlight\Expect\Expect;
+
+final class DiagnosticValidationTest
+{
+    #[Test]
+    #[DataSet('nonPositiveLines')]
+    public function directConstructionRejectsNonPositiveLines(int $line): void
+    {
+        Expect::that(
+            static fn(): Diagnostic => new Diagnostic(DiagnosticSeverity::Warning, 'Warning.', '/tests/ProbeTest.php', $line),
+        )
+            ->because('a diagnostic MUST identify a positive source line')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Diagnostic line MUST be greater than zero.',
+            );
+    }
+
+    #[Test]
+    #[DataSet('nonPositiveLines')]
+    public function wireInputNormalizesNonPositiveLines(int $line): void
+    {
+        $restored = Diagnostic::fromWire([
+            'severity' => DiagnosticSeverity::Warning->value,
+            'message' => 'Warning.',
+            'file' => '/tests/ProbeTest.php',
+            'line' => $line,
+        ]);
+
+        Expect::that($restored->line)
+            ->because('wire diagnostics MUST identify at least the first source line')
+            ->toBe(1);
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function nonPositiveLines(): iterable
+    {
+        yield 'zero' => [0];
+
+        yield 'negative' => [-10];
+    }
+}


### PR DESCRIPTION
Diagnostic documents positive source lines, but direct construction accepted zero and negative values. Reject invalid direct input and normalize legacy wire values to line 1, with focused dataset coverage and an updated API reference.