### PR TITLE
fix(core): reject invalid test channels

### DIFF
--- a/docs/api-test-contracts.md
+++ b/docs/api-test-contracts.md
@@ -77,17 +77,29 @@ final readonly class TestChannel
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestChannel.php#L16)
 
-### `__construct()`
+### `$number`
 
 ```php
-public function __construct(public int $number)
+public int $number;
 ```
 
 PHPDoc:
 
-- `@param positive-int $number`
+- `@var positive-int`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestChannel.php#L21)
+
+### `__construct()`
+
+```php
+public function __construct(int $number)
+```
+
+PHPDoc:
+
+- `@throws \InvalidArgumentException`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestChannel.php#L26)
 
 ### `label()`
 
@@ -99,7 +111,7 @@ PHPDoc:
 
 - `@return non-empty-string`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestChannel.php#L26)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestChannel.php#L38)
 
 ## `TestId`
 

--- a/src/Core/Test/TestChannel.php
+++ b/src/Core/Test/TestChannel.php
@@ -16,9 +16,21 @@ namespace Greenlight\Core\Test;
 final readonly class TestChannel
 {
     /**
-     * @param positive-int $number
+     * @var positive-int
      */
-    public function __construct(public int $number) {}
+    public int $number;
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(int $number)
+    {
+        if ($number < 1) {
+            throw new \InvalidArgumentException('Test channel number MUST be greater than zero.');
+        }
+
+        $this->number = $number;
+    }
 
     /**
      * @return non-empty-string

--- a/tests/Unit/Core/TestChannelTest.php
+++ b/tests/Unit/Core/TestChannelTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Core;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Test\TestChannel;
 use Greenlight\Expect\Expect;
@@ -17,5 +18,27 @@ final readonly class TestChannelTest
 
         Expect::that($channel->number)->because('exposes the slot number and a prefixed label')->toBe(3)
             ->and($channel->label())->toBe('gl-3');
+    }
+
+    #[Test]
+    #[DataSet('nonPositiveNumbers')]
+    public function rejectsNonPositiveNumbers(int $number): void
+    {
+        Expect::that(static fn(): TestChannel => new TestChannel($number))
+            ->because('a test channel MUST identify a positive worker slot')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Test channel number MUST be greater than zero.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function nonPositiveNumbers(): iterable
+    {
+        yield 'zero' => [0];
+
+        yield 'negative' => [-1];
     }
 }


### PR DESCRIPTION
TestChannel promises a positive worker slot but accepted zero and negative values. Reject invalid construction with an exact diagnostic, cover both boundaries with a dataset, and update the generated API reference.