### PR TITLE
test(discovery): cover class exclusion precedence

### DIFF
--- a/tests/Unit/Discovery/FilterTest.php
+++ b/tests/Unit/Discovery/FilterTest.php
@@ -60,7 +60,7 @@ final class FilterTest
     }
 
     #[Test]
-    public function classFiltersMatchBySubstringOrWildcard(): void
+    public function classFiltersMatchBySubstringOrWildcardAndExclusionWins(): void
     {
         $substring = new Filter(includeClasses: ['Invoice']);
 
@@ -76,6 +76,11 @@ final class FilterTest
 
         Expect::that($question->accepts('App\V1Test', 'm', [], '/f'))->because('class filters match by substring or wildcard')->toBeTrue();
         Expect::that($question->accepts('App\V12Test', 'm', [], '/f'))->because('class filters match by substring or wildcard')->toBeFalse();
+        $excluded = new Filter(includeClasses: ['App\\'], excludeClasses: ['Legacy']);
+
+        Expect::that($excluded->accepts('App\\LegacyTest', 'm', [], '/f'))
+            ->because('class exclusion MUST take priority over inclusion')
+            ->toBeFalse();
     }
 
     #[Test]


### PR DESCRIPTION
Covers the remaining class-filter decision with a direct assertion that an exclude match takes priority over a matching include. This protects the selection rule used by `--exclude-class` without involving discovery fixtures.