### PR TITLE
test(cli): cover configured plan details

### DIFF
--- a/tests/Unit/Cli/PlanFormatterTest.php
+++ b/tests/Unit/Cli/PlanFormatterTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Cli;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Cli\PlanFormatter;
 use Greenlight\Config\Configuration;
 use Greenlight\Config\CoverageConfiguration;
 use Greenlight\Config\CoverageExport;
 use Greenlight\Config\GreenlightConfig;
+use Greenlight\Config\SuiteConfiguration;
 use Greenlight\Config\WatchConfiguration;
 use Greenlight\Config\WorkerCount;
 use Greenlight\Core\Result\ResultPolicy;
@@ -77,5 +79,65 @@ final class PlanFormatterTest
             ->toContain('  order: random (seed chosen at run time)')
             ->and($formatted)
             ->toContain('  plugins: ' . NamedFakePlugin::class);
+    }
+
+    /**
+     * @param positive-int $failureLimit
+     */
+    #[Test]
+    #[DataSet('failureLimits')]
+    public function formatsConfiguredPlanDetails(int $failureLimit, string $expectedFailureLimit): void
+    {
+        $configuration = new Configuration(
+            paths: ['tests'],
+            suites: [
+                new SuiteConfiguration('unit', ['tests/Unit'], ['fast']),
+                new SuiteConfiguration('acceptance', ['tests/Acceptance'], []),
+            ],
+            workers: WorkerCount::exactly(3),
+            recycleAfterTests: 25,
+            recycleAboveMemoryBytes: 256 * 1024 * 1024,
+            coverage: null,
+            watch: new WatchConfiguration(),
+            plugins: [new NamedFakePlugin()],
+            policy: new ResultPolicy(),
+            stopAfterFailures: $failureLimit,
+            randomizeOrder: true,
+            randomSeed: 4242,
+            groups: ['smoke', 'unit'],
+            resourceLimits: ['database' => 2, 'redis' => 1],
+        );
+
+        Expect::that(PlanFormatter::format($configuration, '/project/greenlight.php'))
+            ->because('the run plan MUST show each configured execution detail')
+            ->toBe(
+                <<<PLAN
+                    Run plan
+                      configuration file: /project/greenlight.php
+                      test paths: tests
+                      suite unit: tests/Unit [tags: fast]
+                      suite acceptance: tests/Acceptance
+                      workers: 3
+                      resource limits: database=2, redis=1
+                      recycle: after 25 tests or above 256M memory
+                      stop after: {$expectedFailureLimit}
+                      order: random (seed 4242)
+                      groups: smoke, unit
+                      plugins: Greenlight\Tests\Fixture\Plugins\NamedFakePlugin
+                      artifacts: build/greenlight-artifacts
+                      coverage: (off)
+
+                    PLAN,
+            );
+    }
+
+    /**
+     * @return iterable<string, array{positive-int, non-empty-string}>
+     */
+    public static function failureLimits(): iterable
+    {
+        yield 'singular' => [1, '1 failure'];
+
+        yield 'plural' => [3, '3 failures'];
     }
 }


### PR DESCRIPTION
Adds exact coverage for a fully configured run plan, including suites and tags, resource limits, worker recycling, explicit random seeds, failure-limit grammar, groups, plugins, and disabled coverage. The singular and plural stop limits share one dataset-backed contract.