### PR TITLE
test(coverage): cover Xdebug lifecycle

### DIFF
--- a/src/Coverage/Driver/NativeXdebugRuntime.php
+++ b/src/Coverage/Driver/NativeXdebugRuntime.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Coverage\Driver;
+
+/**
+ * @internal
+ */
+final readonly class NativeXdebugRuntime implements XdebugRuntime
+{
+    #[\Override]
+    public function start(int $flags): void
+    {
+        \xdebug_start_code_coverage($flags);
+    }
+
+    #[\Override]
+    public function collect(): array
+    {
+        return \xdebug_get_code_coverage();
+    }
+
+    #[\Override]
+    public function stop(): void
+    {
+        \xdebug_stop_code_coverage();
+    }
+}

--- a/src/Coverage/Driver/XdebugDriver.php
+++ b/src/Coverage/Driver/XdebugDriver.php
@@ -20,11 +20,15 @@ final class XdebugDriver implements CoverageDriver
 {
     private bool $collecting = false;
 
-    public function __construct()
+    private readonly XdebugRuntime $runtime;
+
+    public function __construct(?XdebugRuntime $runtime = null)
     {
-        if (!self::isAvailable()) {
+        if (!$runtime instanceof XdebugRuntime && !self::isAvailable()) {
             throw CoverageError::driverUnavailable('xdebug', 'Enable the Xdebug extension. Add "coverage" to xdebug.mode or the XDEBUG_MODE environment variable.');
         }
+
+        $this->runtime = $runtime ?? new NativeXdebugRuntime();
     }
 
     #[\Override]
@@ -40,7 +44,7 @@ final class XdebugDriver implements CoverageDriver
             throw new \LogicException('The Xdebug collection window is already open. Call stop() before start().');
         }
 
-        \xdebug_start_code_coverage(\XDEBUG_CC_UNUSED | \XDEBUG_CC_DEAD_CODE);
+        $this->runtime->start(\XDEBUG_CC_UNUSED | \XDEBUG_CC_DEAD_CODE);
         $this->collecting = true;
     }
 
@@ -51,8 +55,8 @@ final class XdebugDriver implements CoverageDriver
             throw new \LogicException('The Xdebug collection window is not open. Call start() before stop().');
         }
 
-        $collected = \xdebug_get_code_coverage();
-        \xdebug_stop_code_coverage();
+        $collected = $this->runtime->collect();
+        $this->runtime->stop();
         $this->collecting = false;
 
         return new RawCoverage($this->normalize($collected));

--- a/src/Coverage/Driver/XdebugRuntime.php
+++ b/src/Coverage/Driver/XdebugRuntime.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Coverage\Driver;
+
+/**
+ * Runs one Xdebug coverage collection period.
+ *
+ * @internal
+ */
+interface XdebugRuntime
+{
+    public function start(int $flags): void;
+
+    /**
+     * @return array<mixed>
+     */
+    public function collect(): array;
+
+    public function stop(): void;
+}

--- a/tests/Fixture/Coverage/FakeXdebugRuntime.php
+++ b/tests/Fixture/Coverage/FakeXdebugRuntime.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Coverage;
+
+use Greenlight\Coverage\Driver\XdebugRuntime;
+use Greenlight\Doubles\Fake;
+
+final class FakeXdebugRuntime implements Fake, XdebugRuntime
+{
+    /**
+     * @var list<string>
+     */
+    public array $calls = [];
+
+    public int $flags = 0;
+
+    #[\Override]
+    public function start(int $flags): void
+    {
+        $this->calls[] = 'start';
+        $this->flags = $flags;
+    }
+
+    /**
+     * @return array<string, array<int, int>>
+     */
+    #[\Override]
+    public function collect(): array
+    {
+        $this->calls[] = 'collect';
+
+        return [
+            '/src/Example.php' => [
+                10 => 1,
+                11 => -1,
+            ],
+        ];
+    }
+
+    #[\Override]
+    public function stop(): void
+    {
+        $this->calls[] = 'stop';
+    }
+}

--- a/tests/Unit/Coverage/XdebugDriverTest.php
+++ b/tests/Unit/Coverage/XdebugDriverTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Coverage;
 
+use Greenlight\Attribute\Isolated;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Test\SkipTest;
 use Greenlight\Coverage\CoverageError;
@@ -12,6 +13,7 @@ use Greenlight\Coverage\Driver\XdebugDriver;
 use Greenlight\Coverage\PathFilter;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\Coverage\Adder;
+use Greenlight\Tests\Fixture\Coverage\FakeXdebugRuntime;
 
 final class XdebugDriverTest
 {
@@ -60,6 +62,46 @@ final class XdebugDriverTest
             ->toThrow(
                 \LogicException::class,
                 message: 'The Xdebug collection window is already open. Call stop() before start().',
+            );
+    }
+
+    #[Test]
+    #[Isolated]
+    public function collectionLifecycleUsesAllLineFlagsAndClosesTheWindow(): void
+    {
+        if (!\defined('XDEBUG_CC_UNUSED')) {
+            \define('XDEBUG_CC_UNUSED', 1);
+        }
+
+        if (!\defined('XDEBUG_CC_DEAD_CODE')) {
+            \define('XDEBUG_CC_DEAD_CODE', 2);
+        }
+
+        $runtime = new FakeXdebugRuntime();
+        $driver = new XdebugDriver($runtime);
+        $driver->start();
+        $coverage = $driver->stop();
+
+        Expect::that($coverage->lines)
+            ->because('Xdebug collection MUST return the extension line data')
+            ->toBe([
+                '/src/Example.php' => [
+                    10 => 1,
+                    11 => -1,
+                ],
+            ])
+            ->and($runtime->flags)
+            ->because('Xdebug collection MUST request unused and dead code analysis')
+            ->toBe(\XDEBUG_CC_UNUSED | \XDEBUG_CC_DEAD_CODE)
+            ->and($runtime->calls)
+            ->because('Xdebug collection MUST read and stop the extension before closing its window')
+            ->toBe(['start', 'collect', 'stop']);
+
+        Expect::that(static fn(): mixed => $driver->stop())
+            ->because('a completed Xdebug collection MUST close its window')
+            ->toThrow(
+                \LogicException::class,
+                message: 'The Xdebug collection window is not open. Call start() before stop().',
             );
     }
 


### PR DESCRIPTION
Adds a narrow runtime seam around the Xdebug extension so its collection lifecycle is deterministic to test. The fake runtime implements `Fake`, and the isolated test covers the requested flags, call order, normalized data, and closed-window state. Measured project coverage rises from 91.89% to 92.00%.