### PR TITLE
fix(events): reject empty suite names

### DIFF
--- a/docs/api-events.md
+++ b/docs/api-events.md
@@ -165,17 +165,29 @@ final readonly class SuiteFinished implements Event
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteFinished.php#L9)
 
-### `__construct()`
+### `$suite`
 
 ```php
-public function __construct(public string $suite, public float $occurredAt)
+public string $suite;
 ```
 
 PHPDoc:
 
-- `@param non-empty-string $suite`
+- `@var non-empty-string`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteFinished.php#L14)
+
+### `__construct()`
+
+```php
+public function __construct(string $suite, public float $occurredAt)
+```
+
+PHPDoc:
+
+- `@throws \InvalidArgumentException`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteFinished.php#L19)
 
 ### `toWire()`
 
@@ -184,7 +196,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteFinished.php#L16)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteFinished.php#L28)
 
 ### `fromWire()`
 
@@ -193,7 +205,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteFinished.php#L25)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteFinished.php#L37)
 
 ## `SuiteStarted`
 
@@ -205,17 +217,29 @@ final readonly class SuiteStarted implements Event
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteStarted.php#L9)
 
-### `__construct()`
+### `$suite`
 
 ```php
-public function __construct(public string $suite, public float $occurredAt)
+public string $suite;
 ```
 
 PHPDoc:
 
-- `@param non-empty-string $suite`
+- `@var non-empty-string`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteStarted.php#L14)
+
+### `__construct()`
+
+```php
+public function __construct(string $suite, public float $occurredAt)
+```
+
+PHPDoc:
+
+- `@throws \InvalidArgumentException`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteStarted.php#L19)
 
 ### `toWire()`
 
@@ -224,7 +248,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteStarted.php#L16)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteStarted.php#L28)
 
 ### `fromWire()`
 
@@ -233,7 +257,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteStarted.php#L25)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteStarted.php#L37)
 
 ## `TestClassFinished`
 

--- a/src/Core/Event/SuiteFinished.php
+++ b/src/Core/Event/SuiteFinished.php
@@ -9,9 +9,21 @@ use Greenlight\Core\Wire\Wire;
 final readonly class SuiteFinished implements Event
 {
     /**
-     * @param non-empty-string $suite
+     * @var non-empty-string
      */
-    public function __construct(public string $suite, public float $occurredAt) {}
+    public string $suite;
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(string $suite, public float $occurredAt)
+    {
+        if ($suite === '') {
+            throw new \InvalidArgumentException('Suite name MUST NOT be empty.');
+        }
+
+        $this->suite = $suite;
+    }
 
     #[\Override]
     public function toWire(): array

--- a/src/Core/Event/SuiteStarted.php
+++ b/src/Core/Event/SuiteStarted.php
@@ -9,9 +9,21 @@ use Greenlight\Core\Wire\Wire;
 final readonly class SuiteStarted implements Event
 {
     /**
-     * @param non-empty-string $suite
+     * @var non-empty-string
      */
-    public function __construct(public string $suite, public float $occurredAt) {}
+    public string $suite;
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(string $suite, public float $occurredAt)
+    {
+        if ($suite === '') {
+            throw new \InvalidArgumentException('Suite name MUST NOT be empty.');
+        }
+
+        $this->suite = $suite;
+    }
 
     #[\Override]
     public function toWire(): array

--- a/tests/Unit/Core/SuiteEventValidationTest.php
+++ b/tests/Unit/Core/SuiteEventValidationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\SuiteFinished;
+use Greenlight\Core\Event\SuiteStarted;
+use Greenlight\Expect\Expect;
+
+final readonly class SuiteEventValidationTest
+{
+    /**
+     * @param class-string<SuiteStarted|SuiteFinished> $eventClass
+     */
+    #[Test]
+    #[DataSet('suiteEvents')]
+    public function rejectsAnEmptySuiteName(string $eventClass): void
+    {
+        Expect::that(static fn(): SuiteStarted|SuiteFinished => new $eventClass('', 1.0))
+            ->because('a suite lifecycle event MUST identify its suite')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Suite name MUST NOT be empty.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{class-string<SuiteStarted|SuiteFinished>}>
+     */
+    public static function suiteEvents(): iterable
+    {
+        yield 'started' => [SuiteStarted::class];
+
+        yield 'finished' => [SuiteFinished::class];
+    }
+}


### PR DESCRIPTION
SuiteStarted and SuiteFinished promise a non-empty suite identity but accepted an empty string through direct construction. Enforce the contract at both lifecycle boundaries, cover them with one dataset, and update the generated event API reference.