### PR TITLE
fix(events): reject empty class names

### DIFF
--- a/docs/api-events.md
+++ b/docs/api-events.md
@@ -245,11 +245,23 @@ final readonly class TestClassFinished implements Event
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassFinished.php#L9)
 
+### `$class`
+
+```php
+public string $class;
+```
+
+PHPDoc:
+
+- `@var non-empty-string`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassFinished.php#L14)
+
 ### `__construct()`
 
 ```php
 public function __construct(
-    public string $class,
+    string $class,
     public float $occurredAt,
     public string $workerId = '',
 )
@@ -257,10 +269,10 @@ public function __construct(
 
 PHPDoc:
 
-- `@param non-empty-string $class`
 - `@param string $workerId The worker that ran the class, or an empty string from a producer without worker attribution`
+- `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassFinished.php#L16)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassFinished.php#L22)
 
 ### `toWire()`
 
@@ -269,7 +281,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassFinished.php#L22)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassFinished.php#L34)
 
 ### `fromWire()`
 
@@ -278,7 +290,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassFinished.php#L32)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassFinished.php#L44)
 
 ## `TestClassStarted`
 
@@ -290,11 +302,23 @@ final readonly class TestClassStarted implements Event
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassStarted.php#L9)
 
+### `$class`
+
+```php
+public string $class;
+```
+
+PHPDoc:
+
+- `@var non-empty-string`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassStarted.php#L14)
+
 ### `__construct()`
 
 ```php
 public function __construct(
-    public string $class,
+    string $class,
     public float $occurredAt,
     public string $workerId = '',
 )
@@ -302,10 +326,10 @@ public function __construct(
 
 PHPDoc:
 
-- `@param non-empty-string $class`
 - `@param string $workerId The worker that ran the class, or an empty string from a producer without worker attribution`
+- `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassStarted.php#L16)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassStarted.php#L22)
 
 ### `toWire()`
 
@@ -314,7 +338,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassStarted.php#L22)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassStarted.php#L34)
 
 ### `fromWire()`
 
@@ -323,7 +347,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassStarted.php#L32)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassStarted.php#L44)
 
 ## `TestFinished`
 

--- a/src/Core/Event/TestClassFinished.php
+++ b/src/Core/Event/TestClassFinished.php
@@ -9,15 +9,27 @@ use Greenlight\Core\Wire\Wire;
 final readonly class TestClassFinished implements Event
 {
     /**
-     * @param non-empty-string $class
+     * @var non-empty-string
+     */
+    public string $class;
+
+    /**
      * @param string $workerId The worker that ran the class, or an empty
      *   string from a producer without worker attribution
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct(
-        public string $class,
+        string $class,
         public float $occurredAt,
         public string $workerId = '',
-    ) {}
+    ) {
+        if ($class === '') {
+            throw new \InvalidArgumentException('Test class name MUST NOT be empty.');
+        }
+
+        $this->class = $class;
+    }
 
     #[\Override]
     public function toWire(): array

--- a/src/Core/Event/TestClassStarted.php
+++ b/src/Core/Event/TestClassStarted.php
@@ -9,15 +9,27 @@ use Greenlight\Core\Wire\Wire;
 final readonly class TestClassStarted implements Event
 {
     /**
-     * @param non-empty-string $class
+     * @var non-empty-string
+     */
+    public string $class;
+
+    /**
      * @param string $workerId The worker that ran the class, or an empty
      *   string from a producer without worker attribution
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct(
-        public string $class,
+        string $class,
         public float $occurredAt,
         public string $workerId = '',
-    ) {}
+    ) {
+        if ($class === '') {
+            throw new \InvalidArgumentException('Test class name MUST NOT be empty.');
+        }
+
+        $this->class = $class;
+    }
 
     #[\Override]
     public function toWire(): array

--- a/tests/Unit/Core/TestClassEventValidationTest.php
+++ b/tests/Unit/Core/TestClassEventValidationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\TestClassFinished;
+use Greenlight\Core\Event\TestClassStarted;
+use Greenlight\Expect\Expect;
+
+final readonly class TestClassEventValidationTest
+{
+    /**
+     * @param class-string<TestClassStarted|TestClassFinished> $eventClass
+     */
+    #[Test]
+    #[DataSet('classEvents')]
+    public function rejectsAnEmptyClassName(string $eventClass): void
+    {
+        Expect::that(static fn(): TestClassStarted|TestClassFinished => new $eventClass('', 1.0))
+            ->because('a test-class lifecycle event MUST identify its class')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Test class name MUST NOT be empty.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{class-string<TestClassStarted|TestClassFinished>}>
+     */
+    public static function classEvents(): iterable
+    {
+        yield 'started' => [TestClassStarted::class];
+
+        yield 'finished' => [TestClassFinished::class];
+    }
+}


### PR DESCRIPTION
TestClassStarted and TestClassFinished promise a non-empty class identity but accepted an empty string through direct construction. Enforce the contract at both lifecycle boundaries, cover them with one dataset, and update the generated event API reference.