### PR TITLE
test(runner): cover leak detection warning

### DIFF
--- a/src/Runner/Worker/LeakDetector.php
+++ b/src/Runner/Worker/LeakDetector.php
@@ -30,11 +30,17 @@ final class LeakDetector
     private array $watched = [];
 
     /**
+     * @param list<string>|null $xdebugModes Explicit mode snapshot. A null value reads the environment.
+     *
      * @return non-empty-string|null A warning if the environment can cause incorrect leak reports
      */
-    public static function environmentWarning(): ?string
+    public static function environmentWarning(?array $xdebugModes = null): ?string
     {
-        if (!\extension_loaded('xdebug') || !\in_array('develop', self::xdebugModes(), true)) {
+        if (!\in_array(
+            'develop',
+            $xdebugModes ?? (\extension_loaded('xdebug') ? self::xdebugModes() : []),
+            true,
+        )) {
             return null;
         }
 

--- a/tests/Unit/Runner/Worker/LeakDetectorTest.php
+++ b/tests/Unit/Runner/Worker/LeakDetectorTest.php
@@ -12,6 +12,20 @@ use Greenlight\Runner\Worker\LeakDetector;
 final class LeakDetectorTest
 {
     #[Test]
+    public function anExplicitModeSnapshotControlsTheEnvironmentWarning(): void
+    {
+        Expect::that(LeakDetector::environmentWarning(['develop']))
+            ->because('Xdebug develop mode MUST explain its leak-detection false positives')
+            ->toBe(
+                'Warning: Xdebug develop mode keeps caught exceptions in memory. Thus, leak detection reports '
+                . 'false positives. Rerun with XDEBUG_MODE=off to get correct results.',
+            )
+            ->and(LeakDetector::environmentWarning(['coverage']))
+            ->because('Xdebug modes without develop MUST NOT warn about leak detection')
+            ->toBeNull();
+    }
+
+    #[Test]
     public function sweepDropsCollectedInstancesAndReportsRetainedInstancesOnce(): void
     {
         $detector = new LeakDetector();


### PR DESCRIPTION
Makes the Xdebug mode snapshot injectable at the existing internal warning boundary, then covers both the develop-mode warning and the safe-mode result directly. This closes the previously unmeasured warning branch while preserving environment-driven production behavior.