### PR TITLE
fix(events): reject invalid worker identities

### DIFF
--- a/docs/api-events.md
+++ b/docs/api-events.md
@@ -407,11 +407,23 @@ final readonly class WorkerRecycled implements Event
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerRecycled.php#L9)
 
+### `$workerId`
+
+```php
+public string $workerId;
+```
+
+PHPDoc:
+
+- `@var non-empty-string`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerRecycled.php#L14)
+
 ### `__construct()`
 
 ```php
 public function __construct(
-    public string $workerId,
+    string $workerId,
     public RecycleReason $reason,
     public float $occurredAt,
 )
@@ -419,9 +431,9 @@ public function __construct(
 
 PHPDoc:
 
-- `@param non-empty-string $workerId`
+- `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerRecycled.php#L14)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerRecycled.php#L19)
 
 ### `toWire()`
 
@@ -430,7 +442,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerRecycled.php#L20)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerRecycled.php#L31)
 
 ### `fromWire()`
 
@@ -439,7 +451,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerRecycled.php#L30)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerRecycled.php#L41)
 
 ## `WorkerSpawned`
 
@@ -451,22 +463,45 @@ final readonly class WorkerSpawned implements Event
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerSpawned.php#L9)
 
+### `$workerId`
+
+```php
+public string $workerId;
+```
+
+PHPDoc:
+
+- `@var non-empty-string`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerSpawned.php#L14)
+
+### `$pid`
+
+```php
+public int $pid;
+```
+
+PHPDoc:
+
+- `@var positive-int`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerSpawned.php#L19)
+
 ### `__construct()`
 
 ```php
 public function __construct(
-    public string $workerId,
-    public int $pid,
+    string $workerId,
+    int $pid,
     public float $occurredAt,
 )
 ```
 
 PHPDoc:
 
-- `@param non-empty-string $workerId`
-- `@param positive-int $pid`
+- `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerSpawned.php#L15)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerSpawned.php#L24)
 
 ### `toWire()`
 
@@ -475,7 +510,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerSpawned.php#L21)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerSpawned.php#L41)
 
 ### `fromWire()`
 
@@ -484,4 +519,4 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerSpawned.php#L31)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerSpawned.php#L51)

--- a/src/Core/Event/WorkerRecycled.php
+++ b/src/Core/Event/WorkerRecycled.php
@@ -9,13 +9,24 @@ use Greenlight\Core\Wire\Wire;
 final readonly class WorkerRecycled implements Event
 {
     /**
-     * @param non-empty-string $workerId
+     * @var non-empty-string
+     */
+    public string $workerId;
+
+    /**
+     * @throws \InvalidArgumentException
      */
     public function __construct(
-        public string $workerId,
+        string $workerId,
         public RecycleReason $reason,
         public float $occurredAt,
-    ) {}
+    ) {
+        if ($workerId === '') {
+            throw new \InvalidArgumentException('Worker ID MUST NOT be empty.');
+        }
+
+        $this->workerId = $workerId;
+    }
 
     #[\Override]
     public function toWire(): array

--- a/src/Core/Event/WorkerSpawned.php
+++ b/src/Core/Event/WorkerSpawned.php
@@ -9,14 +9,34 @@ use Greenlight\Core\Wire\Wire;
 final readonly class WorkerSpawned implements Event
 {
     /**
-     * @param non-empty-string $workerId
-     * @param positive-int $pid
+     * @var non-empty-string
+     */
+    public string $workerId;
+
+    /**
+     * @var positive-int
+     */
+    public int $pid;
+
+    /**
+     * @throws \InvalidArgumentException
      */
     public function __construct(
-        public string $workerId,
-        public int $pid,
+        string $workerId,
+        int $pid,
         public float $occurredAt,
-    ) {}
+    ) {
+        if ($workerId === '') {
+            throw new \InvalidArgumentException('Worker ID MUST NOT be empty.');
+        }
+
+        if ($pid < 1) {
+            throw new \InvalidArgumentException('Worker PID MUST be greater than zero.');
+        }
+
+        $this->workerId = $workerId;
+        $this->pid = $pid;
+    }
 
     #[\Override]
     public function toWire(): array

--- a/tests/Unit/Core/WorkerEventValidationTest.php
+++ b/tests/Unit/Core/WorkerEventValidationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\RecycleReason;
+use Greenlight\Core\Event\WorkerRecycled;
+use Greenlight\Core\Event\WorkerSpawned;
+use Greenlight\Expect\Expect;
+
+final readonly class WorkerEventValidationTest
+{
+    #[Test]
+    public function workerEventsRejectAnEmptyWorkerId(): void
+    {
+        Expect::that(static fn(): WorkerSpawned => new WorkerSpawned('', 1, 1.0))
+            ->because('a spawned-worker event MUST identify its worker')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Worker ID MUST NOT be empty.',
+            )
+            ->and(static fn(): WorkerRecycled => new WorkerRecycled('', RecycleReason::TestCount, 1.0))
+            ->because('a recycled-worker event MUST identify its worker')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Worker ID MUST NOT be empty.',
+            );
+    }
+
+    #[Test]
+    #[DataSet('nonPositivePids')]
+    public function aSpawnedWorkerRejectsANonPositivePid(int $pid): void
+    {
+        Expect::that(static fn(): WorkerSpawned => new WorkerSpawned('worker-1', $pid, 1.0))
+            ->because('a spawned-worker event MUST identify a positive process ID')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Worker PID MUST be greater than zero.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function nonPositivePids(): iterable
+    {
+        yield 'zero' => [0];
+
+        yield 'negative' => [-1];
+    }
+}


### PR DESCRIPTION
Worker lifecycle events promise non-empty worker identities, and WorkerSpawned promises a positive process ID, but direct construction did not enforce those contracts. Reject invalid identities and process IDs with exact diagnostics, cover the boundaries with Greenlight expectations, and update the generated event API reference.