### PR TITLE
fix(conditions): reject empty class names

### DIFF
--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -396,6 +396,18 @@ final readonly class ClassAvailable implements Condition
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ClassAvailable.php#L9)
 
+### `__construct()`
+
+```php
+public function __construct(string $class)
+```
+
+PHPDoc:
+
+- `@throws \InvalidArgumentException`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ClassAvailable.php#L22)
+
 ### `isSatisfied()`
 
 ```php
@@ -403,7 +415,7 @@ final readonly class ClassAvailable implements Condition
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ClassAvailable.php#L19)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ClassAvailable.php#L31)
 
 ## `EnvironmentVariableEquals`
 

--- a/src/Condition/ClassAvailable.php
+++ b/src/Condition/ClassAvailable.php
@@ -12,9 +12,21 @@ final readonly class ClassAvailable implements Condition
      * The class name has the string type because the class can be absent from
      * the current environment.
      *
-     * @param non-empty-string $class
+     * @var non-empty-string
      */
-    public function __construct(private string $class) {}
+    private string $class;
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(string $class)
+    {
+        if ($class === '') {
+            throw new \InvalidArgumentException('Class name MUST NOT be empty.');
+        }
+
+        $this->class = $class;
+    }
 
     #[\Override]
     public function isSatisfied(): bool

--- a/tests/Unit/Condition/ConditionsTest.php
+++ b/tests/Unit/Condition/ConditionsTest.php
@@ -96,4 +96,15 @@ final class ConditionsTest
         Expect::that(new ClassAvailable(\stdClass::class)->isSatisfied())->because('class available checks autoloadable classes')->toBeTrue()
             ->and(new ClassAvailable('Greenlight\NoSuchClassAnywhere')->isSatisfied())->toBeFalse();
     }
+
+    #[Test]
+    public function classAvailableRejectsAnEmptyClassName(): void
+    {
+        Expect::that(static fn(): ClassAvailable => new ClassAvailable(''))
+            ->because('a class availability condition MUST identify the class')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Class name MUST NOT be empty.',
+            );
+    }
 }


### PR DESCRIPTION
ClassAvailable promises a non-empty class name but accepted an empty string and silently evaluated it as unavailable. Enforce the constructor contract with an exact diagnostic, cover the invalid boundary with Greenlight expectations, and update the generated condition API reference.