### PR TITLE
fix(config): reject invalid watch debounce

### DIFF
--- a/src/Config/WatchConfiguration.php
+++ b/src/Config/WatchConfiguration.php
@@ -8,7 +8,22 @@ namespace Greenlight\Config;
 final readonly class WatchConfiguration
 {
     /**
-     * @param positive-int $debounceMilliseconds
+     * @var positive-int
      */
-    public function __construct(public int $debounceMilliseconds = 200) {}
+    public int $debounceMilliseconds;
+
+    /**
+     * @throws InvalidConfiguration
+     */
+    public function __construct(int $debounceMilliseconds = 200)
+    {
+        if ($debounceMilliseconds < 1) {
+            throw new InvalidConfiguration(\sprintf(
+                'The watch debounce must be at least 1 millisecond, got %d.',
+                $debounceMilliseconds,
+            ));
+        }
+
+        $this->debounceMilliseconds = $debounceMilliseconds;
+    }
 }

--- a/tests/Unit/Config/WatchConfigurationTest.php
+++ b/tests/Unit/Config/WatchConfigurationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Config;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Config\InvalidConfiguration;
+use Greenlight\Config\WatchConfiguration;
+use Greenlight\Expect\Expect;
+
+final readonly class WatchConfigurationTest
+{
+    #[Test]
+    #[DataSet('nonPositiveDebounces')]
+    public function rejectsANonPositiveDebounce(int $milliseconds): void
+    {
+        Expect::that(static fn(): WatchConfiguration => new WatchConfiguration($milliseconds))
+            ->because('a watch configuration MUST have a positive debounce')
+            ->toThrow(
+                InvalidConfiguration::class,
+                message: \sprintf(
+                    'The watch debounce must be at least 1 millisecond, got %d.',
+                    $milliseconds,
+                ),
+            );
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function nonPositiveDebounces(): iterable
+    {
+        yield 'zero' => [0];
+
+        yield 'negative' => [-1];
+    }
+}


### PR DESCRIPTION
Enforces the documented positive debounce contract at the `WatchConfiguration` constructor boundary, not only through `WatchBuilder`. Direct construction with zero or a negative value now produces the same exact `InvalidConfiguration` diagnostic as the builder.