### PR TITLE
fix(conditions): reject empty function names

### DIFF
--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -491,6 +491,18 @@ final readonly class FunctionAvailable implements Condition
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/FunctionAvailable.php#L9)
 
+### `__construct()`
+
+```php
+public function __construct(string $function)
+```
+
+PHPDoc:
+
+- `@throws \InvalidArgumentException`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/FunctionAvailable.php#L19)
+
 ### `isSatisfied()`
 
 ```php
@@ -498,7 +510,7 @@ final readonly class FunctionAvailable implements Condition
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/FunctionAvailable.php#L13)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/FunctionAvailable.php#L28)
 
 ## `OperatingSystemFamily`
 

--- a/src/Condition/FunctionAvailable.php
+++ b/src/Condition/FunctionAvailable.php
@@ -8,7 +8,22 @@ use Greenlight\Core\Condition;
 
 final readonly class FunctionAvailable implements Condition
 {
-    public function __construct(private string $function) {}
+    /**
+     * @var non-empty-string
+     */
+    private string $function;
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(string $function)
+    {
+        if ($function === '') {
+            throw new \InvalidArgumentException('Function name MUST NOT be empty.');
+        }
+
+        $this->function = $function;
+    }
 
     #[\Override]
     public function isSatisfied(): bool

--- a/tests/Unit/Condition/FunctionAvailableTest.php
+++ b/tests/Unit/Condition/FunctionAvailableTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Condition;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Condition\FunctionAvailable;
+use Greenlight\Expect\Expect;
+
+final readonly class FunctionAvailableTest
+{
+    #[Test]
+    public function rejectsAnEmptyFunctionName(): void
+    {
+        Expect::that(static fn(): FunctionAvailable => new FunctionAvailable(''))
+            ->because('a function availability condition MUST identify the function')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Function name MUST NOT be empty.',
+            );
+    }
+}


### PR DESCRIPTION
FunctionAvailable accepted an empty function name and silently evaluated it as unavailable, which can hide an invalid skip condition. Reject the empty identifier with an exact diagnostic, cover the boundary with a direct Greenlight expectation, and update the generated condition API reference.