### PR TITLE
fix(config): reject invalid coverage exports

### DIFF
--- a/src/Config/CoverageExport.php
+++ b/src/Config/CoverageExport.php
@@ -8,8 +8,25 @@ namespace Greenlight\Config;
 final readonly class CoverageExport
 {
     /**
-     * @param non-empty-string $format
-     * @param non-empty-string $target
+     * @var non-empty-string
      */
-    public function __construct(public string $format, public string $target) {}
+    public string $format;
+
+    /**
+     * @var non-empty-string
+     */
+    public string $target;
+
+    /**
+     * @throws InvalidConfiguration
+     */
+    public function __construct(string $format, string $target)
+    {
+        if ($format === '' || $target === '') {
+            throw new InvalidConfiguration('Coverage exports need a non-empty format and target.');
+        }
+
+        $this->format = $format;
+        $this->target = $target;
+    }
 }

--- a/tests/Unit/Config/CoverageExportTest.php
+++ b/tests/Unit/Config/CoverageExportTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Config;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Config\CoverageExport;
+use Greenlight\Config\InvalidConfiguration;
+use Greenlight\Expect\Expect;
+
+final class CoverageExportTest
+{
+    #[Test]
+    #[DataSet('incompleteExports')]
+    public function rejectsAnIncompleteExport(string $format, string $target): void
+    {
+        Expect::that(static fn(): CoverageExport => new CoverageExport($format, $target))
+            ->because('a coverage export MUST identify its format and target')
+            ->toThrow(
+                InvalidConfiguration::class,
+                message: 'Coverage exports need a non-empty format and target.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function incompleteExports(): iterable
+    {
+        yield 'empty format' => ['', 'coverage.json'];
+        yield 'empty target' => ['json', ''];
+    }
+}


### PR DESCRIPTION
CoverageExport documents non-empty format and target values, but direct construction accepted empty strings and violated the stored type contract. Validate both values at the value-object boundary and cover each invalid component with focused data rows.