### PR TITLE
fix(coverage): clean up failed PCOV collection

### DIFF
--- a/src/Coverage/Driver/PcovDriver.php
+++ b/src/Coverage/Driver/PcovDriver.php
@@ -51,10 +51,19 @@ final class PcovDriver implements CoverageDriver
             throw new \LogicException('The pcov collection window is not open. Call start() before stop().');
         }
 
-        $collected = \pcov\collect();
-        \pcov\stop();
-        \pcov\clear();
-        $this->collecting = false;
+        try {
+            $collected = \pcov\collect();
+        } finally {
+            try {
+                \pcov\stop();
+            } finally {
+                try {
+                    \pcov\clear();
+                } finally {
+                    $this->collecting = false;
+                }
+            }
+        }
 
         return new RawCoverage($this->normalize($collected));
     }

--- a/tests/Fixture/Coverage/FailingPcovRuntime.php
+++ b/tests/Fixture/Coverage/FailingPcovRuntime.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Coverage;
+
+use Greenlight\Doubles\Fake;
+
+final class FailingPcovRuntime implements Fake
+{
+    /**
+     * @var list<string>
+     */
+    public static array $calls = [];
+
+    public static ?\Throwable $collectFailure = null;
+
+    public static ?\Throwable $stopFailure = null;
+
+    public static ?\Throwable $clearFailure = null;
+
+    public static function reset(): void
+    {
+        self::$calls = [];
+        self::$collectFailure = null;
+        self::$stopFailure = null;
+        self::$clearFailure = null;
+    }
+
+    public static function start(): void
+    {
+        self::$calls[] = 'start';
+    }
+
+    /**
+     * @return array<string, array<int, int>>
+     */
+    public static function collect(): array
+    {
+        self::$calls[] = 'collect';
+
+        if (self::$collectFailure instanceof \Throwable) {
+            throw self::$collectFailure;
+        }
+
+        return ['/src/Example.php' => [10 => 1]];
+    }
+
+    public static function stop(): void
+    {
+        self::$calls[] = 'stop';
+
+        if (self::$stopFailure instanceof \Throwable) {
+            throw self::$stopFailure;
+        }
+    }
+
+    public static function clear(): void
+    {
+        self::$calls[] = 'clear';
+
+        if (self::$clearFailure instanceof \Throwable) {
+            throw self::$clearFailure;
+        }
+    }
+}

--- a/tests/Unit/Coverage/PcovDriverFailureTest.php
+++ b/tests/Unit/Coverage/PcovDriverFailureTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Isolated;
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\Driver\PcovDriver;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Tests\Fixture\Coverage\FailingPcovRuntime;
+
+final class PcovDriverFailureTest
+{
+    #[Test]
+    #[Isolated]
+    public function collectionFailureStopsAndClearsTheRuntimeAndClosesTheWindow(): void
+    {
+        $this->installFakePcovFunctions();
+        $driver = new \ReflectionClass(PcovDriver::class)->newInstanceWithoutConstructor();
+
+        FailingPcovRuntime::reset();
+        FailingPcovRuntime::$collectFailure = new \RuntimeException('PCOV collection failed.');
+        $driver->start();
+
+        Expect::that(static fn(): mixed => $driver->stop())
+            ->because('a PCOV collection failure MUST remain the reported failure')
+            ->toThrow(
+                \RuntimeException::class,
+                message: 'PCOV collection failed.',
+            )
+            ->and(FailingPcovRuntime::$calls)
+            ->because('a PCOV collection failure MUST still stop and clear extension state')
+            ->toBe(['start', 'collect', 'stop', 'clear']);
+
+        Expect::that(static fn(): mixed => $driver->stop())
+            ->because('a failed PCOV collection MUST close its collection window')
+            ->toThrow(
+                \LogicException::class,
+                message: 'The pcov collection window is not open. Call start() before stop().',
+            );
+    }
+
+    /**
+     * @param 'stop'|'clear' $operation
+     */
+    #[Test]
+    #[Isolated]
+    #[DataSet('cleanupFailures')]
+    public function cleanupFailuresStillClearStateAndCloseTheWindow(
+        string $operation,
+        string $message,
+    ): void {
+        $this->installFakePcovFunctions();
+        $driver = new \ReflectionClass(PcovDriver::class)->newInstanceWithoutConstructor();
+
+        FailingPcovRuntime::reset();
+
+        if ($operation === 'stop') {
+            FailingPcovRuntime::$stopFailure = new \RuntimeException($message);
+        } else {
+            FailingPcovRuntime::$clearFailure = new \RuntimeException($message);
+        }
+
+        $driver->start();
+
+        Expect::that(static fn(): mixed => $driver->stop())
+            ->because('a PCOV cleanup failure MUST remain the reported failure')
+            ->toThrow(
+                \RuntimeException::class,
+                message: $message,
+            )
+            ->and(FailingPcovRuntime::$calls)
+            ->because('PCOV cleanup MUST attempt clear even if stop fails')
+            ->toBe(['start', 'collect', 'stop', 'clear']);
+
+        Expect::that(static fn(): mixed => $driver->stop())
+            ->because('a PCOV cleanup failure MUST close its collection window')
+            ->toThrow(
+                \LogicException::class,
+                message: 'The pcov collection window is not open. Call start() before stop().',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{'stop'|'clear', non-empty-string}>
+     */
+    public static function cleanupFailures(): iterable
+    {
+        yield 'stop failure' => ['stop', 'PCOV stop failed.'];
+
+        yield 'clear failure' => ['clear', 'PCOV clear failed.'];
+    }
+
+    private function installFakePcovFunctions(): void
+    {
+        if (\function_exists('pcov\start')) {
+            Fail::because('Expected an isolated worker without loaded PCOV functions.');
+        }
+
+        eval(<<<'PHP'
+            namespace pcov;
+
+            function start(): void
+            {
+                \Greenlight\Tests\Fixture\Coverage\FailingPcovRuntime::start();
+            }
+
+            function collect(): array
+            {
+                return \Greenlight\Tests\Fixture\Coverage\FailingPcovRuntime::collect();
+            }
+
+            function stop(): void
+            {
+                \Greenlight\Tests\Fixture\Coverage\FailingPcovRuntime::stop();
+            }
+
+            function clear(): void
+            {
+                \Greenlight\Tests\Fixture\Coverage\FailingPcovRuntime::clear();
+            }
+            PHP);
+    }
+}


### PR DESCRIPTION
Ensures a PCOV collection exception still stops and clears extension state and closes the driver window. The isolated fake-runtime test preserves the original collection error, verifies cleanup order, and confirms a second stop is rejected.