### PR TITLE
fix(conditions): reject empty extension names

### DIFF
--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -453,6 +453,18 @@ final readonly class ExtensionLoaded implements Condition
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ExtensionLoaded.php#L9)
 
+### `__construct()`
+
+```php
+public function __construct(string $extension)
+```
+
+PHPDoc:
+
+- `@throws \InvalidArgumentException`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ExtensionLoaded.php#L19)
+
 ### `isSatisfied()`
 
 ```php
@@ -460,7 +472,7 @@ final readonly class ExtensionLoaded implements Condition
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ExtensionLoaded.php#L13)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ExtensionLoaded.php#L28)
 
 ## `ExtensionMissing`
 
@@ -472,6 +484,18 @@ final readonly class ExtensionMissing implements Condition
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ExtensionMissing.php#L9)
 
+### `__construct()`
+
+```php
+public function __construct(string $extension)
+```
+
+PHPDoc:
+
+- `@throws \InvalidArgumentException`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ExtensionMissing.php#L19)
+
 ### `isSatisfied()`
 
 ```php
@@ -479,7 +503,7 @@ final readonly class ExtensionMissing implements Condition
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ExtensionMissing.php#L13)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ExtensionMissing.php#L28)
 
 ## `FunctionAvailable`
 

--- a/src/Condition/ExtensionLoaded.php
+++ b/src/Condition/ExtensionLoaded.php
@@ -8,7 +8,22 @@ use Greenlight\Core\Condition;
 
 final readonly class ExtensionLoaded implements Condition
 {
-    public function __construct(private string $extension) {}
+    /**
+     * @var non-empty-string
+     */
+    private string $extension;
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(string $extension)
+    {
+        if ($extension === '') {
+            throw new \InvalidArgumentException('Extension name MUST NOT be empty.');
+        }
+
+        $this->extension = $extension;
+    }
 
     #[\Override]
     public function isSatisfied(): bool

--- a/src/Condition/ExtensionMissing.php
+++ b/src/Condition/ExtensionMissing.php
@@ -8,7 +8,22 @@ use Greenlight\Core\Condition;
 
 final readonly class ExtensionMissing implements Condition
 {
-    public function __construct(private string $extension) {}
+    /**
+     * @var non-empty-string
+     */
+    private string $extension;
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(string $extension)
+    {
+        if ($extension === '') {
+            throw new \InvalidArgumentException('Extension name MUST NOT be empty.');
+        }
+
+        $this->extension = $extension;
+    }
 
     #[\Override]
     public function isSatisfied(): bool

--- a/tests/Unit/Condition/ExtensionConditionValidationTest.php
+++ b/tests/Unit/Condition/ExtensionConditionValidationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Condition;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Condition\ExtensionLoaded;
+use Greenlight\Condition\ExtensionMissing;
+use Greenlight\Expect\Expect;
+
+final readonly class ExtensionConditionValidationTest
+{
+    /**
+     * @param class-string<ExtensionLoaded|ExtensionMissing> $conditionClass
+     */
+    #[Test]
+    #[DataSet('extensionConditions')]
+    public function rejectsAnEmptyExtensionName(string $conditionClass): void
+    {
+        Expect::that(static fn(): ExtensionLoaded|ExtensionMissing => new $conditionClass(''))
+            ->because('an extension availability condition MUST identify the extension')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Extension name MUST NOT be empty.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{class-string<ExtensionLoaded|ExtensionMissing>}>
+     */
+    public static function extensionConditions(): iterable
+    {
+        yield 'loaded' => [ExtensionLoaded::class];
+
+        yield 'missing' => [ExtensionMissing::class];
+    }
+}


### PR DESCRIPTION
ExtensionLoaded and ExtensionMissing accepted an empty extension name and silently produced opposite answers, hiding an invalid skip condition. Reject the empty identifier at both boundaries with an exact diagnostic, cover the pair with one dataset, and update the generated condition API reference.