### PR TITLE
fix(config): reject invalid suite configurations

### DIFF
--- a/src/Config/SuiteConfiguration.php
+++ b/src/Config/SuiteConfiguration.php
@@ -8,13 +8,83 @@ namespace Greenlight\Config;
 final readonly class SuiteConfiguration
 {
     /**
-     * @param non-empty-string $name
-     * @param non-empty-list<non-empty-string> $paths
-     * @param list<non-empty-string> $tags
+     * @var non-empty-string
      */
-    public function __construct(
-        public string $name,
-        public array $paths,
-        public array $tags,
-    ) {}
+    public string $name;
+
+    /**
+     * @var non-empty-list<non-empty-string>
+     */
+    public array $paths;
+
+    /**
+     * @var list<non-empty-string>
+     */
+    public array $tags;
+
+    /**
+     * @param array<mixed> $paths
+     * @param array<mixed> $tags
+     *
+     * @throws InvalidConfiguration
+     */
+    public function __construct(string $name, array $paths, array $tags)
+    {
+        if ($name === '') {
+            throw new InvalidConfiguration('Suite names cannot be empty.');
+        }
+
+        if (!\array_is_list($paths)) {
+            throw new InvalidConfiguration(\sprintf('Suite "%s" paths must be a list.', $name));
+        }
+
+        $validatedPaths = [];
+
+        foreach ($paths as $path) {
+            if (!\is_string($path)) {
+                throw new InvalidConfiguration(\sprintf(
+                    'Suite "%s" was given a path that is not a string.',
+                    $name,
+                ));
+            }
+
+            if ($path === '') {
+                throw new InvalidConfiguration(\sprintf('Suite "%s" was given an empty path.', $name));
+            }
+
+            $validatedPaths[] = $path;
+        }
+
+        if ($validatedPaths === []) {
+            throw new InvalidConfiguration(\sprintf(
+                'Suite "%s" has no paths. Call in() with at least one directory inside its configurator.',
+                $name,
+            ));
+        }
+
+        if (!\array_is_list($tags)) {
+            throw new InvalidConfiguration(\sprintf('Suite "%s" tags must be a list.', $name));
+        }
+
+        $validatedTags = [];
+
+        foreach ($tags as $tag) {
+            if (!\is_string($tag)) {
+                throw new InvalidConfiguration(\sprintf(
+                    'Suite "%s" was given a tag that is not a string.',
+                    $name,
+                ));
+            }
+
+            if ($tag === '') {
+                throw new InvalidConfiguration(\sprintf('Suite "%s" was given an empty tag.', $name));
+            }
+
+            $validatedTags[] = $tag;
+        }
+
+        $this->name = $name;
+        $this->paths = $validatedPaths;
+        $this->tags = $validatedTags;
+    }
 }

--- a/tests/Unit/Config/SuiteConfigurationTest.php
+++ b/tests/Unit/Config/SuiteConfigurationTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Config;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Config\InvalidConfiguration;
+use Greenlight\Config\SuiteConfiguration;
+use Greenlight\Expect\Expect;
+
+final class SuiteConfigurationTest
+{
+    /**
+     * @param array<mixed> $paths
+     * @param array<mixed> $tags
+     */
+    #[Test]
+    #[DataSet('invalidSuites')]
+    public function rejectsAnInvalidSuite(
+        string $name,
+        array $paths,
+        array $tags,
+        string $message,
+    ): void {
+        Expect::that(static fn(): SuiteConfiguration => new SuiteConfiguration($name, $paths, $tags))
+            ->because('a suite configuration MUST satisfy its documented value domains')
+            ->toThrow(InvalidConfiguration::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{string, array<mixed>, array<mixed>, string}>
+     */
+    public static function invalidSuites(): iterable
+    {
+        yield 'empty name' => [
+            '',
+            ['tests'],
+            [],
+            'Suite names cannot be empty.',
+        ];
+        yield 'paths are not a list' => [
+            'unit',
+            ['source' => 'tests'],
+            [],
+            'Suite "unit" paths must be a list.',
+        ];
+        yield 'path is not a string' => [
+            'unit',
+            [42],
+            [],
+            'Suite "unit" was given a path that is not a string.',
+        ];
+        yield 'empty path' => [
+            'unit',
+            [''],
+            [],
+            'Suite "unit" was given an empty path.',
+        ];
+        yield 'no paths' => [
+            'unit',
+            [],
+            [],
+            'Suite "unit" has no paths. Call in() with at least one directory inside its configurator.',
+        ];
+        yield 'tags are not a list' => [
+            'unit',
+            ['tests'],
+            ['kind' => 'fast'],
+            'Suite "unit" tags must be a list.',
+        ];
+        yield 'tag is not a string' => [
+            'unit',
+            ['tests'],
+            [42],
+            'Suite "unit" was given a tag that is not a string.',
+        ];
+        yield 'empty tag' => [
+            'unit',
+            ['tests'],
+            [''],
+            'Suite "unit" was given an empty tag.',
+        ];
+    }
+}


### PR DESCRIPTION
SuiteConfiguration documents a non-empty name, a non-empty list of non-empty paths, and a list of non-empty tags, but direct construction did not enforce those domains. Validate the complete value-object boundary while retaining the builder diagnostics for empty values.