### PR TITLE
fix(conditions): reject empty environment names

### DIFF
--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -422,7 +422,7 @@ final readonly class EnvironmentVariableEquals implements Condition
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableEquals.php#L13)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableEquals.php#L28)
 
 ## `EnvironmentVariableSet`
 
@@ -434,6 +434,18 @@ final readonly class EnvironmentVariableSet implements Condition
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableSet.php#L9)
 
+### `__construct()`
+
+```php
+public function __construct(string $name)
+```
+
+PHPDoc:
+
+- `@throws \InvalidArgumentException`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableSet.php#L19)
+
 ### `isSatisfied()`
 
 ```php
@@ -441,7 +453,7 @@ final readonly class EnvironmentVariableSet implements Condition
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableSet.php#L13)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableSet.php#L28)
 
 ## `ExtensionLoaded`
 

--- a/src/Condition/EnvironmentVariableEquals.php
+++ b/src/Condition/EnvironmentVariableEquals.php
@@ -8,7 +8,22 @@ use Greenlight\Core\Condition;
 
 final readonly class EnvironmentVariableEquals implements Condition
 {
-    public function __construct(private string $name, private string $value) {}
+    /**
+     * @var non-empty-string
+     */
+    private string $name;
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(string $name, private string $value)
+    {
+        if ($name === '') {
+            throw new \InvalidArgumentException('Environment variable name MUST NOT be empty.');
+        }
+
+        $this->name = $name;
+    }
 
     #[\Override]
     public function isSatisfied(): bool

--- a/src/Condition/EnvironmentVariableSet.php
+++ b/src/Condition/EnvironmentVariableSet.php
@@ -8,7 +8,22 @@ use Greenlight\Core\Condition;
 
 final readonly class EnvironmentVariableSet implements Condition
 {
-    public function __construct(private string $name) {}
+    /**
+     * @var non-empty-string
+     */
+    private string $name;
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(string $name)
+    {
+        if ($name === '') {
+            throw new \InvalidArgumentException('Environment variable name MUST NOT be empty.');
+        }
+
+        $this->name = $name;
+    }
 
     #[\Override]
     public function isSatisfied(): bool

--- a/tests/Unit/Condition/EnvironmentVariableConditionValidationTest.php
+++ b/tests/Unit/Condition/EnvironmentVariableConditionValidationTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Condition;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Condition\EnvironmentVariableEquals;
+use Greenlight\Condition\EnvironmentVariableSet;
+use Greenlight\Expect\Expect;
+
+final readonly class EnvironmentVariableConditionValidationTest
+{
+    #[Test]
+    public function rejectsAnEmptyEnvironmentVariableName(): void
+    {
+        Expect::that(static fn(): EnvironmentVariableSet => new EnvironmentVariableSet(''))
+            ->because('a presence condition MUST identify the environment variable')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Environment variable name MUST NOT be empty.',
+            )
+            ->and(static fn(): EnvironmentVariableEquals => new EnvironmentVariableEquals('', 'value'))
+            ->because('an equality condition MUST identify the environment variable')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Environment variable name MUST NOT be empty.',
+            );
+    }
+}


### PR DESCRIPTION
EnvironmentVariableSet and EnvironmentVariableEquals accepted an empty variable name and silently evaluated it as absent, which could hide an invalid skip condition. Reject the empty identifier at both public boundaries with an exact diagnostic, cover both paths directly, and update the generated condition API reference.