### PR TITLE
fix(attributes): reject empty data-set providers

### DIFF
--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -134,10 +134,9 @@ public function __construct(string $provider, ?string $method = null)
 
 PHPDoc:
 
-- `@param non-empty-string $provider`
-- `@param non-empty-string|null $method`
+- `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataSet.php#L32)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataSet.php#L31)
 
 ## `Group`
 

--- a/src/Attribute/DataSet.php
+++ b/src/Attribute/DataSet.php
@@ -26,11 +26,14 @@ final readonly class DataSet
      * arguments, it names the provider class and `$method` names the provider
      * method.
      *
-     * @param non-empty-string $provider
-     * @param non-empty-string|null $method
+     * @throws \InvalidArgumentException
      */
     public function __construct(string $provider, ?string $method = null)
     {
+        if ($provider === '' || $method === '') {
+            throw new \InvalidArgumentException('Data-set provider names cannot be empty.');
+        }
+
         $this->provider = $method ?? $provider;
         $this->providerClass = $method === null ? null : $provider;
     }

--- a/tests/Unit/Attribute/AttributeContractTest.php
+++ b/tests/Unit/Attribute/AttributeContractTest.php
@@ -51,6 +51,28 @@ final class AttributeContractTest
     }
 
     #[Test]
+    #[DataSet('emptyDataSetProviderNames')]
+    public function dataSetRejectsEmptyProviderNames(string $provider, ?string $method): void
+    {
+        Expect::that(static fn(): DataSet => new DataSet($provider, $method))
+            ->because('a data-set provider name MUST NOT be empty')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Data-set provider names cannot be empty.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{string, string|null}>
+     */
+    public static function emptyDataSetProviderNames(): iterable
+    {
+        yield 'local provider' => ['', null];
+        yield 'external provider class' => ['', 'rows'];
+        yield 'external provider method' => [self::class, ''];
+    }
+
+    #[Test]
     public function methodOrClassAttributesTargetBoth(): void
     {
         foreach ([Skip::class, SkipUnless::class, Retry::class, Timeout::class, Isolated::class] as $attribute) {


### PR DESCRIPTION
DataSet stores provider names as non-empty strings, but its public constructor accepted empty local names, external class names, and external method names. Reject each invalid form at the attribute boundary with one exact diagnostic.