### PR TITLE
test(reporting): cover skewed worker profiles

### DIFF
--- a/tests/Unit/Reporting/WorkerProfileTest.php
+++ b/tests/Unit/Reporting/WorkerProfileTest.php
@@ -23,4 +23,40 @@ final class WorkerProfileTest
             ->and($profile->utilizationPercent())
             ->toBeNull();
     }
+
+    #[Test]
+    public function clockSkewKeepsProfileMetricsBounded(): void
+    {
+        $profile = new WorkerProfile();
+        $profile->spawned(100.0);
+        $profile->classStarted(90.0);
+        $profile->classFinished(110.0);
+
+        Expect::that($profile->bootLatency())
+            ->because('worker clock skew MUST NOT produce negative boot latency')
+            ->toBe(0.0)
+            ->and($profile->window())
+            ->toBe(10.0)
+            ->and($profile->utilizationPercent())
+            ->because('worker utilization MUST stay within its percentage range')
+            ->toBe(100);
+    }
+
+    #[Test]
+    public function reversedClassTimestampsDoNotProduceNegativeMetrics(): void
+    {
+        $profile = new WorkerProfile();
+        $profile->spawned(20.0);
+        $profile->classStarted(15.0);
+        $profile->classFinished(14.0);
+
+        Expect::that($profile->busy)
+            ->because('a reversed class timestamp MUST NOT produce negative busy time')
+            ->toBe(0.0)
+            ->and($profile->window())
+            ->because('a reversed worker period MUST NOT produce a negative window')
+            ->toBe(0.0)
+            ->and($profile->utilizationPercent())
+            ->toBeNull();
+    }
 }


### PR DESCRIPTION
Cover worker-profile behavior when deterministic event timestamps reflect clock skew or reversed class boundaries. The tests protect non-negative boot, busy, and window metrics, and ensure utilization remains within 100%.