### PR TITLE
fix(conditions): reject empty PHP versions

### DIFF
--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -531,6 +531,18 @@ final readonly class PhpVersionAtLeast implements Condition
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/PhpVersionAtLeast.php#L9)
 
+### `__construct()`
+
+```php
+public function __construct(string $version)
+```
+
+PHPDoc:
+
+- `@throws \InvalidArgumentException`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/PhpVersionAtLeast.php#L19)
+
 ### `isSatisfied()`
 
 ```php
@@ -538,7 +550,7 @@ final readonly class PhpVersionAtLeast implements Condition
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/PhpVersionAtLeast.php#L13)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/PhpVersionAtLeast.php#L28)
 
 ## `PhpVersionLessThan`
 
@@ -550,6 +562,18 @@ final readonly class PhpVersionLessThan implements Condition
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/PhpVersionLessThan.php#L9)
 
+### `__construct()`
+
+```php
+public function __construct(string $version)
+```
+
+PHPDoc:
+
+- `@throws \InvalidArgumentException`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/PhpVersionLessThan.php#L19)
+
 ### `isSatisfied()`
 
 ```php
@@ -557,4 +581,4 @@ final readonly class PhpVersionLessThan implements Condition
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/PhpVersionLessThan.php#L13)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/PhpVersionLessThan.php#L28)

--- a/src/Condition/PhpVersionAtLeast.php
+++ b/src/Condition/PhpVersionAtLeast.php
@@ -8,7 +8,22 @@ use Greenlight\Core\Condition;
 
 final readonly class PhpVersionAtLeast implements Condition
 {
-    public function __construct(private string $version) {}
+    /**
+     * @var non-empty-string
+     */
+    private string $version;
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(string $version)
+    {
+        if ($version === '') {
+            throw new \InvalidArgumentException('PHP version MUST NOT be empty.');
+        }
+
+        $this->version = $version;
+    }
 
     #[\Override]
     public function isSatisfied(): bool

--- a/src/Condition/PhpVersionLessThan.php
+++ b/src/Condition/PhpVersionLessThan.php
@@ -8,7 +8,22 @@ use Greenlight\Core\Condition;
 
 final readonly class PhpVersionLessThan implements Condition
 {
-    public function __construct(private string $version) {}
+    /**
+     * @var non-empty-string
+     */
+    private string $version;
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(string $version)
+    {
+        if ($version === '') {
+            throw new \InvalidArgumentException('PHP version MUST NOT be empty.');
+        }
+
+        $this->version = $version;
+    }
 
     #[\Override]
     public function isSatisfied(): bool

--- a/tests/Unit/Condition/PhpVersionConditionValidationTest.php
+++ b/tests/Unit/Condition/PhpVersionConditionValidationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Condition;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Condition\PhpVersionAtLeast;
+use Greenlight\Condition\PhpVersionLessThan;
+use Greenlight\Core\Condition;
+use Greenlight\Expect\Expect;
+
+final readonly class PhpVersionConditionValidationTest
+{
+    /**
+     * @param \Closure(): Condition $create
+     */
+    #[Test]
+    #[DataSet('emptyVersionConditions')]
+    public function rejectsAnEmptyPhpVersion(\Closure $create): void
+    {
+        Expect::that($create)
+            ->because('a PHP version condition MUST identify its comparison version')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'PHP version MUST NOT be empty.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{\Closure(): Condition}>
+     */
+    public static function emptyVersionConditions(): iterable
+    {
+        yield 'at least' => [static fn(): PhpVersionAtLeast => new PhpVersionAtLeast('')];
+        yield 'less than' => [static fn(): PhpVersionLessThan => new PhpVersionLessThan('')];
+    }
+}


### PR DESCRIPTION
The PHP version conditions accepted an empty comparison version. PHP treats that value as older than every real version, so an invalid at-least condition silently passed and could run unsupported tests. Reject the empty version at both public boundaries with an exact diagnostic, cover both condition variants through a data set, and update the generated API reference.