### PR TITLE
fix(conditions): reject empty operating system families

### DIFF
--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -512,6 +512,18 @@ final readonly class OperatingSystemFamily implements Condition
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/OperatingSystemFamily.php#L10)
 
+### `__construct()`
+
+```php
+public function __construct(string $family)
+```
+
+PHPDoc:
+
+- `@throws \InvalidArgumentException`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/OperatingSystemFamily.php#L20)
+
 ### `isSatisfied()`
 
 ```php
@@ -519,7 +531,7 @@ final readonly class OperatingSystemFamily implements Condition
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/OperatingSystemFamily.php#L14)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/OperatingSystemFamily.php#L29)
 
 ## `PhpVersionAtLeast`
 

--- a/src/Condition/OperatingSystemFamily.php
+++ b/src/Condition/OperatingSystemFamily.php
@@ -9,7 +9,22 @@ use Greenlight\Core\Condition;
 /** Compares the value to `PHP_OS_FAMILY` without case sensitivity. */
 final readonly class OperatingSystemFamily implements Condition
 {
-    public function __construct(private string $family) {}
+    /**
+     * @var non-empty-string
+     */
+    private string $family;
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(string $family)
+    {
+        if ($family === '') {
+            throw new \InvalidArgumentException('Operating system family MUST NOT be empty.');
+        }
+
+        $this->family = $family;
+    }
 
     #[\Override]
     public function isSatisfied(): bool

--- a/tests/Unit/Condition/OperatingSystemFamilyValidationTest.php
+++ b/tests/Unit/Condition/OperatingSystemFamilyValidationTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Condition;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Condition\OperatingSystemFamily;
+use Greenlight\Expect\Expect;
+
+final readonly class OperatingSystemFamilyValidationTest
+{
+    #[Test]
+    public function rejectsAnEmptyFamily(): void
+    {
+        Expect::that(static fn(): OperatingSystemFamily => new OperatingSystemFamily(''))
+            ->because('an operating-system condition MUST identify the family')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Operating system family MUST NOT be empty.',
+            );
+    }
+}


### PR DESCRIPTION
OperatingSystemFamily accepted an empty name and silently made the condition false on every platform. Enforce non-empty internal state at direct construction and cover the exact failure.