### PR TITLE
test(coverage): cover driver preference order

### DIFF
--- a/tests/Unit/Coverage/DriverSelectorTest.php
+++ b/tests/Unit/Coverage/DriverSelectorTest.php
@@ -9,6 +9,7 @@ use Greenlight\Coverage\Driver\CoverageDriver;
 use Greenlight\Coverage\Driver\DriverSelector;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\Coverage\AvailableFakeDriver;
+use Greenlight\Tests\Fixture\Coverage\RecordingFakeDriver;
 use Greenlight\Tests\Fixture\Coverage\UnavailableFakeDriver;
 
 final class DriverSelectorTest
@@ -29,6 +30,18 @@ final class DriverSelectorTest
 
         Expect::that($selection->driver)->because('an available candidate is selected with no reason')->toBeInstanceOf(AvailableFakeDriver::class)
             ->and($selection->reason)->toBeNull();
+    }
+
+    #[Test]
+    public function firstAvailableCandidateWins(): void
+    {
+        $selection = new DriverSelector([RecordingFakeDriver::class, AvailableFakeDriver::class])->select();
+
+        Expect::that($selection->driver)
+            ->because('candidate order determines coverage-driver preference')
+            ->toBeInstanceOf(RecordingFakeDriver::class)
+            ->and($selection->reason)
+            ->toBeNull();
     }
 
     #[Test]


### PR DESCRIPTION
Cover the ordered coverage-driver selection contract with two deterministic available fakes. This protects the first-match preference that keeps PCOV ahead of Xdebug when both configured candidates are available.