### PR TITLE
fix(harness): reject empty service definitions

### DIFF
--- a/docs/api-fixtures-harness.md
+++ b/docs/api-fixtures-harness.md
@@ -170,11 +170,23 @@ final readonly class ServiceDefinition
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceDefinition.php#L11)
 
+### `$type`
+
+```php
+public string $type;
+```
+
+PHPDoc:
+
+- `@var class-string`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceDefinition.php#L16)
+
 ### `__construct()`
 
 ```php
 public function __construct(
-    public string $type,
+    string $type,
     public Scope $scope,
     public \Closure $factory,
 )
@@ -183,10 +195,11 @@ public function __construct(
 PHPDoc:
 
 - `@template T of object`
-- `@param class-string<T> $type`
+- `@param class-string<T>|'' $type`
 - `@param \Closure(): T $factory`
+- `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceDefinition.php#L19)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceDefinition.php#L26)
 
 ## `ServiceResolver`
 

--- a/src/Harness/ServiceDefinition.php
+++ b/src/Harness/ServiceDefinition.php
@@ -11,14 +11,27 @@ namespace Greenlight\Harness;
 final readonly class ServiceDefinition
 {
     /**
+     * @var class-string
+     */
+    public string $type;
+
+    /**
      * @template T of object
      *
-     * @param class-string<T> $type
+     * @param class-string<T>|'' $type
      * @param \Closure(): T $factory
+     *
+     * @throws \InvalidArgumentException
      */
     public function __construct(
-        public string $type,
+        string $type,
         public Scope $scope,
         public \Closure $factory,
-    ) {}
+    ) {
+        if ($type === '') {
+            throw new \InvalidArgumentException('Harness service type MUST NOT be empty.');
+        }
+
+        $this->type = $type;
+    }
 }

--- a/tests/Unit/Harness/ServiceDefinitionValidationTest.php
+++ b/tests/Unit/Harness/ServiceDefinitionValidationTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Harness;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Harness\Scope;
+use Greenlight\Harness\ServiceDefinition;
+
+final readonly class ServiceDefinitionValidationTest
+{
+    #[Test]
+    public function rejectsAnEmptyServiceType(): void
+    {
+        Expect::that(static fn(): ServiceDefinition => new ServiceDefinition(
+            '',
+            Scope::PerTest,
+            static fn(): \stdClass => new \stdClass(),
+        ))
+            ->because('a harness service definition MUST identify its injected type')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Harness service type MUST NOT be empty.',
+            );
+    }
+}


### PR DESCRIPTION
ServiceDefinition accepted an empty injected type and allowed it into the harness registry, deferring the invalid configuration until service resolution. Reject the empty type at the public definition boundary with an exact diagnostic, cover the failure directly, and update the generated harness API reference.