### PR TITLE
test(expect): cover diagnostic string escapes

### DIFF
--- a/tests/Unit/Expect/ValueRendererTest.php
+++ b/tests/Unit/Expect/ValueRendererTest.php
@@ -34,7 +34,11 @@ final class ValueRendererTest
     #[Test]
     public function escapesControlCharactersInStrings(): void
     {
-        Expect::that(new ValueRenderer()->render("a\nb\tc"))->because('escapes control characters in strings')->toBe("'a\\nb\\tc'");
+        $rendered = new ValueRenderer()->render("backslash\\ newline\ncarriage\r tab\t nul\0");
+
+        Expect::that($rendered)
+            ->because('diagnostic strings escape every control character onto one line')
+            ->toBe("'backslash\\\\ newline\\ncarriage\\r tab\\t nul\\0'");
     }
 
     #[Test]


### PR DESCRIPTION
Cover every diagnostic-string escape in one exact public rendering assertion. The test protects backslash, line-feed, carriage-return, tab, and NUL output so failure values remain single-line and unambiguous.