### PR TITLE
test(phpstan): cover mixed plugin configurations

### DIFF
--- a/tests/Fixture/PhpStanExtensionMixed/greenlight.php
+++ b/tests/Fixture/PhpStanExtensionMixed/greenlight.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Tests\Fixture\PhpStanExtension\DigestExtension;
+use Greenlight\Tests\Fixture\Plugins\FakeCapabilityPlugin;
+
+return GreenlightConfig::create()
+    ->paths([__DIR__ . '/../DiscoveryBasic'])
+    ->plugins(
+        new FakeCapabilityPlugin(),
+        new DigestExtension(),
+    );

--- a/tests/Unit/PhpStan/MatcherMapPluginFilteringTest.php
+++ b/tests/Unit/PhpStan/MatcherMapPluginFilteringTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\PhpStan;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\PhpStan\MatcherMap;
+
+final class MatcherMapPluginFilteringTest
+{
+    private const string CONFIG = __DIR__ . '/../../Fixture/PhpStanExtensionMixed/greenlight.php';
+
+    #[Test]
+    public function ignoresPluginsThatDoNotProvideExpectationMatchers(): void
+    {
+        $map = MatcherMap::fromConfigFiles([self::CONFIG]);
+
+        Expect::that($map->names())
+            ->because('matcher discovery MUST ignore plugins that do not provide expectation matchers')
+            ->toBe([
+                'toBeHexadecimal',
+                'toHaveDigestLength',
+                'toBePositive',
+            ])
+            ->and($map->has('toHaveDigestLength'))
+            ->because('matcher discovery MUST retain expectation extensions from a mixed plugin configuration')
+            ->toBeTrue();
+    }
+}


### PR DESCRIPTION
Cover matcher discovery through a real configuration containing both an ordinary Greenlight plugin and an expectation extension. Assert that non-extension plugins are ignored while the extension matcher set remains intact.