### PR TITLE
fix(reporting): exclude threshold-duration tests

### DIFF
--- a/src/Reporting/SlowTests.php
+++ b/src/Reporting/SlowTests.php
@@ -37,7 +37,7 @@ final class SlowTests
 
     public function record(TestFinished $event): void
     {
-        if ($event->result->durationSeconds < self::THRESHOLD_SECONDS) {
+        if ($event->result->durationSeconds <= self::THRESHOLD_SECONDS) {
             return;
         }
 

--- a/tests/Unit/Reporting/SlowTestsThresholdTest.php
+++ b/tests/Unit/Reporting/SlowTestsThresholdTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\TestFinished;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\SlowTests;
+use Greenlight\Reporting\Style;
+
+final class SlowTestsThresholdTest
+{
+    #[Test]
+    public function rendersOnlyTestsAboveTheHalfSecondThreshold(): void
+    {
+        $slow = new SlowTests();
+        $slow->record($this->finished('exactlyAtThreshold', 0.500));
+        $slow->record($this->finished('aboveThreshold', 0.501));
+
+        Expect::that($slow->render(new Style(ansi: false)))
+            ->because('the slow-test block MUST contain only tests above the half-second threshold')
+            ->toBe("\nSlowest tests:\n  0.501s Acme\\SlowTest::aboveThreshold\n");
+    }
+
+    /**
+     * @param non-empty-string $method
+     */
+    private function finished(string $method, float $duration): TestFinished
+    {
+        return new TestFinished(
+            new TestResult(
+                new TestId('Acme\\SlowTest', $method),
+                Outcome::Passed,
+                $duration,
+                0,
+            ),
+            1.0,
+        );
+    }
+}


### PR DESCRIPTION
Align the slow-test collector with its documented contract by listing only tests above the half-second threshold. Add exact canned-duration coverage for the 0.500-second boundary and the first displayed millisecond above it.