### PR TITLE
test(coverage): cover unusable raw entries

### DIFF
--- a/tests/Unit/Coverage/CoverageMapTest.php
+++ b/tests/Unit/Coverage/CoverageMapTest.php
@@ -64,6 +64,23 @@ final class CoverageMapTest
     }
 
     #[Test]
+    public function fromRawDropsUnusableDriverEntries(): void
+    {
+        $map = CoverageMap::fromRaw(new RawCoverage([
+            '' => [1 => 1],
+            '/src/A.php' => [1 => 0, 2 => -2, 3 => 1, 4 => -1],
+        ]));
+
+        Expect::that($map->toWire())
+            ->because('raw coverage MUST keep only usable paths and documented driver statuses')
+            ->toBe([
+                'files' => [
+                    '/src/A.php' => [[3], [4]],
+                ],
+            ]);
+    }
+
+    #[Test]
     public function filesAreSortedByPath(): void
     {
         $map = new CoverageMap([


### PR DESCRIPTION
Cover selective normalization of raw coverage-driver output. Empty file paths and undocumented statuses are discarded while valid covered and uncovered lines from the same payload survive exactly.