### PR TITLE
test(core): cover decimal integer boundaries

### DIFF
--- a/tests/Unit/Core/DecimalIntegerTest.php
+++ b/tests/Unit/Core/DecimalIntegerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\DecimalInteger;
+use Greenlight\Expect\Expect;
+
+final class DecimalIntegerTest
+{
+    #[Test]
+    #[DataSet('decimalText')]
+    public function parsesOnlyRepresentableNonnegativeDecimalText(string $raw, ?int $expected): void
+    {
+        Expect::that(DecimalInteger::parse($raw))
+            ->because('decimal integer parsing MUST accept every representable value without overflow')
+            ->toBe($expected);
+    }
+
+    /**
+     * @return iterable<string, array{string, int|null}>
+     */
+    public static function decimalText(): iterable
+    {
+        yield 'zero' => ['0', 0];
+        yield 'zero padded' => ['0000', 0];
+        yield 'machine maximum' => [(string) \PHP_INT_MAX, \PHP_INT_MAX];
+        yield 'padded machine maximum' => ['000' . \PHP_INT_MAX, \PHP_INT_MAX];
+        yield 'overflow' => [\PHP_INT_MAX . '0', null];
+        yield 'negative' => ['-1', null];
+        yield 'fraction' => ['1.0', null];
+        yield 'empty' => ['', null];
+    }
+}


### PR DESCRIPTION
Cover the shared overflow-safe decimal parser with exact machine bounds, padded forms, overflow, and malformed values. This pins acceptance of every representable nonnegative integer while rejecting unsafe input.