### PR TITLE
test(cli): cover fish short option aliases

### DIFF
--- a/tests/Unit/Cli/CompletionScriptsTest.php
+++ b/tests/Unit/Cli/CompletionScriptsTest.php
@@ -94,6 +94,14 @@ final class CompletionScriptsTest
     }
 
     #[Test]
+    public function fishPreservesShortAliasesFromTheOptionSpecifications(): void
+    {
+        Expect::that($this->scripts()->render('fish'))
+            ->because('fish completion MUST include each configured short option alias')
+            ->toContain('complete -c greenlight -l help -s h');
+    }
+
+    #[Test]
     public function returnsNullForAnUnknownShell(): void
     {
         Expect::that($this->scripts()->render('powershell'))->because('returns null for an unknown shell')->toBeNull();


### PR DESCRIPTION
Covers the fish completion branch that emits short aliases from option specifications. This protects configured aliases such as `-h` from silently disappearing while long-option completion still renders.