### PR TITLE
fix(expect): escape rendered string delimiters

### DIFF
--- a/src/Expect/ValueRenderer.php
+++ b/src/Expect/ValueRenderer.php
@@ -89,6 +89,7 @@ final class ValueRenderer
     {
         $printable = \strtr($value, [
             '\\' => '\\\\',
+            "'" => "\\'",
             "\n" => '\n',
             "\r" => '\r',
             "\t" => '\t',

--- a/tests/Unit/Expect/ValueRendererTest.php
+++ b/tests/Unit/Expect/ValueRendererTest.php
@@ -42,6 +42,14 @@ final class ValueRendererTest
     }
 
     #[Test]
+    public function escapesTheStringDelimiter(): void
+    {
+        Expect::that(new ValueRenderer()->render("can't"))
+            ->because('rendered string delimiters MUST remain unambiguous')
+            ->toBe("'can\\'t'");
+    }
+
+    #[Test]
     public function truncatesLongStrings(): void
     {
         $rendered = new ValueRenderer()->render(\str_repeat('x', 500));


### PR DESCRIPTION
Escapes embedded single quotes in rendered string values. Failure diagnostics now keep their single-quote delimiters unambiguous for values such as contractions.