### PR TITLE
test(core): cover every summary outcome

### DIFF
--- a/tests/Unit/Core/ResultSummaryOutcomeTest.php
+++ b/tests/Unit/Core/ResultSummaryOutcomeTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\ResultSummary;
+use Greenlight\Expect\Expect;
+
+final class ResultSummaryOutcomeTest
+{
+    /**
+     * @param array{passed: int, failed: int, errored: int, skipped: int} $expected
+     */
+    #[Test]
+    #[DataSet('outcomes')]
+    public function addIncrementsOnlyTheSelectedOutcome(Outcome $outcome, array $expected): void
+    {
+        $original = new ResultSummary(passed: 1, failed: 2, errored: 3, skipped: 4);
+
+        Expect::that($original->add($outcome)->toWire())
+            ->because('adding an outcome MUST increment only its matching summary count')
+            ->toBe($expected)
+            ->and($original->toWire())
+            ->because('adding an outcome MUST leave the original summary unchanged')
+            ->toBe([
+                'passed' => 1,
+                'failed' => 2,
+                'errored' => 3,
+                'skipped' => 4,
+            ]);
+    }
+
+    /**
+     * @return iterable<string, array{Outcome, array{passed: int, failed: int, errored: int, skipped: int}}>
+     */
+    public static function outcomes(): iterable
+    {
+        yield 'passed' => [
+            Outcome::Passed,
+            ['passed' => 2, 'failed' => 2, 'errored' => 3, 'skipped' => 4],
+        ];
+        yield 'failed' => [
+            Outcome::Failed,
+            ['passed' => 1, 'failed' => 3, 'errored' => 3, 'skipped' => 4],
+        ];
+        yield 'errored' => [
+            Outcome::Errored,
+            ['passed' => 1, 'failed' => 2, 'errored' => 4, 'skipped' => 4],
+        ];
+        yield 'skipped' => [
+            Outcome::Skipped,
+            ['passed' => 1, 'failed' => 2, 'errored' => 3, 'skipped' => 5],
+        ];
+    }
+}


### PR DESCRIPTION
Covers exact immutable ResultSummary accounting for every outcome. In particular, it prevents errored tests from being silently counted as failures while totals still appear plausible.