### PR TITLE
test(runner): cover shard seed preservation

### DIFF
--- a/tests/Unit/Runner/PlanShardSeedTest.php
+++ b/tests/Unit/Runner/PlanShardSeedTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Discovery\ExecutionPlan;
+use Greenlight\Discovery\PlanEntry;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\PlanShard;
+
+final class PlanShardSeedTest
+{
+    #[Test]
+    public function selectingAShardPreservesThePlanSeed(): void
+    {
+        $plan = new ExecutionPlan([
+            new PlanEntry(
+                new TestId('Acme\\PaymentTest', 'charges'),
+                new TestMetadata('Acme\\PaymentTest', 'charges'),
+            ),
+        ], seed: 86420);
+
+        Expect::that(PlanShard::select($plan, index: 1, count: 2)->seed)
+            ->because('each shard MUST preserve the seed that defines its plan order')
+            ->toBe(86420);
+    }
+}


### PR DESCRIPTION
Covers the multi-shard path preserving the execution-plan seed. This protects reproducible plan ordering when CI partitions a seeded run.