### PR TITLE
test(harness): cover disposal failure continuation

### DIFF
--- a/tests/Fixture/Harness/RecordingDisposable.php
+++ b/tests/Fixture/Harness/RecordingDisposable.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Harness;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Harness\Disposable;
+
+final class RecordingDisposable implements Disposable, Fake
+{
+    private static int $disposals = 0;
+
+    public function initialize(): void {}
+
+    #[\Override]
+    public function dispose(): void
+    {
+        ++self::$disposals;
+    }
+
+    public static function reset(): void
+    {
+        self::$disposals = 0;
+    }
+
+    public static function disposals(): int
+    {
+        return self::$disposals;
+    }
+}

--- a/tests/Unit/Harness/ScopeContainerFailureContinuationTest.php
+++ b/tests/Unit/Harness/ScopeContainerFailureContinuationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Harness;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Harness\Scope;
+use Greenlight\Harness\ScopeContainer;
+use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Tests\Fixture\Harness\FailingDisposable;
+use Greenlight\Tests\Fixture\Harness\RecordingDisposable;
+
+final class ScopeContainerFailureContinuationTest
+{
+    #[Test]
+    public function disposalContinuesAfterAServiceThrows(): void
+    {
+        FailingDisposable::reset();
+        RecordingDisposable::reset();
+        $container = new ScopeContainer();
+        $recording = $container->get(new ServiceDefinition(
+            RecordingDisposable::class,
+            Scope::PerTest,
+            static fn(): RecordingDisposable => new RecordingDisposable(),
+        ));
+        $failing = $container->get(new ServiceDefinition(
+            FailingDisposable::class,
+            Scope::PerTest,
+            static fn(): FailingDisposable => new FailingDisposable(),
+        ));
+
+        if (!$recording instanceof RecordingDisposable || !$failing instanceof FailingDisposable) {
+            Fail::because('Expected ScopeContainer to resolve both disposable fixture types.');
+        }
+
+        $recording->initialize();
+        $failing->initialize();
+
+        $failures = $container->dispose();
+
+        Expect::that($failures)
+            ->because('a disposal failure MUST NOT prevent disposal of the remaining services')
+            ->toHaveCount(1)
+            ->and($failures[0]->getMessage())
+            ->toBe('disposal broke')
+            ->and(FailingDisposable::disposals())
+            ->toBe(1)
+            ->and(RecordingDisposable::disposals())
+            ->toBe(1);
+    }
+}


### PR DESCRIPTION
Verify that a service disposal failure does not prevent remaining constructed services from being disposed. The test fixture implements the Fake marker so Greenlight identifies it as test-only infrastructure.