### PR TITLE
test(runner): cover worker count budget boundaries

### DIFF
--- a/tests/Unit/Runner/Worker/WorkerBudgetTest.php
+++ b/tests/Unit/Runner/Worker/WorkerBudgetTest.php
@@ -12,6 +12,26 @@ use Greenlight\Runner\Worker\WorkerBudget;
 final readonly class WorkerBudgetTest
 {
     #[Test]
+    public function countBudgetExhaustionUsesAnInclusiveBoundary(): void
+    {
+        $disabled = new WorkerBudget();
+        $limited = new WorkerBudget(maxTests: 3);
+
+        Expect::that($disabled->exhaustedByCount(\PHP_INT_MAX))
+            ->because('an unset test-count budget MUST remain disabled')
+            ->toBeFalse()
+            ->and($limited->exhaustedByCount(2))
+            ->because('the worker MUST continue below its test-count budget')
+            ->toBeFalse()
+            ->and($limited->exhaustedByCount(3))
+            ->because('the worker MUST recycle when it reaches its test-count budget')
+            ->toBeTrue()
+            ->and($limited->exhaustedByCount(4))
+            ->because('the test-count budget MUST remain exhausted above its boundary')
+            ->toBeTrue();
+    }
+
+    #[Test]
     #[DataSet('invalidBudgets')]
     public function rejectsInvalidBudgets(?int $maxTests, ?int $maxMemoryBytes, string $message): void
     {


### PR DESCRIPTION
Pin disabled, below-limit, exact-limit, and above-limit behavior for worker test-count budgets. This protects the inclusive recycling boundary without timing or environment dependence.