### PR TITLE
fix(protocol): reject JSON list envelopes

### DIFF
--- a/src/Runner/Protocol/JsonFrameCodec.php
+++ b/src/Runner/Protocol/JsonFrameCodec.php
@@ -46,8 +46,12 @@ final readonly class JsonFrameCodec implements FrameCodec
             throw ProtocolError::malformedFrame('body is not valid JSON: ' . $e->getMessage());
         }
 
-        if (!\is_array($decoded)) {
-            throw ProtocolError::malformedFrame('body decodes to ' . \get_debug_type($decoded) . ', not a map');
+        if (!\is_array($decoded)
+            || (\array_is_list($decoded) && !\str_starts_with(\ltrim($body), '{'))
+        ) {
+            $type = \is_array($decoded) ? 'list' : \get_debug_type($decoded);
+
+            throw ProtocolError::malformedFrame('body decodes to ' . $type . ', not a map');
         }
 
         $envelope = [];

--- a/tests/Unit/Runner/Protocol/JsonFrameCodecTest.php
+++ b/tests/Unit/Runner/Protocol/JsonFrameCodecTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Runner\Protocol;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
@@ -92,5 +93,39 @@ final class JsonFrameCodecTest
                 ProtocolError::class,
                 message: 'Malformed frame: body decodes to null, not a map.',
             );
+    }
+
+    /**
+     * @param non-empty-string $body
+     */
+    #[Test]
+    #[DataSet('jsonLists')]
+    public function jsonListBodyProducesAProtocolError(string $body): void
+    {
+        $codec = new JsonFrameCodec();
+
+        Expect::that(static fn(): array => $codec->decode($body))
+            ->because('a JSON list is not a protocol envelope map')
+            ->toThrow(
+                ProtocolError::class,
+                message: 'Malformed frame: body decodes to list, not a map.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function jsonLists(): iterable
+    {
+        yield 'empty list' => ['[]'];
+        yield 'non-empty list' => ['[{"v":1,"t":"ready","p":[]}]'];
+    }
+
+    #[Test]
+    public function emptyJsonObjectRemainsAValidMap(): void
+    {
+        Expect::that(new JsonFrameCodec()->decode('{}'))
+            ->because('an empty JSON object is still a protocol map')
+            ->toBe([]);
     }
 }


### PR DESCRIPTION
Rejects top-level JSON lists at the worker protocol boundary instead of treating them as envelope maps. Keeps empty JSON objects distinguishable from empty lists and adds exact regression coverage for both list shapes.