### PR TITLE
test(coverage): reject non-positive wire lines

### DIFF
--- a/tests/Unit/Coverage/CoverageMapTest.php
+++ b/tests/Unit/Coverage/CoverageMapTest.php
@@ -210,6 +210,14 @@ final class CoverageMapTest
             ['files' => ['/src/A.php' => [['one'], []]]],
             '/positive line numbers/',
         ];
+        yield 'zero line number' => [
+            ['files' => ['/src/A.php' => [[0], []]]],
+            '/positive line numbers/',
+        ];
+        yield 'negative line number' => [
+            ['files' => ['/src/A.php' => [[-1], []]]],
+            '/positive line numbers/',
+        ];
     }
 
     private function sampleA(): CoverageMap


### PR DESCRIPTION
Covers zero and negative line numbers at the CoverageMap wire boundary. This pins the typed InvalidWirePayload diagnostic instead of allowing malformed input to reach FileCoverage and leak a lower-level constructor error.