### PR TITLE
test(conditions): cover class autoloading

### DIFF
--- a/tests/Fixture/Condition/AutoloadableConditionProbe.php
+++ b/tests/Fixture/Condition/AutoloadableConditionProbe.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Condition;
+
+use Greenlight\Doubles\Fake;
+
+final class AutoloadableConditionProbe implements Fake {}

--- a/tests/Unit/Condition/ClassAvailableAutoloadTest.php
+++ b/tests/Unit/Condition/ClassAvailableAutoloadTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Condition;
+
+use Greenlight\Attribute\Isolated;
+use Greenlight\Attribute\Test;
+use Greenlight\Condition\ClassAvailable;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Condition\AutoloadableConditionProbe;
+
+final readonly class ClassAvailableAutoloadTest
+{
+    #[Test]
+    #[Isolated]
+    public function loadsAnAvailableClassBeforeReportingSuccess(): void
+    {
+        Expect::that(\class_exists(AutoloadableConditionProbe::class, false))
+            ->because('the fixture MUST start unloaded so the test covers autoloading')
+            ->toBeFalse()
+            ->and(new ClassAvailable(AutoloadableConditionProbe::class)->isSatisfied())
+            ->because('class availability MUST include classes that the autoloader can load')
+            ->toBeTrue()
+            ->and(\class_exists(AutoloadableConditionProbe::class, false))
+            ->because('the successful condition MUST load the available class')
+            ->toBeTrue();
+    }
+}


### PR DESCRIPTION
Verify that ClassAvailable triggers the configured autoloader for a class that is available but not loaded yet. The append-only fixture implements Fake so Greenlight identifies it as test-only infrastructure.