### PR TITLE
fix(wire): reject lists where maps are required

### DIFF
--- a/src/Core/Wire/Wire.php
+++ b/src/Core/Wire/Wire.php
@@ -195,7 +195,7 @@ final class Wire
     {
         $value = self::require($payload, $key);
 
-        if (!\is_array($value)) {
+        if (!\is_array($value) || ($value !== [] && \array_is_list($value))) {
             throw InvalidWirePayload::wrongType($key, 'a map', $value);
         }
 
@@ -290,7 +290,7 @@ final class Wire
         $maps = [];
 
         foreach ($value as $item) {
-            if (!\is_array($item)) {
+            if (!\is_array($item) || ($item !== [] && \array_is_list($item))) {
                 throw InvalidWirePayload::wrongType($key, 'a list of maps', $item);
             }
 

--- a/tests/Unit/Core/WireTest.php
+++ b/tests/Unit/Core/WireTest.php
@@ -95,6 +95,46 @@ final class WireTest
     }
 
     #[Test]
+    public function mapReadersRejectNonEmptyLists(): void
+    {
+        $list = ['field' => ['first', 'second']];
+        $listOfLists = ['field' => [['first']]];
+
+        Expect::that(static fn(): array => Wire::map($list, 'field'))
+            ->because('a non-empty list is not a wire map')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "field" must be a map, got array.',
+            )
+            ->and(static fn(): ?array => Wire::nullableMap($list, 'field'))
+            ->because('a nullable wire map MUST validate its non-null shape')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "field" must be a map, got array.',
+            )
+            ->and(static fn(): array => Wire::listOfMaps($listOfLists, 'field'))
+            ->because('each item in a wire list of maps MUST be a map')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "field" must be a list of maps, got array.',
+            );
+    }
+
+    #[Test]
+    public function mapReadersKeepEmptyMaps(): void
+    {
+        $emptyMap = ['field' => []];
+
+        Expect::that(Wire::map($emptyMap, 'field'))
+            ->because('an empty decoded JSON object is a valid wire map')
+            ->toBe([])
+            ->and(Wire::nullableMap($emptyMap, 'field'))
+            ->toBe([])
+            ->and(Wire::listOfMaps(['field' => [[]]], 'field'))
+            ->toBe([[]]);
+    }
+
+    #[Test]
     #[DataSet('nonFiniteFloats')]
     public function floatReadersRejectNonFiniteValues(float $value): void
     {


### PR DESCRIPTION
Rejects non-empty JSON lists passed to map readers, including entries in list-of-maps payloads. Empty decoded maps remain valid because PHP represents both empty JSON objects and arrays as the same associative-decoding value.