### PR TITLE
test(cli): preserve shard coordinate order

### DIFF
--- a/tests/Unit/Cli/CliOverridesTest.php
+++ b/tests/Unit/Cli/CliOverridesTest.php
@@ -120,6 +120,16 @@ final class CliOverridesTest
     }
 
     #[Test]
+    public function validShardKeepsIndexAndCountOrder(): void
+    {
+        $overrides = CliOverrides::fromArguments(new ParsedArguments(null, ['shard' => ['2/3']]));
+
+        Expect::that($overrides->shard)
+            ->because('--shard MUST keep the selected index before the total count')
+            ->toBe([2, 3]);
+    }
+
+    #[Test]
     public function shardOutOfRangeNamesTheValidRange(): void
     {
         try {


### PR DESCRIPTION
Pins valid `--shard=n/m` parsing to the `[selected index, total count]` coordinate order used by `PlanShard`. Prevents two valid integers from being silently swapped before test selection.