### PR TITLE
test(expect): cover null-valued subset keys

### DIFF
--- a/tests/Unit/Expect/IterableMatchersTest.php
+++ b/tests/Unit/Expect/IterableMatchersTest.php
@@ -291,6 +291,14 @@ final class IterableMatchersTest
     }
 
     #[Test]
+    public function toContainSubsetTreatsANullValuedKeyAsPresent(): void
+    {
+        Expect::that(['optional' => null])
+            ->because('subset matching MUST distinguish a null-valued key from a missing key')
+            ->toContainSubset(['optional' => null]);
+    }
+
+    #[Test]
     public function toContainSubsetFailsOnMissingKeyWithPath(): void
     {
         $detail = FailureProbe::detailOf(


### PR DESCRIPTION
Pin toContainSubset behavior when a subject key exists with a null value. This distinguishes key presence from isset-style checks and prevents a valid null-valued subset from being reported as missing.