### PR TITLE
test(core): cover attachment wire numeric bounds

### DIFF
--- a/tests/Unit/Core/AttachmentWireTest.php
+++ b/tests/Unit/Core/AttachmentWireTest.php
@@ -62,4 +62,23 @@ final class AttachmentWireTest
             ->and($staged->retention)
             ->toBe(AttachmentRetention::OnFailure);
     }
+
+    #[Test]
+    public function wireDecodingNormalizesNumericBounds(): void
+    {
+        $attachment = Attachment::fromWire([
+            'name' => 'response.json',
+            'kind' => AttachmentKind::Value->value,
+            'mediaType' => 'application/json',
+            'sizeBytes' => -1,
+            'sha256' => \str_repeat('a', 64),
+            'attempt' => 0,
+            'path' => 'build/artifacts/response.json',
+            'retention' => AttachmentRetention::Always->value,
+        ]);
+
+        Expect::that([$attachment->sizeBytes, $attachment->attempt])
+            ->because('attachment wire decoding MUST preserve its numeric bounds')
+            ->toBe([0, 1]);
+    }
 }


### PR DESCRIPTION
Add focused coverage that attachment wire decoding clamps negative byte counts and non-positive attempt numbers to valid constructor bounds. This protects worker-originated metadata from bypassing the decoder normalization contract.