### PR TITLE
fix(core): match wildcard characters as UTF-8

### DIFF
--- a/src/Core/Wildcard.php
+++ b/src/Core/Wildcard.php
@@ -26,7 +26,10 @@ final class Wildcard
                 : \str_contains($subject, $pattern);
         }
 
-        $regex = '/^' . \strtr(\preg_quote($pattern, '/'), ['\*' => '.*', '\?' => '.']) . '$/' . ($caseInsensitive ? 'i' : '');
+        $regex = '/^'
+            . \strtr(\preg_quote($pattern, '/'), ['\*' => '.*', '\?' => '.'])
+            . '$/'
+            . ($caseInsensitive ? 'iu' : 'u');
 
         return \preg_match($regex, $subject) === 1;
     }

--- a/tests/Unit/Core/WildcardTest.php
+++ b/tests/Unit/Core/WildcardTest.php
@@ -92,6 +92,13 @@ final class WildcardTest
             true,
         ];
 
+        yield 'question mark matches one UTF-8 character' => [
+            'Tést',
+            'T?st',
+            false,
+            true,
+        ];
+
         yield 'question mark does not match zero characters' => [
             'Tst',
             'T?st',


### PR DESCRIPTION
Make the wildcard question mark match one UTF-8 character instead of one byte. This keeps filters correct for Unicode class names, methods, and data-set labels, and adds a focused regression case for the documented one-character contract.