### PR TITLE
test(attribute): reject negative retry times

### DIFF
--- a/tests/Unit/Attribute/RetryTimesValidationTest.php
+++ b/tests/Unit/Attribute/RetryTimesValidationTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Attribute;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Retry;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+
+final class RetryTimesValidationTest
+{
+    #[Test]
+    #[DataSet('nonPositiveTimes')]
+    public function rejectsNonPositiveTimes(int $times): void
+    {
+        Expect::that(static fn(): Retry => new Retry($times))
+            ->because('retry times MUST be positive')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Retry times must be at least 1.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function nonPositiveTimes(): iterable
+    {
+        yield 'zero' => [0];
+        yield 'negative' => [-1];
+    }
+}


### PR DESCRIPTION
Add DataSet coverage for zero and negative retry counts with the exact validation diagnostic. This protects the lower-bound guard from weakening to a zero-only check.