### PR TITLE
test(harness): cover lazy factory failures

### DIFF
--- a/tests/Fixture/Harness/LazyFactoryProbe.php
+++ b/tests/Fixture/Harness/LazyFactoryProbe.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Harness;
+
+use Greenlight\Doubles\Fake;
+
+final readonly class LazyFactoryProbe implements Fake
+{
+    public function __construct(private string $value) {}
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+}

--- a/tests/Unit/Harness/ScopeContainerLazyFactoryTest.php
+++ b/tests/Unit/Harness/ScopeContainerLazyFactoryTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Harness;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Harness\Scope;
+use Greenlight\Harness\ScopeContainer;
+use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Tests\Fixture\Harness\LazyFactoryProbe;
+
+final class ScopeContainerLazyFactoryTest
+{
+    #[Test]
+    public function aLazyFactoryFailureIsDeferredAndPropagated(): void
+    {
+        $factoryCalls = 0;
+        $container = new ScopeContainer();
+        $service = $container->get(new ServiceDefinition(
+            LazyFactoryProbe::class,
+            Scope::PerTest,
+            static function () use (&$factoryCalls): LazyFactoryProbe {
+                ++$factoryCalls;
+
+                throw new \RuntimeException('factory broke');
+            },
+        ));
+
+        if (!$service instanceof LazyFactoryProbe) {
+            Fail::because(\sprintf(
+                'Expected ScopeContainer::get() to return LazyFactoryProbe, got %s.',
+                \get_debug_type($service),
+            ));
+        }
+
+        Expect::that($factoryCalls)
+            ->because('ScopeContainer::get() MUST NOT invoke a lazy factory')
+            ->toBe(0);
+
+        Expect::that(static fn() => $service->value())
+            ->because('the lazy factory failure MUST propagate from the first service use')
+            ->toThrow(\RuntimeException::class, message: 'factory broke')
+            ->and($factoryCalls)
+            ->toBe(1);
+    }
+}


### PR DESCRIPTION
Covers the lazy-service failure boundary in ScopeContainer. The test proves that get() does not invoke the factory and that the exact factory exception propagates from the first stateful service use.