### PR TITLE
fix(core): reject negative expectation counts

### DIFF
--- a/docs/api-results.md
+++ b/docs/api-results.md
@@ -471,6 +471,18 @@ PHPDoc:
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/TestResult.php#L27)
 
+### `$expectations`
+
+```php
+public int $expectations;
+```
+
+PHPDoc:
+
+- `@var non-negative-int`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/TestResult.php#L32)
+
 ### `__construct()`
 
 ```php
@@ -486,7 +498,7 @@ public function __construct(
     public array $transformations = [],
     public ?CapturedOutput $output = null,
     public bool $risky = false,
-    public int $expectations = 0,
+    int $expectations = 0,
     public array $attachments = [],
 )
 ```
@@ -495,11 +507,10 @@ PHPDoc:
 
 - `@param list<FailureDetail> $failures`
 - `@param list<OutcomeTransformation> $transformations`
-- `@param non-negative-int $expectations`
 - `@param list<Attachment> $attachments`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/TestResult.php#L37)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/TestResult.php#L41)
 
 ### `withOutcome()`
 
@@ -511,7 +522,7 @@ PHPDoc:
 
 - `@param non-empty-string $transformedBy`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/TestResult.php#L66)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/TestResult.php#L75)
 
 ### `toWire()`
 
@@ -520,7 +531,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/TestResult.php#L171)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/TestResult.php#L180)
 
 ### `fromWire()`
 
@@ -529,7 +540,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/TestResult.php#L197)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/TestResult.php#L206)
 
 ## `ThrowableDetail`
 

--- a/src/Core/Result/TestResult.php
+++ b/src/Core/Result/TestResult.php
@@ -27,9 +27,13 @@ final readonly class TestResult implements WireSerializable
     public int $attempts;
 
     /**
+     * @var non-negative-int
+     */
+    public int $expectations;
+
+    /**
      * @param list<FailureDetail> $failures
      * @param list<OutcomeTransformation> $transformations
-     * @param non-negative-int $expectations
      * @param list<Attachment> $attachments
      *
      * @throws \InvalidArgumentException
@@ -46,7 +50,7 @@ final readonly class TestResult implements WireSerializable
         public array $transformations = [],
         public ?CapturedOutput $output = null,
         public bool $risky = false,
-        public int $expectations = 0,
+        int $expectations = 0,
         public array $attachments = [],
     ) {
         if (!\is_finite($durationSeconds) || $durationSeconds < 0.0) {
@@ -57,7 +61,12 @@ final readonly class TestResult implements WireSerializable
             throw new \InvalidArgumentException('Attempts must be at least 1.');
         }
 
+        if ($expectations < 0) {
+            throw new \InvalidArgumentException('Expectation count MUST NOT be negative.');
+        }
+
         $this->attempts = $attempts;
+        $this->expectations = $expectations;
     }
 
     /**

--- a/tests/Unit/Core/TestResultExpectationValidationTest.php
+++ b/tests/Unit/Core/TestResultExpectationValidationTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+
+final class TestResultExpectationValidationTest
+{
+    #[Test]
+    public function expectationCountsStartAtZero(): void
+    {
+        $id = new TestId('Example\\ExpectationTest', 'counts');
+
+        Expect::that(new TestResult($id, Outcome::Passed, 0.1, 0, expectations: 0)->expectations)
+            ->because('a result MAY contain no verified expectations')
+            ->toBe(0)
+            ->and(static fn(): TestResult => new TestResult(
+                $id,
+                Outcome::Passed,
+                0.1,
+                0,
+                expectations: -1,
+            ))
+            ->because('a result MUST NOT contain a negative expectation count')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Expectation count MUST NOT be negative.',
+            );
+    }
+}


### PR DESCRIPTION
TestResult documents its expectation count as non-negative and wire decoding already normalizes the value, but direct construction accepted negative counts. Enforce the invariant at construction, cover the zero and negative boundary with an exact diagnostic assertion, and refresh the generated API reference.