### PR TITLE
fix(artifacts): reject media type control bytes

### DIFF
--- a/src/Runner/Artifact/StagedAttachments.php
+++ b/src/Runner/Artifact/StagedAttachments.php
@@ -199,7 +199,12 @@ final class StagedAttachments implements Attachments
             throw AttachmentError::invalidName($name);
         }
 
-        if (\preg_match('~^[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*/[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*(?:\s*;\s*[^=\s]+=(?:"[^"]*"|[^;\s]+))*$~', $mediaType) !== 1) {
+        if (\preg_match('/[\x00-\x1F\x7F]/', $mediaType) === 1
+            || \preg_match(
+                '~^[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*/[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*(?:\s*;\s*[^=\s]+=(?:"[^"]*"|[^;\s]+))*$~',
+                $mediaType,
+            ) !== 1
+        ) {
             throw AttachmentError::invalidMediaType($mediaType);
         }
     }

--- a/tests/Unit/Artifact/AttachmentMediaTypeValidationTest.php
+++ b/tests/Unit/Artifact/AttachmentMediaTypeValidationTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\ArtifactStore;
+use Greenlight\Runner\Artifact\TestArtifactBudget;
+
+final readonly class AttachmentMediaTypeValidationTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    #[DataSet('mediaTypesWithControlBytes')]
+    public function controlBytesInQuotedParametersAreRejected(string $mediaType): void
+    {
+        $root = $this->tempDirectory->subdirectory('media-type-control-bytes');
+        $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-1');
+        $budget = new TestArtifactBudget();
+        $attachments = $store->forAttempt(
+            new TestId('Example\EvidenceTest', 'captures'),
+            1,
+            $budget,
+        );
+
+        try {
+            Expect::that(static fn() => $attachments->text(
+                'report.txt',
+                'body',
+                $mediaType,
+            ))
+                ->because('attachment media types MUST NOT contain control bytes')
+                ->toThrow(
+                    AttachmentError::class,
+                    message: \sprintf(
+                        'Attachment media type "%s" is invalid.',
+                        $mediaType,
+                    ),
+                )
+                ->and($attachments->collected())
+                ->toBe([])
+                ->and([$budget->attachments, $budget->bytes])
+                ->because('an invalid media type MUST NOT consume the shared test budget')
+                ->toBe([0, 0]);
+        } finally {
+            $store->cleanup();
+        }
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function mediaTypesWithControlBytes(): iterable
+    {
+        yield 'null' => ["text/plain; name=\"report\x00.txt\""];
+        yield 'tab' => ["text/plain; name=\"report\t.txt\""];
+        yield 'line feed' => ["text/plain; name=\"report\n.txt\""];
+        yield 'carriage return' => ["text/plain; name=\"report\r.txt\""];
+        yield 'delete' => ["text/plain; name=\"report\x7F.txt\""];
+    }
+}


### PR DESCRIPTION
Rejects C0 and DEL control bytes before an attachment media type reaches staging. The focused dataset covers quoted parameters, where the existing grammar accepted these bytes, and verifies rejected writes leave collected attachments and the shared test budget unchanged.