### PR TITLE
fix(cli): detect equal-metadata file rewrites

### DIFF
--- a/src/Cli/Watch/StatChangeDetector.php
+++ b/src/Cli/Watch/StatChangeDetector.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Greenlight\Cli\Watch;
 
+use Greenlight\Core\ErrorTrap;
+
 /**
  * A portable file change detector.
  *
- * poll() records mtime and size for each PHP file in the specified
- * directories. It reports a path when its fingerprint changes. It also
- * reports new and removed paths.
+ * poll() records the modification time, size, and content hash for each PHP
+ * file in the specified directories. It reports a path when its fingerprint
+ * changes. It also reports new and removed paths.
  *
  * The first poll creates the initial record and reports no changes.
  *
@@ -80,10 +82,31 @@ final class StatChangeDetector implements ChangeDetector
                 }
 
                 $path = $file->getPathname();
-                $snapshot[$path] = $file->getMTime() . ':' . $file->getSize();
+                $fingerprint = $this->fingerprint($path);
+
+                if ($fingerprint !== null) {
+                    $snapshot[$path] = $fingerprint;
+                }
             }
         }
 
         return $snapshot;
+    }
+
+    private function fingerprint(string $path): ?string
+    {
+        \clearstatcache(true, $path);
+
+        return ErrorTrap::run(static function () use ($path): ?string {
+            $mtime = \filemtime($path);
+            $size = \filesize($path);
+            $contentHash = \sha1_file($path);
+
+            if (!\is_int($mtime) || !\is_int($size) || !\is_string($contentHash)) {
+                return null;
+            }
+
+            return $mtime . ':' . $size . ':' . $contentHash;
+        });
     }
 }

--- a/tests/Unit/Cli/StatChangeDetectorContentTest.php
+++ b/tests/Unit/Cli/StatChangeDetectorContentTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\Watch\StatChangeDetector;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class StatChangeDetectorContentTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function equalSizeRewriteWithRestoredModificationTimeIsReported(): void
+    {
+        $directory = $this->tempDirectory->subdirectory('watch-content');
+        $source = $directory . '/ContentProbeTest.php';
+        $original = '<?php // alpha';
+        $replacement = '<?php // bravo';
+        $mtime = 1_700_000_000;
+        \file_put_contents($source, $original);
+
+        if (!\touch($source, $mtime)) {
+            Fail::because('Expected to set the initial source modification time.');
+        }
+
+        \clearstatcache(true, $source);
+        $detector = new StatChangeDetector([$directory]);
+
+        Expect::that($detector->poll())
+            ->because('the first poll MUST only record the source fingerprint')
+            ->toBe([]);
+
+        \file_put_contents($source, $replacement);
+
+        if (!\touch($source, $mtime)) {
+            Fail::because('Expected to restore the source modification time.');
+        }
+
+        \clearstatcache(true, $source);
+
+        Expect::that([\filemtime($source), \filesize($source)])
+            ->because('the rewrite MUST preserve the metadata in the original fingerprint')
+            ->toBe([$mtime, \strlen($original)])
+            ->and($detector->poll())
+            ->because('the content fingerprint MUST report an equal-size rewrite')
+            ->toBe([$source]);
+    }
+}


### PR DESCRIPTION
Watch mode fingerprinted PHP files only by modification time and size. An editor could replace a file with equal-length content and preserve its timestamp, so the next run never started. Include a content hash in the existing detector fingerprint and cover the blind spot with a deterministic rewrite that restores the original metadata.