### PR TITLE
fix(discovery): invalidate equal-metadata rewrites

### DIFF
--- a/src/Discovery/DiscoveryCache.php
+++ b/src/Discovery/DiscoveryCache.php
@@ -9,9 +9,10 @@ use Greenlight\Core\AtomicFileError;
 use Greenlight\Core\ErrorTrap;
 
 /**
- * Stores one discovery cache entry for each file. The path, mtime, size, and
- * external provider files identify an entry. Entries do not contain filter
- * results. Thus, a filter change does not require another parse operation.
+ * Stores one discovery cache entry for each file. The path, modification time,
+ * size, content hash, and external provider files identify an entry. Entries
+ * do not contain filter results. Thus, a filter change does not require
+ * another parse operation.
  *
  * Discovery parses the file after a cache miss, stale file, corrupt cache, or
  * version mismatch. A data provider can change output without a file change.
@@ -73,7 +74,12 @@ final class DiscoveryCache
 
         $stat = $this->stat($file);
 
-        if ($stat === null || $stat['mtime'] !== $cached->mtime || $stat['size'] !== $cached->size) {
+        if (
+            $stat === null
+            || $stat['mtime'] !== $cached->mtime
+            || $stat['size'] !== $cached->size
+            || $stat['contentHash'] !== $cached->contentHash
+        ) {
             return null;
         }
 
@@ -113,13 +119,14 @@ final class DiscoveryCache
             $stat['size'],
             \array_map(static fn(PlanEntry $entry): array => $entry->toWire(), $entries),
             $this->providerDependencies($entries),
+            $stat['contentHash'],
         );
     }
 
     /**
      * @param list<PlanEntry> $entries
      *
-     * @return array<non-empty-string, array{mtime: int, size: int}>
+     * @return array<non-empty-string, array{mtime: int, size: int, contentHash?: string}>
      */
     private function providerDependencies(array $entries): array
     {
@@ -148,7 +155,9 @@ final class DiscoveryCache
                 $stat = $this->stat($file);
 
                 if ($stat !== null) {
-                    $dependencies[$file] = $stat;
+                    $dependencies[$file] = $stat['contentHash'] === null
+                        ? ['mtime' => $stat['mtime'], 'size' => $stat['size']]
+                        : ['mtime' => $stat['mtime'], 'size' => $stat['size'], 'contentHash' => $stat['contentHash']];
                 }
             }
         }
@@ -157,19 +166,26 @@ final class DiscoveryCache
     }
 
     /**
-     * @return array{mtime: int, size: int}|null
+     * @return array{mtime: int, size: int, contentHash: ?non-empty-string}|null
      */
     private function stat(string $file): ?array
     {
+        \clearstatcache(true, $file);
+
         return ErrorTrap::run(static function () use ($file): ?array {
             $mtime = \filemtime($file);
             $size = \filesize($file);
+            $contentHash = \sha1_file($file);
 
             if (!\is_int($mtime) || !\is_int($size)) {
                 return null;
             }
 
-            return ['mtime' => $mtime, 'size' => $size];
+            return [
+                'mtime' => $mtime,
+                'size' => $size,
+                'contentHash' => \is_string($contentHash) ? $contentHash : null,
+            ];
         });
     }
 

--- a/src/Discovery/DiscoveryCacheEntry.php
+++ b/src/Discovery/DiscoveryCacheEntry.php
@@ -17,13 +17,14 @@ final readonly class DiscoveryCacheEntry implements \JsonSerializable
 {
     /**
      * @param list<array<string, mixed>> $entries
-     * @param array<non-empty-string, array{mtime: int, size: int}> $dependencies
+     * @param array<non-empty-string, array{mtime: int, size: int, contentHash?: string}> $dependencies
      */
     public function __construct(
         public int $mtime,
         public int $size,
         public array $entries,
         public array $dependencies = [],
+        public ?string $contentHash = null,
     ) {}
 
     /**
@@ -32,6 +33,12 @@ final readonly class DiscoveryCacheEntry implements \JsonSerializable
     public static function fromDecoded(array $decoded): ?self
     {
         if (!\is_int($decoded['mtime'] ?? null) || !\is_int($decoded['size'] ?? null) || !\is_array($decoded['entries'] ?? null)) {
+            return null;
+        }
+
+        $contentHash = $decoded['contentHash'] ?? null;
+
+        if ($contentHash !== null && (!\is_string($contentHash) || \preg_match('/^[0-9a-f]{40}$/', $contentHash) !== 1)) {
             return null;
         }
 
@@ -69,14 +76,22 @@ final readonly class DiscoveryCacheEntry implements \JsonSerializable
                 || !\is_array($stat)
                 || !\is_int($stat['mtime'] ?? null)
                 || !\is_int($stat['size'] ?? null)
+                || (
+                    \array_key_exists('contentHash', $stat)
+                    && (!\is_string($stat['contentHash']) || \preg_match('/^[0-9a-f]{40}$/', $stat['contentHash']) !== 1)
+                )
             ) {
                 return null;
             }
 
             $dependencies[$path] = ['mtime' => $stat['mtime'], 'size' => $stat['size']];
+
+            if (isset($stat['contentHash'])) {
+                $dependencies[$path]['contentHash'] = $stat['contentHash'];
+            }
         }
 
-        return new self($decoded['mtime'], $decoded['size'], $payloads, $dependencies);
+        return new self($decoded['mtime'], $decoded['size'], $payloads, $dependencies, $contentHash);
     }
 
     /**
@@ -104,17 +119,24 @@ final readonly class DiscoveryCacheEntry implements \JsonSerializable
      *     mtime: int,
      *     size: int,
      *     entries: list<array<string, mixed>>,
-     *     dependencies: array<non-empty-string, array{mtime: int, size: int}>
+     *     dependencies: array<non-empty-string, array{mtime: int, size: int, contentHash?: string}>,
+     *     contentHash?: string
      * }
      */
     #[\Override]
     public function jsonSerialize(): array
     {
-        return [
+        $serialized = [
             'mtime' => $this->mtime,
             'size' => $this->size,
             'entries' => $this->entries,
             'dependencies' => $this->dependencies,
         ];
+
+        if ($this->contentHash !== null) {
+            $serialized['contentHash'] = $this->contentHash;
+        }
+
+        return $serialized;
     }
 }

--- a/tests/Unit/Discovery/DiscoveryCacheContentFingerprintTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheContentFingerprintTest.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Discovery\DiscoveryCache;
+use Greenlight\Discovery\PlanEntry;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class DiscoveryCacheContentFingerprintTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function equalSizeRewriteWithRestoredModificationTimeInvalidatesTheEntry(): void
+    {
+        $directory = $this->tempDirectory->subdirectory('discovery-content');
+        $source = $directory . '/ContentProbeTest.php';
+        $cacheFile = $this->cacheFile($directory);
+        $original = '<?php // alpha';
+        $replacement = '<?php // bravo';
+        $mtime = 1_700_000_000;
+        \file_put_contents($source, $original);
+
+        if (!\touch($source, $mtime)) {
+            Fail::because('Expected to set the initial source modification time.');
+        }
+
+        \clearstatcache(true, $source);
+        $id = new TestId('Example\\ContentProbeTest', 'runs');
+        $entry = new PlanEntry($id, new TestMetadata($id->class, $id->method));
+        $cache = DiscoveryCache::forDirectories([$directory]);
+        $cache->store($source, [$entry]);
+
+        try {
+            Expect::that($cache->persist())
+                ->because('the discovery cache MUST persist the initial source fingerprint')
+                ->toBeTrue();
+
+            $warm = DiscoveryCache::forDirectories([$directory])->lookup($source);
+            Expect::that(\array_map(
+                static fn(PlanEntry $cached): array => $cached->toWire(),
+                $warm ?? [],
+            ))
+                ->because('unchanged source content MUST use the cached plan entry')
+                ->toBe([$entry->toWire()]);
+
+            \file_put_contents($source, $replacement);
+
+            if (!\touch($source, $mtime)) {
+                Fail::because('Expected to restore the source modification time.');
+            }
+
+            \clearstatcache(true, $source);
+
+            Expect::that([\filemtime($source), \filesize($source)])
+                ->because('the rewrite MUST preserve the cached source metadata')
+                ->toBe([$mtime, \strlen($original)])
+                ->and(DiscoveryCache::forDirectories([$directory])->lookup($source))
+                ->because('the content fingerprint MUST invalidate an equal-size rewrite')
+                ->toBeNull();
+        } finally {
+            @\unlink($cacheFile);
+        }
+    }
+
+    #[Test]
+    public function equalSizeProviderRewriteWithRestoredModificationTimeInvalidatesTheEntry(): void
+    {
+        $directory = $this->tempDirectory->subdirectory('discovery-provider-content');
+        $source = $directory . '/ProviderProbeTest.php';
+        $provider = $directory . '/ContentRows.php';
+        $cacheFile = $this->cacheFile($directory);
+        $shortClass = 'ContentRows' . \bin2hex(\random_bytes(6));
+        $providerClass = 'GreenlightDiscoveryFingerprint\\' . $shortClass;
+        $providerSource = <<<PHP
+            <?php
+
+            declare(strict_types=1);
+
+            namespace GreenlightDiscoveryFingerprint;
+
+            final class {$shortClass}
+            {
+                /** @return iterable<string, array{int}> */
+                public static function rows(): iterable
+                {
+                    yield 'alpha' => [1];
+                }
+            }
+            PHP;
+        $mtime = 1_700_000_000;
+        \file_put_contents($source, "<?php\n");
+        \file_put_contents($provider, $providerSource);
+
+        if (!\touch($provider, $mtime)) {
+            Fail::because('Expected to set the initial provider modification time.');
+        }
+
+        \clearstatcache(true, $provider);
+        require_once $provider;
+        $id = new TestId('Example\\ProviderProbeTest', 'runs');
+        $entry = new PlanEntry(
+            $id,
+            new TestMetadata(
+                $id->class,
+                $id->method,
+                dataSetProvider: 'rows',
+                dataSetProviderClass: $providerClass,
+            ),
+        );
+        $cache = DiscoveryCache::forDirectories([$directory]);
+        $cache->store($source, [$entry]);
+
+        try {
+            Expect::that($cache->persist())
+                ->because('the discovery cache MUST persist the provider fingerprint')
+                ->toBeTrue()
+                ->and(DiscoveryCache::forDirectories([$directory])->lookup($source))
+                ->because('unchanged provider content MUST keep the cached plan entry')
+                ->not()
+                ->toBeNull();
+
+            \file_put_contents($provider, \str_replace('alpha', 'bravo', $providerSource));
+
+            if (!\touch($provider, $mtime)) {
+                Fail::because('Expected to restore the provider modification time.');
+            }
+
+            \clearstatcache(true, $provider);
+
+            Expect::that([\filemtime($provider), \filesize($provider)])
+                ->because('the rewrite MUST preserve the cached provider metadata')
+                ->toBe([$mtime, \strlen($providerSource)])
+                ->and(DiscoveryCache::forDirectories([$directory])->lookup($source))
+                ->because('the content fingerprint MUST invalidate an equal-size provider rewrite')
+                ->toBeNull();
+        } finally {
+            @\unlink($cacheFile);
+        }
+    }
+
+    private function cacheFile(string $directory): string
+    {
+        return \sprintf(
+            '%s/greenlight-discovery-%s.json',
+            \rtrim(\sys_get_temp_dir(), '/'),
+            \substr(\sha1($directory), 0, 12),
+        );
+    }
+}


### PR DESCRIPTION
Discovery cache entries used only modification time and size. Equal-length source or provider edits with a restored timestamp could reuse stale test metadata.

Persist optional content hashes for source and external provider fingerprints. Old hashless entries remain readable but become clean cache misses.