### PR TITLE
fix(harness): validate service factory results

### DIFF
--- a/src/Harness/ScopeContainer.php
+++ b/src/Harness/ScopeContainer.php
@@ -72,14 +72,26 @@ final class ScopeContainer
     private function instantiate(ServiceDefinition $definition): object
     {
         $reflection = new \ReflectionClass($definition->type);
+        $factory = static function () use ($definition): object {
+            $service = ($definition->factory)();
+
+            if (!$service instanceof $definition->type) {
+                throw UnresolvableService::factoryTypeMismatch(
+                    $definition->type,
+                    $service::class,
+                );
+            }
+
+            return $service;
+        };
 
         try {
-            return $reflection->newLazyProxy(static fn(): object => ($definition->factory)());
+            return $reflection->newLazyProxy($factory);
         } catch (\ReflectionException|\Error) {
             // Greenlight constructs a class immediately if PHP cannot create a
             // lazy proxy for it. The factory has not run, so this catch does
             // not hide a factory error.
-            return ($definition->factory)();
+            return $factory();
         }
     }
 }

--- a/src/Harness/UnresolvableService.php
+++ b/src/Harness/UnresolvableService.php
@@ -48,6 +48,16 @@ final class UnresolvableService extends \RuntimeException
         ));
     }
 
+    public static function factoryTypeMismatch(string $type, string $actual): self
+    {
+        return new self(\sprintf(
+            'Service definition for type "%s" created "%s". Its factory MUST return an instance of "%s".',
+            $type,
+            $actual,
+            $type,
+        ));
+    }
+
     public static function unsupportedParameter(string $parameter, string $consumer): self
     {
         return new self(\sprintf(

--- a/tests/Fixture/Harness/FactoryContractTarget.php
+++ b/tests/Fixture/Harness/FactoryContractTarget.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Harness;
+
+use Greenlight\Doubles\Fake;
+
+class FactoryContractTarget implements Fake
+{
+    private string $value = 'ready';
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+}

--- a/tests/Unit/Harness/HarnessServiceFactoryContractTest.php
+++ b/tests/Unit/Harness/HarnessServiceFactoryContractTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Harness;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Harness\HarnessRegistry;
+use Greenlight\Harness\HarnessScopes;
+use Greenlight\Harness\Scope;
+use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Harness\UnresolvableService;
+use Greenlight\Tests\Fixture\Harness\FactoryContractTarget;
+
+final class HarnessServiceFactoryContractTest
+{
+    #[Test]
+    public function anImmediateFactoryMustReturnTheRegisteredType(): void
+    {
+        $scopes = $this->scopesFor(\Countable::class);
+
+        Expect::that(static fn(): object => $scopes->resolve(\Countable::class, 'probe'))
+            ->because('an immediate harness factory MUST return its registered type')
+            ->toThrow(
+                UnresolvableService::class,
+                message: 'Service definition for type "Countable" created "stdClass". '
+                . 'Its factory MUST return an instance of "Countable".',
+            );
+    }
+
+    #[Test]
+    public function aLazyFactoryMustReturnTheRegisteredTypeWhenInitialized(): void
+    {
+        $scopes = $this->scopesFor(FactoryContractTarget::class);
+        $service = $scopes->resolve(FactoryContractTarget::class, 'probe');
+        \assert($service instanceof FactoryContractTarget);
+
+        Expect::that(static fn(): string => $service->value())
+            ->because('a lazy harness factory MUST return its registered type when initialized')
+            ->toThrow(
+                UnresolvableService::class,
+                message: 'Service definition for type "Greenlight\\Tests\\Fixture\\Harness\\FactoryContractTarget" '
+                . 'created "stdClass". Its factory MUST return an instance of '
+                . '"Greenlight\\Tests\\Fixture\\Harness\\FactoryContractTarget".',
+            );
+    }
+
+    /**
+     * @param class-string $type
+     */
+    private function scopesFor(string $type): HarnessScopes
+    {
+        return new HarnessScopes(new HarnessRegistry([
+            new ServiceDefinition(
+                $type,
+                Scope::PerRun,
+                static fn(): object => new \stdClass(),
+            ),
+        ]));
+    }
+}


### PR DESCRIPTION
Validates every registered harness factory result at the shared scope boundary. Immediate services now fail with a focused domain error instead of escaping with the wrong type, and lazy services report the same error when first initialized instead of leaking a PHP proxy TypeError. Focused regressions cover both construction paths with a PSR-4 Fake fixture.