### PR TITLE
fix(artifacts): block unsafe attachment discard paths

### DIFF
--- a/src/Runner/Artifact/ArtifactStore.php
+++ b/src/Runner/Artifact/ArtifactStore.php
@@ -290,6 +290,7 @@ final class ArtifactStore
     public function discard(StagedAttachment $attachment): void
     {
         $storageKey = $attachment->storageKey;
+        $this->assertSafeStorageKey($storageKey);
         $this->removeFile($this->metadataPath($storageKey), 'attachment recovery metadata');
         $this->removeFile($this->session->stagingDirectory . '/' . $storageKey, 'attachment staging file');
         $this->release($attachment->sizeBytes);
@@ -326,10 +327,7 @@ final class ArtifactStore
             }
 
             $storageKey = $attachment->storageKey;
-
-            if (!$this->safeStorageKey($storageKey)) {
-                throw AttachmentError::storage('Attachment metadata contains an unsafe storage key');
-            }
+            $this->assertSafeStorageKey($storageKey);
 
             $source = $this->session->stagingDirectory . '/' . $storageKey;
             $destination = $this->outputDirectory . '/' . $storageKey;
@@ -743,16 +741,18 @@ final class ArtifactStore
         return $this->session->stagingDirectory . '/' . $storageKey . '.meta.json';
     }
 
-    private function safeStorageKey(string $storageKey): bool
+    private function assertSafeStorageKey(string $storageKey): void
     {
         if ($storageKey === '' || \str_starts_with($storageKey, '/') || \str_contains($storageKey, '\\')) {
-            return false;
+            throw AttachmentError::storage('Attachment metadata contains an unsafe storage key');
         }
 
-        return \array_all(
+        if (!\array_all(
             \explode('/', $storageKey),
             static fn(string $segment): bool => !\in_array($segment, ['', '.', '..'], true),
-        );
+        )) {
+            throw AttachmentError::storage('Attachment metadata contains an unsafe storage key');
+        }
     }
 
     private function createDirectorySafely(string $directory): void

--- a/tests/Unit/Artifact/ArtifactStorageKeyTest.php
+++ b/tests/Unit/Artifact/ArtifactStorageKeyTest.php
@@ -62,6 +62,57 @@ final readonly class ArtifactStorageKeyTest
         }
     }
 
+    #[Test]
+    public function discardedAttachmentsCannotEscapeTheStagingDirectory(): void
+    {
+        $root = $this->tempDirectory->subdirectory('unsafe-discard');
+        $store = ArtifactStore::open(
+            new ArtifactConfiguration($root),
+            $root,
+            'run-unsafe-discard',
+        );
+        $staging = $store->session()->stagingDirectory;
+        $sentinelName = \basename($staging) . '-sentinel';
+        $sentinel = \dirname($staging) . '/' . $sentinelName;
+        $storageKey = '../' . $sentinelName;
+        $attachment = new StagedAttachment(
+            'evidence.txt',
+            AttachmentKind::Text,
+            'text/plain',
+            8,
+            \hash('sha256', 'evidence'),
+            1,
+            'run-unsafe-discard/evidence.txt',
+            AttachmentRetention::OnFailure,
+            $storageKey,
+        );
+        $result = new TestResult(
+            new TestId('Example\EvidenceTest', 'rejectsUnsafeDiscard'),
+            Outcome::Passed,
+            0.1,
+            0,
+            attachments: [$attachment],
+        );
+
+        try {
+            Expect::that(\file_put_contents($sentinel, 'preserve'))
+                ->because('the sentinel file MUST exist before publication')
+                ->toBe(8);
+            Expect::that(static fn(): TestResult => $store->publish($result))
+                ->because('discard MUST validate a staging coordinate before removing files')
+                ->toThrow(
+                    AttachmentError::class,
+                    message: 'Attachment metadata contains an unsafe storage key.',
+                );
+            Expect::that(\file_get_contents($sentinel))
+                ->because('unsafe metadata MUST NOT remove files outside staging')
+                ->toBe('preserve');
+        } finally {
+            @\unlink($sentinel);
+            $store->cleanup();
+        }
+    }
+
     /**
      * @return iterable<string, array{string, non-empty-string}>
      */


### PR DESCRIPTION
A successful result could discard forged OnFailure attachment metadata before validating its storage key, which allowed traversal outside private staging. Validate every destructive discard coordinate centrally before unlinking, and cover the forged traversal with a sentinel file.