### PR TITLE
fix(plugin): preserve test identity after subscribers

### DIFF
--- a/src/Runner/Worker/TestExecutor.php
+++ b/src/Runner/Worker/TestExecutor.php
@@ -44,9 +44,9 @@ use Greenlight\Runner\Artifact\TestArtifactBudget;
  *
  * An `After` hook runs if constructor injection created a test instance. It
  * runs even when a previous test-body operation did not complete.
- * `applyAfterSubscribers()` validates each outcome change against the
- * transformation log. Greenlight removes each reference to the test instance
- * when the attempt ends.
+ * `applyAfterSubscribers()` preserves the test identity. It validates each
+ * outcome change against the transformation log. Greenlight removes each
+ * reference to the test instance when the attempt ends.
  *
  * @internal
  */
@@ -306,8 +306,8 @@ final readonly class TestExecutor
     }
 
     /**
-     * Runs afterTest() subscribers and validates each outcome change against
-     * the transformation log.
+     * Runs afterTest() subscribers. It preserves the test identity and validates
+     * each outcome change against the transformation log.
      *
      * A change without a new transformation-log entry has no source. This
      * condition causes a test error that identifies the plugin.
@@ -342,6 +342,19 @@ final readonly class TestExecutor
                         )),
                     ]);
                 }
+
+                continue;
+            }
+
+            if (!$replacement->id->equals($result->id)) {
+                $result = $result->erroredBy(
+                    ThrowableDetail::fromThrowable(new \RuntimeException(\sprintf(
+                        'Plugin "%s" changed the test identity during afterTest() from "%s" to "%s".',
+                        $subscriber::class,
+                        $result->id,
+                        $replacement->id,
+                    ))),
+                );
 
                 continue;
             }

--- a/tests/Unit/Plugin/PluginTest.php
+++ b/tests/Unit/Plugin/PluginTest.php
@@ -9,6 +9,7 @@ use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\ResultSummary;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Core\Test\SkipTest;
+use Greenlight\Core\Test\TestId;
 use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\TestDiscoverer;
 use Greenlight\Doubles\Fake;
@@ -101,6 +102,42 @@ final class PluginTest
 
         Expect::that($results[0]->outcome)->because('unattributed outcome changes error the test naming the plugin')->toBe(Outcome::Errored)
             ->and($results[0]->error?->message)->toContain('without a new transformation-log entry from withOutcome()');
+    }
+
+    #[Test]
+    public function afterTestCannotReplaceTheTestIdentity(): void
+    {
+        $rogue = new class implements TestLifecycleSubscriber, Fake {
+            #[\Override]
+            public function beforeTest(TestContext $context): void {}
+
+            #[\Override]
+            public function afterTest(TestContext $context, TestResult $result): TestResult
+            {
+                return new TestResult(
+                    new TestId('Rogue\\InjectedTest', 'wrong'),
+                    $result->outcome,
+                    $result->durationSeconds,
+                    $result->memoryDeltaBytes,
+                );
+            }
+        };
+
+        [, $results] = $this->runSuite('Lifecycle/Order', [$rogue]);
+        $result = $results[0];
+        $expectedId = 'Greenlight\\Tests\\Fixture\\Lifecycle\\Order\\OrderTest::theTest';
+
+        Expect::that((string) $result->id)
+            ->because('afterTest() MUST NOT replace the executed test identity')
+            ->toBe($expectedId)
+            ->and($result->outcome)
+            ->toBe(Outcome::Errored)
+            ->and($result->error?->message)
+            ->toBe(\sprintf(
+                'Plugin "%s" changed the test identity during afterTest() from "%s" to "Rogue\\InjectedTest::wrong".',
+                $rogue::class,
+                $expectedId,
+            ));
     }
 
     #[Test]


### PR DESCRIPTION
An afterTest subscriber could return a TestResult for another TestId. The worker then attributed the executed test outcome to the replacement ID and corrupted result accounting.

Reject identity changes before outcome-provenance validation. Greenlight keeps the original ID, marks its result errored, and names the responsible plugin plus both identities.