### PR TITLE
fix(artifacts): validate attachment media metadata

### DIFF
--- a/docs/api-artifacts.md
+++ b/docs/api-artifacts.md
@@ -42,7 +42,7 @@ public function __construct(
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachment.php#L39)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachment.php#L43)
 
 ### `fromWire()`
 
@@ -51,7 +51,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachment.php#L54)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachment.php#L58)
 
 ## `AttachmentError`
 

--- a/src/Core/Artifact/Attachment.php
+++ b/src/Core/Artifact/Attachment.php
@@ -25,7 +25,11 @@ readonly class Attachment implements WireSerializable
         public AttachmentRetention $retention = AttachmentRetention::OnFailure,
     ) {
         if ($name === ''
-            || $mediaType === ''
+            || \preg_match('/[\x00-\x1F\x7F]/', $mediaType) === 1
+            || \preg_match(
+                '~^[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*/[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*(?:\s*;\s*[^=\s]+=(?:"[^"]*"|[^;\s]+))*$~',
+                $mediaType,
+            ) !== 1
             || $sizeBytes < 0
             || \preg_match('/^[0-9a-f]{64}$/', $sha256) !== 1
             || $attempt < 1

--- a/tests/Unit/Core/AttachmentMediaTypeContractTest.php
+++ b/tests/Unit/Core/AttachmentMediaTypeContractTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Artifact\Attachment;
+use Greenlight\Core\Artifact\AttachmentKind;
+use Greenlight\Expect\Expect;
+
+final class AttachmentMediaTypeContractTest
+{
+    #[Test]
+    #[DataSet('invalidMediaTypes')]
+    public function constructionAndWireDecodingRejectInvalidMediaTypes(string $mediaType): void
+    {
+        Expect::that(static fn(): Attachment => new Attachment(
+            'attachment',
+            AttachmentKind::Text,
+            $mediaType,
+            1,
+            \str_repeat('a', 64),
+            1,
+            'attachment.txt',
+        ))
+            ->because('attachment construction MUST reject an invalid media type')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Attachment metadata is invalid.',
+            );
+
+        Expect::that(static fn(): Attachment => Attachment::fromWire([
+            'name' => 'attachment',
+            'kind' => AttachmentKind::Text->value,
+            'mediaType' => $mediaType,
+            'sizeBytes' => 1,
+            'sha256' => \str_repeat('a', 64),
+            'attempt' => 1,
+            'path' => 'attachment.txt',
+        ]))
+            ->because('attachment wire decoding MUST reject an invalid media type')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Attachment metadata is invalid.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function invalidMediaTypes(): iterable
+    {
+        yield 'missing subtype' => ['text'];
+        yield 'null byte' => ["text/plain; note=\"before\0after\""];
+        yield 'tab' => ["text/plain; note=\"before\tafter\""];
+        yield 'line feed' => ["text/plain; note=\"before\nafter\""];
+        yield 'carriage return' => ["text/plain; note=\"before\rafter\""];
+        yield 'delete' => ["text/plain; note=\"before\x7Fafter\""];
+    }
+}

--- a/tests/Unit/Core/AttachmentValidMediaTypeTest.php
+++ b/tests/Unit/Core/AttachmentValidMediaTypeTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Artifact\Attachment;
+use Greenlight\Core\Artifact\AttachmentKind;
+use Greenlight\Expect\Expect;
+
+final readonly class AttachmentValidMediaTypeTest
+{
+    #[Test]
+    #[DataSet('validMediaTypes')]
+    public function validMediaTypesSurviveConstructionAndTheWire(string $mediaType): void
+    {
+        $attachment = new Attachment(
+            'attachment',
+            AttachmentKind::Text,
+            $mediaType,
+            1,
+            \str_repeat('a', 64),
+            1,
+            'attachment.txt',
+        );
+        $restored = Attachment::fromWire($attachment->toWire());
+
+        Expect::that($attachment->mediaType)
+            ->because('attachment construction MUST preserve a valid media type')
+            ->toBe($mediaType)
+            ->and($restored->mediaType)
+            ->because('attachment wire decoding MUST preserve a valid media type')
+            ->toBe($mediaType);
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function validMediaTypes(): iterable
+    {
+        yield 'vendor type with a structured suffix' => ['application/vnd.api+json'];
+        yield 'quoted parameter containing a semicolon' => ['text/plain; note="left;right"'];
+    }
+}


### PR DESCRIPTION
Applies the staging media-type contract to core attachment metadata so direct construction and wire decoding cannot admit malformed values. The focused dataset covers missing subtype syntax plus NUL, tab, line-feed, carriage-return, and DEL bytes through both entry paths.