### PR TITLE
fix(fixture): avoid root symbolic link traversal

### DIFF
--- a/src/Fixture/TempDirectory.php
+++ b/src/Fixture/TempDirectory.php
@@ -72,11 +72,29 @@ final class TempDirectory implements Disposable
     #[\Override]
     public function dispose(): void
     {
-        if ($this->path === null || !\is_dir($this->path)) {
+        if ($this->path === null) {
             return;
         }
 
         $path = $this->path;
+
+        if (\is_link($path)) {
+            if (!ErrorTrap::run(static fn(): bool => \unlink($path), $warning)) {
+                throw new \RuntimeException(\sprintf(
+                    'Failed to remove temp directory symbolic link "%s"%s.',
+                    $path,
+                    $warning === null ? '' : ': ' . $warning,
+                ));
+            }
+
+            $this->path = null;
+
+            return;
+        }
+
+        if (!\is_dir($path)) {
+            return;
+        }
 
         $entries = new \RecursiveIteratorIterator(
             new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),

--- a/tests/Unit/Fixture/TempDirectoryRootSymbolicLinkTest.php
+++ b/tests/Unit/Fixture/TempDirectoryRootSymbolicLinkTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Fixture;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Fixture\TempDirectory;
+
+final class TempDirectoryRootSymbolicLinkTest
+{
+    #[Test]
+    public function disposalDoesNotFollowAReplacedRootSymbolicLink(): void
+    {
+        $directory = new TempDirectory();
+        $target = new TempDirectory();
+        $root = $directory->path();
+        $sentinel = $target->path() . '/sentinel.txt';
+
+        if (\file_put_contents($sentinel, 'keep') === false) {
+            Fail::because('Expected to create the target sentinel file.');
+        }
+
+        if (!\rmdir($root) || !\symlink($target->path(), $root)) {
+            Fail::because('Expected to replace the temp directory root with a symbolic link.');
+        }
+
+        try {
+            Expect::that(static fn() => $directory->dispose())
+                ->because('disposal MUST remove the root symbolic link without entry traversal')
+                ->not()
+                ->toThrow(\Throwable::class);
+
+            Expect::that(\is_link($root))
+                ->because('disposal MUST remove the root symbolic link')
+                ->toBeFalse()
+                ->and(\file_get_contents($sentinel))
+                ->because('disposal MUST leave the root symbolic link target unchanged')
+                ->toBe('keep');
+        } finally {
+            if (\is_link($root)) {
+                \unlink($root);
+            }
+
+            $directory->dispose();
+            $target->dispose();
+        }
+    }
+}


### PR DESCRIPTION
TempDirectory disposal followed its root path after test code replaced the directory with a symbolic link. Cleanup could then delete files in the external target. Detect a root symbolic link before recursive traversal, remove only the link, and cover the boundary with an external sentinel.