### PR TITLE
test(doubles): execute static proxy returns

### DIFF
--- a/tests/Unit/Doubles/ProxyStaticReturnTest.php
+++ b/tests/Unit/Doubles/ProxyStaticReturnTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\MockPlan;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Doubles\Wide;
+
+final class ProxyStaticReturnTest
+{
+    #[Test]
+    public function aConfiguredStaticReturnAcceptsTheGeneratedProxy(): void
+    {
+        $double = null;
+        $doubles = new Doubles();
+
+        try {
+            $double = $doubles->mock(Wide::class, static function (MockPlan $plan) use (&$double): void {
+                $plan->expects('returnsStatic')->andReturnsUsing(static function () use (&$double): ?Wide {
+                    return $double;
+                });
+            });
+
+            Expect::that($double->returnsStatic())
+                ->because('a static return type MUST accept the generated proxy instance')
+                ->toBe($double);
+        } finally {
+            $doubles->dispose();
+        }
+    }
+}


### PR DESCRIPTION
TypeRenderer coverage checked the source spelling of static return types, but no test executed that contract through a generated proxy.

Configure returnsStatic() to return the exact generated double and call it. This pins both loadable proxy source and PHP runtime return-type compatibility.