### PR TITLE
fix(expect): preserve mixed numeric precision

### DIFF
--- a/src/Expect/Equality.php
+++ b/src/Expect/Equality.php
@@ -116,7 +116,14 @@ final class Equality
                 return $a === $b;
             }
 
-            return (float) $a === (float) $b;
+            if (\is_float($a) && \is_float($b)) {
+                return $a === $b;
+            }
+
+            $integer = \is_int($a) ? $a : $b;
+            $float = \is_float($a) ? $a : $b;
+
+            return (float) $integer === $float && (int) $float === $integer;
         }
 
         if (\is_array($a) && \is_array($b)) {

--- a/tests/Unit/Expect/ToBeAndToEqualTest.php
+++ b/tests/Unit/Expect/ToBeAndToEqualTest.php
@@ -66,6 +66,22 @@ final class ToBeAndToEqualTest
     }
 
     #[Test]
+    public function toEqualDoesNotRoundLargeIntegers(): void
+    {
+        $integer = 9_007_199_254_740_993;
+        $roundedFloat = (float) $integer;
+
+        Expect::that($integer)
+            ->because('toEqual() keeps integer precision')
+            ->not()
+            ->toEqual($roundedFloat);
+        Expect::that($roundedFloat)
+            ->because('toEqual() keeps integer precision in both operand orders')
+            ->not()
+            ->toEqual($integer);
+    }
+
+    #[Test]
     public function toEqualKeepsOtherScalarsStrict(): void
     {
         $detail = FailureProbe::detailOf(static fn() => Expect::that('1')->toEqual(1));


### PR DESCRIPTION
## Summary

- require mixed integers and floats to round-trip without precision loss
- cover the IEEE-754 integer boundary in both operand orders