### PR TITLE
fix(expect): canonicalize object property order

### DIFF
--- a/src/Expect/Equality.php
+++ b/src/Expect/Equality.php
@@ -90,8 +90,10 @@ final class Equality
 
             $seen[] = $id;
             $parts = [];
+            $properties = \get_mangled_object_vars($value);
+            \ksort($properties, \SORT_STRING);
 
-            foreach (\get_mangled_object_vars($value) as $name => $item) {
+            foreach ($properties as $name => $item) {
                 $parts[] = $name . '=>' . self::sortKey($item, $seen);
             }
 

--- a/tests/Unit/Expect/CanonicalObjectPropertyOrderTest.php
+++ b/tests/Unit/Expect/CanonicalObjectPropertyOrderTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+
+final class CanonicalObjectPropertyOrderTest
+{
+    #[Test]
+    public function canonicalEqualityIgnoresObjectPropertyInsertionOrder(): void
+    {
+        $first = $this->objectWithProperties(['a' => 1, 'b' => 2]);
+        $second = $this->objectWithProperties(['a' => 2, 'b' => 1]);
+        $equivalentFirst = $this->objectWithProperties(['b' => 2, 'a' => 1]);
+        $equivalentSecond = $this->objectWithProperties(['b' => 1, 'a' => 2]);
+
+        Expect::that([$first, $second])
+            ->because('canonical equality MUST ignore object property insertion order')
+            ->toEqualCanonicalizing([$equivalentFirst, $equivalentSecond]);
+    }
+
+    /** @param array<string, int> $properties */
+    private function objectWithProperties(array $properties): \stdClass
+    {
+        $object = new \stdClass();
+
+        foreach ($properties as $name => $value) {
+            $object->{$name} = $value;
+        }
+
+        return $object;
+    }
+}


### PR DESCRIPTION
Canonical list sort keys depended on object property insertion order, while deep equality compares object state without regard to that order. Sort object properties before deriving canonical keys so equivalent unordered lists remain equal.