### PR TITLE
fix(discovery): reject empty filter values

### DIFF
--- a/src/Discovery/Filter.php
+++ b/src/Discovery/Filter.php
@@ -26,30 +26,71 @@ use Greenlight\Core\Wildcard;
  */
 final readonly class Filter
 {
+    /** @var list<non-empty-string> */
+    public array $includeGroups;
+
+    /** @var list<non-empty-string> */
+    public array $excludeGroups;
+
+    /** @var list<non-empty-string> */
+    public array $includeClasses;
+
+    /** @var list<non-empty-string> */
+    public array $excludeClasses;
+
+    /** @var list<non-empty-string> */
+    public array $includeMethods;
+
+    /** @var list<non-empty-string> */
+    public array $excludeMethods;
+
+    /** @var list<non-empty-string> */
+    public array $includePaths;
+
+    /** @var list<non-empty-string> */
+    public array $excludePaths;
+
+    /** @var list<non-empty-string> */
+    public array $includeIds;
+
+    /** @var list<non-empty-string> */
+    public array $includeExactIds;
+
     /**
-     * @param list<non-empty-string> $includeGroups
-     * @param list<non-empty-string> $excludeGroups
-     * @param list<non-empty-string> $includeClasses
-     * @param list<non-empty-string> $excludeClasses
-     * @param list<non-empty-string> $includeMethods
-     * @param list<non-empty-string> $excludeMethods
-     * @param list<non-empty-string> $includePaths
-     * @param list<non-empty-string> $excludePaths
-     * @param list<non-empty-string> $includeIds
-     * @param list<non-empty-string> $includeExactIds
+     * @param list<string> $includeGroups
+     * @param list<string> $excludeGroups
+     * @param list<string> $includeClasses
+     * @param list<string> $excludeClasses
+     * @param list<string> $includeMethods
+     * @param list<string> $excludeMethods
+     * @param list<string> $includePaths
+     * @param list<string> $excludePaths
+     * @param list<string> $includeIds
+     * @param list<string> $includeExactIds
      */
     public function __construct(
-        public array $includeGroups = [],
-        public array $excludeGroups = [],
-        public array $includeClasses = [],
-        public array $excludeClasses = [],
-        public array $includeMethods = [],
-        public array $excludeMethods = [],
-        public array $includePaths = [],
-        public array $excludePaths = [],
-        public array $includeIds = [],
-        public array $includeExactIds = [],
-    ) {}
+        array $includeGroups = [],
+        array $excludeGroups = [],
+        array $includeClasses = [],
+        array $excludeClasses = [],
+        array $includeMethods = [],
+        array $excludeMethods = [],
+        array $includePaths = [],
+        array $excludePaths = [],
+        array $includeIds = [],
+        array $includeExactIds = [],
+    ) {
+        $this->includeGroups = $this->validateValues('includeGroups', $includeGroups);
+        $this->excludeGroups = $this->validateValues('excludeGroups', $excludeGroups);
+        $this->includeClasses = $this->validateValues('includeClasses', $includeClasses);
+        $this->excludeClasses = $this->validateValues('excludeClasses', $excludeClasses);
+        $this->includeMethods = $this->validateValues('includeMethods', $includeMethods);
+        $this->excludeMethods = $this->validateValues('excludeMethods', $excludeMethods);
+        $this->includePaths = $this->validateValues('includePaths', $includePaths);
+        $this->excludePaths = $this->validateValues('excludePaths', $excludePaths);
+        $this->includeIds = $this->validateValues('includeIds', $includeIds);
+        $this->includeExactIds = $this->validateValues('includeExactIds', $includeExactIds);
+    }
 
     public static function all(): self
     {
@@ -128,5 +169,29 @@ final readonly class Filter
     private function anyPrefixMatches(string $path, array $prefixes): bool
     {
         return \array_any($prefixes, static fn(string $prefix): bool => \str_starts_with($path, $prefix));
+    }
+
+    /**
+     * @param non-empty-string $dimension
+     * @param list<string> $values
+     *
+     * @return list<non-empty-string>
+     */
+    private function validateValues(string $dimension, array $values): array
+    {
+        $validated = [];
+
+        foreach ($values as $value) {
+            if ($value === '') {
+                throw new \InvalidArgumentException(\sprintf(
+                    'Filter "%s" MUST contain only non-empty strings.',
+                    $dimension,
+                ));
+            }
+
+            $validated[] = $value;
+        }
+
+        return $validated;
     }
 }

--- a/tests/Unit/Discovery/FilterValidationTest.php
+++ b/tests/Unit/Discovery/FilterValidationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\Filter;
+use Greenlight\Expect\Expect;
+
+final class FilterValidationTest
+{
+    #[Test]
+    #[DataSet('filterDimensions')]
+    public function emptyFilterValuesAreRejected(string $dimension): void
+    {
+        Expect::that(static fn(): Filter => self::withEmptyValue($dimension))
+            ->because('an empty filter value MUST NOT broaden or suppress test selection')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: \sprintf(
+                    'Filter "%s" MUST contain only non-empty strings.',
+                    $dimension,
+                ),
+            );
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function filterDimensions(): iterable
+    {
+        yield 'included group' => ['includeGroups'];
+        yield 'excluded group' => ['excludeGroups'];
+        yield 'included class' => ['includeClasses'];
+        yield 'excluded class' => ['excludeClasses'];
+        yield 'included method' => ['includeMethods'];
+        yield 'excluded method' => ['excludeMethods'];
+        yield 'included path' => ['includePaths'];
+        yield 'excluded path' => ['excludePaths'];
+        yield 'included test ID' => ['includeIds'];
+        yield 'included exact test ID' => ['includeExactIds'];
+    }
+
+    private static function withEmptyValue(string $dimension): Filter
+    {
+        return match ($dimension) {
+            'includeGroups' => new Filter(includeGroups: ['']),
+            'excludeGroups' => new Filter(excludeGroups: ['']),
+            'includeClasses' => new Filter(includeClasses: ['']),
+            'excludeClasses' => new Filter(excludeClasses: ['']),
+            'includeMethods' => new Filter(includeMethods: ['']),
+            'excludeMethods' => new Filter(excludeMethods: ['']),
+            'includePaths' => new Filter(includePaths: ['']),
+            'excludePaths' => new Filter(excludePaths: ['']),
+            'includeIds' => new Filter(includeIds: ['']),
+            'includeExactIds' => new Filter(includeExactIds: ['']),
+            default => throw new \LogicException(\sprintf('Unknown filter dimension "%s".', $dimension)),
+        };
+    }
+}


### PR DESCRIPTION
An empty class, method, path, or test-ID pattern can match every discovered test, while an empty exclusion can suppress selection. Validate each filter dimension at construction and retain narrowed non-empty-string properties for downstream matching.