### PR TITLE
fix(expect): canonicalize associative key order

### DIFF
--- a/src/Expect/Equality.php
+++ b/src/Expect/Equality.php
@@ -56,6 +56,7 @@ final class Equality
     {
         if (\is_array($value)) {
             $parts = [];
+            \ksort($value, \SORT_STRING);
 
             foreach ($value as $key => $item) {
                 $parts[] = \var_export($key, true) . '=>' . self::sortKey($item, $seen);

--- a/tests/Unit/Expect/CanonicalAssociativeArrayOrderTest.php
+++ b/tests/Unit/Expect/CanonicalAssociativeArrayOrderTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+
+final class CanonicalAssociativeArrayOrderTest
+{
+    #[Test]
+    public function canonicalEqualityIgnoresAssociativeKeyInsertionOrder(): void
+    {
+        $first = ['a' => 1, 'b' => 2];
+        $second = ['a' => 2, 'b' => 1];
+        $equivalentFirst = ['b' => 2, 'a' => 1];
+        $equivalentSecond = ['b' => 1, 'a' => 2];
+
+        Expect::that([$first, $second])
+            ->because('canonical equality MUST ignore associative key insertion order')
+            ->toEqualCanonicalizing([$equivalentFirst, $equivalentSecond]);
+    }
+}


### PR DESCRIPTION
Canonical list sort keys depended on associative key insertion order, while deep equality compares associative entries by key. Sort array keys only while deriving canonical sort keys so equivalent unordered lists remain equal.