### PR TITLE
fix(coverage): reject multiline LCOV paths

### DIFF
--- a/src/Coverage/Export/LcovExporter.php
+++ b/src/Coverage/Export/LcovExporter.php
@@ -9,7 +9,8 @@ use Greenlight\Coverage\CoverageMap;
 /**
  * Each file produces one SF record and one DA record for each executable
  * line. A DA record has a hit count of one or zero. LF and LH contain line
- * totals.
+ * totals. Each SF record stays on one line. A source path cannot contain a
+ * line break.
  *
  * @internal
  */
@@ -23,6 +24,10 @@ final readonly class LcovExporter implements CoverageExporter
         $out = '';
 
         foreach ($map->files() as $path => $file) {
+            if (\strpbrk($path, "\r\n") !== false) {
+                throw new \InvalidArgumentException('LCOV file paths MUST NOT contain line breaks.');
+            }
+
             $out .= 'SF:' . $path . "\n";
 
             $hits = [];

--- a/tests/Unit/Coverage/LcovExporterTest.php
+++ b/tests/Unit/Coverage/LcovExporterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Coverage;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Coverage\CoverageMap;
 use Greenlight\Coverage\Export\LcovExporter;
@@ -45,5 +46,31 @@ final class LcovExporterTest
     {
         Expect::that(new LcovExporter()->export(CoverageMap::empty()))->because('empty map produces an empty tracefile')
             ->toBe([LcovExporter::FILE_NAME => '']);
+    }
+
+    /**
+     * @param non-empty-string $path
+     */
+    #[Test]
+    #[DataSet('pathsThatCanInjectRecords')]
+    public function lineBreaksInFilePathsAreRejected(string $path): void
+    {
+        $map = new CoverageMap([new FileCoverage($path, [1], [])]);
+
+        Expect::that(static fn(): array => new LcovExporter()->export($map))
+            ->because('LCOV SF records MUST stay on one line')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'LCOV file paths MUST NOT contain line breaks.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function pathsThatCanInjectRecords(): iterable
+    {
+        yield 'line feed' => ["/src/A.php\nDA:999,1"];
+        yield 'carriage return' => ["/src/A.php\rDA:999,1"];
     }
 }


### PR DESCRIPTION
## Summary

- reject carriage returns and line feeds in LCOV source paths
- prevent file names from injecting extra tracefile records
- cover both record-breaking characters with a focused data set