### PR TITLE
fix(doubles): reject empty proxy directory

### DIFF
--- a/docs/api-doubles.md
+++ b/docs/api-doubles.md
@@ -192,7 +192,7 @@ public function __construct(?string $proxyDirectory = null)
 
 PHPDoc:
 
-- `@param non-empty-string|null $proxyDirectory Directory for generated proxy classes. The default is a project directory in the system temporary directory. A hash of the current working directory identifies it.`
+- `@param string|null $proxyDirectory Directory for generated proxy classes. An empty string is invalid. The default is a project directory in the system temporary directory. A hash of the current working directory identifies it.`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L51)
 
@@ -212,7 +212,7 @@ PHPDoc:
 - `@param \Closure(MockPlan): void|null $plan`
 - `@return T`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L83)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L87)
 
 ### `stub()`
 
@@ -230,7 +230,7 @@ PHPDoc:
 - `@param class-string<T> $type`
 - `@return T`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L99)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L103)
 
 ### `spy()`
 
@@ -248,7 +248,7 @@ PHPDoc:
 - `@param class-string<T> $type`
 - `@return T`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L115)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L119)
 
 ### `callsTo()`
 
@@ -263,7 +263,7 @@ PHPDoc:
 
 - `@return list<list<mixed>>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L126)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L130)
 
 ### `dispose()`
 
@@ -275,7 +275,7 @@ One `ExpectationFailed` contains the details for all unmet expectations.
 public function dispose(): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L139)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L143)
 
 ## `Fake`
 

--- a/src/Doubles/Doubles.php
+++ b/src/Doubles/Doubles.php
@@ -43,13 +43,17 @@ final class Doubles implements Disposable
     private \WeakMap $doubles;
 
     /**
-     * @param non-empty-string|null $proxyDirectory Directory for generated
-     *   proxy classes. The default is a project directory in the system
-     *   temporary directory. A hash of the current working directory
-     *   identifies it.
+     * @param string|null $proxyDirectory Directory for generated proxy
+     *   classes. An empty string is invalid. The default is a project
+     *   directory in the system temporary directory. A hash of the current
+     *   working directory identifies it.
      */
     public function __construct(?string $proxyDirectory = null)
     {
+        if ($proxyDirectory === '') {
+            throw new \InvalidArgumentException('Proxy directory MUST NOT be empty.');
+        }
+
         if ($proxyDirectory === null) {
             $workingDirectory = \getcwd();
 

--- a/tests/Unit/Doubles/DoublesProxyDirectoryValidationTest.php
+++ b/tests/Unit/Doubles/DoublesProxyDirectoryValidationTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Expect\Expect;
+
+final class DoublesProxyDirectoryValidationTest
+{
+    #[Test]
+    public function emptyProxyDirectoryIsRejected(): void
+    {
+        Expect::that(static fn(): Doubles => new Doubles(''))
+            ->because('an empty proxy directory MUST NOT resolve generated files from the filesystem root')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Proxy directory MUST NOT be empty.',
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Reject an empty explicit proxy directory before generated paths resolve from the filesystem root.
- Cover the constructor boundary and exact diagnostic.