### PR TITLE
fix(doubles): preserve reference arguments

### DIFF
--- a/src/Doubles/ProxyGenerator.php
+++ b/src/Doubles/ProxyGenerator.php
@@ -195,11 +195,13 @@ final readonly class ProxyGenerator
     {
         $returnType = $method->getReturnType() ?? $method->getTentativeReturnType();
         $returnName = $returnType instanceof \ReflectionNamedType ? $returnType->getName() : null;
+        $arguments = $this->renderInvocationArguments($method);
 
         $invoke = \sprintf(
-            "\$this->%s->invoke(\$this, '%s', \\func_get_args());",
+            "\$this->%s->invoke(\$this, '%s', %s);",
             self::HANDLER_PROPERTY,
             $method->name,
+            $arguments,
         );
 
         if ($returnName === 'void') {
@@ -220,6 +222,31 @@ final readonly class ProxyGenerator
             "    %s\n    {\n%s    }\n",
             $this->renderSignature($method, $returnType),
             $body,
+        );
+    }
+
+    private function renderInvocationArguments(\ReflectionMethod $method): string
+    {
+        $parameters = $method->getParameters();
+
+        if (!\array_any($parameters, static fn(\ReflectionParameter $parameter): bool => $parameter->isPassedByReference())) {
+            return '\func_get_args()';
+        }
+
+        $arguments = \array_map(
+            static function (\ReflectionParameter $parameter): string {
+                $prefix = $parameter->isVariadic()
+                    ? '...'
+                    : ($parameter->isPassedByReference() ? '&' : '');
+
+                return $prefix . '$' . $parameter->name;
+            },
+            $parameters,
+        );
+
+        return \sprintf(
+            '\array_slice([%s], 0, \func_num_args())',
+            \implode(', ', $arguments),
         );
     }
 

--- a/tests/Unit/Doubles/ProxyByReferenceTest.php
+++ b/tests/Unit/Doubles/ProxyByReferenceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\MockPlan;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Doubles\Wide;
+
+final class ProxyByReferenceTest
+{
+    #[Test]
+    public function configuredCallbacksCanChangeByReferenceArguments(): void
+    {
+        $doubles = new Doubles();
+        $wide = $doubles->mock(Wide::class, static function (MockPlan $plan): void {
+            $plan->expects('byReference')
+                ->andReturnsUsing(static function (array &$items): void {
+                    $items[] = 'changed';
+                });
+        });
+        $items = ['original'];
+
+        try {
+            $wide->byReference($items);
+
+            Expect::that($items)
+                ->because('a doubled method MUST preserve by-reference argument changes')
+                ->toBe(['original', 'changed']);
+        } finally {
+            $doubles->dispose();
+        }
+    }
+}


### PR DESCRIPTION
Generated doubles used func_get_args(), which copies by-reference arguments before configured callbacks run. Render reference-preserving invocation arrays for methods with by-reference parameters while retaining the exact number of supplied arguments.