### PR TITLE
fix(plugins): reject empty framework environments

### DIFF
--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -204,7 +204,7 @@ final class LaravelPlugin implements HarnessProvider, ServiceResolver, TestLifec
 ```php
 public function __construct(
     string|\Closure $application,
-    string $env = 'testing',
+    private readonly string $env = 'testing',
     private readonly bool $refreshBetweenTests = true,
 )
 ```
@@ -214,7 +214,7 @@ PHPDoc:
 - `@param string|\Closure(): Application $application A path to the file that returns the application, usually bootstrap/app.php, or a closure returning the application when exotic construction is needed.`
 - `@param bool $refreshBetweenTests Set to false only when no service carries state; tests on one worker then share one unreset application for the worker lifetime.`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L51)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L46)
 
 ### `services()`
 
@@ -227,7 +227,7 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L75)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L69)
 
 ### `resolve()`
 
@@ -242,7 +242,7 @@ PHPDoc:
 - `@param list<object> $attributes`
 - `@throws LaravelBridgeError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L92)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L86)
 
 ### `beforeTest()`
 
@@ -251,7 +251,7 @@ PHPDoc:
 public function beforeTest(TestContext $context): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L122)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L116)
 
 ### `afterTest()`
 
@@ -260,7 +260,7 @@ public function beforeTest(TestContext $context): void
 public function afterTest(TestContext $context, TestResult $result): TestResult
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L125)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L119)
 
 ## `Laravel\Service`
 

--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -204,7 +204,7 @@ final class LaravelPlugin implements HarnessProvider, ServiceResolver, TestLifec
 ```php
 public function __construct(
     string|\Closure $application,
-    private readonly string $env = 'testing',
+    string $env = 'testing',
     private readonly bool $refreshBetweenTests = true,
 )
 ```
@@ -212,10 +212,9 @@ public function __construct(
 PHPDoc:
 
 - `@param string|\Closure(): Application $application A path to the file that returns the application, usually bootstrap/app.php, or a closure returning the application when exotic construction is needed.`
-- `@param non-empty-string $env`
 - `@param bool $refreshBetweenTests Set to false only when no service carries state; tests on one worker then share one unreset application for the worker lifetime.`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L47)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L51)
 
 ### `services()`
 
@@ -228,7 +227,7 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L66)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L75)
 
 ### `resolve()`
 
@@ -243,7 +242,7 @@ PHPDoc:
 - `@param list<object> $attributes`
 - `@throws LaravelBridgeError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L83)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L92)
 
 ### `beforeTest()`
 
@@ -252,7 +251,7 @@ PHPDoc:
 public function beforeTest(TestContext $context): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L113)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L122)
 
 ### `afterTest()`
 
@@ -261,7 +260,7 @@ public function beforeTest(TestContext $context): void
 public function afterTest(TestContext $context, TestResult $result): TestResult
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L116)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L125)
 
 ## `Laravel\Service`
 
@@ -716,10 +715,9 @@ public function __construct(
 PHPDoc:
 
 - `@param string|\Closure(): KernelInterface $kernel A kernel class name that Greenlight constructs as new $kernel($env, $debug), or a closure that constructs the kernel. Use a closure for other constructor requirements.`
-- `@param non-empty-string $env`
 - `@param bool $resetBetweenTests For a container without stateful services, use false to disable resets. Tests on one worker then share all service instances.`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L52)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L51)
 
 ### `services()`
 
@@ -747,7 +745,7 @@ PHPDoc:
 - `@param list<object> $attributes`
 - `@throws SymfonyBridgeError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L85)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L88)
 
 ### `beforeTest()`
 
@@ -756,7 +754,7 @@ PHPDoc:
 public function beforeTest(TestContext $context): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L115)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L118)
 
 ### `afterTest()`
 
@@ -765,7 +763,7 @@ public function beforeTest(TestContext $context): void
 public function afterTest(TestContext $context, TestResult $result): TestResult
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L118)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L121)
 
 ## `TempestPlugin`
 

--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -732,7 +732,7 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L72)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L75)
 
 ### `resolve()`
 

--- a/src/Laravel/LaravelPlugin.php
+++ b/src/Laravel/LaravelPlugin.php
@@ -35,11 +35,6 @@ final class LaravelPlugin implements HarnessProvider, ServiceResolver, TestLifec
     private ?LaravelProcessState $processState = null;
 
     /**
-     * @var non-empty-string
-     */
-    private readonly string $env;
-
-    /**
      * @param string|\Closure(): Application $application
      *   A path to the file that returns the application, usually
      *   bootstrap/app.php, or a closure returning the application when
@@ -50,14 +45,13 @@ final class LaravelPlugin implements HarnessProvider, ServiceResolver, TestLifec
      */
     public function __construct(
         string|\Closure $application,
-        string $env = 'testing',
+        private readonly string $env = 'testing',
         private readonly bool $refreshBetweenTests = true,
     ) {
         if (\trim($env) === '') {
             throw new \InvalidArgumentException('Framework environment MUST NOT be empty.');
         }
 
-        $this->env = $env;
         $this->factory = $application instanceof \Closure
             ? $application
             : static function () use ($application): mixed {

--- a/src/Laravel/LaravelPlugin.php
+++ b/src/Laravel/LaravelPlugin.php
@@ -35,20 +35,29 @@ final class LaravelPlugin implements HarnessProvider, ServiceResolver, TestLifec
     private ?LaravelProcessState $processState = null;
 
     /**
+     * @var non-empty-string
+     */
+    private readonly string $env;
+
+    /**
      * @param string|\Closure(): Application $application
      *   A path to the file that returns the application, usually
      *   bootstrap/app.php, or a closure returning the application when
      *   exotic construction is needed.
-     * @param non-empty-string $env
      * @param bool $refreshBetweenTests
      *   Set to false only when no service carries state; tests on one worker
      *   then share one unreset application for the worker lifetime.
      */
     public function __construct(
         string|\Closure $application,
-        private readonly string $env = 'testing',
+        string $env = 'testing',
         private readonly bool $refreshBetweenTests = true,
     ) {
+        if ($env === '') {
+            throw new \InvalidArgumentException('Framework environment MUST NOT be empty.');
+        }
+
+        $this->env = $env;
         $this->factory = $application instanceof \Closure
             ? $application
             : static function () use ($application): mixed {

--- a/src/Laravel/LaravelPlugin.php
+++ b/src/Laravel/LaravelPlugin.php
@@ -53,7 +53,7 @@ final class LaravelPlugin implements HarnessProvider, ServiceResolver, TestLifec
         string $env = 'testing',
         private readonly bool $refreshBetweenTests = true,
     ) {
-        if ($env === '') {
+        if (\trim($env) === '') {
             throw new \InvalidArgumentException('Framework environment MUST NOT be empty.');
         }
 

--- a/src/Symfony/SymfonyPlugin.php
+++ b/src/Symfony/SymfonyPlugin.php
@@ -44,7 +44,6 @@ final class SymfonyPlugin implements HarnessProvider, ServiceResolver, TestLifec
      *   A kernel class name that Greenlight constructs as
      *   new $kernel($env, $debug), or a closure that constructs the kernel.
      *   Use a closure for other constructor requirements.
-     * @param non-empty-string $env
      * @param bool $resetBetweenTests
      *   For a container without stateful services, use false to disable
      *   resets. Tests on one worker then share all service instances.
@@ -55,6 +54,10 @@ final class SymfonyPlugin implements HarnessProvider, ServiceResolver, TestLifec
         bool $debug = false,
         private readonly bool $resetBetweenTests = true,
     ) {
+        if ($env === '') {
+            throw new \InvalidArgumentException('Framework environment MUST NOT be empty.');
+        }
+
         $this->factory = $kernel instanceof \Closure
             ? $kernel
             : static function () use ($kernel, $env, $debug): KernelInterface {

--- a/src/Symfony/SymfonyPlugin.php
+++ b/src/Symfony/SymfonyPlugin.php
@@ -54,7 +54,7 @@ final class SymfonyPlugin implements HarnessProvider, ServiceResolver, TestLifec
         bool $debug = false,
         private readonly bool $resetBetweenTests = true,
     ) {
-        if ($env === '') {
+        if (\trim($env) === '') {
             throw new \InvalidArgumentException('Framework environment MUST NOT be empty.');
         }
 

--- a/tests/Unit/FrameworkPluginEnvironmentValidationTest.php
+++ b/tests/Unit/FrameworkPluginEnvironmentValidationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Laravel\LaravelPlugin;
+use Greenlight\Symfony\SymfonyPlugin;
+
+final class FrameworkPluginEnvironmentValidationTest
+{
+    /**
+     * @param \Closure(): object $construct
+     */
+    #[Test]
+    #[DataSet('frameworkPlugins')]
+    public function emptyEnvironmentIsRejected(\Closure $construct): void
+    {
+        Expect::that($construct)
+            ->because('a framework plugin environment MUST identify the environment to boot')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Framework environment MUST NOT be empty.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{\Closure(): object}>
+     */
+    public static function frameworkPlugins(): iterable
+    {
+        yield 'Laravel' => [
+            static fn(): LaravelPlugin => new LaravelPlugin('/unused/bootstrap.php', env: ''),
+        ];
+
+        yield 'Symfony' => [
+            static fn(): SymfonyPlugin => new SymfonyPlugin('UnusedKernel', env: ''),
+        ];
+    }
+}

--- a/tests/Unit/FrameworkPluginEnvironmentValidationTest.php
+++ b/tests/Unit/FrameworkPluginEnvironmentValidationTest.php
@@ -17,7 +17,7 @@ final class FrameworkPluginEnvironmentValidationTest
      */
     #[Test]
     #[DataSet('frameworkPlugins')]
-    public function emptyEnvironmentIsRejected(\Closure $construct): void
+    public function blankEnvironmentIsRejected(\Closure $construct): void
     {
         Expect::that($construct)
             ->because('a framework plugin environment MUST identify the environment to boot')
@@ -32,12 +32,20 @@ final class FrameworkPluginEnvironmentValidationTest
      */
     public static function frameworkPlugins(): iterable
     {
-        yield 'Laravel' => [
+        yield 'Laravel empty' => [
             static fn(): LaravelPlugin => new LaravelPlugin('/unused/bootstrap.php', env: ''),
         ];
 
-        yield 'Symfony' => [
+        yield 'Laravel whitespace' => [
+            static fn(): LaravelPlugin => new LaravelPlugin('/unused/bootstrap.php', env: " \t"),
+        ];
+
+        yield 'Symfony empty' => [
             static fn(): SymfonyPlugin => new SymfonyPlugin('UnusedKernel', env: ''),
+        ];
+
+        yield 'Symfony whitespace' => [
+            static fn(): SymfonyPlugin => new SymfonyPlugin('UnusedKernel', env: " \t"),
         ];
     }
 }


### PR DESCRIPTION
## Summary

- Reject empty Laravel and Symfony environment names at plugin construction.
- Cover both public constructors with one focused dataset and exact diagnostic.
- Regenerate the integration API reference.