### PR TITLE
fix(config): reject null artifact directories

### DIFF
--- a/docs/api-configuration.md
+++ b/docs/api-configuration.md
@@ -32,7 +32,7 @@ public function directory(string $directory): self
 public function maxAttachmentsPerTest(int $count): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L30)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L34)
 
 ### `maxAttachmentSize()`
 
@@ -40,7 +40,7 @@ public function maxAttachmentsPerTest(int $count): self
 public function maxAttachmentSize(string $size): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L41)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L45)
 
 ### `maxTestSize()`
 
@@ -48,7 +48,7 @@ public function maxAttachmentSize(string $size): self
 public function maxTestSize(string $size): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L48)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L52)
 
 ### `maxRunAttachments()`
 
@@ -56,7 +56,7 @@ public function maxTestSize(string $size): self
 public function maxRunAttachments(int $count): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L55)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L59)
 
 ### `maxRunSize()`
 
@@ -64,7 +64,7 @@ public function maxRunAttachments(int $count): self
 public function maxRunSize(string $size): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L66)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L70)
 
 ## `CoverageBuilder`
 

--- a/src/Config/ArtifactBuilder.php
+++ b/src/Config/ArtifactBuilder.php
@@ -22,6 +22,10 @@ final class ArtifactBuilder
             throw new InvalidConfiguration('Artifact directory cannot be empty.');
         }
 
+        if (\str_contains($directory, "\0")) {
+            throw new InvalidConfiguration('Artifact directory cannot contain a null byte.');
+        }
+
         $this->directory = $directory;
 
         return $this;

--- a/tests/Unit/Config/ArtifactDirectoryValidationTest.php
+++ b/tests/Unit/Config/ArtifactDirectoryValidationTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Config;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactBuilder;
+use Greenlight\Config\InvalidConfiguration;
+use Greenlight\Expect\Expect;
+
+final class ArtifactDirectoryValidationTest
+{
+    #[Test]
+    public function nullBytesAreRejectedAtTheConfigurationBoundary(): void
+    {
+        Expect::that(static fn(): ArtifactBuilder => new ArtifactBuilder()->directory("artifacts\0hidden"))
+            ->because('artifact directories MUST be valid file-system paths')
+            ->toThrow(
+                InvalidConfiguration::class,
+                message: 'Artifact directory cannot contain a null byte.',
+            );
+    }
+}


### PR DESCRIPTION
Artifact directories with NUL bytes currently reach file-system functions and can produce raw ValueError exceptions. Reject these paths at the public configuration boundary with InvalidConfiguration and focused regression coverage.