### PR TITLE
fix(config): reject null coverage export targets

### DIFF
--- a/src/Config/CoverageExport.php
+++ b/src/Config/CoverageExport.php
@@ -26,6 +26,10 @@ final readonly class CoverageExport
             throw new InvalidConfiguration('Coverage exports need a non-empty format and target.');
         }
 
+        if (\str_contains($target, "\0")) {
+            throw new InvalidConfiguration('Coverage export target cannot contain a null byte.');
+        }
+
         $this->format = $format;
         $this->target = $target;
     }

--- a/tests/Unit/Config/CoverageExportPathValidationTest.php
+++ b/tests/Unit/Config/CoverageExportPathValidationTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Config;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\CoverageBuilder;
+use Greenlight\Config\InvalidConfiguration;
+use Greenlight\Expect\Expect;
+
+final class CoverageExportPathValidationTest
+{
+    #[Test]
+    public function nullBytesAreRejectedAtTheConfigurationBoundary(): void
+    {
+        Expect::that(static fn(): CoverageBuilder => new CoverageBuilder()->export('json', "coverage\0hidden.json"))
+            ->because('coverage export targets MUST be valid file-system paths')
+            ->toThrow(
+                InvalidConfiguration::class,
+                message: 'Coverage export target cannot contain a null byte.',
+            );
+    }
+}


### PR DESCRIPTION
Coverage export targets with NUL bytes currently reach directory and atomic-file operations, where PHP can throw raw ValueError exceptions. Reject these targets at the public configuration boundary with InvalidConfiguration and focused regression coverage.