### PR TITLE
fix(doubles): reject unknown recorded methods

### DIFF
--- a/docs/api-doubles.md
+++ b/docs/api-doubles.md
@@ -253,7 +253,8 @@ PHPDoc:
 ### `callsTo()`
 
 Gets the calls to one method of a double from this factory. The result
-uses call order. Each entry contains the arguments for one call.
+uses call order. Each entry contains the arguments for one call. The
+method must exist on the doubled type.
 
 ```php
 public function callsTo(object $double, string $method): array
@@ -263,7 +264,7 @@ PHPDoc:
 
 - `@return list<list<mixed>>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L130)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L131)
 
 ### `dispose()`
 
@@ -275,7 +276,7 @@ One `ExpectationFailed` contains the details for all unmet expectations.
 public function dispose(): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L143)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L150)
 
 ## `Fake`
 

--- a/src/Doubles/Doubles.php
+++ b/src/Doubles/Doubles.php
@@ -123,7 +123,8 @@ final class Doubles implements Disposable
 
     /**
      * Gets the calls to one method of a double from this factory. The result
-     * uses call order. Each entry contains the arguments for one call.
+     * uses call order. Each entry contains the arguments for one call. The
+     * method must exist on the doubled type.
      *
      * @return list<list<mixed>>
      */
@@ -133,7 +134,13 @@ final class Doubles implements Disposable
             throw DoublesError::foreignDouble($double::class);
         }
 
-        return $this->doubles[$double]->recordedCalls[$method] ?? [];
+        $state = $this->doubles[$double];
+
+        if (!\method_exists($state->type, $method)) {
+            throw DoublesError::noSuchRecordedMethod($state->type, $method);
+        }
+
+        return $state->recordedCalls[$method] ?? [];
     }
 
     /**

--- a/src/Doubles/DoublesError.php
+++ b/src/Doubles/DoublesError.php
@@ -57,6 +57,11 @@ final class DoublesError extends \LogicException
         return new self(\sprintf('%s has no method %s(). Doubles cannot plan it.', $type, $method));
     }
 
+    public static function noSuchRecordedMethod(string $type, string $method): self
+    {
+        return new self(\sprintf('%s has no method %s(). Doubles cannot inspect calls to it.', $type, $method));
+    }
+
     public static function staticMethod(string $type, string $method): self
     {
         return new self(\sprintf('%s::%s() is static. Doubles cannot intercept static methods.', $type, $method));

--- a/tests/Unit/Doubles/SpyMethodValidationTest.php
+++ b/tests/Unit/Doubles/SpyMethodValidationTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\DoublesError;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Doubles\Notifier;
+
+final class SpyMethodValidationTest
+{
+    #[Test]
+    public function rejectsAnUnknownMethodInsteadOfReportingThatItWasNotCalled(): void
+    {
+        $doubles = new Doubles();
+        $spy = $doubles->spy(Notifier::class);
+
+        Expect::that(static fn(): array => $doubles->callsTo($spy, 'notifiy'))
+            ->because('a misspelled method MUST NOT look like an uncalled method')
+            ->toThrow(
+                DoublesError::class,
+                message: 'Greenlight\Tests\Fixture\Doubles\Notifier has no method notifiy(). '
+                . 'Doubles cannot inspect calls to it.',
+            );
+
+        $doubles->dispose();
+    }
+}


### PR DESCRIPTION
## Summary

- reject unknown method names passed to `Doubles::callsTo()`
- prevent misspelled spy assertions from looking like uncalled methods
- document the method-existence contract in the generated API reference