### PR TITLE
fix(events): reject invalid worker PID payloads

### DIFF
--- a/src/Core/Event/WorkerSpawned.php
+++ b/src/Core/Event/WorkerSpawned.php
@@ -53,7 +53,7 @@ final readonly class WorkerSpawned implements Event
     {
         return new self(
             Wire::nonEmptyString($payload, 'workerId'),
-            \max(1, Wire::int($payload, 'pid')),
+            Wire::int($payload, 'pid'),
             Wire::float($payload, 'occurredAt'),
         );
     }

--- a/tests/Unit/Core/WorkerEventValidationTest.php
+++ b/tests/Unit/Core/WorkerEventValidationTest.php
@@ -42,6 +42,22 @@ final readonly class WorkerEventValidationTest
             );
     }
 
+    #[Test]
+    #[DataSet('nonPositivePids')]
+    public function aSpawnedWorkerRejectsANonPositiveWirePid(int $pid): void
+    {
+        Expect::that(static fn(): WorkerSpawned => WorkerSpawned::fromWire([
+            'workerId' => 'worker-1',
+            'pid' => $pid,
+            'occurredAt' => 1.0,
+        ]))
+            ->because('a spawned-worker wire event MUST identify a positive process ID')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Worker PID MUST be greater than zero.',
+            );
+    }
+
     /**
      * @return iterable<string, array{int}>
      */


### PR DESCRIPTION
WorkerSpawned already rejects non-positive PIDs during direct construction, but its wire decoder silently normalized them to 1. This lets malformed event payloads cross the wire as valid-looking process identities.\n\nPass the decoded PID through the existing constructor invariant and cover zero and negative payloads.