### PR TITLE
fix(artifacts): reject null source paths

### DIFF
--- a/src/Runner/Artifact/StagedAttachments.php
+++ b/src/Runner/Artifact/StagedAttachments.php
@@ -87,6 +87,14 @@ final class StagedAttachments implements Attachments
         AttachmentRetention $retention = AttachmentRetention::OnFailure,
     ): void {
         $this->guard($name, $mediaType ?? 'application/octet-stream');
+
+        if (\str_contains($sourcePath, "\0")) {
+            throw AttachmentError::source(
+                \strtr($sourcePath, ["\0" => '\0']),
+                'contains a null byte',
+            );
+        }
+
         $this->recordAttempt();
         $sequence = \count($this->attachments) + 1;
         $storageKey = $this->storageKey($name, $sequence);

--- a/tests/Unit/Artifact/AttachmentSourcePathValidationTest.php
+++ b/tests/Unit/Artifact/AttachmentSourcePathValidationTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\ArtifactStore;
+use Greenlight\Runner\Artifact\TestArtifactBudget;
+
+final readonly class AttachmentSourcePathValidationTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function nullBytesAreRejectedBeforeFileSystemAccess(): void
+    {
+        $root = $this->tempDirectory->subdirectory('null-source-path');
+        $configuration = new ArtifactConfiguration($root);
+        $store = ArtifactStore::open($configuration, $root, 'run-null-source');
+        $attachments = $store->forAttempt(
+            new TestId('Example\EvidenceTest', 'invalidSource'),
+            1,
+            new TestArtifactBudget(),
+        );
+
+        try {
+            Expect::that(static fn() => $attachments->file('copy.bin', "source\0hidden.txt"))
+                ->because('attachment source paths MUST be valid file-system paths')
+                ->toThrow(
+                    AttachmentError::class,
+                    message: 'Attachment source "source\0hidden.txt" contains a null byte.',
+                );
+        } finally {
+            $store->cleanup();
+        }
+    }
+}


### PR DESCRIPTION
File attachments with NUL bytes in their source path currently reach fopen(), which throws a raw ValueError. Reject these paths before file-system access with a typed AttachmentError, escape the control byte in the diagnostic, and add focused regression coverage.