### PR TITLE
fix(coverage): reject null LCOV paths

### DIFF
--- a/src/Coverage/Export/LcovExporter.php
+++ b/src/Coverage/Export/LcovExporter.php
@@ -10,7 +10,7 @@ use Greenlight\Coverage\CoverageMap;
  * Each file produces one SF record and one DA record for each executable
  * line. A DA record has a hit count of one or zero. LF and LH contain line
  * totals. Each SF record stays on one line. A source path cannot contain a
- * line break.
+ * line break or null byte.
  *
  * @internal
  */
@@ -24,6 +24,10 @@ final readonly class LcovExporter implements CoverageExporter
         $out = '';
 
         foreach ($map->files() as $path => $file) {
+            if (\str_contains($path, "\0")) {
+                throw new \InvalidArgumentException('LCOV file paths MUST NOT contain null bytes.');
+            }
+
             if (\strpbrk($path, "\r\n") !== false) {
                 throw new \InvalidArgumentException('LCOV file paths MUST NOT contain line breaks.');
             }

--- a/tests/Unit/Coverage/LcovNullPathValidationTest.php
+++ b/tests/Unit/Coverage/LcovNullPathValidationTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Coverage\Export\LcovExporter;
+use Greenlight\Coverage\FileCoverage;
+use Greenlight\Expect\Expect;
+
+final class LcovNullPathValidationTest
+{
+    #[Test]
+    public function nullBytesAreRejectedBeforeWritingTheSourceRecord(): void
+    {
+        $map = new CoverageMap([
+            new FileCoverage("/src/A\0hidden.php", [1], []),
+        ]);
+
+        Expect::that(static fn(): array => new LcovExporter()->export($map))
+            ->because('LCOV source records MUST contain valid file paths')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'LCOV file paths MUST NOT contain null bytes.',
+            );
+    }
+}


### PR DESCRIPTION
LCOV source records can currently contain NUL bytes from wire or synthetic coverage maps, which produces invalid tracefiles for downstream consumers. Reject these paths before serialization and add focused regression coverage.