### PR TITLE
fix(protocol): reject negative completion memory

### DIFF
--- a/src/Runner/Protocol/Messages/Done.php
+++ b/src/Runner/Protocol/Messages/Done.php
@@ -25,16 +25,31 @@ use Greenlight\Runner\Protocol\Message;
 final readonly class Done implements Message
 {
     /**
-     * @param non-negative-int $peakMemoryBytes
+     * @var non-negative-int
+     */
+    public int $peakMemoryBytes;
+
+    /**
      * @param list<TestId> $leaks
+     *
+     * @throws \InvalidArgumentException when peak memory is negative
      */
     public function __construct(
         public ResultSummary $summary,
-        public int $peakMemoryBytes,
+        int $peakMemoryBytes,
         public ?CoverageMap $coverage = null,
         public array $leaks = [],
         public ?RecycleReason $wantsRecycle = null,
-    ) {}
+    ) {
+        if ($peakMemoryBytes < 0) {
+            throw new \InvalidArgumentException(\sprintf(
+                'Done message peak memory MUST NOT be negative. Actual value: %d.',
+                $peakMemoryBytes,
+            ));
+        }
+
+        $this->peakMemoryBytes = $peakMemoryBytes;
+    }
 
     #[\Override]
     public static function tag(): string

--- a/tests/Unit/Runner/Protocol/DoneValidationTest.php
+++ b/tests/Unit/Runner/Protocol/DoneValidationTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Protocol;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\ResultSummary;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\Protocol\Messages\Done;
+
+final readonly class DoneValidationTest
+{
+    #[Test]
+    #[DataSet('negativeMemoryMeasurements')]
+    public function directMessagesRejectNegativePeakMemory(int $peakMemoryBytes): void
+    {
+        Expect::that(static fn(): Done => new Done(new ResultSummary(), $peakMemoryBytes))
+            ->because('worker completion messages MUST NOT report negative peak memory')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: \sprintf(
+                    'Done message peak memory MUST NOT be negative. Actual value: %d.',
+                    $peakMemoryBytes,
+                ),
+            );
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function negativeMemoryMeasurements(): iterable
+    {
+        yield 'minus one' => [-1];
+        yield 'minimum integer' => [\PHP_INT_MIN];
+    }
+}


### PR DESCRIPTION
## Summary

- reject negative peak-memory measurements in worker completion messages
- preserve the validated non-negative property contract at runtime
- cover the direct-message boundary with exact diagnostics