### PR TITLE
test(artifacts): cover partial stream writes

### DIFF
--- a/tests/Fixture/Artifact/PartialWriteStream.php
+++ b/tests/Fixture/Artifact/PartialWriteStream.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Artifact;
+
+use Greenlight\Doubles\Fake;
+
+/**
+ * Simulates a stream that accepts at most two bytes from each write.
+ */
+final class PartialWriteStream implements Fake
+{
+    public mixed $context;
+
+    public static string $written = '';
+
+    public static int $writes = 0;
+
+    private static bool $pause = false;
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        self::$written = '';
+        self::$writes = 0;
+        self::$pause = false;
+
+        return true;
+    }
+
+    public function stream_write(string $data): int
+    {
+        if (self::$pause) {
+            self::$pause = false;
+
+            return 0;
+        }
+
+        $chunk = \substr($data, 0, 2);
+        self::$written .= $chunk;
+        self::$writes++;
+        self::$pause = \strlen($chunk) < \strlen($data);
+
+        return \strlen($chunk);
+    }
+}

--- a/tests/Unit/Artifact/ArtifactStreamPartialWriteTest.php
+++ b/tests/Unit/Artifact/ArtifactStreamPartialWriteTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Runner\Artifact\StreamWriter;
+use Greenlight\Tests\Fixture\Artifact\PartialWriteStream;
+
+final class ArtifactStreamPartialWriteTest
+{
+    private const string SCHEME = 'greenlight-partial-write';
+
+    #[Test]
+    public function partialWritesContinueUntilEveryByteIsWritten(): void
+    {
+        if (!\stream_wrapper_register(self::SCHEME, PartialWriteStream::class)) {
+            Fail::because('The test could not register the partial-write stream.');
+        }
+
+        $stream = \fopen(self::SCHEME . '://attachment', 'wb');
+
+        if ($stream === false) {
+            \stream_wrapper_unregister(self::SCHEME);
+            Fail::because('The test could not open the partial-write stream.');
+        }
+
+        try {
+            StreamWriter::writeFully($stream, 'evidence');
+
+            Expect::that(PartialWriteStream::$written)
+                ->because('a partial write MUST continue from the first unwritten byte')
+                ->toBe('evidence')
+                ->and(PartialWriteStream::$writes)
+                ->because('the fixture accepts at most two bytes from each write')
+                ->toBe(4);
+        } finally {
+            \fclose($stream);
+            \stream_wrapper_unregister(self::SCHEME);
+        }
+    }
+}


### PR DESCRIPTION
Add a stream fixture that forces fwrite() to return positive partial progress and pin the StreamWriter completion loop. The test verifies that storage resumes at the first unwritten byte until the complete attachment has been written.