### PR TITLE
fix(coverage): ignore null source paths

### DIFF
--- a/src/Coverage/Ignore/IgnoreScanner.php
+++ b/src/Coverage/Ignore/IgnoreScanner.php
@@ -37,6 +37,10 @@ final readonly class IgnoreScanner
      */
     public function ignoredLines(string $path): array
     {
+        if (\str_contains($path, "\0")) {
+            return [];
+        }
+
         $source = ErrorTrap::run(static fn(): string|false => \file_get_contents($path), $warning);
 
         if (!\is_string($source)) {

--- a/tests/Unit/Coverage/IgnoreScannerTest.php
+++ b/tests/Unit/Coverage/IgnoreScannerTest.php
@@ -18,6 +18,14 @@ final class IgnoreScannerTest
     }
 
     #[Test]
+    public function nullByteFilePathYieldsNoIgnoredLines(): void
+    {
+        Expect::that(new IgnoreScanner()->ignoredLines("/invalid\0path.php"))
+            ->because('null byte file path yields no ignored lines')
+            ->toBe([]);
+    }
+
+    #[Test]
     public function fileWithoutMarkersYieldsNoIgnoredLines(): void
     {
         $source = <<<'PHP'


### PR DESCRIPTION
Coverage ignore scanning treats unreadable source files as having no ignored lines, but a NUL byte in a path currently escapes that contract as a raw ValueError. Treat the invalid path as unreadable and add focused regression coverage.