### PR TITLE
test(config): cover additive plugin calls

### DIFF
--- a/tests/Unit/Config/PluginCompositionTest.php
+++ b/tests/Unit/Config/PluginCompositionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Config;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Plugins\NamedFakePlugin;
+
+final readonly class PluginCompositionTest
+{
+    #[Test]
+    public function repeatedPluginCallsAppendInConfigurationOrder(): void
+    {
+        $first = new NamedFakePlugin();
+        $second = new NamedFakePlugin();
+
+        $plugins = GreenlightConfig::create()
+            ->plugins($first)
+            ->plugins($second)
+            ->build()
+            ->plugins;
+
+        Expect::that($plugins)
+            ->because('repeated plugin calls MUST retain every configured plugin in order')
+            ->toBe([$first, $second]);
+    }
+}


### PR DESCRIPTION
## Summary

- cover plugins configured across separate `plugins()` calls
- preserve plugin identity and configuration order
- protect helper-based configuration from replacing earlier plugins