### PR TITLE
fix(wire): reject numeric map keys

### DIFF
--- a/src/Core/Wire/Wire.php
+++ b/src/Core/Wire/Wire.php
@@ -202,7 +202,11 @@ final class Wire
         $map = [];
 
         foreach ($value as $mapKey => $mapValue) {
-            $map[(string) $mapKey] = $mapValue;
+            if (!\is_string($mapKey)) {
+                throw InvalidWirePayload::wrongType($key, 'a map with string keys', $value);
+            }
+
+            $map[$mapKey] = $mapValue;
         }
 
         return $map;
@@ -297,7 +301,11 @@ final class Wire
             $map = [];
 
             foreach ($item as $mapKey => $mapValue) {
-                $map[(string) $mapKey] = $mapValue;
+                if (!\is_string($mapKey)) {
+                    throw InvalidWirePayload::wrongType($key, 'a list of maps with string keys', $item);
+                }
+
+                $map[$mapKey] = $mapValue;
             }
 
             $maps[] = $map;

--- a/tests/Unit/Core/WireTest.php
+++ b/tests/Unit/Core/WireTest.php
@@ -135,6 +135,32 @@ final class WireTest
     }
 
     #[Test]
+    public function mapReadersRejectNumericKeysInMixedMaps(): void
+    {
+        $map = ['field' => [0 => 'numeric', 'named' => 'value']];
+        $listOfMaps = ['field' => [[0 => 'numeric', 'named' => 'value']]];
+
+        Expect::that(static fn(): array => Wire::map($map, 'field'))
+            ->because('wire maps MUST have string keys')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "field" must be a map with string keys, got array.',
+            )
+            ->and(static fn(): ?array => Wire::nullableMap($map, 'field'))
+            ->because('nullable wire maps MUST validate non-null keys')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "field" must be a map with string keys, got array.',
+            )
+            ->and(static fn(): array => Wire::listOfMaps($listOfMaps, 'field'))
+            ->because('each wire map in a list MUST have string keys')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "field" must be a list of maps with string keys, got array.',
+            );
+    }
+
+    #[Test]
     #[DataSet('nonFiniteFloats')]
     public function floatReadersRejectNonFiniteValues(float $value): void
     {

--- a/tests/Unit/Coverage/CoverageMapTest.php
+++ b/tests/Unit/Coverage/CoverageMapTest.php
@@ -198,6 +198,10 @@ final class CoverageMapTest
             ['files' => ['' => [[], []]]],
             '/non-empty file paths/',
         ];
+        yield 'numeric file path' => [
+            ['files' => [0 => [[1], []], '/src/A.php' => [[1], []]]],
+            '/map with string keys/',
+        ];
         yield 'wrong file shape' => [
             ['files' => ['/src/A.php' => [[1]]]],
             '/two-element list/',


### PR DESCRIPTION
Wire map readers currently cast numeric keys to strings, but PHP converts numeric string array keys back to integers. A mixed-key map can therefore pass shape validation and leak a raw TypeError into consumers such as coverage-map decoding. Reject non-string map keys at the shared wire boundary and add focused reader and coverage-map regressions.