### PR TITLE
test(doubles): require true predicate results

### DIFF
--- a/tests/Unit/Doubles/PredicateMatcherStrictReturnTest.php
+++ b/tests/Unit/Doubles/PredicateMatcherStrictReturnTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Argument;
+use Greenlight\Expect\Expect;
+
+final class PredicateMatcherStrictReturnTest
+{
+    #[Test]
+    public function truthyPredicateResultsDoNotMatch(): void
+    {
+        $matcher = Argument::predicate(static fn(): int => 1, 'truthy result');
+
+        Expect::that($matcher->matches('value'))
+            ->because('an argument predicate MUST return the boolean value true to match')
+            ->toBeFalse();
+    }
+}


### PR DESCRIPTION
Cover the strict result contract for argument predicates. A predicate now has a focused regression test proving that truthy non-boolean values do not select a mock expectation.