### PR TITLE
test(core): cover result copy mutators

### DIFF
--- a/tests/Unit/Core/TestResultCopyTest.php
+++ b/tests/Unit/Core/TestResultCopyTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Core;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Artifact\Attachment;
 use Greenlight\Core\Artifact\AttachmentKind;
@@ -18,6 +19,32 @@ use Greenlight\Expect\Expect;
 
 final class TestResultCopyTest
 {
+    /**
+     * @param callable(TestResult): TestResult $mutate
+     * @param array<string, mixed> $changes
+     */
+    #[Test]
+    #[DataSet('resultMutations')]
+    public function resultMutatorsReplaceOnlyTheirTargetState(callable $mutate, array $changes): void
+    {
+        $original = $this->completeResult();
+        $originalWire = $original->toWire();
+        $expected = \array_replace($originalWire, $changes);
+
+        $replacement = $mutate($original);
+
+        Expect::that($replacement)
+            ->because('a result mutation MUST produce a replacement result')
+            ->not()
+            ->toBe($original)
+            ->and($original->toWire())
+            ->because('a result mutation MUST NOT change the original result')
+            ->toBe($originalWire)
+            ->and($replacement->toWire())
+            ->because('a result mutation MUST preserve all state that it does not replace')
+            ->toBe($expected);
+    }
+
     #[Test]
     public function withAttemptsReplacesOnlyTheAttemptCount(): void
     {
@@ -63,5 +90,89 @@ final class TestResultCopyTest
             ->and($recovered->toWire())
             ->because('the replacement MUST preserve all result state except the recovered attempt count')
             ->toBe($expected);
+    }
+
+    /**
+     * @return iterable<
+     *     string,
+     *     array{
+     *         callable(TestResult): TestResult,
+     *         array<string, mixed>,
+     *     },
+     * >
+     */
+    public static function resultMutations(): iterable
+    {
+        $replacementAttachment = new Attachment(
+            'replacement.txt',
+            AttachmentKind::Text,
+            'text/plain',
+            11,
+            \str_repeat('b', 64),
+            3,
+            'artifacts/replacement.txt',
+        );
+        $replacementError = new ThrowableDetail(
+            \LogicException::class,
+            'replacement error',
+            '/tests/ReplacementTest.php',
+            24,
+        );
+        $replacementFailure = new FailureDetail('replacement failure', 'ready', 'waiting');
+
+        yield 'risky status' => [
+            static fn(TestResult $result): TestResult => $result->asRisky(),
+            ['risky' => true],
+        ];
+        yield 'attachments' => [
+            static fn(TestResult $result): TestResult => $result->withAttachments([$replacementAttachment]),
+            ['attachments' => [$replacementAttachment->toWire()]],
+        ];
+        yield 'error' => [
+            static fn(TestResult $result): TestResult => $result->erroredBy($replacementError),
+            [
+                'outcome' => Outcome::Errored->value,
+                'error' => $replacementError->toWire(),
+            ],
+        ];
+        yield 'failures' => [
+            static fn(TestResult $result): TestResult => $result->withFailures([$replacementFailure]),
+            ['failures' => [$replacementFailure->toWire()]],
+        ];
+    }
+
+    private function completeResult(): TestResult
+    {
+        return new TestResult(
+            id: new TestId('Example\\CopyTest', 'preservesState', 'row'),
+            outcome: Outcome::Failed,
+            durationSeconds: 0.125,
+            memoryDeltaBytes: 2048,
+            attempts: 2,
+            failures: [new FailureDetail('expected ready', 'ready', 'waiting')],
+            error: new ThrowableDetail(
+                \RuntimeException::class,
+                'worker stopped',
+                '/tests/CopyTest.php',
+                42,
+            ),
+            skipReason: 'dependency is unavailable',
+            transformations: [
+                new OutcomeTransformation('quarantine', Outcome::Passed, Outcome::Failed),
+            ],
+            output: new CapturedOutput('captured output', stdoutTruncated: true),
+            expectations: 7,
+            attachments: [
+                new Attachment(
+                    'failure.txt',
+                    AttachmentKind::Text,
+                    'text/plain',
+                    7,
+                    \str_repeat('a', 64),
+                    2,
+                    'artifacts/failure.txt',
+                ),
+            ],
+        );
     }
 }


### PR DESCRIPTION
Cover the immutable copy contract for risky status, attachments, lifecycle errors, and replacement failures. Each DataSet case starts from a fully populated result and proves that the mutator changes only its documented target state while leaving the original untouched.