### PR TITLE
test(cli): preserve empty option values

### DIFF
--- a/tests/Unit/Cli/ParsedArgumentsEmptyValueTest.php
+++ b/tests/Unit/Cli/ParsedArgumentsEmptyValueTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\ParsedArguments;
+use Greenlight\Expect\Expect;
+
+final class ParsedArgumentsEmptyValueTest
+{
+    #[Test]
+    public function repeatableValuesPreserveEmptyStrings(): void
+    {
+        $arguments = new ParsedArguments(null, [
+            'group' => ['first', '', null, 'last'],
+        ]);
+
+        Expect::that($arguments->values('group'))
+            ->because('empty option values MUST remain available for downstream validation')
+            ->toBe(['first', '', 'last']);
+    }
+}


### PR DESCRIPTION
Cover empty strings in repeatable parsed option values. The regression test pins the null-only filtering contract so malformed empty values still reach downstream validation instead of disappearing.