### PR TITLE
fix(doubles): canonicalize planned method names

### DIFF
--- a/src/Doubles/MockPlan.php
+++ b/src/Doubles/MockPlan.php
@@ -31,7 +31,7 @@ final readonly class MockPlan
      */
     public function expects(string $method): MethodExpectation
     {
-        $this->assertPlannable($method);
+        $method = $this->assertPlannable($method);
 
         $expectation = new MethodExpectation($method);
         $this->state->expectations[] = $expectation;
@@ -41,8 +41,10 @@ final readonly class MockPlan
 
     /**
      * @param non-empty-string $method
+     *
+     * @return non-empty-string
      */
-    private function assertPlannable(string $method): void
+    private function assertPlannable(string $method): string
     {
         $reflection = new \ReflectionClass($this->state->type);
 
@@ -63,5 +65,7 @@ final readonly class MockPlan
         if ($declared->isFinal()) {
             throw DoublesError::finalMethod($this->state->type, $method);
         }
+
+        return $declared->getName();
     }
 }

--- a/tests/Unit/Doubles/MockMethodCaseTest.php
+++ b/tests/Unit/Doubles/MockMethodCaseTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\MockPlan;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Doubles\Calculator;
+
+final class MockMethodCaseTest
+{
+    #[Test]
+    public function expectationMethodNamesFollowPhpCaseInsensitivity(): void
+    {
+        $doubles = new Doubles();
+        $calculator = $doubles->mock(Calculator::class, static function (MockPlan $plan): void {
+            $plan->expects('ADD')->with(1, 2)->once()->andReturns(3);
+        });
+
+        Expect::that($calculator->add(1, 2))
+            ->because('mock method names MUST follow PHP case-insensitive dispatch')
+            ->toBe(3);
+
+        $doubles->dispose();
+    }
+}


### PR DESCRIPTION
Canonicalize a planned mock method through reflection before storing its expectation. This keeps mock dispatch consistent with PHP method-name case insensitivity and adds a focused regression for an uppercase plan calling the declared lowercase method.