### PR TITLE
test(cli): cover zero-valued NO_COLOR

### DIFF
--- a/tests/Unit/Cli/TerminalCapabilitiesTest.php
+++ b/tests/Unit/Cli/TerminalCapabilitiesTest.php
@@ -68,6 +68,22 @@ final class TerminalCapabilitiesTest
     }
 
     #[Test]
+    public function aZeroNoColorValueStillDisablesColor(): void
+    {
+        $capabilities = TerminalCapabilities::detect(
+            stdoutIsTty: true,
+            env: ['NO_COLOR' => '0'],
+            noAnsiFlag: false,
+        );
+
+        Expect::that($capabilities->interactive)
+            ->because('a zero NO_COLOR value keeps interactivity but disables color')
+            ->toBeTrue()
+            ->and($capabilities->color)
+            ->toBeFalse();
+    }
+
+    #[Test]
     public function anEmptyNoColorIsIgnored(): void
     {
         $capabilities = TerminalCapabilities::detect(stdoutIsTty: true, env: ['NO_COLOR' => ''], noAnsiFlag: false);


### PR DESCRIPTION
Adds regression coverage for `NO_COLOR=0`. The variable is presence-based, so every non-empty value disables color while TTY interactivity remains enabled.

The test detects an implementation that incorrectly reuses boolean-like CI parsing for `NO_COLOR`.