### PR TITLE
test(conditions): distinguish absent environment values

### DIFF
--- a/tests/Unit/Condition/EnvironmentVariableAbsenceTest.php
+++ b/tests/Unit/Condition/EnvironmentVariableAbsenceTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Condition;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Condition\EnvironmentVariableEquals;
+use Greenlight\Condition\EnvironmentVariableSet;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\EnvironmentSandbox;
+
+final readonly class EnvironmentVariableAbsenceTest
+{
+    public function __construct(private EnvironmentSandbox $environment) {}
+
+    #[Test]
+    public function anAbsentVariableDoesNotEqualAnEmptyValue(): void
+    {
+        $name = 'GREENLIGHT_CONDITION_ABSENT_EMPTY_VALUE';
+        $this->environment->unset($name);
+
+        Expect::that(new EnvironmentVariableSet($name)->isSatisfied())
+            ->because('an absent environment variable MUST remain absent')
+            ->toBeFalse()
+            ->and(new EnvironmentVariableEquals($name, '')->isSatisfied())
+            ->because('absence MUST remain distinct from an empty environment variable value')
+            ->toBeFalse();
+    }
+}


### PR DESCRIPTION
An unset environment variable returns false, while a present empty variable returns an empty string. Add a focused regression test that protects the strict comparison and ensures absence cannot satisfy an empty expected value.