### PR TITLE
fix(fixture): reject NUL environment values

### DIFF
--- a/docs/api-fixtures-harness.md
+++ b/docs/api-fixtures-harness.md
@@ -27,7 +27,7 @@ public function set(string $name, string $value): void
 
 PHPDoc:
 
-- `@throws \InvalidArgumentException If $name is empty or contains "=" or a null byte.`
+- `@throws \InvalidArgumentException If $name is invalid or $value contains a null byte.`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/EnvironmentSandbox.php#L23)
 
@@ -41,7 +41,7 @@ PHPDoc:
 
 - `@throws \InvalidArgumentException If $name is empty or contains "=" or a null byte.`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/EnvironmentSandbox.php#L36)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/EnvironmentSandbox.php#L41)
 
 ### `dispose()`
 
@@ -50,7 +50,7 @@ PHPDoc:
 public function dispose(): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/EnvironmentSandbox.php#L45)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/EnvironmentSandbox.php#L50)
 
 ## `TempDirectory`
 

--- a/src/Fixture/EnvironmentSandbox.php
+++ b/src/Fixture/EnvironmentSandbox.php
@@ -18,11 +18,16 @@ final class EnvironmentSandbox implements Disposable
     private array $originals = [];
 
     /**
-     * @throws \InvalidArgumentException If $name is empty or contains "=" or a null byte.
+     * @throws \InvalidArgumentException If $name is invalid or $value contains a null byte.
      */
     public function set(string $name, string $value): void
     {
         $this->validateName($name);
+
+        if (\str_contains($value, "\0")) {
+            throw new \InvalidArgumentException('Environment variable values cannot contain a null byte.');
+        }
+
         $this->record($name);
 
         \putenv($name . '=' . $value);

--- a/tests/Unit/Fixture/EnvironmentSandboxValueValidationTest.php
+++ b/tests/Unit/Fixture/EnvironmentSandboxValueValidationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Fixture;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\EnvironmentSandbox;
+
+final readonly class EnvironmentSandboxValueValidationTest
+{
+    public function __construct(private EnvironmentSandbox $environment) {}
+
+    #[Test]
+    public function aNullByteValueIsRejectedBeforeEnvironmentChannelsDiverge(): void
+    {
+        $name = 'GREENLIGHT_SANDBOX_NULL_VALUE';
+        $this->environment->unset($name);
+
+        Expect::that(fn() => $this->environment->set($name, "before\0after"))
+            ->because('a null byte value MUST be rejected before putenv truncates it')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Environment variable values cannot contain a null byte.',
+            )
+            ->and([
+                \getenv($name),
+                \array_key_exists($name, $_ENV),
+                \array_key_exists($name, $_SERVER),
+            ])
+            ->because('a rejected value MUST NOT change any environment channel')
+            ->toBe([false, false, false]);
+    }
+}


### PR DESCRIPTION
PHP silently truncates a value at its first NUL when EnvironmentSandbox passes it to putenv(), while the superglobal channels retain the full string. Reject these values before any channel changes, and add a focused regression test that protects the three-channel consistency contract.