### PR TITLE
fix(laravel): reject NUL environments

### DIFF
--- a/src/Laravel/LaravelProcessState.php
+++ b/src/Laravel/LaravelProcessState.php
@@ -27,8 +27,15 @@ final readonly class LaravelProcessState
         private mixed $serverEnvironment,
     ) {}
 
+    /**
+     * @throws \InvalidArgumentException If $environment contains a null byte.
+     */
     public static function setEnvironment(string $environment): self
     {
+        if (\str_contains($environment, "\0")) {
+            throw new \InvalidArgumentException('Laravel environment MUST NOT contain a null byte.');
+        }
+
         $state = new self(
             Container::getInstance(),
             Facade::getFacadeApplication(),

--- a/tests/Unit/Laravel/LaravelProcessEnvironmentValidationTest.php
+++ b/tests/Unit/Laravel/LaravelProcessEnvironmentValidationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Laravel;
+
+use Greenlight\Attribute\SkipUnless;
+use Greenlight\Attribute\Test;
+use Greenlight\Condition\ClassAvailable;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\EnvironmentSandbox;
+use Greenlight\Laravel\LaravelProcessState;
+use Illuminate\Foundation\Application as LaravelApplication;
+
+final readonly class LaravelProcessEnvironmentValidationTest
+{
+    public function __construct(private EnvironmentSandbox $environment) {}
+
+    #[Test]
+    #[SkipUnless(ClassAvailable::class, LaravelApplication::class)]
+    public function aNullByteEnvironmentIsRejectedBeforeProcessStateChanges(): void
+    {
+        $this->environment->set('APP_ENV', 'before-laravel');
+
+        Expect::that(static fn(): LaravelProcessState => LaravelProcessState::setEnvironment("testing\0truncated"))
+            ->because('a NUL environment MUST be rejected before putenv truncates it')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Laravel environment MUST NOT contain a null byte.',
+            )
+            ->and([
+                \getenv('APP_ENV'),
+                $_ENV['APP_ENV'] ?? null,
+                $_SERVER['APP_ENV'] ?? null,
+            ])
+            ->because('a rejected Laravel environment MUST NOT change process state')
+            ->toBe(['before-laravel', 'before-laravel', 'before-laravel']);
+    }
+}


### PR DESCRIPTION
LaravelProcessState writes APP_ENV through the process environment and both PHP superglobals. PHP truncates the process value at a NUL while the superglobals keep the full string. Reject the value before state capture or mutation, with a focused regression test for all three channels.