### PR TITLE
test(config): preserve copied configuration state

### DIFF
--- a/tests/Unit/Config/ConfigurationCopyStateTest.php
+++ b/tests/Unit/Config/ConfigurationCopyStateTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Config;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Config\Configuration;
+use Greenlight\Config\CoverageConfiguration;
+use Greenlight\Config\CoverageExport;
+use Greenlight\Config\SuiteConfiguration;
+use Greenlight\Config\WatchConfiguration;
+use Greenlight\Config\WorkerCount;
+use Greenlight\Core\Result\ResultPolicy;
+use Greenlight\Doubles\Fake;
+use Greenlight\Expect\Expect;
+use Greenlight\Plugin\Plugin;
+
+final class ConfigurationCopyStateTest
+{
+    /**
+     * @param \Closure(Configuration): Configuration $mutate
+     */
+    #[Test]
+    #[DataSet('selectionCopies')]
+    public function selectionCopiesChangeOnlyTheirTarget(
+        \Closure $mutate,
+        string $target,
+        mixed $replacement,
+    ): void {
+        $original = $this->configuration();
+        $originalState = \get_object_vars($original);
+        $expectedState = $originalState;
+        $expectedState[$target] = $replacement;
+
+        $copy = $mutate($original);
+
+        Expect::that($copy)
+            ->because('a configuration copy MUST be a new value')
+            ->not()
+            ->toBe($original)
+            ->and(\get_object_vars($copy))
+            ->because('a configuration copy MUST change only its requested selection')
+            ->toBe($expectedState)
+            ->and(\get_object_vars($original))
+            ->because('a configuration copy MUST leave its source unchanged')
+            ->toBe($originalState);
+    }
+
+    /**
+     * @return iterable<string, array{\Closure(Configuration): Configuration, non-empty-string, mixed}>
+     */
+    public static function selectionCopies(): iterable
+    {
+        $onlyTests = ['App\\ReplacementTest::runs'];
+
+        yield 'only test IDs' => [
+            static fn(Configuration $configuration): Configuration => $configuration
+                ->withOnlyTests($onlyTests),
+            'onlyTests',
+            $onlyTests,
+        ];
+
+        $excludePaths = ['/project/replacement'];
+
+        yield 'excluded paths' => [
+            static fn(Configuration $configuration): Configuration => $configuration
+                ->withExcludePaths($excludePaths),
+            'excludePaths',
+            $excludePaths,
+        ];
+    }
+
+    private function configuration(): Configuration
+    {
+        $plugin = new class implements Plugin, Fake {};
+
+        return new Configuration(
+            paths: ['/project/tests'],
+            suites: [
+                new SuiteConfiguration(
+                    'integration',
+                    ['/project/tests/Integration'],
+                    ['database'],
+                ),
+            ],
+            workers: WorkerCount::exactly(2),
+            recycleAfterTests: 3,
+            recycleAboveMemoryBytes: 4_096,
+            coverage: new CoverageConfiguration(
+                ['/project/src'],
+                'xdebug',
+                [new CoverageExport('json', '/project/build/coverage.json')],
+            ),
+            watch: new WatchConfiguration(750),
+            plugins: [$plugin],
+            policy: new ResultPolicy(
+                failOnDeprecation: true,
+                failOnNotice: true,
+                ignoreDeprecations: ['legacy'],
+                failOnRisky: true,
+            ),
+            stopAfterFailures: 4,
+            randomizeOrder: true,
+            randomSeed: 1_234,
+            groups: ['fast'],
+            filters: ['*Invoice*'],
+            onlyTests: ['App\\OriginalTest::runs'],
+            shard: [2, 3],
+            excludeGroups: ['slow'],
+            excludeClasses: ['Legacy*'],
+            excludeMethods: ['flaky*'],
+            excludePaths: ['/project/generated'],
+            artifacts: new ArtifactConfiguration(
+                directory: '/project/build/artifacts',
+                maxAttachmentsPerTest: 5,
+                maxAttachmentBytes: 1_024,
+                maxTestBytes: 4_096,
+                maxRunAttachments: 100,
+                maxRunBytes: 8_192,
+            ),
+            resourceLimits: ['database' => 2],
+        );
+    }
+}


### PR DESCRIPTION
Populate every configuration field with a non-default value and exercise both selection copy mutators through one dataset. Compare the complete public state so each copy changes only its requested selection, retains object-backed settings, and leaves the source unchanged. This catches silent resets that the existing two-field cross-check does not detect.