### PR TITLE
test(reporting): mark recording reporters as fakes

### DIFF
--- a/tests/Unit/Doubles/FakeFixtureTest.php
+++ b/tests/Unit/Doubles/FakeFixtureTest.php
@@ -25,6 +25,8 @@ use Greenlight\Tests\Fixture\Plugins\EvenNumbersExtension as PluginEvenNumbersEx
 use Greenlight\Tests\Fixture\Plugins\ProbeProvider;
 use Greenlight\Tests\Fixture\Plugins\QuarantinePlugin;
 use Greenlight\Tests\Fixture\Symfony\BareKernel;
+use Greenlight\Tests\Unit\Reporting\RecordingReporter;
+use Greenlight\Tests\Unit\Reporting\RecordingTickingReporter;
 use Illuminate\Foundation\Application as LaravelApplication;
 
 final class FakeFixtureTest
@@ -70,6 +72,8 @@ final class FakeFixtureTest
         yield ProbeProvider::class => [ProbeProvider::class];
         yield QuarantinePlugin::class => [QuarantinePlugin::class];
         yield BareKernel::class => [BareKernel::class];
+        yield RecordingReporter::class => [RecordingReporter::class];
+        yield RecordingTickingReporter::class => [RecordingTickingReporter::class];
     }
 
     /**

--- a/tests/Unit/Reporting/RecordingReporter.php
+++ b/tests/Unit/Reporting/RecordingReporter.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Reporting;
 
 use Greenlight\Core\Event\Event;
+use Greenlight\Doubles\Fake;
 use Greenlight\Reporting\Reporter;
 
-final class RecordingReporter implements Reporter
+final class RecordingReporter implements Reporter, Fake
 {
     public int $eventCount = 0;
 

--- a/tests/Unit/Reporting/RecordingTickingReporter.php
+++ b/tests/Unit/Reporting/RecordingTickingReporter.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Reporting;
 
 use Greenlight\Core\Event\Event;
+use Greenlight\Doubles\Fake;
 use Greenlight\Reporting\Reporter;
 use Greenlight\Reporting\Ticking;
 
-final class RecordingTickingReporter implements Reporter, Ticking
+final class RecordingTickingReporter implements Reporter, Ticking, Fake
 {
     /**
      * @var list<float>


### PR DESCRIPTION
Marks the reusable recording reporter implementations as intentional in-memory fakes.

Extends the shared Fake contract data set so removing either marker is detected directly.