### PR TITLE
test(discovery): cover non-public data providers

### DIFF
--- a/tests/Fixture/DiscoveryProviderNonPublic/NonPublicProviderTest.php
+++ b/tests/Fixture/DiscoveryProviderNonPublic/NonPublicProviderTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\DiscoveryProviderNonPublic;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+
+final class NonPublicProviderTest
+{
+    #[Test]
+    // Deliberately broken to drive the runtime discovery-error path.
+    // @phpstan-ignore-next-line greenlight.dataProvider.provider
+    #[DataSet('privateProvider')]
+    public function needsData(int $value): void
+    {
+        self::privateProvider();
+        echo $value;
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    private static function privateProvider(): iterable
+    {
+        yield 'one' => [1];
+    }
+}

--- a/tests/Unit/Discovery/DataSetExpansionTest.php
+++ b/tests/Unit/Discovery/DataSetExpansionTest.php
@@ -154,6 +154,18 @@ final class DataSetExpansionTest
     }
 
     #[Test]
+    public function nonPublicProviderIsRejected(): void
+    {
+        $message = $this->discoveryErrorMessage('DiscoveryProviderNonPublic');
+
+        Expect::that($message)
+            ->because('a non-public data-set provider MUST fail discovery')
+            ->toContain('Declare the provider as public and static')
+            ->and($message)
+            ->toContain('privateProvider');
+    }
+
+    #[Test]
     public function nonIterableProviderIsRejected(): void
     {
         $message = $this->discoveryErrorMessage('DiscoveryProviderNotIterable');


### PR DESCRIPTION
Adds a PSR-4-safe discovery fixture for a private static data-set provider.

Existing coverage exercised only the static requirement. The new case proves discovery also rejects non-public providers and fails if the visibility guard is removed.