### PR TITLE
test(harness): reject duplicate initial services

### DIFF
--- a/tests/Unit/Harness/HarnessRegistryConstructionTest.php
+++ b/tests/Unit/Harness/HarnessRegistryConstructionTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Harness;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Harness\HarnessRegistry;
+use Greenlight\Harness\Scope;
+use Greenlight\Harness\ServiceDefinition;
+
+final class HarnessRegistryConstructionTest
+{
+    #[Test]
+    public function duplicateInitialServiceTypesAreRejected(): void
+    {
+        $registered = new ServiceDefinition(
+            \ArrayObject::class,
+            Scope::PerRun,
+            static fn(): \ArrayObject => new \ArrayObject(),
+        );
+        $duplicate = new ServiceDefinition(
+            \ArrayObject::class,
+            Scope::PerTest,
+            static fn(): \ArrayObject => new \ArrayObject(),
+        );
+
+        Expect::that(static fn(): HarnessRegistry => new HarnessRegistry([
+            $registered,
+            $duplicate,
+        ]))
+            ->because('initial definitions have one entry for each service type')
+            ->toThrow(
+                \LogicException::class,
+                message: 'A harness service for ArrayObject is already registered.',
+            );
+    }
+}


### PR DESCRIPTION
HarnessRegistry accepts initial definitions through its constructor as well as through register(). Add a focused regression test that ensures duplicate initial service types are rejected instead of silently replacing the first definition.