### PR TITLE
test(discovery): reject normalized data set key collisions

### DIFF
--- a/tests/Fixture/DiscoveryProviderNormalizedDuplicate/NormalizedDuplicateKeysTest.php
+++ b/tests/Fixture/DiscoveryProviderNormalizedDuplicate/NormalizedDuplicateKeysTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\DiscoveryProviderNormalizedDuplicate;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+
+final class NormalizedDuplicateKeysTest
+{
+    #[Test]
+    #[DataSet('rows')]
+    public function needsData(int $value): void
+    {
+        echo $value;
+    }
+
+    /**
+     * @return iterable<int|string, array{int}>
+     */
+    public static function rows(): iterable
+    {
+        yield 1 => [1];
+
+        yield '#1' => [2];
+    }
+}

--- a/tests/Unit/Discovery/DataSetNormalizedKeyCollisionTest.php
+++ b/tests/Unit/Discovery/DataSetNormalizedKeyCollisionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\DataSetExpander;
+use Greenlight\Discovery\DiscoveryError;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\DiscoveryProviderNormalizedDuplicate\NormalizedDuplicateKeysTest;
+
+final class DataSetNormalizedKeyCollisionTest
+{
+    #[Test]
+    public function integerAndPrintableStringKeysCannotNormalizeToTheSameKey(): void
+    {
+        $reflection = new \ReflectionClass(NormalizedDuplicateKeysTest::class);
+
+        Expect::that(static fn(): array => new DataSetExpander()->rowsFor(
+            $reflection,
+            'needsData',
+            'rows',
+            5.0,
+        ))
+            ->because('provider keys MUST remain unique after normalization')
+            ->toThrow(
+                DiscoveryError::class,
+                message: 'Data sets for '
+                    . NormalizedDuplicateKeysTest::class
+                    . '::needsData() contain key "#1" more than once. '
+                    . 'Use each key only once for the test method.',
+            );
+    }
+}


### PR DESCRIPTION
Data-set provider keys share one normalized string key space. Add a focused generator fixture proving that integer key 1 and string key #1 are rejected because both identify the same data set after normalization.