### PR TITLE
test(discovery): cover invalid resource attributes

### DIFF
--- a/tests/Fixture/DiscoveryAttributeArgumentsInvalid/WrongResourceTypeTest.php
+++ b/tests/Fixture/DiscoveryAttributeArgumentsInvalid/WrongResourceTypeTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\DiscoveryAttributeArgumentsInvalid;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+
+final class WrongResourceTypeTest
+{
+    #[Test]
+    #[RequiresResource([])]
+    public function neverDiscovered(): void {}
+}

--- a/tests/Unit/Discovery/MetadataFactoryResourceErrorTest.php
+++ b/tests/Unit/Discovery/MetadataFactoryResourceErrorTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\DiscoveryError;
+use Greenlight\Discovery\MetadataFactory;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Tests\Fixture\DiscoveryAttributeArgumentsInvalid\WrongResourceTypeTest;
+
+final readonly class MetadataFactoryResourceErrorTest
+{
+    #[Test]
+    public function invalidResourceArgumentsAreWrappedWithTheirLocationAndCause(): void
+    {
+        $class = $this->fixtureClass();
+        $capture = new class {
+            public ?DiscoveryError $error = null;
+        };
+        $attempt = static function () use ($capture, $class): array {
+            try {
+                return new MetadataFactory()->forClass(new \ReflectionClass($class));
+            } catch (DiscoveryError $error) {
+                $capture->error = $error;
+
+                throw $error;
+            }
+        };
+
+        Expect::that($attempt)
+            ->because('discovery MUST wrap an invalid resource attribute with its method location')
+            ->toThrow(
+                DiscoveryError::class,
+                matching: '/^Attribute on '
+                    . \preg_quote($class . '::neverDiscovered()', '/')
+                    . ' is invalid:/',
+            );
+
+        $error = $capture->error;
+
+        if (!$error instanceof DiscoveryError) {
+            Fail::because('Expected discovery to throw the captured resource attribute error.');
+        }
+
+        Expect::that($error->getPrevious())
+            ->because('the discovery error MUST preserve the invalid resource attribute cause')
+            ->toBeInstanceOf(\TypeError::class);
+    }
+
+    /**
+     * @return class-string
+     */
+    private function fixtureClass(): string
+    {
+        return WrongResourceTypeTest::class;
+    }
+}


### PR DESCRIPTION
Adds a PSR-4-safe fixture with an invalid `#[RequiresResource]` argument.

The focused test proves discovery wraps the constructor failure in a location-aware `DiscoveryError` and preserves the original `TypeError` as its cause.