### PR TITLE
fix(coverage): relativize Windows HTML paths

### DIFF
--- a/src/Coverage/Export/HtmlExporter.php
+++ b/src/Coverage/Export/HtmlExporter.php
@@ -179,10 +179,23 @@ final readonly class HtmlExporter implements CoverageExporter
 
     private function displayPath(string $path): string
     {
-        $root = \rtrim($this->projectRoot, '/');
+        $root = \rtrim($this->projectRoot, '/\\');
 
-        if ($root !== '' && \str_starts_with($path, $root . '/')) {
-            return \substr($path, \strlen($root) + 1);
+        if ($root === '') {
+            return $path;
+        }
+
+        $windowsPath = \preg_match('/^(?:[A-Za-z]:[\/\\\\]|\\\\\\\\)/', $root) === 1;
+
+        foreach (['/', '\\'] as $separator) {
+            $prefix = $root . $separator;
+            $insideRoot = $windowsPath
+                ? \strncasecmp($path, $prefix, \strlen($prefix)) === 0
+                : \str_starts_with($path, $prefix);
+
+            if ($insideRoot) {
+                return \substr($path, \strlen($prefix));
+            }
         }
 
         return $path;

--- a/tests/Unit/Coverage/HtmlExporterWindowsPathTest.php
+++ b/tests/Unit/Coverage/HtmlExporterWindowsPathTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Coverage\Export\HtmlExporter;
+use Greenlight\Coverage\FileCoverage;
+use Greenlight\Expect\Expect;
+
+final readonly class HtmlExporterWindowsPathTest
+{
+    /**
+     * @param non-empty-string $root
+     * @param non-empty-string $path
+     * @param non-empty-string $relative
+     */
+    #[Test]
+    #[DataSet('windowsPaths')]
+    public function windowsPathsInsideTheProjectRootAreRelative(
+        string $root,
+        string $path,
+        string $relative,
+    ): void {
+        $exporter = new HtmlExporter($root);
+        $pages = $exporter->export(new CoverageMap([
+            new FileCoverage($path, [1], []),
+        ]));
+
+        Expect::that($pages[HtmlExporter::INDEX_FILE_NAME])
+            ->because('HTML coverage MUST show Windows project paths relative to the project root')
+            ->toContain('>' . $relative . '<')
+            ->not()
+            ->toContain($path);
+        Expect::that($pages[HtmlExporter::pageName($path)])
+            ->because('HTML coverage pages MUST show Windows project paths relative to the project root')
+            ->toContain('<h1>' . $relative . '</h1>');
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string, non-empty-string, non-empty-string}>
+     */
+    public static function windowsPaths(): iterable
+    {
+        yield 'drive path' => [
+            'C:\project',
+            'C:\project\src\Example.php',
+            'src\Example.php',
+        ];
+        yield 'case-insensitive drive path' => [
+            'C:\Project',
+            'c:\project\src\Example.php',
+            'src\Example.php',
+        ];
+        yield 'UNC path' => [
+            '\\\\Server\Share\project',
+            '\\\\server\share\project\src\Example.php',
+            'src\Example.php',
+        ];
+    }
+}


### PR DESCRIPTION
Recognize Windows drive and UNC project roots when rendering HTML coverage paths. Preserve Windows case-insensitive root matching and accept either directory separator, so in-project files use the same relative labels as Unix paths. Add focused regression coverage for drive, case-variant drive, and UNC paths.