### PR TITLE
test(reporting): exclude failed risky guidance

### DIFF
--- a/tests/Unit/Reporting/PlainReporterRiskyFailureTest.php
+++ b/tests/Unit/Reporting/PlainReporterRiskyFailureTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\TestFinished;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\PlainReporter;
+
+final class PlainReporterRiskyFailureTest
+{
+    #[Test]
+    public function failedRiskyTestsDoNotReceivePassedTestGuidance(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new PlainReporter($output);
+        $reporter->onEvent(new TestFinished(
+            new TestResult(
+                new TestId('Acme\\RiskyTest', 'failsWithoutExpectations'),
+                Outcome::Failed,
+                0.01,
+                0,
+                risky: true,
+            ),
+            1_750_000_000.5,
+        ));
+        $reporter->finish();
+
+        Expect::that($output->buffer())
+            ->because('a failed risky test MUST keep its failure without passed-test guidance')
+            ->toContain('FAIL Acme\RiskyTest::failsWithoutExpectations')
+            ->not()
+            ->toContain('These tests passed without a verified expectation.');
+    }
+}


### PR DESCRIPTION
Covers PlainReporter when a failed result is also marked risky.

The focused test proves failure output remains intact without the guidance reserved for tests that passed without expectations. Removing the successful-outcome guard makes the test fail.