### PR TITLE
test(cli): cover debounce boundary

### DIFF
--- a/tests/Unit/Cli/WatchTest.php
+++ b/tests/Unit/Cli/WatchTest.php
@@ -53,6 +53,17 @@ final readonly class WatchTest
     }
 
     #[Test]
+    public function debounceFiresAtTheExactQuietPeriodBoundary(): void
+    {
+        $debouncer = new Debouncer(0.5);
+        $debouncer->noteChange(4.0);
+
+        Expect::that($debouncer->shouldFire(4.5))
+            ->because('the quiet period includes its exact boundary')
+            ->toBeTrue();
+    }
+
+    #[Test]
     public function statDetectorReportsTouchedNewAndDeletedFiles(): void
     {
         $dir = \sys_get_temp_dir() . '/greenlight-watch-' . \bin2hex(\random_bytes(4));


### PR DESCRIPTION
Adds deterministic coverage for the exact debounce quiet-period boundary. This pins the documented inclusive threshold without wall-clock timing or sleeps.