### PR TITLE
test(expect): cover observation history byte limit

### DIFF
--- a/tests/Unit/Expect/ObservationLogTest.php
+++ b/tests/Unit/Expect/ObservationLogTest.php
@@ -48,6 +48,18 @@ final class ObservationLogTest
     }
 
     #[Test]
+    public function renderedHistoryAtTheByteLimitIsNotTruncated(): void
+    {
+        $value = \str_repeat('x', 2_041);
+        $log = new ObservationLog(0.0);
+        $log->record(0.0, $value);
+
+        Expect::that($log->render())
+            ->because('history at the byte limit MUST remain unchanged')
+            ->toBe('+0.0ms ' . $value);
+    }
+
+    #[Test]
     public function anIdenticalTailGroupDoesNotRepeatTheFirstObservation(): void
     {
         $log = new ObservationLog(0.0);


### PR DESCRIPTION
Add exact-boundary coverage for temporal observation histories at the 2,048-byte rendering limit. The test proves content that fits exactly remains unchanged instead of receiving a truncation marker.