### PR TITLE
fix(reporting): report truncated diagnostics

### DIFF
--- a/src/Reporting/ProblemDetails.php
+++ b/src/Reporting/ProblemDetails.php
@@ -92,6 +92,10 @@ final class ProblemDetails
                     $diagnostic->line,
                 );
             }
+
+            if ($captured->diagnosticsTruncated) {
+                $lines[] = '  additional diagnostics omitted';
+            }
         }
 
         if ($result->attachments !== []) {

--- a/tests/Unit/Reporting/ProblemDetailsTest.php
+++ b/tests/Unit/Reporting/ProblemDetailsTest.php
@@ -103,6 +103,31 @@ final class ProblemDetailsTest
     }
 
     #[Test]
+    public function truncatedDiagnosticsReportTheOmittedEntries(): void
+    {
+        $result = new TestResult(
+            new TestId('Acme\\FailureTest', 'reportsTruncatedDiagnostics'),
+            Outcome::Failed,
+            0.1,
+            0,
+            output: new CapturedOutput(
+                '',
+                diagnostics: [
+                    new Diagnostic(DiagnosticSeverity::Warning, 'first warning', 'FailureTest.php', 13),
+                ],
+                diagnosticsTruncated: true,
+            ),
+        );
+
+        Expect::that(ProblemDetails::render($result))
+            ->because('bounded diagnostics MUST report omitted entries')
+            ->toBe(
+                "  warning: first warning at FailureTest.php:13\n"
+                . "  additional diagnostics omitted\n",
+            );
+    }
+
+    #[Test]
     public function multipleFailureDetailsRenderCompletelyInOrder(): void
     {
         $result = new TestResult(


### PR DESCRIPTION
Report when bounded output capture omitted additional PHP diagnostics. Shared problem details now append an explicit marker after the retained diagnostics, with focused coverage for the truncation flag.