### PR TITLE
test(reporting): cover plain worker summary boundary

### DIFF
--- a/tests/Unit/Reporting/PlainReporterWorkerSummaryTest.php
+++ b/tests/Unit/Reporting/PlainReporterWorkerSummaryTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\RunFinished;
+use Greenlight\Core\Event\WorkerSpawned;
+use Greenlight\Core\Result\ResultSummary;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\PlainReporter;
+
+final class PlainReporterWorkerSummaryTest
+{
+    #[Test]
+    public function oneSpawnedWorkerIsReportedWithoutAZeroRecycleCount(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new PlainReporter($output);
+        $reporter->onEvent(new WorkerSpawned('w-1', 101, 1.0));
+        $reporter->onEvent(new RunFinished('run-1', new ResultSummary(passed: 1), 0.1, 1.3));
+        $reporter->finish();
+
+        Expect::that($output->buffer())
+            ->because('the plain summary MUST report its only spawned worker')
+            ->toContain("Workers: 1 spawned\n")
+            ->not()
+            ->toContain('recycled');
+    }
+
+    #[Test]
+    public function inProcessRunsDoNotRenderAWorkerSummary(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new PlainReporter($output);
+        $reporter->onEvent(new RunFinished('run-1', new ResultSummary(passed: 1), 0.1, 1.3));
+        $reporter->finish();
+
+        Expect::that($output->buffer())
+            ->because('an in-process run MUST NOT report a spawned worker')
+            ->not()
+            ->toContain('Workers:');
+    }
+}


### PR DESCRIPTION
Add direct PlainReporter coverage for the one-worker and in-process boundaries. One spawned worker is reported without a zero recycle count, while an in-process run omits the worker summary.