### PR TITLE
fix(phpstan): preserve DNF matcher types

### DIFF
--- a/src/PhpStan/MatcherMap.php
+++ b/src/PhpStan/MatcherMap.php
@@ -157,7 +157,12 @@ final readonly class MatcherMap
     public static function typeName(?\ReflectionType $type): string
     {
         if ($type instanceof \ReflectionUnionType) {
-            return \implode('|', \array_map(self::typeName(...), $type->getTypes()));
+            return \implode('|', \array_map(
+                static fn(\ReflectionType $member): string => $member instanceof \ReflectionIntersectionType
+                    ? '(' . self::typeName($member) . ')'
+                    : self::typeName($member),
+                $type->getTypes(),
+            ));
         }
 
         if ($type instanceof \ReflectionIntersectionType) {

--- a/tests/Fixture/PhpStanIdeHelperDnf/DnfExtension.php
+++ b/tests/Fixture/PhpStanIdeHelperDnf/DnfExtension.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\PhpStanIdeHelperDnf;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Expect\ExpectationExtension;
+
+final class DnfExtension implements ExpectationExtension, Fake
+{
+    #[\Override]
+    public function matchers(): array
+    {
+        return [
+            'toCompareWith' => static fn(
+                mixed $subject,
+                (\Countable&\Iterator)|string $comparison,
+            ): bool => $subject === $comparison,
+        ];
+    }
+}

--- a/tests/Fixture/PhpStanIdeHelperDnf/greenlight.php
+++ b/tests/Fixture/PhpStanIdeHelperDnf/greenlight.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Tests\Fixture\PhpStanIdeHelperDnf\DnfExtension;
+
+return GreenlightConfig::create()
+    ->paths([__DIR__ . '/../DiscoveryBasic'])
+    ->plugins(new DnfExtension());

--- a/tests/Unit/PhpStan/IdeHelperTest.php
+++ b/tests/Unit/PhpStan/IdeHelperTest.php
@@ -25,4 +25,14 @@ final class IdeHelperTest
             ->toContain('final class Expectation {}')
             ->toContain('The IDE does not execute or autoload');
     }
+
+    #[Test]
+    public function preservesParenthesesAroundIntersectionsInsideUnions(): void
+    {
+        $map = MatcherMap::fromConfigFiles([\dirname(__DIR__, 2) . '/Fixture/PhpStanIdeHelperDnf/greenlight.php']);
+
+        Expect::that(IdeHelper::render($map))
+            ->because('generated matcher annotations preserve disjunctive normal form types')
+            ->toContain(' * @method self toCompareWith((Countable&Iterator)|string $comparison)');
+    }
 }


### PR DESCRIPTION
Generated IDE-helper annotations flattened a union that contains an intersection into an ambiguous type. Preserve the native DNF parentheses when rendering union members.\n\nAdd a PSR-4 expectation-extension fixture that pins the generated method signature end to end.