### PR TITLE
fix(phpstan): map literal boolean matcher types

### DIFF
--- a/src/PhpStan/NativeType.php
+++ b/src/PhpStan/NativeType.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\CoverageIgnore;
 use PHPStan\Type\ArrayType;
 use PHPStan\Type\BooleanType;
 use PHPStan\Type\CallableType;
+use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\FloatType;
 use PHPStan\Type\IntegerType;
 use PHPStan\Type\IntersectionType;
@@ -61,6 +62,8 @@ final class NativeType
             'int' => new IntegerType(),
             'float' => new FloatType(),
             'bool' => new BooleanType(),
+            'true' => new ConstantBooleanType(true),
+            'false' => new ConstantBooleanType(false),
             'array' => new ArrayType(new MixedType(), new MixedType()),
             'iterable' => new IterableType(new MixedType(), new MixedType()),
             'callable' => new CallableType(),

--- a/tests/Unit/PhpStan/NativeTypeTest.php
+++ b/tests/Unit/PhpStan/NativeTypeTest.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\PhpStan\NativeType;
+use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\VerbosityLevel;
 
 final class NativeTypeTest
@@ -39,6 +40,20 @@ final class NativeTypeTest
             ->toBe($expected);
     }
 
+    #[Test]
+    #[DataSet('literalBooleanTypes')]
+    public function reflectedLiteralBooleansRemainBooleanTypes(string $method, bool $expected): void
+    {
+        $type = new \ReflectionMethod(self::class, $method)->getParameters()[0]->getType();
+        $mapped = NativeType::fromReflection($type);
+
+        Expect::that($mapped::class)
+            ->because('literal native booleans map to PHPStan boolean constants')
+            ->toBe(ConstantBooleanType::class)
+            ->and($mapped->describe(VerbosityLevel::typeOnly()))
+            ->toBe($expected ? 'true' : 'false');
+    }
+
     /**
      * @return iterable<string, array{non-empty-string, non-empty-string}>
      */
@@ -64,6 +79,15 @@ final class NativeTypeTest
         yield 'class' => ['class', [\DateTimeInterface::class]];
     }
 
+    /**
+     * @return iterable<string, array{non-empty-string, bool}>
+     */
+    public static function literalBooleanTypes(): iterable
+    {
+        yield 'true' => ['literalTrue', true];
+        yield 'false' => ['literalFalse', false];
+    }
+
     /** @param mixed $value */
     public function untyped($value): mixed
     {
@@ -76,6 +100,16 @@ final class NativeTypeTest
     }
 
     public function union(int|string $value): int|string
+    {
+        return $value;
+    }
+
+    public function literalTrue(true $value): true
+    {
+        return $value;
+    }
+
+    public function literalFalse(false $value): false
     {
         return $value;
     }


### PR DESCRIPTION
Native matcher reflection exposed literal true and false types as object class names. Map them to PHPStan constant boolean types so valid literal boolean subjects remain accepted.\n\nPin both literal mappings with focused reflected-type coverage.