### PR TITLE
test(doubles): cover protected proxy properties

### DIFF
--- a/tests/Fixture/Doubles/ProtectedPropertyContract.php
+++ b/tests/Fixture/Doubles/ProtectedPropertyContract.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+abstract class ProtectedPropertyContract
+{
+    abstract protected string $status { get; set; }
+}

--- a/tests/Unit/Doubles/ProxyProtectedPropertyTest.php
+++ b/tests/Unit/Doubles/ProxyProtectedPropertyTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Fixture\Doubles\ProtectedPropertyContract;
+
+final readonly class ProxyProtectedPropertyTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function generatedProxiesPreserveProtectedAbstractProperties(): void
+    {
+        $doubles = new Doubles($this->tempDirectory->subdirectory('proxies'));
+        $double = $doubles->stub(ProtectedPropertyContract::class);
+
+        try {
+            $property = new \ReflectionProperty($double, 'status');
+
+            Expect::that($property->isProtected())
+                ->because('a proxy property MUST preserve protected visibility')
+                ->toBeTrue()
+                ->and((string) $property->getType())
+                ->toBe('string');
+        } finally {
+            $doubles->dispose();
+        }
+    }
+}


### PR DESCRIPTION
Add an abstract protected property contract and generate its proxy in an isolated cache. The test pins the property visibility and type so generated class doubles do not widen protected state.