### PR TITLE
test(doubles): cover concrete class methods

### DIFF
--- a/tests/Unit/Doubles/ClassMethodInterceptionTest.php
+++ b/tests/Unit/Doubles/ClassMethodInterceptionTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\MockPlan;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Fixture\Doubles\Clock;
+
+final readonly class ClassMethodInterceptionTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function classDoublesInterceptConcreteMethods(): void
+    {
+        $doubles = new Doubles($this->tempDirectory->subdirectory('proxies'));
+        $clock = $doubles->mock(Clock::class, static function (MockPlan $plan): void {
+            $plan->expects('now')->once()->andReturns('fixed-time');
+        });
+
+        try {
+            Expect::that($clock->now())
+                ->because('a class double MUST use its configured answer for a concrete method')
+                ->toBe('fixed-time');
+        } finally {
+            $doubles->dispose();
+        }
+    }
+}


### PR DESCRIPTION
Add a fresh class double around a concrete method and prove the configured answer replaces the original implementation. This pins the non-final class-method interception path.