### PR TITLE
test(protocol): preserve completed worker payloads

### DIFF
--- a/tests/Unit/Runner/Protocol/DoneResultPayloadWireTest.php
+++ b/tests/Unit/Runner/Protocol/DoneResultPayloadWireTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Protocol;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\ResultSummary;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\Protocol\Messages\Done;
+
+final readonly class DoneResultPayloadWireTest
+{
+    #[Test]
+    public function accumulatedCoverageAndLeaksSurviveTheWire(): void
+    {
+        $payload = [
+            'summary' => new ResultSummary(passed: 1)->toWire(),
+            'peakMemoryBytes' => 4096,
+            'coverage' => [
+                'files' => [
+                    '/project/src/Example.php' => [[10, 12], [11]],
+                ],
+            ],
+            'leaks' => [[
+                'class' => 'App\LeakyTest',
+                'method' => 'retainsItself',
+                'dataSetKey' => 'first',
+            ]],
+            'wantsRecycle' => null,
+        ];
+
+        $done = Done::fromWire($payload);
+
+        Expect::that($done->toWire())
+            ->because('a completed assignment MUST preserve its coverage and leaked test IDs')
+            ->toBe($payload);
+    }
+}


### PR DESCRIPTION
Pins the non-empty fields that a completed worker sends back to the orchestrator. The direct wire contract now proves that accumulated coverage and leaked test IDs both survive decoding.