### PR TITLE
test(reporting): cover recycle reason summary

### DIFF
--- a/tests/Unit/Reporting/PlainReporterWorkerSummaryTest.php
+++ b/tests/Unit/Reporting/PlainReporterWorkerSummaryTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Reporting;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\RecycleReason;
 use Greenlight\Core\Event\RunFinished;
+use Greenlight\Core\Event\WorkerRecycled;
 use Greenlight\Core\Event\WorkerSpawned;
 use Greenlight\Core\Result\ResultSummary;
 use Greenlight\Expect\Expect;
@@ -41,5 +43,22 @@ final class PlainReporterWorkerSummaryTest
             ->because('an in-process run MUST NOT report a spawned worker')
             ->not()
             ->toContain('Workers:');
+    }
+
+    #[Test]
+    public function recycleReasonsAreCountedInCanonicalOrder(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new PlainReporter($output);
+        $reporter->onEvent(new WorkerSpawned('w-1', 101, 1.0));
+        $reporter->onEvent(new WorkerRecycled('w-1', RecycleReason::Crash, 1.1));
+        $reporter->onEvent(new WorkerRecycled('w-2', RecycleReason::Memory, 1.2));
+        $reporter->onEvent(new WorkerRecycled('w-3', RecycleReason::TestCount, 1.3));
+        $reporter->onEvent(new WorkerRecycled('w-4', RecycleReason::Crash, 1.4));
+        $reporter->finish();
+
+        Expect::that($output->buffer())
+            ->because('the plain summary MUST count and order every worker recycle reason')
+            ->toBe("Workers: 1 spawned, 4 recycled (test-count: 1, memory: 1, crash: 2)\n");
     }
 }


### PR DESCRIPTION
Exercise mixed worker recycle reasons in reverse arrival order. Pin the aggregate recycle count and the canonical test-count, memory, crash breakdown used in deterministic plain logs.