### PR TITLE
fix(doubles): preserve concrete protected methods

### DIFF
--- a/src/Doubles/ProxyGenerator.php
+++ b/src/Doubles/ProxyGenerator.php
@@ -192,7 +192,9 @@ final readonly class ProxyGenerator
             throw DoublesError::attachHandlerCollision($method->getDeclaringClass()->name);
         }
 
-        if ($method->isFinal()) {
+        if ($method->isFinal()
+            || ($method->isProtected() && !$method->isAbstract())
+        ) {
             return null;
         }
 

--- a/tests/Fixture/Doubles/AbstractProtectedMethodService.php
+++ b/tests/Fixture/Doubles/AbstractProtectedMethodService.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+abstract class AbstractProtectedMethodService
+{
+    abstract protected function prefix(): string;
+}

--- a/tests/Fixture/Doubles/ProtectedMethodService.php
+++ b/tests/Fixture/Doubles/ProtectedMethodService.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+class ProtectedMethodService
+{
+    final public function message(): string
+    {
+        return $this->prefix() . 'message';
+    }
+
+    protected function prefix(): string
+    {
+        return 'original ';
+    }
+}

--- a/tests/Unit/Doubles/ProtectedMethodInterceptionTest.php
+++ b/tests/Unit/Doubles/ProtectedMethodInterceptionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Fixture\Doubles\AbstractProtectedMethodService;
+use Greenlight\Tests\Fixture\Doubles\ProtectedMethodService;
+
+final readonly class ProtectedMethodInterceptionTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function classDoublesPreserveConcreteProtectedMethods(): void
+    {
+        $doubles = new Doubles($this->tempDirectory->subdirectory('proxies'));
+        $double = $doubles->stub(ProtectedMethodService::class);
+
+        try {
+            Expect::that($double->message())
+                ->because('a class double MUST preserve concrete protected implementation details')
+                ->toBe('original message');
+        } finally {
+            $doubles->dispose();
+        }
+    }
+
+    #[Test]
+    public function classDoublesImplementAbstractProtectedMethods(): void
+    {
+        $doubles = new Doubles($this->tempDirectory->subdirectory('abstract-proxies'));
+
+        try {
+            Expect::that($doubles->stub(AbstractProtectedMethodService::class))
+                ->because('a class double MUST implement an abstract protected method')
+                ->toBeInstanceOf(AbstractProtectedMethodService::class);
+        } finally {
+            $doubles->dispose();
+        }
+    }
+}


### PR DESCRIPTION
Class doubles cannot configure protected interactions, but generated subclasses intercepted concrete protected methods anyway. Preserve inherited concrete implementations while continuing to generate required abstract protected methods, with focused regression coverage for both sides of the boundary.