### PR TITLE
test(doubles): cover global constant defaults

### DIFF
--- a/tests/Fixture/Doubles/GlobalConstantDefault.php
+++ b/tests/Fixture/Doubles/GlobalConstantDefault.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+interface GlobalConstantDefault
+{
+    public function limit(int $value = \PHP_INT_MAX): int;
+}

--- a/tests/Unit/Doubles/ProxyGlobalConstantDefaultTest.php
+++ b/tests/Unit/Doubles/ProxyGlobalConstantDefaultTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\MockPlan;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Fixture\Doubles\GlobalConstantDefault;
+
+final readonly class ProxyGlobalConstantDefaultTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function globalConstantDefaultsRemainConstantsOnGeneratedMethods(): void
+    {
+        $doubles = new Doubles($this->tempDirectory->subdirectory('proxies'));
+        $double = $doubles->mock(GlobalConstantDefault::class, static function (MockPlan $plan): void {
+            $plan->expects('limit')->once()->andReturns(42);
+        });
+        $parameter = new \ReflectionMethod($double, 'limit')->getParameters()[0];
+
+        try {
+            $answer = $double->limit();
+
+            Expect::that($parameter->getDefaultValueConstantName())
+                ->because('a generated method MUST preserve its global default constant')
+                ->toBe('PHP_INT_MAX')
+                ->and($parameter->getDefaultValue())
+                ->toBe(\PHP_INT_MAX)
+                ->and($answer)
+                ->toBe(42);
+        } finally {
+            $doubles->dispose();
+        }
+    }
+}


### PR DESCRIPTION
Generate a proxy in an isolated cache for a method whose optional parameter uses PHP_INT_MAX. Prove the reflected signature preserves the constant identity and value while omitted calls still dispatch through the configured plan.