### PR TITLE
fix(doubles): resolve parent constant defaults

### DIFF
--- a/src/Doubles/ProxyGenerator.php
+++ b/src/Doubles/ProxyGenerator.php
@@ -330,6 +330,16 @@ final readonly class ProxyGenerator
                 return '\\' . $context->name . '::' . \substr($constant, 6);
             }
 
+            if (\str_starts_with($constant, 'parent::')) {
+                $parent = $context->getParentClass();
+
+                if ($parent === false) {
+                    throw DoublesError::parentTypeWithoutParent($context->name);
+                }
+
+                return '\\' . $parent->name . '::' . \substr($constant, 8);
+            }
+
             return '\\' . $constant;
         }
 

--- a/tests/Fixture/Doubles/ParentConstantDefault.php
+++ b/tests/Fixture/Doubles/ParentConstantDefault.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+class ParentConstantDefault extends ParentConstantDefaultBase
+{
+    public const string MODE = 'child';
+
+    public function mode(string $value = parent::MODE): string
+    {
+        return $value;
+    }
+}

--- a/tests/Fixture/Doubles/ParentConstantDefaultBase.php
+++ b/tests/Fixture/Doubles/ParentConstantDefaultBase.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+class ParentConstantDefaultBase
+{
+    public const string MODE = 'inherited';
+}

--- a/tests/Unit/Doubles/ProxyParentConstantDefaultTest.php
+++ b/tests/Unit/Doubles/ProxyParentConstantDefaultTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\MockPlan;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Fixture\Doubles\ParentConstantDefault;
+use Greenlight\Tests\Fixture\Doubles\ParentConstantDefaultBase;
+
+final readonly class ProxyParentConstantDefaultTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function parentConstantDefaultsResolveAgainstTheParentType(): void
+    {
+        $doubles = new Doubles($this->tempDirectory->subdirectory('proxies'));
+        $double = $doubles->mock(ParentConstantDefault::class, static function (MockPlan $plan): void {
+            $plan->expects('mode')->once()->andReturns('answered');
+        });
+        $parameter = new \ReflectionMethod($double, 'mode')->getParameters()[0];
+
+        try {
+            $answer = $double->mode();
+
+            Expect::that($parameter->getDefaultValueConstantName())
+                ->because('a generated method MUST resolve a parent constant against the parent type')
+                ->toBe(ParentConstantDefaultBase::class . '::MODE')
+                ->and($parameter->getDefaultValue())
+                ->toBe('inherited')
+                ->and($answer)
+                ->toBe('answered');
+        } finally {
+            $doubles->dispose();
+        }
+    }
+}


### PR DESCRIPTION
Generated proxies emitted parent:: parameter defaults as an invalid fully qualified token. Resolve them against the declaring type’s actual parent instead. The regression fixture shadows the constant on the child so coverage also proves the original parent value is preserved.