### PR TITLE
test(expect): cover negative infinity rendering

### DIFF
--- a/tests/Unit/Expect/ValueRendererNegativeInfinityTest.php
+++ b/tests/Unit/Expect/ValueRendererNegativeInfinityTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\ValueRenderer;
+
+final class ValueRendererNegativeInfinityTest
+{
+    #[Test]
+    public function negativeInfinityKeepsItsSign(): void
+    {
+        Expect::that(new ValueRenderer()->render(-\INF))
+            ->because('negative infinity MUST retain its sign in failure diagnostics')
+            ->toBe('-INF');
+    }
+}


### PR DESCRIPTION
Pins the negative-infinity diagnostic representation so failure output retains the numeric sign. The focused assertion kills a sign-removal mutant.