### PR TITLE
fix(core): match wildcards across line breaks

### DIFF
--- a/src/Core/Wildcard.php
+++ b/src/Core/Wildcard.php
@@ -26,10 +26,10 @@ final class Wildcard
                 : \str_contains($subject, $pattern);
         }
 
-        $regex = '/^'
+        $regex = '/\A'
             . \strtr(\preg_quote($pattern, '/'), ['\*' => '.*', '\?' => '.'])
-            . '$/'
-            . ($caseInsensitive ? 'iu' : 'u');
+            . '\z/'
+            . ($caseInsensitive ? 'isu' : 'su');
 
         return \preg_match($regex, $subject) === 1;
     }

--- a/tests/Unit/Core/WildcardTest.php
+++ b/tests/Unit/Core/WildcardTest.php
@@ -85,6 +85,13 @@ final class WildcardTest
             true,
         ];
 
+        yield 'star matches across line breaks' => [
+            "first\nsecond",
+            'first*second',
+            false,
+            true,
+        ];
+
         yield 'question mark matches exactly one character' => [
             'Test',
             'T?st',
@@ -99,6 +106,13 @@ final class WildcardTest
             true,
         ];
 
+        yield 'question mark matches one line break' => [
+            "first\nsecond",
+            'first?second',
+            false,
+            true,
+        ];
+
         yield 'question mark does not match zero characters' => [
             'Tst',
             'T?st',
@@ -109,6 +123,13 @@ final class WildcardTest
         yield 'question mark does not match many characters' => [
             'Toast',
             'T?st',
+            false,
+            false,
+        ];
+
+        yield 'wildcard pattern rejects unmatched trailing line breaks' => [
+            "first\nsecond\n",
+            'first*second',
             false,
             false,
         ];

--- a/tests/Unit/Core/WildcardTest.php
+++ b/tests/Unit/Core/WildcardTest.php
@@ -92,6 +92,13 @@ final class WildcardTest
             true,
         ];
 
+        yield 'case-insensitive star matches across line breaks' => [
+            "FIRST\nSECOND",
+            'first*second',
+            true,
+            true,
+        ];
+
         yield 'question mark matches exactly one character' => [
             'Test',
             'T?st',


### PR DESCRIPTION
Makes shell-style wildcards operate on complete multiline text, including diagnostic messages. Absolute anchors preserve the whole-subject contract when the subject has a trailing line break. Focused data rows kill both dotall-removal and end-anchor regression mutants.