### PR TITLE
fix(reporting): emit JUnit error fallback

### DIFF
--- a/src/Reporting/JUnitReporter.php
+++ b/src/Reporting/JUnitReporter.php
@@ -186,14 +186,20 @@ final class JUnitReporter implements Reporter
 
         $error = $result->error;
 
-        if ($result->outcome === Outcome::Errored && $error instanceof ThrowableDetail) {
+        if ($result->outcome === Outcome::Errored) {
             $writer->startElement('error');
-            $writer->writeAttribute('type', $this->xml($error->class));
-            $writer->writeAttribute('message', $this->xml($error->message));
 
-            $body = $error->stackFrames;
-            $body[] = 'at ' . $error->file . ':' . $error->line;
-            $writer->text($this->xml(\implode("\n", $body)));
+            if ($error instanceof ThrowableDetail) {
+                $writer->writeAttribute('type', $this->xml($error->class));
+                $writer->writeAttribute('message', $this->xml($error->message));
+
+                $body = $error->stackFrames;
+                $body[] = 'at ' . $error->file . ':' . $error->line;
+                $writer->text($this->xml(\implode("\n", $body)));
+            } else {
+                $writer->writeAttribute('type', 'error');
+                $writer->writeAttribute('message', 'errored');
+            }
 
             $writer->endElement();
         }

--- a/tests/Unit/Reporting/JUnitErrorFallbackTest.php
+++ b/tests/Unit/Reporting/JUnitErrorFallbackTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\TestFinished;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\JUnitReporter;
+
+final class JUnitErrorFallbackTest
+{
+    #[Test]
+    public function erroredOutcomeWithoutDetailsWritesAnErrorElement(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new JUnitReporter($output);
+        $reporter->onEvent(new TestFinished(new TestResult(
+            new TestId('Acme\PartialResultTest', 'missingErrorDetail'),
+            Outcome::Errored,
+            0.002,
+            0,
+        ), 1.0));
+
+        $reporter->finish();
+
+        Expect::that($output->buffer())
+            ->because('the error count and testcase element MUST remain consistent without details')
+            ->toBe(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                . "<testsuites name=\"greenlight\" tests=\"1\" failures=\"0\" errors=\"1\" skipped=\"0\" time=\"0.002000\">\n"
+                . "  <testsuite name=\"Acme\\PartialResultTest\" tests=\"1\" failures=\"0\" errors=\"1\" skipped=\"0\" assertions=\"0\" time=\"0.002000\">\n"
+                . "    <testcase name=\"missingErrorDetail\" classname=\"Acme\\PartialResultTest\" assertions=\"0\" time=\"0.002000\">\n"
+                . "      <error type=\"error\" message=\"errored\"/>\n"
+                . "    </testcase>\n"
+                . "  </testsuite>\n"
+                . "</testsuites>\n",
+            );
+    }
+}


### PR DESCRIPTION
Keep JUnit suite error counts consistent with testcase elements when an errored result has no structured throwable detail. Emit the same generic errored fallback used by the other CI reporters.