### PR TITLE
fix(expect): truncate Unicode values by code point

### DIFF
--- a/src/Expect/ValueRenderer.php
+++ b/src/Expect/ValueRenderer.php
@@ -87,24 +87,53 @@ final class ValueRenderer
 
     private function renderString(string $value): string
     {
-        $printable = \strtr($value, [
-            '\\' => '\\\\',
-            "'" => "\\'",
-            "\n" => '\n',
-            "\r" => '\r',
-            "\t" => '\t',
-            "\0" => '\0',
-        ]);
+        $value = Utf8::scrub($value);
+        $printable = '';
+        $printableCharacters = 0;
+        $offset = 0;
+        $bytes = \strlen($value);
 
-        if (\strlen($printable) <= self::MAX_STRING_CHARS) {
+        while ($offset < $bytes) {
+            if (\preg_match('/./us', $value, $matches, offset: $offset) !== 1) {
+                break;
+            }
+
+            $character = $matches[0];
+            $escaped = \strtr($character, [
+                '\\' => '\\\\',
+                "'" => "\\'",
+                "\n" => '\n',
+                "\r" => '\r',
+                "\t" => '\t',
+                "\0" => '\0',
+            ]);
+            $escapedCharacters = $this->codePointLength($escaped);
+
+            if ($printableCharacters + $escapedCharacters > self::MAX_STRING_CHARS) {
+                break;
+            }
+
+            $printable .= $escaped;
+            $printableCharacters += $escapedCharacters;
+            $offset += \strlen($character);
+        }
+
+        if ($offset === $bytes) {
             return "'" . $printable . "'";
         }
 
         return \sprintf(
             "'%s...' (truncated from %d characters)",
-            \substr($printable, 0, self::MAX_STRING_CHARS),
-            \strlen($value),
+            $printable,
+            $this->codePointLength($value),
         );
+    }
+
+    private function codePointLength(string $value): int
+    {
+        $length = \preg_match_all('/./us', $value);
+
+        return $length === false ? \strlen($value) : $length;
     }
 
     /**

--- a/tests/Unit/Expect/ValueRendererTest.php
+++ b/tests/Unit/Expect/ValueRendererTest.php
@@ -59,6 +59,30 @@ final class ValueRendererTest
     }
 
     #[Test]
+    public function truncatesUnicodeStringsByCodePoint(): void
+    {
+        $rendered = new ValueRenderer()->render(\str_repeat('é', 121));
+
+        Expect::that($rendered)
+            ->because('diagnostic truncation MUST preserve complete Unicode characters')
+            ->toBe(
+                "'" . \str_repeat('é', 120) . "...' (truncated from 121 characters)",
+            );
+    }
+
+    #[Test]
+    public function truncationDoesNotSplitAnEscapedCharacter(): void
+    {
+        $rendered = new ValueRenderer()->render(\str_repeat('a', 119) . "\ntail");
+
+        Expect::that($rendered)
+            ->because('diagnostic truncation MUST keep escape sequences complete')
+            ->toBe(
+                "'" . \str_repeat('a', 119) . "...' (truncated from 124 characters)",
+            );
+    }
+
+    #[Test]
     public function rendersArraysWithDepthAndItemLimits(): void
     {
         $renderer = new ValueRenderer();


### PR DESCRIPTION
Add regression coverage for long multibyte diagnostic values. Count and truncate valid UTF-8 by code point so rendered output keeps complete characters and reports the correct original length.