### PR TITLE
fix(expect): preserve UTF-8 in observation history

### DIFF
--- a/src/Expect/ObservationLog.php
+++ b/src/Expect/ObservationLog.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Greenlight\Expect;
 
+use Greenlight\Core\Wire\Utf8;
+
 /**
  * Keeps a bounded history of rendered poll attempts.
  *
@@ -102,12 +104,18 @@ final class ObservationLog
             \array_splice($parts, 1, 0, \sprintf('... %d earlier changes omitted ...', $this->omittedGroups));
         }
 
-        $rendered = \implode("\n", $parts);
+        $rendered = Utf8::scrub(\implode("\n", $parts));
 
         if (\strlen($rendered) <= self::MAX_RENDERED_BYTES) {
             return $rendered;
         }
 
-        return \substr($rendered, 0, self::MAX_RENDERED_BYTES - 3) . '...';
+        $truncated = \substr($rendered, 0, self::MAX_RENDERED_BYTES - 3);
+
+        while (\preg_match('//u', $truncated) !== 1) {
+            $truncated = \substr($truncated, 0, -1);
+        }
+
+        return $truncated . '...';
     }
 }

--- a/tests/Unit/Expect/ObservationLogTest.php
+++ b/tests/Unit/Expect/ObservationLogTest.php
@@ -60,6 +60,17 @@ final class ObservationLogTest
     }
 
     #[Test]
+    public function truncationDoesNotSplitAUnicodeCharacter(): void
+    {
+        $log = new ObservationLog(0.0);
+        $log->record(0.0, \str_repeat('€', 1_000));
+
+        Expect::that($log->render())
+            ->because('bounded observation history MUST remain valid UTF-8')
+            ->toBe('+0.0ms ' . \str_repeat('€', 679) . '...');
+    }
+
+    #[Test]
     public function anIdenticalTailGroupDoesNotRepeatTheFirstObservation(): void
     {
         $log = new ObservationLog(0.0);


### PR DESCRIPTION
Add regression coverage for a multibyte character crossing the observation-history byte limit. Scrub the rendered history and back up to a complete code-point boundary before appending the truncation marker.