### PR TITLE
test(reporting): cover partial GitHub diffs

### DIFF
--- a/tests/Unit/Reporting/GithubReporterTest.php
+++ b/tests/Unit/Reporting/GithubReporterTest.php
@@ -107,6 +107,33 @@ final class GithubReporterTest
     }
 
     #[Test]
+    #[DataSet('partialDiffs')]
+    public function partialFailureDiffsRetainTheAvailableSide(
+        ?string $expected,
+        ?string $actual,
+        string $diff,
+    ): void {
+        $output = new BufferOutput();
+        $reporter = new GithubReporter($output);
+        $result = new TestResult(
+            new TestId('Acme\PartialDiffTest', 'reports'),
+            Outcome::Failed,
+            0.001,
+            0,
+            failures: [
+                new FailureDetail('Values differ.', $expected, $actual),
+            ],
+        );
+
+        $reporter->onEvent(new TestFinished($result, 1.0));
+        $reporter->finish();
+
+        Expect::that($output->buffer())
+            ->because('a GitHub annotation MUST retain each available diff side independently')
+            ->toBe('::error::Acme\PartialDiffTest::reports: Values differ.' . $diff . "\n");
+    }
+
+    #[Test]
     #[DataSet('outcomesWithoutDetails')]
     public function outcomesWithoutDetailsStillProduceAnnotations(Outcome $outcome, string $summary): void
     {
@@ -182,6 +209,16 @@ final class GithubReporterTest
                 . '%0Aattachments:%0Arequest.log: build/request.log'
                 . "\n",
             );
+    }
+
+    /**
+     * @return iterable<string, array{?string, ?string, string}>
+     */
+    public static function partialDiffs(): iterable
+    {
+        yield 'expected only' => ['left', null, '%0Aexpected: left'];
+
+        yield 'actual only' => [null, 'right', '%0Aactual: right'];
     }
 
     /**


### PR DESCRIPTION
Protect one-sided failure diffs in GitHub workflow annotations. Expected-only and actual-only details are asserted independently so neither available side can be coupled to the presence of the other.