### PR TITLE
fix(core): preserve UTF-8 diagnostic boundaries

### DIFF
--- a/src/Capture/OutputCapture.php
+++ b/src/Capture/OutputCapture.php
@@ -15,8 +15,8 @@ use Greenlight\Core\Wire\Utf8;
  *
  * If output is too long, Greenlight keeps the first part. This part usually
  * contains useful error information. The final part frequently contains
- * repeated information. A cut can divide a multibyte character. The final
- * conversion then replaces the incomplete bytes with U+FFFD.
+ * repeated information. Greenlight removes a partial multibyte character at
+ * the size limit.
  *
  * @internal
  */
@@ -131,8 +131,13 @@ final class OutputCapture
 
         $this->errorHandler = null;
 
+        $scrubbedStdout = Utf8::scrub($this->stdout);
+        $boundedStdout = Utf8::headBytes($scrubbedStdout, $this->maxStdoutBytes);
+        $this->stdoutTruncated = $this->stdoutTruncated
+            || \strlen($boundedStdout) < \strlen($scrubbedStdout);
+
         $captured = new CapturedOutput(
-            Utf8::scrub($this->stdout),
+            $boundedStdout,
             $this->diagnostics,
             $this->stdoutTruncated,
             $this->diagnosticsTruncated,
@@ -151,19 +156,20 @@ final class OutputCapture
      */
     private function appendChunk(string $chunk): string
     {
-        $remaining = $this->maxStdoutBytes - \strlen($this->stdout);
-
-        if ($remaining >= \strlen($chunk)) {
-            $this->stdout .= $chunk;
-        } else {
-            if ($remaining > 0) {
-                $this->stdout .= \substr($chunk, 0, $remaining);
-            }
-
-            if ($chunk !== '') {
-                $this->stdoutTruncated = true;
-            }
+        if ($this->stdoutTruncated || $chunk === '') {
+            return '';
         }
+
+        $combined = $this->stdout . $chunk;
+
+        if (\strlen($combined) <= $this->maxStdoutBytes) {
+            $this->stdout = $combined;
+
+            return '';
+        }
+
+        $this->stdout = Utf8::headBytes($combined, $this->maxStdoutBytes);
+        $this->stdoutTruncated = true;
 
         return '';
     }

--- a/src/Core/Wire/Utf8.php
+++ b/src/Core/Wire/Utf8.php
@@ -18,6 +18,56 @@ final class Utf8
     /** @codeCoverageIgnore */
     private function __construct() {}
 
+    public static function headBytes(string $value, int $maxBytes): string
+    {
+        if ($maxBytes < 0) {
+            throw new \InvalidArgumentException(\sprintf('Byte bound must be zero or greater, got %d.', $maxBytes));
+        }
+
+        if ($maxBytes === 0) {
+            return '';
+        }
+
+        $value = self::scrub($value);
+
+        if (\strlen($value) <= $maxBytes) {
+            return $value;
+        }
+
+        $bounded = \substr($value, 0, $maxBytes);
+
+        while (\preg_match('//u', $bounded) !== 1) {
+            $bounded = \substr($bounded, 0, -1);
+        }
+
+        return $bounded;
+    }
+
+    public static function tailBytes(string $value, int $maxBytes): string
+    {
+        if ($maxBytes < 0) {
+            throw new \InvalidArgumentException(\sprintf('Byte bound must be zero or greater, got %d.', $maxBytes));
+        }
+
+        if ($maxBytes === 0) {
+            return '';
+        }
+
+        $value = self::scrub($value);
+
+        if (\strlen($value) <= $maxBytes) {
+            return $value;
+        }
+
+        $bounded = \substr($value, -$maxBytes);
+
+        while (\preg_match('//u', $bounded) !== 1) {
+            $bounded = \substr($bounded, 1);
+        }
+
+        return $bounded;
+    }
+
     public static function scrub(string $value): string
     {
         if (\preg_match('//u', $value) === 1) {

--- a/src/Expect/ObservationLog.php
+++ b/src/Expect/ObservationLog.php
@@ -110,12 +110,6 @@ final class ObservationLog
             return $rendered;
         }
 
-        $truncated = \substr($rendered, 0, self::MAX_RENDERED_BYTES - 3);
-
-        while (\preg_match('//u', $truncated) !== 1) {
-            $truncated = \substr($truncated, 0, -1);
-        }
-
-        return $truncated . '...';
+        return Utf8::headBytes($rendered, self::MAX_RENDERED_BYTES - 3) . '...';
     }
 }

--- a/src/Runner/Orchestrator/Orchestrator.php
+++ b/src/Runner/Orchestrator/Orchestrator.php
@@ -22,6 +22,7 @@ use Greenlight\Core\Result\TestResult;
 use Greenlight\Core\Result\ThrowableDetail;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Core\Wire\InvalidWirePayload;
+use Greenlight\Core\Wire\Utf8;
 use Greenlight\Coverage\CoverageMap;
 use Greenlight\Discovery\ExecutionPlan;
 use Greenlight\Discovery\PlanEntry;
@@ -707,7 +708,7 @@ final class Orchestrator
                     throw ProtocolError::workerNeverConnected(
                         $handle->workerId,
                         $this->connectDeadlineSeconds,
-                        \substr(\trim($handle->diagnostics), -2048),
+                        Utf8::tailBytes(\trim($handle->diagnostics), 2_048),
                     );
                 }
 
@@ -755,7 +756,7 @@ final class Orchestrator
                     throw ProtocolError::workerStalled(
                         $handle->workerId,
                         $this->progressDeadlineSeconds,
-                        \substr(\trim($handle->diagnostics), -2048),
+                        Utf8::tailBytes(\trim($handle->diagnostics), 2_048),
                     );
                 }
 
@@ -796,7 +797,7 @@ final class Orchestrator
             $diagnostics = \trim($handle->diagnostics);
 
             if ($diagnostics !== '') {
-                $message .= "\nWorker output:\n" . \substr($diagnostics, -2048);
+                $message .= "\nWorker output:\n" . Utf8::tailBytes($diagnostics, 2_048);
             }
 
             $this->recordSyntheticResult($handle, $sink, new TestResult(
@@ -824,7 +825,7 @@ final class Orchestrator
             $message = \sprintf('Worker "%s" crashed during this test: %s.', $handle->workerId, $reason);
 
             if ($diagnostics !== '') {
-                $message .= "\nWorker output:\n" . \substr($diagnostics, -2048);
+                $message .= "\nWorker output:\n" . Utf8::tailBytes($diagnostics, 2_048);
             }
 
             $this->recordSyntheticResult($handle, $sink, new TestResult(

--- a/src/Runner/Orchestrator/WorkerHandle.php
+++ b/src/Runner/Orchestrator/WorkerHandle.php
@@ -7,6 +7,7 @@ namespace Greenlight\Runner\Orchestrator;
 use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Result\ResultSummary;
 use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Wire\Utf8;
 use Greenlight\Discovery\ExecutionPlan;
 use Greenlight\Runner\Protocol\SocketChannel;
 
@@ -18,6 +19,8 @@ use Greenlight\Runner\Protocol\SocketChannel;
  */
 final class WorkerHandle
 {
+    private const int MAX_DIAGNOSTIC_BYTES = 65_536;
+
     public ?SocketChannel $channel = null;
 
     public bool $ready = false;
@@ -49,6 +52,9 @@ final class WorkerHandle
     public bool $done = false;
 
     public string $diagnostics = '';
+
+    /** @var array{string, string} */
+    private array $diagnosticCarry = ['', ''];
 
     public readonly float $spawnedAt;
 
@@ -116,7 +122,7 @@ final class WorkerHandle
     public function drainPipes(): void
     {
         ErrorTrap::run(function (): void {
-            foreach ([$this->stdout, $this->stderr] as $pipe) {
+            foreach ([$this->stdout, $this->stderr] as $index => $pipe) {
                 if (!\is_resource($pipe)) {
                     continue;
                 }
@@ -124,11 +130,88 @@ final class WorkerHandle
                 \stream_set_blocking($pipe, false);
                 $bytes = \fread($pipe, 8192);
 
-                if (\is_string($bytes) && $bytes !== '') {
-                    $this->diagnostics = \substr($this->diagnostics . $bytes, -65536);
+                if (!\is_string($bytes)) {
+                    continue;
+                }
+
+                [$complete, $this->diagnosticCarry[$index]] = $this->completeUtf8Prefix(
+                    $this->diagnosticCarry[$index] . $bytes,
+                );
+
+                if (\feof($pipe) && $this->diagnosticCarry[$index] !== '') {
+                    $complete .= $this->diagnosticCarry[$index];
+                    $this->diagnosticCarry[$index] = '';
+                }
+
+                if ($complete !== '') {
+                    $this->diagnostics = Utf8::tailBytes(
+                        $this->diagnostics . $complete,
+                        self::MAX_DIAGNOSTIC_BYTES,
+                    );
                 }
             }
         });
+    }
+
+    /**
+     * @return array{string, string}
+     */
+    private function completeUtf8Prefix(string $value): array
+    {
+        if (\preg_match('//u', $value) === 1) {
+            return [$value, ''];
+        }
+
+        $maxCarryBytes = \min(3, \strlen($value));
+
+        for ($carryBytes = 1; $carryBytes <= $maxCarryBytes; ++$carryBytes) {
+            $prefix = \substr($value, 0, -$carryBytes);
+            $carry = \substr($value, -$carryBytes);
+
+            if (\preg_match('//u', $prefix) === 1 && $this->isIncompleteUtf8Suffix($carry)) {
+                return [$prefix, $carry];
+            }
+        }
+
+        return [Utf8::scrub($value), ''];
+    }
+
+    private function isIncompleteUtf8Suffix(string $value): bool
+    {
+        $length = \strlen($value);
+        $lead = \ord($value[0]);
+        $expectedLength = match (true) {
+            $lead >= 0xC2 && $lead <= 0xDF => 2,
+            $lead >= 0xE0 && $lead <= 0xEF => 3,
+            $lead >= 0xF0 && $lead <= 0xF4 => 4,
+            default => 0,
+        };
+
+        if ($expectedLength === 0 || $length >= $expectedLength) {
+            return false;
+        }
+
+        for ($index = 1; $index < $length; ++$index) {
+            $byte = \ord($value[$index]);
+            $minimum = match (true) {
+                $index !== 1 => 0x80,
+                $lead === 0xE0 => 0xA0,
+                $lead === 0xF0 => 0x90,
+                default => 0x80,
+            };
+            $maximum = match (true) {
+                $index !== 1 => 0xBF,
+                $lead === 0xED => 0x9F,
+                $lead === 0xF4 => 0x8F,
+                default => 0xBF,
+            };
+
+            if ($byte < $minimum || $byte > $maximum) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     public function terminate(): void

--- a/tests/Fixture/CrashUnicodeDiagnostics/CrashUnicodeDiagnosticsTest.php
+++ b/tests/Fixture/CrashUnicodeDiagnostics/CrashUnicodeDiagnosticsTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\CrashUnicodeDiagnostics;
+
+use Greenlight\Attribute\Test;
+
+final class CrashUnicodeDiagnosticsTest
+{
+    #[Test]
+    public function writesUnicodeDiagnosticsThenExits(): never
+    {
+        \fwrite(\STDERR, 'xx€' . \str_repeat('y', 2046));
+
+        exit(23);
+    }
+}

--- a/tests/Unit/Capture/OutputCaptureTest.php
+++ b/tests/Unit/Capture/OutputCaptureTest.php
@@ -205,6 +205,27 @@ final class OutputCaptureTest
     }
 
     #[Test]
+    public function truncationDoesNotKeepAPartialUnicodeCharacter(): void
+    {
+        $capture = new OutputCapture(maxStdoutBytes: 4);
+        $capture->start();
+
+        echo 'ab€cd';
+
+        $captured = $capture->stop();
+
+        Expect::that($captured->stdout)
+            ->because('captured output MUST contain only complete Unicode characters within its byte limit')
+            ->toBe('ab');
+        Expect::that(\strlen($captured->stdout))
+            ->because('captured output MUST stay within its byte limit')
+            ->toBeLessThanOrEqual(4);
+        Expect::that($captured->stdoutTruncated)
+            ->because('captured output beyond the byte limit MUST be marked as truncated')
+            ->toBeTrue();
+    }
+
+    #[Test]
     public function diagnosticsBeyondTheBoundAreDroppedAndFlagged(): void
     {
         $capture = new OutputCapture(maxDiagnostics: 2);

--- a/tests/Unit/Core/Utf8Test.php
+++ b/tests/Unit/Core/Utf8Test.php
@@ -33,6 +33,66 @@ final class Utf8Test
     }
 
     #[Test]
+    public function byteBoundsKeepCompleteUnicodeCharacters(): void
+    {
+        $value = 'ab€cd';
+
+        Expect::that(Utf8::headBytes($value, 4))
+            ->because('the head bound MUST exclude a partial Unicode character')
+            ->toBe('ab');
+        Expect::that(Utf8::tailBytes($value, 4))
+            ->because('the tail bound MUST exclude a partial Unicode character')
+            ->toBe('cd');
+        Expect::that(Utf8::headBytes($value, 5))
+            ->because('the head bound MUST keep a complete Unicode character')
+            ->toBe('ab€');
+        Expect::that(Utf8::tailBytes($value, 5))
+            ->because('the tail bound MUST keep a complete Unicode character')
+            ->toBe('€cd');
+    }
+
+    #[Test]
+    public function byteBoundsScrubInvalidInputWithoutExceedingTheLimit(): void
+    {
+        $value = "a\xFFb";
+
+        Expect::that(Utf8::headBytes($value, 4))
+            ->because('the head bound MUST scrub invalid input before it applies the byte limit')
+            ->toBe("a\u{FFFD}");
+        Expect::that(Utf8::tailBytes($value, 4))
+            ->because('the tail bound MUST scrub invalid input before it applies the byte limit')
+            ->toBe("\u{FFFD}b");
+    }
+
+    #[Test]
+    public function byteBoundsRejectNegativeLimits(): void
+    {
+        Expect::that(static fn(): string => Utf8::headBytes('value', -1))
+            ->because('the head byte bound MUST reject a negative limit')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Byte bound must be zero or greater, got -1.',
+            );
+        Expect::that(static fn(): string => Utf8::tailBytes('value', -2))
+            ->because('the tail byte bound MUST reject a negative limit')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Byte bound must be zero or greater, got -2.',
+            );
+    }
+
+    #[Test]
+    public function zeroByteBoundsReturnAnEmptyString(): void
+    {
+        Expect::that(Utf8::headBytes('value', 0))
+            ->because('a zero-byte head cannot retain input')
+            ->toBe('');
+        Expect::that(Utf8::tailBytes('value', 0))
+            ->because('a zero-byte tail cannot retain input')
+            ->toBe('');
+    }
+
+    #[Test]
     public function throwableWithBinaryMessageSurvivesTheWire(): void
     {
         $detail = ThrowableDetail::fromThrowable(new \RuntimeException("query failed: \xB1\x31\xFF"));

--- a/tests/Unit/Runner/Orchestrator/OrchestratorTest.php
+++ b/tests/Unit/Runner/Orchestrator/OrchestratorTest.php
@@ -19,6 +19,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Runner\Orchestrator\Orchestrator;
 use Greenlight\Runner\Protocol\ProtocolError;
 use Greenlight\Tests\Fixture\CrashDiagnostics\CrashDiagnosticsTest;
+use Greenlight\Tests\Fixture\CrashUnicodeDiagnostics\CrashUnicodeDiagnosticsTest;
 use Greenlight\Tests\Fixture\LeakSuite\CleanTest;
 use Greenlight\Tests\Fixture\Lifecycle\Bail\AaTest;
 use Greenlight\Tests\Fixture\Lifecycle\Bail\BbTest;
@@ -535,6 +536,35 @@ final class OrchestratorTest
             );
     }
 
+    #[Test]
+    #[Timeout(30.0)]
+    public function crashedWorkerKeepsACompleteUnicodeDiagnosticTail(): void
+    {
+        $root = \dirname(__DIR__, 4);
+        $sink = new CollectingEventSink();
+        $orchestrator = new Orchestrator(
+            workerCommand: [\PHP_BINARY, $root . '/bin/greenlight'],
+            workingDirectory: $root,
+        );
+
+        $summary = $orchestrator->run($this->crashUnicodeDiagnosticsPlan(), $sink, 1);
+        $results = $sink->results();
+
+        Expect::that($summary->errored)
+            ->because('a worker crash MUST produce one synthetic error result')
+            ->toBe(1);
+        Expect::that($results)
+            ->because('a worker crash MUST produce one synthetic test result')
+            ->toHaveCount(1);
+        Expect::that($results[0]->error?->message)
+            ->because('the diagnostic tail MUST contain only complete Unicode characters within its byte limit')
+            ->toBe(
+                "Worker \"w-1\" crashed during this test: the worker process exited unexpectedly.\n"
+                . "Worker output:\n"
+                . \str_repeat('y', 2046),
+            );
+    }
+
     private function plan(): ExecutionPlan
     {
         $id = new TestId('Example\NeverExecutedTest', 'irrelevant');
@@ -656,6 +686,15 @@ final class OrchestratorTest
     private function crashDiagnosticsPlan(): ExecutionPlan
     {
         $id = new TestId(CrashDiagnosticsTest::class, 'writesDiagnosticsThenExits');
+
+        return new ExecutionPlan([
+            new PlanEntry($id, new TestMetadata($id->class, $id->method)),
+        ]);
+    }
+
+    private function crashUnicodeDiagnosticsPlan(): ExecutionPlan
+    {
+        $id = new TestId(CrashUnicodeDiagnosticsTest::class, 'writesUnicodeDiagnosticsThenExits');
 
         return new ExecutionPlan([
             new PlanEntry($id, new TestMetadata($id->class, $id->method)),

--- a/tests/Unit/Runner/Orchestrator/WorkerHandleTest.php
+++ b/tests/Unit/Runner/Orchestrator/WorkerHandleTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Runner\Orchestrator;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Core\Test\TestMetadata;
@@ -54,6 +55,102 @@ final class WorkerHandleTest
             ->toBe([$remaining->id]);
     }
 
+    #[Test]
+    public function drainedDiagnosticsKeepACompleteUnicodeTailWithinTheByteLimit(): void
+    {
+        $stdout = $this->stream();
+        \fwrite($stdout, 'z');
+        \rewind($stdout);
+
+        $handle = new WorkerHandle(
+            'worker-1',
+            1,
+            $this->stream(),
+            $stdout,
+            $this->stream(),
+        );
+        $handle->diagnostics = 'xx€' . \str_repeat('y', 65_533);
+
+        $handle->drainPipes();
+
+        Expect::that($handle->diagnostics)
+            ->because('drained diagnostics MUST contain only complete Unicode characters within the byte limit')
+            ->toBe(\str_repeat('y', 65_533) . 'z');
+        Expect::that(\strlen($handle->diagnostics))
+            ->because('drained diagnostics MUST stay within the byte limit')
+            ->toBeLessThanOrEqual(65_536);
+    }
+
+    #[Test]
+    #[DataSet('splitUnicodeSequences')]
+    public function diagnosticsPreserveAUnicodeCharacterSplitAcrossPipeReads(
+        string $lead,
+        string $remainder,
+        string $expected,
+    ): void {
+        [$reader, $writer] = $this->streamPair();
+        $handle = new WorkerHandle(
+            'worker-1',
+            1,
+            $this->stream(),
+            $reader,
+            $this->stream(),
+        );
+
+        \fwrite($writer, $lead);
+        $handle->drainPipes();
+        \fwrite($writer, $remainder);
+        $handle->drainPipes();
+
+        Expect::that($handle->diagnostics)
+            ->because('pipe reads MUST combine the bytes of one Unicode character')
+            ->toBe($expected);
+    }
+
+    #[Test]
+    #[DataSet('malformedUtf8Prefixes')]
+    public function malformedTrailingBytesAreScrubbedWithoutWaitingForAnotherPipeRead(string $malformed): void
+    {
+        [$reader, $writer] = $this->streamPair();
+        $handle = new WorkerHandle(
+            'worker-1',
+            1,
+            $this->stream(),
+            $reader,
+            $this->stream(),
+        );
+
+        \fwrite($writer, $malformed);
+        $handle->drainPipes();
+
+        Expect::that($handle->diagnostics)
+            ->because('malformed trailing bytes MUST be scrubbed during the current pipe read')
+            ->toBe("\u{FFFD}");
+    }
+
+    /**
+     * @return iterable<string, array{string, string, string}>
+     */
+    public static function splitUnicodeSequences(): iterable
+    {
+        yield 'two-byte minimum lead' => ["\xC2", "\xA2", '¢'];
+        yield 'three-byte minimum lead' => ["\xE0", "\xA0\x80", "\u{0800}"];
+        yield 'four-byte minimum lead' => ["\xF0", "\x90\x80\x80", "\u{10000}"];
+        yield 'four-byte maximum lead' => ["\xF4", "\x8F\xBF\xBF", "\u{10FFFF}"];
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function malformedUtf8Prefixes(): iterable
+    {
+        yield 'invalid lead' => ["\xFF"];
+        yield 'overlong three-byte prefix' => ["\xE0\x80"];
+        yield 'surrogate prefix' => ["\xED\xA0"];
+        yield 'overlong four-byte prefix' => ["\xF0\x80"];
+        yield 'out-of-range prefix' => ["\xF4\x90"];
+    }
+
     /**
      * @param non-empty-string $method
      */
@@ -87,5 +184,19 @@ final class WorkerHandleTest
         }
 
         return $stream;
+    }
+
+    /**
+     * @return array{resource, resource}
+     */
+    private function streamPair(): array
+    {
+        $streams = \stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+
+        if (!\is_array($streams) || \count($streams) !== 2) {
+            Fail::because('Expected the connected streams to open.');
+        }
+
+        return [$streams[0], $streams[1]];
     }
 }


### PR DESCRIPTION
- Add shared UTF-8 head and tail byte bounds with exact negative and zero-limit contracts.\n- Apply the bounds to captured output, observation history, worker diagnostics, and orchestrator error tails.\n- Preserve valid characters split across pipe reads while scrubbing malformed prefixes immediately.\n- Add focused boundary coverage for each consumer and UTF-8 lead class.