### PR TITLE
fix(reporting): preserve partial TeamCity diffs

### DIFF
--- a/src/Reporting/TeamCityReporter.php
+++ b/src/Reporting/TeamCityReporter.php
@@ -152,11 +152,24 @@ final class TeamCityReporter implements Reporter
             'message' => $failure->message ?? 'failed',
         ];
 
+        $hasComparison = $failure !== null
+            && $failure->expected !== null
+            && $failure->actual !== null;
         $details = [];
 
         foreach ($result->failures as $index => $detail) {
             if ($index > 0) {
                 $details[] = $detail->message;
+            }
+
+            if ($index > 0 || !$hasComparison) {
+                if ($detail->expected !== null) {
+                    $details[] = 'expected: ' . $detail->expected;
+                }
+
+                if ($detail->actual !== null) {
+                    $details[] = 'actual: ' . $detail->actual;
+                }
             }
 
             if ($detail->location !== null) {

--- a/tests/Unit/Reporting/TeamCityPartialDiffTest.php
+++ b/tests/Unit/Reporting/TeamCityPartialDiffTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\TestFinished;
+use Greenlight\Core\Result\FailureDetail;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\TeamCityReporter;
+
+final class TeamCityPartialDiffTest
+{
+    #[Test]
+    public function partialFailureDiffsRemainInTheDetails(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new TeamCityReporter($output);
+        $result = new TestResult(
+            new TestId('Acme\PartialDiffTest', 'reports'),
+            Outcome::Failed,
+            0.001,
+            0,
+            failures: [
+                new FailureDetail('primary failure', expected: 'left'),
+                new FailureDetail('secondary failure', actual: 'right'),
+            ],
+        );
+
+        $reporter->onEvent(new TestFinished($result, 1.0));
+
+        Expect::that($output->buffer())
+            ->because('TeamCity details MUST retain each available partial diff side')
+            ->toBe(
+                "##teamcity[testFailed name='Acme\\PartialDiffTest::reports' message='primary failure'"
+                . " details='expected: left|nsecondary failure|nactual: right'"
+                . " flowId='Acme\\PartialDiffTest']\n"
+                . "##teamcity[testFinished name='Acme\\PartialDiffTest::reports' duration='1'"
+                . " flowId='Acme\\PartialDiffTest']\n",
+            );
+    }
+}


### PR DESCRIPTION
Preserve expected-only and actual-only failure values in TeamCity `details`, including partial diffs from later failure records. Complete expected/actual pairs still use TeamCity comparison-failure attributes without duplicating those values in `details`.