### PR TITLE
test(cli): preserve falsey option values

### DIFF
--- a/tests/Unit/Cli/ParsedArgumentsTest.php
+++ b/tests/Unit/Cli/ParsedArgumentsTest.php
@@ -41,4 +41,19 @@ final class ParsedArgumentsTest
             ->and($arguments->has('missing'))
             ->toBeFalse();
     }
+
+    #[Test]
+    public function valuesPreserveFalseyStrings(): void
+    {
+        $arguments = new ParsedArguments(null, [
+            'option' => ['', null, '0'],
+        ]);
+
+        Expect::that($arguments->values('option'))
+            ->because('repeatable option values MUST remove only absent null entries')
+            ->toBe(['', '0'])
+            ->and($arguments->value('option'))
+            ->because('a singular option lookup MUST preserve a final zero string')
+            ->toBe('0');
+    }
 }


### PR DESCRIPTION
Protect repeatable option extraction from truthiness filtering. Empty-string and zero-string values remain present in input order; only the null marker for an absent value is removed.