### PR TITLE
test(runner): cover Linux CPU info parsing

### DIFF
--- a/src/Runner/CpuCores.php
+++ b/src/Runner/CpuCores.php
@@ -51,9 +51,9 @@ final class CpuCores
             $cpuinfo = ErrorTrap::run(static fn(): string|false => \file_get_contents('/proc/cpuinfo'));
 
             if (\is_string($cpuinfo)) {
-                $count = \preg_match_all('/^processor\s*:/m', $cpuinfo);
+                $count = LinuxCpuInfo::processorCount($cpuinfo);
 
-                if ($count > 0) {
+                if ($count !== null) {
                     return $count;
                 }
             }

--- a/src/Runner/LinuxCpuInfo.php
+++ b/src/Runner/LinuxCpuInfo.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Runner;
+
+use Greenlight\Attribute\CoverageIgnore;
+
+/**
+ * Reads the logical processor count from a Linux CPU information document.
+ *
+ * @internal
+ */
+final class LinuxCpuInfo
+{
+    #[CoverageIgnore]
+    private function __construct() {}
+
+    /**
+     * @return positive-int|null
+     */
+    public static function processorCount(string $cpuinfo): ?int
+    {
+        $count = \preg_match_all('/^processor\s*:/m', $cpuinfo);
+
+        return $count > 0 ? $count : null;
+    }
+}

--- a/tests/Unit/Runner/LinuxCpuInfoTest.php
+++ b/tests/Unit/Runner/LinuxCpuInfoTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\LinuxCpuInfo;
+
+final class LinuxCpuInfoTest
+{
+    #[Test]
+    #[DataSet('cpuInfoDocuments')]
+    public function processorCountUsesOnlyProcessorRecords(string $cpuinfo, ?int $expected): void
+    {
+        $count = LinuxCpuInfo::processorCount($cpuinfo);
+
+        Expect::that($count)
+            ->because('the Linux probe MUST count only processor records')
+            ->toBe($expected);
+    }
+
+    /**
+     * @return iterable<string, array{string, positive-int|null}>
+     */
+    public static function cpuInfoDocuments(): iterable
+    {
+        yield 'two processors' => [
+            <<<'CPUINFO'
+            processor   : 0
+            vendor_id   : GenuineIntel
+
+            processor   : 1
+            vendor_id   : GenuineIntel
+            CPUINFO,
+            2,
+        ];
+        yield 'one processor with a tab separator' => ["processor\t: 0\n", 1];
+        yield 'empty document' => ['', null];
+        yield 'misleading and indented fields' => [
+            <<<'CPUINFO'
+            physical processor : 0
+            processor count    : 8
+             processor         : 1
+            CPUINFO,
+            null,
+        ];
+    }
+}


### PR DESCRIPTION
Extract the Linux CPU-info record parser into a focused internal seam. Cover realistic processor records, accepted separators, empty input, and misleading fields so automatic worker counts cannot silently drift.