### PR TITLE
test(expect): cover date time implementation equality

### DIFF
--- a/tests/Unit/Expect/DateTimeImplementationEqualityTest.php
+++ b/tests/Unit/Expect/DateTimeImplementationEqualityTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+
+final class DateTimeImplementationEqualityTest
+{
+    #[Test]
+    public function mutableAndImmutableDateTimesCompareByInstant(): void
+    {
+        $mutable = new \DateTime('2026-07-28T12:00:00.123456+00:00');
+        $immutable = new \DateTimeImmutable('2026-07-28T13:00:00.123456+01:00');
+
+        Expect::that($mutable)
+            ->because('date time equality MUST ignore implementation and time zone differences')
+            ->toEqual($immutable);
+    }
+}


### PR DESCRIPTION
Pin the instant-based equality contract across mutable and immutable DateTime implementations and different time zones. This prevents concrete-class or local-format comparisons from replacing the timestamp comparison.