### PR TITLE
test(laravel): cover string factory reset

### DIFF
--- a/tests/Unit/Laravel/LaravelStateResetterTest.php
+++ b/tests/Unit/Laravel/LaravelStateResetterTest.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Laravel;
 
+use Greenlight\Attribute\SkipUnless;
 use Greenlight\Attribute\Test;
+use Greenlight\Condition\ClassAvailable;
 use Greenlight\Expect\Expect;
 use Greenlight\Laravel\LaravelStateResetter;
 use Illuminate\Support\Str;
 
+#[SkipUnless(ClassAvailable::class, Str::class)]
 final class LaravelStateResetterTest
 {
     #[Test]

--- a/tests/Unit/Laravel/LaravelStateResetterTest.php
+++ b/tests/Unit/Laravel/LaravelStateResetterTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Laravel;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Laravel\LaravelStateResetter;
+use Illuminate\Support\Str;
+
+final class LaravelStateResetterTest
+{
+    #[Test]
+    public function customRandomStringFactoriesDoNotSurviveReset(): void
+    {
+        $factoryCalls = 0;
+        Str::createRandomStringsUsing(static function (int $length) use (&$factoryCalls): string {
+            ++$factoryCalls;
+
+            return \str_repeat('x', $length);
+        });
+
+        try {
+            LaravelStateResetter::reset();
+            Str::random(8);
+
+            Expect::that($factoryCalls)
+                ->because('Laravel reset MUST remove a custom random-string factory')
+                ->toBe(0);
+        } finally {
+            Str::createRandomStringsNormally();
+        }
+    }
+}


### PR DESCRIPTION
Dirty Laravel’s global random-string factory before framework teardown.

Assert that the reset removes the custom factory so it cannot leak into the next test application.