### PR TITLE
test(config): cover memory size round trip

### DIFF
--- a/tests/Unit/Config/MemorySizeRoundTripTest.php
+++ b/tests/Unit/Config/MemorySizeRoundTripTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Config;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\MemorySize;
+use Greenlight\Expect\Expect;
+
+final readonly class MemorySizeRoundTripTest
+{
+    #[Test]
+    public function plainByteFormatCanBeParsed(): void
+    {
+        $bytes = 1000;
+
+        Expect::that(MemorySize::parseToBytes(MemorySize::format($bytes)))
+            ->because('a formatted plain-byte size MUST parse to its original value')
+            ->toBe($bytes);
+    }
+}


### PR DESCRIPTION
Exercise the plain-byte output produced by MemorySize::format().

Assert that parsing the formatted value returns the original byte count, including the generated B suffix.