### PR TITLE
test(runner): cover concurrent lease identity

### DIFF
--- a/tests/Unit/Runner/Orchestrator/ResourceLeaseIdentityTest.php
+++ b/tests/Unit/Runner/Orchestrator/ResourceLeaseIdentityTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Orchestrator;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Discovery\ExecutionPlan;
+use Greenlight\Discovery\PlanEntry;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Runner\Orchestrator\ResourceLease;
+use Greenlight\Runner\Orchestrator\ResourceScheduler;
+use Greenlight\Runner\Orchestrator\SchedulingUnit;
+
+final readonly class ResourceLeaseIdentityTest
+{
+    #[Test]
+    public function concurrentLeasesHaveDistinctIdentityAndReleaseIndependently(): void
+    {
+        $scheduler = new ResourceScheduler([
+            $this->unit('Acme\\FirstTest'),
+            $this->unit('Acme\\SecondTest'),
+        ], [], ['database' => 2]);
+
+        $first = $this->assigned($scheduler);
+        $second = $this->assigned($scheduler);
+
+        Expect::that([$first->id, $second->id])
+            ->because('concurrent resource leases MUST have distinct identities')
+            ->toBe([1, 2]);
+
+        Expect::that(static function () use ($scheduler, $first, $second): void {
+            $scheduler->release($first);
+            $scheduler->release($second);
+        })
+            ->because('each concurrent resource lease MUST release independently')
+            ->not()
+            ->toThrow(\Throwable::class);
+    }
+
+    /**
+     * @param non-empty-string $class
+     */
+    private function unit(string $class): SchedulingUnit
+    {
+        $id = new TestId($class, 'runs');
+
+        return new SchedulingUnit(new ExecutionPlan([
+            new PlanEntry($id, new TestMetadata($class, 'runs', resources: ['database'])),
+        ]), false);
+    }
+
+    private function assigned(ResourceScheduler $scheduler): ResourceLease
+    {
+        $decision = $scheduler->dispatch(true);
+
+        if (!$decision->lease instanceof ResourceLease) {
+            Fail::because(\sprintf('Expected an assignment, got %s.', $decision->kind->name));
+        }
+
+        return $decision->lease;
+    }
+}


### PR DESCRIPTION
Protect concurrent resource lease identity and independent release. Multiple active leases must receive distinct monotonic IDs.