### PR TITLE
test(coverage): cover removed source files

### DIFF
--- a/tests/Unit/Coverage/BaselineRemovedFileTest.php
+++ b/tests/Unit/Coverage/BaselineRemovedFileTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Coverage\Diff\BaselineDiff;
+use Greenlight\Coverage\FileCoverage;
+use Greenlight\Expect\Expect;
+
+final readonly class BaselineRemovedFileTest
+{
+    #[Test]
+    public function removedSourceFilesAreNotCoverageRegressions(): void
+    {
+        $baseline = new CoverageMap([
+            new FileCoverage('/src/Removed.php', [1], []),
+        ]);
+        $report = BaselineDiff::between($baseline, CoverageMap::empty());
+
+        Expect::that($report->hasRegressions())
+            ->because('removing a source file MUST NOT fail the coverage regression gate')
+            ->toBeFalse();
+    }
+}


### PR DESCRIPTION
Pins the coverage-diff classification for deleted source files. A file that no longer exists can have a negative per-file delta, but it must not fail the regression gate unless retained code loses coverage.