### PR TITLE
fix(fixture): recreate temp directory after disposal

### DIFF
--- a/src/Fixture/TempDirectory.php
+++ b/src/Fixture/TempDirectory.php
@@ -95,6 +95,8 @@ final class TempDirectory implements Disposable
         }
 
         if (!\is_dir($path)) {
+            $this->path = null;
+
             return;
         }
 
@@ -122,5 +124,7 @@ final class TempDirectory implements Disposable
                 $warning === null ? '' : ': ' . $warning,
             ));
         }
+
+        $this->path = null;
     }
 }

--- a/tests/Unit/Fixture/TempDirectoryReuseTest.php
+++ b/tests/Unit/Fixture/TempDirectoryReuseTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Fixture;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class TempDirectoryReuseTest
+{
+    #[Test]
+    #[DataSet('disposedRoots')]
+    public function useAfterDisposalCreatesAFreshDirectory(bool $externallyRemoved): void
+    {
+        $directory = new TempDirectory();
+        $first = $directory->path();
+
+        if ($externallyRemoved) {
+            \rmdir($first);
+        }
+
+        $directory->dispose();
+        $second = $directory->path();
+
+        try {
+            Expect::that($second)
+                ->because('use after disposal MUST create a fresh temp directory')
+                ->not()->toBe($first)
+                ->and(\is_dir($second))
+                ->toBeTrue();
+        } finally {
+            $directory->dispose();
+        }
+    }
+
+    /**
+     * @return iterable<string, array{bool}>
+     */
+    public static function disposedRoots(): iterable
+    {
+        yield 'normal disposal' => [false];
+
+        yield 'root already removed' => [true];
+    }
+}


### PR DESCRIPTION
Clears the memoized TempDirectory path after successful disposal. A later path() call now creates a fresh writable directory instead of returning the deleted path, matching the existing unused and symlink-disposal lifecycle behavior.