### PR TITLE
test(fixture): cover environment sandbox reuse

### DIFF
--- a/tests/Unit/Fixture/EnvironmentSandboxReuseTest.php
+++ b/tests/Unit/Fixture/EnvironmentSandboxReuseTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Fixture;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\EnvironmentSandbox;
+
+final readonly class EnvironmentSandboxReuseTest
+{
+    #[Test]
+    public function useAfterDisposalCapturesANewBaseline(): void
+    {
+        $name = 'GREENLIGHT_SANDBOX_REUSE_' . \strtoupper(\bin2hex(\random_bytes(6)));
+        $sandbox = new EnvironmentSandbox();
+
+        try {
+            $sandbox->set($name, 'first session');
+            $sandbox->dispose();
+
+            \putenv($name . '=new baseline');
+            $_ENV[$name] = 'new baseline';
+            $_SERVER[$name] = 'new baseline';
+
+            $sandbox->set($name, 'second session');
+            $sandbox->dispose();
+
+            Expect::that(\getenv($name))
+                ->because('use after disposal MUST capture the new environment baseline')
+                ->toBe('new baseline')
+                ->and($_ENV[$name] ?? null)
+                ->toBe('new baseline')
+                ->and($_SERVER[$name] ?? null)
+                ->toBe('new baseline');
+        } finally {
+            $sandbox->dispose();
+            \putenv($name);
+            unset($_ENV[$name], $_SERVER[$name]);
+        }
+    }
+}


### PR DESCRIPTION
Pins the reusable EnvironmentSandbox lifecycle. After disposal, a second session must capture and restore the current process, ENV, and SERVER baseline instead of retaining the first session backup.