### PR TITLE
test(worker): cover assigned artifact sessions

### DIFF
--- a/tests/Fixture/WorkerProcess/WorkerAttachmentTest.php
+++ b/tests/Fixture/WorkerProcess/WorkerAttachmentTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\WorkerProcess;
+
+use Greenlight\Core\Artifact\Attachments;
+
+final readonly class WorkerAttachmentTest
+{
+    public function __construct(private Attachments $attachments) {}
+
+    public function recordsEvidence(): void
+    {
+        $this->attachments->text('worker.txt', 'worker evidence');
+    }
+}

--- a/tests/Unit/Runner/Worker/WorkerArtifactSessionTest.php
+++ b/tests/Unit/Runner/Worker/WorkerArtifactSessionTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Worker;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Attribute\Timeout;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Fixture\EnvironmentSandbox;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Worker\WorkerProcess;
+use Greenlight\Tests\Support\Subprocess;
+
+final readonly class WorkerArtifactSessionTest
+{
+    public function __construct(
+        private EnvironmentSandbox $environment,
+        private TempDirectory $tempDirectory,
+    ) {}
+
+    #[Test]
+    #[Timeout(5.0)]
+    public function assignmentArtifactSettingsStageWorkerEvidence(): void
+    {
+        $root = \dirname(__DIR__, 4);
+        $artifactRoot = $this->tempDirectory->subdirectory('worker-artifact-session');
+        $server = Subprocess::start($root, [
+            \PHP_BINARY,
+            '-r',
+            <<<'PHP'
+            require $argv[1];
+
+            $artifactRoot = $argv[2];
+            $socketPath = '/tmp/greenlight-worker-' . bin2hex(random_bytes(6)) . '.sock';
+            register_shutdown_function(static fn() => @unlink($socketPath));
+            $address = 'unix://' . $socketPath;
+            $server = stream_socket_server($address);
+
+            if (!is_resource($server)) {
+                exit(2);
+            }
+
+            fwrite(STDOUT, $address . "\n");
+            fflush(STDOUT);
+
+            $connection = stream_socket_accept($server, 2.0);
+
+            if (!is_resource($connection)) {
+                exit(3);
+            }
+
+            $channel = new Greenlight\Runner\Protocol\SocketChannel($connection);
+
+            if (!$channel->receive(2.0) instanceof Greenlight\Runner\Protocol\Messages\Hello) {
+                exit(4);
+            }
+
+            if (class_exists(Greenlight\Runner\Protocol\Messages\Bootstrap::class)) {
+                $channel->send(new Greenlight\Runner\Protocol\Messages\Bootstrap(
+                    1,
+                    null,
+                    Greenlight\Harness\IntegrationResources::empty(),
+                ));
+
+                if (!$channel->receive(2.0) instanceof Greenlight\Runner\Protocol\Messages\Ready) {
+                    exit(5);
+                }
+            }
+
+            $class = Greenlight\Tests\Fixture\WorkerProcess\WorkerAttachmentTest::class;
+            $id = new Greenlight\Core\Test\TestId($class, 'recordsEvidence');
+            $session = new Greenlight\Runner\Artifact\ArtifactSession(
+                $artifactRoot . '/staging',
+                $artifactRoot . '/public',
+            );
+            $channel->send(new Greenlight\Runner\Protocol\Messages\Assign(
+                new Greenlight\Discovery\ExecutionPlan([
+                    new Greenlight\Discovery\PlanEntry(
+                        $id,
+                        new Greenlight\Core\Test\TestMetadata(
+                            $class,
+                            'recordsEvidence',
+                            noExpectations: true,
+                        ),
+                    ),
+                ]),
+                artifactSession: $session,
+                artifactConfiguration: new Greenlight\Config\ArtifactConfiguration(
+                    $artifactRoot . '/published',
+                ),
+            ));
+
+            $finished = null;
+            $done = null;
+
+            do {
+                $message = $channel->receive(2.0);
+
+                if ($message instanceof Greenlight\Runner\Protocol\Messages\EventEnvelope
+                    && $message->event instanceof Greenlight\Core\Event\TestFinished
+                ) {
+                    $finished = $message->event;
+                }
+
+                if ($message instanceof Greenlight\Runner\Protocol\Messages\Done) {
+                    $done = $message;
+                }
+            } while ($message instanceof Greenlight\Runner\Protocol\Message && $done === null);
+
+            $attachment = $finished?->result->attachments[0] ?? null;
+
+            if (!$done instanceof Greenlight\Runner\Protocol\Messages\Done
+                || $done->summary->passed !== 1
+                || !$attachment instanceof Greenlight\Core\Artifact\StagedAttachment
+                || file_get_contents($session->stagingDirectory . '/' . $attachment->storageKey) !== 'worker evidence'
+            ) {
+                exit(6);
+            }
+
+            $channel->send(new Greenlight\Runner\Protocol\Messages\Drain());
+            PHP,
+            $root . '/vendor/autoload.php',
+            $artifactRoot,
+        ]);
+
+        try {
+            $address = \trim($server->readStdoutUntil("\n", 2.0));
+
+            if ($address === '') {
+                Fail::because('Worker protocol server did not publish its address.');
+            }
+
+            $this->environment->set('GREENLIGHT_CHANNEL', '1');
+            $workerExit = new WorkerProcess(0.01)->run($address, 'worker-under-test', 'token');
+            $serverExit = $server->wait(2.0)->exitCode;
+        } finally {
+            $server->terminate();
+        }
+
+        Expect::that($workerExit)
+            ->because('a worker with artifact settings MUST complete its assignment')
+            ->toBe(0)
+            ->and($serverExit)
+            ->because('the worker MUST stage evidence in the assigned artifact session')
+            ->toBe(0);
+    }
+}

--- a/tests/Unit/Runner/Worker/WorkerProcessTest.php
+++ b/tests/Unit/Runner/Worker/WorkerProcessTest.php
@@ -9,11 +9,14 @@ use Greenlight\Attribute\Test;
 use Greenlight\Attribute\Timeout;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
+use Greenlight\Fixture\TempDirectory;
 use Greenlight\Runner\Worker\WorkerProcess;
 use Greenlight\Tests\Support\Subprocess;
 
-final class WorkerProcessTest
+final readonly class WorkerProcessTest
 {
+    public function __construct(private TempDirectory $tempDirectory) {}
+
     #[Test]
     public function connectionFailureNamesTheExactAddress(): void
     {
@@ -189,6 +192,21 @@ final class WorkerProcessTest
 
     #[Test]
     #[Timeout(5.0)]
+    public function assignmentArtifactSettingsStageWorkerEvidence(): void
+    {
+        $artifactRoot = $this->tempDirectory->subdirectory('worker-artifact-session');
+        [$workerExit, $serverExit] = $this->runScenario('artifact-assignment', $artifactRoot);
+
+        Expect::that($workerExit)
+            ->because('a worker with artifact settings MUST complete its assignment')
+            ->toBe(0)
+            ->and($serverExit)
+            ->because('the worker MUST stage evidence in the assigned artifact session')
+            ->toBe(0);
+    }
+
+    #[Test]
+    #[Timeout(5.0)]
     #[DataSet('cleanControlChannelEndings')]
     public function controlChannelEndingsStopTheWorkerCleanly(string $scenario): void
     {
@@ -213,7 +231,7 @@ final class WorkerProcessTest
     /**
      * @return array{int, int}
      */
-    private function runScenario(string $scenario): array
+    private function runScenario(string $scenario, string $artifactRoot = ''): array
     {
         $root = \dirname(__DIR__, 4);
         $server = Subprocess::start($root, [
@@ -223,6 +241,7 @@ final class WorkerProcessTest
             require $argv[1];
 
             $scenario = $argv[2];
+            $artifactRoot = $argv[3];
             $socketPath = '/tmp/greenlight-worker-' . bin2hex(random_bytes(6)) . '.sock';
             register_shutdown_function(static fn() => @unlink($socketPath));
             $address = 'unix://' . $socketPath;
@@ -316,6 +335,61 @@ final class WorkerProcessTest
                 exit(0);
             }
 
+            if ($scenario === 'artifact-assignment') {
+                $class = Greenlight\Tests\Fixture\WorkerProcess\WorkerAttachmentTest::class;
+                $id = new Greenlight\Core\Test\TestId($class, 'recordsEvidence');
+                $session = new Greenlight\Runner\Artifact\ArtifactSession(
+                    $artifactRoot . '/staging',
+                    $artifactRoot . '/public',
+                );
+                $channel->send(new Greenlight\Runner\Protocol\Messages\Assign(
+                    new Greenlight\Discovery\ExecutionPlan([
+                        new Greenlight\Discovery\PlanEntry(
+                            $id,
+                            new Greenlight\Core\Test\TestMetadata(
+                                $class,
+                                'recordsEvidence',
+                                noExpectations: true,
+                            ),
+                        ),
+                    ]),
+                    artifactSession: $session,
+                    artifactConfiguration: new Greenlight\Config\ArtifactConfiguration(
+                        $artifactRoot . '/published',
+                    ),
+                ));
+
+                $finished = null;
+                $done = null;
+
+                do {
+                    $message = $channel->receive(2.0);
+
+                    if ($message instanceof Greenlight\Runner\Protocol\Messages\EventEnvelope
+                        && $message->event instanceof Greenlight\Core\Event\TestFinished
+                    ) {
+                        $finished = $message->event;
+                    }
+
+                    if ($message instanceof Greenlight\Runner\Protocol\Messages\Done) {
+                        $done = $message;
+                    }
+                } while ($message instanceof Greenlight\Runner\Protocol\Message && $done === null);
+
+                $attachment = $finished?->result->attachments[0] ?? null;
+
+                if (!$done instanceof Greenlight\Runner\Protocol\Messages\Done
+                    || $done->summary->passed !== 1
+                    || !$attachment instanceof Greenlight\Core\Artifact\StagedAttachment
+                    || file_get_contents($session->stagingDirectory . '/' . $attachment->storageKey) !== 'worker evidence'
+                ) {
+                    exit(10);
+                }
+
+                $channel->send(new Greenlight\Runner\Protocol\Messages\Drain());
+                exit(0);
+            }
+
             if ($scenario === 'empty-assignment-memory-recycles') {
                 $channel->send(new Greenlight\Runner\Protocol\Messages\Assign(
                     new Greenlight\Discovery\ExecutionPlan([]),
@@ -357,6 +431,7 @@ final class WorkerProcessTest
             PHP,
             $root . '/vendor/autoload.php',
             $scenario,
+            $artifactRoot,
         ]);
 
         try {

--- a/tests/Unit/Runner/Worker/WorkerProcessTest.php
+++ b/tests/Unit/Runner/Worker/WorkerProcessTest.php
@@ -9,14 +9,11 @@ use Greenlight\Attribute\Test;
 use Greenlight\Attribute\Timeout;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
-use Greenlight\Fixture\TempDirectory;
 use Greenlight\Runner\Worker\WorkerProcess;
 use Greenlight\Tests\Support\Subprocess;
 
-final readonly class WorkerProcessTest
+final class WorkerProcessTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
-
     #[Test]
     public function connectionFailureNamesTheExactAddress(): void
     {
@@ -192,21 +189,6 @@ final readonly class WorkerProcessTest
 
     #[Test]
     #[Timeout(5.0)]
-    public function assignmentArtifactSettingsStageWorkerEvidence(): void
-    {
-        $artifactRoot = $this->tempDirectory->subdirectory('worker-artifact-session');
-        [$workerExit, $serverExit] = $this->runScenario('artifact-assignment', $artifactRoot);
-
-        Expect::that($workerExit)
-            ->because('a worker with artifact settings MUST complete its assignment')
-            ->toBe(0)
-            ->and($serverExit)
-            ->because('the worker MUST stage evidence in the assigned artifact session')
-            ->toBe(0);
-    }
-
-    #[Test]
-    #[Timeout(5.0)]
     #[DataSet('cleanControlChannelEndings')]
     public function controlChannelEndingsStopTheWorkerCleanly(string $scenario): void
     {
@@ -231,7 +213,7 @@ final readonly class WorkerProcessTest
     /**
      * @return array{int, int}
      */
-    private function runScenario(string $scenario, string $artifactRoot = ''): array
+    private function runScenario(string $scenario): array
     {
         $root = \dirname(__DIR__, 4);
         $server = Subprocess::start($root, [
@@ -241,7 +223,6 @@ final readonly class WorkerProcessTest
             require $argv[1];
 
             $scenario = $argv[2];
-            $artifactRoot = $argv[3];
             $socketPath = '/tmp/greenlight-worker-' . bin2hex(random_bytes(6)) . '.sock';
             register_shutdown_function(static fn() => @unlink($socketPath));
             $address = 'unix://' . $socketPath;
@@ -335,61 +316,6 @@ final readonly class WorkerProcessTest
                 exit(0);
             }
 
-            if ($scenario === 'artifact-assignment') {
-                $class = Greenlight\Tests\Fixture\WorkerProcess\WorkerAttachmentTest::class;
-                $id = new Greenlight\Core\Test\TestId($class, 'recordsEvidence');
-                $session = new Greenlight\Runner\Artifact\ArtifactSession(
-                    $artifactRoot . '/staging',
-                    $artifactRoot . '/public',
-                );
-                $channel->send(new Greenlight\Runner\Protocol\Messages\Assign(
-                    new Greenlight\Discovery\ExecutionPlan([
-                        new Greenlight\Discovery\PlanEntry(
-                            $id,
-                            new Greenlight\Core\Test\TestMetadata(
-                                $class,
-                                'recordsEvidence',
-                                noExpectations: true,
-                            ),
-                        ),
-                    ]),
-                    artifactSession: $session,
-                    artifactConfiguration: new Greenlight\Config\ArtifactConfiguration(
-                        $artifactRoot . '/published',
-                    ),
-                ));
-
-                $finished = null;
-                $done = null;
-
-                do {
-                    $message = $channel->receive(2.0);
-
-                    if ($message instanceof Greenlight\Runner\Protocol\Messages\EventEnvelope
-                        && $message->event instanceof Greenlight\Core\Event\TestFinished
-                    ) {
-                        $finished = $message->event;
-                    }
-
-                    if ($message instanceof Greenlight\Runner\Protocol\Messages\Done) {
-                        $done = $message;
-                    }
-                } while ($message instanceof Greenlight\Runner\Protocol\Message && $done === null);
-
-                $attachment = $finished?->result->attachments[0] ?? null;
-
-                if (!$done instanceof Greenlight\Runner\Protocol\Messages\Done
-                    || $done->summary->passed !== 1
-                    || !$attachment instanceof Greenlight\Core\Artifact\StagedAttachment
-                    || file_get_contents($session->stagingDirectory . '/' . $attachment->storageKey) !== 'worker evidence'
-                ) {
-                    exit(10);
-                }
-
-                $channel->send(new Greenlight\Runner\Protocol\Messages\Drain());
-                exit(0);
-            }
-
             if ($scenario === 'empty-assignment-memory-recycles') {
                 $channel->send(new Greenlight\Runner\Protocol\Messages\Assign(
                     new Greenlight\Discovery\ExecutionPlan([]),
@@ -431,7 +357,6 @@ final readonly class WorkerProcessTest
             PHP,
             $root . '/vendor/autoload.php',
             $scenario,
-            $artifactRoot,
         ]);
 
         try {


### PR DESCRIPTION
Covers the worker-process boundary that converts assigned artifact settings into a worker-owned staging store. The protocol scenario proves that test evidence is returned as staged attachment metadata and written into the exact assigned session; a PSR-4 fixture keeps the worker test class autoloadable.