### PR TITLE
fix(doubles): canonicalize recorded method names

### DIFF
--- a/docs/api-doubles.md
+++ b/docs/api-doubles.md
@@ -272,7 +272,7 @@ One `ExpectationFailed` contains the details for all unmet expectations.
 public function dispose(): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L150)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L153)
 
 ## `Fake`
 

--- a/src/Doubles/Doubles.php
+++ b/src/Doubles/Doubles.php
@@ -135,10 +135,13 @@ final class Doubles implements Disposable
         }
 
         $state = $this->doubles[$double];
+        $reflection = new \ReflectionClass($state->type);
 
-        if (!\method_exists($state->type, $method)) {
+        if (!$reflection->hasMethod($method)) {
             throw DoublesError::noSuchRecordedMethod($state->type, $method);
         }
+
+        $method = $reflection->getMethod($method)->getName();
 
         return $state->recordedCalls[$method] ?? [];
     }

--- a/tests/Unit/Doubles/SpyMethodCaseTest.php
+++ b/tests/Unit/Doubles/SpyMethodCaseTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Doubles\Notifier;
+
+final class SpyMethodCaseTest
+{
+    #[Test]
+    #[DataSet('methodNames')]
+    public function recordedMethodNamesFollowPhpCaseInsensitivity(string $method): void
+    {
+        $doubles = new Doubles();
+        $notifier = $doubles->spy(Notifier::class);
+        $notifier->notify('ops', 'deployed');
+
+        Expect::that($doubles->callsTo($notifier, $method))
+            ->because('recorded method names MUST follow PHP case-insensitive dispatch')
+            ->toBe([['ops', 'deployed']]);
+
+        $doubles->dispose();
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function methodNames(): iterable
+    {
+        yield 'upper case' => ['NOTIFY'];
+        yield 'mixed case' => ['NoTiFy'];
+    }
+}


### PR DESCRIPTION
PHP method names are case-insensitive, but callsTo() indexed recorded calls with the caller's original casing. Canonicalize validated method names through reflection and add a named case matrix so spies return the same recordings for uppercase and mixed-case lookups.