### PR TITLE
test(artifacts): cover test quota rollback

### DIFF
--- a/tests/Unit/Artifact/ArtifactTestQuotaRollbackTest.php
+++ b/tests/Unit/Artifact/ArtifactTestQuotaRollbackTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\ArtifactStore;
+use Greenlight\Runner\Artifact\TestArtifactBudget;
+
+final readonly class ArtifactTestQuotaRollbackTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function aTestQuotaRejectionReleasesTheRunQuota(): void
+    {
+        $root = $this->tempDirectory->subdirectory('test-quota-rollback');
+        $configuration = new ArtifactConfiguration(
+            $root,
+            maxAttachmentsPerTest: 10,
+            maxAttachmentBytes: 4,
+            maxTestBytes: 4,
+            maxRunAttachments: 10,
+            maxRunBytes: 6,
+        );
+        $store = ArtifactStore::open($configuration, $root, 'run-1');
+
+        try {
+            $first = $store->forAttempt(
+                new TestId('Example\EvidenceTest', 'first'),
+                1,
+                new TestArtifactBudget(),
+            );
+            $first->text('accepted.txt', '1234');
+
+            Expect::that(static fn() => $first->text('rejected.txt', '12'))
+                ->because('the per-test byte limit MUST reject excess evidence')
+                ->toThrow(
+                    AttachmentError::class,
+                    message: 'Attachments for this test exceed the limit of 4 bytes.',
+                );
+
+            $second = $store->forAttempt(
+                new TestId('Example\EvidenceTest', 'second'),
+                1,
+                new TestArtifactBudget(),
+            );
+            $second->text('accepted.txt', '12');
+
+            Expect::that($second->collected())
+                ->because('a test quota rejection MUST release its run quota')
+                ->toHaveCount(1);
+        } finally {
+            $store->cleanup();
+        }
+    }
+}


### PR DESCRIPTION
A staged attachment reserves run-wide quota before the per-test aggregate limit is checked. Cover the rollback contract by rejecting evidence at the per-test boundary, then proving another test can consume the released run quota.