### PR TITLE
test(discovery): pin exact ID case sensitivity

### DIFF
--- a/tests/Unit/Discovery/ExactIdCaseTest.php
+++ b/tests/Unit/Discovery/ExactIdCaseTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\Filter;
+use Greenlight\Expect\Expect;
+
+final class ExactIdCaseTest
+{
+    /**
+     * @param list<non-empty-string> $patterns
+     * @param list<non-empty-string> $exactIds
+     */
+    #[Test]
+    #[DataSet('caseRules')]
+    public function exactAndPatternIdsApplyTheirDistinctCaseRules(
+        array $patterns,
+        array $exactIds,
+        string $renderedId,
+        bool $accepted,
+    ): void {
+        $filter = new Filter(includeIds: $patterns, includeExactIds: $exactIds);
+
+        Expect::that($filter->acceptsId($renderedId))
+            ->because('exact IDs MUST match verbatim, while ID patterns MUST ignore letter case')
+            ->toBe($accepted);
+    }
+
+    /**
+     * @return iterable<string, array{
+     *     list<non-empty-string>,
+     *     list<non-empty-string>,
+     *     non-empty-string,
+     *     bool
+     * }>
+     */
+    public static function caseRules(): iterable
+    {
+        $canonical = 'Acme\\InvoiceTest::calculatesTotal';
+
+        yield 'canonical exact ID' => [[], [$canonical], $canonical, true];
+        yield 'case-only exact ID difference' => [[], [$canonical], 'acme\\InvoiceTest::calculatesTotal', false];
+        yield 'case-only pattern difference' => [['acme\\invoicetest::CALCULATESTOTAL'], [], $canonical, true];
+    }
+}


### PR DESCRIPTION
Pins the distinct ID-selection contracts with a named data set: exact IDs match the canonical rendered ID verbatim, while regular ID patterns remain case-insensitive. This prevents a case-folding change from silently broadening exact test selection.