### PR TITLE
test(protocol): cover worker fatal attribution

### DIFF
--- a/tests/Unit/Runner/Protocol/ProtocolErrorWorkerFatalTest.php
+++ b/tests/Unit/Runner/Protocol/ProtocolErrorWorkerFatalTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Protocol;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\Protocol\ProtocolError;
+
+final class ProtocolErrorWorkerFatalTest
+{
+    #[Test]
+    public function workerFatalAttributesTheWorkerAndSource(): void
+    {
+        $error = ProtocolError::workerFatal(
+            'worker-5',
+            'The worker could not load its configuration',
+            '/project/greenlight.php',
+            17,
+        );
+
+        Expect::that($error->getMessage())
+            ->because(
+                'a fatal worker error MUST identify its worker, message, and source location',
+            )
+            ->toStartWith('Worker "worker-5" reported a fatal Greenlight error:')
+            ->toContain('The worker could not load its configuration')
+            ->toContain('(/project/greenlight.php:17)');
+    }
+}


### PR DESCRIPTION
Covers the worker-fatal diagnostic components that the orchestrator integration test leaves unasserted. The focused assertion now protects worker attribution, the original fatal message, and its source file and line without locking unrelated punctuation.