### PR TITLE
test(coverage): ignore attribute arguments

### DIFF
--- a/tests/Unit/Coverage/IgnoreScannerAttributeArgumentTest.php
+++ b/tests/Unit/Coverage/IgnoreScannerAttributeArgumentTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\Ignore\IgnoreScanner;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class IgnoreScannerAttributeArgumentTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function coverageIgnoreNamesInsideAttributeArgumentsDoNotIgnoreCode(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            final class Example
+            {
+                #[Metadata('value', CoverageIgnore::class)]
+                public function covered(): int
+                {
+                    return 1;
+                }
+            }
+            PHP;
+        $file = $this->tempDirectory->path() . '/Example.php';
+        \file_put_contents($file, $source);
+
+        Expect::that(new IgnoreScanner()->ignoredLines($file))
+            ->because('attribute arguments MUST NOT be interpreted as coverage attributes')
+            ->toBe([]);
+    }
+}


### PR DESCRIPTION
The coverage-ignore scanner must inspect attribute names without treating tokens inside their argument lists as more attributes. Cover a CoverageIgnore::class argument and prove the surrounding method remains executable coverage.