### PR TITLE
test(worker): preserve positional data arguments

### DIFF
--- a/tests/Fixture/Runner/Worker/AssociativeDataSetProbe.php
+++ b/tests/Fixture/Runner/Worker/AssociativeDataSetProbe.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Runner\Worker;
+
+final class AssociativeDataSetProbe
+{
+    public function accepts(string $currency, int $minorUnits): void {}
+
+    /**
+     * @return iterable<string, array{currency: string, minorUnits: int}>
+     */
+    public static function associativeRows(): iterable
+    {
+        yield 'sterling' => [
+            'currency' => 'GBP',
+            'minorUnits' => 100,
+        ];
+    }
+}

--- a/tests/Unit/Runner/Worker/ClassContextPositionalArgumentsTest.php
+++ b/tests/Unit/Runner/Worker/ClassContextPositionalArgumentsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Worker;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\Worker\ClassContext;
+use Greenlight\Tests\Fixture\Runner\Worker\AssociativeDataSetProbe;
+
+final readonly class ClassContextPositionalArgumentsTest
+{
+    #[Test]
+    public function associativeProviderRowsBecomePositionalArguments(): void
+    {
+        $arguments = ClassContext::for(AssociativeDataSetProbe::class)->argumentsFor(
+            'associativeRows',
+            null,
+            'accepts',
+            'sterling',
+        );
+
+        Expect::that($arguments)
+            ->because('provider row keys MUST NOT become named test arguments')
+            ->toBe(['GBP', 100]);
+    }
+}


### PR DESCRIPTION
Pin the worker contract that data-provider row keys label data, not PHP named arguments. An associative row is normalized into a positional list in provider iteration order before the test method runs.