### PR TITLE
test(harness): cover failed lazy factory disposal

### DIFF
--- a/tests/Fixture/Harness/LazyDisposableFactoryProbe.php
+++ b/tests/Fixture/Harness/LazyDisposableFactoryProbe.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Harness;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Harness\Disposable;
+
+final class LazyDisposableFactoryProbe implements Disposable, Fake
+{
+    private static int $disposals = 0;
+
+    public function __construct(private string $value) {}
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    #[\Override]
+    public function dispose(): void
+    {
+        if ($this->value !== '') {
+            ++self::$disposals;
+        }
+    }
+
+    public static function reset(): void
+    {
+        self::$disposals = 0;
+    }
+
+    public static function disposals(): int
+    {
+        return self::$disposals;
+    }
+}

--- a/tests/Unit/Harness/ScopeContainerFailedLazyFactoryDisposalTest.php
+++ b/tests/Unit/Harness/ScopeContainerFailedLazyFactoryDisposalTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Harness;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Harness\Scope;
+use Greenlight\Harness\ScopeContainer;
+use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Tests\Fixture\Harness\LazyDisposableFactoryProbe;
+
+final class ScopeContainerFailedLazyFactoryDisposalTest
+{
+    #[Test]
+    public function disposalDoesNotRetryAFailedLazyFactory(): void
+    {
+        LazyDisposableFactoryProbe::reset();
+        $factoryCalls = 0;
+        $container = new ScopeContainer();
+        $service = $container->get(new ServiceDefinition(
+            LazyDisposableFactoryProbe::class,
+            Scope::PerTest,
+            static function () use (&$factoryCalls): LazyDisposableFactoryProbe {
+                ++$factoryCalls;
+
+                throw new \RuntimeException('factory broke');
+            },
+        ));
+
+        if (!$service instanceof LazyDisposableFactoryProbe) {
+            Fail::because(\sprintf(
+                'Expected ScopeContainer::get() to return LazyDisposableFactoryProbe, got %s.',
+                \get_debug_type($service),
+            ));
+        }
+
+        Expect::that(static fn(): string => $service->value())
+            ->because('the lazy factory failure MUST propagate from service use')
+            ->toThrow(\RuntimeException::class, message: 'factory broke');
+
+        $failures = $container->dispose();
+
+        Expect::that($factoryCalls)
+            ->because('scope disposal MUST NOT retry a failed lazy factory')
+            ->toBe(1)
+            ->and($failures)
+            ->because('an uninitialized service has nothing to dispose')
+            ->toBe([])
+            ->and(LazyDisposableFactoryProbe::disposals())
+            ->toBe(0);
+    }
+}


### PR DESCRIPTION
Pin the scope cleanup contract after lazy service initialization fails. Disposal MUST skip the uninitialized proxy, MUST NOT retry the broken factory, and MUST report no synthetic cleanup failure.