### PR TITLE
test(reporting): retain zero captured output

### DIFF
--- a/tests/Unit/Reporting/ProblemDetailsZeroOutputTest.php
+++ b/tests/Unit/Reporting/ProblemDetailsZeroOutputTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\CapturedOutput;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\ProblemDetails;
+
+final class ProblemDetailsZeroOutputTest
+{
+    #[Test]
+    public function zeroCapturedOutputIsNotTreatedAsEmpty(): void
+    {
+        $result = new TestResult(
+            new TestId('Acme\\OutputTest', 'printsZero'),
+            Outcome::Failed,
+            0.1,
+            0,
+            output: new CapturedOutput('0'),
+        );
+
+        Expect::that(ProblemDetails::render($result))
+            ->because('captured output MUST preserve the string "0"')
+            ->toBe("  captured output:\n    0\n");
+    }
+}


### PR DESCRIPTION
Pins the distinction between empty captured output and the meaningful string `0`. This prevents PHP truthiness from silently dropping valid test output.