### PR TITLE
test(protocol): retain zero frame warning

### DIFF
--- a/tests/Unit/Runner/Protocol/ProtocolErrorZeroWarningTest.php
+++ b/tests/Unit/Runner/Protocol/ProtocolErrorZeroWarningTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Protocol;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\Protocol\ProtocolError;
+
+final readonly class ProtocolErrorZeroWarningTest
+{
+    #[Test]
+    public function malformedFramePreservesAZeroWarning(): void
+    {
+        Expect::that(ProtocolError::malformedFrame('read failed', '0')->getMessage())
+            ->because('the warning string "0" MUST remain distinct from no warning')
+            ->toBe('Malformed frame: read failed: 0.');
+    }
+}


### PR DESCRIPTION
Pins the distinction between an absent malformed-frame warning and the meaningful string 0. This prevents PHP truthiness from silently dropping warning text.