### PR TITLE
fix(capture): preserve replacement output buffers

### DIFF
--- a/src/Capture/OutputCapture.php
+++ b/src/Capture/OutputCapture.php
@@ -34,6 +34,7 @@ final class OutputCapture
 
     /** Contains the ob_get_level() of the capture buffer, or null if inactive. */
     private ?int $bufferLevel = null;
+    private bool $bufferClosed = false;
 
     /** @var (\Closure(int, string, string, int): bool)|null */
     private ?\Closure $errorHandler = null;
@@ -67,6 +68,7 @@ final class OutputCapture
         $this->stdoutTruncated = false;
         $this->diagnostics = [];
         $this->diagnosticsTruncated = false;
+        $this->bufferClosed = false;
 
         $handler = function (int $severity, string $message, string $file = '', int $line = 0): bool {
             $mapped = DiagnosticSeverity::fromErrorLevel($severity);
@@ -83,8 +85,17 @@ final class OutputCapture
         $this->errorHandler = $handler;
         \set_error_handler($handler);
 
-        \ob_start($this->appendChunk(...), 1);
+        \ob_start($this->handleChunk(...), 1);
         $this->bufferLevel = \ob_get_level();
+    }
+
+    private function handleChunk(string $chunk, int $phase): string
+    {
+        if (($phase & \PHP_OUTPUT_HANDLER_FINAL) !== 0) {
+            $this->bufferClosed = true;
+        }
+
+        return $this->appendChunk($chunk);
     }
 
     /**
@@ -107,7 +118,7 @@ final class OutputCapture
             \ob_end_flush();
         }
 
-        if (\ob_get_level() === $level) {
+        if (!$this->bufferClosed && \ob_get_level() === $level) {
             \ob_end_clean();
         }
 
@@ -138,7 +149,7 @@ final class OutputCapture
      * stop propagation. This callback MUST NOT throw because an output-handler
      * exception is fatal.
      */
-    private function appendChunk(string $chunk, int $phase): string
+    private function appendChunk(string $chunk): string
     {
         $remaining = $this->maxStdoutBytes - \strlen($this->stdout);
 

--- a/tests/Unit/Capture/OutputCaptureBufferReplacementTest.php
+++ b/tests/Unit/Capture/OutputCaptureBufferReplacementTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Capture;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Capture\OutputCapture;
+use Greenlight\Expect\Expect;
+
+final readonly class OutputCaptureBufferReplacementTest
+{
+    #[Test]
+    public function stopPreservesAReplacementBufferAtTheCapturedLevel(): void
+    {
+        $baseline = \ob_get_level();
+        $capture = new OutputCapture();
+        $capture->start();
+
+        echo 'captured';
+        \ob_end_flush();
+        \ob_start();
+        echo 'replacement';
+
+        $captured = $capture->stop();
+        $levelAfterStop = \ob_get_level();
+        $replacement = $levelAfterStop > $baseline ? \ob_get_clean() : null;
+
+        Expect::that($captured->stdout)
+            ->because('closing the capture buffer MUST preserve the output collected before replacement')
+            ->toBe('captured')
+            ->and($levelAfterStop)
+            ->because('stop MUST leave a replacement buffer at the captured stack level open')
+            ->toBe($baseline + 1)
+            ->and($replacement)
+            ->because('stop MUST preserve content in the replacement buffer')
+            ->toBe('replacement')
+            ->and(\ob_get_level())
+            ->because('the test MUST restore the output-buffer baseline')
+            ->toBe($baseline);
+    }
+}

--- a/tests/Unit/Capture/OutputCaptureClosedBufferReuseTest.php
+++ b/tests/Unit/Capture/OutputCaptureClosedBufferReuseTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Capture;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Capture\OutputCapture;
+use Greenlight\Core\Result\CapturedOutput;
+use Greenlight\Expect\Expect;
+
+final readonly class OutputCaptureClosedBufferReuseTest
+{
+    #[Test]
+    public function captureCanBeReusedAfterItsBufferWasClosed(): void
+    {
+        [$first, $second, $levelAfterSecondStop, $baseline] = $this->captureTwice();
+
+        Expect::that($first->stdout)
+            ->because('closing the first capture buffer MUST preserve its output')
+            ->toBe('first')
+            ->and($second->stdout)
+            ->because('a reused capture MUST collect output in its second window')
+            ->toBe('second')
+            ->and($levelAfterSecondStop)
+            ->because('the second stop MUST restore the original output-buffer level')
+            ->toBe($baseline);
+    }
+
+    /**
+     * @return array{CapturedOutput, CapturedOutput, int, int}
+     */
+    private function captureTwice(): array
+    {
+        $baseline = \ob_get_level();
+        $capture = new OutputCapture();
+
+        try {
+            $capture->start();
+            echo 'first';
+            \ob_end_flush();
+            $first = $capture->stop();
+
+            $capture->start();
+            echo 'second';
+            $second = $capture->stop();
+
+            return [$first, $second, \ob_get_level(), $baseline];
+        } finally {
+            while (\ob_get_level() > $baseline) {
+                \ob_end_clean();
+            }
+        }
+    }
+}


### PR DESCRIPTION
OutputCapture currently treats any buffer at its recorded stack level as the capture buffer. If test code closes that buffer and opens a replacement at the same level, stop() closes the replacement and discards its content.

Track the capture buffer final phase so stop() can leave a user-owned replacement open. Add a regression test through the public capture API.