### PR TITLE
test(core): retain zero test data key

### DIFF
--- a/tests/Unit/Core/TestIdZeroDataSetKeyTest.php
+++ b/tests/Unit/Core/TestIdZeroDataSetKeyTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+
+final readonly class TestIdZeroDataSetKeyTest
+{
+    #[Test]
+    public function zeroDataSetKeyRemainsInTheRenderedId(): void
+    {
+        $id = new TestId('Acme\\DataSetTest', 'checksValue', '0');
+
+        Expect::that((string) $id)
+            ->because('a rendered test ID MUST preserve the data-set key "0"')
+            ->toBe('Acme\\DataSetTest::checksValue[0]');
+    }
+}


### PR DESCRIPTION
Covers the string 0 as a meaningful data-set key in the canonical rendered test ID. The bracketed key must remain present so reporters and selectors do not collapse the case into its parent test.