### PR TITLE
test(doubles): identify framework counters as fakes

### DIFF
--- a/tests/Fixture/Laravel/VisitCounter.php
+++ b/tests/Fixture/Laravel/VisitCounter.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Fixture\Laravel;
 
+use Greenlight\Doubles\Fake;
+
 /**
  * Stateful singleton with no reset contract. The fresh application for each
  * test is the only isolation mechanism.
  */
-final class VisitCounter
+final class VisitCounter implements Fake
 {
     private int $visits = 0;
 

--- a/tests/Fixture/Symfony/VisitCounter.php
+++ b/tests/Fixture/Symfony/VisitCounter.php
@@ -4,12 +4,13 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Fixture\Symfony;
 
+use Greenlight\Doubles\Fake;
 use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * ResetInterface lets services_resetter clear state between tests.
  */
-final class VisitCounter implements ResetInterface
+final class VisitCounter implements Fake, ResetInterface
 {
     private int $visits = 0;
 

--- a/tests/Unit/Doubles/FakeFixtureTest.php
+++ b/tests/Unit/Doubles/FakeFixtureTest.php
@@ -15,6 +15,7 @@ use Greenlight\Tests\Fixture\DiscoveryAttributes\AlwaysTrue;
 use Greenlight\Tests\Fixture\Expect\EvenNumbersExtension as ExpectEvenNumbersExtension;
 use Greenlight\Tests\Fixture\Expect\PositiveNumbersExtension;
 use Greenlight\Tests\Fixture\Laravel\ThrowingKernel;
+use Greenlight\Tests\Fixture\Laravel\VisitCounter as LaravelVisitCounter;
 use Greenlight\Tests\Fixture\Lifecycle\DisposeFails\FailingDisposalProbe;
 use Greenlight\Tests\Fixture\Lifecycle\Skips\AlwaysCondition;
 use Greenlight\Tests\Fixture\Lifecycle\Skips\NeverCondition;
@@ -25,6 +26,7 @@ use Greenlight\Tests\Fixture\Plugins\EvenNumbersExtension as PluginEvenNumbersEx
 use Greenlight\Tests\Fixture\Plugins\ProbeProvider;
 use Greenlight\Tests\Fixture\Plugins\QuarantinePlugin;
 use Greenlight\Tests\Fixture\Symfony\BareKernel;
+use Greenlight\Tests\Fixture\Symfony\VisitCounter as SymfonyVisitCounter;
 use Greenlight\Tests\Unit\Reporting\RecordingReporter;
 use Greenlight\Tests\Unit\Reporting\RecordingTickingReporter;
 use Illuminate\Foundation\Application as LaravelApplication;
@@ -72,8 +74,10 @@ final class FakeFixtureTest
         yield ProbeProvider::class => [ProbeProvider::class];
         yield QuarantinePlugin::class => [QuarantinePlugin::class];
         yield BareKernel::class => [BareKernel::class];
+        yield LaravelVisitCounter::class => [LaravelVisitCounter::class];
         yield RecordingReporter::class => [RecordingReporter::class];
         yield RecordingTickingReporter::class => [RecordingTickingReporter::class];
+        yield SymfonyVisitCounter::class => [SymfonyVisitCounter::class];
     }
 
     /**


### PR DESCRIPTION
The Laravel and Symfony visit counters are manual in-memory framework test doubles. Mark both with the Fake contract and add them to the fixture contract dataset so Greenlight tooling can distinguish them from production code under test.