### PR TITLE
test(expect): cover exact string render limit

### DIFF
--- a/tests/Unit/Expect/ValueRendererStringBoundaryTest.php
+++ b/tests/Unit/Expect/ValueRendererStringBoundaryTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\ValueRenderer;
+
+final readonly class ValueRendererStringBoundaryTest
+{
+    #[Test]
+    public function aStringAtTheCharacterLimitRemainsComplete(): void
+    {
+        $value = \str_repeat('x', 120);
+
+        Expect::that(new ValueRenderer()->render($value))
+            ->because('a diagnostic string at the limit MUST remain complete')
+            ->toBe("'" . $value . "'");
+    }
+}


### PR DESCRIPTION
Covers the exact 120-character diagnostic string boundary. Pins that a value at the limit remains complete and quoted instead of receiving a truncation marker.