### PR TITLE
test(coverage): guard HTML path escaping

### DIFF
--- a/tests/Unit/Coverage/HtmlExporterPathEscapingTest.php
+++ b/tests/Unit/Coverage/HtmlExporterPathEscapingTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Coverage\Export\HtmlExporter;
+use Greenlight\Coverage\FileCoverage;
+use Greenlight\Expect\Expect;
+
+final readonly class HtmlExporterPathEscapingTest
+{
+    #[Test]
+    public function filePathsCannotInjectMarkupIntoTheReport(): void
+    {
+        $path = '/src/"><script>coverage</script>.php';
+        $pages = new HtmlExporter()->export(new CoverageMap([
+            new FileCoverage($path, [1], []),
+        ]));
+        $escaped = '/src/&quot;&gt;&lt;script&gt;coverage&lt;/script&gt;.php';
+        $index = $pages[HtmlExporter::INDEX_FILE_NAME];
+        $file = $pages[HtmlExporter::pageName($path)];
+
+        Expect::that($index)
+            ->because('coverage file paths MUST remain text in the HTML index')
+            ->toContain('>' . $escaped . '</a>')
+            ->not()
+            ->toContain('<script>coverage</script>')
+            ->and($file)
+            ->because('coverage file paths MUST remain text in the HTML file page')
+            ->toContain('<title>' . $escaped . '</title>')
+            ->toContain('<h1>' . $escaped . '</h1>')
+            ->not()
+            ->toContain('<script>coverage</script>');
+    }
+}


### PR DESCRIPTION
Coverage paths are supplied by coverage drivers and rendered into generated HTML reports. Add a focused regression test that uses markup-bearing path text and pins escaping in the index, document title, and file heading so a path cannot inject report markup.