### PR TITLE
test(expect): cover object property render limit

### DIFF
--- a/tests/Fixture/Expect/WideObject.php
+++ b/tests/Fixture/Expect/WideObject.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Expect;
+
+use Greenlight\Doubles\Fake;
+
+final class WideObject implements Fake
+{
+    public int $one = 1;
+
+    public int $two = 2;
+
+    public int $three = 3;
+
+    public int $four = 4;
+
+    public int $five = 5;
+
+    public int $six = 6;
+
+    public int $seven = 7;
+
+    public int $eight = 8;
+
+    public int $nine = 9;
+
+    public int $ten = 10;
+
+    public int $eleven = 11;
+}

--- a/tests/Unit/Expect/ValueRendererObjectLimitTest.php
+++ b/tests/Unit/Expect/ValueRendererObjectLimitTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\ValueRenderer;
+use Greenlight\Tests\Fixture\Expect\WideObject;
+
+final readonly class ValueRendererObjectLimitTest
+{
+    #[Test]
+    public function objectRenderingStopsAfterTenProperties(): void
+    {
+        Expect::that(new ValueRenderer()->render(new WideObject()))
+            ->because('object diagnostics MUST stay within the property limit')
+            ->toBe(
+                WideObject::class
+                . ' {one: 1, two: 2, three: 3, four: 4, five: 5, six: 6, '
+                . 'seven: 7, eight: 8, nine: 9, ten: 10, ...}',
+            );
+    }
+}


### PR DESCRIPTION
Covers the ten-property limit for rendered object diagnostics. Adds a PSR-4 fixture marked as a Fake and pins omission of the eleventh property behind the truncation marker.