### PR TITLE
test(expect): exclude static object state

### DIFF
--- a/tests/Fixture/Expect/StaticPropertyObject.php
+++ b/tests/Fixture/Expect/StaticPropertyObject.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Expect;
+
+use Greenlight\Doubles\Fake;
+
+final class StaticPropertyObject implements Fake
+{
+    public static int $shared = 1;
+
+    public int $local = 2;
+}

--- a/tests/Unit/Expect/ValueRendererStaticPropertyTest.php
+++ b/tests/Unit/Expect/ValueRendererStaticPropertyTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\ValueRenderer;
+use Greenlight\Tests\Fixture\Expect\StaticPropertyObject;
+
+final readonly class ValueRendererStaticPropertyTest
+{
+    #[Test]
+    public function objectRenderingExcludesStaticProperties(): void
+    {
+        Expect::that(new ValueRenderer()->render(new StaticPropertyObject()))
+            ->because('object diagnostics MUST contain only instance state')
+            ->toBe(StaticPropertyObject::class . ' {local: 2}');
+    }
+}


### PR DESCRIPTION
Covers the static-property exclusion in rendered object diagnostics. Adds a PSR-4 fixture marked as a Fake and pins that only instance state appears.