### PR TITLE
fix(coverage): reject list-shaped file maps

### DIFF
--- a/src/Coverage/Export/JsonExporter.php
+++ b/src/Coverage/Export/JsonExporter.php
@@ -52,32 +52,33 @@ final readonly class JsonExporter implements CoverageExporter
     public static function import(string $json): CoverageMap
     {
         try {
-            $document = \json_decode($json, true, 512, \JSON_THROW_ON_ERROR);
+            $document = \json_decode($json, flags: \JSON_THROW_ON_ERROR);
         } catch (\JsonException $e) {
             throw CoverageError::invalidJson($e->getMessage());
         }
 
-        if (!\is_array($document)) {
+        if (!$document instanceof \stdClass) {
             throw CoverageError::invalidJson('use an object at the top level.');
         }
 
-        if (($document['v'] ?? null) !== self::VERSION) {
+        if (($document->v ?? null) !== self::VERSION) {
             throw CoverageError::invalidJson(\sprintf('unsupported or missing schema version, expected %d.', self::VERSION));
         }
 
-        $rawFiles = $document['files'] ?? null;
+        $rawFiles = $document->files ?? null;
 
-        if (!\is_array($rawFiles)) {
+        if (!$rawFiles instanceof \stdClass) {
             throw CoverageError::invalidJson('use an object for "files".');
         }
 
         $files = [];
 
-        foreach ($rawFiles as $path => $entry) {
-            if (!\is_string($path) || $path === '' || !\is_array($entry)) {
+        foreach (\get_object_vars($rawFiles) as $path => $entry) {
+            if (!\is_string($path) || $path === '' || !$entry instanceof \stdClass) {
                 throw CoverageError::invalidJson('map each file path in "files" to an object.');
             }
 
+            $entry = \get_object_vars($entry);
             $files[] = new FileCoverage(
                 $path,
                 self::lineList($entry, 'covered', $path),

--- a/tests/Unit/Coverage/JsonExporterObjectShapeTest.php
+++ b/tests/Unit/Coverage/JsonExporterObjectShapeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\CoverageError;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Coverage\Export\JsonExporter;
+use Greenlight\Expect\Expect;
+
+final readonly class JsonExporterObjectShapeTest
+{
+    #[Test]
+    #[DataSet('invalidObjectShapes')]
+    public function importRejectsInvalidObjectShapes(string $json, string $message): void
+    {
+        Expect::that(
+            static fn(): CoverageMap => JsonExporter::import($json),
+        )
+            ->because('the coverage JSON schema requires object-shaped file maps and entries')
+            ->toThrow(
+                CoverageError::class,
+                message: $message,
+            );
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string, non-empty-string}>
+     */
+    public static function invalidObjectShapes(): iterable
+    {
+        yield 'file map is a list' => [
+            '{"v":1,"files":[]}',
+            'Coverage JSON document is invalid: use an object for "files".',
+        ];
+        yield 'file path becomes an integer key' => [
+            '{"v":1,"files":{"0":{"covered":[],"uncovered":[]}}}',
+            'Coverage JSON document is invalid: map each file path in "files" to an object.',
+        ];
+        yield 'file entry is a list' => [
+            '{"v":1,"files":{"/a.php":[]}}',
+            'Coverage JSON document is invalid: map each file path in "files" to an object.',
+        ];
+    }
+}


### PR DESCRIPTION
The published coverage JSON schema requires the files member to remain an object, including for an empty report. Preserve JSON object and list shapes during import so a list cannot masquerade as an empty file map, and add a focused regression test for the existing object-shape diagnostic.