### PR TITLE
test(core): normalize negative retry counts

### DIFF
--- a/tests/Unit/Core/TestMetadataWireTest.php
+++ b/tests/Unit/Core/TestMetadataWireTest.php
@@ -77,5 +77,6 @@ final class TestMetadataWireTest
         yield 'data-set provider' => ['dataSetProvider', '', null];
         yield 'data-set provider class' => ['dataSetProviderClass', '', null];
         yield 'retry count' => ['retryTimes', 0, 1];
+        yield 'negative retry count' => ['retryTimes', -1, 1];
     }
 }


### PR DESCRIPTION
Covers legacy wire metadata with a negative retry count. This preserves normalization of every nonpositive retry count to the current minimum of one, rather than handling zero alone.