### PR TITLE
test(core): cover negative result attempts

### DIFF
--- a/tests/Unit/Core/TestResultWireTest.php
+++ b/tests/Unit/Core/TestResultWireTest.php
@@ -58,6 +58,7 @@ final class TestResultWireTest
     {
         yield 'duration' => ['durationSeconds', -0.25, 0.0];
         yield 'attempts' => ['attempts', 0, 1];
+        yield 'negative attempts' => ['attempts', -1, 1];
         yield 'expectations' => ['expectations', -1, 0];
     }
 


### PR DESCRIPTION
Pins the wire-decoding contract for legacy or malformed negative attempt counts. The existing boundary row covered zero only, so a zero-specific fallback could replace the lower-bound clamp without detection.