### PR TITLE
fix(coverage): match ignore attributes case-insensitively

### DIFF
--- a/src/Coverage/Ignore/IgnoreScanner.php
+++ b/src/Coverage/Ignore/IgnoreScanner.php
@@ -246,7 +246,7 @@ final readonly class IgnoreScanner
                 $slash = \strrpos($token->text, '\\');
                 $name = $slash === false ? $token->text : \substr($token->text, $slash + 1);
 
-                if ($name === self::ATTRIBUTE) {
+                if (\strcasecmp($name, self::ATTRIBUTE) === 0) {
                     $matched = true;
                 }
 

--- a/tests/Unit/Coverage/IgnoreScannerTest.php
+++ b/tests/Unit/Coverage/IgnoreScannerTest.php
@@ -97,6 +97,26 @@ final class IgnoreScannerTest
     }
 
     #[Test]
+    public function attributeNamesFollowPhpCaseInsensitivity(): void
+    {
+        $source = <<<'PHP'
+            <?php
+            final class A
+            {
+                #[\gReEnLiGhT\aTtRiBuTe\cOvErAgEiGnOrE]
+                public function dropped(): int
+                {
+                    return 1;
+                }
+            }
+            PHP;
+
+        Expect::that($this->scan($source))
+            ->because('CoverageIgnore attribute names MUST follow PHP case-insensitive class-name rules')
+            ->toBe([5, 6, 7, 8]);
+    }
+
+    #[Test]
     public function unrelatedAttributesDoNotIgnore(): void
     {
         $source = <<<'PHP'


### PR DESCRIPTION
PHP resolves attribute class names case-insensitively, but the source-only coverage scanner required the exact `CoverageIgnore` casing. Valid mixed-case and lowercase references therefore failed to exclude their declarations.

Match the attribute basename with PHP class-name semantics and pin qualified mixed-case coverage with a focused regression.