### PR TITLE
test(config): cover nonpositive artifact wire limits

### DIFF
--- a/tests/Unit/Config/ArtifactConfigurationWireTest.php
+++ b/tests/Unit/Config/ArtifactConfigurationWireTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Config;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Expect\Expect;
@@ -30,5 +31,36 @@ final class ArtifactConfigurationWireTest
         Expect::that($restored)
             ->because('workers MUST receive every configured artifact safety limit')
             ->toEqual($configuration);
+    }
+
+    #[Test]
+    #[DataSet('nonpositiveLimits')]
+    public function nonpositiveArtifactLimitsNormalizeToOne(string $field, int $value): void
+    {
+        $payload = new ArtifactConfiguration()->toWire();
+        $payload[$field] = $value;
+
+        $restored = ArtifactConfiguration::fromWire(JsonWire::roundTrip($payload));
+
+        Expect::that($restored->toWire()[$field])
+            ->because('artifact safety limits MUST remain positive across the worker wire')
+            ->toBe(1);
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string, int}>
+     */
+    public static function nonpositiveLimits(): iterable
+    {
+        foreach ([
+            'max attachments per test' => 'maxAttachmentsPerTest',
+            'max attachment bytes' => 'maxAttachmentBytes',
+            'max test bytes' => 'maxTestBytes',
+            'max run attachments' => 'maxRunAttachments',
+            'max run bytes' => 'maxRunBytes',
+        ] as $label => $field) {
+            yield $label . ': zero' => [$field, 0];
+            yield $label . ': negative' => [$field, -1];
+        }
     }
 }


### PR DESCRIPTION
Artifact configuration normalizes every wire-level safety limit to at least one, but coverage only exercised positive round trips.

Add named data rows for zero and negative values across all five limits. This pins each independent normalization boundary used by worker configuration.