### PR TITLE
fix(doubles): match reserved methods case-insensitively

### DIFF
--- a/src/Doubles/ProxyGenerator.php
+++ b/src/Doubles/ProxyGenerator.php
@@ -180,7 +180,9 @@ final readonly class ProxyGenerator
 
     private function renderMethod(\ReflectionMethod $method): ?string
     {
-        if (\in_array($method->name, ['__construct', '__destruct', '__clone'], true)) {
+        $name = \strtolower($method->name);
+
+        if (\in_array($name, ['__construct', '__destruct', '__clone'], true)) {
             return null;
         }
 
@@ -188,7 +190,7 @@ final readonly class ProxyGenerator
             return null;
         }
 
-        if ($method->name === '__greenlightAttachHandler') {
+        if ($name === '__greenlightattachhandler') {
             throw DoublesError::attachHandlerCollision($method->getDeclaringClass()->name);
         }
 

--- a/tests/Fixture/Doubles/MixedCaseDestructor.php
+++ b/tests/Fixture/Doubles/MixedCaseDestructor.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+class MixedCaseDestructor
+{
+    public function __DESTRUCT() {}
+}

--- a/tests/Fixture/Doubles/MixedCaseHandlerCollision.php
+++ b/tests/Fixture/Doubles/MixedCaseHandlerCollision.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+interface MixedCaseHandlerCollision
+{
+    public function __GreenlightAttachHandler(): void;
+}

--- a/tests/Fixture/Doubles/MixedCaseMagicMethods.php
+++ b/tests/Fixture/Doubles/MixedCaseMagicMethods.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+class MixedCaseMagicMethods
+{
+    public function __Construct() {}
+
+    public function __CLONE() {}
+}

--- a/tests/Unit/Doubles/BoundaryTest.php
+++ b/tests/Unit/Doubles/BoundaryTest.php
@@ -13,6 +13,9 @@ use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\Doubles\Calculator;
 use Greenlight\Tests\Fixture\Doubles\FinalService;
 use Greenlight\Tests\Fixture\Doubles\HandlerCollision;
+use Greenlight\Tests\Fixture\Doubles\MixedCaseDestructor;
+use Greenlight\Tests\Fixture\Doubles\MixedCaseHandlerCollision;
+use Greenlight\Tests\Fixture\Doubles\MixedCaseMagicMethods;
 use Greenlight\Tests\Fixture\Doubles\PlanningBoundaries;
 use Greenlight\Tests\Fixture\Doubles\ReadonlyService;
 use Greenlight\Tests\Fixture\Doubles\ReusableBehavior;
@@ -66,18 +69,54 @@ final class BoundaryTest
             );
     }
 
+    /**
+     * @param class-string $type
+     */
     #[Test]
-    public function theProxyHandlerMethodCannotBeDeclaredByTheDoubledType(): void
+    #[DataSet('handlerCollisions')]
+    public function theProxyHandlerMethodCannotBeDeclaredByTheDoubledType(string $type): void
     {
         $doubles = new Doubles();
 
-        Expect::that(static fn(): object => $doubles->mock(HandlerCollision::class))
+        Expect::that(static fn(): object => $doubles->mock($type))
             ->because('the proxy handler method cannot be declared by the doubled type')
             ->toThrow(
                 DoublesError::class,
-                message: HandlerCollision::class . ' declares __greenlightAttachHandler(). '
+                message: $type . ' declares __greenlightAttachHandler(). '
                     . 'This method conflicts with the proxy handler method.',
             );
+    }
+
+    /**
+     * @return iterable<string, array{class-string}>
+     */
+    public static function handlerCollisions(): iterable
+    {
+        yield 'exact case' => [HandlerCollision::class];
+        yield 'mixed case' => [MixedCaseHandlerCollision::class];
+    }
+
+    #[Test]
+    public function mixedCaseConstructorAndCloneMethodsAreNotIntercepted(): void
+    {
+        $double = new Doubles()->stub(MixedCaseMagicMethods::class);
+        $reflection = new \ReflectionClass($double);
+        $constructor = $reflection->getMethod('__construct');
+        $clone = $reflection->getMethod('__clone');
+
+        Expect::that($constructor->getDeclaringClass()->name)
+            ->because('PHP magic method names MUST remain case-insensitive in generated proxies')
+            ->toBe(MixedCaseMagicMethods::class)
+            ->and($clone->getDeclaringClass()->name)
+            ->toBe(MixedCaseMagicMethods::class);
+    }
+
+    #[Test]
+    public function aMixedCaseDestructorDoesNotCreateADuplicateProxyMethod(): void
+    {
+        Expect::that(new Doubles()->stub(MixedCaseDestructor::class))
+            ->because('a mixed-case destructor MUST produce a valid proxy class')
+            ->toBeInstanceOf(MixedCaseDestructor::class);
     }
 
     #[Test]


### PR DESCRIPTION
PHP preserves declared method casing in reflection while resolving method names case-insensitively. The proxy generator compared reserved names exactly, so mixed-case handler and destructor declarations produced duplicate methods, while mixed-case constructors and clone methods were intercepted.

Normalize reflected method names once before reserved-method handling. Add append-only PSR-4 fixtures and focused coverage for handler collisions and all three magic methods.