### PR TITLE
test(orchestrator): cover isolated recycling remainder

### DIFF
--- a/tests/Fixture/Runner/Orchestrator/RecycleBeforeIsolatedWorker.php
+++ b/tests/Fixture/Runner/Orchestrator/RecycleBeforeIsolatedWorker.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Runner\Orchestrator;
+
+use Greenlight\Core\Event\RecycleReason;
+use Greenlight\Core\Result\ResultSummary;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Doubles\Fake;
+use Greenlight\Discovery\PlanEntry;
+use Greenlight\Runner\Protocol\Messages\Assign;
+use Greenlight\Runner\Protocol\Messages\Hello;
+use Greenlight\Runner\Protocol\Messages\Recycling;
+use Greenlight\Runner\Protocol\SocketChannel;
+use Greenlight\Runner\Worker\WorkerProcess;
+
+final readonly class RecycleBeforeIsolatedWorker implements Fake
+{
+    /**
+     * @param non-empty-string $address
+     * @param non-empty-string $workerId
+     * @param non-empty-string $token
+     */
+    public static function run(string $address, string $workerId, string $token): int
+    {
+        if ($workerId !== 'w-1') {
+            return new WorkerProcess()->run($address, $workerId, $token);
+        }
+
+        $stream = \stream_socket_client($address);
+
+        if (!\is_resource($stream)) {
+            return 2;
+        }
+
+        $channel = new SocketChannel($stream);
+        $pid = \getmypid();
+        $channel->send(new Hello($workerId, $token, $pid === false ? 1 : \max(1, $pid)));
+        $assignment = $channel->receive(5.0);
+
+        if (!$assignment instanceof Assign) {
+            $channel->close();
+
+            return 3;
+        }
+
+        $channel->send(new Recycling(
+            RecycleReason::TestCount,
+            \array_map(static fn(PlanEntry $entry): TestId => $entry->id, $assignment->slice->entries),
+            new ResultSummary(),
+        ));
+        $channel->close();
+
+        return 0;
+    }
+}

--- a/tests/Unit/Runner/Orchestrator/OrchestratorIsolatedRemainderTest.php
+++ b/tests/Unit/Runner/Orchestrator/OrchestratorIsolatedRemainderTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Orchestrator;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Attribute\Timeout;
+use Greenlight\Core\Event\TestClassStarted;
+use Greenlight\Core\Result\ResultSummary;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Discovery\ExecutionPlan;
+use Greenlight\Discovery\PlanEntry;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\Orchestrator\Orchestrator;
+use Greenlight\Tests\Fixture\LeakSuite\CleanTest;
+use Greenlight\Tests\Fixture\Runner\Orchestrator\RecycleBeforeIsolatedWorker;
+use Greenlight\Tests\Support\CollectingEventSink;
+
+final class OrchestratorIsolatedRemainderTest
+{
+    #[Test]
+    #[Timeout(30.0)]
+    public function aRecyclingWorkerRequeuesItsUnstartedIsolatedTest(): void
+    {
+        $root = \dirname(__DIR__, 4);
+        $bootstrap = \sprintf(
+            'require %s; exit(%s::run($argv[2], $argv[3], $argv[4]));',
+            \var_export($root . '/vendor/autoload.php', true),
+            RecycleBeforeIsolatedWorker::class,
+        );
+        $orchestrator = new Orchestrator(
+            workerCommand: [\PHP_BINARY, '-r', $bootstrap],
+            workingDirectory: $root,
+        );
+        $sink = new CollectingEventSink();
+        $id = new TestId(CleanTest::class, 'passesAndIsCollectable');
+        $plan = new ExecutionPlan([
+            new PlanEntry($id, new TestMetadata($id->class, $id->method, isolated: true)),
+        ]);
+
+        $summary = $orchestrator->run($plan, $sink, 1);
+        $workers = [];
+
+        foreach ($sink->events as $event) {
+            if ($event instanceof TestClassStarted) {
+                $workers[] = $event->workerId;
+            }
+        }
+
+        Expect::that($summary)
+            ->because('the replacement worker MUST execute the requeued isolated test')
+            ->toEqual(new ResultSummary(passed: 1))
+            ->and($workers)
+            ->toBe(['w-2']);
+    }
+}


### PR DESCRIPTION
Covers an isolated assignment that a worker returns untouched when it recycles. A deterministic protocol fixture makes the first worker recycle and verifies that a fresh replacement executes the requeued test.