### PR TITLE
fix(doubles): reject handler property collisions

### DIFF
--- a/src/Doubles/DoublesError.php
+++ b/src/Doubles/DoublesError.php
@@ -127,6 +127,11 @@ final class DoublesError extends \LogicException
         return new self(\sprintf('%s declares __greenlightAttachHandler(). This method conflicts with the proxy handler method.', $class));
     }
 
+    public static function handlerPropertyCollision(string $class): self
+    {
+        return new self(\sprintf('%s declares $__greenlightHandler. This property conflicts with the proxy handler storage property.', $class));
+    }
+
     public static function defaultValueNotReproducible(string $parameter, string $class, string $method): self
     {
         return new self(\sprintf(

--- a/src/Doubles/ProxyGenerator.php
+++ b/src/Doubles/ProxyGenerator.php
@@ -117,6 +117,14 @@ final readonly class ProxyGenerator
      */
     private function renderBody(\ReflectionClass $reflection): string
     {
+        if ($reflection->hasProperty(self::HANDLER_PROPERTY)) {
+            $property = $reflection->getProperty(self::HANDLER_PROPERTY);
+
+            if (!$property->isPrivate()) {
+                throw DoublesError::handlerPropertyCollision($property->getDeclaringClass()->name);
+            }
+        }
+
         $sections = [
             \sprintf("    private \\Greenlight\\Doubles\\CallHandler \$%s;\n", self::HANDLER_PROPERTY),
             \sprintf(

--- a/tests/Fixture/Doubles/PrivateHandlerProperty.php
+++ b/tests/Fixture/Doubles/PrivateHandlerProperty.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+class PrivateHandlerProperty
+{
+    private mixed $__greenlightHandler = null;
+
+    public function handlerStorage(): mixed
+    {
+        return $this->__greenlightHandler;
+    }
+}

--- a/tests/Fixture/Doubles/ProtectedHandlerPropertyCollision.php
+++ b/tests/Fixture/Doubles/ProtectedHandlerPropertyCollision.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+class ProtectedHandlerPropertyCollision
+{
+    protected mixed $__greenlightHandler;
+}

--- a/tests/Fixture/Doubles/PublicHandlerPropertyCollision.php
+++ b/tests/Fixture/Doubles/PublicHandlerPropertyCollision.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+class PublicHandlerPropertyCollision
+{
+    public mixed $__greenlightHandler;
+}

--- a/tests/Fixture/Doubles/PublicStaticHandlerPropertyCollision.php
+++ b/tests/Fixture/Doubles/PublicStaticHandlerPropertyCollision.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+use Greenlight\Doubles\Fake;
+
+class PublicStaticHandlerPropertyCollision implements Fake
+{
+    public static mixed $__greenlightHandler;
+}

--- a/tests/Unit/Doubles/HandlerPropertyCollisionTest.php
+++ b/tests/Unit/Doubles/HandlerPropertyCollisionTest.php
@@ -12,6 +12,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\Doubles\PrivateHandlerProperty;
 use Greenlight\Tests\Fixture\Doubles\ProtectedHandlerPropertyCollision;
 use Greenlight\Tests\Fixture\Doubles\PublicHandlerPropertyCollision;
+use Greenlight\Tests\Fixture\Doubles\PublicStaticHandlerPropertyCollision;
 
 final class HandlerPropertyCollisionTest
 {
@@ -38,6 +39,7 @@ final class HandlerPropertyCollisionTest
     {
         yield 'public property' => [PublicHandlerPropertyCollision::class];
         yield 'protected property' => [ProtectedHandlerPropertyCollision::class];
+        yield 'public static property' => [PublicStaticHandlerPropertyCollision::class];
     }
 
     #[Test]

--- a/tests/Unit/Doubles/HandlerPropertyCollisionTest.php
+++ b/tests/Unit/Doubles/HandlerPropertyCollisionTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\DoublesError;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Doubles\PrivateHandlerProperty;
+use Greenlight\Tests\Fixture\Doubles\ProtectedHandlerPropertyCollision;
+use Greenlight\Tests\Fixture\Doubles\PublicHandlerPropertyCollision;
+
+final class HandlerPropertyCollisionTest
+{
+    /**
+     * @param class-string $type
+     */
+    #[Test]
+    #[DataSet('visibleHandlerProperties')]
+    public function visibleHandlerPropertiesCannotBeDoubled(string $type): void
+    {
+        Expect::that(static fn(): object => new Doubles()->stub($type))
+            ->because('a visible property conflicts with proxy handler storage')
+            ->toThrow(
+                DoublesError::class,
+                message: $type . ' declares $__greenlightHandler. '
+                    . 'This property conflicts with the proxy handler storage property.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{class-string}>
+     */
+    public static function visibleHandlerProperties(): iterable
+    {
+        yield 'public property' => [PublicHandlerPropertyCollision::class];
+        yield 'protected property' => [ProtectedHandlerPropertyCollision::class];
+    }
+
+    #[Test]
+    public function privateHandlerPropertiesRemainValid(): void
+    {
+        Expect::that(new Doubles()->stub(PrivateHandlerProperty::class))
+            ->because('a private parent property does not conflict with proxy handler storage')
+            ->toBeInstanceOf(PrivateHandlerProperty::class);
+    }
+}


### PR DESCRIPTION
## Summary

- reject public and protected `$__greenlightHandler` properties before proxy generation
- preserve valid private parent properties
- cover both collision visibilities and the private-property control