### PR TITLE
test(rector): preserve versioned extension requirements

### DIFF
--- a/tests/Acceptance/RectorVersionedExtensionRequirementTest.php
+++ b/tests/Acceptance/RectorVersionedExtensionRequirementTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorVersionedExtensionRequirementTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function versionedExtensionRequirementsRemainUnchanged(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                #[RequiresPhpExtension('json', '>=99')]
+                public function testVersionedExtension(): void
+                {
+                    $this->assertTrue(true);
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'versioned-extension-requirement',
+        );
+
+        Expect::that($probe->changed)
+            ->because('Greenlight cannot preserve an extension version constraint')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->toBe($source)
+            ->toContain("#[RequiresPhpExtension('json', '>=99')]");
+    }
+}


### PR DESCRIPTION
## Summary

- keep versioned PHPUnit extension requirements unchanged
- prevent conversion from discarding an unsupported version constraint
- pin the original source and attribute byte-for-byte