### PR TITLE
test(artifact): cover cleanup symlink safety

### DIFF
--- a/tests/Unit/Artifact/ArtifactCleanupSymlinkTest.php
+++ b/tests/Unit/Artifact/ArtifactCleanupSymlinkTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\ArtifactStore;
+
+final readonly class ArtifactCleanupSymlinkTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function cleanupRemovesDirectoryLinksWithoutChangingTheirTargets(): void
+    {
+        $root = $this->tempDirectory->subdirectory('cleanup-symlink');
+        $target = $this->tempDirectory->subdirectory('cleanup-symlink-target');
+        $store = ArtifactStore::open(
+            new ArtifactConfiguration($root),
+            $root,
+            'run-cleanup-symlink',
+        );
+        $staging = $store->session()->stagingDirectory;
+        $link = $staging . '/external';
+        $sentinel = $target . '/sentinel.txt';
+
+        if (!\mkdir($staging, 0o700)) {
+            Fail::because('Expected to create the artifact staging directory.');
+        }
+
+        if (\file_put_contents($sentinel, 'keep') === false) {
+            Fail::because('Expected to create the target sentinel file.');
+        }
+
+        if (!\symlink($target, $link)) {
+            Fail::because('Expected to create the staging directory symbolic link.');
+        }
+
+        try {
+            $store->cleanup();
+
+            Expect::that(\is_dir($staging))
+                ->because('cleanup MUST remove the artifact staging directory')
+                ->toBeFalse()
+                ->and(\is_link($link))
+                ->because('cleanup MUST remove symbolic links inside artifact staging')
+                ->toBeFalse()
+                ->and(\file_get_contents($sentinel))
+                ->because('cleanup MUST leave symbolic link targets unchanged')
+                ->toBe('keep');
+        } finally {
+            if (\is_link($link)) {
+                \unlink($link);
+            }
+
+            if (\is_dir($staging)) {
+                \rmdir($staging);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Cover the artifact cleanup branch that distinguishes directory symbolic links from real directories. The test verifies that cleanup removes the staging link and staging directory while preserving the external target and its contents.