### PR TITLE
fix(doubles): allow private handler methods

### DIFF
--- a/src/Doubles/ProxyGenerator.php
+++ b/src/Doubles/ProxyGenerator.php
@@ -176,11 +176,15 @@ final readonly class ProxyGenerator
             return null;
         }
 
+        if ($method->isPrivate()) {
+            return null;
+        }
+
         if ($method->name === '__greenlightAttachHandler') {
             throw DoublesError::attachHandlerCollision($method->getDeclaringClass()->name);
         }
 
-        if ($method->isFinal() || $method->isPrivate()) {
+        if ($method->isFinal()) {
             return null;
         }
 

--- a/tests/Fixture/Doubles/PrivateHandlerMethod.php
+++ b/tests/Fixture/Doubles/PrivateHandlerMethod.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+class PrivateHandlerMethod
+{
+    public function __construct()
+    {
+        $this->__greenlightAttachHandler();
+    }
+
+    private function __greenlightAttachHandler(): void {}
+}

--- a/tests/Unit/Doubles/PrivateHandlerMethodTest.php
+++ b/tests/Unit/Doubles/PrivateHandlerMethodTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Doubles\PrivateHandlerMethod;
+
+final class PrivateHandlerMethodTest
+{
+    #[Test]
+    public function privateParentHandlerMethodsRemainValid(): void
+    {
+        Expect::that(new Doubles()->stub(PrivateHandlerMethod::class))
+            ->because('a private parent method does not conflict with the proxy handler method')
+            ->toBeInstanceOf(PrivateHandlerMethod::class);
+    }
+}


### PR DESCRIPTION
## Summary

- allow private parent \`__greenlightAttachHandler()\` methods
- keep public and protected handler-method collisions rejected
- cover the valid private-method boundary