### PR TITLE
fix(harness): reject invalid fixture secret types

### DIFF
--- a/docs/api-fixtures-harness.md
+++ b/docs/api-fixtures-harness.md
@@ -143,7 +143,7 @@ public static function from(array $values = [], #[\SensitiveParameter] array $se
 PHPDoc:
 
 - `@param array<string, mixed> $values`
-- `@param array<string, string> $secrets`
+- `@param array<mixed> $secrets`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L40)
 
@@ -153,7 +153,7 @@ PHPDoc:
 public static function empty(): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L53)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L61)
 
 ### `has()`
 
@@ -161,7 +161,7 @@ public static function empty(): self
 public function has(string $key): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L58)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L66)
 
 ### `value()`
 
@@ -169,7 +169,7 @@ public function has(string $key): bool
 public function value(string $key): mixed
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L63)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L71)
 
 ### `string()`
 
@@ -177,7 +177,7 @@ public function value(string $key): mixed
 public function string(string $key): string
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L72)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L80)
 
 ### `int()`
 
@@ -185,7 +185,7 @@ public function string(string $key): string
 public function int(string $key): int
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L83)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L91)
 
 ### `float()`
 
@@ -193,7 +193,7 @@ public function int(string $key): int
 public function float(string $key): float
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L94)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L102)
 
 ### `bool()`
 
@@ -201,7 +201,7 @@ public function float(string $key): float
 public function bool(string $key): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L105)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L113)
 
 ### `list()`
 
@@ -213,7 +213,7 @@ PHPDoc:
 
 - `@return list<mixed>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L119)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L127)
 
 ### `map()`
 
@@ -225,7 +225,7 @@ PHPDoc:
 
 - `@return array<string, mixed>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L133)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L141)
 
 ### `secret()`
 
@@ -233,7 +233,7 @@ PHPDoc:
 public function secret(string $key): SensitiveValue
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L145)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L153)
 
 ### `mergedWith()`
 
@@ -241,7 +241,7 @@ public function secret(string $key): SensitiveValue
 public function mergedWith(self $channel): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L156)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L164)
 
 ### `toWire()`
 
@@ -250,7 +250,7 @@ public function mergedWith(self $channel): self
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L164)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L172)
 
 ### `fromWire()`
 
@@ -259,7 +259,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L173)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L181)
 
 ### `__debugInfo()`
 
@@ -271,7 +271,7 @@ PHPDoc:
 
 - `@return array{values: array<string, mixed>, secrets: array<string, string>}`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L198)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/FixtureResource.php#L206)
 
 ## `IntegrationResources`
 

--- a/src/Harness/FixtureResource.php
+++ b/src/Harness/FixtureResource.php
@@ -35,19 +35,27 @@ final readonly class FixtureResource implements WireSerializable
 
     /**
      * @param array<string, mixed> $values
-     * @param array<string, string> $secrets
+     * @param array<mixed> $secrets
      */
     public static function from(array $values = [], #[\SensitiveParameter] array $secrets = []): self
     {
         self::validateMap($values, 'values');
+        $validatedSecrets = [];
 
         foreach ($secrets as $key => $secret) {
-            if ($key === '' || !self::validUtf8($key) || !self::validUtf8($secret)) {
+            if (!\is_string($key)
+                || $key === ''
+                || !self::validUtf8($key)
+                || !\is_string($secret)
+                || !self::validUtf8($secret)
+            ) {
                 throw new \InvalidArgumentException('Fixture secrets must be a map of non-empty UTF-8 string keys to UTF-8 strings.');
             }
+
+            $validatedSecrets[$key] = $secret;
         }
 
-        return new self($values, $secrets);
+        return new self($values, $validatedSecrets);
     }
 
     public static function empty(): self

--- a/tests/Unit/Harness/IntegrationResourcesTest.php
+++ b/tests/Unit/Harness/IntegrationResourcesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Harness;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Harness\FixtureResource;
@@ -94,5 +95,31 @@ final class IntegrationResourcesTest
             ->toThrow(\InvalidArgumentException::class, matching: '/UTF-8/')
             ->and(static fn(): FixtureResource => FixtureResource::from(secrets: ['token' => "\xB1\x31"]))
             ->toThrow(\InvalidArgumentException::class, matching: '/UTF-8/');
+    }
+
+    /**
+     * @param array<mixed> $secrets
+     */
+    #[Test]
+    #[DataSet('invalidSecretTypes')]
+    public function secretMapsRejectInvalidRuntimeTypes(array $secrets): void
+    {
+        Expect::that(static fn(): FixtureResource => FixtureResource::from(
+            secrets: $secrets,
+        ))
+            ->because('fixture secret maps MUST reject invalid runtime types at their boundary')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Fixture secrets must be a map of non-empty UTF-8 string keys to UTF-8 strings.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{array<mixed>}>
+     */
+    public static function invalidSecretTypes(): iterable
+    {
+        yield 'integer key' => [[0 => 'secret']];
+        yield 'integer value' => [['token' => 123]];
     }
 }


### PR DESCRIPTION
## Summary

- reject non-string fixture secret keys and values at the public boundary
- preserve the documented invalid-argument diagnostic instead of leaking a type error
- cover both invalid runtime shapes with named data-set rows

Stacks on #15.