### PR TITLE
test(coverage): cover Xdebug ini fallback

### DIFF
--- a/tests/Unit/Coverage/XdebugDriverIniFallbackTest.php
+++ b/tests/Unit/Coverage/XdebugDriverIniFallbackTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\SkipUnless;
+use Greenlight\Attribute\Test;
+use Greenlight\Condition\ExtensionLoaded;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\Subprocess;
+
+final class XdebugDriverIniFallbackTest
+{
+    #[Test]
+    #[SkipUnless(ExtensionLoaded::class, 'xdebug')]
+    public function availabilityUsesTheIniModeWhenXdebugInfoIsDisabled(): void
+    {
+        $root = \dirname(__DIR__, 3);
+        $result = Subprocess::run($root, [
+            \PHP_BINARY,
+            '-d',
+            'xdebug.mode=coverage',
+            '-d',
+            'disable_functions=xdebug_info',
+            '-r',
+            <<<'PHP'
+                require 'vendor/autoload.php';
+
+                echo \function_exists('xdebug_info') ? "enabled\n" : "disabled\n";
+                echo \Greenlight\Coverage\Driver\XdebugDriver::isAvailable()
+                    ? "available\n"
+                    : "unavailable\n";
+                PHP,
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('the isolated Xdebug availability probe MUST exit successfully')
+            ->toBe(0)
+            ->and($result->stdout)
+            ->because('Xdebug availability MUST fall back to the configured INI mode')
+            ->toBe("disabled\navailable");
+    }
+}


### PR DESCRIPTION
Cover Xdebug availability detection when the optional xdebug_info function is disabled. The subprocess pins coverage mode in the INI configuration and verifies that the driver falls back to that source instead of reporting Xdebug as unavailable.