### PR TITLE
test(expect): cover symmetric object sharing

### DIFF
--- a/tests/Unit/Expect/CyclicEqualityTopologyTest.php
+++ b/tests/Unit/Expect/CyclicEqualityTopologyTest.php
@@ -39,4 +39,17 @@ final readonly class CyclicEqualityTopologyTest
             ->not()
             ->toEqual($right);
     }
+
+    #[Test]
+    public function deepEqualityPreservesSharedObjectRelationshipsOnTheRight(): void
+    {
+        $left = (object) ['first' => new \stdClass(), 'second' => new \stdClass()];
+        $shared = new \stdClass();
+        $right = (object) ['first' => $shared, 'second' => $shared];
+
+        Expect::that($left)
+            ->because('deep equality MUST distinguish duplicating state from sharing one object')
+            ->not()
+            ->toEqual($right);
+    }
 }


### PR DESCRIPTION
Adds the reverse object-sharing topology assertion to the cyclic equality fix. This protects the right-to-left identity map as well as the existing left-to-right assertion.