### PR TITLE
fix(harness): reject invalid fixture wire IDs

### DIFF
--- a/src/Harness/IntegrationResources.php
+++ b/src/Harness/IntegrationResources.php
@@ -75,7 +75,7 @@ final readonly class IntegrationResources implements WireSerializable
         $fixtures = [];
 
         foreach ($raw as $id => $resource) {
-            if ($id === '' || !\is_array($resource)) {
+            if ($id === '' || \preg_match('//u', $id) !== 1 || !\is_array($resource)) {
                 throw InvalidWirePayload::wrongType('fixtures', 'a map of fixture resource payloads', $resource);
             }
 

--- a/tests/Unit/Harness/IntegrationResourcesValidationTest.php
+++ b/tests/Unit/Harness/IntegrationResourcesValidationTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Harness;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Wire\InvalidWirePayload;
+use Greenlight\Expect\Expect;
+use Greenlight\Harness\IntegrationResources;
+
+final readonly class IntegrationResourcesValidationTest
+{
+    #[Test]
+    public function wireInputRejectsNonUtf8FixtureIdsAtTheWireBoundary(): void
+    {
+        Expect::that(static fn(): IntegrationResources => IntegrationResources::fromWire([
+            'fixtures' => [
+                "\xB1\x31" => [
+                    'values' => [],
+                    'secrets' => [],
+                ],
+            ],
+        ]))
+            ->because('invalid fixture IDs MUST remain protocol errors at the wire boundary')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "fixtures" must be a map of fixture resource payloads, got array.',
+            );
+    }
+
+    #[Test]
+    public function missingFixturesAreReportedExactly(): void
+    {
+        $resources = IntegrationResources::empty();
+
+        Expect::that(static fn() => $resources->fixture('database'))
+            ->because('a worker MUST identify a fixture that is not available to its channel')
+            ->toThrow(
+                \OutOfBoundsException::class,
+                message: 'No integration fixture named "database" is available to this worker.',
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- reject non-UTF-8 integration fixture IDs during wire decoding
- keep malformed worker resource payloads inside the protocol error boundary
- cover the invalid wire ID and missing worker fixture diagnostics

Stacks on #15.