### PR TITLE
fix(harness): clarify fixture value diagnostics

### DIFF
--- a/src/Harness/FixtureResource.php
+++ b/src/Harness/FixtureResource.php
@@ -74,7 +74,7 @@ final readonly class FixtureResource implements WireSerializable
         $value = $this->value($key);
 
         if (!\is_string($value)) {
-            throw $this->wrongType($key, 'string', $value);
+            throw $this->wrongType($key, 'a string', $value);
         }
 
         return $value;
@@ -85,7 +85,7 @@ final readonly class FixtureResource implements WireSerializable
         $value = $this->value($key);
 
         if (!\is_int($value)) {
-            throw $this->wrongType($key, 'integer', $value);
+            throw $this->wrongType($key, 'an integer', $value);
         }
 
         return $value;
@@ -96,7 +96,7 @@ final readonly class FixtureResource implements WireSerializable
         $value = $this->value($key);
 
         if (!\is_float($value) && !\is_int($value)) {
-            throw $this->wrongType($key, 'float', $value);
+            throw $this->wrongType($key, 'a float', $value);
         }
 
         return (float) $value;
@@ -107,7 +107,7 @@ final readonly class FixtureResource implements WireSerializable
         $value = $this->value($key);
 
         if (!\is_bool($value)) {
-            throw $this->wrongType($key, 'boolean', $value);
+            throw $this->wrongType($key, 'a boolean', $value);
         }
 
         return $value;
@@ -121,7 +121,7 @@ final readonly class FixtureResource implements WireSerializable
         $value = $this->value($key);
 
         if (!\is_array($value) || !\array_is_list($value)) {
-            throw $this->wrongType($key, 'list', $value);
+            throw $this->wrongType($key, 'a list', $value);
         }
 
         return $value;
@@ -135,7 +135,7 @@ final readonly class FixtureResource implements WireSerializable
         $value = $this->value($key);
 
         if (!\is_array($value) || \array_is_list($value)) {
-            throw $this->wrongType($key, 'map', $value);
+            throw $this->wrongType($key, 'a map', $value);
         }
 
         /** @var array<string, mixed> $value */
@@ -214,7 +214,7 @@ final readonly class FixtureResource implements WireSerializable
     private function wrongType(string $key, string $expected, mixed $actual): \UnexpectedValueException
     {
         return new \UnexpectedValueException(\sprintf(
-            'Fixture resource value "%s" must be a %s, got %s.',
+            'Fixture resource value "%s" must be %s, got %s.',
             $key,
             $expected,
             \get_debug_type($actual),

--- a/tests/Unit/Harness/FixtureResourceAccessTest.php
+++ b/tests/Unit/Harness/FixtureResourceAccessTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Harness;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Harness\FixtureResource;
+
+final readonly class FixtureResourceAccessTest
+{
+    #[Test]
+    public function hasFindsOrdinaryValuesAndSecrets(): void
+    {
+        $resource = FixtureResource::from(
+            ['host' => 'database'],
+            ['password' => 'secret'],
+        );
+
+        Expect::that($resource->has('host'))
+            ->because('ordinary fixture values MUST be discoverable')
+            ->toBeTrue()
+            ->and($resource->has('password'))
+            ->because('fixture secrets MUST be discoverable without revealing them')
+            ->toBeTrue()
+            ->and($resource->has('missing'))
+            ->because('unknown fixture keys MUST remain absent')
+            ->toBeFalse();
+    }
+
+    #[Test]
+    public function missingValuesAndSecretsAreReportedExactly(): void
+    {
+        $resource = FixtureResource::empty();
+
+        Expect::that(static fn(): mixed => $resource->value('host'))
+            ->because('missing ordinary values MUST identify their key')
+            ->toThrow(
+                \OutOfBoundsException::class,
+                message: 'Fixture resource has no ordinary value named "host".',
+            )
+            ->and(static fn() => $resource->secret('password'))
+            ->because('missing secrets MUST identify their key')
+            ->toThrow(
+                \OutOfBoundsException::class,
+                message: 'Fixture resource has no secret named "password".',
+            );
+    }
+
+    #[Test]
+    #[DataSet('wrongTypedValues')]
+    public function typedAccessorsReportWrongValuesExactly(
+        string $accessor,
+        string $key,
+        string $message,
+    ): void {
+        $resource = FixtureResource::from([
+            'asString' => 42,
+            'asInt' => '42',
+            'asFloat' => false,
+            'asBool' => 1,
+            'asList' => ['key' => 'value'],
+            'asMap' => ['value'],
+        ]);
+
+        Expect::that(static fn(): mixed => match ($accessor) {
+            'string' => $resource->string($key),
+            'int' => $resource->int($key),
+            'float' => $resource->float($key),
+            'bool' => $resource->bool($key),
+            'list' => $resource->list($key),
+            'map' => $resource->map($key),
+            default => throw new \LogicException('The data set supplied an unknown fixture resource accessor.'),
+        })
+            ->because('typed fixture access MUST identify the key, expected type, and actual type')
+            ->toThrow(\UnexpectedValueException::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{string, string, string}>
+     */
+    public static function wrongTypedValues(): iterable
+    {
+        yield 'string accessor' => [
+            'string',
+            'asString',
+            'Fixture resource value "asString" must be a string, got int.',
+        ];
+        yield 'integer accessor' => [
+            'int',
+            'asInt',
+            'Fixture resource value "asInt" must be an integer, got string.',
+        ];
+        yield 'float accessor' => [
+            'float',
+            'asFloat',
+            'Fixture resource value "asFloat" must be a float, got bool.',
+        ];
+        yield 'boolean accessor' => [
+            'bool',
+            'asBool',
+            'Fixture resource value "asBool" must be a boolean, got int.',
+        ];
+        yield 'list accessor' => [
+            'list',
+            'asList',
+            'Fixture resource value "asList" must be a list, got array.',
+        ];
+        yield 'map accessor' => [
+            'map',
+            'asMap',
+            'Fixture resource value "asMap" must be a map, got array.',
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

- cover ordinary, secret, and missing fixture resource keys
- cover every typed accessor mismatch with named data-set rows
- correct the integer mismatch diagnostic to use the proper article

Stacks on #15.