### PR TITLE
test(cli): cover signal capability requirements

### DIFF
--- a/tests/Unit/Cli/SystemSignalOperationsTest.php
+++ b/tests/Unit/Cli/SystemSignalOperationsTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Cli;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Cli\SystemSignalOperations;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\Subprocess;
 
 final class SystemSignalOperationsTest
 {
@@ -42,5 +44,44 @@ final class SystemSignalOperationsTest
             \pcntl_signal(\SIGUSR1, $handlerBefore);
             \pcntl_async_signals($asyncBefore);
         }
+    }
+
+    #[Test]
+    #[DataSet('requiredPcntlFunctions')]
+    public function availabilityRequiresEveryPcntlFunction(string $function): void
+    {
+        $root = \dirname(__DIR__, 3);
+        $result = Subprocess::run($root, [
+            \PHP_BINARY,
+            '-d',
+            'disable_functions=' . $function,
+            '-r',
+            <<<'PHP'
+            require $argv[1];
+
+            echo (new \Greenlight\Cli\SystemSignalOperations())->available()
+                ? 'available'
+                : 'unavailable';
+            PHP,
+            $root . '/vendor/autoload.php',
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because(\sprintf('the capability check runs with %s disabled', $function))
+            ->toBe(0)
+            ->and($result->stdout)
+            ->because(\sprintf('native signal handling requires %s', $function))
+            ->toBe('unavailable')
+            ->and($result->stderr)
+            ->toBe('');
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function requiredPcntlFunctions(): iterable
+    {
+        yield 'signal registration' => ['pcntl_signal'];
+        yield 'asynchronous delivery' => ['pcntl_async_signals'];
     }
 }


### PR DESCRIPTION
Exercise the native signal capability gate with each required PCNTL function disabled independently. The coverage protects both operands before the signal operations are used by the CLI.