### PR TITLE
test(doubles): cover static handler property collisions

### DIFF
--- a/tests/Fixture/Doubles/PublicStaticHandlerPropertyCollision.php
+++ b/tests/Fixture/Doubles/PublicStaticHandlerPropertyCollision.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+use Greenlight\Doubles\Fake;
+
+class PublicStaticHandlerPropertyCollision implements Fake
+{
+    public static mixed $__greenlightHandler;
+}

--- a/tests/Unit/Doubles/HandlerPropertyCollisionTest.php
+++ b/tests/Unit/Doubles/HandlerPropertyCollisionTest.php
@@ -12,6 +12,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\Doubles\PrivateHandlerProperty;
 use Greenlight\Tests\Fixture\Doubles\ProtectedHandlerPropertyCollision;
 use Greenlight\Tests\Fixture\Doubles\PublicHandlerPropertyCollision;
+use Greenlight\Tests\Fixture\Doubles\PublicStaticHandlerPropertyCollision;
 
 final class HandlerPropertyCollisionTest
 {
@@ -38,6 +39,7 @@ final class HandlerPropertyCollisionTest
     {
         yield 'public property' => [PublicHandlerPropertyCollision::class];
         yield 'protected property' => [ProtectedHandlerPropertyCollision::class];
+        yield 'public static property' => [PublicStaticHandlerPropertyCollision::class];
     }
 
     #[Test]


### PR DESCRIPTION
Adds a public static reserved-property fixture to the handler collision matrix. The coverage proves that proxy generation rejects the collision before PHP terminates the worker for redeclaring static storage as non-static.\n\nStacked on #813.