### PR TITLE
fix(plugins): reject invalid fixture dependency types

### DIFF
--- a/docs/api-plugins.md
+++ b/docs/api-plugins.md
@@ -181,7 +181,7 @@ public function __construct(
 PHPDoc:
 
 - `@param \Closure(IntegrationFixtureContext): void $provision`
-- `@param list<string> $dependsOn`
+- `@param list<mixed> $dependsOn`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/IntegrationFixtureDefinition.php#L26)
 

--- a/src/Plugin/IntegrationFixtureDefinition.php
+++ b/src/Plugin/IntegrationFixtureDefinition.php
@@ -21,7 +21,7 @@ final readonly class IntegrationFixtureDefinition
 
     /**
      * @param \Closure(IntegrationFixtureContext): void $provision
-     * @param list<string> $dependsOn
+     * @param list<mixed> $dependsOn
      */
     public function __construct(
         string $id,
@@ -33,9 +33,10 @@ final readonly class IntegrationFixtureDefinition
         }
 
         $seen = [];
+        $validatedDependencies = [];
 
         foreach ($dependsOn as $dependency) {
-            if ($dependency === '' || \preg_match('//u', $dependency) !== 1) {
+            if (!\is_string($dependency) || $dependency === '' || \preg_match('//u', $dependency) !== 1) {
                 throw new \InvalidArgumentException(\sprintf('Integration fixture "%s" has an invalid dependency ID.', $id));
             }
 
@@ -48,9 +49,10 @@ final readonly class IntegrationFixtureDefinition
             }
 
             $seen[$dependency] = true;
+            $validatedDependencies[] = $dependency;
         }
 
         $this->id = $id;
-        $this->dependsOn = $dependsOn;
+        $this->dependsOn = $validatedDependencies;
     }
 }

--- a/tests/Unit/Plugin/IntegrationFixtureDefinitionTest.php
+++ b/tests/Unit/Plugin/IntegrationFixtureDefinitionTest.php
@@ -61,4 +61,32 @@ final readonly class IntegrationFixtureDefinitionTest
             'Integration fixture "database" declares dependency "network" more than once.',
         ];
     }
+
+    /**
+     * @param list<mixed> $dependencies
+     */
+    #[Test]
+    #[DataSet('invalidRuntimeDependencies')]
+    public function invalidRuntimeDependencyTypesAreRejected(array $dependencies): void
+    {
+        Expect::that(static fn(): IntegrationFixtureDefinition => new IntegrationFixtureDefinition(
+            'database',
+            static function (): void {},
+            $dependencies,
+        ))
+            ->because('integration fixture dependencies MUST reject invalid runtime types at their boundary')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Integration fixture "database" has an invalid dependency ID.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{array<mixed>}>
+     */
+    public static function invalidRuntimeDependencies(): iterable
+    {
+        yield 'integer' => [[123]];
+        yield 'object' => [[new \stdClass()]];
+    }
 }


### PR DESCRIPTION
## Summary

- reject non-string integration fixture dependency IDs at the public boundary
- preserve the documented invalid-argument diagnostic instead of leaking a type error
- cover integer and object runtime inputs with named data-set rows

Stacks on #15.