### PR TITLE
test(harness): cover sensitive value redaction

### DIFF
--- a/tests/Unit/Harness/SensitiveValueTest.php
+++ b/tests/Unit/Harness/SensitiveValueTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Harness;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Harness\SensitiveValue;
+
+final readonly class SensitiveValueTest
+{
+    #[Test]
+    public function valueIsRevealedOnlyOnExplicitRequest(): void
+    {
+        $secret = 'database-password';
+        $value = new SensitiveValue($secret);
+
+        Expect::that(\hash_equals($secret, $value->reveal()))
+            ->because('a sensitive fixture value MUST reveal its original value explicitly')
+            ->toBe(true);
+    }
+
+    #[Test]
+    public function debugAndExportRepresentationsDoNotDiscloseTheValue(): void
+    {
+        $secret = 'database-password';
+        $value = new SensitiveValue($secret);
+
+        \ob_start();
+        \var_dump($value);
+        $dump = \ob_get_clean();
+        $export = \var_export($value, true);
+
+        Expect::that($value->__debugInfo() === ['value' => '[redacted]'])
+            ->because('debug information MUST contain only the redaction marker')
+            ->toBe(true);
+        Expect::that(\is_string($dump) && \str_contains($dump, '[redacted]'))
+            ->because('object dumps MUST identify the redacted value')
+            ->toBe(true);
+        Expect::that(\is_string($dump) && \str_contains($dump, $secret))
+            ->because('object dumps MUST NOT disclose the sensitive value')
+            ->toBe(false);
+        Expect::that(\str_contains($export, $secret))
+            ->because('object exports MUST NOT disclose the sensitive value')
+            ->toBe(false);
+    }
+}


### PR DESCRIPTION
## Summary

- cover explicit sensitive fixture value revelation
- pin the exact debug redaction marker
- prove object dumps and exports do not disclose the underlying value