### PR TITLE
test(reporting): retain zero boot latency

### DIFF
--- a/tests/Unit/Reporting/ProfileZeroBootLatencyTest.php
+++ b/tests/Unit/Reporting/ProfileZeroBootLatencyTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\RunFinished;
+use Greenlight\Core\Event\RunStarted;
+use Greenlight\Core\Event\TestClassFinished;
+use Greenlight\Core\Event\TestClassStarted;
+use Greenlight\Core\Event\WorkerSpawned;
+use Greenlight\Core\Result\ResultSummary;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\ProfileAggregator;
+use Greenlight\Reporting\Style;
+
+final readonly class ProfileZeroBootLatencyTest
+{
+    #[Test]
+    public function zeroBootLatencyRemainsAMeasuredValue(): void
+    {
+        $aggregator = new ProfileAggregator();
+
+        foreach ([
+            new RunStarted('run-1', 1, 1, 100.0),
+            new WorkerSpawned('w-1', 1, 100.0),
+            new TestClassStarted('Acme\ExampleTest', 100.0, 'w-1'),
+            new TestClassFinished('Acme\ExampleTest', 101.0, 'w-1'),
+            new RunFinished('run-1', new ResultSummary(passed: 1), 1.0, 101.0),
+        ] as $event) {
+            $aggregator->onEvent($event);
+        }
+
+        Expect::that($aggregator->render(new Style(ansi: false)))
+            ->because('zero boot latency is measured and MUST NOT be treated as missing')
+            ->toContain(
+                'Boot latency: 0.000s average (spawn to first class, 1 worker)',
+            );
+    }
+}


### PR DESCRIPTION
Adds deterministic profiling coverage for a worker whose first class starts at the spawn timestamp. This proves measured 0.000s boot latency remains distinct from missing timing data.