### PR TITLE
test(runner): cover in-process bootstrap failures

### DIFF
--- a/tests/Unit/Runner/InProcessRunnerTest.php
+++ b/tests/Unit/Runner/InProcessRunnerTest.php
@@ -9,9 +9,13 @@ use Greenlight\Cli\CliOverrides;
 use Greenlight\Cli\ConfigurationResolver;
 use Greenlight\Config\GreenlightConfig;
 use Greenlight\Core\Result\TestResult;
+use Greenlight\Doubles\Fake;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
+use Greenlight\Plugin\WorkerBootstrapContext;
+use Greenlight\Plugin\WorkerBootstrapSubscriber;
 use Greenlight\Runner\InProcessRunner;
+use Greenlight\Runner\Protocol\ProtocolError;
 use Greenlight\Tests\Fixture\Plugins\RecordingRunSubscriber;
 use Greenlight\Tests\Support\CollectingEventSink;
 
@@ -103,6 +107,40 @@ final readonly class InProcessRunnerTest
         Expect::that($shardedIds)
             ->because('all in-process shards reconstitute the complete run exactly once')
             ->toBe($completeIds);
+    }
+
+    #[Test]
+    public function workerBootstrapFailuresUseTheWorkerFatalProtocolError(): void
+    {
+        $failure = new \RuntimeException('worker bootstrap exploded');
+        $plugin = new readonly class ($failure) implements WorkerBootstrapSubscriber, Fake {
+            public function __construct(private \RuntimeException $failure) {}
+
+            #[\Override]
+            public function onWorkerBootstrap(WorkerBootstrapContext $context): void
+            {
+                throw $this->failure;
+            }
+        };
+        $configuration = GreenlightConfig::create()->plugins($plugin)->build();
+        $fixtureDirectory = \dirname(__DIR__, 2) . '/Fixture/DiscoveryBasic';
+
+        Expect::that(fn() => new InProcessRunner($this->tempDirectory->path())->run(
+            $configuration,
+            [$fixtureDirectory],
+            new CollectingEventSink(),
+        ))
+            ->because('in-process bootstrap failures MUST use the worker fatal protocol contract')
+            ->toThrow(
+                static function (ProtocolError $error) use ($failure): void {
+                    Expect::that($error->getMessage())->toBe(\sprintf(
+                        'Worker "in-process" reported a fatal Greenlight error: worker bootstrap exploded (%s:%d)',
+                        $failure->getFile(),
+                        $failure->getLine(),
+                    ));
+                    Expect::that($error->getPrevious())->toBe($failure);
+                },
+            );
     }
 
     /**


### PR DESCRIPTION
Cover in-process worker bootstrap subscriber failures and verify the worker-fatal protocol error retains the exact bootstrap failure as its previous cause.