### PR TITLE
test(artifacts): cover post-copy integrity

### DIFF
--- a/src/Runner/Artifact/ArtifactStore.php
+++ b/src/Runner/Artifact/ArtifactStore.php
@@ -29,12 +29,14 @@ final class ArtifactStore
         private readonly ArtifactConfiguration $configuration,
         private readonly ?string $outputDirectory,
         private readonly bool $ownsStaging,
+        private readonly FileCopier $fileCopier,
     ) {}
 
     public static function open(
         ArtifactConfiguration $configuration,
         string $workingDirectory,
         string $runId,
+        ?FileCopier $fileCopier = null,
     ): self {
         $configured = \rtrim($configuration->directory, '/');
 
@@ -61,14 +63,27 @@ final class ArtifactStore
         $staging = \rtrim(\sys_get_temp_dir(), '/') . '/greenlight-artifacts-'
             . \substr(\hash('sha256', $runId), 0, 16)
             . '-' . \bin2hex(\random_bytes(6));
-        return new self(new ArtifactSession($staging, $output), $configuration, $output, true);
+        return new self(
+            new ArtifactSession($staging, $output),
+            $configuration,
+            $output,
+            true,
+            $fileCopier ?? new NativeFileCopier(),
+        );
     }
 
     public static function fromSession(
         ArtifactSession $session,
         ArtifactConfiguration $configuration,
+        ?FileCopier $fileCopier = null,
     ): self {
-        return new self($session, $configuration, null, false);
+        return new self(
+            $session,
+            $configuration,
+            null,
+            false,
+            $fileCopier ?? new NativeFileCopier(),
+        );
     }
 
     public function session(): ArtifactSession
@@ -347,7 +362,7 @@ final class ArtifactStore
             }
 
             try {
-                FileCopier::copy($source, $part);
+                $this->fileCopier->copy($source, $part);
 
                 if (\filesize($part) !== $attachment->sizeBytes || \hash_file('sha256', $part) !== $attachment->sha256) {
                     throw AttachmentError::storage('Published attachment content does not match its metadata');

--- a/src/Runner/Artifact/FileCopier.php
+++ b/src/Runner/Artifact/FileCopier.php
@@ -4,57 +4,12 @@ declare(strict_types=1);
 
 namespace Greenlight\Runner\Artifact;
 
-use Greenlight\Attribute\CoverageIgnore;
-use Greenlight\Core\Artifact\AttachmentError;
-
 /**
  * Copies attachment files into their output directory.
  *
  * @internal
  */
-final class FileCopier
+interface FileCopier
 {
-    private const int COPY_CHUNK_BYTES = 1024 * 1024;
-
-    public static function copy(string $sourcePath, string $destinationPath): void
-    {
-        $source = \fopen($sourcePath, 'rb');
-        $destination = \fopen($destinationPath, 'xb');
-
-        if ($source === false || $destination === false) {
-            if (\is_resource($source)) {
-                \fclose($source);
-            }
-
-            if (\is_resource($destination)) {
-                \fclose($destination);
-            }
-
-            throw AttachmentError::storage('Failed to copy attachment into its output directory');
-        }
-
-        try {
-            while (!\feof($source)) {
-                $chunk = \fread($source, self::COPY_CHUNK_BYTES);
-
-                if ($chunk === false) {
-                    throw AttachmentError::storage('Failed to read attachment staging content');
-                }
-
-                if ($chunk !== '') {
-                    StreamWriter::writeFully($destination, $chunk);
-                }
-            }
-
-            if (!\fflush($destination)) {
-                throw AttachmentError::storage('Failed to flush the published attachment');
-            }
-        } finally {
-            \fclose($destination);
-            \fclose($source);
-        }
-    }
-
-    #[CoverageIgnore]
-    private function __construct() {}
+    public function copy(string $sourcePath, string $destinationPath): void;
 }

--- a/src/Runner/Artifact/NativeFileCopier.php
+++ b/src/Runner/Artifact/NativeFileCopier.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Runner\Artifact;
+
+use Greenlight\Core\Artifact\AttachmentError;
+
+/** @internal */
+final readonly class NativeFileCopier implements FileCopier
+{
+    private const int COPY_CHUNK_BYTES = 1024 * 1024;
+
+    #[\Override]
+    public function copy(string $sourcePath, string $destinationPath): void
+    {
+        $source = \fopen($sourcePath, 'rb');
+        $destination = \fopen($destinationPath, 'xb');
+
+        if ($source === false || $destination === false) {
+            if (\is_resource($source)) {
+                \fclose($source);
+            }
+
+            if (\is_resource($destination)) {
+                \fclose($destination);
+            }
+
+            throw AttachmentError::storage('Failed to copy attachment into its output directory');
+        }
+
+        try {
+            while (!\feof($source)) {
+                $chunk = \fread($source, self::COPY_CHUNK_BYTES);
+
+                if ($chunk === false) {
+                    throw AttachmentError::storage('Failed to read attachment staging content');
+                }
+
+                if ($chunk !== '') {
+                    StreamWriter::writeFully($destination, $chunk);
+                }
+            }
+
+            if (!\fflush($destination)) {
+                throw AttachmentError::storage('Failed to flush the published attachment');
+            }
+        } finally {
+            \fclose($destination);
+            \fclose($source);
+        }
+    }
+}

--- a/tests/Fixture/Artifact/CorruptingFileCopier.php
+++ b/tests/Fixture/Artifact/CorruptingFileCopier.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Artifact;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Runner\Artifact\FileCopier;
+
+final readonly class CorruptingFileCopier implements Fake, FileCopier
+{
+    #[\Override]
+    public function copy(string $sourcePath, string $destinationPath): void
+    {
+        $contents = \file_get_contents($sourcePath);
+
+        if (!\is_string($contents) || $contents === '') {
+            throw new \RuntimeException('The corrupting file copier did not read the source.');
+        }
+
+        $contents[0] = $contents[0] === "\0" ? "\1" : "\0";
+
+        if (\file_put_contents($destinationPath, $contents, \LOCK_EX) !== \strlen($contents)) {
+            throw new \RuntimeException('The corrupting file copier did not write the destination.');
+        }
+    }
+}

--- a/tests/Unit/Artifact/ArtifactCopyFlushFailureTest.php
+++ b/tests/Unit/Artifact/ArtifactCopyFlushFailureTest.php
@@ -9,7 +9,7 @@ use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\TempDirectory;
-use Greenlight\Runner\Artifact\FileCopier;
+use Greenlight\Runner\Artifact\NativeFileCopier;
 use Greenlight\Tests\Fixture\Artifact\UnflushableStream;
 
 final readonly class ArtifactCopyFlushFailureTest
@@ -34,7 +34,7 @@ final readonly class ArtifactCopyFlushFailureTest
 
             UnflushableStream::reset();
 
-            Expect::that(static fn() => FileCopier::copy(
+            Expect::that(static fn() => new NativeFileCopier()->copy(
                 $source,
                 self::SCHEME . '://destination',
             ))

--- a/tests/Unit/Artifact/ArtifactCopyOpenFailureTest.php
+++ b/tests/Unit/Artifact/ArtifactCopyOpenFailureTest.php
@@ -9,7 +9,7 @@ use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\TempDirectory;
-use Greenlight\Runner\Artifact\FileCopier;
+use Greenlight\Runner\Artifact\NativeFileCopier;
 use Greenlight\Tests\Fixture\Artifact\TrackedOpenStream;
 
 final readonly class ArtifactCopyOpenFailureTest
@@ -30,7 +30,7 @@ final readonly class ArtifactCopyOpenFailureTest
         try {
             TrackedOpenStream::reset();
 
-            Expect::that(static fn() => FileCopier::copy(
+            Expect::that(static fn() => new NativeFileCopier()->copy(
                 $root . '/missing-source.txt',
                 self::SCHEME . '://destination',
             ))
@@ -46,7 +46,7 @@ final readonly class ArtifactCopyOpenFailureTest
 
             TrackedOpenStream::reset();
 
-            Expect::that(static fn() => FileCopier::copy(
+            Expect::that(static fn() => new NativeFileCopier()->copy(
                 self::SCHEME . '://source',
                 $root . '/missing/destination.txt',
             ))

--- a/tests/Unit/Artifact/ArtifactCopyReadFailureTest.php
+++ b/tests/Unit/Artifact/ArtifactCopyReadFailureTest.php
@@ -9,7 +9,7 @@ use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\TempDirectory;
-use Greenlight\Runner\Artifact\FileCopier;
+use Greenlight\Runner\Artifact\NativeFileCopier;
 use Greenlight\Tests\Fixture\Artifact\UnreadableCopySourceStream;
 
 final readonly class ArtifactCopyReadFailureTest
@@ -29,7 +29,7 @@ final readonly class ArtifactCopyReadFailureTest
             UnreadableCopySourceStream::reset();
             $destination = $this->tempDirectory->path() . '/destination.txt';
 
-            Expect::that(static fn() => FileCopier::copy(
+            Expect::that(static fn() => new NativeFileCopier()->copy(
                 self::SCHEME . '://source',
                 $destination,
             ))

--- a/tests/Unit/Artifact/ArtifactPostCopyIntegrityTest.php
+++ b/tests/Unit/Artifact/ArtifactPostCopyIntegrityTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\ArtifactStore;
+use Greenlight\Runner\Artifact\TestArtifactBudget;
+use Greenlight\Tests\Fixture\Artifact\CorruptingFileCopier;
+
+final readonly class ArtifactPostCopyIntegrityTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function postCopyCorruptionRejectsPublicationAndRemovesThePartialFile(): void
+    {
+        $root = $this->tempDirectory->subdirectory('post-copy-integrity');
+        $store = ArtifactStore::open(
+            new ArtifactConfiguration($root),
+            $root,
+            'run-post-copy-integrity',
+            new CorruptingFileCopier(),
+        );
+        $id = new TestId('Example\EvidenceTest', 'fails');
+        $attempt = $store->forAttempt($id, 1, new TestArtifactBudget());
+        $attempt->text('evidence.txt', 'evidence');
+        $staged = $attempt->seal()[0];
+        $result = new TestResult(
+            $id,
+            Outcome::Failed,
+            0.1,
+            0,
+            attachments: [$staged],
+        );
+
+        try {
+            Expect::that(static fn(): TestResult => $store->publish($result))
+                ->because('post-copy corruption MUST reject attachment publication')
+                ->toThrow(
+                    AttachmentError::class,
+                    message: 'Published attachment content does not match its metadata.',
+                )
+                ->and(\is_file($staged->path))
+                ->because('a rejected publication MUST NOT leave the final attachment')
+                ->toBeFalse()
+                ->and(\glob($staged->path . '.part-*'))
+                ->because('a rejected publication MUST remove its partial attachment')
+                ->toBe([]);
+        } finally {
+            $store->cleanup();
+        }
+    }
+}


### PR DESCRIPTION
Adds an internal file-copy seam so publication can deterministically verify corrupted copy output. A Fake copier preserves the file size while changing its content; the focused test pins rejection and partial-file cleanup.