### PR TITLE
test: integrate mutation-resistant coverage

### DIFF
--- a/src/Cli/CliError.php
+++ b/src/Cli/CliError.php
@@ -67,7 +67,12 @@ final class CliError extends \RuntimeException
         $message = \sprintf('--shard requires 1 <= n <= m. Received "%s".', $raw);
 
         if ($count >= 1) {
-            $message .= \sprintf(' Valid n values for %d shards are 1 through %d.', $count, $count);
+            $message .= \sprintf(
+                ' Valid n values for %d %s are 1 through %d.',
+                $count,
+                $count === 1 ? 'shard' : 'shards',
+                $count,
+            );
         }
 
         return new self($message);

--- a/src/Discovery/DataSetExpander.php
+++ b/src/Discovery/DataSetExpander.php
@@ -53,7 +53,7 @@ final readonly class DataSetExpander
      * @param non-empty-string|null $provider
      * @param non-empty-string|null $providerClass
      *
-     * @return array<string, mixed>
+     * @return array<array-key, mixed>
      *
      * @throws DiscoveryError
      */
@@ -113,7 +113,7 @@ final readonly class DataSetExpander
      * @param non-empty-string $testMethod
      * @param non-empty-string $provider
      *
-     * @return non-empty-array<string, mixed>
+     * @return non-empty-array<array-key, mixed>
      *
      * @throws DiscoveryError
      */

--- a/src/Discovery/TestDiscoverer.php
+++ b/src/Discovery/TestDiscoverer.php
@@ -146,7 +146,7 @@ final readonly class TestDiscoverer
             }
 
             foreach (\array_keys($rows) as $key) {
-                $entries[] = new PlanEntry(new TestId($metadata->class, $metadata->method, $key), $metadata);
+                $entries[] = new PlanEntry(new TestId($metadata->class, $metadata->method, (string) $key), $metadata);
             }
         }
 

--- a/src/Runner/Worker/ClassContext.php
+++ b/src/Runner/Worker/ClassContext.php
@@ -23,7 +23,7 @@ final class ClassContext
     /**
      * Resolved data sets for each test method.
      *
-     * @var array<string, array<string, mixed>>
+     * @var array<string, array<array-key, mixed>>
      */
     private array $dataSets = [];
 

--- a/tests/Acceptance/CliTest.php
+++ b/tests/Acceptance/CliTest.php
@@ -198,6 +198,25 @@ final readonly class CliTest
         yield 'empty token' => [['__worker', 'tcp://127.0.0.1:1', 'worker-1', '']];
     }
 
+    #[Test]
+    public function anInternalWorkerConnectionFailureExitsWithADiagnostic(): void
+    {
+        $result = $this->runCli([
+            '__worker',
+            'invalid://worker',
+            'worker-1',
+            'secret-token',
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('an internal worker connection failure MUST report a failed process')
+            ->toBe(1)
+            ->and($result->stderr)
+            ->toStartWith('The worker did not connect to invalid://worker:')
+            ->and($result->stdout)
+            ->toBe('');
+    }
+
     /**
      * @param list<string> $arguments
      */

--- a/tests/Acceptance/CommandErrorsTest.php
+++ b/tests/Acceptance/CommandErrorsTest.php
@@ -27,6 +27,22 @@ final readonly class CommandErrorsTest
     }
 
     #[Test]
+    public function anInvalidRunOverrideExitsWithAUsageError(): void
+    {
+        $result = GreenlightCli::run(\dirname(__DIR__, 2), [
+            'run',
+            '--bail=0',
+            '--no-ansi',
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('an invalid run override MUST exit with a usage error')
+            ->toBe(64)
+            ->and($result->stderr)
+            ->toBe('greenlight: --bail requires a positive integer. Received "0".');
+    }
+
+    #[Test]
     public function coverageDiffWithoutBaselineOrCurrentIsAUsageError(): void
     {
         $result = GreenlightCli::run(\dirname(__DIR__, 2), ['coverage:diff']);

--- a/tests/Acceptance/CoverageDiffErrorTest.php
+++ b/tests/Acceptance/CoverageDiffErrorTest.php
@@ -78,6 +78,35 @@ final readonly class CoverageDiffErrorTest
             ));
     }
 
+    #[Test]
+    #[DataSet('invalidExportLabels')]
+    public function emptyCoverageExportsAreMalformedNotUnreadable(string $invalidLabel): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'coverage-diff-empty-' . $invalidLabel);
+        $valid = '{"v":1,"files":{}}';
+
+        foreach (['baseline', 'current'] as $label) {
+            $project->writeFile($label . '.json', $label === $invalidLabel ? '' : $valid);
+        }
+
+        $result = GreenlightCli::run($project->directory, [
+            'coverage:diff',
+            '--baseline=baseline.json',
+            '--current=current.json',
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('empty readable exports are malformed instead of unreadable')
+            ->toBe(1)
+            ->and($result->output())
+            ->toContain(\sprintf(
+                'The %s file is not a valid coverage export: '
+                . 'Coverage JSON document is invalid: Syntax error',
+                $invalidLabel,
+            ))
+            ->not()->toContain('could not read');
+    }
+
     /**
      * @return iterable<string, array{non-empty-string}>
      */

--- a/tests/Acceptance/CoverageDiffZeroPercentageOutputTest.php
+++ b/tests/Acceptance/CoverageDiffZeroPercentageOutputTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Coverage\Export\JsonExporter;
+use Greenlight\Coverage\FileCoverage;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\GreenlightCli;
+
+final readonly class CoverageDiffZeroPercentageOutputTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function aPresentZeroPercentageFileDoesNotRenderAsAbsent(): void
+    {
+        $directory = $this->tempDirectory->subdirectory('zero-percentage-file-delta');
+        $baseline = new CoverageMap([
+            new FileCoverage('/project/src/Zero.php', [1], []),
+        ]);
+        $current = new CoverageMap([
+            new FileCoverage('/project/src/Zero.php', [], [1]),
+        ]);
+        $this->writeExport($directory . '/baseline.json', $baseline);
+        $this->writeExport($directory . '/current.json', $current);
+
+        $result = GreenlightCli::run(
+            $directory,
+            [
+                'coverage:diff',
+                '--baseline=baseline.json',
+                '--current=current.json',
+            ],
+        );
+
+        Expect::that($result->exitCode)
+            ->because('a zero-percent current file MUST report a coverage regression')
+            ->toBe(1)
+            ->and($result->stdoutLines())
+            ->because('a present zero-percent file MUST NOT render as absent')
+            ->toBe([
+                'Coverage: baseline 100.00%, current 0.00% (-100.00)',
+                '/project/src/Zero.php: 100.00% -> 0.00% (-100.00), newly uncovered lines: 1',
+            ]);
+    }
+
+    private function writeExport(string $path, CoverageMap $map): void
+    {
+        $files = new JsonExporter()->export($map);
+        \file_put_contents($path, $files[JsonExporter::FILE_NAME]);
+    }
+}

--- a/tests/Acceptance/InternalWorkerArityTest.php
+++ b/tests/Acceptance/InternalWorkerArityTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\GreenlightCli;
+
+final class InternalWorkerArityTest
+{
+    #[Test]
+    public function surplusWorkerArgumentsAreAUsageError(): void
+    {
+        $result = GreenlightCli::run(
+            \dirname(__DIR__, 2),
+            ['__worker', 'tcp://127.0.0.1:1', 'worker-1', 'secret-token', 'surplus'],
+        );
+
+        Expect::that($result->exitCode)
+            ->because('the internal worker entry MUST accept exactly three operands')
+            ->toBe(64)
+            ->and($result->stderr)
+            ->toBe('__worker requires <address> <workerId> <token>.')
+            ->and($result->stdout)
+            ->toBe('');
+    }
+}

--- a/tests/Acceptance/PhpStanAttributeArgumentRuleTest.php
+++ b/tests/Acceptance/PhpStanAttributeArgumentRuleTest.php
@@ -60,12 +60,17 @@ final readonly class PhpStanAttributeArgumentRuleTest
 
             #[SkipUnless(extra: ['APP_ENV'], condition: EnvironmentVariableSet::class)]
             final class BadNamedAttributeArgumentProbe {}
+
+            #[RequiresResource(name: 'Postgres primary')]
+            #[Retry(times: 0)]
+            #[Timeout(seconds: 0.0)]
+            final class BadNamedDomainAttributeArgumentProbe {}
             PHP,
         );
 
         Expect::that($probe->exitCode)->because('attribute arguments must have valid values')->toBe(1)
             ->and($probe->goodPassed)->toBeTrue()
-            ->and(\count($probe->errors))->toBe(5)
+            ->and(\count($probe->errors))->toBe(8)
             ->and($probe->messages())->toContain('#[RequiresResource] name "Postgres primary" does not match')
             ->toContain('#[Retry] times must be at least 1')
             ->toContain('#[SkipUnless] argument 1 must be a scalar or null')

--- a/tests/Acceptance/PhpStanDataProviderShapeRuleTest.php
+++ b/tests/Acceptance/PhpStanDataProviderShapeRuleTest.php
@@ -155,6 +155,13 @@ final readonly class PhpStanDataProviderShapeRuleTest
                 }
 
                 #[Test]
+                #[DataSet('protectedProvider')]
+                public function providerMustBePublic(int $value): void
+                {
+                    echo $value;
+                }
+
+                #[Test]
                 #[DataSet(SharedBadProviders::class, 'abstractProvider')]
                 public function providerMustBeConcrete(int $value): void
                 {
@@ -211,13 +218,21 @@ final readonly class PhpStanDataProviderShapeRuleTest
                 {
                     yield 'value' => [$value];
                 }
+
+                /**
+                 * @return iterable<string, array{int}>
+                 */
+                protected static function protectedProvider(): iterable
+                {
+                    yield 'value' => [1];
+                }
             }
             PHP,
         );
 
         Expect::that($probe->exitCode)->because('provider and row shapes are checked against the signature')->toBe(1)
             ->and($probe->goodPassed)->toBeTrue()
-            ->and(\count($probe->errors))->toBe(10)
+            ->and(\count($probe->errors))->toBe(11)
             ->and($probe->messages())->toContain('Data provider doesNotExist() for missingProvider() does not exist')
             ->toContain('notStatic() must be public and static')
             ->toContain('notIterable() must return an iterable of argument arrays. It returns string')
@@ -225,6 +240,7 @@ final readonly class PhpStanDataProviderShapeRuleTest
             ->toContain('Data provider stringRows() row argument #1 for typedRows() has type string, but the parameter requires int')
             ->toContain('requiredArgument() must not require arguments')
             ->toContain('SharedBadProviders::notStatic() must be public and static')
+            ->toContain('BadProviderProbe::protectedProvider() must be public and static')
             ->toContain('SharedBadProviders::abstractProvider() must be concrete')
             ->toContain('#[DataRow] supplies 2 arguments, but tooManyInline() expects exactly 1')
             ->toContain('#[DataRow] argument #1 for wrongInlineType() has type string, but the parameter requires int');

--- a/tests/Acceptance/PhpStanDataProviderShapeRuleTest.php
+++ b/tests/Acceptance/PhpStanDataProviderShapeRuleTest.php
@@ -61,6 +61,13 @@ final readonly class PhpStanDataProviderShapeRuleTest
                 }
 
                 #[Test]
+                #[DataRow(['one', 'two'])]
+                public function variadicValues(string ...$values): void
+                {
+                    echo \implode('', $values);
+                }
+
+                #[Test]
                 #[DataSet(SharedProviders::class, 'sums')]
                 public function addsFromSharedProvider(int $left, int $right, int $expected): void
                 {

--- a/tests/Acceptance/PhpStanMissingDataProviderClassTest.php
+++ b/tests/Acceptance/PhpStanMissingDataProviderClassTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\PhpStanProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class PhpStanMissingDataProviderClassTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function missingExternalProviderClassIsReported(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace GreenlightMissingProviderClassProbe;
+
+            use Greenlight\Attribute\Test;
+
+            final class GoodMissingProviderClassProbe
+            {
+                #[Test]
+                public function passes(): void {}
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace GreenlightMissingProviderClassProbe;
+
+            use Greenlight\Attribute\DataSet;
+            use Greenlight\Attribute\Test;
+
+            final class BadMissingProviderClassProbe
+            {
+                #[Test]
+                #[DataSet(MissingProviders::class, 'rows')]
+                public function testValue(int $value): void
+                {
+                    echo $value;
+                }
+            }
+            PHP,
+        );
+
+        Expect::that($probe->exitCode)
+            ->because('PHPStan rejects a data set that references a missing provider class')
+            ->toBe(1)
+            ->and($probe->goodPassed)->toBeTrue()
+            ->and(\count($probe->errors))->toBe(2)
+            ->and($probe->messages())->toContain(
+                'Data provider class GreenlightMissingProviderClassProbe\MissingProviders referenced by testValue() does not exist.',
+            );
+    }
+}

--- a/tests/Acceptance/PhpStanTestAttributePlacementRuleTest.php
+++ b/tests/Acceptance/PhpStanTestAttributePlacementRuleTest.php
@@ -52,8 +52,16 @@ final readonly class PhpStanTestAttributePlacementRuleTest
             namespace GreenlightTestAttributePlacementProbe;
 
             use Greenlight\Attribute\DataRow;
+            use Greenlight\Attribute\DataSet;
             use Greenlight\Attribute\Group;
+            use Greenlight\Attribute\Isolated;
             use Greenlight\Attribute\NoExpectations;
+            use Greenlight\Attribute\RequiresResource;
+            use Greenlight\Attribute\Retry;
+            use Greenlight\Attribute\Skip;
+            use Greenlight\Attribute\SkipUnless;
+            use Greenlight\Attribute\Timeout;
+            use Greenlight\Condition\EnvironmentVariableSet;
 
             final class BadTestAttributePlacementProbe
             {
@@ -66,15 +74,56 @@ final readonly class PhpStanTestAttributePlacementRuleTest
 
                 #[NoExpectations]
                 public function assertionHelper(): void {}
+
+                #[DataSet('rows')]
+                #[Isolated]
+                #[RequiresResource('database')]
+                #[Retry(1)]
+                #[Skip('not ready')]
+                #[SkipUnless(EnvironmentVariableSet::class, 'APP_ENV')]
+                #[Timeout(1.0)]
+                public function metadataHelper(int $value): void
+                {
+                    echo $value;
+                }
+
+                /**
+                 * @return iterable<array{int}>
+                 */
+                public static function rows(): iterable
+                {
+                    yield [1];
+                }
             }
             PHP,
         );
 
         Expect::that($probe->exitCode)->because('test metadata on methods requires the test attribute')->toBe(1)
             ->and($probe->goodPassed)->toBeTrue()
-            ->and(\count($probe->errors))->toBe(3)
+            ->and(\count($probe->errors))->toBe(10)
             ->and($probe->messages())->toContain('#[Group] on GreenlightTestAttributePlacementProbe\BadTestAttributePlacementProbe::dataHelper() has no effect')
             ->toContain('#[DataRow] on GreenlightTestAttributePlacementProbe\BadTestAttributePlacementProbe::dataHelper() has no effect')
-            ->toContain('#[NoExpectations] on GreenlightTestAttributePlacementProbe\BadTestAttributePlacementProbe::assertionHelper() has no effect');
+            ->toContain('#[NoExpectations] on GreenlightTestAttributePlacementProbe\BadTestAttributePlacementProbe::assertionHelper() has no effect')
+            ->toContain(
+                '#[DataSet] on GreenlightTestAttributePlacementProbe\BadTestAttributePlacementProbe::metadataHelper() has no effect',
+            )
+            ->toContain(
+                '#[Isolated] on GreenlightTestAttributePlacementProbe\BadTestAttributePlacementProbe::metadataHelper() has no effect',
+            )
+            ->toContain(
+                '#[RequiresResource] on GreenlightTestAttributePlacementProbe\BadTestAttributePlacementProbe::metadataHelper() has no effect',
+            )
+            ->toContain(
+                '#[Retry] on GreenlightTestAttributePlacementProbe\BadTestAttributePlacementProbe::metadataHelper() has no effect',
+            )
+            ->toContain(
+                '#[Skip] on GreenlightTestAttributePlacementProbe\BadTestAttributePlacementProbe::metadataHelper() has no effect',
+            )
+            ->toContain(
+                '#[SkipUnless] on GreenlightTestAttributePlacementProbe\BadTestAttributePlacementProbe::metadataHelper() has no effect',
+            )
+            ->toContain(
+                '#[Timeout] on GreenlightTestAttributePlacementProbe\BadTestAttributePlacementProbe::metadataHelper() has no effect',
+            );
     }
 }

--- a/tests/Acceptance/PhpStanTestConstructorRuleTest.php
+++ b/tests/Acceptance/PhpStanTestConstructorRuleTest.php
@@ -114,4 +114,62 @@ final readonly class PhpStanTestConstructorRuleTest
             ->toContain('Greenlight cannot resolve constructor parameter $object of test class GreenlightTestConstructorProbe\InvalidParametersProbe')
             ->toContain('Greenlight cannot resolve constructor parameter $value of test class GreenlightTestConstructorProbe\InvalidInheritedTestConstructorProbe');
     }
+
+    #[Test]
+    public function scalarVariadicConstructorParametersAreRejected(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace GreenlightTestConstructorVariadicProbe;
+
+            use Greenlight\Attribute\Test;
+
+            interface Service {}
+
+            final class GoodTestConstructorProbe
+            {
+                public function __construct(Service ...$services)
+                {
+                    echo \count($services);
+                }
+
+                #[Test]
+                public function testMethod(): void {}
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace GreenlightTestConstructorVariadicProbe;
+
+            use Greenlight\Attribute\Test;
+
+            final class ScalarVariadicConstructorProbe
+            {
+                public function __construct(int ...$values)
+                {
+                    echo \count($values);
+                }
+
+                #[Test]
+                public function testMethod(): void {}
+            }
+            PHP,
+        );
+
+        Expect::that($probe->exitCode)->because('scalar variadic parameters cannot be resolved')->toBe(1)
+            ->and($probe->goodPassed)->toBeTrue()
+            ->and($probe->errors)->toHaveCount(1)
+            ->and($probe->messages())->toContain(
+                'Greenlight cannot resolve constructor parameter $values of test class '
+                . 'GreenlightTestConstructorVariadicProbe\ScalarVariadicConstructorProbe',
+            );
+    }
 }

--- a/tests/Acceptance/PhpStanTestConstructorRuleTest.php
+++ b/tests/Acceptance/PhpStanTestConstructorRuleTest.php
@@ -35,13 +35,14 @@ final readonly class PhpStanTestConstructorRuleTest
             {
                 public function __construct(
                     private Service $service,
+                    private ?Service $nullableService,
                     private int $defaulted = 1,
                 ) {}
 
                 #[Test]
                 public function testMethod(): void
                 {
-                    echo $this->service::class, $this->defaulted;
+                    echo $this->service::class, \get_debug_type($this->nullableService), $this->defaulted;
                 }
             }
 

--- a/tests/Acceptance/PhpStanTestMethodRuleTest.php
+++ b/tests/Acceptance/PhpStanTestMethodRuleTest.php
@@ -47,6 +47,12 @@ final readonly class PhpStanTestMethodRuleTest
                 {
                     echo $value;
                 }
+
+                #[Test]
+                public function testMethodWithVariadicParameter(string ...$values): void
+                {
+                    echo \implode('', $values);
+                }
             }
 
             abstract class GoodAbstractProbe

--- a/tests/Acceptance/RectorDefaultFailureMessageTest.php
+++ b/tests/Acceptance/RectorDefaultFailureMessageTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorDefaultFailureMessageTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function failureWithoutAMessageGetsANonEmptyDefault(): void
+    {
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testFails(): void
+                {
+                    $this->fail();
+                }
+            }
+
+            PHP_WRAP,
+            name: 'default-failure-message',
+        );
+
+        Expect::that($probe->changed)
+            ->because('a PHPUnit failure without a message MUST be convertible')
+            ->toBeTrue()
+            ->and($probe->code)
+            ->because('Greenlight failures MUST have a non-empty reason')
+            ->toContain("\Greenlight\Expect\Fail::because('Test failed.');");
+    }
+}

--- a/tests/Acceptance/RectorDefaultSkipReasonTest.php
+++ b/tests/Acceptance/RectorDefaultSkipReasonTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorDefaultSkipReasonTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function skipWithoutAReasonGetsANonEmptyDefault(): void
+    {
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testSkips(): void
+                {
+                    $this->markTestSkipped();
+                }
+            }
+
+            PHP_WRAP,
+            name: 'default-skip-reason',
+        );
+
+        Expect::that($probe->changed)
+            ->because('a PHPUnit skip without a reason MUST be convertible')
+            ->toBeTrue()
+            ->and($probe->code)
+            ->because('Greenlight skips MUST have a non-empty reason')
+            ->toContain("throw new \Greenlight\Core\Test\SkipTest('Skipped.');");
+    }
+}

--- a/tests/Acceptance/RectorDuplicateExceptionExpectationTest.php
+++ b/tests/Acceptance/RectorDuplicateExceptionExpectationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorDuplicateExceptionExpectationTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function duplicateExceptionTypesLeaveTheClassUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testFails(): void
+                {
+                    $this->expectException(\RuntimeException::class);
+                    $this->expectException(\LogicException::class);
+                    throw new \LogicException('boom');
+                }
+            }
+
+            PHP_WRAP;
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'duplicate-exception-expectations',
+        );
+
+        Expect::that($probe->changed)
+            ->because('duplicate exception expectations MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}

--- a/tests/Acceptance/RectorDuplicateExceptionMessageTest.php
+++ b/tests/Acceptance/RectorDuplicateExceptionMessageTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorDuplicateExceptionMessageTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesDuplicateExceptionMessageConstraintsUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testFailure(): void
+                {
+                    $this->expectException(\RuntimeException::class);
+                    $this->expectExceptionMessage('first');
+                    $this->expectExceptionMessageMatches('/second/');
+                    throw new \RuntimeException('second');
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'duplicate-exception-message',
+        );
+
+        Expect::that($probe->changed)
+            ->because('duplicate exception message constraints MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}

--- a/tests/Acceptance/RectorDynamicDataProviderTest.php
+++ b/tests/Acceptance/RectorDynamicDataProviderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorDynamicDataProviderTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesDynamicDataProviderReferencesUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\Attributes\DataProvider;
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                private const string PROVIDER = 'values';
+
+                #[DataProvider(self::PROVIDER)]
+                public function testValue(int $value): void
+                {
+                    $this->assertSame(1, $value);
+                }
+
+                public static function values(): iterable
+                {
+                    yield [1];
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'dynamic-data-provider',
+        );
+
+        Expect::that($probe->changed)
+            ->because('a dynamic data provider reference MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}

--- a/tests/Acceptance/RectorDynamicExceptionMessageTest.php
+++ b/tests/Acceptance/RectorDynamicExceptionMessageTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorDynamicExceptionMessageTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function dynamicExactMessagesLeaveTheClassUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testFails(): void
+                {
+                    $message = 'boom';
+                    $this->expectException(\RuntimeException::class);
+                    $this->expectExceptionMessage($message);
+                    throw new \RuntimeException('boom');
+                }
+            }
+
+            PHP_WRAP;
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'dynamic-exception-message',
+        );
+
+        Expect::that($probe->changed)
+            ->because('a dynamic exact exception message MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}

--- a/tests/Acceptance/RectorDynamicMethodCallTest.php
+++ b/tests/Acceptance/RectorDynamicMethodCallTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorDynamicMethodCallTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesDynamicMethodCallsUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testValue(): void
+                {
+                    $method = 'checkValue';
+                    $this->{$method}(1);
+                }
+
+                private function checkValue(int $value): void
+                {
+                    $this->assertSame(1, $value);
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'dynamic-method-call',
+        );
+
+        Expect::that($probe->changed)
+            ->because('a dynamic method call MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}

--- a/tests/Acceptance/RectorExceptionExpectationArityTest.php
+++ b/tests/Acceptance/RectorExceptionExpectationArityTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorExceptionExpectationArityTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesExceptionExpectationsWithSurplusArgumentsUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testFailure(): void
+                {
+                    $this->expectException(\RuntimeException::class, 'surplus');
+                    throw new \RuntimeException('failure');
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'exception-expectation-arity',
+        );
+
+        Expect::that($probe->changed)
+            ->because('exception expectations with surplus arguments MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}

--- a/tests/Acceptance/RectorExceptionMessageDelimiterTest.php
+++ b/tests/Acceptance/RectorExceptionMessageDelimiterTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorExceptionMessageDelimiterTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function exactMessagesEscapeTheGeneratedPatternDelimiter(): void
+    {
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testFails(): void
+                {
+                    $this->expectException(\RuntimeException::class);
+                    $this->expectExceptionMessage('path /tmp');
+                    throw new \RuntimeException('path /tmp');
+                }
+            }
+
+            PHP_WRAP,
+            name: 'exception-message-delimiter',
+        );
+
+        Expect::that($probe->changed)
+            ->because('the exception expectation MUST be convertible')
+            ->toBeTrue()
+            ->and($probe->code)
+            ->because('the generated matcher MUST escape its slash delimiter')
+            ->toContain(
+                "->toThrow(\\RuntimeException::class, matching: '/path \\/tmp/');",
+            );
+    }
+}

--- a/tests/Acceptance/RectorMessageOnlyThrowableTest.php
+++ b/tests/Acceptance/RectorMessageOnlyThrowableTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorMessageOnlyThrowableTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function messageOnlyExceptionExpectationsAcceptAllThrowables(): void
+    {
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testError(): void
+                {
+                    $this->expectExceptionMessage('boom');
+                    throw new \Error('boom');
+                }
+            }
+
+            PHP_WRAP,
+            name: 'message-only-throwable',
+        );
+
+        Expect::that($probe->changed)
+            ->because('the message-only exception expectation MUST be convertible')
+            ->toBeTrue()
+            ->and($probe->code)
+            ->because('the converted expectation MUST accept all throwable values')
+            ->toContain("->toThrow(\Throwable::class, matching: '/boom/');");
+    }
+}

--- a/tests/Acceptance/RectorMissingDataProviderTest.php
+++ b/tests/Acceptance/RectorMissingDataProviderTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorMissingDataProviderTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesMissingDataProvidersUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\Attributes\DataProvider;
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                #[DataProvider('missing')]
+                public function testValue(int $value): void
+                {
+                    $this->assertSame(1, $value);
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'missing-data-provider',
+        );
+
+        Expect::that($probe->changed)
+            ->because('a missing data provider MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}

--- a/tests/Acceptance/RectorNamedAssertionArgumentTest.php
+++ b/tests/Acceptance/RectorNamedAssertionArgumentTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorNamedAssertionArgumentTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesNamedAssertionArgumentsUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testValue(): void
+                {
+                    $this->assertSame(expected: 'value', actual: 'value');
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'named-assertion-argument',
+        );
+
+        Expect::that($probe->changed)
+            ->because('an assertion with named arguments MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}

--- a/tests/Acceptance/RectorNamedTestWithDataTest.php
+++ b/tests/Acceptance/RectorNamedTestWithDataTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorNamedTestWithDataTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesNamedTestWithDataUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\Attributes\TestWith;
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                #[TestWith(data: [1])]
+                public function testValue(int $value): void
+                {
+                    $this->assertSame(1, $value);
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'named-test-with-data',
+        );
+
+        Expect::that($probe->changed)
+            ->because('named TestWith data MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}

--- a/tests/Acceptance/RectorNonStaticDataProviderTest.php
+++ b/tests/Acceptance/RectorNonStaticDataProviderTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorNonStaticDataProviderTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesNonStaticDataProvidersUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\Attributes\DataProvider;
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                #[DataProvider('values')]
+                public function testValue(int $value): void
+                {
+                    $this->assertSame(1, $value);
+                }
+
+                public function values(): iterable
+                {
+                    yield [1];
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'non-static-data-provider',
+        );
+
+        Expect::that($probe->changed)
+            ->because('a non-static data provider MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}

--- a/tests/Acceptance/RectorParentAssertionCallTest.php
+++ b/tests/Acceptance/RectorParentAssertionCallTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorParentAssertionCallTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesParentAssertionCallsUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testValue(): void
+                {
+                    parent::assertTrue(true);
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'parent-assertion-call',
+        );
+
+        Expect::that($probe->changed)
+            ->because('a parent assertion call MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}

--- a/tests/Acceptance/RectorPhpUnitFunctionCallTest.php
+++ b/tests/Acceptance/RectorPhpUnitFunctionCallTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorPhpUnitFunctionCallTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesPhpUnitFunctionCallsUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testValue(): void
+                {
+                    \PHPUnit\Framework\assertTrue(true);
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'phpunit-function-call',
+        );
+
+        Expect::that($probe->changed)
+            ->because('a PHPUnit function call MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}

--- a/tests/Acceptance/RectorPhpUnitStaticCallTest.php
+++ b/tests/Acceptance/RectorPhpUnitStaticCallTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorPhpUnitStaticCallTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesPhpUnitStaticCallsUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testValue(): void
+                {
+                    TestCase::assertTrue(true);
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'phpunit-static-call',
+        );
+
+        Expect::that($probe->changed)
+            ->because('a PHPUnit static call MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}

--- a/tests/Acceptance/RectorPrivateDataProviderTest.php
+++ b/tests/Acceptance/RectorPrivateDataProviderTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorPrivateDataProviderTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesPrivateDataProvidersUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\Attributes\DataProvider;
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                #[DataProvider('values')]
+                public function testValue(int $value): void
+                {
+                    $this->assertSame(1, $value);
+                }
+
+                private static function values(): iterable
+                {
+                    yield [1];
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'private-data-provider',
+        );
+
+        Expect::that($probe->changed)
+            ->because('a private data provider MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}

--- a/tests/Acceptance/RectorSurplusFailArgumentTest.php
+++ b/tests/Acceptance/RectorSurplusFailArgumentTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorSurplusFailArgumentTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesSurplusFailArgumentsUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testValue(): void
+                {
+                    $this->fail('Not supported.', 'extra');
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'surplus-fail-argument',
+        );
+
+        Expect::that($probe->changed)
+            ->because('fail() with surplus arguments MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}

--- a/tests/Acceptance/RectorSurplusNoExpectationsArgumentTest.php
+++ b/tests/Acceptance/RectorSurplusNoExpectationsArgumentTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorSurplusNoExpectationsArgumentTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesSurplusNoExpectationsArgumentsUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testValue(): void
+                {
+                    $this->expectNotToPerformAssertions('extra');
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'surplus-no-expectations-argument',
+        );
+
+        Expect::that($probe->changed)
+            ->because('expectNotToPerformAssertions() with arguments MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}

--- a/tests/Acceptance/RectorSurplusTestWithArgumentTest.php
+++ b/tests/Acceptance/RectorSurplusTestWithArgumentTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorSurplusTestWithArgumentTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesSurplusTestWithArgumentsUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\Attributes\TestWith;
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                #[TestWith([1], 'one', 'extra')]
+                public function testValue(int $value): void
+                {
+                    $this->assertSame(1, $value);
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'surplus-test-with-argument',
+        );
+
+        Expect::that($probe->changed)
+            ->because('a TestWith attribute with surplus arguments MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}

--- a/tests/Acceptance/RectorUnpackedAssertionArgumentTest.php
+++ b/tests/Acceptance/RectorUnpackedAssertionArgumentTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorUnpackedAssertionArgumentTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesUnpackedAssertionArgumentsUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testValue(): void
+                {
+                    $arguments = [true];
+
+                    $this->assertTrue(...$arguments);
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'unpacked-assertion-argument',
+        );
+
+        Expect::that($probe->changed)
+            ->because('an assertion with unpacked arguments MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}

--- a/tests/Acceptance/RectorUnpackedTestWithTest.php
+++ b/tests/Acceptance/RectorUnpackedTestWithTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorUnpackedTestWithTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesUnpackedTestWithArgumentsUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\Attributes\TestWith;
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                #[TestWith(...[[1]])]
+                public function testValue(int $value): void
+                {
+                    $this->assertSame(1, $value);
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'unpacked-test-with',
+        );
+
+        Expect::that($probe->changed)
+            ->because('a TestWith attribute with unpacked arguments MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}

--- a/tests/Acceptance/RectorUnsupportedAssertCallTest.php
+++ b/tests/Acceptance/RectorUnsupportedAssertCallTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorUnsupportedAssertCallTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesUnsupportedAssertCallsUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\Assert;
+            use PHPUnit\Framework\Constraint\IsTrue;
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testValue(): void
+                {
+                    Assert::assertThat(true, new IsTrue());
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'unsupported-assert-call',
+        );
+
+        Expect::that($probe->changed)
+            ->because('an unsupported Assert call MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}

--- a/tests/Acceptance/RepeatReporterIsolationTest.php
+++ b/tests/Acceptance/RepeatReporterIsolationTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\GreenlightCli;
+
+final readonly class RepeatReporterIsolationTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function eachIterationUsesAFreshReporter(): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'repeat-reporter-isolation');
+        $project->writeFile('tests/ProbeTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace RepeatReporterIsolationProbe;
+
+            use Greenlight\Attribute\Test;
+
+            final class ProbeTest
+            {
+                #[Test]
+                public function passes(): void {}
+            }
+            PHP);
+        $project->configureWithTestFiles(['tests/ProbeTest.php']);
+
+        $result = GreenlightCli::run($project->directory, [
+            'run',
+            '--reporter=junit',
+            '--workers=1',
+            '--no-ansi',
+            '--repeat=2',
+        ]);
+        $output = $result->output();
+
+        Expect::that($result->exitCode)
+            ->because('repeated runs MUST complete with a fresh reporter for each iteration')
+            ->toBe(0);
+        Expect::that(\substr_count($output, '<?xml version="1.0" encoding="UTF-8"?>'))
+            ->because('each iteration MUST emit its own JUnit document')
+            ->toBe(2);
+        Expect::that(\substr_count($output, '<testsuites name="greenlight" tests="1"'))
+            ->because('each JUnit document MUST contain only its iteration')
+            ->toBe(2);
+        Expect::that($output)
+            ->not()
+            ->toContain('<testsuites name="greenlight" tests="2"');
+    }
+}

--- a/tests/Acceptance/RepeatSingleIterationTest.php
+++ b/tests/Acceptance/RepeatSingleIterationTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\GreenlightCli;
+
+final readonly class RepeatSingleIterationTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function oneIterationUsesTheStandardRunOutput(): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'repeat-single-iteration');
+        $project->writeFile('tests/ProbeTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace RepeatSingleIterationProbe;
+
+            use Greenlight\Attribute\Test;
+
+            final class ProbeTest
+            {
+                #[Test]
+                public function passes(): void {}
+            }
+            PHP);
+        $project->configureWithTestFiles(['tests/ProbeTest.php']);
+
+        $result = GreenlightCli::run($project->directory, [
+            'run',
+            '--reporter=plain',
+            '--workers=1',
+            '--no-ansi',
+            '--repeat=1',
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('one requested iteration MUST complete as a standard run')
+            ->toBe(0);
+        Expect::that($result->output())
+            ->because('one requested iteration MUST omit repeat-loop output')
+            ->toContain('1 test, 1 passed')
+            ->not()
+            ->toContain('Repeat:');
+    }
+}

--- a/tests/Fixture/DataRowsZeroLabel/ZeroLabelRowTest.php
+++ b/tests/Fixture/DataRowsZeroLabel/ZeroLabelRowTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\DataRowsZeroLabel;
+
+use Greenlight\Attribute\DataRow;
+use Greenlight\Attribute\Test;
+
+final class ZeroLabelRowTest
+{
+    #[Test]
+    #[DataRow(['value'], label: '0')]
+    public function accepts(string $value): void {}
+}

--- a/tests/Unit/Attribute/AttributeContractTest.php
+++ b/tests/Unit/Attribute/AttributeContractTest.php
@@ -31,6 +31,14 @@ final class AttributeContractTest
     }
 
     #[Test]
+    public function skipPreservesAZeroStringReason(): void
+    {
+        Expect::that(new Skip('0')->reason)
+            ->because('the skip attribute MUST preserve a zero-string reason')
+            ->toBe('0');
+    }
+
+    #[Test]
     public function methodOnlyAttributesTargetMethods(): void
     {
         foreach ([Test::class, Before::class, After::class, DataSet::class, NoExpectations::class] as $attribute) {

--- a/tests/Unit/Attribute/AttributeContractTest.php
+++ b/tests/Unit/Attribute/AttributeContractTest.php
@@ -82,6 +82,22 @@ final class AttributeContractTest
     }
 
     #[Test]
+    public function groupRejectsAnEmptyName(): void
+    {
+        Expect::that(static fn(): Group => new Group(''))
+            ->because('group names cannot be empty')
+            ->toThrow(\InvalidArgumentException::class, message: 'Group names cannot be empty.');
+    }
+
+    #[Test]
+    public function groupPreservesAZeroStringName(): void
+    {
+        Expect::that(new Group('0')->name)
+            ->because('the group attribute MUST preserve a zero-string name')
+            ->toBe('0');
+    }
+
+    #[Test]
     public function resourceRequirementsAreRepeatableOnMethodsAndClasses(): void
     {
         Expect::that($this->flags(RequiresResource::class))->because('resource requirements are repeatable on methods and classes')

--- a/tests/Unit/Capture/OutputCaptureMinimumDiagnosticsTest.php
+++ b/tests/Unit/Capture/OutputCaptureMinimumDiagnosticsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Capture;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Capture\OutputCapture;
+use Greenlight\Expect\Expect;
+
+final class OutputCaptureMinimumDiagnosticsTest
+{
+    #[Test]
+    public function oneDiagnosticBoundRetainsTheFirstAndReportsTruncation(): void
+    {
+        $capture = new OutputCapture(maxDiagnostics: 1);
+        $capture->start();
+
+        try {
+            \trigger_error('first diagnostic', \E_USER_NOTICE);
+            \trigger_error('second diagnostic', \E_USER_NOTICE);
+        } finally {
+            $captured = $capture->stop();
+        }
+
+        Expect::that($captured->diagnostics)
+            ->because('the minimum diagnostic bound MUST retain only the first entry')
+            ->toHaveCount(1)
+            ->and($captured->diagnostics[0]->message)
+            ->toBe('first diagnostic')
+            ->and($captured->diagnosticsTruncated)
+            ->toBeTrue();
+    }
+}

--- a/tests/Unit/Cli/CliOverridesResourceLimitShapeTest.php
+++ b/tests/Unit/Cli/CliOverridesResourceLimitShapeTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\CliError;
+use Greenlight\Cli\CliOverrides;
+use Greenlight\Cli\ParsedArguments;
+use Greenlight\Expect\Expect;
+
+final readonly class CliOverridesResourceLimitShapeTest
+{
+    #[Test]
+    public function resourceLimitsRejectSurplusDelimiters(): void
+    {
+        $raw = 'postgres=1=surplus';
+
+        Expect::that(static fn(): CliOverrides => CliOverrides::fromArguments(
+            new ParsedArguments(null, ['resource-limit' => [$raw]]),
+        ))
+            ->because('a resource limit requires exactly one name-value delimiter')
+            ->toThrow(
+                CliError::class,
+                message: '--resource-limit requires <name>=<limit>, such as postgres=2. '
+                    . 'Received "postgres=1=surplus".',
+            );
+    }
+}

--- a/tests/Unit/Cli/CliOverridesSingleShardRangeTest.php
+++ b/tests/Unit/Cli/CliOverridesSingleShardRangeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\CliError;
+use Greenlight\Cli\CliOverrides;
+use Greenlight\Cli\ParsedArguments;
+use Greenlight\Expect\Expect;
+
+final readonly class CliOverridesSingleShardRangeTest
+{
+    #[Test]
+    public function invalidSingleShardIndexNamesTheOnlyValidIndex(): void
+    {
+        Expect::that(static fn(): CliOverrides => CliOverrides::fromArguments(
+            new ParsedArguments(null, ['shard' => ['2/1']]),
+        ))
+            ->because('single-shard guidance MUST name its only valid index')
+            ->toThrow(
+                CliError::class,
+                message: '--shard requires 1 <= n <= m. Received "2/1". Valid n values for 1 shard are 1 through 1.',
+            );
+    }
+}

--- a/tests/Unit/Cli/CoverageMissingIncludePathTest.php
+++ b/tests/Unit/Cli/CoverageMissingIncludePathTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\Application;
+use Greenlight\Config\CoverageConfiguration;
+use Greenlight\Coverage\Driver\DriverSelector;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Runner\CoverageCollector;
+use Greenlight\Runner\CoverageSettings;
+use Greenlight\Tests\Fixture\Coverage\RecordingFakeDriver;
+
+final class CoverageMissingIncludePathTest
+{
+    #[Test]
+    public function anUnresolvedIncludePathRemainsRestrictive(): void
+    {
+        $application = new \ReflectionClass(Application::class)->newInstanceWithoutConstructor();
+        $configuration = new CoverageConfiguration(['future/src'], null, []);
+        $settings = new \ReflectionMethod(Application::class, 'coverageSettings')
+            ->invoke($application, $configuration, '/project');
+
+        if (!$settings instanceof CoverageSettings) {
+            Fail::because('Expected coverage configuration to create coverage settings.');
+        }
+
+        Expect::that($settings->includePaths)
+            ->because('an unresolved non-empty include path MUST remain absolute')
+            ->toBe(['/project/future/src']);
+
+        $collector = CoverageCollector::create(
+            $settings,
+            selector: new DriverSelector([RecordingFakeDriver::class]),
+        );
+
+        if (!$collector instanceof CoverageCollector) {
+            Fail::because('Expected the available driver to create a coverage collector.');
+        }
+
+        $collector->start();
+
+        Expect::that($collector->stop()->files())
+            ->because('an unresolved include path MUST NOT broaden coverage to all files')
+            ->toBe([]);
+    }
+}

--- a/tests/Unit/Cli/Watch/DebouncerZeroTimestampTest.php
+++ b/tests/Unit/Cli/Watch/DebouncerZeroTimestampTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli\Watch;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\Watch\Debouncer;
+use Greenlight\Expect\Expect;
+
+final class DebouncerZeroTimestampTest
+{
+    #[Test]
+    public function aZeroTimestampStartsTheQuietPeriod(): void
+    {
+        $debouncer = new Debouncer(0.5);
+        $debouncer->noteChange(0.0);
+
+        Expect::that($debouncer->shouldFire(0.5))
+            ->because('a zero timestamp MUST start the quiet period')
+            ->toBeTrue();
+    }
+}

--- a/tests/Unit/Cli/Watch/StatChangeDetectorEmptySnapshotTest.php
+++ b/tests/Unit/Cli/Watch/StatChangeDetectorEmptySnapshotTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli\Watch;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\Watch\StatChangeDetector;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class StatChangeDetectorEmptySnapshotTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function firstPhpFileAfterAnEmptySnapshotIsReported(): void
+    {
+        $directory = $this->tempDirectory->subdirectory('empty-watch-directory');
+        $detector = new StatChangeDetector([$directory]);
+
+        Expect::that($detector->poll())
+            ->because('the first poll MUST record an empty snapshot')
+            ->toBe([]);
+
+        $file = $directory . '/FirstTest.php';
+        \file_put_contents($file, '<?php');
+
+        Expect::that($detector->poll())
+            ->because('the first PHP file MUST be reported after an empty snapshot')
+            ->toBe([$file]);
+    }
+}

--- a/tests/Unit/Config/ArtifactBuilderMinimumCountsTest.php
+++ b/tests/Unit/Config/ArtifactBuilderMinimumCountsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Config;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactBuilder;
+use Greenlight\Expect\Expect;
+
+final class ArtifactBuilderMinimumCountsTest
+{
+    #[Test]
+    public function oneAttachmentIsAValidSafetyLimit(): void
+    {
+        $configuration = new ArtifactBuilder()
+            ->maxAttachmentsPerTest(1)
+            ->maxRunAttachments(1)
+            ->toConfiguration();
+
+        Expect::that([
+            $configuration->maxAttachmentsPerTest,
+            $configuration->maxRunAttachments,
+        ])
+            ->because('artifact limits MUST accept their documented minimum')
+            ->toBe([1, 1]);
+    }
+}

--- a/tests/Unit/Config/GreenlightConfigTest.php
+++ b/tests/Unit/Config/GreenlightConfigTest.php
@@ -119,18 +119,40 @@ final class GreenlightConfigTest
     }
 
     /**
+     * @param list<string> $paths
+     */
+    #[Test]
+    #[DataSet('invalidPaths')]
+    public function invalidPathsGiveExactGuidance(array $paths, string $message): void
+    {
+        Expect::that(static function () use ($paths): void {
+            GreenlightConfig::create()->paths($paths);
+        })
+            ->because('each invalid path shape MUST identify the required fix')
+            ->toThrow(InvalidConfiguration::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{list<string>, non-empty-string}>
+     */
+    public static function invalidPaths(): iterable
+    {
+        yield 'no directories' => [
+            [],
+            'paths() needs at least one directory.',
+        ];
+
+        yield 'empty directory' => [
+            [''],
+            'Test paths cannot be empty strings.',
+        ];
+    }
+
+    /**
      * @return iterable<string, array{\Closure(): void}>
      */
     public static function invalidInputs(): iterable
     {
-        yield 'empty paths' => [static function (): void {
-            GreenlightConfig::create()->paths([]);
-        }];
-
-        yield 'empty path string' => [static function (): void {
-            GreenlightConfig::create()->paths(['']);
-        }];
-
         yield 'empty suite name' => [static function (): void {
             GreenlightConfig::create()->suite('', static fn(SuiteBuilder $suite) => $suite->in('tests'));
         }];

--- a/tests/Unit/Config/GreenlightConfigTest.php
+++ b/tests/Unit/Config/GreenlightConfigTest.php
@@ -149,37 +149,110 @@ final class GreenlightConfigTest
     }
 
     /**
+     * @param \Closure(): void $configure
+     */
+    #[Test]
+    #[DataSet('invalidSuites')]
+    public function invalidSuitesGiveExactGuidance(\Closure $configure, string $message): void
+    {
+        Expect::that($configure)
+            ->because('each invalid suite definition MUST identify the required fix')
+            ->toThrow(InvalidConfiguration::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{\Closure(): void, non-empty-string}>
+     */
+    public static function invalidSuites(): iterable
+    {
+        yield 'empty name' => [
+            static function (): void {
+                GreenlightConfig::create()->suite(
+                    '',
+                    static fn(SuiteBuilder $suite) => $suite->in('tests'),
+                );
+            },
+            'Suite names cannot be empty.',
+        ];
+
+        yield 'duplicate name' => [
+            static function (): void {
+                GreenlightConfig::create()
+                    ->suite('unit', static fn(SuiteBuilder $suite) => $suite->in('tests'))
+                    ->suite('unit', static fn(SuiteBuilder $suite) => $suite->in('tests'));
+            },
+            'Suite "unit" is declared twice.',
+        ];
+
+        yield 'no paths' => [
+            static function (): void {
+                GreenlightConfig::create()
+                    ->suite('unit', static function (SuiteBuilder $suite): void {})
+                    ->build();
+            },
+            'Suite "unit" has no paths. Call in() with at least one directory inside its configurator.',
+        ];
+
+        yield 'empty path' => [
+            static function (): void {
+                GreenlightConfig::create()->suite(
+                    'unit',
+                    static fn(SuiteBuilder $suite) => $suite->in(''),
+                );
+            },
+            'Suite "unit" was given an empty path.',
+        ];
+
+        yield 'empty tag' => [
+            static function (): void {
+                GreenlightConfig::create()->suite(
+                    'unit',
+                    static fn(SuiteBuilder $suite) => $suite->in('tests')->tag(''),
+                );
+            },
+            'Suite "unit" was given an empty tag.',
+        ];
+    }
+
+    /**
+     * @param \Closure(): void $configure
+     */
+    #[Test]
+    #[DataSet('invalidResourceLimits')]
+    public function invalidResourceLimitsGiveExactGuidance(\Closure $configure, string $message): void
+    {
+        Expect::that($configure)
+            ->because('each invalid resource limit MUST identify the required fix')
+            ->toThrow(InvalidConfiguration::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{\Closure(): void, non-empty-string}>
+     */
+    public static function invalidResourceLimits(): iterable
+    {
+        yield 'negative limit' => [
+            static function (): void {
+                GreenlightConfig::create()->resourceLimit('redis', -2);
+            },
+            'Resource "redis" must have a limit of at least 1, got -2.',
+        ];
+
+        yield 'duplicate declaration' => [
+            static function (): void {
+                GreenlightConfig::create()
+                    ->resourceLimit('redis')
+                    ->resourceLimit('redis', 3);
+            },
+            'Resource limit "redis" is declared twice.',
+        ];
+    }
+
+    /**
      * @return iterable<string, array{\Closure(): void}>
      */
     public static function invalidInputs(): iterable
     {
-        yield 'empty suite name' => [static function (): void {
-            GreenlightConfig::create()->suite('', static fn(SuiteBuilder $suite) => $suite->in('tests'));
-        }];
-
-        yield 'duplicate suite' => [static function (): void {
-            GreenlightConfig::create()
-                ->suite('unit', static fn(SuiteBuilder $suite) => $suite->in('tests'))
-                ->suite('unit', static fn(SuiteBuilder $suite) => $suite->in('tests'));
-        }];
-
-        yield 'suite without paths' => [static function (): void {
-            GreenlightConfig::create()
-                ->suite('unit', static function (SuiteBuilder $suite): void {})
-                ->build();
-        }];
-
-        yield 'empty suite path' => [static function (): void {
-            GreenlightConfig::create()->suite('unit', static fn(SuiteBuilder $suite) => $suite->in(''));
-        }];
-
-        yield 'empty suite tag' => [static function (): void {
-            GreenlightConfig::create()->suite(
-                'unit',
-                static fn(SuiteBuilder $suite) => $suite->in('tests')->tag(''),
-            );
-        }];
-
         yield 'zero workers' => [static function (): void {
             GreenlightConfig::create()->workers(count: 0);
         }];

--- a/tests/Unit/Config/WorkerCountMinimumTest.php
+++ b/tests/Unit/Config/WorkerCountMinimumTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Config;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\WorkerCount;
+use Greenlight\Expect\Expect;
+
+final readonly class WorkerCountMinimumTest
+{
+    #[Test]
+    public function oneWorkerIsAValidFixedCount(): void
+    {
+        $workers = WorkerCount::exactly(1);
+
+        Expect::that($workers->fixed)
+            ->because('a fixed runner MUST support the minimum worker count')
+            ->toBe(1)
+            ->and($workers->isAuto())
+            ->toBeFalse()
+            ->and($workers->describe())
+            ->toBe('1');
+    }
+}

--- a/tests/Unit/Core/AtomicFileEmptyWriteTest.php
+++ b/tests/Unit/Core/AtomicFileEmptyWriteTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\AtomicFile;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class AtomicFileEmptyWriteTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function writeReplacesTheTargetWithEmptyContent(): void
+    {
+        $path = $this->tempDirectory->path() . '/state.bin';
+        \file_put_contents($path, 'old');
+
+        AtomicFile::write($path, '');
+
+        Expect::that(\file_get_contents($path))
+            ->because('an empty atomic write MUST replace the target')
+            ->toBe('')
+            ->and(\glob($path . '.tmp-*'))
+            ->because('an empty atomic write MUST leave no temporary file')
+            ->toBe([]);
+    }
+}

--- a/tests/Unit/Core/AtomicFileTest.php
+++ b/tests/Unit/Core/AtomicFileTest.php
@@ -142,4 +142,24 @@ final readonly class AtomicFileTest
             ->because('the rename diagnostic omits punctuation for a missing warning')
             ->toBe('Cannot rename "/state.json.tmp-1-abcd" to "/state.json".');
     }
+
+    #[Test]
+    public function temporaryWriteErrorsPreserveZeroStringWarnings(): void
+    {
+        $write = AtomicFileError::cannotWriteTemporary('/state.json.tmp-1-abcd', '0');
+
+        Expect::that($write->getMessage())
+            ->because('the temporary-write diagnostic MUST preserve a zero-string warning')
+            ->toBe('Cannot write temporary file "/state.json.tmp-1-abcd": 0.');
+    }
+
+    #[Test]
+    public function renameErrorsPreserveZeroStringWarnings(): void
+    {
+        $rename = AtomicFileError::cannotRename('/state.json.tmp-1-abcd', '/state.json', '0');
+
+        Expect::that($rename->getMessage())
+            ->because('the rename diagnostic MUST preserve a zero-string warning')
+            ->toBe('Cannot rename "/state.json.tmp-1-abcd" to "/state.json": 0.');
+    }
 }

--- a/tests/Unit/Core/AttachmentNullRetentionWireTest.php
+++ b/tests/Unit/Core/AttachmentNullRetentionWireTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Artifact\Attachment;
+use Greenlight\Core\Artifact\StagedAttachment;
+use Greenlight\Core\Wire\InvalidWirePayload;
+use Greenlight\Expect\Expect;
+
+final readonly class AttachmentNullRetentionWireTest
+{
+    #[Test]
+    public function explicitNullRetentionIsRejected(): void
+    {
+        $payload = [
+            'name' => 'response.json',
+            'kind' => 'value',
+            'mediaType' => 'application/json',
+            'sizeBytes' => 2,
+            'sha256' => \str_repeat('a', 64),
+            'attempt' => 1,
+            'path' => 'build/artifacts/response.json',
+            'retention' => null,
+        ];
+        $message = 'Wire payload key "retention" must be a string, got null.';
+
+        Expect::that(static fn(): Attachment => Attachment::fromWire($payload))
+            ->because('an explicit null retention MUST NOT use the missing-field default')
+            ->toThrow(InvalidWirePayload::class, message: $message);
+
+        Expect::that(static fn(): StagedAttachment => StagedAttachment::fromWire([
+            ...$payload,
+            'storageKey' => 'attempt/response.json',
+        ]))
+            ->because('staged attachment retention MUST use the same wire contract')
+            ->toThrow(InvalidWirePayload::class, message: $message);
+    }
+}

--- a/tests/Unit/Core/ClassLifecycleNullWorkerWireTest.php
+++ b/tests/Unit/Core/ClassLifecycleNullWorkerWireTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\TestClassFinished;
+use Greenlight\Core\Event\TestClassStarted;
+use Greenlight\Core\Wire\InvalidWirePayload;
+use Greenlight\Expect\Expect;
+
+final readonly class ClassLifecycleNullWorkerWireTest
+{
+    /**
+     * @param class-string<TestClassStarted|TestClassFinished> $eventClass
+     */
+    #[Test]
+    #[DataSet('classLifecycleEvents')]
+    public function explicitNullWorkerIdIsRejected(string $eventClass): void
+    {
+        $payload = [
+            'class' => 'App\ExampleTest',
+            'occurredAt' => 1_780_000_000.5,
+            'workerId' => null,
+        ];
+
+        Expect::that(static fn(): TestClassStarted|TestClassFinished => $eventClass::fromWire($payload))
+            ->because('class lifecycle worker IDs MUST distinguish explicit null from a missing legacy field')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "workerId" must be a string, got null.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{class-string<TestClassStarted|TestClassFinished>}>
+     */
+    public static function classLifecycleEvents(): iterable
+    {
+        yield 'class started' => [TestClassStarted::class];
+        yield 'class finished' => [TestClassFinished::class];
+    }
+}

--- a/tests/Unit/Core/SkipTestTest.php
+++ b/tests/Unit/Core/SkipTestTest.php
@@ -17,4 +17,16 @@ final class SkipTestTest
             ->because('skip reasons cannot be empty')
             ->toThrow(\InvalidArgumentException::class, message: 'Skip reasons cannot be empty.');
     }
+
+    #[Test]
+    public function aZeroStringReasonIsPreserved(): void
+    {
+        $skip = new SkipTest('0');
+
+        Expect::that($skip->reason)
+            ->because('a skip signal MUST preserve a zero-string reason')
+            ->toBe('0')
+            ->and($skip->getMessage())
+            ->toBe('0');
+    }
 }

--- a/tests/Unit/Core/TestMetadataNullNoExpectationsWireTest.php
+++ b/tests/Unit/Core/TestMetadataNullNoExpectationsWireTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Core\Wire\InvalidWirePayload;
+use Greenlight\Expect\Expect;
+
+final readonly class TestMetadataNullNoExpectationsWireTest
+{
+    #[Test]
+    public function explicitNullNoExpectationsPolicyIsRejected(): void
+    {
+        $payload = new TestMetadata('App\ExampleTest', 'checksValue')->toWire();
+        $payload['noExpectations'] = null;
+
+        Expect::that(static fn(): TestMetadata => TestMetadata::fromWire($payload))
+            ->because('explicit null is not the backward-compatible missing-key default')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "noExpectations" must be a boolean, got null.',
+            );
+    }
+}

--- a/tests/Unit/Core/TestMetadataNullResourcesWireTest.php
+++ b/tests/Unit/Core/TestMetadataNullResourcesWireTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Core\Wire\InvalidWirePayload;
+use Greenlight\Expect\Expect;
+
+final readonly class TestMetadataNullResourcesWireTest
+{
+    #[Test]
+    public function explicitNullResourcesAreRejected(): void
+    {
+        $payload = new TestMetadata('App\ExampleTest', 'checksValue')->toWire();
+        $payload['resources'] = null;
+
+        Expect::that(static fn(): TestMetadata => TestMetadata::fromWire($payload))
+            ->because('explicit null is not the backward-compatible missing-key default')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "resources" must be a list of strings, got null.',
+            );
+    }
+}

--- a/tests/Unit/Core/TestMetadataNullSkipUnlessArgumentsWireTest.php
+++ b/tests/Unit/Core/TestMetadataNullSkipUnlessArgumentsWireTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Core\Wire\InvalidWirePayload;
+use Greenlight\Expect\Expect;
+
+final readonly class TestMetadataNullSkipUnlessArgumentsWireTest
+{
+    #[Test]
+    public function explicitNullSkipUnlessArgumentsAreRejected(): void
+    {
+        $payload = new TestMetadata('App\ExampleTest', 'checksValue')->toWire();
+        $payload['skipUnlessArguments'] = null;
+
+        Expect::that(static fn(): TestMetadata => TestMetadata::fromWire($payload))
+            ->because('explicit null is not the backward-compatible missing-key default')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "skipUnlessArguments" must be a list of scalars or nulls, got null.',
+            );
+    }
+}

--- a/tests/Unit/Core/TestMetadataWireTest.php
+++ b/tests/Unit/Core/TestMetadataWireTest.php
@@ -58,7 +58,7 @@ final class TestMetadataWireTest
 
     #[Test]
     #[DataSet('invalidTimeouts')]
-    public function invalidTimeoutsAreRejectedOnBothSides(float $seconds): void
+    public function invalidTimeoutsAreRejectedOnBothSides(float $seconds, string $wireMessage): void
     {
         Expect::that(
             static fn(): TestMetadata => new TestMetadata(
@@ -80,7 +80,7 @@ final class TestMetadataWireTest
             ->because('invalid timeouts are rejected as wire protocol errors')
             ->toThrow(
                 InvalidWirePayload::class,
-                message: 'Wire payload key "timeoutSeconds" must be a finite float greater than zero or null, got float.',
+                message: $wireMessage,
             );
     }
 
@@ -109,13 +109,16 @@ final class TestMetadataWireTest
     }
 
     /**
-     * @return iterable<string, array{float}>
+     * @return iterable<string, array{float, non-empty-string}>
      */
     public static function invalidTimeouts(): iterable
     {
-        yield 'zero' => [0.0];
-        yield 'negative' => [-0.5];
-        yield 'positive infinity' => [\INF];
-        yield 'not a number' => [\NAN];
+        $positive = 'Wire payload key "timeoutSeconds" must be a finite float greater than zero or null, got float.';
+        $finite = 'Wire payload key "timeoutSeconds" must be a finite float or null, got float.';
+
+        yield 'zero' => [0.0, $positive];
+        yield 'negative' => [-0.5, $positive];
+        yield 'positive infinity' => [\INF, $finite];
+        yield 'not a number' => [\NAN, $finite];
     }
 }

--- a/tests/Unit/Core/TestMetadataZeroSkipReasonTest.php
+++ b/tests/Unit/Core/TestMetadataZeroSkipReasonTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\JsonWire;
+
+final readonly class TestMetadataZeroSkipReasonTest
+{
+    #[Test]
+    public function retainsAZeroSkipReasonAcrossTheWire(): void
+    {
+        $metadata = new TestMetadata('App\ExampleTest', 'example', skipReason: '0');
+        $decoded = TestMetadata::fromWire(JsonWire::roundTrip($metadata->toWire()));
+
+        Expect::that($metadata->skipReason)
+            ->because('test metadata MUST retain each non-empty skip reason')
+            ->toBe('0')
+            ->and($decoded->skipReason)
+            ->because('the skip reason MUST survive the wire')
+            ->toBe('0');
+    }
+}

--- a/tests/Unit/Core/TestResultNullAttachmentsWireTest.php
+++ b/tests/Unit/Core/TestResultNullAttachmentsWireTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Wire\InvalidWirePayload;
+use Greenlight\Expect\Expect;
+
+final readonly class TestResultNullAttachmentsWireTest
+{
+    #[Test]
+    public function explicitNullAttachmentsAreRejected(): void
+    {
+        $payload = new TestResult(
+            new TestId('App\ExampleTest', 'passes'),
+            Outcome::Passed,
+            0.1,
+            0,
+        )->toWire();
+        $payload['attachments'] = null;
+
+        Expect::that(static fn(): TestResult => TestResult::fromWire($payload))
+            ->because('explicit null attachments MUST NOT use the missing-field default')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "attachments" must be a list of maps, got null.',
+            );
+    }
+}

--- a/tests/Unit/Core/TestResultNullExpectationsWireTest.php
+++ b/tests/Unit/Core/TestResultNullExpectationsWireTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Wire\InvalidWirePayload;
+use Greenlight\Expect\Expect;
+
+final readonly class TestResultNullExpectationsWireTest
+{
+    #[Test]
+    public function explicitNullExpectationCountIsRejected(): void
+    {
+        $payload = new TestResult(
+            new TestId('App\ExampleTest', 'passes'),
+            Outcome::Passed,
+            0.1,
+            0,
+        )->toWire();
+        $payload['expectations'] = null;
+
+        Expect::that(static fn(): TestResult => TestResult::fromWire($payload))
+            ->because('an explicit null expectation count MUST NOT use the missing-field default')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "expectations" must be an integer, got null.',
+            );
+    }
+}

--- a/tests/Unit/Core/TestResultNullRiskyWireTest.php
+++ b/tests/Unit/Core/TestResultNullRiskyWireTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Wire\InvalidWirePayload;
+use Greenlight\Expect\Expect;
+
+final readonly class TestResultNullRiskyWireTest
+{
+    #[Test]
+    public function explicitNullRiskyFlagIsRejected(): void
+    {
+        $payload = new TestResult(
+            new TestId('App\ExampleTest', 'passes'),
+            Outcome::Passed,
+            0.1,
+            0,
+        )->toWire();
+        $payload['risky'] = null;
+
+        Expect::that(static fn(): TestResult => TestResult::fromWire($payload))
+            ->because('an explicit null risky flag MUST NOT use the missing-field default')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "risky" must be a boolean, got null.',
+            );
+    }
+}

--- a/tests/Unit/Coverage/CoverageMapExactWireShapeTest.php
+++ b/tests/Unit/Coverage/CoverageMapExactWireShapeTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Wire\InvalidWirePayload;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Expect\Expect;
+
+final readonly class CoverageMapExactWireShapeTest
+{
+    #[Test]
+    public function rejectsASurplusLineSet(): void
+    {
+        Expect::that(static fn(): CoverageMap => CoverageMap::fromWire([
+            'files' => [
+                '/src/A.php' => [[1], [2], [3]],
+            ],
+        ]))
+            ->because('each coverage file MUST contain exactly two line sets')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "files" must be a two-element list of line lists per file, got array.',
+            );
+    }
+}

--- a/tests/Unit/Coverage/DriverSelectionTest.php
+++ b/tests/Unit/Coverage/DriverSelectionTest.php
@@ -20,4 +20,14 @@ final readonly class DriverSelectionTest
                 message: 'Coverage unavailability requires a nonempty reason.',
             );
     }
+
+    #[Test]
+    public function unavailableSelectionsPreserveAZeroStringReason(): void
+    {
+        $selection = DriverSelection::unavailable('0');
+
+        Expect::that($selection->reason)
+            ->because('coverage unavailability MUST preserve a zero-string reason')
+            ->toBe('0');
+    }
 }

--- a/tests/Unit/Coverage/HtmlExporterEmptySourceTest.php
+++ b/tests/Unit/Coverage/HtmlExporterEmptySourceTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Coverage\Export\HtmlExporter;
+use Greenlight\Coverage\FileCoverage;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class HtmlExporterEmptySourceTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function emptyReadableSourceProducesNoLineBoxes(): void
+    {
+        $path = $this->tempDirectory->path() . '/Empty.php';
+        \file_put_contents($path, '');
+        $map = new CoverageMap([
+            new FileCoverage($path, [1], []),
+        ]);
+
+        $page = new HtmlExporter()->export($map)[HtmlExporter::pageName($path)];
+
+        Expect::that(\is_readable($path))
+            ->because('the empty source MUST be readable')
+            ->toBeTrue()
+            ->and($page)
+            ->because('an empty source MUST retain a valid empty source block')
+            ->toContain("<pre>\n</pre>")
+            ->not()
+            ->toContain('<span class="cov"><span class="num">1</span></span>');
+    }
+}

--- a/tests/Unit/Coverage/IgnoreScannerMultilineEndTest.php
+++ b/tests/Unit/Coverage/IgnoreScannerMultilineEndTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\Ignore\IgnoreScanner;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class IgnoreScannerMultilineEndTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function multilineEndMarkerIncludesItsCompleteComment(): void
+    {
+        $path = $this->tempDirectory->path() . '/subject.php';
+        \file_put_contents($path, <<<'PHP'
+            <?php
+            // @codeCoverageIgnoreStart
+            $ignored = 1;
+            /*
+             * @codeCoverageIgnoreEnd
+             */
+            $kept = 2;
+            PHP);
+
+        Expect::that(\array_keys(new IgnoreScanner()->ignoredLines($path)))
+            ->because('a multiline end marker MUST include its complete comment')
+            ->toBe([2, 3, 4, 5, 6]);
+    }
+}

--- a/tests/Unit/Coverage/IgnoreScannerRepeatedStartTest.php
+++ b/tests/Unit/Coverage/IgnoreScannerRepeatedStartTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\Ignore\IgnoreScanner;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class IgnoreScannerRepeatedStartTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function anAdditionalStartDoesNotNarrowTheActiveRange(): void
+    {
+        $path = $this->tempDirectory->path() . '/subject.php';
+        \file_put_contents($path, <<<'PHP'
+            <?php
+            $before = 1;
+            // @codeCoverageIgnoreStart
+            $first = 2;
+            // @codeCoverageIgnoreStart
+            $second = 3;
+            // @codeCoverageIgnoreEnd
+            $after = 4;
+            PHP);
+
+        Expect::that(\array_keys(new IgnoreScanner()->ignoredLines($path)))
+            ->because('an additional start marker MUST keep the earliest active range boundary')
+            ->toBe([3, 4, 5, 6, 7]);
+    }
+}

--- a/tests/Unit/Discovery/ClassFileParserDanglingNamespaceTest.php
+++ b/tests/Unit/Discovery/ClassFileParserDanglingNamespaceTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\ClassFileParser;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class ClassFileParserDanglingNamespaceTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function aDanglingNamespaceTokenAtEndOfFileIsIgnored(): void
+    {
+        $file = $this->tempDirectory->path() . '/DanglingNamespace.php';
+        \file_put_contents($file, '<?php namespace');
+
+        Expect::that(ClassFileParser::declarationsIn($file))
+            ->because('a dangling namespace token does not declare a namespace or class')
+            ->toBe([]);
+    }
+}

--- a/tests/Unit/Discovery/ClassFileParserDanglingTokenTest.php
+++ b/tests/Unit/Discovery/ClassFileParserDanglingTokenTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\ClassFileParser;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class ClassFileParserDanglingTokenTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function aDanglingClassTokenAtEndOfFileIsIgnored(): void
+    {
+        $file = $this->tempDirectory->path() . '/Dangling.php';
+        \file_put_contents($file, '<?php class');
+
+        Expect::that(ClassFileParser::declarationsIn($file))
+            ->because('a dangling class token does not declare a class')
+            ->toBe([]);
+    }
+}

--- a/tests/Unit/Discovery/ClassFileParserEmptyFileTest.php
+++ b/tests/Unit/Discovery/ClassFileParserEmptyFileTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\ClassFileParser;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class ClassFileParserEmptyFileTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function emptyReadableFileContainsNoDeclarations(): void
+    {
+        $file = $this->tempDirectory->path() . '/EmptyTest.php';
+        \file_put_contents($file, '');
+
+        Expect::that(\is_readable($file))
+            ->because('the empty test file MUST be readable')
+            ->toBeTrue()
+            ->and(ClassFileParser::declarationsIn($file))
+            ->because('an empty test file MUST contain no declarations')
+            ->toBe([]);
+    }
+}

--- a/tests/Unit/Discovery/ClassFileParserTest.php
+++ b/tests/Unit/Discovery/ClassFileParserTest.php
@@ -15,6 +15,41 @@ final readonly class ClassFileParserTest
     public function __construct(private TempDirectory $tempDirectory) {}
 
     #[Test]
+    public function returnsOnlyNamedClassLikeDeclarations(): void
+    {
+        $file = $this->tempDirectory->path() . '/ClassLikeDeclarations.php';
+        \file_put_contents($file, <<<'PHP'
+            <?php
+
+            namespace Example;
+
+            interface Contract {}
+            trait SharedBehavior {}
+            enum State {}
+            final class NamedTest {}
+
+            $name = NamedTest::class;
+            PHP);
+
+        $declarations = \array_map(
+            static fn(ClassDeclaration $declaration): array => [
+                $declaration->fqcn(),
+                $declaration->kind,
+            ],
+            ClassFileParser::declarationsIn($file),
+        );
+
+        Expect::that($declarations)
+            ->because('discovery MUST return only named class-like declarations')
+            ->toBe([
+                ['Example\Contract', 'interface'],
+                ['Example\SharedBehavior', 'trait'],
+                ['Example\State', 'enum'],
+                ['Example\NamedTest', 'class'],
+            ]);
+    }
+
+    #[Test]
     public function aGlobalBracketedNamespaceClearsThePreviousNamespace(): void
     {
         $file = $this->tempDirectory->path() . '/Declarations.php';

--- a/tests/Unit/Discovery/DataRowTest.php
+++ b/tests/Unit/Discovery/DataRowTest.php
@@ -13,6 +13,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\DataRows\InlineRowsTest;
 use Greenlight\Tests\Fixture\DataRowsConflict\DuplicateRowKeyTest;
 use Greenlight\Tests\Fixture\DataRowsDuplicateInline\DuplicateInlineRowKeyTest;
+use Greenlight\Tests\Fixture\DataRowsZeroLabel\ZeroLabelRowTest;
 
 final class DataRowTest
 {
@@ -24,6 +25,20 @@ final class DataRowTest
         Expect::that(\array_keys($rows))->because('inline rows expand with labels and positions')->toBe(['small', '#1'])
             ->and($rows['small'])->toBe([1, 2, 3])
             ->and($rows['#1'])->toBe([10, 20, 30]);
+    }
+
+    #[Test]
+    public function aZeroStringInlineLabelRemainsThePlanDataSetKey(): void
+    {
+        $plan = new TestDiscoverer()->discover(
+            [\dirname(__DIR__, 2) . '/Fixture/DataRowsZeroLabel'],
+            Filter::all(),
+        );
+        $ids = \array_map(static fn($entry): string => (string) $entry->id, $plan->entries);
+
+        Expect::that($ids)
+            ->because('a zero-string inline label MUST remain the plan data-set key')
+            ->toBe([ZeroLabelRowTest::class . '::accepts[0]']);
     }
 
     #[Test]

--- a/tests/Unit/Discovery/DiscoveryCacheEmptyPlanTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheEmptyPlanTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\DiscoveryCache;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class DiscoveryCacheEmptyPlanTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function anEmptyPlanRemainsAValidCacheHit(): void
+    {
+        $directory = $this->tempDirectory->subdirectory('empty-plan');
+        $source = $directory . '/NoTests.php';
+        \file_put_contents($source, '<?php');
+        $cacheFile = \sprintf(
+            '%s/greenlight-discovery-%s.json',
+            \rtrim(\sys_get_temp_dir(), '/'),
+            \substr(\sha1($directory), 0, 12),
+        );
+
+        try {
+            $cache = DiscoveryCache::forDirectories([$directory]);
+            $cache->store($source, []);
+
+            Expect::that($cache->persist())
+                ->because('an empty execution plan MUST be persisted')
+                ->toBeTrue()
+                ->and(DiscoveryCache::forDirectories([$directory])->lookup($source))
+                ->because('an empty execution plan is a valid cache hit, not corrupt data')
+                ->toBe([]);
+        } finally {
+            @\unlink($cacheFile);
+        }
+    }
+}

--- a/tests/Unit/Discovery/DiscoveryCacheEntryNullDependencyHashTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheEntryNullDependencyHashTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\DiscoveryCacheEntry;
+use Greenlight\Expect\Expect;
+
+final class DiscoveryCacheEntryNullDependencyHashTest
+{
+    #[Test]
+    public function aNullDependencyContentHashIsRejected(): void
+    {
+        $decoded = [
+            'mtime' => 100,
+            'size' => 200,
+            'entries' => [['class' => 'Example\Test']],
+            'dependencies' => [
+                '/project/tests/Provider.php' => [
+                    'mtime' => 300,
+                    'size' => 400,
+                    'contentHash' => null,
+                ],
+            ],
+        ];
+
+        Expect::that(DiscoveryCacheEntry::fromDecoded($decoded))
+            ->because('an explicit null dependency content hash is malformed')
+            ->toBeNull();
+    }
+}

--- a/tests/Unit/Discovery/DiscoveryCacheEntryTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheEntryTest.php
@@ -20,8 +20,13 @@ final class DiscoveryCacheEntryTest
             'size' => 200,
             'entries' => [['class' => 'Example\Test']],
             'dependencies' => [
-                '/project/tests/Provider.php' => ['mtime' => 300, 'size' => 400],
+                '/project/tests/Provider.php' => [
+                    'mtime' => 300,
+                    'size' => 400,
+                    'contentHash' => \str_repeat('b', 40),
+                ],
             ],
+            'contentHash' => \str_repeat('a', 40),
         ];
 
         $entry = DiscoveryCacheEntry::fromDecoded($decoded);
@@ -73,6 +78,8 @@ final class DiscoveryCacheEntryTest
 
         yield 'invalid top-level field' => [[...$valid, 'mtime' => '100']];
 
+        yield 'invalid content hash' => [[...$valid, 'contentHash' => \str_repeat('g', 40)]];
+
         yield 'entry is not a map' => [[...$valid, 'entries' => ['not a map']]];
 
         yield 'entry key is not a string' => [[...$valid, 'entries' => [[0 => 'value']]]];
@@ -87,5 +94,16 @@ final class DiscoveryCacheEntryTest
         yield 'dependency path is empty' => [[...$valid, 'dependencies' => ['' => ['mtime' => 300, 'size' => 400]]]];
 
         yield 'dependency stat is invalid' => [[...$valid, 'dependencies' => ['/project/tests/Provider.php' => ['mtime' => '300', 'size' => 400]]]];
+
+        yield 'dependency content hash is invalid' => [[
+            ...$valid,
+            'dependencies' => [
+                '/project/tests/Provider.php' => [
+                    'mtime' => 300,
+                    'size' => 400,
+                    'contentHash' => \str_repeat('g', 40),
+                ],
+            ],
+        ]];
     }
 }

--- a/tests/Unit/Discovery/DiscoveryErrorTest.php
+++ b/tests/Unit/Discovery/DiscoveryErrorTest.php
@@ -47,6 +47,14 @@ final class DiscoveryErrorTest
     }
 
     #[Test]
+    public function unreadableFilesPreserveAZeroStringReason(): void
+    {
+        Expect::that(DiscoveryError::unreadableFile('/project/tests/ExampleTest.php', '0')->getMessage())
+            ->because('an unreadable-file diagnostic MUST preserve a zero-string reason')
+            ->toBe('Greenlight cannot read test file "/project/tests/ExampleTest.php": 0.');
+    }
+
+    #[Test]
     public function dataProviderErrorsGiveExactGuidance(): void
     {
         $cause = new \RuntimeException('provider failed');

--- a/tests/Unit/Discovery/FilterIncludeCompositionTest.php
+++ b/tests/Unit/Discovery/FilterIncludeCompositionTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\Filter;
+use Greenlight\Expect\Expect;
+
+final class FilterIncludeCompositionTest
+{
+    /**
+     * @param list<string> $groups
+     */
+    #[Test]
+    #[DataSet('candidates')]
+    public function everyConfiguredIncludeDimensionMustMatch(
+        string $class,
+        string $method,
+        array $groups,
+        string $path,
+        bool $accepted,
+    ): void {
+        $filter = new Filter(
+            includeGroups: ['slow'],
+            includeClasses: ['App\\Invoice*'],
+            includeMethods: ['calculates*'],
+            includePaths: ['/repo/tests/Unit/'],
+        );
+
+        Expect::that($filter->accepts($class, $method, $groups, $path))
+            ->because('a candidate MUST satisfy every configured include dimension')
+            ->toBe($accepted);
+    }
+
+    /**
+     * @return iterable<string, array{string, string, list<string>, string, bool}>
+     */
+    public static function candidates(): iterable
+    {
+        yield 'all dimensions match' => [
+            'App\\InvoiceTest',
+            'calculatesTotal',
+            ['slow'],
+            '/repo/tests/Unit/InvoiceTest.php',
+            true,
+        ];
+        yield 'group does not match' => [
+            'App\\InvoiceTest',
+            'calculatesTotal',
+            ['fast'],
+            '/repo/tests/Unit/InvoiceTest.php',
+            false,
+        ];
+        yield 'class does not match' => [
+            'App\\OrderTest',
+            'calculatesTotal',
+            ['slow'],
+            '/repo/tests/Unit/OrderTest.php',
+            false,
+        ];
+        yield 'method does not match' => [
+            'App\\InvoiceTest',
+            'refundsTotal',
+            ['slow'],
+            '/repo/tests/Unit/InvoiceTest.php',
+            false,
+        ];
+        yield 'path does not match' => [
+            'App\\InvoiceTest',
+            'calculatesTotal',
+            ['slow'],
+            '/repo/tests/Acceptance/InvoiceTest.php',
+            false,
+        ];
+    }
+}

--- a/tests/Unit/Doubles/EmptyArgumentConstraintTest.php
+++ b/tests/Unit/Doubles/EmptyArgumentConstraintTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\MockPlan;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\ExpectationFailed;
+use Greenlight\Tests\Fixture\Doubles\Wide;
+
+final class EmptyArgumentConstraintTest
+{
+    #[Test]
+    public function anExplicitEmptyConstraintRejectsSuppliedOptionalArguments(): void
+    {
+        $doubles = new Doubles();
+        $wide = $doubles->mock(Wide::class, static function (MockPlan $plan): void {
+            $plan->expects('withDefaults')
+                ->with()
+                ->once()
+                ->andReturns('default');
+        });
+
+        Expect::that(static fn(): string => $wide->withDefaults(11))
+            ->because('an explicit empty argument constraint MUST reject supplied optional arguments')
+            ->toThrow(ExpectationFailed::class, '/unexpected call/');
+    }
+}

--- a/tests/Unit/Doubles/ProxyStorageTest.php
+++ b/tests/Unit/Doubles/ProxyStorageTest.php
@@ -40,6 +40,14 @@ final readonly class ProxyStorageTest
     }
 
     #[Test]
+    public function aProxyDirectoryErrorPreservesAZeroStringReason(): void
+    {
+        Expect::that(DoublesError::proxyDirectoryNotCreated('/tmp/proxies', '0')->getMessage())
+            ->because('a proxy-directory diagnostic MUST preserve a zero-string reason')
+            ->toBe('Doubles could not create the proxy directory /tmp/proxies: 0.');
+    }
+
+    #[Test]
     public function aProxyFileCollisionPreservesTheFileWriteFailure(): void
     {
         $sourceDirectory = $this->tempDirectory->subdirectory('proxy-file-discovery');

--- a/tests/Unit/Doubles/ZeroCardinalityTest.php
+++ b/tests/Unit/Doubles/ZeroCardinalityTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\MockPlan;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Doubles\Calculator;
+
+final class ZeroCardinalityTest
+{
+    #[Test]
+    public function anUncalledZeroCardinalityExpectationPassesVerification(): void
+    {
+        Expect::that(static function (): void {
+            $doubles = new Doubles();
+            $doubles->mock(Calculator::class, static function (MockPlan $plan): void {
+                $plan->expects('add')->times(0);
+            });
+
+            $doubles->dispose();
+        })
+            ->because('times(0) MUST permit an uncalled expectation')
+            ->not()
+            ->toThrow(\Throwable::class);
+    }
+}

--- a/tests/Unit/Expect/BecauseTest.php
+++ b/tests/Unit/Expect/BecauseTest.php
@@ -23,6 +23,18 @@ final class BecauseTest
     }
 
     #[Test]
+    public function becausePreservesAZeroStringReason(): void
+    {
+        $detail = FailureProbe::detailOf(
+            static fn() => Expect::that(false)->because('0')->toBeTrue(),
+        );
+
+        Expect::that($detail->message)
+            ->because('because() MUST preserve a zero-string reason')
+            ->toBe('Expected false to be true because 0.');
+    }
+
+    #[Test]
     public function becauseDoesNotChangeAPassingMatcher(): void
     {
         Expect::that(true)->because('a passing matcher consumes the reason without reporting it')->toBeTrue();

--- a/tests/Unit/Expect/ExpectationFailedSingleDetailTest.php
+++ b/tests/Unit/Expect/ExpectationFailedSingleDetailTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\FailureDetail;
+use Greenlight\Core\Result\SourceLocation;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\ExpectationFailed;
+
+final class ExpectationFailedSingleDetailTest
+{
+    #[Test]
+    public function oneDetailUsesTheSingularDiagnostic(): void
+    {
+        $detail = new FailureDetail(
+            'Expected values to match.',
+            location: new SourceLocation('/tests/ExampleTest.php', 12),
+        );
+
+        $failure = ExpectationFailed::fromDetails([$detail]);
+
+        Expect::that($failure->getMessage())
+            ->because('one detail MUST use the singular diagnostic')
+            ->toBe('Expected values to match. (at /tests/ExampleTest.php:12)')
+            ->and($failure->details)
+            ->toBe([$detail])
+            ->and($failure->detail())
+            ->toBe($detail);
+    }
+}

--- a/tests/Unit/Expect/FailTest.php
+++ b/tests/Unit/Expect/FailTest.php
@@ -48,6 +48,18 @@ final class FailTest
     }
 
     #[Test]
+    public function aZeroStringReasonRemainsTheFailureMessage(): void
+    {
+        $detail = FailureProbe::detailOf(
+            static fn() => Fail::because('0'),
+        );
+
+        Expect::that($detail->message)
+            ->because('an explicit failure MUST preserve a zero-string reason')
+            ->toBe('0');
+    }
+
+    #[Test]
     public function failureLocationPointsAtTheCallSite(): void
     {
         $line = __LINE__ + 1;

--- a/tests/Unit/Fixture/EnvironmentBackupNullServerTest.php
+++ b/tests/Unit/Fixture/EnvironmentBackupNullServerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Fixture;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\EnvironmentBackup;
+
+final readonly class EnvironmentBackupNullServerTest
+{
+    #[Test]
+    public function restorePreservesANullServerValueAsPresent(): void
+    {
+        $name = 'GREENLIGHT_ENVIRONMENT_BACKUP_NULL_SERVER_' . \strtoupper(\bin2hex(\random_bytes(6)));
+        \putenv($name . '=process-original');
+        $_ENV[$name] = 'env-original';
+        $_SERVER[$name] = null;
+        $backup = EnvironmentBackup::capture($name);
+
+        try {
+            \putenv($name . '=changed');
+            $_ENV[$name] = 'changed';
+            $_SERVER[$name] = 'changed';
+
+            $backup->restore();
+
+            Expect::that(\getenv($name))
+                ->because('restore MUST preserve explicit null presence in the server environment')
+                ->toBe('process-original')
+                ->and($_ENV[$name] ?? null)
+                ->toBe('env-original')
+                ->and(\array_key_exists($name, $_SERVER))
+                ->toBeTrue()
+                ->and($_SERVER[$name])
+                ->toBeNull();
+        } finally {
+            \putenv($name);
+            unset($_ENV[$name], $_SERVER[$name]);
+        }
+    }
+}

--- a/tests/Unit/Laravel/LaravelProcessNullEnvironmentTest.php
+++ b/tests/Unit/Laravel/LaravelProcessNullEnvironmentTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Laravel;
+
+use Greenlight\Attribute\SkipUnless;
+use Greenlight\Attribute\Test;
+use Greenlight\Condition\ClassAvailable;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\EnvironmentBackup;
+use Greenlight\Laravel\LaravelProcessState;
+use Illuminate\Foundation\Application as LaravelApplication;
+
+final readonly class LaravelProcessNullEnvironmentTest
+{
+    #[Test]
+    #[SkipUnless(ClassAvailable::class, LaravelApplication::class)]
+    public function restorePreservesNullEnvironmentValuesAsPresent(): void
+    {
+        $backup = EnvironmentBackup::capture('APP_ENV');
+        $state = null;
+
+        try {
+            \putenv('APP_ENV=process-original');
+            $_ENV['APP_ENV'] = null;
+            $_SERVER['APP_ENV'] = null;
+
+            $state = LaravelProcessState::setEnvironment('testing');
+            $state->restore();
+
+            Expect::that(\getenv('APP_ENV'))
+                ->because('restore MUST preserve present null environment values')
+                ->toBe('process-original')
+                ->and(\array_key_exists('APP_ENV', $_ENV))
+                ->toBeTrue()
+                ->and($_ENV['APP_ENV'])
+                ->toBeNull()
+                ->and(\array_key_exists('APP_ENV', $_SERVER))
+                ->toBeTrue()
+                ->and($_SERVER['APP_ENV'])
+                ->toBeNull();
+        } finally {
+            $state?->restore();
+            $backup->restore();
+        }
+    }
+}

--- a/tests/Unit/Reporting/JUnitReporterTest.php
+++ b/tests/Unit/Reporting/JUnitReporterTest.php
@@ -9,6 +9,7 @@ use Greenlight\Core\Event\RunFinished;
 use Greenlight\Core\Event\TestFinished;
 use Greenlight\Core\Result\FailureDetail;
 use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\ResultSummary;
 use Greenlight\Core\Result\SourceLocation;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Core\Test\TestId;
@@ -150,6 +151,40 @@ final class JUnitReporterTest
         Expect::that((string) $document['time'])
             ->because('test durations provide the total when RunFinished is absent')
             ->toBe('0.527000');
+    }
+
+    #[Test]
+    public function anExplicitZeroRunDurationOverridesTheTestDurationTotal(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new JUnitReporter($output);
+        $reporter->onEvent(new TestFinished(new TestResult(
+            new TestId('Acme\ZeroDurationTest', 'passes'),
+            Outcome::Passed,
+            0.5,
+            0,
+        ), 1.0));
+        $reporter->onEvent(new RunFinished(
+            'run-1',
+            new ResultSummary(passed: 1),
+            0.0,
+            1.0,
+        ));
+
+        $reporter->finish();
+        $document = \simplexml_load_string($output->buffer());
+
+        Expect::that($document)
+            ->because('JUnit output with an explicit zero run duration MUST remain valid')
+            ->toBeInstanceOf(\SimpleXMLElement::class);
+
+        if ($document === false) {
+            return;
+        }
+
+        Expect::that((string) $document['time'])
+            ->because('an explicit zero run duration MUST override the test duration total')
+            ->toBe('0.000000');
     }
 
     #[Test]

--- a/tests/Unit/Reporting/PlainReporterFirstRetryTest.php
+++ b/tests/Unit/Reporting/PlainReporterFirstRetryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\TestFinished;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\PlainReporter;
+
+final readonly class PlainReporterFirstRetryTest
+{
+    #[Test]
+    public function aFirstRetryIsReportedAsTwoAttempts(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new PlainReporter($output);
+        $reporter->onEvent(new TestFinished(
+            new TestResult(
+                new TestId('Acme\\RetryTest', 'passesOnFirstRetry'),
+                Outcome::Passed,
+                0.01,
+                0,
+                attempts: 2,
+            ),
+            1_750_000_000.5,
+        ));
+
+        Expect::that($output->buffer())
+            ->because('the first retry MUST report both attempts')
+            ->toBe("PASS Acme\\RetryTest::passesOnFirstRetry (0.010s) (attempts: 2)\n");
+    }
+}

--- a/tests/Unit/Reporting/ProblemDetailsTwoAttemptsTest.php
+++ b/tests/Unit/Reporting/ProblemDetailsTwoAttemptsTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\ProblemDetails;
+
+final readonly class ProblemDetailsTwoAttemptsTest
+{
+    #[Test]
+    public function theFirstRetryIsReported(): void
+    {
+        $result = new TestResult(
+            new TestId('Acme\\FlakyTest', 'failsTwice'),
+            Outcome::Failed,
+            0.1,
+            0,
+            attempts: 2,
+        );
+
+        Expect::that(ProblemDetails::render($result))
+            ->because('a retried result MUST report its total attempt count')
+            ->toBe("  after 2 attempts\n");
+    }
+}

--- a/tests/Unit/Reporting/ProfileAggregatorZeroUtilizationTest.php
+++ b/tests/Unit/Reporting/ProfileAggregatorZeroUtilizationTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\RunFinished;
+use Greenlight\Core\Event\RunStarted;
+use Greenlight\Core\Event\TestClassFinished;
+use Greenlight\Core\Event\TestClassStarted;
+use Greenlight\Core\Event\WorkerSpawned;
+use Greenlight\Core\Result\ResultSummary;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\ProfileAggregator;
+use Greenlight\Reporting\Style;
+
+final readonly class ProfileAggregatorZeroUtilizationTest
+{
+    #[Test]
+    public function measurableIdleTimeRendersZeroUtilization(): void
+    {
+        $aggregator = new ProfileAggregator();
+
+        foreach ([
+            new RunStarted('run-1', 1, 1, 100.0),
+            new WorkerSpawned('w-1', 11, 100.0),
+            new TestClassStarted('Acme\InstantTest', 101.0, 'w-1'),
+            new TestClassFinished('Acme\InstantTest', 101.0, 'w-1'),
+            new RunFinished('run-1', new ResultSummary(passed: 1), 1.0, 101.0),
+        ] as $event) {
+            $aggregator->onEvent($event);
+        }
+
+        Expect::that($aggregator->render(new Style(ansi: false)))
+            ->because('measured idle time MUST render zero utilization')
+            ->toContain("\n  w-1           1  0.000s    0%\n");
+    }
+}

--- a/tests/Unit/Reporting/SummaryFormatTest.php
+++ b/tests/Unit/Reporting/SummaryFormatTest.php
@@ -63,6 +63,21 @@ final class SummaryFormatTest
     }
 
     #[Test]
+    public function zeroStringSkipReasonsRemainDistinctFromNoReason(): void
+    {
+        $block = SummaryFormat::skipped([
+            $this->skip('App\AlphaTest::one', '0'),
+        ], new Style(ansi: false));
+
+        Expect::that($block)
+            ->because('a zero-string skip reason MUST remain distinct from a missing reason')
+            ->toBe(
+                "\nSkipped:\n"
+                . "  App\AlphaTest::one (0)\n",
+            );
+    }
+
+    #[Test]
     public function sharedReasonsGroupWithACap(): void
     {
         $results = [];

--- a/tests/Unit/Reporting/SummaryFormatZeroPassedColorTest.php
+++ b/tests/Unit/Reporting/SummaryFormatZeroPassedColorTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\ResultSummary;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\Style;
+use Greenlight\Reporting\SummaryFormat;
+
+final class SummaryFormatZeroPassedColorTest
+{
+    #[Test]
+    public function aZeroPassedCountRemainsUnstyled(): void
+    {
+        $formatted = SummaryFormat::tests(
+            new ResultSummary(failed: 1),
+            0,
+            new Style(ansi: true),
+        );
+
+        Expect::that($formatted)
+            ->because('a zero passed count MUST remain plain while failures use the error style')
+            ->toBe("1 test, 0 passed, \x1b[31m1 failed\x1b[0m, 0 expectations");
+    }
+}

--- a/tests/Unit/Reporting/TeamCityReasonlessSkipTest.php
+++ b/tests/Unit/Reporting/TeamCityReasonlessSkipTest.php
@@ -35,4 +35,27 @@ final class TeamCityReasonlessSkipTest
                 . "##teamcity[testFinished name='Acme\\NetworkTest::pings' duration='0' flowId='Acme\\NetworkTest']\n",
             );
     }
+
+    #[Test]
+    public function zeroStringSkipReasonsRemainDistinctFromNoReason(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new TeamCityReporter($output);
+        $result = new TestResult(
+            new TestId('Acme\NetworkTest', 'pings'),
+            Outcome::Skipped,
+            0.0,
+            0,
+            skipReason: '0',
+        );
+
+        $reporter->onEvent(new TestFinished($result, 1.0));
+
+        Expect::that($output->buffer())
+            ->because('a zero-string skip reason MUST remain distinct from a missing reason')
+            ->toBe(
+                "##teamcity[testIgnored name='Acme\\NetworkTest::pings' message='0' flowId='Acme\\NetworkTest']\n"
+                . "##teamcity[testFinished name='Acme\\NetworkTest::pings' duration='0' flowId='Acme\\NetworkTest']\n",
+            );
+    }
 }

--- a/tests/Unit/Reporting/TeamCityReporterTest.php
+++ b/tests/Unit/Reporting/TeamCityReporterTest.php
@@ -74,6 +74,29 @@ final class TeamCityReporterTest
     }
 
     #[Test]
+    public function zeroStringFailureMessagesRemainDistinctFromMissingDetails(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new TeamCityReporter($output);
+        $result = new TestResult(
+            new TestId('Acme\FailureTest', 'fails'),
+            Outcome::Failed,
+            0.001,
+            0,
+            failures: [new FailureDetail('0')],
+        );
+
+        $reporter->onEvent(new TestFinished($result, 1.0));
+
+        Expect::that($output->buffer())
+            ->because('a zero-string failure message MUST remain distinct from missing failure details')
+            ->toBe(
+                "##teamcity[testFailed name='Acme\FailureTest::fails' message='0' flowId='Acme\FailureTest']\n"
+                . "##teamcity[testFinished name='Acme\FailureTest::fails' duration='1' flowId='Acme\FailureTest']\n",
+            );
+    }
+
+    #[Test]
     public function incompleteAndMultipleFailureDetailsRemainReportable(): void
     {
         $output = new BufferOutput();

--- a/tests/Unit/Reporting/WorkerProfileZeroTimestampTest.php
+++ b/tests/Unit/Reporting/WorkerProfileZeroTimestampTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\WorkerProfile;
+
+final readonly class WorkerProfileZeroTimestampTest
+{
+    #[Test]
+    public function zeroLifecycleTimestampsRemainMeasured(): void
+    {
+        $profile = new WorkerProfile();
+        $profile->spawned(0.0);
+        $profile->classStarted(0.0);
+
+        Expect::that($profile->classFinished(0.5))
+            ->because('a zero class-start timestamp is known timing data')
+            ->toBe(0.5)
+            ->and($profile->busy)->toBe(0.5)
+            ->and($profile->bootLatency())->toBe(0.0)
+            ->and($profile->window())->toBe(0.5)
+            ->and($profile->utilizationPercent())->toBe(100);
+    }
+}

--- a/tests/Unit/Runner/Protocol/FrameMinimumSizeTest.php
+++ b/tests/Unit/Runner/Protocol/FrameMinimumSizeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Protocol;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\Protocol\FrameBuffer;
+use Greenlight\Runner\Protocol\JsonFrameCodec;
+
+final readonly class FrameMinimumSizeTest
+{
+    #[Test]
+    public function aOneByteFrameIsAValidProtocolLimit(): void
+    {
+        $codec = new JsonFrameCodec(1);
+        $buffer = new FrameBuffer(1);
+        $buffer->feed(\pack('N', 1) . 'x');
+
+        Expect::that($codec->maxFrameBytes)
+            ->because('the protocol MUST support the smallest valid frame')
+            ->toBe(1)
+            ->and($buffer->next())
+            ->toBe('x');
+    }
+}

--- a/tests/Unit/Symfony/SymfonyPluginInvalidKernelCacheTest.php
+++ b/tests/Unit/Symfony/SymfonyPluginInvalidKernelCacheTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Symfony;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Symfony\SymfonyBridgeError;
+use Greenlight\Symfony\SymfonyPlugin;
+use Greenlight\Tests\Fixture\Symfony\BareKernel;
+use Greenlight\Tests\Fixture\Symfony\Greeter;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+final class SymfonyPluginInvalidKernelCacheTest
+{
+    #[Test]
+    public function anInvalidKernelIsNotCached(): void
+    {
+        $factoryCalls = 0;
+        $plugin = new SymfonyPlugin(static function () use (&$factoryCalls): KernelInterface {
+            ++$factoryCalls;
+
+            return BareKernel::withoutTestContainer();
+        });
+        $resolve = static fn(): ?object => $plugin->resolve(Greeter::class, []);
+
+        Expect::that($resolve)
+            ->because('the first invalid kernel fails validation')
+            ->toThrow(SymfonyBridgeError::class, matching: '/without the Symfony test container/');
+        Expect::that($resolve)
+            ->because('a later resolution validates a new kernel')
+            ->toThrow(SymfonyBridgeError::class, matching: '/without the Symfony test container/');
+        Expect::that($factoryCalls)
+            ->because('an invalid kernel MUST NOT enter the plugin cache')
+            ->toBe(2);
+    }
+}


### PR DESCRIPTION
Integrate 96 focused coverage and correctness pull requests while preserving their individual commits. This pull request began as the timeout diagnostic fix and became the landing branch for the coverage campaign. A merge commit retains the component history that a squash would collapse.