### PR TITLE
test(reporting): retain zero makespan spread

### DIFF
--- a/tests/Unit/Reporting/ProfileZeroMakespanSpreadTest.php
+++ b/tests/Unit/Reporting/ProfileZeroMakespanSpreadTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\RunFinished;
+use Greenlight\Core\Event\RunStarted;
+use Greenlight\Core\Event\TestClassFinished;
+use Greenlight\Core\Event\TestClassStarted;
+use Greenlight\Core\Event\WorkerSpawned;
+use Greenlight\Core\Result\ResultSummary;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\ProfileAggregator;
+use Greenlight\Reporting\Style;
+
+final readonly class ProfileZeroMakespanSpreadTest
+{
+    #[Test]
+    public function simultaneousWorkerFinishesRetainAZeroMakespanSpread(): void
+    {
+        $aggregator = new ProfileAggregator();
+
+        foreach ([
+            new RunStarted('run-1', 2, 2, 100.0),
+            new WorkerSpawned('w-1', 1, 100.0),
+            new WorkerSpawned('w-2', 2, 100.0),
+            new TestClassStarted('Acme\FirstTest', 100.0, 'w-1'),
+            new TestClassStarted('Acme\SecondTest', 100.0, 'w-2'),
+            new TestClassFinished('Acme\FirstTest', 101.0, 'w-1'),
+            new TestClassFinished('Acme\SecondTest', 101.0, 'w-2'),
+            new RunFinished('run-1', new ResultSummary(passed: 2), 1.0, 101.0),
+        ] as $event) {
+            $aggregator->onEvent($event);
+        }
+
+        Expect::that($aggregator->render(new Style(ansi: false)))
+            ->because('zero makespan spread is measured and MUST NOT be treated as missing')
+            ->toContain(
+                'Makespan spread: 0.000s between first and last worker finish',
+            );
+    }
+}


### PR DESCRIPTION
Adds deterministic profile coverage for two workers that finish at the same timestamp. This proves a measured 0.000s makespan spread remains distinct from missing worker timing data.\n\nStacked on #846 because both changes cover falsey profile timing values.