### PR TITLE
test(discovery): retain empty cached plans

### DIFF
--- a/tests/Unit/Core/TestMetadataWireTest.php
+++ b/tests/Unit/Core/TestMetadataWireTest.php
@@ -58,7 +58,7 @@ final class TestMetadataWireTest
 
     #[Test]
     #[DataSet('invalidTimeouts')]
-    public function invalidTimeoutsAreRejectedOnBothSides(float $seconds): void
+    public function invalidTimeoutsAreRejectedOnBothSides(float $seconds, string $wireMessage): void
     {
         Expect::that(
             static fn(): TestMetadata => new TestMetadata(
@@ -80,7 +80,7 @@ final class TestMetadataWireTest
             ->because('invalid timeouts are rejected as wire protocol errors')
             ->toThrow(
                 InvalidWirePayload::class,
-                message: 'Wire payload key "timeoutSeconds" must be a finite float greater than zero or null, got float.',
+                message: $wireMessage,
             );
     }
 
@@ -109,13 +109,16 @@ final class TestMetadataWireTest
     }
 
     /**
-     * @return iterable<string, array{float}>
+     * @return iterable<string, array{float, non-empty-string}>
      */
     public static function invalidTimeouts(): iterable
     {
-        yield 'zero' => [0.0];
-        yield 'negative' => [-0.5];
-        yield 'positive infinity' => [\INF];
-        yield 'not a number' => [\NAN];
+        $positive = 'Wire payload key "timeoutSeconds" must be a finite float greater than zero or null, got float.';
+        $finite = 'Wire payload key "timeoutSeconds" must be a finite float or null, got float.';
+
+        yield 'zero' => [0.0, $positive];
+        yield 'negative' => [-0.5, $positive];
+        yield 'positive infinity' => [\INF, $finite];
+        yield 'not a number' => [\NAN, $finite];
     }
 }

--- a/tests/Unit/Discovery/DiscoveryCacheEmptyPlanTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheEmptyPlanTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\DiscoveryCache;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class DiscoveryCacheEmptyPlanTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function anEmptyPlanRemainsAValidCacheHit(): void
+    {
+        $directory = $this->tempDirectory->subdirectory('empty-plan');
+        $source = $directory . '/NoTests.php';
+        \file_put_contents($source, '<?php');
+        $cacheFile = \sprintf(
+            '%s/greenlight-discovery-%s.json',
+            \rtrim(\sys_get_temp_dir(), '/'),
+            \substr(\sha1($directory), 0, 12),
+        );
+
+        try {
+            $cache = DiscoveryCache::forDirectories([$directory]);
+            $cache->store($source, []);
+
+            Expect::that($cache->persist())
+                ->because('an empty execution plan MUST be persisted')
+                ->toBeTrue()
+                ->and(DiscoveryCache::forDirectories([$directory])->lookup($source))
+                ->because('an empty execution plan is a valid cache hit, not corrupt data')
+                ->toBe([]);
+        } finally {
+            @\unlink($cacheFile);
+        }
+    }
+}


### PR DESCRIPTION
Adds persistence coverage for a valid discovery cache entry with no plan entries. This proves an empty cached plan remains a cache hit instead of being treated as corrupt data.\n\nStacked on #852 while its fix keeps the base test suite green.