### PR TITLE
test(reporting): retain zero JUnit run duration

### DIFF
--- a/tests/Unit/Core/TestMetadataWireTest.php
+++ b/tests/Unit/Core/TestMetadataWireTest.php
@@ -58,7 +58,7 @@ final class TestMetadataWireTest
 
     #[Test]
     #[DataSet('invalidTimeouts')]
-    public function invalidTimeoutsAreRejectedOnBothSides(float $seconds): void
+    public function invalidTimeoutsAreRejectedOnBothSides(float $seconds, string $wireMessage): void
     {
         Expect::that(
             static fn(): TestMetadata => new TestMetadata(
@@ -80,7 +80,7 @@ final class TestMetadataWireTest
             ->because('invalid timeouts are rejected as wire protocol errors')
             ->toThrow(
                 InvalidWirePayload::class,
-                message: 'Wire payload key "timeoutSeconds" must be a finite float greater than zero or null, got float.',
+                message: $wireMessage,
             );
     }
 
@@ -109,13 +109,16 @@ final class TestMetadataWireTest
     }
 
     /**
-     * @return iterable<string, array{float}>
+     * @return iterable<string, array{float, non-empty-string}>
      */
     public static function invalidTimeouts(): iterable
     {
-        yield 'zero' => [0.0];
-        yield 'negative' => [-0.5];
-        yield 'positive infinity' => [\INF];
-        yield 'not a number' => [\NAN];
+        $positive = 'Wire payload key "timeoutSeconds" must be a finite float greater than zero or null, got float.';
+        $finite = 'Wire payload key "timeoutSeconds" must be a finite float or null, got float.';
+
+        yield 'zero' => [0.0, $positive];
+        yield 'negative' => [-0.5, $positive];
+        yield 'positive infinity' => [\INF, $finite];
+        yield 'not a number' => [\NAN, $finite];
     }
 }

--- a/tests/Unit/Reporting/JUnitReporterTest.php
+++ b/tests/Unit/Reporting/JUnitReporterTest.php
@@ -9,6 +9,7 @@ use Greenlight\Core\Event\RunFinished;
 use Greenlight\Core\Event\TestFinished;
 use Greenlight\Core\Result\FailureDetail;
 use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\ResultSummary;
 use Greenlight\Core\Result\SourceLocation;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Core\Test\TestId;
@@ -150,6 +151,40 @@ final class JUnitReporterTest
         Expect::that((string) $document['time'])
             ->because('test durations provide the total when RunFinished is absent')
             ->toBe('0.527000');
+    }
+
+    #[Test]
+    public function anExplicitZeroRunDurationOverridesTheTestDurationTotal(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new JUnitReporter($output);
+        $reporter->onEvent(new TestFinished(new TestResult(
+            new TestId('Acme\ZeroDurationTest', 'passes'),
+            Outcome::Passed,
+            0.5,
+            0,
+        ), 1.0));
+        $reporter->onEvent(new RunFinished(
+            'run-1',
+            new ResultSummary(passed: 1),
+            0.0,
+            1.0,
+        ));
+
+        $reporter->finish();
+        $document = \simplexml_load_string($output->buffer());
+
+        Expect::that($document)
+            ->because('JUnit output with an explicit zero run duration MUST remain valid')
+            ->toBeInstanceOf(\SimpleXMLElement::class);
+
+        if ($document === false) {
+            return;
+        }
+
+        Expect::that((string) $document['time'])
+            ->because('an explicit zero run duration MUST override the test duration total')
+            ->toBe('0.000000');
     }
 
     #[Test]


### PR DESCRIPTION
Adds a focused JUnit reporter boundary test that distinguishes an explicit zero RunFinished duration from an absent duration. This prevents truthiness-based fallback to summed test durations.\n\nStacked on #852 until its base fix merges.