### PR TITLE
fix(integrations): reject invalid fixture definitions

### DIFF
--- a/src/Runner/Integration/IntegrationFixtureManager.php
+++ b/src/Runner/Integration/IntegrationFixtureManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Runner\Integration;
 
 use Greenlight\Plugin\IntegrationFixtureDefinition;
+use Greenlight\Plugin\IntegrationFixtureProvider;
 use Greenlight\Plugin\PluginRegistry;
 
 /**
@@ -38,6 +39,8 @@ final class IntegrationFixtureManager
             } catch (\Throwable $failure) {
                 throw IntegrationFixtureError::provider($provider::class, $failure);
             }
+
+            $provided = self::validatedDefinitions($provider, $provided);
 
             foreach ($provided as $definition) {
                 if (isset($definitions[$definition->id])) {
@@ -81,6 +84,31 @@ final class IntegrationFixtureManager
         }
 
         return $session;
+    }
+
+    /**
+     * @param array<mixed> $provided
+     *
+     * @return list<IntegrationFixtureDefinition>
+     */
+    private static function validatedDefinitions(IntegrationFixtureProvider $provider, array $provided): array
+    {
+        $definitions = [];
+
+        foreach ($provided as $definition) {
+            if (!$definition instanceof IntegrationFixtureDefinition) {
+                throw new IntegrationFixtureError(\sprintf(
+                    'Integration fixture provider "%s" returned %s. '
+                    . 'It MUST return IntegrationFixtureDefinition instances.',
+                    $provider::class,
+                    \get_debug_type($definition),
+                ));
+            }
+
+            $definitions[] = $definition;
+        }
+
+        return $definitions;
     }
 
     /**

--- a/tests/Fixture/Plugins/FakeIntegrationFixtureProvider.php
+++ b/tests/Fixture/Plugins/FakeIntegrationFixtureProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Plugins;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Plugin\IntegrationFixtureDefinition;
+use Greenlight\Plugin\IntegrationFixtureProvider;
+
+final class FakeIntegrationFixtureProvider implements Fake, IntegrationFixtureProvider
+{
+    /**
+     * @param list<IntegrationFixtureDefinition> $definitions
+     */
+    public function __construct(private array $definitions) {}
+
+    #[\Override]
+    public function integrationFixtures(): array
+    {
+        return $this->definitions;
+    }
+}

--- a/tests/Unit/Runner/Integration/IntegrationFixtureManagerTest.php
+++ b/tests/Unit/Runner/Integration/IntegrationFixtureManagerTest.php
@@ -13,6 +13,7 @@ use Greenlight\Plugin\IntegrationFixtureProvider;
 use Greenlight\Plugin\PluginRegistry;
 use Greenlight\Runner\Integration\IntegrationFixtureError;
 use Greenlight\Runner\Integration\IntegrationFixtureManager;
+use Greenlight\Tests\Fixture\Plugins\FakeIntegrationFixtureProvider;
 
 final class IntegrationFixtureManagerTest
 {
@@ -205,6 +206,28 @@ final class IntegrationFixtureManagerTest
             1,
             null,
         ))->toThrow(IntegrationFixtureError::class, matching: '/provider.*provider exploded/');
+    }
+
+    #[Test]
+    public function invalidProviderEntriesAreRejectedAtThePluginBoundary(): void
+    {
+        $provider = new FakeIntegrationFixtureProvider([]);
+        new \ReflectionProperty($provider, 'definitions')->setValue($provider, [new \stdClass()]);
+
+        Expect::that(fn() => IntegrationFixtureManager::provision(
+            PluginRegistry::orchestratorSide([$provider]),
+            'run-8',
+            1,
+            1,
+            null,
+        ))
+            ->because('integration fixture providers MUST return fixture definitions')
+            ->toThrow(
+                IntegrationFixtureError::class,
+                message: 'Integration fixture provider "'
+                    . FakeIntegrationFixtureProvider::class
+                    . '" returned stdClass. It MUST return IntegrationFixtureDefinition instances.',
+            );
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- validate every integration fixture provider entry at the plugin boundary
- replace undefined-property warnings and a leaked type error with an exact IntegrationFixtureError
- cover the runtime contract with a reusable Fake-aware provider fixture

Stacks on #851, which stacks on #15.