### PR TITLE
test(runner): cover socket listener failures

### DIFF
--- a/src/Runner/Orchestrator/NativeServerSocketRuntime.php
+++ b/src/Runner/Orchestrator/NativeServerSocketRuntime.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Runner\Orchestrator;
+
+/** @internal */
+final readonly class NativeServerSocketRuntime implements ServerSocketRuntime
+{
+    #[\Override]
+    public function listen(string $address, ?string &$errorMessage)
+    {
+        $errorCode = 0;
+
+        return \stream_socket_server($address, $errorCode, $errorMessage);
+    }
+
+    #[\Override]
+    public function name($server): string|false
+    {
+        return \stream_socket_get_name($server, false);
+    }
+}

--- a/src/Runner/Orchestrator/ServerSocket.php
+++ b/src/Runner/Orchestrator/ServerSocket.php
@@ -24,35 +24,43 @@ final class ServerSocket
         private readonly ?string $unixPath,
     ) {}
 
-    public static function listen(?string $temporaryDirectory = null): self
-    {
+    public static function listen(
+        ?string $temporaryDirectory = null,
+        ?ServerSocketRuntime $runtime = null,
+    ): self {
         $temporaryDirectory ??= \sys_get_temp_dir();
+        $runtime ??= new NativeServerSocketRuntime();
         $socketPath = \rtrim($temporaryDirectory, '/')
             . '/greenlight-' . \bin2hex(\random_bytes(6)) . '/orchestrator.sock';
+        $errorMessage = null;
 
-        $server = ErrorTrap::run(static function () use ($socketPath) {
+        $server = ErrorTrap::run(static function () use ($runtime, $socketPath, &$errorMessage) {
             \mkdir(\dirname($socketPath), 0o700, true);
 
-            return \stream_socket_server('unix://' . $socketPath, $errorCode, $errorMessage);
+            return $runtime->listen('unix://' . $socketPath, $errorMessage);
         });
 
         if (\is_resource($server)) {
             return new self($server, 'unix://' . $socketPath, $socketPath);
         }
 
-        $server = ErrorTrap::run(static function () use (&$errorCode, &$errorMessage) {
-            return \stream_socket_server('tcp://127.0.0.1:0', $errorCode, $errorMessage);
+        ErrorTrap::run(static fn(): bool => \rmdir(\dirname($socketPath)));
+
+        $server = ErrorTrap::run(static function () use ($runtime, &$errorMessage) {
+            return $runtime->listen('tcp://127.0.0.1:0', $errorMessage);
         });
 
         if (!\is_resource($server)) {
             throw ProtocolError::malformedFrame(
-                'Greenlight did not open an orchestrator socket: ' . $errorMessage,
+                'Greenlight did not open an orchestrator socket: ' . ($errorMessage ?? 'unknown error'),
             );
         }
 
-        $name = \stream_socket_get_name($server, false);
+        $name = $runtime->name($server);
 
         if ($name === false || $name === '') {
+            ErrorTrap::run(static fn(): bool => \fclose($server));
+
             throw ProtocolError::malformedFrame(
                 'Greenlight did not resolve the orchestrator socket address',
             );

--- a/src/Runner/Orchestrator/ServerSocketRuntime.php
+++ b/src/Runner/Orchestrator/ServerSocketRuntime.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Runner\Orchestrator;
+
+/**
+ * Supplies native stream operations to the orchestrator listener.
+ *
+ * @internal
+ */
+interface ServerSocketRuntime
+{
+    /**
+     * @param-out string|null $errorMessage
+     *
+     * @return resource|false
+     */
+    public function listen(string $address, ?string &$errorMessage);
+
+    /**
+     * @param resource $server
+     */
+    public function name($server): string|false;
+}

--- a/tests/Fixture/Runner/Orchestrator/ControlledServerSocketRuntime.php
+++ b/tests/Fixture/Runner/Orchestrator/ControlledServerSocketRuntime.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Runner\Orchestrator;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Runner\Orchestrator\ServerSocketRuntime;
+
+final class ControlledServerSocketRuntime implements Fake, ServerSocketRuntime
+{
+    /** @var resource|null */
+    private $tcpServer = null;
+
+    private ?string $unixAddress = null;
+
+    public function __construct(
+        private readonly bool $tcpOpens,
+        private readonly string|false $tcpName = false,
+    ) {}
+
+    #[\Override]
+    public function listen(string $address, ?string &$errorMessage)
+    {
+        if (\str_starts_with($address, 'unix://')) {
+            $this->unixAddress = $address;
+            $errorMessage = 'the fixture rejected the Unix listener';
+
+            return false;
+        }
+
+        if (!$this->tcpOpens) {
+            $errorMessage = 'the fixture rejected the TCP listener';
+
+            return false;
+        }
+
+        $server = \fopen('php://temp', 'r+');
+
+        if (!\is_resource($server)) {
+            throw new \RuntimeException('The controlled socket runtime did not create its TCP stream.');
+        }
+
+        return $this->tcpServer = $server;
+    }
+
+    #[\Override]
+    public function name($server): string|false
+    {
+        return $this->tcpName;
+    }
+
+    public function tcpServerIsOpen(): bool
+    {
+        return \is_resource($this->tcpServer);
+    }
+
+    public function unixDirectoryExists(): bool
+    {
+        return $this->unixAddress !== null
+            && \is_dir(\dirname(\substr($this->unixAddress, \strlen('unix://'))));
+    }
+}

--- a/tests/Unit/Runner/Orchestrator/ServerSocketFailureTest.php
+++ b/tests/Unit/Runner/Orchestrator/ServerSocketFailureTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Orchestrator;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\Orchestrator\ServerSocket;
+use Greenlight\Runner\Protocol\ProtocolError;
+use Greenlight\Tests\Fixture\Runner\Orchestrator\ControlledServerSocketRuntime;
+
+final readonly class ServerSocketFailureTest
+{
+    #[Test]
+    public function failureOfBothTransportsReportsTheTcpDiagnostic(): void
+    {
+        $runtime = new ControlledServerSocketRuntime(tcpOpens: false);
+
+        Expect::that(static fn(): ServerSocket => ServerSocket::listen('/tmp', $runtime))
+            ->because('failure of both listener transports MUST report the TCP failure')
+            ->toThrow(
+                ProtocolError::class,
+                message: 'Malformed frame: Greenlight did not open an orchestrator socket: '
+                    . 'the fixture rejected the TCP listener.',
+            );
+        Expect::that($runtime->unixDirectoryExists())
+            ->because('a failed Unix listener MUST remove its generated directory')
+            ->toBeFalse();
+    }
+
+    #[Test]
+    public function unresolvedTcpAddressClosesTheListener(): void
+    {
+        $runtime = new ControlledServerSocketRuntime(tcpOpens: true);
+
+        Expect::that(static fn(): ServerSocket => ServerSocket::listen('/tmp', $runtime))
+            ->because('an unresolved listener address MUST reject the listener')
+            ->toThrow(
+                ProtocolError::class,
+                message: 'Malformed frame: Greenlight did not resolve the orchestrator socket address.',
+            );
+        Expect::that($runtime->tcpServerIsOpen())
+            ->because('an unresolved listener address MUST close its stream')
+            ->toBeFalse();
+    }
+}


### PR DESCRIPTION
Adds an internal runtime seam to exercise transport-open and address-resolution failures deterministically. The focused coverage pins the exact protocol diagnostics and verifies cleanup of failed Unix directories and unresolved TCP listener streams.