### PR TITLE
test(reporting): retain zero TeamCity skip reason

### DIFF
--- a/tests/Unit/Reporting/TeamCityReasonlessSkipTest.php
+++ b/tests/Unit/Reporting/TeamCityReasonlessSkipTest.php
@@ -35,4 +35,27 @@ final class TeamCityReasonlessSkipTest
                 . "##teamcity[testFinished name='Acme\\NetworkTest::pings' duration='0' flowId='Acme\\NetworkTest']\n",
             );
     }
+
+    #[Test]
+    public function zeroStringSkipReasonsRemainDistinctFromNoReason(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new TeamCityReporter($output);
+        $result = new TestResult(
+            new TestId('Acme\NetworkTest', 'pings'),
+            Outcome::Skipped,
+            0.0,
+            0,
+            skipReason: '0',
+        );
+
+        $reporter->onEvent(new TestFinished($result, 1.0));
+
+        Expect::that($output->buffer())
+            ->because('a zero-string skip reason MUST remain distinct from a missing reason')
+            ->toBe(
+                "##teamcity[testIgnored name='Acme\\NetworkTest::pings' message='0' flowId='Acme\\NetworkTest']\n"
+                . "##teamcity[testFinished name='Acme\\NetworkTest::pings' duration='0' flowId='Acme\\NetworkTest']\n",
+            );
+    }
 }


### PR DESCRIPTION
Adds a focused TeamCity reporter boundary test that distinguishes the valid skip reason 0 from an absent reason. This prevents truthiness-based fallback to the generic skipped message.\n\nStacked on #852 until its base fix merges.