### PR TITLE
test(reporting): retain zero skip reasons

### DIFF
--- a/tests/Unit/Reporting/SummaryFormatTest.php
+++ b/tests/Unit/Reporting/SummaryFormatTest.php
@@ -63,6 +63,21 @@ final class SummaryFormatTest
     }
 
     #[Test]
+    public function zeroStringSkipReasonsRemainDistinctFromNoReason(): void
+    {
+        $block = SummaryFormat::skipped([
+            $this->skip('App\AlphaTest::one', '0'),
+        ], new Style(ansi: false));
+
+        Expect::that($block)
+            ->because('a zero-string skip reason MUST remain distinct from a missing reason')
+            ->toBe(
+                "\nSkipped:\n"
+                . "  App\AlphaTest::one (0)\n",
+            );
+    }
+
+    #[Test]
     public function sharedReasonsGroupWithACap(): void
     {
         $results = [];


### PR DESCRIPTION
Adds a focused skipped-summary boundary test that distinguishes the valid skip reason 0 from an absent reason. This prevents truthiness-based fallback to the generic no-reason text.\n\nStacked on #852 until its base fix merges.