### PR TITLE
test(reporting): retain zero TeamCity failure message

### DIFF
--- a/tests/Unit/Reporting/TeamCityReasonlessSkipTest.php
+++ b/tests/Unit/Reporting/TeamCityReasonlessSkipTest.php
@@ -35,4 +35,27 @@ final class TeamCityReasonlessSkipTest
                 . "##teamcity[testFinished name='Acme\\NetworkTest::pings' duration='0' flowId='Acme\\NetworkTest']\n",
             );
     }
+
+    #[Test]
+    public function zeroStringSkipReasonsRemainDistinctFromNoReason(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new TeamCityReporter($output);
+        $result = new TestResult(
+            new TestId('Acme\NetworkTest', 'pings'),
+            Outcome::Skipped,
+            0.0,
+            0,
+            skipReason: '0',
+        );
+
+        $reporter->onEvent(new TestFinished($result, 1.0));
+
+        Expect::that($output->buffer())
+            ->because('a zero-string skip reason MUST remain distinct from a missing reason')
+            ->toBe(
+                "##teamcity[testIgnored name='Acme\\NetworkTest::pings' message='0' flowId='Acme\\NetworkTest']\n"
+                . "##teamcity[testFinished name='Acme\\NetworkTest::pings' duration='0' flowId='Acme\\NetworkTest']\n",
+            );
+    }
 }

--- a/tests/Unit/Reporting/TeamCityReporterTest.php
+++ b/tests/Unit/Reporting/TeamCityReporterTest.php
@@ -74,6 +74,29 @@ final class TeamCityReporterTest
     }
 
     #[Test]
+    public function zeroStringFailureMessagesRemainDistinctFromMissingDetails(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new TeamCityReporter($output);
+        $result = new TestResult(
+            new TestId('Acme\FailureTest', 'fails'),
+            Outcome::Failed,
+            0.001,
+            0,
+            failures: [new FailureDetail('0')],
+        );
+
+        $reporter->onEvent(new TestFinished($result, 1.0));
+
+        Expect::that($output->buffer())
+            ->because('a zero-string failure message MUST remain distinct from missing failure details')
+            ->toBe(
+                "##teamcity[testFailed name='Acme\FailureTest::fails' message='0' flowId='Acme\FailureTest']\n"
+                . "##teamcity[testFinished name='Acme\FailureTest::fails' duration='1' flowId='Acme\FailureTest']\n",
+            );
+    }
+
+    #[Test]
     public function incompleteAndMultipleFailureDetailsRemainReportable(): void
     {
         $output = new BufferOutput();


### PR DESCRIPTION
Adds a focused TeamCity reporter boundary test that distinguishes the valid failure message 0 from absent failure details. This prevents truthiness-based fallback to the generic failed message.\n\nStacked on #861 to keep the nearby TeamCity reporter coverage changes ordered.