### PR TITLE
test(harness): cover integer float access

### DIFF
--- a/tests/Unit/Harness/FixtureResourceFloatTest.php
+++ b/tests/Unit/Harness/FixtureResourceFloatTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Harness;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Harness\FixtureResource;
+
+final readonly class FixtureResourceFloatTest
+{
+    #[Test]
+    public function floatAccessNormalizesIntegerValues(): void
+    {
+        $resource = FixtureResource::from(['ratio' => 42]);
+
+        Expect::that($resource->float('ratio'))
+            ->because('float fixture access MUST normalize integer values')
+            ->toBe(42.0);
+    }
+}


### PR DESCRIPTION
## Summary

- cover integer values through the fixture float accessor
- assert strict normalization to a float result