### PR TITLE
test(reporting): cover missing XMLWriter

### DIFF
--- a/src/Reporting/JUnitReporter.php
+++ b/src/Reporting/JUnitReporter.php
@@ -40,7 +40,14 @@ final class JUnitReporter implements Reporter
 
     private ?float $runDurationSeconds = null;
 
-    public function __construct(private readonly Output $output) {}
+    private readonly XmlWriterRuntime $xmlWriter;
+
+    public function __construct(
+        private readonly Output $output,
+        ?XmlWriterRuntime $xmlWriter = null,
+    ) {
+        $this->xmlWriter = $xmlWriter ?? new NativeXmlWriterRuntime();
+    }
 
     #[\Override]
     public function onEvent(Event $event): void
@@ -75,7 +82,7 @@ final class JUnitReporter implements Reporter
     #[\Override]
     public function finish(): void
     {
-        if (!\class_exists(\XMLWriter::class)) {
+        if (!$this->xmlWriter->isAvailable()) {
             throw ReportingError::xmlUnavailable();
         }
 
@@ -130,11 +137,11 @@ final class JUnitReporter implements Reporter
 
     private function renderCase(TestResult $result): string
     {
-        if (!\class_exists(\XMLWriter::class)) {
+        if (!$this->xmlWriter->isAvailable()) {
             throw ReportingError::xmlUnavailable();
         }
 
-        $writer = new \XMLWriter();
+        $writer = $this->xmlWriter->create();
         $writer->openMemory();
         $writer->setIndent(true);
         $writer->setIndentString('  ');

--- a/src/Reporting/NativeXmlWriterRuntime.php
+++ b/src/Reporting/NativeXmlWriterRuntime.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Reporting;
+
+/** @internal */
+final readonly class NativeXmlWriterRuntime implements XmlWriterRuntime
+{
+    #[\Override]
+    public function isAvailable(): bool
+    {
+        return \class_exists(\XMLWriter::class);
+    }
+
+    #[\Override]
+    public function create(): \XMLWriter
+    {
+        return new \XMLWriter();
+    }
+}

--- a/src/Reporting/XmlWriterRuntime.php
+++ b/src/Reporting/XmlWriterRuntime.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Reporting;
+
+/**
+ * Supplies XMLWriter availability and instances to XML reporters.
+ *
+ * @internal
+ */
+interface XmlWriterRuntime
+{
+    public function isAvailable(): bool;
+
+    public function create(): \XMLWriter;
+}

--- a/tests/Fixture/Reporting/UnavailableXmlWriterRuntime.php
+++ b/tests/Fixture/Reporting/UnavailableXmlWriterRuntime.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Reporting;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Reporting\XmlWriterRuntime;
+
+final readonly class UnavailableXmlWriterRuntime implements Fake, XmlWriterRuntime
+{
+    #[\Override]
+    public function isAvailable(): bool
+    {
+        return false;
+    }
+
+    #[\Override]
+    public function create(): \XMLWriter
+    {
+        throw new \RuntimeException('The unavailable XMLWriter runtime MUST NOT create a writer.');
+    }
+}

--- a/tests/Unit/Reporting/JUnitXmlWriterRequirementTest.php
+++ b/tests/Unit/Reporting/JUnitXmlWriterRequirementTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\TestFinished;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\JUnitReporter;
+use Greenlight\Reporting\ReportingError;
+use Greenlight\Tests\Fixture\Reporting\UnavailableXmlWriterRuntime;
+
+final readonly class JUnitXmlWriterRequirementTest
+{
+    #[Test]
+    public function finishingWithoutXmlWriterFailsExactly(): void
+    {
+        $reporter = new JUnitReporter(new BufferOutput(), new UnavailableXmlWriterRuntime());
+
+        Expect::that(static fn() => $reporter->finish())
+            ->because('finishing JUnit output MUST require XMLWriter')
+            ->toThrow(
+                ReportingError::class,
+                message: 'The XMLWriter extension is required for JUnit output. Enable ext-xmlwriter.',
+            );
+    }
+
+    #[Test]
+    public function renderingATestCaseWithoutXmlWriterFailsExactly(): void
+    {
+        $reporter = new JUnitReporter(new BufferOutput(), new UnavailableXmlWriterRuntime());
+        $result = new TestResult(
+            new TestId('Example\PassingTest', 'passes'),
+            Outcome::Passed,
+            0.0,
+            0,
+        );
+
+        Expect::that(static fn() => $reporter->onEvent(new TestFinished($result, 1.0)))
+            ->because('rendering a JUnit test case MUST require XMLWriter')
+            ->toThrow(
+                ReportingError::class,
+                message: 'The XMLWriter extension is required for JUnit output. Enable ext-xmlwriter.',
+            );
+    }
+}


### PR DESCRIPTION
Adds an internal XMLWriter runtime seam so the JUnit extension boundary can be exercised deterministically. Exact tests pin the same ReportingError for empty completion and test-case rendering, while existing JUnit output continues through the native runtime.