### PR TITLE
fix(runner): skip empty-plan worker setup

### DIFF
--- a/src/Runner/InProcessRunner.php
+++ b/src/Runner/InProcessRunner.php
@@ -8,6 +8,7 @@ use Greenlight\Config\Configuration;
 use Greenlight\Core\Event\RunFinished;
 use Greenlight\Core\Event\RunStarted;
 use Greenlight\Core\GracefulShutdown;
+use Greenlight\Core\Result\ResultSummary;
 use Greenlight\Core\Result\ThrowableDetail;
 use Greenlight\Core\Test\TestChannel;
 use Greenlight\Discovery\DiscoveryCache;
@@ -20,7 +21,6 @@ use Greenlight\Runner\Artifact\ArtifactStore;
 use Greenlight\Runner\Artifact\PublishingEventSink;
 use Greenlight\Runner\Integration\IntegrationFixtureError;
 use Greenlight\Runner\Integration\IntegrationFixtureManager;
-use Greenlight\Runner\Integration\ProvisionedIntegrationFixtures;
 use Greenlight\Runner\Protocol\ProtocolError;
 use Greenlight\Runner\Worker\EventSink;
 use Greenlight\Runner\Worker\LeakDetector;
@@ -80,9 +80,17 @@ final readonly class InProcessRunner
             }
 
             $sink = new PublishingEventSink($artifactStore, $sink);
-            $fixtures = \count($plan) === 0
-                ? new ProvisionedIntegrationFixtures()
-                : IntegrationFixtureManager::provision($orchestratorSide, $runId, 1, 1, $configuration->shard);
+
+            if (\count($plan) === 0) {
+                $sink->emit(new RunStarted($runId, 0, 1, \microtime(true), $artifactStore->publicDirectory()));
+                $durationSeconds = (\hrtime(true) - $startedAt) / 1_000_000_000;
+                $summary = new ResultSummary();
+                $sink->emit(new RunFinished($runId, $summary, $durationSeconds, \microtime(true)));
+
+                return new RunResult($summary, 0, $durationSeconds, $seed);
+            }
+
+            $fixtures = IntegrationFixtureManager::provision($orchestratorSide, $runId, 1, 1, $configuration->shard);
             $collector = null;
             $collectingCoverage = false;
 

--- a/tests/Acceptance/IntegrationFixtureRunTest.php
+++ b/tests/Acceptance/IntegrationFixtureRunTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Acceptance;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -62,6 +63,25 @@ final readonly class IntegrationFixtureRunTest
         Expect::that($dryRun->exitCode)->toBe(0);
         Expect::that(\is_file($project->path('markers/provisioned.log')))->toBeFalse();
         Expect::that(\is_file($project->path('markers/cleaned.log')))->toBeFalse();
+    }
+
+    #[Test]
+    #[DataSet('runnerWorkerCounts')]
+    public function filteredEmptyPlansDoNotProvisionInfrastructure(int $workers): void
+    {
+        $project = $this->writeProject('empty-plan-' . $workers, workers: $workers);
+        $result = GreenlightCli::run($project->directory, ['run', '--filter=MissingTest', '--no-ansi']);
+
+        Expect::that($result->exitCode)
+            ->because('a filtered empty plan MUST use the no-tests exit')
+            ->toBe(1);
+        Expect::that($result->output())->toContain('Greenlight found no tests.');
+        Expect::that(\is_file($project->path('markers/provisioned.log')))
+            ->because('a filtered empty plan MUST NOT provision integration fixtures')
+            ->toBeFalse();
+        Expect::that(\is_file($project->path('markers/cleaned.log')))
+            ->because('an unprovisioned fixture graph has no cleanup to run')
+            ->toBeFalse();
     }
 
     #[Test]
@@ -140,6 +160,15 @@ final readonly class IntegrationFixtureRunTest
         Expect::that(\is_file($project->path('markers/executed.log')))->toBeFalse();
         Expect::that($this->matches($project->path('markers/resource-*')))->toBe([]);
         Expect::that($this->lines($project->path('markers/cleaned.log')))->toBe(['cleaned']);
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function runnerWorkerCounts(): iterable
+    {
+        yield 'in-process runner' => [1];
+        yield 'parallel runner' => [2];
     }
 
     /**


### PR DESCRIPTION
## Summary

- return an empty in-process run before worker bootstrap and harness-service setup
- keep filtered empty plans from provisioning or cleaning integration fixtures
- cover in-process and parallel runners with named acceptance rows