### PR TITLE
test(discovery): retain zero unreadable reasons

### DIFF
--- a/tests/Unit/Discovery/DiscoveryErrorTest.php
+++ b/tests/Unit/Discovery/DiscoveryErrorTest.php
@@ -47,6 +47,14 @@ final class DiscoveryErrorTest
     }
 
     #[Test]
+    public function unreadableFilesPreserveAZeroStringReason(): void
+    {
+        Expect::that(DiscoveryError::unreadableFile('/project/tests/ExampleTest.php', '0')->getMessage())
+            ->because('an unreadable-file diagnostic MUST preserve a zero-string reason')
+            ->toBe('Greenlight cannot read test file "/project/tests/ExampleTest.php": 0.');
+    }
+
+    #[Test]
     public function dataProviderErrorsGiveExactGuidance(): void
     {
         $cause = new \RuntimeException('provider failed');


### PR DESCRIPTION
Adds a focused unreadable-file diagnostic boundary test that distinguishes the valid reason 0 from an absent reason. This prevents truthiness-based formatting from silently dropping discovery context.\n\nStacked on #852 until its base fix merges.