### PR TITLE
fix(coverage): close failed Xdebug windows

### DIFF
--- a/src/Coverage/Driver/XdebugDriver.php
+++ b/src/Coverage/Driver/XdebugDriver.php
@@ -22,8 +22,10 @@ final class XdebugDriver implements CoverageDriver
 
     private readonly XdebugRuntime $runtime;
 
-    public function __construct(?XdebugRuntime $runtime = null)
-    {
+    public function __construct(
+        ?XdebugRuntime $runtime = null,
+        private readonly ?int $flags = null,
+    ) {
         if (!$runtime instanceof XdebugRuntime && !self::isAvailable()) {
             throw CoverageError::driverUnavailable('xdebug', 'Enable the Xdebug extension. Add "coverage" to xdebug.mode or the XDEBUG_MODE environment variable.');
         }
@@ -44,7 +46,7 @@ final class XdebugDriver implements CoverageDriver
             throw new \LogicException('The Xdebug collection window is already open. Call stop() before start().');
         }
 
-        $this->runtime->start(\XDEBUG_CC_UNUSED | \XDEBUG_CC_DEAD_CODE);
+        $this->runtime->start($this->flags ?? \XDEBUG_CC_UNUSED | \XDEBUG_CC_DEAD_CODE);
         $this->collecting = true;
     }
 

--- a/src/Coverage/Driver/XdebugDriver.php
+++ b/src/Coverage/Driver/XdebugDriver.php
@@ -55,9 +55,15 @@ final class XdebugDriver implements CoverageDriver
             throw new \LogicException('The Xdebug collection window is not open. Call start() before stop().');
         }
 
-        $collected = $this->runtime->collect();
-        $this->runtime->stop();
-        $this->collecting = false;
+        try {
+            $collected = $this->runtime->collect();
+        } finally {
+            try {
+                $this->runtime->stop();
+            } finally {
+                $this->collecting = false;
+            }
+        }
 
         return new RawCoverage($this->normalize($collected));
     }

--- a/tests/Fixture/Coverage/FailingXdebugRuntime.php
+++ b/tests/Fixture/Coverage/FailingXdebugRuntime.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Coverage;
+
+use Greenlight\Coverage\Driver\XdebugRuntime;
+use Greenlight\Doubles\Fake;
+
+final class FailingXdebugRuntime implements Fake, XdebugRuntime
+{
+    /**
+     * @var list<string>
+     */
+    public array $calls = [];
+
+    public ?\Throwable $collectFailure = null;
+
+    public ?\Throwable $stopFailure = null;
+
+    #[\Override]
+    public function start(int $flags): void
+    {
+        $this->calls[] = 'start';
+    }
+
+    /**
+     * @return array<string, array<int, int>>
+     */
+    #[\Override]
+    public function collect(): array
+    {
+        $this->calls[] = 'collect';
+
+        if ($this->collectFailure instanceof \Throwable) {
+            throw $this->collectFailure;
+        }
+
+        return ['/src/Example.php' => [10 => 1]];
+    }
+
+    #[\Override]
+    public function stop(): void
+    {
+        $this->calls[] = 'stop';
+
+        if ($this->stopFailure instanceof \Throwable) {
+            throw $this->stopFailure;
+        }
+    }
+}

--- a/tests/Fixture/Coverage/StartFailingXdebugRuntime.php
+++ b/tests/Fixture/Coverage/StartFailingXdebugRuntime.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Coverage;
+
+use Greenlight\Coverage\Driver\XdebugRuntime;
+use Greenlight\Doubles\Fake;
+
+final class StartFailingXdebugRuntime implements Fake, XdebugRuntime
+{
+    /**
+     * @var list<string>
+     */
+    public array $calls = [];
+
+    #[\Override]
+    public function start(int $flags): void
+    {
+        $this->calls[] = 'start';
+
+        throw new \RuntimeException('Xdebug start failed.');
+    }
+
+    #[\Override]
+    public function collect(): array
+    {
+        $this->calls[] = 'collect';
+
+        return [];
+    }
+
+    #[\Override]
+    public function stop(): void
+    {
+        $this->calls[] = 'stop';
+    }
+}

--- a/tests/Fixture/Coverage/StartFailingXdebugRuntime.php
+++ b/tests/Fixture/Coverage/StartFailingXdebugRuntime.php
@@ -14,12 +14,14 @@ final class StartFailingXdebugRuntime implements Fake, XdebugRuntime
      */
     public array $calls = [];
 
+    public function __construct(private readonly \RuntimeException $failure) {}
+
     #[\Override]
     public function start(int $flags): void
     {
         $this->calls[] = 'start';
 
-        throw new \RuntimeException('Xdebug start failed.');
+        throw $this->failure;
     }
 
     #[\Override]

--- a/tests/Unit/Coverage/XdebugDriverFailureTest.php
+++ b/tests/Unit/Coverage/XdebugDriverFailureTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Coverage;
 
 use Greenlight\Attribute\DataSet;
-use Greenlight\Attribute\Isolated;
 use Greenlight\Attribute\Test;
 use Greenlight\Coverage\Driver\XdebugDriver;
 use Greenlight\Expect\Expect;
@@ -17,20 +16,11 @@ final readonly class XdebugDriverFailureTest
      * @param 'collect'|'stop' $operation
      */
     #[Test]
-    #[Isolated]
     #[DataSet('runtimeFailures')]
     public function runtimeFailuresStopAndCloseTheCollectionWindow(
         string $operation,
         string $message,
     ): void {
-        if (!\defined('XDEBUG_CC_UNUSED')) {
-            \define('XDEBUG_CC_UNUSED', 1);
-        }
-
-        if (!\defined('XDEBUG_CC_DEAD_CODE')) {
-            \define('XDEBUG_CC_DEAD_CODE', 2);
-        }
-
         $runtime = new FailingXdebugRuntime();
 
         if ($operation === 'collect') {
@@ -39,7 +29,7 @@ final readonly class XdebugDriverFailureTest
             $runtime->stopFailure = new \RuntimeException($message);
         }
 
-        $driver = new XdebugDriver($runtime);
+        $driver = new XdebugDriver($runtime, flags: 3);
         $driver->start();
 
         Expect::that(static fn(): mixed => $driver->stop())

--- a/tests/Unit/Coverage/XdebugDriverFailureTest.php
+++ b/tests/Unit/Coverage/XdebugDriverFailureTest.php
@@ -22,11 +22,12 @@ final readonly class XdebugDriverFailureTest
         string $message,
     ): void {
         $runtime = new FailingXdebugRuntime();
+        $failure = new \RuntimeException($message);
 
         if ($operation === 'collect') {
-            $runtime->collectFailure = new \RuntimeException($message);
+            $runtime->collectFailure = $failure;
         } else {
-            $runtime->stopFailure = new \RuntimeException($message);
+            $runtime->stopFailure = $failure;
         }
 
         $driver = new XdebugDriver($runtime, flags: 3);
@@ -34,16 +35,46 @@ final readonly class XdebugDriverFailureTest
 
         Expect::that(static fn(): mixed => $driver->stop())
             ->because('an Xdebug runtime failure MUST remain the reported failure')
-            ->toThrow(
-                \RuntimeException::class,
-                message: $message,
-            )
-            ->and($runtime->calls)
+            ->toThrow(static function (\RuntimeException $caught) use ($failure): void {
+                Expect::that($caught)->toBe($failure);
+            });
+
+        Expect::that($runtime->calls)
             ->because('Xdebug collection MUST stop the runtime after every collection attempt')
             ->toBe(['start', 'collect', 'stop']);
 
         Expect::that(static fn(): mixed => $driver->stop())
             ->because('an Xdebug runtime failure MUST close the collection window')
+            ->toThrow(
+                \LogicException::class,
+                message: 'The Xdebug collection window is not open. Call start() before stop().',
+            );
+    }
+
+    #[Test]
+    public function aStopFailureRetainsTheCollectionFailureAsItsCause(): void
+    {
+        $runtime = new FailingXdebugRuntime();
+        $collectionFailure = new \RuntimeException('Xdebug collection failed.');
+        $stopFailure = new \RuntimeException('Xdebug stop failed.');
+        $runtime->collectFailure = $collectionFailure;
+        $runtime->stopFailure = $stopFailure;
+        $driver = new XdebugDriver($runtime, flags: 3);
+        $driver->start();
+
+        Expect::that(static fn(): mixed => $driver->stop())
+            ->because('an Xdebug stop failure MUST retain the collection failure as its cause')
+            ->toThrow(static function (\RuntimeException $caught) use ($collectionFailure, $stopFailure): void {
+                Expect::that($caught)->toBe($stopFailure);
+                Expect::that($caught->getPrevious())->toBe($collectionFailure);
+            });
+
+        Expect::that($runtime->calls)
+            ->because('Xdebug collection MUST still stop the runtime after collection fails')
+            ->toBe(['start', 'collect', 'stop']);
+
+        Expect::that(static fn(): mixed => $driver->stop())
+            ->because('combined Xdebug runtime failures MUST close the collection window')
             ->toThrow(
                 \LogicException::class,
                 message: 'The Xdebug collection window is not open. Call start() before stop().',

--- a/tests/Unit/Coverage/XdebugDriverFailureTest.php
+++ b/tests/Unit/Coverage/XdebugDriverFailureTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Isolated;
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\Driver\XdebugDriver;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Coverage\FailingXdebugRuntime;
+
+final readonly class XdebugDriverFailureTest
+{
+    /**
+     * @param 'collect'|'stop' $operation
+     */
+    #[Test]
+    #[Isolated]
+    #[DataSet('runtimeFailures')]
+    public function runtimeFailuresStopAndCloseTheCollectionWindow(
+        string $operation,
+        string $message,
+    ): void {
+        if (!\defined('XDEBUG_CC_UNUSED')) {
+            \define('XDEBUG_CC_UNUSED', 1);
+        }
+
+        if (!\defined('XDEBUG_CC_DEAD_CODE')) {
+            \define('XDEBUG_CC_DEAD_CODE', 2);
+        }
+
+        $runtime = new FailingXdebugRuntime();
+
+        if ($operation === 'collect') {
+            $runtime->collectFailure = new \RuntimeException($message);
+        } else {
+            $runtime->stopFailure = new \RuntimeException($message);
+        }
+
+        $driver = new XdebugDriver($runtime);
+        $driver->start();
+
+        Expect::that(static fn(): mixed => $driver->stop())
+            ->because('an Xdebug runtime failure MUST remain the reported failure')
+            ->toThrow(
+                \RuntimeException::class,
+                message: $message,
+            )
+            ->and($runtime->calls)
+            ->because('Xdebug collection MUST stop the runtime after every collection attempt')
+            ->toBe(['start', 'collect', 'stop']);
+
+        Expect::that(static fn(): mixed => $driver->stop())
+            ->because('an Xdebug runtime failure MUST close the collection window')
+            ->toThrow(
+                \LogicException::class,
+                message: 'The Xdebug collection window is not open. Call start() before stop().',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{'collect'|'stop', non-empty-string}>
+     */
+    public static function runtimeFailures(): iterable
+    {
+        yield 'collection failure' => ['collect', 'Xdebug collection failed.'];
+
+        yield 'stop failure' => ['stop', 'Xdebug stop failed.'];
+    }
+}

--- a/tests/Unit/Coverage/XdebugDriverStartFailureTest.php
+++ b/tests/Unit/Coverage/XdebugDriverStartFailureTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\Driver\XdebugDriver;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Coverage\StartFailingXdebugRuntime;
+
+final readonly class XdebugDriverStartFailureTest
+{
+    #[Test]
+    public function aStartFailureLeavesTheCollectionWindowClosed(): void
+    {
+        $runtime = new StartFailingXdebugRuntime();
+        $driver = new XdebugDriver($runtime, flags: 3);
+
+        Expect::that(static function () use ($driver): void {
+            $driver->start();
+        })
+            ->because('an Xdebug start failure MUST remain the reported failure')
+            ->toThrow(
+                \RuntimeException::class,
+                message: 'Xdebug start failed.',
+            )
+            ->and($runtime->calls)
+            ->because('a failed Xdebug start MUST NOT collect or stop the runtime')
+            ->toBe(['start']);
+
+        Expect::that(static fn(): mixed => $driver->stop())
+            ->because('a failed Xdebug start MUST leave the collection window closed')
+            ->toThrow(
+                \LogicException::class,
+                message: 'The Xdebug collection window is not open. Call start() before stop().',
+            );
+    }
+}

--- a/tests/Unit/Coverage/XdebugDriverStartFailureTest.php
+++ b/tests/Unit/Coverage/XdebugDriverStartFailureTest.php
@@ -14,18 +14,19 @@ final readonly class XdebugDriverStartFailureTest
     #[Test]
     public function aStartFailureLeavesTheCollectionWindowClosed(): void
     {
-        $runtime = new StartFailingXdebugRuntime();
+        $failure = new \RuntimeException('Xdebug start failed.');
+        $runtime = new StartFailingXdebugRuntime($failure);
         $driver = new XdebugDriver($runtime, flags: 3);
 
         Expect::that(static function () use ($driver): void {
             $driver->start();
         })
             ->because('an Xdebug start failure MUST remain the reported failure')
-            ->toThrow(
-                \RuntimeException::class,
-                message: 'Xdebug start failed.',
-            )
-            ->and($runtime->calls)
+            ->toThrow(static function (\RuntimeException $caught) use ($failure): void {
+                Expect::that($caught)->toBe($failure);
+            });
+
+        Expect::that($runtime->calls)
             ->because('a failed Xdebug start MUST NOT collect or stop the runtime')
             ->toBe(['start']);
 

--- a/tests/Unit/Coverage/XdebugDriverTest.php
+++ b/tests/Unit/Coverage/XdebugDriverTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Coverage;
 
-use Greenlight\Attribute\Isolated;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Test\SkipTest;
 use Greenlight\Coverage\CoverageError;
@@ -85,19 +84,10 @@ final class XdebugDriverTest
     }
 
     #[Test]
-    #[Isolated]
     public function collectionLifecycleUsesAllLineFlagsAndClosesTheWindow(): void
     {
-        if (!\defined('XDEBUG_CC_UNUSED')) {
-            \define('XDEBUG_CC_UNUSED', 1);
-        }
-
-        if (!\defined('XDEBUG_CC_DEAD_CODE')) {
-            \define('XDEBUG_CC_DEAD_CODE', 2);
-        }
-
         $runtime = new FakeXdebugRuntime();
-        $driver = new XdebugDriver($runtime);
+        $driver = new XdebugDriver($runtime, flags: 3);
         $driver->start();
         $coverage = $driver->stop();
 

--- a/tests/Unit/Coverage/XdebugDriverTest.php
+++ b/tests/Unit/Coverage/XdebugDriverTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Coverage;
 
+use Greenlight\Attribute\Isolated;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Test\SkipTest;
 use Greenlight\Coverage\CoverageError;
@@ -84,10 +85,19 @@ final class XdebugDriverTest
     }
 
     #[Test]
+    #[Isolated]
     public function collectionLifecycleUsesAllLineFlagsAndClosesTheWindow(): void
     {
+        if (!\defined('XDEBUG_CC_UNUSED')) {
+            \define('XDEBUG_CC_UNUSED', 1);
+        }
+
+        if (!\defined('XDEBUG_CC_DEAD_CODE')) {
+            \define('XDEBUG_CC_DEAD_CODE', 2);
+        }
+
         $runtime = new FakeXdebugRuntime();
-        $driver = new XdebugDriver($runtime, flags: 3);
+        $driver = new XdebugDriver($runtime);
         $driver->start();
         $coverage = $driver->stop();
 


### PR DESCRIPTION
Ensure Xdebug shutdown runs after every collection attempt and closes Greenlight’s logical collection window even when collection or shutdown throws. Typed throwable callbacks pin the exact start, collection, and stop failures, including nested-failure precedence and the cause chain.