### PR TITLE
test(doubles): retain zero proxy directory reasons

### DIFF
--- a/tests/Unit/Doubles/ProxyStorageTest.php
+++ b/tests/Unit/Doubles/ProxyStorageTest.php
@@ -40,6 +40,14 @@ final readonly class ProxyStorageTest
     }
 
     #[Test]
+    public function aProxyDirectoryErrorPreservesAZeroStringReason(): void
+    {
+        Expect::that(DoublesError::proxyDirectoryNotCreated('/tmp/proxies', '0')->getMessage())
+            ->because('a proxy-directory diagnostic MUST preserve a zero-string reason')
+            ->toBe('Doubles could not create the proxy directory /tmp/proxies: 0.');
+    }
+
+    #[Test]
     public function aProxyFileCollisionPreservesTheFileWriteFailure(): void
     {
         $sourceDirectory = $this->tempDirectory->subdirectory('proxy-file-discovery');


### PR DESCRIPTION
Adds focused coverage that requires proxy-directory diagnostics to preserve a zero-string filesystem reason. This is stacked on #852 so the full suite uses the shared TestMetadata diagnostics fix.