### PR TITLE
test(cli): cover invalid run overrides

### DIFF
--- a/tests/Acceptance/CommandErrorsTest.php
+++ b/tests/Acceptance/CommandErrorsTest.php
@@ -27,6 +27,22 @@ final readonly class CommandErrorsTest
     }
 
     #[Test]
+    public function anInvalidRunOverrideExitsWithAUsageError(): void
+    {
+        $result = GreenlightCli::run(\dirname(__DIR__, 2), [
+            'run',
+            '--bail=0',
+            '--no-ansi',
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('an invalid run override MUST exit with a usage error')
+            ->toBe(64)
+            ->and($result->stderr)
+            ->toBe('greenlight: --bail requires a positive integer. Received "0".');
+    }
+
+    #[Test]
     public function coverageDiffWithoutBaselineOrCurrentIsAUsageError(): void
     {
         $result = GreenlightCli::run(\dirname(__DIR__, 2), ['coverage:diff']);


### PR DESCRIPTION
Adds focused application-boundary coverage for an invalid run override. The CLI must emit the exact diagnostic and return the usage exit code. This is stacked on #852 so the full suite uses the shared TestMetadata diagnostics fix.