### PR TITLE
test(coverage): exercise PCOV through runtime seam

### DIFF
--- a/src/Coverage/Driver/NativePcovRuntime.php
+++ b/src/Coverage/Driver/NativePcovRuntime.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Coverage\Driver;
+
+/**
+ * Runs PCOV through its extension functions.
+ *
+ * @internal
+ */
+final readonly class NativePcovRuntime implements PcovRuntime
+{
+    #[\Override]
+    public function start(): void
+    {
+        \pcov\start();
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    #[\Override]
+    public function collect(): array
+    {
+        return \pcov\collect();
+    }
+
+    #[\Override]
+    public function stop(): void
+    {
+        \pcov\stop();
+    }
+
+    #[\Override]
+    public function clear(): void
+    {
+        \pcov\clear();
+    }
+}

--- a/src/Coverage/Driver/PcovDriver.php
+++ b/src/Coverage/Driver/PcovDriver.php
@@ -20,11 +20,15 @@ final class PcovDriver implements CoverageDriver
 {
     private bool $collecting = false;
 
-    public function __construct()
+    private readonly PcovRuntime $runtime;
+
+    public function __construct(?PcovRuntime $runtime = null)
     {
-        if (!self::isAvailable()) {
+        if (!$runtime instanceof PcovRuntime && !self::isAvailable()) {
             throw CoverageError::driverUnavailable('pcov', 'Install and enable the pcov extension.');
         }
+
+        $this->runtime = $runtime ?? new NativePcovRuntime();
     }
 
     #[\Override]
@@ -40,7 +44,7 @@ final class PcovDriver implements CoverageDriver
             throw new \LogicException('The pcov collection window is already open. Call stop() before start().');
         }
 
-        \pcov\start();
+        $this->runtime->start();
         $this->collecting = true;
     }
 
@@ -52,13 +56,13 @@ final class PcovDriver implements CoverageDriver
         }
 
         try {
-            $collected = \pcov\collect();
+            $collected = $this->runtime->collect();
         } finally {
             try {
-                \pcov\stop();
+                $this->runtime->stop();
             } finally {
                 try {
-                    \pcov\clear();
+                    $this->runtime->clear();
                 } finally {
                     $this->collecting = false;
                 }

--- a/src/Coverage/Driver/PcovRuntime.php
+++ b/src/Coverage/Driver/PcovRuntime.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Coverage\Driver;
+
+/**
+ * Runs one PCOV coverage collection period.
+ *
+ * @internal
+ */
+interface PcovRuntime
+{
+    public function start(): void;
+
+    /**
+     * @return array<mixed>
+     */
+    public function collect(): array;
+
+    public function stop(): void;
+
+    public function clear(): void;
+}

--- a/tests/Fixture/Coverage/FailingPcovDriverRuntime.php
+++ b/tests/Fixture/Coverage/FailingPcovDriverRuntime.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Coverage;
+
+use Greenlight\Coverage\Driver\PcovRuntime;
+use Greenlight\Doubles\Fake;
+
+final class FailingPcovDriverRuntime implements Fake, PcovRuntime
+{
+    /**
+     * @var list<string>
+     */
+    public array $calls = [];
+
+    public ?\Throwable $startFailure = null;
+
+    public ?\Throwable $collectFailure = null;
+
+    public ?\Throwable $stopFailure = null;
+
+    public ?\Throwable $clearFailure = null;
+
+    #[\Override]
+    public function start(): void
+    {
+        $this->calls[] = 'start';
+
+        if ($this->startFailure instanceof \Throwable) {
+            throw $this->startFailure;
+        }
+    }
+
+    /**
+     * @return array<string, array<int, int>>
+     */
+    #[\Override]
+    public function collect(): array
+    {
+        $this->calls[] = 'collect';
+
+        if ($this->collectFailure instanceof \Throwable) {
+            throw $this->collectFailure;
+        }
+
+        return ['/src/Example.php' => [10 => 1]];
+    }
+
+    #[\Override]
+    public function stop(): void
+    {
+        $this->calls[] = 'stop';
+
+        if ($this->stopFailure instanceof \Throwable) {
+            throw $this->stopFailure;
+        }
+    }
+
+    #[\Override]
+    public function clear(): void
+    {
+        $this->calls[] = 'clear';
+
+        if ($this->clearFailure instanceof \Throwable) {
+            throw $this->clearFailure;
+        }
+    }
+}

--- a/tests/Fixture/Coverage/FakePcovDriverRuntime.php
+++ b/tests/Fixture/Coverage/FakePcovDriverRuntime.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Coverage;
+
+use Greenlight\Coverage\Driver\PcovRuntime;
+use Greenlight\Doubles\Fake;
+
+final class FakePcovDriverRuntime implements Fake, PcovRuntime
+{
+    /**
+     * @var list<string>
+     */
+    public array $calls = [];
+
+    #[\Override]
+    public function start(): void
+    {
+        $this->calls[] = 'start';
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    #[\Override]
+    public function collect(): array
+    {
+        $this->calls[] = 'collect';
+
+        return [
+            '/src/Example.php' => [
+                10 => 1,
+                11 => -1,
+                'invalid-line' => 1,
+                12 => 'invalid-status',
+            ],
+            7 => [1 => 1],
+            '/src/invalid.php' => 'invalid-lines',
+        ];
+    }
+
+    #[\Override]
+    public function stop(): void
+    {
+        $this->calls[] = 'stop';
+    }
+
+    #[\Override]
+    public function clear(): void
+    {
+        $this->calls[] = 'clear';
+    }
+}

--- a/tests/Unit/Coverage/PcovDriverFailureTest.php
+++ b/tests/Unit/Coverage/PcovDriverFailureTest.php
@@ -5,24 +5,46 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Coverage;
 
 use Greenlight\Attribute\DataSet;
-use Greenlight\Attribute\Isolated;
 use Greenlight\Attribute\Test;
 use Greenlight\Coverage\Driver\PcovDriver;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
-use Greenlight\Tests\Fixture\Coverage\FailingPcovRuntime;
+use Greenlight\Tests\Fixture\Coverage\FailingPcovDriverRuntime;
 
 final class PcovDriverFailureTest
 {
     #[Test]
-    #[Isolated]
+    public function startFailureLeavesTheCollectionWindowClosed(): void
+    {
+        $runtime = new FailingPcovDriverRuntime();
+        $runtime->startFailure = new \RuntimeException('PCOV start failed.');
+        $driver = new PcovDriver($runtime);
+
+        Expect::that(static function () use ($driver): void {
+            $driver->start();
+        })
+            ->because('a PCOV start failure MUST remain the reported failure')
+            ->toThrow(
+                \RuntimeException::class,
+                message: 'PCOV start failed.',
+            )
+            ->and($runtime->calls)
+            ->because('a PCOV start failure MUST stop before collection begins')
+            ->toBe(['start']);
+
+        Expect::that(static fn(): mixed => $driver->stop())
+            ->because('a PCOV start failure MUST leave its collection window closed')
+            ->toThrow(
+                \LogicException::class,
+                message: 'The pcov collection window is not open. Call start() before stop().',
+            );
+    }
+
+    #[Test]
     public function collectionFailureStopsAndClearsTheRuntimeAndClosesTheWindow(): void
     {
-        $this->installFakePcovFunctions();
-        $driver = new \ReflectionClass(PcovDriver::class)->newInstanceWithoutConstructor();
-
-        FailingPcovRuntime::reset();
-        FailingPcovRuntime::$collectFailure = new \RuntimeException('PCOV collection failed.');
+        $runtime = new FailingPcovDriverRuntime();
+        $runtime->collectFailure = new \RuntimeException('PCOV collection failed.');
+        $driver = new PcovDriver($runtime);
         $driver->start();
 
         Expect::that(static fn(): mixed => $driver->stop())
@@ -31,7 +53,7 @@ final class PcovDriverFailureTest
                 \RuntimeException::class,
                 message: 'PCOV collection failed.',
             )
-            ->and(FailingPcovRuntime::$calls)
+            ->and($runtime->calls)
             ->because('a PCOV collection failure MUST still stop and clear extension state')
             ->toBe(['start', 'collect', 'stop', 'clear']);
 
@@ -47,23 +69,20 @@ final class PcovDriverFailureTest
      * @param 'stop'|'clear' $operation
      */
     #[Test]
-    #[Isolated]
     #[DataSet('cleanupFailures')]
     public function cleanupFailuresStillClearStateAndCloseTheWindow(
         string $operation,
         string $message,
     ): void {
-        $this->installFakePcovFunctions();
-        $driver = new \ReflectionClass(PcovDriver::class)->newInstanceWithoutConstructor();
-
-        FailingPcovRuntime::reset();
+        $runtime = new FailingPcovDriverRuntime();
 
         if ($operation === 'stop') {
-            FailingPcovRuntime::$stopFailure = new \RuntimeException($message);
+            $runtime->stopFailure = new \RuntimeException($message);
         } else {
-            FailingPcovRuntime::$clearFailure = new \RuntimeException($message);
+            $runtime->clearFailure = new \RuntimeException($message);
         }
 
+        $driver = new PcovDriver($runtime);
         $driver->start();
 
         Expect::that(static fn(): mixed => $driver->stop())
@@ -72,7 +91,7 @@ final class PcovDriverFailureTest
                 \RuntimeException::class,
                 message: $message,
             )
-            ->and(FailingPcovRuntime::$calls)
+            ->and($runtime->calls)
             ->because('PCOV cleanup MUST attempt clear even if stop fails')
             ->toBe(['start', 'collect', 'stop', 'clear']);
 
@@ -92,36 +111,5 @@ final class PcovDriverFailureTest
         yield 'stop failure' => ['stop', 'PCOV stop failed.'];
 
         yield 'clear failure' => ['clear', 'PCOV clear failed.'];
-    }
-
-    private function installFakePcovFunctions(): void
-    {
-        if (\function_exists('pcov\start')) {
-            Fail::because('Expected an isolated worker without loaded PCOV functions.');
-        }
-
-        eval(<<<'PHP'
-            namespace pcov;
-
-            function start(): void
-            {
-                \Greenlight\Tests\Fixture\Coverage\FailingPcovRuntime::start();
-            }
-
-            function collect(): array
-            {
-                return \Greenlight\Tests\Fixture\Coverage\FailingPcovRuntime::collect();
-            }
-
-            function stop(): void
-            {
-                \Greenlight\Tests\Fixture\Coverage\FailingPcovRuntime::stop();
-            }
-
-            function clear(): void
-            {
-                \Greenlight\Tests\Fixture\Coverage\FailingPcovRuntime::clear();
-            }
-            PHP);
     }
 }

--- a/tests/Unit/Coverage/PcovDriverTest.php
+++ b/tests/Unit/Coverage/PcovDriverTest.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Coverage;
 
-use Greenlight\Attribute\Isolated;
 use Greenlight\Attribute\Test;
 use Greenlight\Coverage\CoverageError;
 use Greenlight\Coverage\Driver\PcovDriver;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
-use Greenlight\Tests\Fixture\Coverage\FakePcovRuntime;
+use Greenlight\Tests\Fixture\Coverage\FakePcovDriverRuntime;
 
 final class PcovDriverTest
 {
@@ -42,7 +40,7 @@ final class PcovDriverTest
     #[Test]
     public function reportsInvalidCollectionStateExactly(): void
     {
-        $driver = new \ReflectionClass(PcovDriver::class)->newInstanceWithoutConstructor();
+        $driver = new PcovDriver(new FakePcovDriverRuntime());
 
         Expect::that(static fn(): mixed => $driver->stop())
             ->toThrow(
@@ -50,8 +48,7 @@ final class PcovDriverTest
                 message: 'The pcov collection window is not open. Call start() before stop().',
             );
 
-        $collecting = new \ReflectionProperty(PcovDriver::class, 'collecting');
-        $collecting->setValue($driver, true);
+        $driver->start();
 
         Expect::that(static fn() => $driver->start())
             ->toThrow(
@@ -61,13 +58,11 @@ final class PcovDriverTest
     }
 
     #[Test]
-    #[Isolated]
     public function collectionLifecycleNormalizesExtensionPayloadsAndClearsState(): void
     {
-        $this->installFakePcovFunctions();
-        $driver = new \ReflectionClass(PcovDriver::class)->newInstanceWithoutConstructor();
+        $runtime = new FakePcovDriverRuntime();
+        $driver = new PcovDriver($runtime);
 
-        FakePcovRuntime::$calls = [];
         $driver->start();
         $coverage = $driver->stop();
 
@@ -79,39 +74,8 @@ final class PcovDriverTest
                     11 => -1,
                 ],
             ])
-            ->and(FakePcovRuntime::$calls)
+            ->and($runtime->calls)
             ->because('PCOV collection MUST stop and clear extension state after reading it')
             ->toBe(['start', 'collect', 'stop', 'clear']);
-    }
-
-    private function installFakePcovFunctions(): void
-    {
-        if (\function_exists('pcov\start')) {
-            Fail::because('Expected an isolated worker without loaded PCOV functions.');
-        }
-
-        eval(<<<'PHP'
-            namespace pcov;
-
-            function start(): void
-            {
-                \Greenlight\Tests\Fixture\Coverage\FakePcovRuntime::start();
-            }
-
-            function collect(): array
-            {
-                return \Greenlight\Tests\Fixture\Coverage\FakePcovRuntime::collect();
-            }
-
-            function stop(): void
-            {
-                \Greenlight\Tests\Fixture\Coverage\FakePcovRuntime::stop();
-            }
-
-            function clear(): void
-            {
-                \Greenlight\Tests\Fixture\Coverage\FakePcovRuntime::clear();
-            }
-            PHP);
     }
 }


### PR DESCRIPTION
Injects a small PCOV runtime seam so lifecycle and cleanup behavior execute through Fake implementations. Removes reflection, eval, and isolated-worker workarounds. Adds coverage for a failed start that must leave the collection window closed. The self-coverage map increases from 93.09% to 93.12%.