### PR TITLE
test(integrations): cover implicit empty resources

### DIFF
--- a/tests/Unit/Runner/Integration/IntegrationFixtureManagerTest.php
+++ b/tests/Unit/Runner/Integration/IntegrationFixtureManagerTest.php
@@ -86,6 +86,29 @@ final class IntegrationFixtureManagerTest
     }
 
     #[Test]
+    public function fixturesThatDoNotExposeResourcesRemainAvailableAsEmptyResources(): void
+    {
+        $session = IntegrationFixtureManager::provision(
+            PluginRegistry::orchestratorSide([
+                $this->provider([
+                    new IntegrationFixtureDefinition('database', static function (): void {}),
+                ]),
+            ]),
+            'run-2',
+            2,
+            2,
+            null,
+        );
+
+        Expect::that($session->forChannel(1)->fixture('database')->toWire())
+            ->because('every provisioned fixture MUST remain available even when it exposes no resources')
+            ->toBe([
+                'values' => [],
+                'secrets' => [],
+            ]);
+    }
+
+    #[Test]
     public function partialProvisioningCleansEverythingAlreadyAcquired(): void
     {
         $trace = [];


### PR DESCRIPTION
Covers the integration fixture guarantee that every successfully provisioned fixture remains available in channel resources even when its callback does not call expose(). The assertion verifies the implicit resource has empty values and secrets.