### PR TITLE
fix(discovery): retain zero-string row labels

### DIFF
--- a/src/Discovery/DataSetExpander.php
+++ b/src/Discovery/DataSetExpander.php
@@ -53,7 +53,7 @@ final readonly class DataSetExpander
      * @param non-empty-string|null $provider
      * @param non-empty-string|null $providerClass
      *
-     * @return array<string, mixed>
+     * @return array<array-key, mixed>
      *
      * @throws DiscoveryError
      */
@@ -113,7 +113,7 @@ final readonly class DataSetExpander
      * @param non-empty-string $testMethod
      * @param non-empty-string $provider
      *
-     * @return non-empty-array<string, mixed>
+     * @return non-empty-array<array-key, mixed>
      *
      * @throws DiscoveryError
      */

--- a/src/Discovery/TestDiscoverer.php
+++ b/src/Discovery/TestDiscoverer.php
@@ -146,7 +146,7 @@ final readonly class TestDiscoverer
             }
 
             foreach (\array_keys($rows) as $key) {
-                $entries[] = new PlanEntry(new TestId($metadata->class, $metadata->method, $key), $metadata);
+                $entries[] = new PlanEntry(new TestId($metadata->class, $metadata->method, (string) $key), $metadata);
             }
         }
 

--- a/src/Runner/Worker/ClassContext.php
+++ b/src/Runner/Worker/ClassContext.php
@@ -23,7 +23,7 @@ final class ClassContext
     /**
      * Resolved data sets for each test method.
      *
-     * @var array<string, array<string, mixed>>
+     * @var array<string, array<array-key, mixed>>
      */
     private array $dataSets = [];
 

--- a/tests/Fixture/DataRowsZeroLabel/ZeroLabelRowTest.php
+++ b/tests/Fixture/DataRowsZeroLabel/ZeroLabelRowTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\DataRowsZeroLabel;
+
+use Greenlight\Attribute\DataRow;
+use Greenlight\Attribute\Test;
+
+final class ZeroLabelRowTest
+{
+    #[Test]
+    #[DataRow(['value'], label: '0')]
+    public function accepts(string $value): void {}
+}

--- a/tests/Unit/Discovery/DataRowTest.php
+++ b/tests/Unit/Discovery/DataRowTest.php
@@ -13,6 +13,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\DataRows\InlineRowsTest;
 use Greenlight\Tests\Fixture\DataRowsConflict\DuplicateRowKeyTest;
 use Greenlight\Tests\Fixture\DataRowsDuplicateInline\DuplicateInlineRowKeyTest;
+use Greenlight\Tests\Fixture\DataRowsZeroLabel\ZeroLabelRowTest;
 
 final class DataRowTest
 {
@@ -24,6 +25,20 @@ final class DataRowTest
         Expect::that(\array_keys($rows))->because('inline rows expand with labels and positions')->toBe(['small', '#1'])
             ->and($rows['small'])->toBe([1, 2, 3])
             ->and($rows['#1'])->toBe([10, 20, 30]);
+    }
+
+    #[Test]
+    public function aZeroStringInlineLabelRemainsThePlanDataSetKey(): void
+    {
+        $plan = new TestDiscoverer()->discover(
+            [\dirname(__DIR__, 2) . '/Fixture/DataRowsZeroLabel'],
+            Filter::all(),
+        );
+        $ids = \array_map(static fn($entry): string => (string) $entry->id, $plan->entries);
+
+        Expect::that($ids)
+            ->because('a zero-string inline label MUST remain the plan data-set key')
+            ->toBe([ZeroLabelRowTest::class . '::accepts[0]']);
     }
 
     #[Test]


### PR DESCRIPTION
Preserves an inline data-row label of `0` in the execution-plan test ID. PHP converts numeric string array keys to integers, so discovery now restores the string at the TestId boundary and documents the runtime array-key shape. Adds an append-only PSR-4 fixture and focused regression. This is stacked on #852.