### PR TITLE
test(coverage): retain zero unavailability reasons

### DIFF
--- a/tests/Unit/Coverage/DriverSelectionTest.php
+++ b/tests/Unit/Coverage/DriverSelectionTest.php
@@ -20,4 +20,14 @@ final readonly class DriverSelectionTest
                 message: 'Coverage unavailability requires a nonempty reason.',
             );
     }
+
+    #[Test]
+    public function unavailableSelectionsPreserveAZeroStringReason(): void
+    {
+        $selection = DriverSelection::unavailable('0');
+
+        Expect::that($selection->reason)
+            ->because('coverage unavailability MUST preserve a zero-string reason')
+            ->toBe('0');
+    }
 }


### PR DESCRIPTION
Adds focused coverage that requires a nonempty zero-string coverage-unavailability reason to remain valid and unchanged. This is stacked on #852.