### PR TITLE
test(expect): retain zero explicit failure reasons

### DIFF
--- a/tests/Unit/Expect/FailTest.php
+++ b/tests/Unit/Expect/FailTest.php
@@ -48,6 +48,18 @@ final class FailTest
     }
 
     #[Test]
+    public function aZeroStringReasonRemainsTheFailureMessage(): void
+    {
+        $detail = FailureProbe::detailOf(
+            static fn() => Fail::because('0'),
+        );
+
+        Expect::that($detail->message)
+            ->because('an explicit failure MUST preserve a zero-string reason')
+            ->toBe('0');
+    }
+
+    #[Test]
     public function failureLocationPointsAtTheCallSite(): void
     {
         $line = __LINE__ + 1;


### PR DESCRIPTION
Adds focused coverage that requires `Fail::because("0")` to preserve the nonempty zero-string message rather than use the empty-reason fallback. This is stacked on #852.