### PR TITLE
test(doubles): cover variadic references

### DIFF
--- a/tests/Fixture/Doubles/VariadicReference.php
+++ b/tests/Fixture/Doubles/VariadicReference.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+interface VariadicReference
+{
+    public function mutate(string &...$values): void;
+}

--- a/tests/Unit/Doubles/ProxyVariadicReferenceTest.php
+++ b/tests/Unit/Doubles/ProxyVariadicReferenceTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\MockPlan;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Fixture\Doubles\VariadicReference;
+
+final readonly class ProxyVariadicReferenceTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function callbacksCanChangeEveryVariadicReferenceArgument(): void
+    {
+        $doubles = new Doubles($this->tempDirectory->subdirectory('proxies'));
+        $double = $doubles->mock(VariadicReference::class, static function (MockPlan $plan): void {
+            $plan->expects('mutate')
+                ->andReturnsUsing(static function (string &...$values): void {
+                    foreach ($values as &$value) {
+                        $value .= ' changed';
+                    }
+                });
+        });
+        $first = 'first';
+        $second = 'second';
+
+        try {
+            $double->mutate($first, $second);
+
+            Expect::that([$first, $second])
+                ->because('a proxy callback MUST preserve every variadic reference')
+                ->toBe(['first changed', 'second changed']);
+        } finally {
+            $doubles->dispose();
+        }
+    }
+}


### PR DESCRIPTION
Exercise proxy generation for parameters that are simultaneously variadic and passed by reference. The isolated proxy fixture verifies that callback mutations flow back to every caller variable.