### PR TITLE
test(core): retain zero skip reasons

### DIFF
--- a/tests/Unit/Core/SkipTestTest.php
+++ b/tests/Unit/Core/SkipTestTest.php
@@ -17,4 +17,16 @@ final class SkipTestTest
             ->because('skip reasons cannot be empty')
             ->toThrow(\InvalidArgumentException::class, message: 'Skip reasons cannot be empty.');
     }
+
+    #[Test]
+    public function aZeroStringReasonIsPreserved(): void
+    {
+        $skip = new SkipTest('0');
+
+        Expect::that($skip->reason)
+            ->because('a skip signal MUST preserve a zero-string reason')
+            ->toBe('0')
+            ->and($skip->getMessage())
+            ->toBe('0');
+    }
 }


### PR DESCRIPTION
Adds focused coverage that requires a `SkipTest` signal to accept and preserve the nonempty zero-string reason in both its public reason and exception message. This is stacked on #852.