### PR TITLE
test(integrations): cover parallel cleanup failure

### DIFF
--- a/tests/Acceptance/IntegrationFixtureRunTest.php
+++ b/tests/Acceptance/IntegrationFixtureRunTest.php
@@ -88,15 +88,18 @@ final readonly class IntegrationFixtureRunTest
     }
 
     #[Test]
-    public function cleanupFailureFailsAnOtherwiseSuccessfulRun(): void
+    #[DataSet('workerCounts')]
+    public function cleanupFailureFailsAnOtherwiseSuccessfulRun(int $workers): void
     {
-        $project = $this->writeProject('cleanup-failure', workers: 1, failCleanup: true);
+        $project = $this->writeProject('cleanup-failure-' . $workers, workers: $workers, failCleanup: true);
         $result = GreenlightCli::run($project->directory, ['run', '--reporter=plain']);
 
         Expect::that($result->exitCode)->toBe(1)
             ->and($result->output())->toContain('Integration fixture teardown failed.')
             ->and($result->output())->toContain('intentional fixture cleanup failure')
-            ->and($this->matches($project->path('markers/resource-*')))->toBe([]);
+            ->not()->toContain('fixture-secret')
+            ->and($this->matches($project->path('markers/resource-*')))->toBe([])
+            ->and($this->lines($project->path('markers/cleaned.log')))->toBe(['cleaned']);
     }
 
     #[Test]
@@ -173,6 +176,15 @@ final readonly class IntegrationFixtureRunTest
     {
         yield 'in-process' => [1, 1];
         yield 'parallel' => [2, 2];
+    }
+
+    /**
+     * @return iterable<string, array{positive-int}>
+     */
+    public static function workerCounts(): iterable
+    {
+        yield 'in-process' => [1];
+        yield 'parallel' => [2];
     }
 
     /**

--- a/tests/Acceptance/IntegrationFixtureRunTest.php
+++ b/tests/Acceptance/IntegrationFixtureRunTest.php
@@ -89,6 +89,32 @@ final readonly class IntegrationFixtureRunTest
 
     #[Test]
     #[DataSet('workerCounts')]
+    public function provisioningAndRollbackFailuresAreBothReported(int $workers): void
+    {
+        $project = $this->writeProject(
+            'provisioning-and-rollback-failure-' . $workers,
+            workers: $workers,
+            failProvisioning: true,
+            failCleanup: true,
+        );
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=plain']);
+
+        Expect::that($result->exitCode)->toBe(1)
+            ->and($result->output())
+            ->because('the provisioning failure MUST remain the primary run failure')
+            ->toContain('intentional fixture provisioning failure')
+            ->and($result->output())
+            ->because('rollback failures MUST remain visible after a provisioning failure')
+            ->toContain('Additionally, cleanup for integration fixture "probe" failed')
+            ->toContain('intentional fixture cleanup failure')
+            ->not()->toContain('tests,')
+            ->not()->toContain('fixture-secret')
+            ->and($this->matches($project->path('markers/resource-*')))->toBe([])
+            ->and($this->lines($project->path('markers/cleaned.log')))->toBe(['cleaned']);
+    }
+
+    #[Test]
+    #[DataSet('workerCounts')]
     public function cleanupFailureFailsAnOtherwiseSuccessfulRun(int $workers): void
     {
         $project = $this->writeProject('cleanup-failure-' . $workers, workers: $workers, failCleanup: true);


### PR DESCRIPTION
Extends the otherwise-successful cleanup-failure acceptance case across in-process and parallel runs. The parallel row covers the branch that turns a successful ParallelRunner result into a teardown failure while resources are removed and secrets remain redacted.