### PR TITLE
test(attributes): retain zero skip reasons

### DIFF
--- a/tests/Unit/Attribute/AttributeContractTest.php
+++ b/tests/Unit/Attribute/AttributeContractTest.php
@@ -31,6 +31,14 @@ final class AttributeContractTest
     }
 
     #[Test]
+    public function skipPreservesAZeroStringReason(): void
+    {
+        Expect::that(new Skip('0')->reason)
+            ->because('the skip attribute MUST preserve a zero-string reason')
+            ->toBe('0');
+    }
+
+    #[Test]
     public function methodOnlyAttributesTargetMethods(): void
     {
         foreach ([Test::class, Before::class, After::class, DataSet::class, NoExpectations::class] as $attribute) {


### PR DESCRIPTION
Adds focused constructor-contract coverage that requires `#[Skip("0")]` to accept and preserve its nonempty zero-string reason. This is stacked on #852.