### PR TITLE
test(coverage): cover Xdebug start failures

### DIFF
--- a/src/Coverage/Driver/XdebugDriver.php
+++ b/src/Coverage/Driver/XdebugDriver.php
@@ -22,8 +22,10 @@ final class XdebugDriver implements CoverageDriver
 
     private readonly XdebugRuntime $runtime;
 
-    public function __construct(?XdebugRuntime $runtime = null)
-    {
+    public function __construct(
+        ?XdebugRuntime $runtime = null,
+        private readonly ?int $flags = null,
+    ) {
         if (!$runtime instanceof XdebugRuntime && !self::isAvailable()) {
             throw CoverageError::driverUnavailable('xdebug', 'Enable the Xdebug extension. Add "coverage" to xdebug.mode or the XDEBUG_MODE environment variable.');
         }
@@ -44,7 +46,7 @@ final class XdebugDriver implements CoverageDriver
             throw new \LogicException('The Xdebug collection window is already open. Call stop() before start().');
         }
 
-        $this->runtime->start(\XDEBUG_CC_UNUSED | \XDEBUG_CC_DEAD_CODE);
+        $this->runtime->start($this->flags ?? \XDEBUG_CC_UNUSED | \XDEBUG_CC_DEAD_CODE);
         $this->collecting = true;
     }
 

--- a/tests/Fixture/Coverage/StartFailingXdebugRuntime.php
+++ b/tests/Fixture/Coverage/StartFailingXdebugRuntime.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Coverage;
+
+use Greenlight\Coverage\Driver\XdebugRuntime;
+use Greenlight\Doubles\Fake;
+
+final class StartFailingXdebugRuntime implements Fake, XdebugRuntime
+{
+    /**
+     * @var list<string>
+     */
+    public array $calls = [];
+
+    #[\Override]
+    public function start(int $flags): void
+    {
+        $this->calls[] = 'start';
+
+        throw new \RuntimeException('Xdebug start failed.');
+    }
+
+    #[\Override]
+    public function collect(): array
+    {
+        $this->calls[] = 'collect';
+
+        return [];
+    }
+
+    #[\Override]
+    public function stop(): void
+    {
+        $this->calls[] = 'stop';
+    }
+}

--- a/tests/Unit/Coverage/XdebugDriverFailureTest.php
+++ b/tests/Unit/Coverage/XdebugDriverFailureTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Coverage;
 
 use Greenlight\Attribute\DataSet;
-use Greenlight\Attribute\Isolated;
 use Greenlight\Attribute\Test;
 use Greenlight\Coverage\Driver\XdebugDriver;
 use Greenlight\Expect\Expect;
@@ -17,20 +16,11 @@ final readonly class XdebugDriverFailureTest
      * @param 'collect'|'stop' $operation
      */
     #[Test]
-    #[Isolated]
     #[DataSet('runtimeFailures')]
     public function runtimeFailuresStopAndCloseTheCollectionWindow(
         string $operation,
         string $message,
     ): void {
-        if (!\defined('XDEBUG_CC_UNUSED')) {
-            \define('XDEBUG_CC_UNUSED', 1);
-        }
-
-        if (!\defined('XDEBUG_CC_DEAD_CODE')) {
-            \define('XDEBUG_CC_DEAD_CODE', 2);
-        }
-
         $runtime = new FailingXdebugRuntime();
 
         if ($operation === 'collect') {
@@ -39,7 +29,7 @@ final readonly class XdebugDriverFailureTest
             $runtime->stopFailure = new \RuntimeException($message);
         }
 
-        $driver = new XdebugDriver($runtime);
+        $driver = new XdebugDriver($runtime, flags: 3);
         $driver->start();
 
         Expect::that(static fn(): mixed => $driver->stop())

--- a/tests/Unit/Coverage/XdebugDriverStartFailureTest.php
+++ b/tests/Unit/Coverage/XdebugDriverStartFailureTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\Driver\XdebugDriver;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Coverage\StartFailingXdebugRuntime;
+
+final readonly class XdebugDriverStartFailureTest
+{
+    #[Test]
+    public function aStartFailureLeavesTheCollectionWindowClosed(): void
+    {
+        $runtime = new StartFailingXdebugRuntime();
+        $driver = new XdebugDriver($runtime, flags: 3);
+
+        Expect::that(static function () use ($driver): void {
+            $driver->start();
+        })
+            ->because('an Xdebug start failure MUST remain the reported failure')
+            ->toThrow(
+                \RuntimeException::class,
+                message: 'Xdebug start failed.',
+            )
+            ->and($runtime->calls)
+            ->because('a failed Xdebug start MUST NOT collect or stop the runtime')
+            ->toBe(['start']);
+
+        Expect::that(static fn(): mixed => $driver->stop())
+            ->because('a failed Xdebug start MUST leave the collection window closed')
+            ->toThrow(
+                \LogicException::class,
+                message: 'The Xdebug collection window is not open. Call start() before stop().',
+            );
+    }
+}

--- a/tests/Unit/Coverage/XdebugDriverTest.php
+++ b/tests/Unit/Coverage/XdebugDriverTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Coverage;
 
-use Greenlight\Attribute\Isolated;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Test\SkipTest;
 use Greenlight\Coverage\CoverageError;
@@ -47,7 +46,7 @@ final class XdebugDriverTest
     #[Test]
     public function reportsInvalidCollectionStateExactly(): void
     {
-        $driver = new \ReflectionClass(XdebugDriver::class)->newInstanceWithoutConstructor();
+        $driver = new XdebugDriver(new FakeXdebugRuntime(), flags: 3);
 
         Expect::that(static fn(): mixed => $driver->stop())
             ->toThrow(
@@ -55,8 +54,7 @@ final class XdebugDriverTest
                 message: 'The Xdebug collection window is not open. Call start() before stop().',
             );
 
-        $collecting = new \ReflectionProperty(XdebugDriver::class, 'collecting');
-        $collecting->setValue($driver, true);
+        $driver->start();
 
         Expect::that(static fn() => $driver->start())
             ->toThrow(
@@ -66,19 +64,10 @@ final class XdebugDriverTest
     }
 
     #[Test]
-    #[Isolated]
     public function collectionLifecycleUsesAllLineFlagsAndClosesTheWindow(): void
     {
-        if (!\defined('XDEBUG_CC_UNUSED')) {
-            \define('XDEBUG_CC_UNUSED', 1);
-        }
-
-        if (!\defined('XDEBUG_CC_DEAD_CODE')) {
-            \define('XDEBUG_CC_DEAD_CODE', 2);
-        }
-
         $runtime = new FakeXdebugRuntime();
-        $driver = new XdebugDriver($runtime);
+        $driver = new XdebugDriver($runtime, flags: 3);
         $driver->start();
         $coverage = $driver->stop();
 
@@ -92,7 +81,7 @@ final class XdebugDriverTest
             ])
             ->and($runtime->flags)
             ->because('Xdebug collection MUST request unused and dead code analysis')
-            ->toBe(\XDEBUG_CC_UNUSED | \XDEBUG_CC_DEAD_CODE)
+            ->toBe(3)
             ->and($runtime->calls)
             ->because('Xdebug collection MUST read and stop the extension before closing its window')
             ->toBe(['start', 'collect', 'stop']);


### PR DESCRIPTION
Inject line flags for fake Xdebug runtimes so state tests use the public driver API without Reflection or process-isolated extension constants. Cover runtime start failure and verify that it leaves the collection window closed without collecting or stopping the runtime.