### PR TITLE
test(watch): cover fixture cleanup failure recovery

### DIFF
--- a/tests/Acceptance/WatchModeTest.php
+++ b/tests/Acceptance/WatchModeTest.php
@@ -81,6 +81,36 @@ final readonly class WatchModeTest
     }
 
     #[Test]
+    public function fixtureCleanupFailuresAreReportedBeforeWatchModeContinues(): void
+    {
+        $project = $this->writeProject(failCleanup: true);
+        $process = GreenlightCli::start(
+            $project->directory,
+            ['run', '--watch', '--reporter=plain'],
+        );
+
+        try {
+            $process->readStdoutUntil('Waiting for changes', 20.0);
+
+            $process->write('q');
+            $result = $process->wait(10.0);
+
+            Expect::that($result->exitCode)
+                ->because('watch mode MUST remain interactive after a fixture cleanup failure')
+                ->toBe(0)
+                ->and($result->output())
+                ->because('watch mode MUST report integration fixture cleanup failures')
+                ->toContain('Integration fixture teardown failed.')
+                ->toContain('intentional fixture cleanup failure')
+                ->and($this->matches($project->path('markers/resource-*')))
+                ->because('watch mode MUST remove orchestrator-owned resources after cleanup failures')
+                ->toBe([]);
+        } finally {
+            $process->terminate();
+        }
+    }
+
+    #[Test]
     public function coverageIncludePathsTriggerWatchReruns(): void
     {
         $project = $this->writeProject(watchCoverageSource: true);
@@ -116,8 +146,10 @@ final readonly class WatchModeTest
         }
     }
 
-    private function writeProject(bool $watchCoverageSource = false): AcceptanceProject
-    {
+    private function writeProject(
+        bool $watchCoverageSource = false,
+        bool $failCleanup = false,
+    ): AcceptanceProject {
         $project = AcceptanceProject::create($this->tempDirectory, 'watch');
         $project->writeFile('markers/.gitkeep', '');
         $project->writeFile('tests/WatchProbeTest.php', <<<'PHP'
@@ -141,6 +173,7 @@ final readonly class WatchModeTest
                 . "\n        ->driver('pcov'))"
             : '';
         $markerDirectory = \var_export($project->path('markers'), true);
+        $failCleanupValue = $failCleanup ? 'true' : 'false';
         $project->writeFile('greenlight.php', \sprintf(
             <<<'PHP'
             <?php
@@ -156,12 +189,23 @@ final readonly class WatchModeTest
                 ->paths([__DIR__ . '/tests'])
                 ->workers(1)%s
                 ->watch(fn($watch) => $watch->debounceMilliseconds(50))
-                ->plugins(new IntegrationProbePlugin(%s));
+                ->plugins(new IntegrationProbePlugin(%s, failCleanup: %s));
             PHP,
             $coverage,
             $markerDirectory,
+            $failCleanupValue,
         ));
 
         return $project;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function matches(string $pattern): array
+    {
+        $matches = \glob($pattern);
+
+        return \is_array($matches) ? $matches : [];
     }
 }


### PR DESCRIPTION
Covers watch-mode recovery after an integration fixture cleanup failure. The acceptance test verifies that watch mode reports the teardown diagnostic, removes orchestrator-owned resources, returns to waiting for changes, and remains interactive until the user quits.