### PR TITLE
test(attributes): retain zero group names

### DIFF
--- a/tests/Unit/Attribute/AttributeContractTest.php
+++ b/tests/Unit/Attribute/AttributeContractTest.php
@@ -31,6 +31,14 @@ final class AttributeContractTest
     }
 
     #[Test]
+    public function skipPreservesAZeroStringReason(): void
+    {
+        Expect::that(new Skip('0')->reason)
+            ->because('the skip attribute MUST preserve a zero-string reason')
+            ->toBe('0');
+    }
+
+    #[Test]
     public function methodOnlyAttributesTargetMethods(): void
     {
         foreach ([Test::class, Before::class, After::class, DataSet::class, NoExpectations::class] as $attribute) {

--- a/tests/Unit/Attribute/AttributeContractTest.php
+++ b/tests/Unit/Attribute/AttributeContractTest.php
@@ -82,6 +82,22 @@ final class AttributeContractTest
     }
 
     #[Test]
+    public function groupRejectsAnEmptyName(): void
+    {
+        Expect::that(static fn(): Group => new Group(''))
+            ->because('group names cannot be empty')
+            ->toThrow(\InvalidArgumentException::class, message: 'Group names cannot be empty.');
+    }
+
+    #[Test]
+    public function groupPreservesAZeroStringName(): void
+    {
+        Expect::that(new Group('0')->name)
+            ->because('the group attribute MUST preserve a zero-string name')
+            ->toBe('0');
+    }
+
+    #[Test]
     public function resourceRequirementsAreRepeatableOnMethodsAndClasses(): void
     {
         Expect::that($this->flags(RequiresResource::class))->because('resource requirements are repeatable on methods and classes')


### PR DESCRIPTION
Adds focused constructor-contract coverage that rejects empty group names while preserving the nonempty zero-string group name. This is stacked on #896.