### PR TITLE
fix(runner): drain diagnostics at crash boundary

### DIFF
--- a/src/Runner/Orchestrator/Orchestrator.php
+++ b/src/Runner/Orchestrator/Orchestrator.php
@@ -727,6 +727,7 @@ final class Orchestrator
 
     private function containCrash(WorkerHandle $handle, EventSink $sink, string $reason): void
     {
+        $handle->drainPipes();
         $inFlight = $handle->inFlight;
 
         if ($inFlight instanceof TestId) {


### PR DESCRIPTION
Drain worker pipes again when crash containment starts. The protocol socket can report EOF before the final stdout or stderr bytes become visible, so relying only on the earlier pump drain can omit crash diagnostics.