### PR TITLE
test(attributes): retain zero service identifiers

### DIFF
--- a/tests/Unit/ServiceAttributeTest.php
+++ b/tests/Unit/ServiceAttributeTest.php
@@ -28,6 +28,18 @@ final readonly class ServiceAttributeTest
     }
 
     /**
+     * @param class-string<LaravelService|SymfonyService> $attribute
+     */
+    #[Test]
+    #[DataSet('serviceAttributes')]
+    public function preservesAZeroStringServiceIdentifier(string $attribute): void
+    {
+        Expect::that((new $attribute('0'))->id)
+            ->because('a zero-string service identifier is not empty')
+            ->toBe('0');
+    }
+
+    /**
      * @return iterable<string, array{class-string<LaravelService|SymfonyService>}>
      */
     public static function serviceAttributes(): iterable


### PR DESCRIPTION
Adds shared contract coverage for Laravel and Symfony service attributes. Both attributes preserve the valid nonempty zero-string container identifier while rejecting an empty identifier.