### PR TITLE
test(artifacts): cover rename failures

### DIFF
--- a/src/Runner/Artifact/ArtifactStore.php
+++ b/src/Runner/Artifact/ArtifactStore.php
@@ -29,12 +29,14 @@ final class ArtifactStore
         private readonly ArtifactConfiguration $configuration,
         private readonly ?string $outputDirectory,
         private readonly bool $ownsStaging,
+        private readonly FileCopier $fileCopier,
     ) {}
 
     public static function open(
         ArtifactConfiguration $configuration,
         string $workingDirectory,
         string $runId,
+        ?FileCopier $fileCopier = null,
     ): self {
         $configured = \rtrim($configuration->directory, '/');
 
@@ -61,14 +63,27 @@ final class ArtifactStore
         $staging = \rtrim(\sys_get_temp_dir(), '/') . '/greenlight-artifacts-'
             . \substr(\hash('sha256', $runId), 0, 16)
             . '-' . \bin2hex(\random_bytes(6));
-        return new self(new ArtifactSession($staging, $output), $configuration, $output, true);
+        return new self(
+            new ArtifactSession($staging, $output),
+            $configuration,
+            $output,
+            true,
+            $fileCopier ?? new NativeFileCopier(),
+        );
     }
 
     public static function fromSession(
         ArtifactSession $session,
         ArtifactConfiguration $configuration,
+        ?FileCopier $fileCopier = null,
     ): self {
-        return new self($session, $configuration, null, false);
+        return new self(
+            $session,
+            $configuration,
+            null,
+            false,
+            $fileCopier ?? new NativeFileCopier(),
+        );
     }
 
     public function session(): ArtifactSession
@@ -347,7 +362,7 @@ final class ArtifactStore
             }
 
             try {
-                FileCopier::copy($source, $part);
+                $this->fileCopier->copy($source, $part);
 
                 if (\filesize($part) !== $attachment->sizeBytes || \hash_file('sha256', $part) !== $attachment->sha256) {
                     throw AttachmentError::storage('Published attachment content does not match its metadata');

--- a/src/Runner/Artifact/ArtifactStore.php
+++ b/src/Runner/Artifact/ArtifactStore.php
@@ -30,6 +30,7 @@ final class ArtifactStore
         private readonly ?string $outputDirectory,
         private readonly bool $ownsStaging,
         private readonly FileCopier $fileCopier,
+        private readonly FileRenamer $fileRenamer,
     ) {}
 
     public static function open(
@@ -37,6 +38,7 @@ final class ArtifactStore
         string $workingDirectory,
         string $runId,
         ?FileCopier $fileCopier = null,
+        ?FileRenamer $fileRenamer = null,
     ): self {
         $configured = \rtrim($configuration->directory, '/');
 
@@ -69,6 +71,7 @@ final class ArtifactStore
             $output,
             true,
             $fileCopier ?? new NativeFileCopier(),
+            $fileRenamer ?? new NativeFileRenamer(),
         );
     }
 
@@ -76,6 +79,7 @@ final class ArtifactStore
         ArtifactSession $session,
         ArtifactConfiguration $configuration,
         ?FileCopier $fileCopier = null,
+        ?FileRenamer $fileRenamer = null,
     ): self {
         return new self(
             $session,
@@ -83,6 +87,7 @@ final class ArtifactStore
             null,
             false,
             $fileCopier ?? new NativeFileCopier(),
+            $fileRenamer ?? new NativeFileRenamer(),
         );
     }
 
@@ -161,7 +166,7 @@ final class ArtifactStore
 
             \chmod($part, 0o600);
 
-            if (!\rename($part, $path)) {
+            if (!$this->fileRenamer->rename($part, $path)) {
                 throw AttachmentError::storage('Failed to finalize attachment staging file');
             }
 
@@ -270,7 +275,7 @@ final class ArtifactStore
 
                 \chmod($part, 0o600);
 
-                if (!\rename($part, $path)) {
+                if (!$this->fileRenamer->rename($part, $path)) {
                     throw AttachmentError::storage('Failed to finalize attachment staging file');
                 }
 
@@ -370,7 +375,7 @@ final class ArtifactStore
 
                 \chmod($part, 0o600);
 
-                if (!\rename($part, $destination)) {
+                if (!$this->fileRenamer->rename($part, $destination)) {
                     throw AttachmentError::storage('Failed to publish attachment');
                 }
             } catch (\Throwable $error) {
@@ -628,7 +633,7 @@ final class ArtifactStore
 
         \chmod($part, 0o600);
 
-        if (!\rename($part, $path)) {
+        if (!$this->fileRenamer->rename($part, $path)) {
             @\unlink($part);
 
             throw AttachmentError::storage('Failed to finalize attachment recovery metadata');
@@ -658,7 +663,7 @@ final class ArtifactStore
 
         \chmod($part, 0o600);
 
-        if (!\rename($part, $path)) {
+        if (!$this->fileRenamer->rename($part, $path)) {
             @\unlink($part);
 
             throw AttachmentError::storage('Greenlight did not finalize the current test attempt record');

--- a/src/Runner/Artifact/FileCopier.php
+++ b/src/Runner/Artifact/FileCopier.php
@@ -4,57 +4,12 @@ declare(strict_types=1);
 
 namespace Greenlight\Runner\Artifact;
 
-use Greenlight\Attribute\CoverageIgnore;
-use Greenlight\Core\Artifact\AttachmentError;
-
 /**
  * Copies attachment files into their output directory.
  *
  * @internal
  */
-final class FileCopier
+interface FileCopier
 {
-    private const int COPY_CHUNK_BYTES = 1024 * 1024;
-
-    public static function copy(string $sourcePath, string $destinationPath): void
-    {
-        $source = \fopen($sourcePath, 'rb');
-        $destination = \fopen($destinationPath, 'xb');
-
-        if ($source === false || $destination === false) {
-            if (\is_resource($source)) {
-                \fclose($source);
-            }
-
-            if (\is_resource($destination)) {
-                \fclose($destination);
-            }
-
-            throw AttachmentError::storage('Failed to copy attachment into its output directory');
-        }
-
-        try {
-            while (!\feof($source)) {
-                $chunk = \fread($source, self::COPY_CHUNK_BYTES);
-
-                if ($chunk === false) {
-                    throw AttachmentError::storage('Failed to read attachment staging content');
-                }
-
-                if ($chunk !== '') {
-                    StreamWriter::writeFully($destination, $chunk);
-                }
-            }
-
-            if (!\fflush($destination)) {
-                throw AttachmentError::storage('Failed to flush the published attachment');
-            }
-        } finally {
-            \fclose($destination);
-            \fclose($source);
-        }
-    }
-
-    #[CoverageIgnore]
-    private function __construct() {}
+    public function copy(string $sourcePath, string $destinationPath): void;
 }

--- a/src/Runner/Artifact/FileRenamer.php
+++ b/src/Runner/Artifact/FileRenamer.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Runner\Artifact;
+
+/**
+ * Renames attachment files atomically.
+ *
+ * @internal
+ */
+interface FileRenamer
+{
+    public function rename(string $sourcePath, string $destinationPath): bool;
+}

--- a/src/Runner/Artifact/NativeFileCopier.php
+++ b/src/Runner/Artifact/NativeFileCopier.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Runner\Artifact;
+
+use Greenlight\Core\Artifact\AttachmentError;
+
+/** @internal */
+final readonly class NativeFileCopier implements FileCopier
+{
+    private const int COPY_CHUNK_BYTES = 1024 * 1024;
+
+    #[\Override]
+    public function copy(string $sourcePath, string $destinationPath): void
+    {
+        $source = \fopen($sourcePath, 'rb');
+        $destination = \fopen($destinationPath, 'xb');
+
+        if ($source === false || $destination === false) {
+            if (\is_resource($source)) {
+                \fclose($source);
+            }
+
+            if (\is_resource($destination)) {
+                \fclose($destination);
+            }
+
+            throw AttachmentError::storage('Failed to copy attachment into its output directory');
+        }
+
+        try {
+            while (!\feof($source)) {
+                $chunk = \fread($source, self::COPY_CHUNK_BYTES);
+
+                if ($chunk === false) {
+                    throw AttachmentError::storage('Failed to read attachment staging content');
+                }
+
+                if ($chunk !== '') {
+                    StreamWriter::writeFully($destination, $chunk);
+                }
+            }
+
+            if (!\fflush($destination)) {
+                throw AttachmentError::storage('Failed to flush the published attachment');
+            }
+        } finally {
+            \fclose($destination);
+            \fclose($source);
+        }
+    }
+}

--- a/src/Runner/Artifact/NativeFileRenamer.php
+++ b/src/Runner/Artifact/NativeFileRenamer.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Runner\Artifact;
+
+/** @internal */
+final readonly class NativeFileRenamer implements FileRenamer
+{
+    #[\Override]
+    public function rename(string $sourcePath, string $destinationPath): bool
+    {
+        return \rename($sourcePath, $destinationPath);
+    }
+}

--- a/tests/Fixture/Artifact/ControlledFileRenamer.php
+++ b/tests/Fixture/Artifact/ControlledFileRenamer.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Artifact;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Runner\Artifact\FileRenamer;
+
+final class ControlledFileRenamer implements Fake, FileRenamer
+{
+    public bool $failNext = false;
+
+    /** @var list<array{string, string}> */
+    public array $calls = [];
+
+    #[\Override]
+    public function rename(string $sourcePath, string $destinationPath): bool
+    {
+        $this->calls[] = [$sourcePath, $destinationPath];
+
+        if ($this->failNext) {
+            $this->failNext = false;
+
+            return false;
+        }
+
+        return \rename($sourcePath, $destinationPath);
+    }
+}

--- a/tests/Fixture/Artifact/CorruptingFileCopier.php
+++ b/tests/Fixture/Artifact/CorruptingFileCopier.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Artifact;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Runner\Artifact\FileCopier;
+
+final readonly class CorruptingFileCopier implements Fake, FileCopier
+{
+    #[\Override]
+    public function copy(string $sourcePath, string $destinationPath): void
+    {
+        $contents = \file_get_contents($sourcePath);
+
+        if (!\is_string($contents) || $contents === '') {
+            throw new \RuntimeException('The corrupting file copier did not read the source.');
+        }
+
+        $contents[0] = $contents[0] === "\0" ? "\1" : "\0";
+
+        if (\file_put_contents($destinationPath, $contents, \LOCK_EX) !== \strlen($contents)) {
+            throw new \RuntimeException('The corrupting file copier did not write the destination.');
+        }
+    }
+}

--- a/tests/Unit/Artifact/ArtifactCopyFlushFailureTest.php
+++ b/tests/Unit/Artifact/ArtifactCopyFlushFailureTest.php
@@ -9,7 +9,7 @@ use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\TempDirectory;
-use Greenlight\Runner\Artifact\FileCopier;
+use Greenlight\Runner\Artifact\NativeFileCopier;
 use Greenlight\Tests\Fixture\Artifact\UnflushableStream;
 
 final readonly class ArtifactCopyFlushFailureTest
@@ -34,7 +34,7 @@ final readonly class ArtifactCopyFlushFailureTest
 
             UnflushableStream::reset();
 
-            Expect::that(static fn() => FileCopier::copy(
+            Expect::that(static fn() => new NativeFileCopier()->copy(
                 $source,
                 self::SCHEME . '://destination',
             ))

--- a/tests/Unit/Artifact/ArtifactCopyOpenFailureTest.php
+++ b/tests/Unit/Artifact/ArtifactCopyOpenFailureTest.php
@@ -9,7 +9,7 @@ use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\TempDirectory;
-use Greenlight\Runner\Artifact\FileCopier;
+use Greenlight\Runner\Artifact\NativeFileCopier;
 use Greenlight\Tests\Fixture\Artifact\TrackedOpenStream;
 
 final readonly class ArtifactCopyOpenFailureTest
@@ -30,7 +30,7 @@ final readonly class ArtifactCopyOpenFailureTest
         try {
             TrackedOpenStream::reset();
 
-            Expect::that(static fn() => FileCopier::copy(
+            Expect::that(static fn() => new NativeFileCopier()->copy(
                 $root . '/missing-source.txt',
                 self::SCHEME . '://destination',
             ))
@@ -46,7 +46,7 @@ final readonly class ArtifactCopyOpenFailureTest
 
             TrackedOpenStream::reset();
 
-            Expect::that(static fn() => FileCopier::copy(
+            Expect::that(static fn() => new NativeFileCopier()->copy(
                 self::SCHEME . '://source',
                 $root . '/missing/destination.txt',
             ))

--- a/tests/Unit/Artifact/ArtifactCopyReadFailureTest.php
+++ b/tests/Unit/Artifact/ArtifactCopyReadFailureTest.php
@@ -9,7 +9,7 @@ use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\TempDirectory;
-use Greenlight\Runner\Artifact\FileCopier;
+use Greenlight\Runner\Artifact\NativeFileCopier;
 use Greenlight\Tests\Fixture\Artifact\UnreadableCopySourceStream;
 
 final readonly class ArtifactCopyReadFailureTest
@@ -29,7 +29,7 @@ final readonly class ArtifactCopyReadFailureTest
             UnreadableCopySourceStream::reset();
             $destination = $this->tempDirectory->path() . '/destination.txt';
 
-            Expect::that(static fn() => FileCopier::copy(
+            Expect::that(static fn() => new NativeFileCopier()->copy(
                 self::SCHEME . '://source',
                 $destination,
             ))

--- a/tests/Unit/Artifact/ArtifactPostCopyIntegrityTest.php
+++ b/tests/Unit/Artifact/ArtifactPostCopyIntegrityTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\ArtifactStore;
+use Greenlight\Runner\Artifact\TestArtifactBudget;
+use Greenlight\Tests\Fixture\Artifact\CorruptingFileCopier;
+
+final readonly class ArtifactPostCopyIntegrityTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function postCopyCorruptionRejectsPublicationAndRemovesThePartialFile(): void
+    {
+        $root = $this->tempDirectory->subdirectory('post-copy-integrity');
+        $store = ArtifactStore::open(
+            new ArtifactConfiguration($root),
+            $root,
+            'run-post-copy-integrity',
+            new CorruptingFileCopier(),
+        );
+        $id = new TestId('Example\EvidenceTest', 'fails');
+        $attempt = $store->forAttempt($id, 1, new TestArtifactBudget());
+        $attempt->text('evidence.txt', 'evidence');
+        $staged = $attempt->seal()[0];
+        $result = new TestResult(
+            $id,
+            Outcome::Failed,
+            0.1,
+            0,
+            attachments: [$staged],
+        );
+
+        try {
+            Expect::that(static fn(): TestResult => $store->publish($result))
+                ->because('post-copy corruption MUST reject attachment publication')
+                ->toThrow(
+                    AttachmentError::class,
+                    message: 'Published attachment content does not match its metadata.',
+                )
+                ->and(\is_file($staged->path))
+                ->because('a rejected publication MUST NOT leave the final attachment')
+                ->toBeFalse()
+                ->and(\glob($staged->path . '.part-*'))
+                ->because('a rejected publication MUST remove its partial attachment')
+                ->toBe([]);
+        } finally {
+            $store->cleanup();
+        }
+    }
+}

--- a/tests/Unit/Artifact/ArtifactRenameFailureTest.php
+++ b/tests/Unit/Artifact/ArtifactRenameFailureTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Core\Artifact\AttachmentKind;
+use Greenlight\Core\Artifact\AttachmentRetention;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\ArtifactSession;
+use Greenlight\Runner\Artifact\ArtifactStore;
+use Greenlight\Runner\Artifact\TestArtifactBudget;
+use Greenlight\Tests\Fixture\Artifact\ControlledFileRenamer;
+
+final readonly class ArtifactRenameFailureTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function byteStagingRenameFailureRollsBackTheFileAndQuota(): void
+    {
+        $root = $this->tempDirectory->subdirectory('byte-staging-rename-failure');
+        [$store, $configuration, $renamer] = $this->store($root);
+        $storageKey = 'Example-EvidenceTest/attempt-1/01-evidence.txt';
+        $path = $store->session()->stagingDirectory . '/' . $storageKey;
+        $renamer->failNext = true;
+
+        Expect::that(static fn() => $store->stageBytes(
+            'evidence',
+            'evidence.txt',
+            $storageKey,
+            'text/plain',
+            AttachmentKind::Text,
+            1,
+            AttachmentRetention::OnFailure,
+            $configuration,
+        ))
+            ->because('a failed byte staging rename MUST reject the attachment')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Failed to finalize attachment staging file.',
+            )
+            ->and(\file_exists($path))
+            ->because('a failed byte staging rename MUST remove the final path')
+            ->toBeFalse()
+            ->and(\file_exists($path . '.part'))
+            ->because('a failed byte staging rename MUST remove the partial path')
+            ->toBeFalse();
+
+        $staged = $store->stageBytes(
+            'evidence',
+            'evidence.txt',
+            $storageKey,
+            'text/plain',
+            AttachmentKind::Text,
+            1,
+            AttachmentRetention::OnFailure,
+            $configuration,
+        );
+
+        Expect::that($staged->name)
+            ->because('a failed byte staging rename MUST release its run quota')
+            ->toBe('evidence.txt');
+    }
+
+    #[Test]
+    public function fileStagingRenameFailureRollsBackTheFileAndQuota(): void
+    {
+        $root = $this->tempDirectory->subdirectory('file-staging-rename-failure');
+        $source = $root . '/source.txt';
+        \file_put_contents($source, 'evidence');
+        [$store, $configuration, $renamer] = $this->store($root);
+        $storageKey = 'Example-EvidenceTest/attempt-1/01-evidence.txt';
+        $path = $store->session()->stagingDirectory . '/' . $storageKey;
+        $renamer->failNext = true;
+
+        Expect::that(static fn() => $store->stageFile(
+            $source,
+            'evidence.txt',
+            $storageKey,
+            'text/plain',
+            1,
+            AttachmentRetention::OnFailure,
+            $configuration,
+        ))
+            ->because('a failed file staging rename MUST reject the attachment')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Failed to finalize attachment staging file.',
+            )
+            ->and(\file_exists($path))
+            ->because('a failed file staging rename MUST remove the final path')
+            ->toBeFalse()
+            ->and(\file_exists($path . '.part'))
+            ->because('a failed file staging rename MUST remove the partial path')
+            ->toBeFalse();
+
+        $staged = $store->stageFile(
+            $source,
+            'evidence.txt',
+            $storageKey,
+            'text/plain',
+            1,
+            AttachmentRetention::OnFailure,
+            $configuration,
+        );
+
+        Expect::that($staged->name)
+            ->because('a failed file staging rename MUST release its run quota')
+            ->toBe('evidence.txt');
+    }
+
+    #[Test]
+    public function publicationRenameFailureRemovesThePartialFileAndPreservesStaging(): void
+    {
+        $root = $this->tempDirectory->subdirectory('publication-rename-failure');
+        $renamer = new ControlledFileRenamer();
+        $store = ArtifactStore::open(
+            new ArtifactConfiguration($root),
+            $root,
+            'run-publication-rename-failure',
+            fileRenamer: $renamer,
+        );
+        $id = new TestId('Example\EvidenceTest', 'fails');
+        $attempt = $store->forAttempt($id, 1, new TestArtifactBudget());
+        $attempt->text('evidence.txt', 'evidence');
+        $staged = $attempt->seal()[0];
+        $source = $store->session()->stagingDirectory . '/' . $staged->storageKey;
+        $result = new TestResult(
+            $id,
+            Outcome::Failed,
+            0.1,
+            0,
+            attachments: [$staged],
+        );
+        $renamer->failNext = true;
+
+        try {
+            Expect::that(static fn(): TestResult => $store->publish($result))
+                ->because('a failed publication rename MUST reject the attachment')
+                ->toThrow(
+                    AttachmentError::class,
+                    message: 'Failed to publish attachment.',
+                )
+                ->and(\file_exists($staged->path))
+                ->because('a failed publication rename MUST NOT leave the final attachment')
+                ->toBeFalse()
+                ->and(\glob($staged->path . '.part-*'))
+                ->because('a failed publication rename MUST remove the partial attachment')
+                ->toBe([])
+                ->and(\is_file($source))
+                ->because('a failed publication rename MUST preserve staging for a retry')
+                ->toBeTrue();
+
+            $published = $store->publish($result);
+
+            Expect::that($published->attachments)
+                ->because('publication MUST succeed after a transient rename failure')
+                ->toHaveCount(1);
+        } finally {
+            $store->cleanup();
+        }
+    }
+
+    /**
+     * @return array{ArtifactStore, ArtifactConfiguration, ControlledFileRenamer}
+     */
+    private function store(string $root): array
+    {
+        $configuration = new ArtifactConfiguration(
+            $root . '/published',
+            maxRunAttachments: 1,
+        );
+        $renamer = new ControlledFileRenamer();
+        $store = ArtifactStore::fromSession(
+            new ArtifactSession($root . '/staging', $root . '/published/run-1'),
+            $configuration,
+            fileRenamer: $renamer,
+        );
+
+        return [$store, $configuration, $renamer];
+    }
+}


### PR DESCRIPTION
## Summary

- route artifact finalization through an injectable file-renaming seam
- cover byte and file staging rename failures, cleanup, and quota rollback
- cover publication rename failure cleanup, staging retention, and retry