### PR TITLE
test(fixtures): cover root link removal failures

### DIFF
--- a/tests/Unit/Fixture/TempDirectoryRootSymbolicLinkTest.php
+++ b/tests/Unit/Fixture/TempDirectoryRootSymbolicLinkTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Fixture;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\SkipTest;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\TempDirectory;
@@ -46,6 +47,50 @@ final class TempDirectoryRootSymbolicLinkTest
 
             $directory->dispose();
             $target->dispose();
+        }
+    }
+
+    #[Test]
+    public function disposalReportsARootSymbolicLinkThatCannotBeRemoved(): void
+    {
+        $owner = new TempDirectory();
+        $temporaryRoot = $owner->subdirectory('blocked-root');
+        $directory = new TempDirectory($temporaryRoot);
+        $target = new TempDirectory();
+        $root = $directory->path();
+
+        if (!\rmdir($root) || !\symlink($target->path(), $root)) {
+            Fail::because('Expected to replace the temp directory root with a symbolic link.');
+        }
+
+        \chmod($temporaryRoot, 0o500);
+        \clearstatcache(true, $temporaryRoot);
+
+        try {
+            if (\is_writable($temporaryRoot)) {
+                throw new SkipTest('The filesystem does not enforce directory write permissions.');
+            }
+
+            Expect::that(static fn() => $directory->dispose())
+                ->because('fixture cleanup MUST report a root symbolic link that it cannot remove')
+                ->toThrow(
+                    \RuntimeException::class,
+                    message: \sprintf(
+                        'Failed to remove temp directory symbolic link "%s": unlink(%s): Permission denied.',
+                        $root,
+                        $root,
+                    ),
+                );
+        } finally {
+            \chmod($temporaryRoot, 0o700);
+
+            if (\is_link($root)) {
+                \unlink($root);
+            }
+
+            $directory->dispose();
+            $target->dispose();
+            $owner->dispose();
         }
     }
 }


### PR DESCRIPTION
Cover the cleanup path where a replaced temporary-directory root is a symbolic link that cannot be removed. The focused test verifies the exact diagnostic and restores permissions and resources in all outcomes.