### PR TITLE
test(harness): cover sensitive value debug redaction

### DIFF
--- a/tests/Unit/Harness/IntegrationResourcesTest.php
+++ b/tests/Unit/Harness/IntegrationResourcesTest.php
@@ -77,6 +77,17 @@ final class IntegrationResourcesTest
     }
 
     #[Test]
+    public function sensitiveValueDebugInformationContainsOnlyTheRedactionMarker(): void
+    {
+        $value = FixtureResource::from(secrets: ['password' => 'do-not-print'])
+            ->secret('password');
+
+        Expect::that($value->__debugInfo())
+            ->because('sensitive value debug information MUST identify redaction without exposing the value')
+            ->toBe(['value' => '[redacted]']);
+    }
+
+    #[Test]
     public function debugRepresentationsKeepNestedSecretsRedacted(): void
     {
         $secret = 'database-password';


### PR DESCRIPTION
Cover the exact debug representation of a sensitive fixture value. The focused assertion locks the visible redaction marker while ensuring the debug shape contains no underlying value.