### PR TITLE
test(protocol): retain zero coverage paths

### DIFF
--- a/tests/Unit/Runner/Protocol/ProtocolTest.php
+++ b/tests/Unit/Runner/Protocol/ProtocolTest.php
@@ -123,18 +123,18 @@ final class ProtocolTest
     }
 
     #[Test]
-    public function assignDropsEmptyCoverageIncludePathsFromTheWire(): void
+    public function assignDropsOnlyEmptyCoverageIncludePathsFromTheWire(): void
     {
         $payload = new Assign(
             new ExecutionPlan([]),
             coverageInclude: ['/app/src'],
         )->toWire();
-        $payload['coverageInclude'] = ['', '/app/src', ''];
+        $payload['coverageInclude'] = ['', '0', '/app/src', ''];
         $assign = Assign::fromWire($payload);
 
         Expect::that($assign->coverageInclude)
-            ->because('workers receive only non-empty coverage include paths')
-            ->toBe(['/app/src']);
+            ->because('workers MUST retain each non-empty coverage include path')
+            ->toBe(['0', '/app/src']);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- extend worker assignment coverage path normalization with the valid string \`0\`
- pin the wire boundary to drop only empty coverage include paths