### PR TITLE
test(coverage): retain zero include paths

### DIFF
--- a/tests/Unit/Coverage/PathFilterTest.php
+++ b/tests/Unit/Coverage/PathFilterTest.php
@@ -48,6 +48,19 @@ final class PathFilterTest
     }
 
     #[Test]
+    public function zeroStringIsAValidRelativeIncludeDirectory(): void
+    {
+        $filter = new PathFilter(['0']);
+
+        Expect::that($filter->accepts('0/Covered.php'))
+            ->because('a zero-string include directory is not empty')
+            ->toBeTrue()
+            ->and($filter->accepts('01/NotCovered.php'))
+            ->because('relative include directories MUST match by path segment')
+            ->toBeFalse();
+    }
+
+    #[Test]
     public function emptyDirectoryEntriesAreRejected(): void
     {
         Expect::that(static fn(): PathFilter => new PathFilter(['']))->because('empty directory entries are rejected')


### PR DESCRIPTION
Adds focused PathFilter coverage for a valid relative directory named zero. The test verifies path-segment normalization and rejects adjacent string-prefix matches.