### PR TITLE
test(protocol): retain zero optional strings

### DIFF
--- a/tests/Unit/Runner/Protocol/AssignOptionalStringWireTest.php
+++ b/tests/Unit/Runner/Protocol/AssignOptionalStringWireTest.php
@@ -42,8 +42,10 @@ final class AssignOptionalStringWireTest
     public static function optionalStrings(): iterable
     {
         yield 'empty coverage driver' => ['coverageDriver', '', null];
+        yield 'zero coverage driver' => ['coverageDriver', '0', '0'];
         yield 'non-empty coverage driver' => ['coverageDriver', 'xdebug', 'xdebug'];
         yield 'empty config file' => ['configFile', '', null];
+        yield 'zero config file' => ['configFile', '0', '0'];
         yield 'non-empty config file' => ['configFile', '/app/greenlight.php', '/app/greenlight.php'];
     }
 }

--- a/tests/Unit/Runner/Protocol/ProtocolTest.php
+++ b/tests/Unit/Runner/Protocol/ProtocolTest.php
@@ -123,18 +123,18 @@ final class ProtocolTest
     }
 
     #[Test]
-    public function assignDropsEmptyCoverageIncludePathsFromTheWire(): void
+    public function assignDropsOnlyEmptyCoverageIncludePathsFromTheWire(): void
     {
         $payload = new Assign(
             new ExecutionPlan([]),
             coverageInclude: ['/app/src'],
         )->toWire();
-        $payload['coverageInclude'] = ['', '/app/src', ''];
+        $payload['coverageInclude'] = ['', '0', '/app/src', ''];
         $assign = Assign::fromWire($payload);
 
         Expect::that($assign->coverageInclude)
-            ->because('workers receive only non-empty coverage include paths')
-            ->toBe(['/app/src']);
+            ->because('workers MUST retain each non-empty coverage include path')
+            ->toBe(['0', '/app/src']);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- cover the string \`0\` at both optional assignment string boundaries
- pin coverage driver and configuration file decoding to reject only empty strings