### PR TITLE
test(conditions): retain zero PHP versions

### DIFF
--- a/tests/Unit/Condition/PhpVersionConditionValidationTest.php
+++ b/tests/Unit/Condition/PhpVersionConditionValidationTest.php
@@ -36,4 +36,25 @@ final readonly class PhpVersionConditionValidationTest
         yield 'at least' => [static fn(): PhpVersionAtLeast => new PhpVersionAtLeast('')];
         yield 'less than' => [static fn(): PhpVersionLessThan => new PhpVersionLessThan('')];
     }
+
+    /**
+     * @param \Closure(): Condition $create
+     */
+    #[Test]
+    #[DataSet('zeroVersionConditions')]
+    public function acceptsZeroAsAPhpVersion(\Closure $create, bool $expected): void
+    {
+        Expect::that($create()->isSatisfied())
+            ->because('the non-empty version "0" MUST retain PHP version comparison semantics')
+            ->toBe($expected);
+    }
+
+    /**
+     * @return iterable<string, array{\Closure(): Condition, bool}>
+     */
+    public static function zeroVersionConditions(): iterable
+    {
+        yield 'at least' => [static fn(): PhpVersionAtLeast => new PhpVersionAtLeast('0'), true];
+        yield 'less than' => [static fn(): PhpVersionLessThan => new PhpVersionLessThan('0'), false];
+    }
 }


### PR DESCRIPTION
Cover the valid non-empty PHP version string "0" through one named data set. Both comparison conditions retain their version_compare semantics and reject only the empty string.