### PR TITLE
test(artifacts): retain zero session directories

### DIFF
--- a/tests/Unit/Artifact/ArtifactSessionTest.php
+++ b/tests/Unit/Artifact/ArtifactSessionTest.php
@@ -12,6 +12,23 @@ use Greenlight\Runner\Artifact\ArtifactSession;
 final readonly class ArtifactSessionTest
 {
     #[Test]
+    #[DataSet('validDirectories')]
+    public function artifactSessionsRetainZeroDirectories(
+        string $stagingDirectory,
+        string $publicDirectory,
+    ): void {
+        $session = new ArtifactSession($stagingDirectory, $publicDirectory);
+        $decoded = ArtifactSession::fromWire($session->toWire());
+
+        Expect::that([$session->stagingDirectory, $session->publicDirectory])
+            ->because('an artifact session MUST retain each non-empty storage directory')
+            ->toBe([$stagingDirectory, $publicDirectory])
+            ->and([$decoded->stagingDirectory, $decoded->publicDirectory])
+            ->because('artifact storage directories MUST survive the wire')
+            ->toBe([$stagingDirectory, $publicDirectory]);
+    }
+
+    #[Test]
     #[DataSet('invalidDirectories')]
     public function artifactSessionsRejectMissingDirectories(
         string $stagingDirectory,
@@ -41,5 +58,14 @@ final readonly class ArtifactSessionTest
             '',
             'Artifact public directory must not be empty.',
         ];
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function validDirectories(): iterable
+    {
+        yield 'zero staging directory' => ['0', '/project/build/artifacts/run-1'];
+        yield 'zero public directory' => ['/project/.greenlight/staging/run-1', '0'];
     }
 }


### PR DESCRIPTION
## Summary

- cover the valid directory name \`0\` independently for artifact staging and publication
- pin direct construction and wire round-trips to reject only empty directory names