### PR TITLE
test(config): retain zero suite builder values

### DIFF
--- a/tests/Unit/Config/SuiteBuilderTest.php
+++ b/tests/Unit/Config/SuiteBuilderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Config;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\SuiteBuilder;
 use Greenlight\Expect\Expect;
@@ -26,5 +27,32 @@ final class SuiteBuilderTest
         Expect::that($suite->tags)
             ->because('repeated tag() calls append each tag')
             ->toBe(['io', 'slow', 'external']);
+    }
+
+    /**
+     * @param list<string> $paths
+     * @param list<string> $tags
+     */
+    #[Test]
+    #[DataSet('zeroStringValues')]
+    public function preservesZeroStringsInBuiltConfiguration(array $paths, array $tags): void
+    {
+        $suite = new SuiteBuilder('suite')
+            ->in(...$paths)
+            ->tag(...$tags)
+            ->toConfiguration();
+
+        Expect::that([$suite->paths, $suite->tags])
+            ->because('zero-string suite builder values are not empty')
+            ->toBe([$paths, $tags]);
+    }
+
+    /**
+     * @return iterable<string, array{list<string>, list<string>}>
+     */
+    public static function zeroStringValues(): iterable
+    {
+        yield 'path' => [['0'], ['fast']];
+        yield 'tag' => [['tests'], ['0']];
     }
 }


### PR DESCRIPTION
Adds focused SuiteBuilder boundary coverage. Named dataset rows verify nonempty zero-string paths and tags survive exactly into the built suite configuration.