### PR TITLE
test(config): retain zero artifact directory

### DIFF
--- a/tests/Unit/Config/ArtifactBuilderTest.php
+++ b/tests/Unit/Config/ArtifactBuilderTest.php
@@ -12,6 +12,18 @@ use Greenlight\Expect\Expect;
 
 final class ArtifactBuilderTest
 {
+    #[Test]
+    public function retainsAZeroArtifactDirectory(): void
+    {
+        $configuration = new ArtifactBuilder()
+            ->directory('0')
+            ->toConfiguration();
+
+        Expect::that($configuration->directory)
+            ->because('the artifact builder MUST retain each non-empty directory')
+            ->toBe('0');
+    }
+
     /**
      * @param \Closure(ArtifactBuilder): void $configure
      */


### PR DESCRIPTION
## Summary

- cover the valid artifact directory name \`0\`
- pin the artifact builder to reject only an empty directory before producing configuration