### PR TITLE
test(config): retain zero suite names

### DIFF
--- a/tests/Unit/Config/GreenlightConfigTest.php
+++ b/tests/Unit/Config/GreenlightConfigTest.php
@@ -100,6 +100,22 @@ final class GreenlightConfigTest
     }
 
     #[Test]
+    public function preservesAZeroStringSuiteNameThroughBuild(): void
+    {
+        $configuration = GreenlightConfig::create()
+            ->suite('0', static fn(SuiteBuilder $suite) => $suite->in('tests')->tag('fast'))
+            ->build();
+
+        Expect::that([
+            $configuration->suites[0]->name,
+            $configuration->suites[0]->paths,
+            $configuration->suites[0]->tags,
+        ])
+            ->because('a zero-string suite name is not empty')
+            ->toBe(['0', ['tests'], ['fast']]);
+    }
+
+    #[Test]
     public function randomizeOrderWithoutSeedStillEnablesRandomization(): void
     {
         $configuration = GreenlightConfig::create()->randomizeOrder()->build();


### PR DESCRIPTION
Adds focused public-configuration coverage for a suite named zero. The test verifies the name, path, and tag survive the complete GreenlightConfig build.