### PR TITLE
test(cli): retain zero option names

### DIFF
--- a/tests/Unit/Cli/OptionSpecTest.php
+++ b/tests/Unit/Cli/OptionSpecTest.php
@@ -6,11 +6,22 @@ namespace Greenlight\Tests\Unit\Cli;
 
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
+use Greenlight\Cli\ArgumentParser;
 use Greenlight\Cli\OptionSpec;
 use Greenlight\Expect\Expect;
 
 final readonly class OptionSpecTest
 {
+    #[Test]
+    public function zeroStringLongNameParsesAsAFlag(): void
+    {
+        $arguments = new ArgumentParser([new OptionSpec('0')])->parse(['--0']);
+
+        Expect::that($arguments->has('0'))
+            ->because('a zero-string long option name is not empty')
+            ->toBeTrue();
+    }
+
     #[Test]
     #[DataSet('invalidDefinitions')]
     public function invalidOptionDefinitionsAreRejected(


### PR DESCRIPTION
Adds focused end-to-end coverage that a nonempty zero-string long option name survives OptionSpec, ArgumentParser, and ParsedArguments lookup.