### PR TITLE
test(core): cover internal throwable frames

### DIFF
--- a/tests/Support/ThrowableDetailStaticFrame.php
+++ b/tests/Support/ThrowableDetailStaticFrame.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Support;
+
+use Greenlight\Doubles\Fake;
+
+final class ThrowableDetailStaticFrame implements Fake
+{
+    public static function fail(mixed $value): never
+    {
+        throw new \RuntimeException('internal frame');
+    }
+}

--- a/tests/Unit/Core/ThrowableDetailTest.php
+++ b/tests/Unit/Core/ThrowableDetailTest.php
@@ -14,6 +14,29 @@ use Greenlight\Expect\Fail;
 final class ThrowableDetailTest
 {
     #[Test]
+    public function rendersNormalInstanceMethodStackFrames(): void
+    {
+        $threw = null;
+
+        try {
+            $callLine = __LINE__ + 1;
+            $this->throwFromInstanceMethod();
+        } catch (\RuntimeException $exception) {
+            $threw = $exception;
+        }
+
+        Expect::that(ThrowableDetail::fromThrowable($threw)->stackFrames[0])
+            ->because('a throwable detail MUST identify the method and source of each stack frame')
+            ->toBe(
+                self::class
+                . '->throwFromInstanceMethod at '
+                . __FILE__
+                . ':'
+                . $callLine,
+            );
+    }
+
+    #[Test]
     public function deepTracesAreBoundedWithATruncationMarker(): void
     {
         $capture = new class implements Fake {
@@ -91,5 +114,10 @@ final class ThrowableDetailTest
         }
 
         $this->throwAtDepth($remaining - 1);
+    }
+
+    private function throwFromInstanceMethod(): never
+    {
+        throw new \RuntimeException('frame');
     }
 }

--- a/tests/Unit/Core/ThrowableDetailTest.php
+++ b/tests/Unit/Core/ThrowableDetailTest.php
@@ -10,6 +10,7 @@ use Greenlight\Core\Result\ThrowableDetail;
 use Greenlight\Doubles\Fake;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
+use Greenlight\Tests\Support\ThrowableDetailStaticFrame;
 
 final class ThrowableDetailTest
 {
@@ -34,6 +35,26 @@ final class ThrowableDetailTest
                 . ':'
                 . $callLine,
             );
+    }
+
+    #[Test]
+    public function rendersInternalStaticMethodStackFrames(): void
+    {
+        $threw = null;
+
+        try {
+            \array_map(ThrowableDetailStaticFrame::fail(...), [null]);
+        } catch (\RuntimeException $exception) {
+            $threw = $exception;
+        }
+
+        if (!$threw instanceof \RuntimeException) {
+            Fail::because('Expected the internal stack frame helper to throw.');
+        }
+
+        Expect::that(ThrowableDetail::fromThrowable($threw)->stackFrames[0])
+            ->because('an internal throwable frame MUST identify its static method without a source location')
+            ->toBe(ThrowableDetailStaticFrame::class . '::fail at [internal]');
     }
 
     #[Test]

--- a/tests/Unit/Core/ThrowableDetailTest.php
+++ b/tests/Unit/Core/ThrowableDetailTest.php
@@ -58,6 +58,29 @@ final class ThrowableDetailTest
     }
 
     #[Test]
+    public function rendersFunctionStackFrames(): void
+    {
+        $threw = null;
+
+        try {
+            $callLine = __LINE__ + 1;
+            throwForThrowableDetailFunctionFrame();
+        } catch (\RuntimeException $exception) {
+            $threw = $exception;
+        }
+
+        Expect::that(ThrowableDetail::fromThrowable($threw)->stackFrames[0])
+            ->because('a throwable detail MUST render a function frame without a class call type')
+            ->toBe(
+                __NAMESPACE__
+                . '\throwForThrowableDetailFunctionFrame at '
+                . __FILE__
+                . ':'
+                . $callLine,
+            );
+    }
+
+    #[Test]
     public function deepTracesAreBoundedWithATruncationMarker(): void
     {
         $capture = new class implements Fake {
@@ -141,4 +164,9 @@ final class ThrowableDetailTest
     {
         throw new \RuntimeException('frame');
     }
+}
+
+function throwForThrowableDetailFunctionFrame(): never
+{
+    throw new \RuntimeException('function frame');
 }


### PR DESCRIPTION
Add deterministic coverage for throwable frames created by an internal static callback. A PSR-4-safe support fixture implements Fake and pins the static call form plus the internal-location marker.