### PR TITLE
test(core): retain zero transformation sources

### DIFF
--- a/tests/Unit/Core/OutcomeTransformationTest.php
+++ b/tests/Unit/Core/OutcomeTransformationTest.php
@@ -8,9 +8,28 @@ use Greenlight\Attribute\Test;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\OutcomeTransformation;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\JsonWire;
 
 final readonly class OutcomeTransformationTest
 {
+    #[Test]
+    public function retainsAZeroSourceAcrossTheWire(): void
+    {
+        $transformation = new OutcomeTransformation('0', Outcome::Failed, Outcome::Skipped);
+        $decoded = OutcomeTransformation::fromWire(JsonWire::roundTrip($transformation->toWire()));
+
+        Expect::that($transformation->transformedBy)
+            ->because('an outcome transformation MUST retain each non-empty source')
+            ->toBe('0')
+            ->and($decoded->transformedBy)
+            ->because('the transformation source MUST survive the wire')
+            ->toBe('0')
+            ->and($decoded->from)
+            ->toBe(Outcome::Failed)
+            ->and($decoded->to)
+            ->toBe(Outcome::Skipped);
+    }
+
     #[Test]
     public function rejectsAnEmptySource(): void
     {


### PR DESCRIPTION
## Summary

- cover the valid outcome-transformation source \`0\`
- pin direct construction and JSON wire round-trips to reject only an empty source
- assert the transformed outcome pair survives decoding