### PR TITLE
test(runner): cover worker termination cleanup

### DIFF
--- a/tests/Unit/Runner/Orchestrator/WorkerHandleTerminationTest.php
+++ b/tests/Unit/Runner/Orchestrator/WorkerHandleTerminationTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Orchestrator;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Attribute\Timeout;
+use Greenlight\Core\ErrorTrap;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Runner\Orchestrator\WorkerHandle;
+use Greenlight\Runner\Protocol\SocketChannel;
+
+final readonly class WorkerHandleTerminationTest
+{
+    #[Test]
+    #[Timeout(5.0)]
+    public function terminationClosesTheChannelAndProcess(): void
+    {
+        $process = null;
+        $pipes = [];
+        $sockets = [];
+
+        try {
+            $process = \proc_open(
+                [
+                    \PHP_BINARY,
+                    '-r',
+                    'fwrite(STDOUT, "ready\n"); fflush(STDOUT); while (true) { usleep(10000); }',
+                ],
+                [
+                    0 => ['pipe', 'r'],
+                    1 => ['pipe', 'w'],
+                    2 => ['pipe', 'w'],
+                ],
+                $pipes,
+                options: ['bypass_shell' => true],
+            );
+
+            if (!\is_resource($process)) {
+                Fail::because('Expected the worker process fixture to start.');
+            }
+
+            $sockets = \stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, 0);
+
+            if ($sockets === false) {
+                Fail::because('Expected the worker channel fixture to open.');
+            }
+
+            \stream_set_timeout($pipes[1], 2);
+
+            Expect::that(\fgets($pipes[1]))
+                ->because('the worker process fixture MUST signal that it is ready')
+                ->toBe("ready\n");
+
+            $channel = new SocketChannel($sockets[0]);
+            $handle = new WorkerHandle(
+                'worker-1',
+                1,
+                $process,
+                $pipes[1],
+                $pipes[2],
+            );
+            $handle->channel = $channel;
+            $handle->terminate();
+
+            Expect::that([$channel->isEof(), \is_resource($process)])
+                ->because('worker termination MUST close its protocol channel and process handle')
+                ->toBe([true, false]);
+        } finally {
+            $resources = $pipes;
+
+            if (\is_array($sockets)) {
+                $resources = [...$resources, ...$sockets];
+            }
+
+            foreach ($resources as $resource) {
+                if (\is_resource($resource)) {
+                    ErrorTrap::run(static fn(): bool => \fclose($resource));
+                }
+            }
+
+            if (\is_resource($process)) {
+                ErrorTrap::run(static fn(): bool => \proc_terminate($process, 9));
+                ErrorTrap::run(static fn(): int => \proc_close($process));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add focused coverage for worker termination cleanup. A readiness-synchronised child process and real socket channel prove that termination closes both resources, with independent cleanup in a finally block.