### PR TITLE
test(core): retain zero metadata groups

### DIFF
--- a/tests/Unit/Core/TestMetadataZeroGroupTest.php
+++ b/tests/Unit/Core/TestMetadataZeroGroupTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\JsonWire;
+
+final readonly class TestMetadataZeroGroupTest
+{
+    #[Test]
+    public function retainsAZeroGroupAcrossTheWire(): void
+    {
+        $metadata = new TestMetadata('App\ExampleTest', 'example', groups: ['0']);
+        $decoded = TestMetadata::fromWire(JsonWire::roundTrip($metadata->toWire()));
+
+        Expect::that($metadata->groups)
+            ->because('test metadata MUST retain each non-empty group name')
+            ->toBe(['0'])
+            ->and($decoded->groups)
+            ->because('the group name MUST survive the wire')
+            ->toBe(['0']);
+    }
+}


### PR DESCRIPTION
## Summary

- cover the valid test-metadata group name \`0\`
- pin direct construction and JSON wire round-trips to reject only empty group names
- keep this boundary test isolated from the shared metadata wire suite