### PR TITLE
test(discovery): cover named class-like declarations

### DIFF
--- a/tests/Unit/Discovery/ClassFileParserTest.php
+++ b/tests/Unit/Discovery/ClassFileParserTest.php
@@ -15,6 +15,41 @@ final readonly class ClassFileParserTest
     public function __construct(private TempDirectory $tempDirectory) {}
 
     #[Test]
+    public function returnsOnlyNamedClassLikeDeclarations(): void
+    {
+        $file = $this->tempDirectory->path() . '/ClassLikeDeclarations.php';
+        \file_put_contents($file, <<<'PHP'
+            <?php
+
+            namespace Example;
+
+            interface Contract {}
+            trait SharedBehavior {}
+            enum State {}
+            final class NamedTest {}
+
+            $name = NamedTest::class;
+            PHP);
+
+        $declarations = \array_map(
+            static fn(ClassDeclaration $declaration): array => [
+                $declaration->fqcn(),
+                $declaration->kind,
+            ],
+            ClassFileParser::declarationsIn($file),
+        );
+
+        Expect::that($declarations)
+            ->because('discovery MUST return only named class-like declarations')
+            ->toBe([
+                ['Example\Contract', 'interface'],
+                ['Example\SharedBehavior', 'trait'],
+                ['Example\State', 'enum'],
+                ['Example\NamedTest', 'class'],
+            ]);
+    }
+
+    #[Test]
     public function aGlobalBracketedNamespaceClearsThePreviousNamespace(): void
     {
         $file = $this->tempDirectory->path() . '/Declarations.php';


### PR DESCRIPTION
## Summary

- Cover named class, interface, trait, and enum discovery in one source file.
- Prove that `::class` literals do not become discovery declarations.