### PR TITLE
test(core): retain zero metadata skip reasons

### DIFF
--- a/tests/Unit/Core/TestMetadataZeroSkipReasonTest.php
+++ b/tests/Unit/Core/TestMetadataZeroSkipReasonTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\JsonWire;
+
+final readonly class TestMetadataZeroSkipReasonTest
+{
+    #[Test]
+    public function retainsAZeroSkipReasonAcrossTheWire(): void
+    {
+        $metadata = new TestMetadata('App\ExampleTest', 'example', skipReason: '0');
+        $decoded = TestMetadata::fromWire(JsonWire::roundTrip($metadata->toWire()));
+
+        Expect::that($metadata->skipReason)
+            ->because('test metadata MUST retain each non-empty skip reason')
+            ->toBe('0')
+            ->and($decoded->skipReason)
+            ->because('the skip reason MUST survive the wire')
+            ->toBe('0');
+    }
+}


### PR DESCRIPTION
## Summary

- cover the valid test-metadata skip reason \`0\`
- pin direct construction and JSON wire round-trips to normalize only an empty reason to null
- keep this boundary test isolated from the shared metadata wire suite