### PR TITLE
test(runner): cover worker process state

### DIFF
--- a/tests/Unit/Runner/Orchestrator/WorkerHandleRunningStateTest.php
+++ b/tests/Unit/Runner/Orchestrator/WorkerHandleRunningStateTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Orchestrator;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Attribute\Timeout;
+use Greenlight\Core\ErrorTrap;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Runner\Orchestrator\WorkerHandle;
+
+final readonly class WorkerHandleRunningStateTest
+{
+    #[Test]
+    #[Timeout(5.0)]
+    public function processStatusDistinguishesLiveAndExitedWorkers(): void
+    {
+        $process = null;
+        $pipes = [];
+
+        try {
+            $process = \proc_open(
+                [
+                    \PHP_BINARY,
+                    '-r',
+                    'fwrite(STDOUT, "ready\n"); fflush(STDOUT); fgets(STDIN); '
+                    . 'fwrite(STDOUT, "exiting\n"); fflush(STDOUT);',
+                ],
+                [
+                    0 => ['pipe', 'r'],
+                    1 => ['pipe', 'w'],
+                    2 => ['pipe', 'w'],
+                ],
+                $pipes,
+                options: ['bypass_shell' => true],
+            );
+
+            if (!\is_resource($process)) {
+                Fail::because('Expected the worker process fixture to start.');
+            }
+
+            \stream_set_timeout($pipes[1], 2);
+
+            Expect::that(\fgets($pipes[1]))
+                ->because('the worker process fixture MUST signal that it is ready')
+                ->toBe("ready\n");
+
+            $handle = new WorkerHandle(
+                'worker-1',
+                1,
+                $process,
+                $pipes[1],
+                $pipes[2],
+            );
+
+            Expect::that($handle->isRunning())
+                ->because('a readiness-confirmed worker process MUST report that it is running')
+                ->toBeTrue();
+
+            \fwrite($pipes[0], "exit\n");
+            \fflush($pipes[0]);
+
+            Expect::that(\fgets($pipes[1]))
+                ->because('the worker process fixture MUST signal that it is exiting')
+                ->toBe("exiting\n");
+
+            \stream_get_contents($pipes[1]);
+            $metadata = \stream_get_meta_data($pipes[1]);
+
+            Expect::that([\feof($pipes[1]), $metadata['timed_out']])
+                ->because('the worker process fixture MUST reach EOF before its stopped state is checked')
+                ->toBe([true, false]);
+
+            $deadline = \microtime(true) + 1.0;
+
+            do {
+                $running = $handle->isRunning();
+
+                if ($running) {
+                    \usleep(1_000);
+                }
+            } while ($running && \microtime(true) < $deadline);
+
+            Expect::that([\is_resource($process), $running])
+                ->because('an exited worker keeps a process handle but MUST not report that it is running')
+                ->toBe([true, false]);
+        } finally {
+            foreach ($pipes as $pipe) {
+                if (\is_resource($pipe)) {
+                    ErrorTrap::run(static fn(): bool => \fclose($pipe));
+                }
+            }
+
+            if (\is_resource($process)) {
+                ErrorTrap::run(static fn(): bool => \proc_terminate($process, 9));
+                ErrorTrap::run(static fn(): int => \proc_close($process));
+            }
+        }
+    }
+}

--- a/tests/Unit/Runner/Orchestrator/WorkerHandleTerminationTest.php
+++ b/tests/Unit/Runner/Orchestrator/WorkerHandleTerminationTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Orchestrator;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Attribute\Timeout;
+use Greenlight\Core\ErrorTrap;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Runner\Orchestrator\WorkerHandle;
+use Greenlight\Runner\Protocol\SocketChannel;
+
+final readonly class WorkerHandleTerminationTest
+{
+    #[Test]
+    #[Timeout(5.0)]
+    public function terminationClosesTheChannelAndProcess(): void
+    {
+        $process = null;
+        $pipes = [];
+        $sockets = [];
+
+        try {
+            $process = \proc_open(
+                [
+                    \PHP_BINARY,
+                    '-r',
+                    'fwrite(STDOUT, "ready\n"); fflush(STDOUT); while (true) { usleep(10000); }',
+                ],
+                [
+                    0 => ['pipe', 'r'],
+                    1 => ['pipe', 'w'],
+                    2 => ['pipe', 'w'],
+                ],
+                $pipes,
+                options: ['bypass_shell' => true],
+            );
+
+            if (!\is_resource($process)) {
+                Fail::because('Expected the worker process fixture to start.');
+            }
+
+            $sockets = \stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, 0);
+
+            if ($sockets === false) {
+                Fail::because('Expected the worker channel fixture to open.');
+            }
+
+            \stream_set_timeout($pipes[1], 2);
+
+            Expect::that(\fgets($pipes[1]))
+                ->because('the worker process fixture MUST signal that it is ready')
+                ->toBe("ready\n");
+
+            $channel = new SocketChannel($sockets[0]);
+            $handle = new WorkerHandle(
+                'worker-1',
+                1,
+                $process,
+                $pipes[1],
+                $pipes[2],
+            );
+            $handle->channel = $channel;
+            $handle->terminate();
+
+            Expect::that([$channel->isEof(), \is_resource($process)])
+                ->because('worker termination MUST close its protocol channel and process handle')
+                ->toBe([true, false]);
+        } finally {
+            $resources = $pipes;
+
+            if (\is_array($sockets)) {
+                $resources = [...$resources, ...$sockets];
+            }
+
+            foreach ($resources as $resource) {
+                if (\is_resource($resource)) {
+                    ErrorTrap::run(static fn(): bool => \fclose($resource));
+                }
+            }
+
+            if (\is_resource($process)) {
+                ErrorTrap::run(static fn(): bool => \proc_terminate($process, 9));
+                ErrorTrap::run(static fn(): int => \proc_close($process));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Add focused coverage for live and naturally exited worker process handles. Bounded readiness, exit, EOF, and status handshakes keep the real-process test deterministic while independent cleanup prevents leaks.