### PR TITLE
test(discovery): ignore dangling class tokens

### DIFF
--- a/tests/Unit/Discovery/ClassFileParserDanglingNamespaceTest.php
+++ b/tests/Unit/Discovery/ClassFileParserDanglingNamespaceTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\ClassFileParser;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class ClassFileParserDanglingNamespaceTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function aDanglingNamespaceTokenAtEndOfFileIsIgnored(): void
+    {
+        $file = $this->tempDirectory->path() . '/DanglingNamespace.php';
+        \file_put_contents($file, '<?php namespace');
+
+        Expect::that(ClassFileParser::declarationsIn($file))
+            ->because('a dangling namespace token does not declare a namespace or class')
+            ->toBe([]);
+    }
+}

--- a/tests/Unit/Discovery/ClassFileParserDanglingTokenTest.php
+++ b/tests/Unit/Discovery/ClassFileParserDanglingTokenTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\ClassFileParser;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class ClassFileParserDanglingTokenTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function aDanglingClassTokenAtEndOfFileIsIgnored(): void
+    {
+        $file = $this->tempDirectory->path() . '/Dangling.php';
+        \file_put_contents($file, '<?php class');
+
+        Expect::that(ClassFileParser::declarationsIn($file))
+            ->because('a dangling class token does not declare a class')
+            ->toBe([]);
+    }
+}

--- a/tests/Unit/Discovery/ClassFileParserTest.php
+++ b/tests/Unit/Discovery/ClassFileParserTest.php
@@ -15,6 +15,41 @@ final readonly class ClassFileParserTest
     public function __construct(private TempDirectory $tempDirectory) {}
 
     #[Test]
+    public function returnsOnlyNamedClassLikeDeclarations(): void
+    {
+        $file = $this->tempDirectory->path() . '/ClassLikeDeclarations.php';
+        \file_put_contents($file, <<<'PHP'
+            <?php
+
+            namespace Example;
+
+            interface Contract {}
+            trait SharedBehavior {}
+            enum State {}
+            final class NamedTest {}
+
+            $name = NamedTest::class;
+            PHP);
+
+        $declarations = \array_map(
+            static fn(ClassDeclaration $declaration): array => [
+                $declaration->fqcn(),
+                $declaration->kind,
+            ],
+            ClassFileParser::declarationsIn($file),
+        );
+
+        Expect::that($declarations)
+            ->because('discovery MUST return only named class-like declarations')
+            ->toBe([
+                ['Example\Contract', 'interface'],
+                ['Example\SharedBehavior', 'trait'],
+                ['Example\State', 'enum'],
+                ['Example\NamedTest', 'class'],
+            ]);
+    }
+
+    #[Test]
     public function aGlobalBracketedNamespaceClearsThePreviousNamespace(): void
     {
         $file = $this->tempDirectory->path() . '/Declarations.php';


### PR DESCRIPTION
## Summary

- cover a class token that ends at end-of-file without a declaration name
- pin the parser null guard so truncated source yields no phantom declaration
- keep this boundary separate from named declarations and anonymous classes