### PR TITLE
fix(config): keep rejected worker updates atomic

### DIFF
--- a/docs/api-configuration.md
+++ b/docs/api-configuration.md
@@ -203,7 +203,7 @@ PHPDoc:
 
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L168)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L169)
 
 ### `coverage()`
 
@@ -215,7 +215,7 @@ PHPDoc:
 
 - `@param callable(CoverageBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L196)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L197)
 
 ### `watch()`
 
@@ -227,7 +227,7 @@ PHPDoc:
 
 - `@param callable(WatchBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L208)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L209)
 
 ### `artifacts()`
 
@@ -239,7 +239,7 @@ PHPDoc:
 
 - `@param callable(ArtifactBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L220)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L221)
 
 ### `failOnDeprecation()`
 
@@ -255,7 +255,7 @@ PHPDoc:
 
 - `@see self::ignoreDeprecationsMatching()`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L236)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L237)
 
 ### `failOnNotice()`
 
@@ -263,7 +263,7 @@ PHPDoc:
 public function failOnNotice(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L243)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L244)
 
 ### `failOnRisky()`
 
@@ -275,7 +275,7 @@ expectations.
 public function failOnRisky(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L255)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L256)
 
 ### `ignoreDeprecationsMatching()`
 
@@ -287,7 +287,7 @@ or "?" matches the complete message. Multiple calls add patterns.
 public function ignoreDeprecationsMatching(string ...$patterns): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L267)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L268)
 
 ### `plugins()`
 
@@ -295,7 +295,7 @@ public function ignoreDeprecationsMatching(string ...$patterns): self
 public function plugins(Plugin ...$plugins): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L280)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L281)
 
 ### `failFast()`
 
@@ -303,7 +303,7 @@ public function plugins(Plugin ...$plugins): self
 public function failFast(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L289)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L290)
 
 ### `randomizeOrder()`
 
@@ -313,7 +313,7 @@ If the seed is null, Greenlight generates and prints a seed at run time.
 public function randomizeOrder(?int $seed = null): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L297)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L298)
 
 ### `build()`
 
@@ -325,7 +325,7 @@ PHPDoc:
 
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L328)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L329)
 
 ## `SuiteBuilder`
 

--- a/src/Config/GreenlightConfig.php
+++ b/src/Config/GreenlightConfig.php
@@ -145,12 +145,13 @@ final class GreenlightConfig
         ?int $recycleAfterTests = null,
         string $recycleAboveMemory = self::DEFAULT_RECYCLE_ABOVE_MEMORY,
     ): self {
-        $this->workers = $this->workerCount($count);
+        $workers = $this->workerCount($count);
 
         if ($recycleAfterTests !== null && $recycleAfterTests < 1) {
             throw new InvalidConfiguration(\sprintf('recycleAfterTests must be at least 1, got %d.', $recycleAfterTests));
         }
 
+        $this->workers = $workers;
         $this->recycleAfterTests = $recycleAfterTests;
         $this->recycleAboveMemory = $recycleAboveMemory;
 

--- a/tests/Unit/Config/GreenlightConfigTest.php
+++ b/tests/Unit/Config/GreenlightConfigTest.php
@@ -108,6 +108,39 @@ final class GreenlightConfigTest
         Expect::that($configuration->randomSeed)->because('randomize order without seed still enables randomization')->toBe(null);
     }
 
+    #[Test]
+    public function aRejectedWorkerConfigurationDoesNotPartiallyChangeTheBuilder(): void
+    {
+        $builder = GreenlightConfig::create()->workers(
+            count: 2,
+            recycleAfterTests: 10,
+            recycleAboveMemory: '64M',
+        );
+
+        Expect::that(static fn(): GreenlightConfig => $builder->workers(
+            count: 8,
+            recycleAfterTests: 0,
+            recycleAboveMemory: '128M',
+        ))
+            ->because('a rejected worker configuration does not partially change the builder')
+            ->toThrow(
+                InvalidConfiguration::class,
+                message: 'recycleAfterTests must be at least 1, got 0.',
+            );
+
+        $configuration = $builder->build();
+
+        Expect::that($configuration->workers->fixed)
+            ->because('a rejected worker configuration retains the prior worker count')
+            ->toBe(2)
+            ->and($configuration->recycleAfterTests)
+            ->because('a rejected worker configuration retains the prior test limit')
+            ->toBe(10)
+            ->and($configuration->recycleAboveMemoryBytes)
+            ->because('a rejected worker configuration retains the prior memory limit')
+            ->toBe(64 * 1024 * 1024);
+    }
+
     /**
      * @param \Closure(): void $callable
      */


### PR DESCRIPTION
A rejected `workers()` call currently assigns the new worker count before it validates `recycleAfterTests`. This leaves a reused builder with a mixed configuration after the exception.

Validate the worker count into a local value, then commit all worker settings together after validation succeeds. Add a regression that preserves the prior count, test limit, and memory limit after a rejected update.