### PR TITLE
test(config): distinguish invalid resource guidance

### DIFF
--- a/tests/Unit/Config/GreenlightConfigTest.php
+++ b/tests/Unit/Config/GreenlightConfigTest.php
@@ -215,6 +215,40 @@ final class GreenlightConfigTest
     }
 
     /**
+     * @param \Closure(): void $configure
+     */
+    #[Test]
+    #[DataSet('invalidResourceLimits')]
+    public function invalidResourceLimitsGiveExactGuidance(\Closure $configure, string $message): void
+    {
+        Expect::that($configure)
+            ->because('each invalid resource limit MUST identify the required fix')
+            ->toThrow(InvalidConfiguration::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{\Closure(): void, non-empty-string}>
+     */
+    public static function invalidResourceLimits(): iterable
+    {
+        yield 'negative limit' => [
+            static function (): void {
+                GreenlightConfig::create()->resourceLimit('redis', -2);
+            },
+            'Resource "redis" must have a limit of at least 1, got -2.',
+        ];
+
+        yield 'duplicate declaration' => [
+            static function (): void {
+                GreenlightConfig::create()
+                    ->resourceLimit('redis')
+                    ->resourceLimit('redis', 3);
+            },
+            'Resource limit "redis" is declared twice.',
+        ];
+    }
+
+    /**
      * @return iterable<string, array{\Closure(): void}>
      */
     public static function invalidInputs(): iterable


### PR DESCRIPTION
Pins the two distinct resource-limit validation paths to their exact public diagnostics. The existing broad invalid-input coverage remains in place so this stack stays merge-compatible with the machine-resource work in #58.