### PR TITLE
test(doubles): pin stub diagnostics

### DIFF
--- a/tests/Unit/Doubles/StubTest.php
+++ b/tests/Unit/Doubles/StubTest.php
@@ -31,7 +31,12 @@ final class StubTest
         $stub = $doubles->stub(Stubbable::class);
 
         Expect::that(static fn(): string => $stub->name())->because('each call is an authoring error')
-            ->toThrow(DoublesError::class, '/Stubs only satisfy a type/');
+            ->toThrow(
+                DoublesError::class,
+                message: 'Code called "name()" on the stub of "' . Stubbable::class . '". '
+                    . 'Stubs only satisfy a type. '
+                    . 'Use mock() with explicit expectations for interactions.',
+            );
 
         $doubles->dispose();
     }
@@ -44,7 +49,12 @@ final class StubTest
 
         Expect::that(static function () use ($stub): void {
             $stub->touch();
-        })->because('even void calls are authoring errors')->toThrow(DoublesError::class, '/Stubs only satisfy a type/');
+        })->because('even void calls are authoring errors')->toThrow(
+            DoublesError::class,
+            message: 'Code called "touch()" on the stub of "' . Stubbable::class . '". '
+                . 'Stubs only satisfy a type. '
+                . 'Use mock() with explicit expectations for interactions.',
+        );
 
         $doubles->dispose();
     }


### PR DESCRIPTION
Replace the two loose StubTest error matchers with exact authoring diagnostics. Value-returning and void calls now pin the called method, stubbed type, and corrective guidance. This prevents an incomplete diagnostic that retains only the broad stub phrase from satisfying the tests.