### PR TITLE
test(config): pin worker validation diagnostics

### DIFF
--- a/tests/Unit/Config/GreenlightConfigWorkerValidationTest.php
+++ b/tests/Unit/Config/GreenlightConfigWorkerValidationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Config;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Config\InvalidConfiguration;
+use Greenlight\Expect\Expect;
+
+final class GreenlightConfigWorkerValidationTest
+{
+    /**
+     * @param \Closure(): void $configure
+     */
+    #[Test]
+    #[DataSet('invalidWorkerConfigurations')]
+    public function invalidWorkerConfigurationsGiveExactGuidance(\Closure $configure, string $message): void
+    {
+        Expect::that($configure)
+            ->because('each invalid worker option MUST identify the required fix')
+            ->toThrow(InvalidConfiguration::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{\Closure(): void, non-empty-string}>
+     */
+    public static function invalidWorkerConfigurations(): iterable
+    {
+        yield 'negative worker count' => [
+            static function (): void {
+                GreenlightConfig::create()->workers(count: -3);
+            },
+            'Worker count must be at least 1, got -3.',
+        ];
+
+        yield 'unsupported worker count string' => [
+            static function (): void {
+                new \ReflectionMethod(GreenlightConfig::class, 'workers')
+                    ->invoke(GreenlightConfig::create(), 'several');
+            },
+            'Worker count must be a positive integer or "auto", got "several".',
+        ];
+
+        yield 'negative recycle limit' => [
+            static function (): void {
+                GreenlightConfig::create()->workers(recycleAfterTests: -4);
+            },
+            'recycleAfterTests must be at least 1, got -4.',
+        ];
+    }
+}


### PR DESCRIPTION
Pins the public worker-configuration entry point to its exact diagnostics for negative counts, unsupported runtime strings, and negative recycle limits. Distinct negative values make the interpolated input observable while the separate test file avoids overlap with the shared invalid-input provider.