### PR TITLE
test(doubles): pin captor diagnostics

### DIFF
--- a/tests/Unit/Doubles/ArgumentMatchingTest.php
+++ b/tests/Unit/Doubles/ArgumentMatchingTest.php
@@ -221,8 +221,9 @@ final class ArgumentMatchingTest
     #[Test]
     public function aCaptorWithoutCapturesRefusesToProduceAValue(): void
     {
-        Expect::that(static fn(): mixed => Argument::captor()->value())->because('a captor without captures refuses to produce a value')
-            ->toThrow(DoublesError::class, '/captor has no value/');
+        Expect::that(static fn(): mixed => Argument::captor()->value())
+            ->because('a captor without captures refuses to produce a value')
+            ->toThrow(DoublesError::class, message: 'The captor has no value. No matched call supplied a value.');
     }
 
     #[Test]
@@ -287,7 +288,8 @@ final class ArgumentMatchingTest
 
         Expect::that(static fn(): mixed => $doubles->mock(Calculator::class, static function (MockPlan $plan): void {
             $plan->expects('add')->captureArgument(-1);
-        }))->because('capture argument rejects negative positions')->toThrow(DoublesError::class, '/-1/');
+        }))->because('capture argument rejects negative positions')
+            ->toThrow(DoublesError::class, message: 'captureArgument(-1) requires a position of zero or more.');
     }
 
     #[Test]


### PR DESCRIPTION
Replace the two loose captor error matchers with exact authoring diagnostics. An empty captor now pins why no value is available, and a negative capture position pins the valid range. This prevents incomplete or misleading diagnostics that retain only the broad phrase or invalid input from satisfying the tests.