### PR TITLE
test(protocol): cover partial socket writes

### DIFF
--- a/tests/Fixture/Runner/Protocol/PartialWriteStream.php
+++ b/tests/Fixture/Runner/Protocol/PartialWriteStream.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Runner\Protocol;
+
+use Greenlight\Doubles\Fake;
+
+/**
+ * Simulates a stream that accepts at most two bytes from each write.
+ */
+final class PartialWriteStream implements Fake
+{
+    public mixed $context;
+
+    public static string $written = '';
+
+    public static int $writes = 0;
+
+    private static bool $pause = false;
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        self::$written = '';
+        self::$writes = 0;
+        self::$pause = false;
+
+        return true;
+    }
+
+    public function stream_write(string $data): int
+    {
+        if (self::$pause) {
+            self::$pause = false;
+
+            return 0;
+        }
+
+        $chunk = \substr($data, 0, 2);
+        self::$written .= $chunk;
+        self::$writes++;
+        self::$pause = \strlen($chunk) < \strlen($data);
+
+        return \strlen($chunk);
+    }
+
+    public function stream_flush(): bool
+    {
+        return true;
+    }
+
+    public function stream_set_option(
+        int $option,
+        int $argumentOne,
+        ?int $argumentTwo,
+    ): bool {
+        return true;
+    }
+}

--- a/tests/Unit/Runner/Protocol/SocketChannelPartialWriteTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelPartialWriteTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Protocol;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Runner\Protocol\JsonFrameCodec;
+use Greenlight\Runner\Protocol\MessageRegistry;
+use Greenlight\Runner\Protocol\Messages\Drain;
+use Greenlight\Runner\Protocol\SocketChannel;
+use Greenlight\Tests\Fixture\Runner\Protocol\PartialWriteStream;
+
+final readonly class SocketChannelPartialWriteTest
+{
+    private const string SCHEME = 'greenlight-protocol-partial-write';
+
+    #[Test]
+    public function sendContinuesUntilTheCompleteFrameIsWritten(): void
+    {
+        if (!\stream_wrapper_register(self::SCHEME, PartialWriteStream::class)) {
+            Fail::because('The test could not register the partial-write stream.');
+        }
+
+        $stream = \fopen(self::SCHEME . '://channel', 'wb');
+
+        if ($stream === false) {
+            \stream_wrapper_unregister(self::SCHEME);
+            Fail::because('The test could not open the partial-write stream.');
+        }
+
+        $codec = new JsonFrameCodec();
+        $message = new Drain();
+        $channel = new SocketChannel($stream, $codec);
+
+        try {
+            $channel->send($message);
+
+            Expect::that(PartialWriteStream::$written)
+                ->because('send() MUST write the complete encoded frame')
+                ->toBe($codec->encode(MessageRegistry::envelope($message)))
+                ->and(PartialWriteStream::$writes)
+                ->because('the fixture accepts at most two bytes from each write')
+                ->toBeGreaterThan(1);
+        } finally {
+            $channel->close();
+            \stream_wrapper_unregister(self::SCHEME);
+        }
+    }
+}


### PR DESCRIPTION
Adds a PSR-4 partial-write stream fixture that identifies itself as Fake and focused SocketChannel coverage. The regression proves that send() continues from each unwritten byte until the complete protocol frame is delivered.