### PR TITLE
test(protocol): restore blocking sends after polls

### DIFF
--- a/tests/Fixture/Runner/Protocol/BlockingWriteStream.php
+++ b/tests/Fixture/Runner/Protocol/BlockingWriteStream.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Runner\Protocol;
+
+use Greenlight\Doubles\Fake;
+
+/**
+ * Accepts writes only while the stream is in blocking mode.
+ */
+final class BlockingWriteStream implements Fake
+{
+    public mixed $context;
+
+    private static string $contents = '';
+
+    private bool $blocking = true;
+
+    public static function contents(): string
+    {
+        return self::$contents;
+    }
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        self::$contents = '';
+
+        return true;
+    }
+
+    public function stream_read(int $count): string
+    {
+        return '';
+    }
+
+    public function stream_write(string $data): int
+    {
+        if (!$this->blocking) {
+            return 0;
+        }
+
+        self::$contents .= $data;
+
+        return \strlen($data);
+    }
+
+    public function stream_eof(): bool
+    {
+        return false;
+    }
+
+    public function stream_flush(): bool
+    {
+        return true;
+    }
+
+    public function stream_set_option(
+        int $option,
+        int $argumentOne,
+        ?int $argumentTwo,
+    ): bool {
+        if ($option === \STREAM_OPTION_BLOCKING) {
+            $this->blocking = $argumentOne === 1;
+        }
+
+        return true;
+    }
+}

--- a/tests/Unit/Runner/Protocol/SocketChannelBlockingSendTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelBlockingSendTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Protocol;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Runner\Protocol\JsonFrameCodec;
+use Greenlight\Runner\Protocol\MessageRegistry;
+use Greenlight\Runner\Protocol\Messages\Drain;
+use Greenlight\Runner\Protocol\SocketChannel;
+use Greenlight\Tests\Fixture\Runner\Protocol\BlockingWriteStream;
+
+final readonly class SocketChannelBlockingSendTest
+{
+    private const string STREAM_SCHEME = 'greenlight-blocking-write';
+
+    #[Test]
+    public function sendRestoresBlockingModeAfterPoll(): void
+    {
+        if (!\stream_wrapper_register(self::STREAM_SCHEME, BlockingWriteStream::class)) {
+            Fail::because('The test could not register the blocking-write stream.');
+        }
+
+        $stream = \fopen(self::STREAM_SCHEME . '://channel', 'r+');
+
+        if ($stream === false) {
+            \stream_wrapper_unregister(self::STREAM_SCHEME);
+            Fail::because('The test could not open the blocking-write stream.');
+        }
+
+        $channel = new SocketChannel($stream);
+
+        try {
+            Expect::that($channel->poll())
+                ->because('poll() MUST leave an empty channel without a message')
+                ->toBeNull();
+
+            $channel->send(new Drain());
+
+            $expected = new JsonFrameCodec()->encode(MessageRegistry::envelope(new Drain()));
+
+            Expect::that(BlockingWriteStream::contents())
+                ->because('send() MUST restore blocking mode and write the complete frame')
+                ->toBe($expected);
+        } finally {
+            $channel->close();
+            \stream_wrapper_unregister(self::STREAM_SCHEME);
+        }
+    }
+}


### PR DESCRIPTION
Adds a PSR-4 Fake stream that accepts writes only in blocking mode. The focused duplex-channel regression proves poll() may switch the stream to nonblocking mode, but a subsequent send() restores blocking mode and emits the complete encoded frame.