### PR TITLE
fix(protocol): reject failed socket flushes

### DIFF
--- a/src/Runner/Protocol/SocketChannel.php
+++ b/src/Runner/Protocol/SocketChannel.php
@@ -62,9 +62,7 @@ final class SocketChannel
                 $remaining -= $written;
             }
 
-            \fflush($this->stream);
-
-            return true;
+            return \fflush($this->stream);
         }, $warning);
 
         if (!$completed) {

--- a/tests/Fixture/Runner/Protocol/FlushFailureStream.php
+++ b/tests/Fixture/Runner/Protocol/FlushFailureStream.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Runner\Protocol;
+
+use Greenlight\Doubles\Fake;
+
+/**
+ * Accepts writes and rejects the final flush.
+ */
+final class FlushFailureStream implements Fake
+{
+    public mixed $context;
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        return true;
+    }
+
+    public function stream_write(string $data): int
+    {
+        return \strlen($data);
+    }
+
+    public function stream_flush(): bool
+    {
+        return false;
+    }
+
+    public function stream_set_option(
+        int $option,
+        int $argumentOne,
+        ?int $argumentTwo,
+    ): bool {
+        return true;
+    }
+}

--- a/tests/Unit/Runner/Protocol/SocketChannelFlushFailureTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelFlushFailureTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Protocol;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Runner\Protocol\Messages\Drain;
+use Greenlight\Runner\Protocol\ProtocolError;
+use Greenlight\Runner\Protocol\SocketChannel;
+use Greenlight\Tests\Fixture\Runner\Protocol\FlushFailureStream;
+
+final readonly class SocketChannelFlushFailureTest
+{
+    private const string STREAM_SCHEME = 'greenlight-flush-failure';
+
+    #[Test]
+    public function aFailedFlushRejectsTheSend(): void
+    {
+        if (!\stream_wrapper_register(self::STREAM_SCHEME, FlushFailureStream::class)) {
+            Fail::because('The test could not register the flush-failure stream.');
+        }
+
+        $stream = \fopen(self::STREAM_SCHEME . '://channel', 'w+');
+
+        if ($stream === false) {
+            \stream_wrapper_unregister(self::STREAM_SCHEME);
+            Fail::because('The test could not open the flush-failure stream.');
+        }
+
+        $channel = new SocketChannel($stream);
+
+        try {
+            Expect::that(static function () use ($channel): void {
+                $channel->send(new Drain());
+            })
+                ->because('a failed flush MUST reject an incomplete send')
+                ->toThrow(
+                    ProtocolError::class,
+                    message: 'Malformed frame: peer closed the connection during a write.',
+                );
+        } finally {
+            $channel->close();
+            \stream_wrapper_unregister(self::STREAM_SCHEME);
+        }
+    }
+}


### PR DESCRIPTION
Makes SocketChannel treat a failed final flush as an incomplete send instead of reporting success. A dedicated PSR-4 Fake stream accepts the complete frame and then rejects the flush, proving the exact ProtocolError and killing the previous ignored-return behavior.