### PR TITLE
test(protocol): cover zero-byte socket writes

### DIFF
--- a/tests/Fixture/Runner/Protocol/ZeroWriteStream.php
+++ b/tests/Fixture/Runner/Protocol/ZeroWriteStream.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Runner\Protocol;
+
+use Greenlight\Doubles\Fake;
+
+/**
+ * Keeps the stream open but cannot write bytes.
+ */
+final class ZeroWriteStream implements Fake
+{
+    public mixed $context;
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        return true;
+    }
+
+    public function stream_write(string $data): int
+    {
+        return 0;
+    }
+
+    public function stream_set_option(
+        int $option,
+        int $argumentOne,
+        ?int $argumentTwo,
+    ): bool {
+        return true;
+    }
+}

--- a/tests/Unit/Runner/Protocol/SocketChannelZeroWriteTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelZeroWriteTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Protocol;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Runner\Protocol\Messages\Drain;
+use Greenlight\Runner\Protocol\ProtocolError;
+use Greenlight\Runner\Protocol\SocketChannel;
+use Greenlight\Tests\Fixture\Runner\Protocol\ZeroWriteStream;
+
+final readonly class SocketChannelZeroWriteTest
+{
+    private const string STREAM_SCHEME = 'greenlight-zero-write';
+
+    #[Test]
+    public function aZeroByteWriteRejectsTheSend(): void
+    {
+        if (!\stream_wrapper_register(self::STREAM_SCHEME, ZeroWriteStream::class)) {
+            Fail::because('The test could not register the zero-write stream.');
+        }
+
+        $stream = \fopen(self::STREAM_SCHEME . '://channel', 'w+');
+
+        if ($stream === false) {
+            \stream_wrapper_unregister(self::STREAM_SCHEME);
+            Fail::because('The test could not open the zero-write stream.');
+        }
+
+        $channel = new SocketChannel($stream);
+
+        try {
+            Expect::that(static function () use ($channel): void {
+                $channel->send(new Drain());
+            })
+                ->because('a zero-byte write MUST reject an incomplete send')
+                ->toThrow(
+                    ProtocolError::class,
+                    message: 'Malformed frame: peer closed the connection during a write.',
+                );
+        } finally {
+            $channel->close();
+            \stream_wrapper_unregister(self::STREAM_SCHEME);
+        }
+    }
+}


### PR DESCRIPTION
Adds a dedicated PSR-4 Fake stream that remains open but cannot make progress on a write. The focused contract test proves SocketChannel rejects a zero-byte write with the exact protocol error instead of reporting a complete frame.