### PR TITLE
test(protocol): pin worker introduction wire values

### DIFF
--- a/tests/Unit/Runner/Protocol/HelloWireContractTest.php
+++ b/tests/Unit/Runner/Protocol/HelloWireContractTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Protocol;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\Protocol\Messages\Hello;
+
+final readonly class HelloWireContractTest
+{
+    #[Test]
+    public function workerIntroductionKeepsItsExactWireValues(): void
+    {
+        Expect::that(new Hello('worker-7', 'run-token', 321)->toWire())
+            ->because('a worker introduction MUST keep its identity, token, and process ID')
+            ->toBe([
+                'workerId' => 'worker-7',
+                'token' => 'run-token',
+                'pid' => 321,
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the worker introduction wire payload to literal identity, token, and process ID values.
- Detect valid-but-wrong PID substitutions that self-round-trip tests cannot expose.

## Mutation proof

Replacing the serialized PID with 4242 left all 2,110 existing tests green. The new focused test fails with the exact 4242-versus-321 mismatch.