### PR TITLE
fix(fixtures): reject linked temp subdirectories

### DIFF
--- a/docs/api-fixtures-harness.md
+++ b/docs/api-fixtures-harness.md
@@ -94,7 +94,7 @@ PHPDoc:
 public function dispose(): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L74)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L97)
 
 ## `Disposable`
 

--- a/src/Fixture/TempDirectory.php
+++ b/src/Fixture/TempDirectory.php
@@ -58,7 +58,20 @@ final class TempDirectory implements Disposable
             }
         }
 
-        $path = $this->path() . '/' . $name;
+        $root = $this->path();
+        $prefix = $root;
+        $this->assertNotSymbolicLink($prefix);
+
+        foreach (\explode('/', $name) as $segment) {
+            $prefix .= '/' . $segment;
+            $this->assertNotSymbolicLink($prefix);
+
+            if (!\file_exists($prefix)) {
+                break;
+            }
+        }
+
+        $path = $root . '/' . $name;
 
         if (!\is_dir($path) && !ErrorTrap::run(static fn(): bool => \mkdir($path, 0700, true), $warning)) {
             throw new \RuntimeException(\sprintf(
@@ -69,6 +82,16 @@ final class TempDirectory implements Disposable
         }
 
         return $path;
+    }
+
+    private function assertNotSymbolicLink(string $path): void
+    {
+        if (\is_link($path)) {
+            throw new \RuntimeException(\sprintf(
+                'Subdirectory path "%s" contains a symbolic link.',
+                $path,
+            ));
+        }
     }
 
     #[\Override]

--- a/tests/Unit/Fixture/TempDirectorySubdirectoryLinkTest.php
+++ b/tests/Unit/Fixture/TempDirectorySubdirectoryLinkTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Fixture;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Fixture\TempDirectory;
+
+final class TempDirectorySubdirectoryLinkTest
+{
+    #[Test]
+    #[DataSet('linkedPaths')]
+    public function subdirectoryRejectsPathsThroughSymbolicLinks(?string $linkName, string $name): void
+    {
+        $directory = new TempDirectory();
+        $target = new TempDirectory();
+        $root = $directory->path();
+        $targetPath = $target->path();
+        $sentinel = $targetPath . '/sentinel.txt';
+        $link = $linkName === null ? $root : $root . '/' . $linkName;
+
+        if (\file_put_contents($sentinel, 'keep') === false) {
+            Fail::because('Expected to create the target sentinel file.');
+        }
+
+        if ($linkName === null && !\rmdir($root)) {
+            Fail::because('Expected to remove the temp directory root.');
+        }
+
+        if (!\symlink($targetPath, $link)) {
+            Fail::because('Expected to create the fixture symbolic link.');
+        }
+
+        try {
+            Expect::that(static fn(): string => $directory->subdirectory($name))
+                ->because('a subdirectory MUST remain inside its temp directory')
+                ->toThrow(
+                    \RuntimeException::class,
+                    message: \sprintf(
+                        'Subdirectory path "%s" contains a symbolic link.',
+                        $link,
+                    ),
+                );
+
+            Expect::that(\file_get_contents($sentinel))
+                ->because('a rejected symbolic link MUST leave its target unchanged')
+                ->toBe('keep')
+                ->and(\is_dir($targetPath . '/created'))
+                ->toBeFalse();
+        } finally {
+            $directory->dispose();
+            $target->dispose();
+        }
+    }
+
+    /**
+     * @return iterable<string, array{?string, non-empty-string}>
+     */
+    public static function linkedPaths(): iterable
+    {
+        yield 'replaced root' => [null, 'created'];
+        yield 'final segment' => ['linked', 'linked'];
+        yield 'intermediate segment' => ['linked', 'linked/created'];
+    }
+}


### PR DESCRIPTION
Prevents TempDirectory::subdirectory() from following a symbolic link at its root or in an existing path prefix. Named regression cases cover replaced-root, final-segment, and intermediate-segment links and prove that rejected paths leave the external target unchanged.