### PR TITLE
test(core): pin failure detail wire values

### DIFF
--- a/tests/Unit/Core/FailureDetailWireContractTest.php
+++ b/tests/Unit/Core/FailureDetailWireContractTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\FailureDetail;
+use Greenlight\Core\Result\SourceLocation;
+use Greenlight\Expect\Expect;
+
+final readonly class FailureDetailWireContractTest
+{
+    #[Test]
+    public function failureDetailKeepsItsExactWireValues(): void
+    {
+        $detail = new FailureDetail(
+            'Values are not identical.',
+            'expected value',
+            'actual value',
+            new SourceLocation('/project/tests/ExampleTest.php', 42),
+        );
+
+        Expect::that($detail->toWire())
+            ->because('a failure detail MUST keep its message, diff, and source location')
+            ->toBe([
+                'message' => 'Values are not identical.',
+                'expected' => 'expected value',
+                'actual' => 'actual value',
+                'location' => [
+                    'file' => '/project/tests/ExampleTest.php',
+                    'line' => 42,
+                ],
+            ]);
+    }
+}


### PR DESCRIPTION
## Summary

- Pin the complete failure-detail wire payload to literal message, diff, and source-location values.
- Detect valid-but-incomplete payloads that self-round-trip tests cannot expose.

## Mutation proof

Replacing every serialized expected diff with null left all 2,110 existing tests green. The new focused test fails on the exact missing expected value.