### PR TITLE
test(protocol): accept whitespace-wrapped empty maps

### DIFF
--- a/tests/Unit/Runner/Protocol/JsonFrameCodecTest.php
+++ b/tests/Unit/Runner/Protocol/JsonFrameCodecTest.php
@@ -128,4 +128,12 @@ final class JsonFrameCodecTest
             ->because('an empty JSON object is still a protocol map')
             ->toBe([]);
     }
+
+    #[Test]
+    public function whitespaceWrappedEmptyJsonObjectRemainsAValidMap(): void
+    {
+        Expect::that(new JsonFrameCodec()->decode("\n \t{}\r\n"))
+            ->because('JSON whitespace MUST NOT make an empty object look like a list')
+            ->toBe([]);
+    }
 }


### PR DESCRIPTION
Pins legal surrounding JSON whitespace at the empty-object boundary. Associative decoding makes {} and [] structurally identical, so the focused case protects the raw-body discriminator that keeps an empty map valid.