### PR TITLE
test(discovery): pin plan identity diagnostics

### DIFF
--- a/tests/Unit/Discovery/PlanEntryIdentityTest.php
+++ b/tests/Unit/Discovery/PlanEntryIdentityTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Discovery\PlanEntry;
+use Greenlight\Expect\Expect;
+
+final readonly class PlanEntryIdentityTest
+{
+    #[Test]
+    public function mismatchedIdentityNamesBothSides(): void
+    {
+        Expect::that(static fn(): PlanEntry => new PlanEntry(
+            new TestId('App\PaymentTest', 'chargesCard'),
+            new TestMetadata('App\RefundTest', 'refundsCard'),
+        ))
+            ->because('a plan identity mismatch MUST identify the test ID and its metadata')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Plan entry identity App\PaymentTest::chargesCard does not match its metadata App\RefundTest::refundsCard.',
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Assert that plan-entry identity mismatches name the test ID and metadata identity.
- Keep the diagnostic actionable when class and method names differ.

## Mutation proof

Replacing the detailed mismatch message with a generic message left all 2,110 existing tests green. The new focused assertion fails that mutant and passes with the production diagnostic.