### PR TITLE
test(core): pin invalid attempt diagnostics

### DIFF
--- a/tests/Unit/Core/TestResultAttemptDiagnosticTest.php
+++ b/tests/Unit/Core/TestResultAttemptDiagnosticTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+
+final readonly class TestResultAttemptDiagnosticTest
+{
+    #[Test]
+    public function invalidAttemptCountNamesTheMinimum(): void
+    {
+        Expect::that(static fn(): TestResult => new TestResult(
+            new TestId('App\PaymentTest', 'chargesCard'),
+            Outcome::Passed,
+            0.1,
+            0,
+            0,
+        ))
+            ->because('an invalid result attempt count MUST name the valid minimum')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Attempts must be at least 1.',
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Assert that invalid result attempt counts name the valid minimum.
- Keep constructor guidance exact for callers that recover attempt state.

## Mutation proof

Replacing the minimum-specific diagnostic with a generic invalid-count message left all 2,110 existing tests green. The new focused assertion fails that mutant and passes with the production diagnostic.