### PR TITLE
test(phpstan): pin matcher conflict diagnostics

### DIFF
--- a/tests/Unit/PhpStan/MatcherMapConflictDiagnosticTest.php
+++ b/tests/Unit/PhpStan/MatcherMapConflictDiagnosticTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\PhpStan;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\PhpStan\MatcherMap;
+use Greenlight\PhpStan\MatcherMapError;
+
+final class MatcherMapConflictDiagnosticTest
+{
+    private const string CONFIG = __DIR__ . '/../../Fixture/PhpStanExtension/greenlight.php';
+    private const string CONFLICTING_CONFIG = __DIR__ . '/../../Fixture/PhpStanExtensionConflict/greenlight.php';
+
+    #[Test]
+    public function conflictingSignaturesIdentifyBothDeclarations(): void
+    {
+        Expect::that(
+            static fn(): MatcherMap => MatcherMap::fromConfigFiles([
+                self::CONFIG,
+                self::CONFLICTING_CONFIG,
+            ]),
+        )
+            ->because('a matcher conflict MUST identify both declarations')
+            ->toThrow(
+                MatcherMapError::class,
+                message: \sprintf(
+                    'Extension matcher "toHaveDigestLength" is declared with conflicting signatures: '
+                    . '(string $subject, int $length) in "%s" and (mixed $subject, string $length) in "%s". '
+                    . 'Static analysis needs one signature per matcher name across all configured files.',
+                    self::CONFIG,
+                    self::CONFLICTING_CONFIG,
+                ),
+            );
+    }
+}


### PR DESCRIPTION
Pins conflicting extension matcher diagnostics to the matcher name, both signatures, both configuration files, and the one-signature guidance. This catches genericized errors that the existing class-only assertion missed.