### PR TITLE
test(core): pin skip-unless diagnostics

### DIFF
--- a/tests/Unit/Core/TestMetadataSkipUnlessDiagnosticTest.php
+++ b/tests/Unit/Core/TestMetadataSkipUnlessDiagnosticTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Expect\Expect;
+
+final readonly class TestMetadataSkipUnlessDiagnosticTest
+{
+    #[Test]
+    public function invalidArgumentNamesItsType(): void
+    {
+        Expect::that(static fn(): TestMetadata => new TestMetadata(
+            'App\PaymentTest',
+            'chargesCard',
+            skipUnlessArguments: [['nested']],
+        ))
+            ->because('invalid skip-unless metadata MUST name the argument type')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Skip-unless arguments must be scalars or null, got array.',
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- Assert that invalid skip-unless arguments name the rejected value type.
- Keep metadata construction guidance specific and actionable.

## Mutation proof

Replacing the type-specific diagnostic with a generic invalid-argument message left all 2,110 existing tests green. The new focused assertion fails that mutant and passes with the production diagnostic.