### PR TITLE
test(expect): pin unknown matcher diagnostics

### DIFF
--- a/tests/Unit/Expect/UnknownMatcherDiagnosticTest.php
+++ b/tests/Unit/Expect/UnknownMatcherDiagnosticTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Expectation;
+
+final class UnknownMatcherDiagnosticTest
+{
+    #[Test]
+    public function unknownMatchersIdentifyTheMissingRegistration(): void
+    {
+        Expect::that(
+            static fn(): Expectation => Expect::that(4)->__call('toBeUnavailableMatcher', []),
+        )
+            ->because('an unknown matcher MUST identify the missing native or extension registration')
+            ->toThrow(
+                \BadMethodCallException::class,
+                message: 'Greenlight has no native or registered extension matcher named toBeUnavailableMatcher.',
+            );
+    }
+}


### PR DESCRIPTION
Pins unknown matcher diagnostics to the attempted matcher and the missing native or extension registration. This catches alternate wording that the existing class-only and name-only assertions missed.