### PR TITLE
test(coverage): pin JSON schema diagnostics

### DIFF
--- a/tests/Unit/Coverage/JsonExporterSchemaDiagnosticTest.php
+++ b/tests/Unit/Coverage/JsonExporterSchemaDiagnosticTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\CoverageError;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Coverage\Export\JsonExporter;
+use Greenlight\Expect\Expect;
+
+final class JsonExporterSchemaDiagnosticTest
+{
+    #[Test]
+    #[DataSet('invalidSchemaVersions')]
+    public function invalidSchemaVersionsIdentifyTheSupportedVersion(string $document): void
+    {
+        Expect::that(static fn(): CoverageMap => JsonExporter::import($document))
+            ->because('an invalid coverage schema MUST identify the supported version')
+            ->toThrow(
+                CoverageError::class,
+                message: 'Coverage JSON document is invalid: unsupported or missing schema version, expected 1.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function invalidSchemaVersions(): iterable
+    {
+        yield 'missing version' => ['{"files":{}}'];
+        yield 'unsupported version' => ['{"v":2,"files":{}}'];
+    }
+}


### PR DESCRIPTION
Pins missing and unsupported coverage JSON schema diagnostics to the supported version. This catches compatibility errors that retain only generic schema-version wording.