### PR TITLE
test(laravel): reset once state

### DIFF
--- a/tests/Unit/Laravel/LaravelOnceStateResetTest.php
+++ b/tests/Unit/Laravel/LaravelOnceStateResetTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Laravel;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Laravel\LaravelStateResetter;
+
+final class LaravelOnceStateResetTest
+{
+    private int $calls = 0;
+
+    #[Test]
+    public function resetClearsMemoizedOnceValues(): void
+    {
+        Expect::that($this->memoizedValue())
+            ->because('Laravel once() MUST memoize a value before the reset')
+            ->toBe(1)
+            ->and($this->memoizedValue())
+            ->toBe(1);
+
+        LaravelStateResetter::reset();
+
+        Expect::that($this->memoizedValue())
+            ->because('a reset MUST discard Laravel once() values from the previous application')
+            ->toBe(2);
+    }
+
+    private function memoizedValue(): int
+    {
+        return \once(fn(): int => ++$this->calls);
+    }
+}

--- a/tests/Unit/Laravel/LaravelOnceStateResetTest.php
+++ b/tests/Unit/Laravel/LaravelOnceStateResetTest.php
@@ -4,10 +4,14 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Laravel;
 
+use Greenlight\Attribute\SkipUnless;
 use Greenlight\Attribute\Test;
+use Greenlight\Condition\FunctionAvailable;
 use Greenlight\Expect\Expect;
 use Greenlight\Laravel\LaravelStateResetter;
+use Illuminate\Support\Once;
 
+#[SkipUnless(FunctionAvailable::class, 'once')]
 final class LaravelOnceStateResetTest
 {
     private int $calls = 0;
@@ -15,17 +19,21 @@ final class LaravelOnceStateResetTest
     #[Test]
     public function resetClearsMemoizedOnceValues(): void
     {
-        Expect::that($this->memoizedValue())
-            ->because('Laravel once() MUST memoize a value before the reset')
-            ->toBe(1)
-            ->and($this->memoizedValue())
-            ->toBe(1);
+        try {
+            Expect::that($this->memoizedValue())
+                ->because('Laravel once() MUST memoize a value before the reset')
+                ->toBe(1)
+                ->and($this->memoizedValue())
+                ->toBe(1);
 
-        LaravelStateResetter::reset();
+            LaravelStateResetter::reset();
 
-        Expect::that($this->memoizedValue())
-            ->because('a reset MUST discard Laravel once() values from the previous application')
-            ->toBe(2);
+            Expect::that($this->memoizedValue())
+                ->because('a reset MUST discard Laravel once() values from the previous application')
+                ->toBe(2);
+        } finally {
+            Once::flush();
+        }
     }
 
     private function memoizedValue(): int


### PR DESCRIPTION
Proves that Laravel application resets flush values memoized by once(). This catches state leakage where a discarded application leaves cached once() results available to the next application.