### PR TITLE
test(config): accept minimum watch debounce

### DIFF
--- a/tests/Unit/Config/WatchMinimumDebounceTest.php
+++ b/tests/Unit/Config/WatchMinimumDebounceTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Config;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\WatchBuilder;
+use Greenlight\Expect\Expect;
+
+final class WatchMinimumDebounceTest
+{
+    #[Test]
+    public function oneMillisecondIsAValidDebounce(): void
+    {
+        $configuration = new WatchBuilder()
+            ->debounceMilliseconds(1)
+            ->toConfiguration();
+
+        Expect::that($configuration->debounceMilliseconds)
+            ->because('watch mode MUST accept its documented minimum debounce')
+            ->toBe(1);
+    }
+}


### PR DESCRIPTION
Pins the documented 1 ms watch debounce minimum through the public builder boundary. The same assertion covers validation in both WatchBuilder and WatchConfiguration.