### PR TITLE
test(core): preserve minimum test channel

### DIFF
--- a/tests/Unit/Core/TestChannelMinimumNumberTest.php
+++ b/tests/Unit/Core/TestChannelMinimumNumberTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\TestChannel;
+use Greenlight\Expect\Expect;
+
+final readonly class TestChannelMinimumNumberTest
+{
+    #[Test]
+    public function channelOneRepresentsAnInProcessRun(): void
+    {
+        $channel = new TestChannel(1);
+
+        Expect::that($channel->number)
+            ->because('in-process runs MUST use the first valid test channel')
+            ->toBe(1)
+            ->and($channel->label())
+            ->toBe('gl-1');
+    }
+}


### PR DESCRIPTION
Pins channel 1 as the public TestChannel lower boundary used by in-process runs. The first channel MUST retain number 1 and the gl-1 resource label.