### PR TITLE
test(config): accept minimum artifact counts

### DIFF
--- a/tests/Unit/Config/ArtifactBuilderMinimumCountsTest.php
+++ b/tests/Unit/Config/ArtifactBuilderMinimumCountsTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Config;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactBuilder;
+use Greenlight\Expect\Expect;
+
+final class ArtifactBuilderMinimumCountsTest
+{
+    #[Test]
+    public function oneAttachmentIsAValidSafetyLimit(): void
+    {
+        $configuration = new ArtifactBuilder()
+            ->maxAttachmentsPerTest(1)
+            ->maxRunAttachments(1)
+            ->toConfiguration();
+
+        Expect::that([
+            $configuration->maxAttachmentsPerTest,
+            $configuration->maxRunAttachments,
+        ])
+            ->because('artifact limits MUST accept their documented minimum')
+            ->toBe([1, 1]);
+    }
+}


### PR DESCRIPTION
Pins the documented minimum attachment counts through the public artifact builder boundary. One focused assertion covers both the per-test and per-run limits.