### PR TITLE
test(protocol): preserve minimum frame size

### DIFF
--- a/tests/Unit/Runner/Protocol/FrameMinimumSizeTest.php
+++ b/tests/Unit/Runner/Protocol/FrameMinimumSizeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Protocol;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\Protocol\FrameBuffer;
+use Greenlight\Runner\Protocol\JsonFrameCodec;
+
+final readonly class FrameMinimumSizeTest
+{
+    #[Test]
+    public function aOneByteFrameIsAValidProtocolLimit(): void
+    {
+        $codec = new JsonFrameCodec(1);
+        $buffer = new FrameBuffer(1);
+        $buffer->feed(\pack('N', 1) . 'x');
+
+        Expect::that($codec->maxFrameBytes)
+            ->because('the protocol MUST support the smallest valid frame')
+            ->toBe(1)
+            ->and($buffer->next())
+            ->toBe('x');
+    }
+}


### PR DESCRIPTION
Pins one byte as the shared lower boundary for protocol frame encoders and decoders. A one-byte frame limit MUST remain valid, and the decoder MUST accept a complete one-byte frame.