### PR TITLE
test(doubles): accept zero call cardinality

### DIFF
--- a/tests/Unit/Doubles/ZeroCardinalityTest.php
+++ b/tests/Unit/Doubles/ZeroCardinalityTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\MockPlan;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Doubles\Calculator;
+
+final class ZeroCardinalityTest
+{
+    #[Test]
+    public function anUncalledZeroCardinalityExpectationPassesVerification(): void
+    {
+        Expect::that(static function (): void {
+            $doubles = new Doubles();
+            $doubles->mock(Calculator::class, static function (MockPlan $plan): void {
+                $plan->expects('add')->times(0);
+            });
+
+            $doubles->dispose();
+        })
+            ->because('times(0) MUST permit an uncalled expectation')
+            ->not()
+            ->toThrow(\Throwable::class);
+    }
+}


### PR DESCRIPTION
Pins the documented times(0) contract through the public doubles API. The focused test verifies that an uncalled zero-cardinality expectation disposes cleanly.