### PR TITLE
test(config): accept minimum worker count

### DIFF
--- a/tests/Unit/Config/WorkerCountMinimumTest.php
+++ b/tests/Unit/Config/WorkerCountMinimumTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Config;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\WorkerCount;
+use Greenlight\Expect\Expect;
+
+final readonly class WorkerCountMinimumTest
+{
+    #[Test]
+    public function oneWorkerIsAValidFixedCount(): void
+    {
+        $workers = WorkerCount::exactly(1);
+
+        Expect::that($workers->fixed)
+            ->because('a fixed runner MUST support the minimum worker count')
+            ->toBe(1)
+            ->and($workers->isAuto())
+            ->toBeFalse()
+            ->and($workers->describe())
+            ->toBe('1');
+    }
+}


### PR DESCRIPTION
Pins one as the valid lower boundary for a fixed worker count. The minimum fixed count MUST expose one, remain distinct from automatic selection, and describe itself as 1.