### PR TITLE
fix(cli): pluralize single-shard guidance

### DIFF
--- a/src/Cli/CliError.php
+++ b/src/Cli/CliError.php
@@ -67,7 +67,12 @@ final class CliError extends \RuntimeException
         $message = \sprintf('--shard requires 1 <= n <= m. Received "%s".', $raw);
 
         if ($count >= 1) {
-            $message .= \sprintf(' Valid n values for %d shards are 1 through %d.', $count, $count);
+            $message .= \sprintf(
+                ' Valid n values for %d %s are 1 through %d.',
+                $count,
+                $count === 1 ? 'shard' : 'shards',
+                $count,
+            );
         }
 
         return new self($message);

--- a/tests/Unit/Cli/CliOverridesSingleShardRangeTest.php
+++ b/tests/Unit/Cli/CliOverridesSingleShardRangeTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\CliError;
+use Greenlight\Cli\CliOverrides;
+use Greenlight\Cli\ParsedArguments;
+use Greenlight\Expect\Expect;
+
+final readonly class CliOverridesSingleShardRangeTest
+{
+    #[Test]
+    public function invalidSingleShardIndexNamesTheOnlyValidIndex(): void
+    {
+        Expect::that(static fn(): CliOverrides => CliOverrides::fromArguments(
+            new ParsedArguments(null, ['shard' => ['2/1']]),
+        ))
+            ->because('single-shard guidance MUST name its only valid index')
+            ->toThrow(
+                CliError::class,
+                message: '--shard requires 1 <= n <= m. Received "2/1". Valid n values for 1 shard are 1 through 1.',
+            );
+    }
+}


### PR DESCRIPTION
Corrects out-of-range guidance for a single shard to use the singular noun. The focused boundary test also pins 1 as the only valid index when the shard count is one.