### PR TITLE
test(expect): cover single-detail aggregation

### DIFF
--- a/tests/Unit/Expect/ExpectationFailedSingleDetailTest.php
+++ b/tests/Unit/Expect/ExpectationFailedSingleDetailTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\FailureDetail;
+use Greenlight\Core\Result\SourceLocation;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\ExpectationFailed;
+
+final class ExpectationFailedSingleDetailTest
+{
+    #[Test]
+    public function oneDetailUsesTheSingularDiagnostic(): void
+    {
+        $detail = new FailureDetail(
+            'Expected values to match.',
+            location: new SourceLocation('/tests/ExampleTest.php', 12),
+        );
+
+        $failure = ExpectationFailed::fromDetails([$detail]);
+
+        Expect::that($failure->getMessage())
+            ->because('one detail MUST use the singular diagnostic')
+            ->toBe('Expected values to match. (at /tests/ExampleTest.php:12)')
+            ->and($failure->details)
+            ->toBe([$detail])
+            ->and($failure->detail())
+            ->toBe($detail);
+    }
+}


### PR DESCRIPTION
Covers the one-detail path through ExpectationFailed::fromDetails(). The assertion preserves the singular diagnostic, structured detail list, and first-detail identity when callers use the aggregate factory.