### PR TITLE
test(rector): preserve default failure message

### DIFF
--- a/tests/Acceptance/RectorDefaultFailureMessageTest.php
+++ b/tests/Acceptance/RectorDefaultFailureMessageTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorDefaultFailureMessageTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function failureWithoutAMessageGetsANonEmptyDefault(): void
+    {
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testFails(): void
+                {
+                    $this->fail();
+                }
+            }
+
+            PHP_WRAP,
+            name: 'default-failure-message',
+        );
+
+        Expect::that($probe->changed)
+            ->because('a PHPUnit failure without a message MUST be convertible')
+            ->toBeTrue()
+            ->and($probe->code)
+            ->because('Greenlight failures MUST have a non-empty reason')
+            ->toContain("\Greenlight\Expect\Fail::because('Test failed.');");
+    }
+}


### PR DESCRIPTION
Pins the migration of PHPUnit fail() calls without an argument. The converted Greenlight failure MUST receive the non-empty default reason.