### PR TITLE
test(core): reject null class worker IDs

### DIFF
--- a/tests/Unit/Core/ClassLifecycleNullWorkerWireTest.php
+++ b/tests/Unit/Core/ClassLifecycleNullWorkerWireTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\TestClassFinished;
+use Greenlight\Core\Event\TestClassStarted;
+use Greenlight\Core\Wire\InvalidWirePayload;
+use Greenlight\Expect\Expect;
+
+final readonly class ClassLifecycleNullWorkerWireTest
+{
+    /**
+     * @param class-string<TestClassStarted|TestClassFinished> $eventClass
+     */
+    #[Test]
+    #[DataSet('classLifecycleEvents')]
+    public function explicitNullWorkerIdIsRejected(string $eventClass): void
+    {
+        $payload = [
+            'class' => 'App\ExampleTest',
+            'occurredAt' => 1_780_000_000.5,
+            'workerId' => null,
+        ];
+
+        Expect::that(static fn(): TestClassStarted|TestClassFinished => $eventClass::fromWire($payload))
+            ->because('class lifecycle worker IDs MUST distinguish explicit null from a missing legacy field')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "workerId" must be a string, got null.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{class-string<TestClassStarted|TestClassFinished>}>
+     */
+    public static function classLifecycleEvents(): iterable
+    {
+        yield 'class started' => [TestClassStarted::class];
+        yield 'class finished' => [TestClassFinished::class];
+    }
+}


### PR DESCRIPTION
Pins the compatibility boundary for class lifecycle worker attribution. Legacy payloads may omit the worker ID, while explicit null remains invalid for both class-started and class-finished events.