### PR TITLE
test(core): reject null result risky flag

### DIFF
--- a/tests/Unit/Core/TestResultNullRiskyWireTest.php
+++ b/tests/Unit/Core/TestResultNullRiskyWireTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Wire\InvalidWirePayload;
+use Greenlight\Expect\Expect;
+
+final readonly class TestResultNullRiskyWireTest
+{
+    #[Test]
+    public function explicitNullRiskyFlagIsRejected(): void
+    {
+        $payload = new TestResult(
+            new TestId('App\ExampleTest', 'passes'),
+            Outcome::Passed,
+            0.1,
+            0,
+        )->toWire();
+        $payload['risky'] = null;
+
+        Expect::that(static fn(): TestResult => TestResult::fromWire($payload))
+            ->because('an explicit null risky flag MUST NOT use the missing-field default')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "risky" must be a boolean, got null.',
+            );
+    }
+}


### PR DESCRIPTION
Pins the compatibility boundary for the TestResult risky flag. Legacy payloads may omit the flag, while explicit null remains an invalid wire value.