### PR TITLE
test(rector): preserve dynamic exception messages

### DIFF
--- a/tests/Acceptance/RectorDynamicExceptionMessageTest.php
+++ b/tests/Acceptance/RectorDynamicExceptionMessageTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorDynamicExceptionMessageTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function dynamicExactMessagesLeaveTheClassUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testFails(): void
+                {
+                    $message = 'boom';
+                    $this->expectException(\RuntimeException::class);
+                    $this->expectExceptionMessage($message);
+                    throw new \RuntimeException('boom');
+                }
+            }
+
+            PHP_WRAP;
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'dynamic-exception-message',
+        );
+
+        Expect::that($probe->changed)
+            ->because('a dynamic exact exception message MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}


### PR DESCRIPTION
Pins the safe migration boundary for dynamic PHPUnit exception messages. The Rector rule MUST leave the class untouched when it cannot synthesize a literal Greenlight matcher.