### PR TITLE
test(core): reject null metadata resources

### DIFF
--- a/tests/Unit/Core/TestMetadataNullResourcesWireTest.php
+++ b/tests/Unit/Core/TestMetadataNullResourcesWireTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Core\Wire\InvalidWirePayload;
+use Greenlight\Expect\Expect;
+
+final readonly class TestMetadataNullResourcesWireTest
+{
+    #[Test]
+    public function explicitNullResourcesAreRejected(): void
+    {
+        $payload = new TestMetadata('App\ExampleTest', 'checksValue')->toWire();
+        $payload['resources'] = null;
+
+        Expect::that(static fn(): TestMetadata => TestMetadata::fromWire($payload))
+            ->because('explicit null is not the backward-compatible missing-key default')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "resources" must be a list of strings, got null.',
+            );
+    }
+}


### PR DESCRIPTION
An omitted resources field uses the backward-compatible empty-list default, but an explicit null must remain an invalid wire shape. Add a focused public-contract test that distinguishes those cases and pins the exact diagnostic.