### PR TITLE
test(cli): require exact internal worker arity

### DIFF
--- a/tests/Acceptance/InternalWorkerArityTest.php
+++ b/tests/Acceptance/InternalWorkerArityTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\GreenlightCli;
+
+final class InternalWorkerArityTest
+{
+    #[Test]
+    public function surplusWorkerArgumentsAreAUsageError(): void
+    {
+        $result = GreenlightCli::run(
+            \dirname(__DIR__, 2),
+            ['__worker', 'tcp://127.0.0.1:1', 'worker-1', 'secret-token', 'surplus'],
+        );
+
+        Expect::that($result->exitCode)
+            ->because('the internal worker entry MUST accept exactly three operands')
+            ->toBe(64)
+            ->and($result->stderr)
+            ->toBe('__worker requires <address> <workerId> <token>.')
+            ->and($result->stdout)
+            ->toBe('');
+    }
+}


### PR DESCRIPTION
## Summary

- cover surplus operands on the hidden worker entry
- preserve usage validation before any worker connection attempt