### PR TITLE
test(rector): preserve duplicate exception expectations

### DIFF
--- a/tests/Acceptance/RectorDuplicateExceptionExpectationTest.php
+++ b/tests/Acceptance/RectorDuplicateExceptionExpectationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorDuplicateExceptionExpectationTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function duplicateExceptionTypesLeaveTheClassUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testFails(): void
+                {
+                    $this->expectException(\RuntimeException::class);
+                    $this->expectException(\LogicException::class);
+                    throw new \LogicException('boom');
+                }
+            }
+
+            PHP_WRAP;
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'duplicate-exception-expectations',
+        );
+
+        Expect::that($probe->changed)
+            ->because('duplicate exception expectations MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}


### PR DESCRIPTION
Pins the safe migration boundary for methods with multiple PHPUnit exception type expectations. The Rector rule MUST leave the class untouched instead of choosing one declaration.