### PR TITLE
test(core): reject null no-expectations metadata

### DIFF
--- a/tests/Unit/Core/TestMetadataNullNoExpectationsWireTest.php
+++ b/tests/Unit/Core/TestMetadataNullNoExpectationsWireTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Core\Wire\InvalidWirePayload;
+use Greenlight\Expect\Expect;
+
+final readonly class TestMetadataNullNoExpectationsWireTest
+{
+    #[Test]
+    public function explicitNullNoExpectationsPolicyIsRejected(): void
+    {
+        $payload = new TestMetadata('App\ExampleTest', 'checksValue')->toWire();
+        $payload['noExpectations'] = null;
+
+        Expect::that(static fn(): TestMetadata => TestMetadata::fromWire($payload))
+            ->because('explicit null is not the backward-compatible missing-key default')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "noExpectations" must be a boolean, got null.',
+            );
+    }
+}


### PR DESCRIPTION
An omitted noExpectations field uses the backward-compatible false default, but an explicit null must remain an invalid wire shape. Add a focused public-contract test that distinguishes those cases and pins the exact diagnostic.