### PR TITLE
test(core): reject null skip-unless arguments

### DIFF
--- a/tests/Unit/Core/TestMetadataNullSkipUnlessArgumentsWireTest.php
+++ b/tests/Unit/Core/TestMetadataNullSkipUnlessArgumentsWireTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Core\Wire\InvalidWirePayload;
+use Greenlight\Expect\Expect;
+
+final readonly class TestMetadataNullSkipUnlessArgumentsWireTest
+{
+    #[Test]
+    public function explicitNullSkipUnlessArgumentsAreRejected(): void
+    {
+        $payload = new TestMetadata('App\ExampleTest', 'checksValue')->toWire();
+        $payload['skipUnlessArguments'] = null;
+
+        Expect::that(static fn(): TestMetadata => TestMetadata::fromWire($payload))
+            ->because('explicit null is not the backward-compatible missing-key default')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "skipUnlessArguments" must be a list of scalars or nulls, got null.',
+            );
+    }
+}


### PR DESCRIPTION
An omitted skipUnlessArguments field uses the backward-compatible empty-list default, but an explicit null must remain an invalid wire shape. Add a focused public-contract test that distinguishes those cases and pins the exact diagnostic.