### PR TITLE
test(rector): preserve private data providers

### DIFF
--- a/tests/Acceptance/RectorPrivateDataProviderTest.php
+++ b/tests/Acceptance/RectorPrivateDataProviderTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorPrivateDataProviderTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesPrivateDataProvidersUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\Attributes\DataProvider;
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                #[DataProvider('values')]
+                public function testValue(int $value): void
+                {
+                    $this->assertSame(1, $value);
+                }
+
+                private static function values(): iterable
+                {
+                    yield [1];
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'private-data-provider',
+        );
+
+        Expect::that($probe->changed)
+            ->because('a private data provider MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}


### PR DESCRIPTION
Pins the safe migration boundary for PHPUnit data providers that are not public. The Rector rule MUST leave the class untouched instead of producing a Greenlight data set that discovery cannot call.