### PR TITLE
test(fixture): preserve null server environment

### DIFF
--- a/tests/Unit/Fixture/EnvironmentBackupNullServerTest.php
+++ b/tests/Unit/Fixture/EnvironmentBackupNullServerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Fixture;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\EnvironmentBackup;
+
+final readonly class EnvironmentBackupNullServerTest
+{
+    #[Test]
+    public function restorePreservesANullServerValueAsPresent(): void
+    {
+        $name = 'GREENLIGHT_ENVIRONMENT_BACKUP_NULL_SERVER_' . \strtoupper(\bin2hex(\random_bytes(6)));
+        \putenv($name . '=process-original');
+        $_ENV[$name] = 'env-original';
+        $_SERVER[$name] = null;
+        $backup = EnvironmentBackup::capture($name);
+
+        try {
+            \putenv($name . '=changed');
+            $_ENV[$name] = 'changed';
+            $_SERVER[$name] = 'changed';
+
+            $backup->restore();
+
+            Expect::that(\getenv($name))
+                ->because('restore MUST preserve explicit null presence in the server environment')
+                ->toBe('process-original')
+                ->and($_ENV[$name] ?? null)
+                ->toBe('env-original')
+                ->and(\array_key_exists($name, $_SERVER))
+                ->toBeTrue()
+                ->and($_SERVER[$name])
+                ->toBeNull();
+        } finally {
+            \putenv($name);
+            unset($_ENV[$name], $_SERVER[$name]);
+        }
+    }
+}


### PR DESCRIPTION
EnvironmentBackup distinguishes an absent server-environment key from a present key whose value is null. Add a focused public-contract test that exercises capture, mutation, restoration, independent channel values, and failure-safe process cleanup.