### PR TITLE
test(coverage): reject surplus wire line sets

### DIFF
--- a/tests/Unit/Coverage/CoverageMapExactWireShapeTest.php
+++ b/tests/Unit/Coverage/CoverageMapExactWireShapeTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Wire\InvalidWirePayload;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Expect\Expect;
+
+final readonly class CoverageMapExactWireShapeTest
+{
+    #[Test]
+    public function rejectsASurplusLineSet(): void
+    {
+        Expect::that(static fn(): CoverageMap => CoverageMap::fromWire([
+            'files' => [
+                '/src/A.php' => [[1], [2], [3]],
+            ],
+        ]))
+            ->because('each coverage file MUST contain exactly two line sets')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "files" must be a two-element list of line lists per file, got array.',
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- reject coverage-map wire entries that contain surplus line sets
- pin the exact invalid-payload diagnostic for the published two-list shape