### PR TITLE
test(rector): preserve named TestWith data

### DIFF
--- a/tests/Acceptance/RectorNamedTestWithDataTest.php
+++ b/tests/Acceptance/RectorNamedTestWithDataTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorNamedTestWithDataTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesNamedTestWithDataUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\Attributes\TestWith;
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                #[TestWith(data: [1])]
+                public function testValue(int $value): void
+                {
+                    $this->assertSame(1, $value);
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'named-test-with-data',
+        );
+
+        Expect::that($probe->changed)
+            ->because('named TestWith data MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}


### PR DESCRIPTION
Pins the safe migration boundary for PHPUnit TestWith attributes whose data argument is named. The Rector rule MUST leave the class untouched instead of silently rewriting the argument positionally.