### PR TITLE
test(rector): preserve dynamic data providers

### DIFF
--- a/tests/Acceptance/RectorDynamicDataProviderTest.php
+++ b/tests/Acceptance/RectorDynamicDataProviderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorDynamicDataProviderTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesDynamicDataProviderReferencesUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\Attributes\DataProvider;
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                private const string PROVIDER = 'values';
+
+                #[DataProvider(self::PROVIDER)]
+                public function testValue(int $value): void
+                {
+                    $this->assertSame(1, $value);
+                }
+
+                public static function values(): iterable
+                {
+                    yield [1];
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'dynamic-data-provider',
+        );
+
+        Expect::that($probe->changed)
+            ->because('a dynamic data provider reference MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}


### PR DESCRIPTION
Pins the safe migration boundary for PHPUnit data-provider references that are not literal strings. The Rector rule MUST leave the class untouched instead of resolving an unsupported expression as a method name.