### PR TITLE
test(discovery): reject null dependency cache hash

### DIFF
--- a/tests/Unit/Discovery/DiscoveryCacheEntryNullDependencyHashTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheEntryNullDependencyHashTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\DiscoveryCacheEntry;
+use Greenlight\Expect\Expect;
+
+final class DiscoveryCacheEntryNullDependencyHashTest
+{
+    #[Test]
+    public function aNullDependencyContentHashIsRejected(): void
+    {
+        $decoded = [
+            'mtime' => 100,
+            'size' => 200,
+            'entries' => [['class' => 'Example\Test']],
+            'dependencies' => [
+                '/project/tests/Provider.php' => [
+                    'mtime' => 300,
+                    'size' => 400,
+                    'contentHash' => null,
+                ],
+            ],
+        ];
+
+        Expect::that(DiscoveryCacheEntry::fromDecoded($decoded))
+            ->because('an explicit null dependency content hash is malformed')
+            ->toBeNull();
+    }
+}


### PR DESCRIPTION
Discovery cache validation distinguishes an omitted dependency content hash from an explicit null value. Replacing the key-presence check with an isset check currently survives the complete suite and accepts malformed cache data. Add a focused test that pins the explicit-null rejection boundary.