### PR TITLE
test(coverage): include multiline ignore end markers

### DIFF
--- a/tests/Unit/Coverage/IgnoreScannerMultilineEndTest.php
+++ b/tests/Unit/Coverage/IgnoreScannerMultilineEndTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\Ignore\IgnoreScanner;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class IgnoreScannerMultilineEndTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function multilineEndMarkerIncludesItsCompleteComment(): void
+    {
+        $path = $this->tempDirectory->path() . '/subject.php';
+        \file_put_contents($path, <<<'PHP'
+            <?php
+            // @codeCoverageIgnoreStart
+            $ignored = 1;
+            /*
+             * @codeCoverageIgnoreEnd
+             */
+            $kept = 2;
+            PHP);
+
+        Expect::that(\array_keys(new IgnoreScanner()->ignoredLines($path)))
+            ->because('a multiline end marker MUST include its complete comment')
+            ->toBe([2, 3, 4, 5, 6]);
+    }
+}


### PR DESCRIPTION
## Summary

- include every line of a multiline coverage-ignore end-marker comment
- assert the exact ignored line set through the complete marker token