### PR TITLE
test(phpstan): retain first matcher declaration

### DIFF
--- a/tests/Unit/PhpStan/MatcherMapFirstDeclarationTest.php
+++ b/tests/Unit/PhpStan/MatcherMapFirstDeclarationTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\PhpStan;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\PhpStan\MatcherMap;
+use Greenlight\PhpStan\MatcherMapError;
+
+final class MatcherMapFirstDeclarationTest
+{
+    private const string CONFIG = __DIR__ . '/../../Fixture/PhpStanExtension/greenlight.php';
+    private const string CONFIG_ALIAS = __DIR__ . '/../../Fixture/PhpStanExtension/../PhpStanExtension/greenlight.php';
+    private const string CONFLICTING_CONFIG = __DIR__ . '/../../Fixture/PhpStanExtensionConflict/greenlight.php';
+
+    #[Test]
+    public function anIdenticalRedeclarationDoesNotReplaceTheFirstDeclarationPath(): void
+    {
+        Expect::that(
+            static fn(): MatcherMap => MatcherMap::fromConfigFiles([
+                self::CONFIG,
+                self::CONFIG_ALIAS,
+                self::CONFLICTING_CONFIG,
+            ]),
+        )->because('a later conflict identifies the first matcher declaration')
+            ->toThrow(
+                MatcherMapError::class,
+                message: \sprintf(
+                    'Extension matcher "toHaveDigestLength" is declared with conflicting signatures: '
+                    . '(string $subject, int $length) in "%s" and '
+                    . '(mixed $subject, string $length) in "%s". '
+                    . 'Static analysis needs one signature per matcher name across all configured files.',
+                    self::CONFIG,
+                    self::CONFLICTING_CONFIG,
+                ),
+            );
+    }
+}


### PR DESCRIPTION
Matcher diagnostics must identify the first declaration when identical signatures repeat before a conflict. Replacing the first-write assignment with an unconditional assignment currently survives the complete suite and changes the reported source path. Add a focused test that pins first-declaration provenance through an aliased identical configuration path.