### PR TITLE
test(expect): preserve positive empty observation count

### DIFF
--- a/tests/Unit/Expect/ObservationLogEmptyCountTest.php
+++ b/tests/Unit/Expect/ObservationLogEmptyCountTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\ObservationLog;
+
+final class ObservationLogEmptyCountTest
+{
+    #[Test]
+    public function aFreshLogReportsOneObservation(): void
+    {
+        $log = new ObservationLog(0.0);
+
+        Expect::that($log->count())
+            ->because('an observation log MUST report at least one observation')
+            ->toBe(1);
+    }
+}


### PR DESCRIPTION
## Summary

- cover the positive observation-count contract before the first value is recorded
- kill the integer-boundary mutant that permits a zero count