### PR TITLE
test(rector): preserve PHPUnit function calls

### DIFF
--- a/tests/Acceptance/RectorPhpUnitFunctionCallTest.php
+++ b/tests/Acceptance/RectorPhpUnitFunctionCallTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorPhpUnitFunctionCallTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesPhpUnitFunctionCallsUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testValue(): void
+                {
+                    \PHPUnit\Framework\assertTrue(true);
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'phpunit-function-call',
+        );
+
+        Expect::that($probe->changed)
+            ->because('a PHPUnit function call MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}


### PR DESCRIPTION
Pins the safe migration boundary for PHPUnit classes that call namespaced framework functions. The Rector rule MUST leave the class untouched because removing the TestCase parent would retain a PHPUnit runtime dependency.