### PR TITLE
test(rector): preserve named assertion arguments

### DIFF
--- a/tests/Acceptance/RectorNamedAssertionArgumentTest.php
+++ b/tests/Acceptance/RectorNamedAssertionArgumentTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorNamedAssertionArgumentTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesNamedAssertionArgumentsUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testValue(): void
+                {
+                    $this->assertSame(expected: 'value', actual: 'value');
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'named-assertion-argument',
+        );
+
+        Expect::that($probe->changed)
+            ->because('an assertion with named arguments MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}


### PR DESCRIPTION
Pins the safe migration boundary for PHPUnit assertions that use named arguments. The Rector rule MUST leave the class untouched because positional conversion cannot preserve named argument semantics.