### PR TITLE
test(phpstan): allow variadic test parameters

### DIFF
--- a/tests/Acceptance/PhpStanTestMethodRuleTest.php
+++ b/tests/Acceptance/PhpStanTestMethodRuleTest.php
@@ -47,6 +47,12 @@ final readonly class PhpStanTestMethodRuleTest
                 {
                     echo $value;
                 }
+
+                #[Test]
+                public function testMethodWithVariadicParameter(string ...$values): void
+                {
+                    echo \implode('', $values);
+                }
             }
 
             abstract class GoodAbstractProbe


### PR DESCRIPTION
Variadic test parameters require no supplied data, so the PHPStan rule must not require a #[DataRow] or #[DataSet] attribute for them. Add a valid variadic method to the acceptance probe. An exact removal of the variadic guard survived the previous suite and this coverage kills it.