### PR TITLE
test(rector): preserve unpacked assertion arguments

### DIFF
--- a/tests/Acceptance/RectorUnpackedAssertionArgumentTest.php
+++ b/tests/Acceptance/RectorUnpackedAssertionArgumentTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorUnpackedAssertionArgumentTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesUnpackedAssertionArgumentsUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testValue(): void
+                {
+                    $arguments = [true];
+
+                    $this->assertTrue(...$arguments);
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'unpacked-assertion-argument',
+        );
+
+        Expect::that($probe->changed)
+            ->because('an assertion with unpacked arguments MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}


### PR DESCRIPTION
Pins the safe migration boundary for PHPUnit assertions that unpack argument arrays. The Rector rule MUST leave the class untouched instead of silently removing unpack semantics during positional conversion.