### PR TITLE
test(core): cover empty atomic writes

### DIFF
--- a/tests/Unit/Core/AtomicFileEmptyWriteTest.php
+++ b/tests/Unit/Core/AtomicFileEmptyWriteTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\AtomicFile;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class AtomicFileEmptyWriteTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function writeReplacesTheTargetWithEmptyContent(): void
+    {
+        $path = $this->tempDirectory->path() . '/state.bin';
+        \file_put_contents($path, 'old');
+
+        AtomicFile::write($path, '');
+
+        Expect::that(\file_get_contents($path))
+            ->because('an empty atomic write MUST replace the target')
+            ->toBe('')
+            ->and(\glob($path . '.tmp-*'))
+            ->because('an empty atomic write MUST leave no temporary file')
+            ->toBe([]);
+    }
+}


### PR DESCRIPTION
Adds focused regression coverage for successful empty atomic writes. The test replaces existing nonempty content with an empty string and verifies that no temporary file remains.\n\nThis detects a strict-to-loose false comparison mutation: file_put_contents() returns integer 0 for a successful zero-byte write, which MUST NOT be treated as failure.