### PR TITLE
test(rector): preserve invalid TestWith labels

### DIFF
--- a/tests/Acceptance/RectorInvalidTestWithLabelTest.php
+++ b/tests/Acceptance/RectorInvalidTestWithLabelTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorInvalidTestWithLabelTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesInvalidNamedLabelsUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\Attributes\TestWith;
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                #[TestWith([1], label: 'one')]
+                public function testValue(int $value): void
+                {
+                    $this->assertSame(1, $value);
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'invalid-test-with-label',
+        );
+
+        Expect::that($probe->changed)
+            ->because('a TestWith label with an invalid name MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}


### PR DESCRIPTION
Pins the safe migration boundary for TestWith labels that use an unsupported named parameter. The Rector rule MUST leave the class untouched instead of silently renaming invalid input. This is distinct from #1034, which covers the first data argument; this PR covers the second label argument.