### PR TITLE
test(phpstan): validate named attribute arguments

### DIFF
--- a/tests/Acceptance/PhpStanAttributeArgumentRuleTest.php
+++ b/tests/Acceptance/PhpStanAttributeArgumentRuleTest.php
@@ -60,12 +60,17 @@ final readonly class PhpStanAttributeArgumentRuleTest
 
             #[SkipUnless(extra: ['APP_ENV'], condition: EnvironmentVariableSet::class)]
             final class BadNamedAttributeArgumentProbe {}
+
+            #[RequiresResource(name: 'Postgres primary')]
+            #[Retry(times: 0)]
+            #[Timeout(seconds: 0.0)]
+            final class BadNamedDomainAttributeArgumentProbe {}
             PHP,
         );
 
         Expect::that($probe->exitCode)->because('attribute arguments must have valid values')->toBe(1)
             ->and($probe->goodPassed)->toBeTrue()
-            ->and(\count($probe->errors))->toBe(5)
+            ->and(\count($probe->errors))->toBe(8)
             ->and($probe->messages())->toContain('#[RequiresResource] name "Postgres primary" does not match')
             ->toContain('#[Retry] times must be at least 1')
             ->toContain('#[SkipUnless] argument 1 must be a scalar or null')


### PR DESCRIPTION
Named Timeout, Retry, and RequiresResource arguments must receive the same domain checks as positional arguments. Add named invalid values to the acceptance probe and pin the three additional diagnostics. Removing the named lookup branch survived the previous suite and this coverage kills that exact mutant.