### PR TITLE
test(coverage): preserve empty HTML sources

### DIFF
--- a/tests/Unit/Coverage/HtmlExporterEmptySourceTest.php
+++ b/tests/Unit/Coverage/HtmlExporterEmptySourceTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Coverage\Export\HtmlExporter;
+use Greenlight\Coverage\FileCoverage;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class HtmlExporterEmptySourceTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function emptyReadableSourceProducesNoLineBoxes(): void
+    {
+        $path = $this->tempDirectory->path() . '/Empty.php';
+        \file_put_contents($path, '');
+        $map = new CoverageMap([
+            new FileCoverage($path, [1], []),
+        ]);
+
+        $page = new HtmlExporter()->export($map)[HtmlExporter::pageName($path)];
+
+        Expect::that(\is_readable($path))
+            ->because('the empty source MUST be readable')
+            ->toBeTrue()
+            ->and($page)
+            ->because('an empty source MUST retain a valid empty source block')
+            ->toContain("<pre>\n</pre>")
+            ->not()
+            ->toContain('<span class="cov"><span class="num">1</span></span>');
+    }
+}


### PR DESCRIPTION
Adds focused regression coverage for a readable zero-byte source in the HTML coverage exporter. The file page retains a valid empty source block and does not invent a covered line-number box from stale coverage metadata.\n\nThis detects a strict-to-loose false comparison mutation: file_get_contents() returns an empty string for a valid empty file, which MUST remain distinct from a read failure.