### PR TITLE
test(phpstan): allow nullable constructor services

### DIFF
--- a/tests/Acceptance/PhpStanTestConstructorRuleTest.php
+++ b/tests/Acceptance/PhpStanTestConstructorRuleTest.php
@@ -35,13 +35,14 @@ final readonly class PhpStanTestConstructorRuleTest
             {
                 public function __construct(
                     private Service $service,
+                    private ?Service $nullableService,
                     private int $defaulted = 1,
                 ) {}
 
                 #[Test]
                 public function testMethod(): void
                 {
-                    echo $this->service::class, $this->defaulted;
+                    echo $this->service::class, \get_debug_type($this->nullableService), $this->defaulted;
                 }
             }
 


### PR DESCRIPTION
A required nullable object parameter is still resolvable as a constructor service. Add a nullable Service to the valid PHPStan probe so the rule must remove null before checking the object type. Removing that normalization survived the previous suite and this case kills the exact mutant.