### PR TITLE
test(rector): preserve unpacked TestWith arguments

### DIFF
--- a/tests/Acceptance/RectorUnpackedTestWithTest.php
+++ b/tests/Acceptance/RectorUnpackedTestWithTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorUnpackedTestWithTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesUnpackedTestWithArgumentsUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\Attributes\TestWith;
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                #[TestWith(...[[1]])]
+                public function testValue(int $value): void
+                {
+                    $this->assertSame(1, $value);
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'unpacked-test-with',
+        );
+
+        Expect::that($probe->changed)
+            ->because('a TestWith attribute with unpacked arguments MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}


### PR DESCRIPTION
Pins the safe migration boundary for TestWith attributes that unpack arguments. The Rector rule MUST leave the class untouched instead of silently discarding unpack semantics. This is distinct from #1055, which covers unpacked assertion-call arguments; this PR covers the attribute conversion path.