### PR TITLE
test(phpstan): allow variadic data row values

### DIFF
--- a/tests/Acceptance/PhpStanDataProviderShapeRuleTest.php
+++ b/tests/Acceptance/PhpStanDataProviderShapeRuleTest.php
@@ -61,6 +61,13 @@ final readonly class PhpStanDataProviderShapeRuleTest
                 }
 
                 #[Test]
+                #[DataRow(['one', 'two'])]
+                public function variadicValues(string ...$values): void
+                {
+                    echo \implode('', $values);
+                }
+
+                #[Test]
                 #[DataSet(SharedProviders::class, 'sums')]
                 public function addsFromSharedProvider(int $left, int $right, int $expected): void
                 {


### PR DESCRIPTION
Covers inline data rows that supply multiple values to a variadic test parameter. The PHPStan rule MUST accept values beyond the declared parameter count when the test signature is variadic. Removing the variadic arity exception survived the previous full suite; this coverage kills that exact mutant.