### PR TITLE
test(rector): preserve surplus TestWith arguments

### DIFF
--- a/tests/Acceptance/RectorSurplusTestWithArgumentTest.php
+++ b/tests/Acceptance/RectorSurplusTestWithArgumentTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorSurplusTestWithArgumentTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesSurplusTestWithArgumentsUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\Attributes\TestWith;
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                #[TestWith([1], 'one', 'extra')]
+                public function testValue(int $value): void
+                {
+                    $this->assertSame(1, $value);
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'surplus-test-with-argument',
+        );
+
+        Expect::that($probe->changed)
+            ->because('a TestWith attribute with surplus arguments MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}


### PR DESCRIPTION
Pins the safe migration boundary for TestWith attributes with surplus arguments. The Rector rule MUST leave the class untouched instead of silently dropping extra input. This is distinct from #1064, which covers an invalid second-argument name, and #1068, which covers unpacking.