### PR TITLE
test(discovery): preserve empty file parsing

### DIFF
--- a/tests/Unit/Discovery/ClassFileParserEmptyFileTest.php
+++ b/tests/Unit/Discovery/ClassFileParserEmptyFileTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\ClassFileParser;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class ClassFileParserEmptyFileTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function emptyReadableFileContainsNoDeclarations(): void
+    {
+        $file = $this->tempDirectory->path() . '/EmptyTest.php';
+        \file_put_contents($file, '');
+
+        Expect::that(\is_readable($file))
+            ->because('the empty test file MUST be readable')
+            ->toBeTrue()
+            ->and(ClassFileParser::declarationsIn($file))
+            ->because('an empty test file MUST contain no declarations')
+            ->toBe([]);
+    }
+}


### PR DESCRIPTION
Adds focused regression coverage for a readable zero-byte PHP file. The class-file parser returns an empty declaration list instead of reporting an I/O failure.\n\nThis detects a strict-to-loose false comparison mutation: file_get_contents() returns an empty string for a valid empty file, which MUST remain distinct from a read failure.