### PR TITLE
test(rector): preserve surplus skip arguments

### DIFF
--- a/tests/Acceptance/RectorSurplusSkipArgumentTest.php
+++ b/tests/Acceptance/RectorSurplusSkipArgumentTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorSurplusSkipArgumentTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesSurplusSkipArgumentsUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testValue(): void
+                {
+                    $this->markTestSkipped('Not supported.', 'extra');
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'surplus-skip-argument',
+        );
+
+        Expect::that($probe->changed)
+            ->because('markTestSkipped() with surplus arguments MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}


### PR DESCRIPTION
Pins the safe migration boundary for markTestSkipped() calls with surplus arguments. The Rector rule MUST leave the class untouched instead of generating an invalid SkipTest construction.