### PR TITLE
test(rector): preserve surplus no-expectations arguments

### DIFF
--- a/tests/Acceptance/RectorSurplusNoExpectationsArgumentTest.php
+++ b/tests/Acceptance/RectorSurplusNoExpectationsArgumentTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorSurplusNoExpectationsArgumentTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesSurplusNoExpectationsArgumentsUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testValue(): void
+                {
+                    $this->expectNotToPerformAssertions('extra');
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'surplus-no-expectations-argument',
+        );
+
+        Expect::that($probe->changed)
+            ->because('expectNotToPerformAssertions() with arguments MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}


### PR DESCRIPTION
Pins the safe migration boundary for expectNotToPerformAssertions() calls with arguments. The Rector rule MUST leave the class untouched instead of silently replacing an invalid call with NoExpectations metadata.