### PR TITLE
test(cli): cover zero debounce timestamps

### DIFF
--- a/tests/Unit/Cli/Watch/DebouncerZeroTimestampTest.php
+++ b/tests/Unit/Cli/Watch/DebouncerZeroTimestampTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli\Watch;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\Watch\Debouncer;
+use Greenlight\Expect\Expect;
+
+final class DebouncerZeroTimestampTest
+{
+    #[Test]
+    public function aZeroTimestampStartsTheQuietPeriod(): void
+    {
+        $debouncer = new Debouncer(0.5);
+        $debouncer->noteChange(0.0);
+
+        Expect::that($debouncer->shouldFire(0.5))
+            ->because('a zero timestamp MUST start the quiet period')
+            ->toBeTrue();
+    }
+}


### PR DESCRIPTION
Covers the valid zero timestamp at the runtime debounce boundary. The focused test proves that recording 0.0 starts the quiet period and fires at its exact boundary, which kills a loose null-comparison mutant.