### PR TITLE
test(reporting): measure zero lifecycle timestamps

### DIFF
--- a/tests/Unit/Reporting/WorkerProfileZeroTimestampTest.php
+++ b/tests/Unit/Reporting/WorkerProfileZeroTimestampTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\WorkerProfile;
+
+final readonly class WorkerProfileZeroTimestampTest
+{
+    #[Test]
+    public function zeroLifecycleTimestampsRemainMeasured(): void
+    {
+        $profile = new WorkerProfile();
+        $profile->spawned(0.0);
+        $profile->classStarted(0.0);
+
+        Expect::that($profile->classFinished(0.5))
+            ->because('a zero class-start timestamp is known timing data')
+            ->toBe(0.5)
+            ->and($profile->busy)->toBe(0.5)
+            ->and($profile->bootLatency())->toBe(0.0)
+            ->and($profile->window())->toBe(0.5)
+            ->and($profile->utilizationPercent())->toBe(100);
+    }
+}


### PR DESCRIPTION
Adds focused coverage for worker lifecycle timing that starts at timestamp 0.0. The worker profile preserves the measured class duration, boot latency, active window, and utilization instead of treating known timing data as absent.