### PR TITLE
test(cli): cover empty watch snapshots

### DIFF
--- a/tests/Unit/Cli/Watch/StatChangeDetectorEmptySnapshotTest.php
+++ b/tests/Unit/Cli/Watch/StatChangeDetectorEmptySnapshotTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli\Watch;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\Watch\StatChangeDetector;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class StatChangeDetectorEmptySnapshotTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function firstPhpFileAfterAnEmptySnapshotIsReported(): void
+    {
+        $directory = $this->tempDirectory->subdirectory('empty-watch-directory');
+        $detector = new StatChangeDetector([$directory]);
+
+        Expect::that($detector->poll())
+            ->because('the first poll MUST record an empty snapshot')
+            ->toBe([]);
+
+        $file = $directory . '/FirstTest.php';
+        \file_put_contents($file, '<?php');
+
+        Expect::that($detector->poll())
+            ->because('the first PHP file MUST be reported after an empty snapshot')
+            ->toBe([$file]);
+    }
+}


### PR DESCRIPTION
Covers the state transition from an initialized empty watch snapshot to the first PHP file. The focused test proves that the next poll reports the new path, complementing the separate content-fingerprint coverage in #615 and killing a loose null-comparison mutant.