### PR TITLE
test(rector): preserve nullsafe method calls

### DIFF
--- a/tests/Acceptance/RectorNullsafeMethodCallTest.php
+++ b/tests/Acceptance/RectorNullsafeMethodCallTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorNullsafeMethodCallTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function leavesNullsafeMethodCallsUntouched(): void
+    {
+        $source = <<<'PHP_WRAP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace App\Tests;
+
+            use PHPUnit\Framework\TestCase;
+
+            final class ProbeTest extends TestCase
+            {
+                public function testValue(): void
+                {
+                    $this?->checkValue(1);
+                }
+
+                private function checkValue(int $value): void
+                {
+                    $this->assertSame(1, $value);
+                }
+            }
+
+            PHP_WRAP;
+
+        $probe = RectorProbe::convert(
+            $this->tempDirectory,
+            $source,
+            name: 'nullsafe-method-call',
+        );
+
+        Expect::that($probe->changed)
+            ->because('a nullsafe method call MUST remain unsupported')
+            ->toBeFalse()
+            ->and($probe->code)
+            ->because('an unsupported class MUST remain byte-identical')
+            ->toBe($source);
+    }
+}


### PR DESCRIPTION
Pins the safe migration boundary for PHPUnit classes that make nullsafe calls on the test instance. The Rector rule MUST leave the class untouched because nullsafe dispatch does not pass through supported framework-call conversion. Replaces #1042 after its merged stack base was retired.