### PR TITLE
fix(core): reject trailing newline in decimal integers

### DIFF
--- a/src/Core/DecimalInteger.php
+++ b/src/Core/DecimalInteger.php
@@ -19,7 +19,7 @@ final class DecimalInteger
      */
     public static function parse(string $raw): ?int
     {
-        if (\preg_match('/^\d+$/', $raw) !== 1) {
+        if (\preg_match('/^\d+\z/', $raw) !== 1) {
             return null;
         }
 

--- a/tests/Unit/Core/DecimalIntegerTest.php
+++ b/tests/Unit/Core/DecimalIntegerTest.php
@@ -36,6 +36,7 @@ final class DecimalIntegerTest
         yield 'overflow' => [\PHP_INT_MAX . '0', null];
         yield 'negative' => ['-1', null];
         yield 'fraction' => ['1.0', null];
+        yield 'trailing newline' => ["1\n", null];
         yield 'empty' => ['', null];
     }
 }


### PR DESCRIPTION
DecimalInteger used a `$` anchor, which PHP permits to match before a final newline. As a result, newline-terminated text such as `"1\n"` was accepted as the integer 1.

Use the absolute end-of-string anchor and cover the boundary in the existing decimal parser dataset.