### PR TITLE
test(cli): cover missing long option names

### DIFF
--- a/src/Cli/ArgumentParser.php
+++ b/src/Cli/ArgumentParser.php
@@ -75,8 +75,13 @@ final class ArgumentParser
                 }
 
                 $separator = \strpos($body, '=');
-                $name = $separator === false ? $body : \substr($body, 0, $separator);
-                $value = $separator === false ? null : \substr($body, $separator + 1);
+                if ($separator === false) {
+                    $name = $body;
+                    $value = null;
+                } else {
+                    $name = \substr($body, 0, $separator);
+                    $value = \substr($body, $separator + 1);
+                }
 
                 $spec = $this->byName[$name] ?? throw CliError::unknownOption('--' . $name);
 

--- a/tests/Unit/Cli/ArgumentParserTest.php
+++ b/tests/Unit/Cli/ArgumentParserTest.php
@@ -118,6 +118,10 @@ final class ArgumentParserTest
             ['--'],
             '"--" requires an option name.',
         ];
+        yield 'missing long option name' => [
+            ['--=value'],
+            'Unknown option "--". Use greenlight --help to list options.',
+        ];
     }
 
     private static function parser(): ArgumentParser


### PR DESCRIPTION
Treat a leading equals sign as a missing long-option name and pin the exact usage diagnostic. The previous suite let a loose false comparison survive. The parser now branches once on the separator result, which removes the duplicate unobservable sentinel check, and the new malformed-input case kills the exact mutant.