### PR TITLE
test(coverage): cover root-qualified ignore attributes

### DIFF
--- a/tests/Unit/Coverage/IgnoreScannerRootAttributeTest.php
+++ b/tests/Unit/Coverage/IgnoreScannerRootAttributeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\Ignore\IgnoreScanner;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class IgnoreScannerRootAttributeTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function rootQualifiedShortAttributeIgnoresTheDeclaration(): void
+    {
+        $path = $this->tempDirectory->path() . '/subject.php';
+        \file_put_contents($path, <<<'PHP'
+            <?php
+            #[\CoverageIgnore]
+            function ignored(): int
+            {
+                return 1;
+            }
+            PHP);
+
+        Expect::that(\array_keys(new IgnoreScanner()->ignoredLines($path)))
+            ->because('a root-qualified CoverageIgnore attribute MUST ignore its declaration')
+            ->toBe([3, 4, 5, 6]);
+    }
+}


### PR DESCRIPTION
Covers the root-qualified short CoverageIgnore form, where the namespace separator is at string index zero. The focused test proves the declaration remains ignored and kills a loose false-comparison mutant in attribute-name extraction.