### PR TITLE
fix(discovery): reject newline-suffixed cache hashes

### DIFF
--- a/src/Discovery/DiscoveryCacheEntry.php
+++ b/src/Discovery/DiscoveryCacheEntry.php
@@ -38,7 +38,7 @@ final readonly class DiscoveryCacheEntry implements \JsonSerializable
 
         $contentHash = $decoded['contentHash'] ?? null;
 
-        if ($contentHash !== null && (!\is_string($contentHash) || \preg_match('/^[0-9a-f]{40}$/', $contentHash) !== 1)) {
+        if ($contentHash !== null && (!\is_string($contentHash) || \preg_match('/^[0-9a-f]{40}\z/', $contentHash) !== 1)) {
             return null;
         }
 
@@ -78,7 +78,7 @@ final readonly class DiscoveryCacheEntry implements \JsonSerializable
                 || !\is_int($stat['size'] ?? null)
                 || (
                     \array_key_exists('contentHash', $stat)
-                    && (!\is_string($stat['contentHash']) || \preg_match('/^[0-9a-f]{40}$/', $stat['contentHash']) !== 1)
+                    && (!\is_string($stat['contentHash']) || \preg_match('/^[0-9a-f]{40}\z/', $stat['contentHash']) !== 1)
                 )
             ) {
                 return null;

--- a/tests/Unit/Discovery/DiscoveryCacheEntryTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheEntryTest.php
@@ -80,6 +80,11 @@ final class DiscoveryCacheEntryTest
 
         yield 'invalid content hash' => [[...$valid, 'contentHash' => \str_repeat('g', 40)]];
 
+        yield 'content hash with trailing newline' => [[
+            ...$valid,
+            'contentHash' => \str_repeat('a', 40) . "\n",
+        ]];
+
         yield 'entry is not a map' => [[...$valid, 'entries' => ['not a map']]];
 
         yield 'entry key is not a string' => [[...$valid, 'entries' => [[0 => 'value']]]];
@@ -102,6 +107,17 @@ final class DiscoveryCacheEntryTest
                     'mtime' => 300,
                     'size' => 400,
                     'contentHash' => \str_repeat('g', 40),
+                ],
+            ],
+        ]];
+
+        yield 'dependency content hash has trailing newline' => [[
+            ...$valid,
+            'dependencies' => [
+                '/project/tests/Provider.php' => [
+                    'mtime' => 300,
+                    'size' => 400,
+                    'contentHash' => \str_repeat('b', 40) . "\n",
                 ],
             ],
         ]];


### PR DESCRIPTION
Discovery cache hash validators used a `$` anchor, which PHP permits to match before a final newline. Corrupt top-level and dependency hashes could therefore be treated as valid SHA-1 values.

Use the absolute end-of-string anchor for both validators and cover both cache-entry shapes.