### PR TITLE
fix(cli): reject trailing shard newlines

### DIFF
--- a/src/Cli/CliOverrides.php
+++ b/src/Cli/CliOverrides.php
@@ -100,7 +100,7 @@ final readonly class CliOverrides
         if ($arguments->has('shard')) {
             $raw = $arguments->value('shard') ?? '';
 
-            if (\preg_match('/^(\d+)\/(\d+)$/', $raw, $matches) !== 1) {
+            if (\preg_match('/^(\d+)\/(\d+)\z/', $raw, $matches) !== 1) {
                 throw CliError::malformedShard($raw);
             }
 

--- a/tests/Unit/Cli/CliOverridesTest.php
+++ b/tests/Unit/Cli/CliOverridesTest.php
@@ -130,6 +130,19 @@ final class CliOverridesTest
     }
 
     #[Test]
+    public function shardWithATrailingNewlineIsMalformed(): void
+    {
+        Expect::that(static fn(): CliOverrides => CliOverrides::fromArguments(
+            new ParsedArguments(null, ['shard' => ["1/2\n"]]),
+        ))
+            ->because('a shard specification MUST match the complete argument')
+            ->toThrow(
+                CliError::class,
+                message: "--shard requires <n>/<m>, such as 1/4. Received \"1/2\n\".",
+            );
+    }
+
+    #[Test]
     public function shardOutOfRangeNamesTheValidRange(): void
     {
         try {


### PR DESCRIPTION
Require \`--shard\` to match the complete argument. PCRE’s dollar anchor accepted a final newline, so \`1/2\n\` silently selected a shard. Use the absolute end anchor and pin the malformed-shard diagnostic.