### PR TITLE
test(worker): cover whitespace in fallback Xdebug modes

### DIFF
--- a/tests/Unit/Runner/Worker/LeakDetectorWhitespaceIniModeTest.php
+++ b/tests/Unit/Runner/Worker/LeakDetectorWhitespaceIniModeTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Worker;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\SkipTest;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\Subprocess;
+
+final readonly class LeakDetectorWhitespaceIniModeTest
+{
+    #[Test]
+    public function iniModeFallbackTrimsCommaSeparatedModes(): void
+    {
+        if (!\extension_loaded('xdebug')) {
+            throw new SkipTest('Xdebug is not loaded');
+        }
+
+        $root = \dirname(__DIR__, 4);
+        $result = Subprocess::run(
+            $root,
+            [
+                \PHP_BINARY,
+                '-d',
+                'xdebug.mode=coverage, develop',
+                '-d',
+                'disable_functions=xdebug_info',
+                '-r',
+                <<<'PHP'
+                require $argv[1];
+
+                echo Greenlight\Runner\Worker\LeakDetector::environmentWarning() ?? 'no warning';
+                PHP,
+                $root . '/vendor/autoload.php',
+            ],
+        );
+
+        Expect::that($result->exitCode)
+            ->because('the fallback process MUST accept comma-separated Xdebug modes')
+            ->toBe(0)
+            ->and($result->stderr)
+            ->toBe('')
+            ->and($result->stdout)
+            ->because('the fallback MUST detect develop mode after separator whitespace')
+            ->toBe(
+                'Warning: Xdebug develop mode keeps caught exceptions in memory. Thus, leak detection reports '
+                . 'false positives. Rerun with XDEBUG_MODE=off to get correct results.',
+            );
+    }
+}


### PR DESCRIPTION
When `xdebug_info()` is unavailable, LeakDetector falls back to the comma-separated `xdebug.mode` INI value. That fallback must trim each entry so separator whitespace does not hide `develop` mode and suppress the leak-detection warning.

Exercise the fallback in a subprocess with `xdebug_info` disabled and a whitespace-separated mode list.