### PR TITLE
fix(discovery): hash trailing newline data-set keys

### DIFF
--- a/src/Discovery/DataSetExpander.php
+++ b/src/Discovery/DataSetExpander.php
@@ -192,7 +192,7 @@ final readonly class DataSetExpander
             throw DiscoveryError::providerKeyInvalid($class, $provider, \get_debug_type($key));
         }
 
-        if ($key !== '' && \preg_match('/^\P{C}+$/u', $key) === 1) {
+        if ($key !== '' && \preg_match('/^\P{C}+\z/u', $key) === 1) {
             return $key;
         }
 

--- a/tests/Unit/Discovery/DataSetExpansionTest.php
+++ b/tests/Unit/Discovery/DataSetExpansionTest.php
@@ -85,6 +85,29 @@ final class DataSetExpansionTest
     }
 
     #[Test]
+    public function aTrailingNewlineKeyBecomesAStableHashPrefix(): void
+    {
+        $rows = new DataSetExpander()->rowsFor(
+            new \ReflectionClass(self::class),
+            __FUNCTION__,
+            'trailingNewlineKey',
+            5.0,
+        );
+
+        Expect::that(\array_keys($rows))
+            ->because('a data-set key MUST NOT preserve a trailing control character')
+            ->toBe([\substr(\hash('sha256', "line\n"), 0, 8)]);
+    }
+
+    /**
+     * @return iterable<string, array<mixed>>
+     */
+    public static function trailingNewlineKey(): iterable
+    {
+        yield "line\n" => [];
+    }
+
+    #[Test]
     public function providerKeysMustBeStringsOrIntegers(): void
     {
         $expander = new DataSetExpander();


### PR DESCRIPTION
Require printable provider keys to match the complete string. PCRE’s dollar anchor accepted a final newline, which allowed a control character into test IDs and reporter output. Use the absolute end anchor so Greenlight derives the stable hash key instead.