### PR TITLE
test(laravel): preserve zero process environment

### DIFF
--- a/tests/Unit/Laravel/LaravelProcessZeroEnvironmentTest.php
+++ b/tests/Unit/Laravel/LaravelProcessZeroEnvironmentTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Laravel;
+
+use Greenlight\Attribute\SkipUnless;
+use Greenlight\Attribute\Test;
+use Greenlight\Condition\ClassAvailable;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\EnvironmentBackup;
+use Greenlight\Laravel\LaravelProcessState;
+use Illuminate\Foundation\Application as LaravelApplication;
+
+final readonly class LaravelProcessZeroEnvironmentTest
+{
+    #[Test]
+    #[SkipUnless(ClassAvailable::class, LaravelApplication::class)]
+    public function restorePreservesAZeroProcessEnvironment(): void
+    {
+        $backup = EnvironmentBackup::capture('APP_ENV');
+        $state = null;
+
+        try {
+            \putenv('APP_ENV=0');
+            $_ENV['APP_ENV'] = 'environment-original';
+            $_SERVER['APP_ENV'] = 'server-original';
+
+            $state = LaravelProcessState::setEnvironment('testing');
+            $state->restore();
+
+            Expect::that(\getenv('APP_ENV'))
+                ->because('restore MUST preserve a zero process environment')
+                ->toBe('0')
+                ->and($_ENV['APP_ENV'])
+                ->toBe('environment-original')
+                ->and($_SERVER['APP_ENV'])
+                ->toBe('server-original');
+        } finally {
+            $state?->restore();
+            $backup->restore();
+        }
+    }
+}


### PR DESCRIPTION
Covers Laravel process-state restoration when APP_ENV originally contains the valid string zero. The focused test proves restore keeps that value distinct from an absent variable and kills a loose false-comparison mutant.