### PR TITLE
fix(core): reject non-finite run durations

### DIFF
--- a/docs/api-events.md
+++ b/docs/api-events.md
@@ -108,7 +108,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L37)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L41)
 
 ### `fromWire()`
 
@@ -117,7 +117,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L48)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L52)
 
 ## `RunStarted`
 

--- a/src/Core/Event/RunFinished.php
+++ b/src/Core/Event/RunFinished.php
@@ -27,6 +27,10 @@ final readonly class RunFinished implements Event
             throw new \InvalidArgumentException('RunFinished requires a non-empty run ID.');
         }
 
+        if (!\is_finite($durationSeconds)) {
+            throw new \InvalidArgumentException('RunFinished duration is not finite.');
+        }
+
         if ($durationSeconds < 0.0) {
             throw new \InvalidArgumentException('RunFinished duration cannot be negative.');
         }

--- a/tests/Unit/Core/RunFinishedNonFiniteDurationTest.php
+++ b/tests/Unit/Core/RunFinishedNonFiniteDurationTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\RunFinished;
+use Greenlight\Core\Result\ResultSummary;
+use Greenlight\Expect\Expect;
+
+final readonly class RunFinishedNonFiniteDurationTest
+{
+    #[Test]
+    #[DataSet('nonFiniteDurations')]
+    public function rejectsANonFiniteDuration(float $duration): void
+    {
+        Expect::that(static fn(): RunFinished => new RunFinished(
+            'run-1',
+            new ResultSummary(passed: 1),
+            $duration,
+            1.0,
+        ))
+            ->because('a run duration MUST remain representable on the wire')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'RunFinished duration is not finite.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{float}>
+     */
+    public static function nonFiniteDurations(): iterable
+    {
+        yield 'positive infinity' => [\INF];
+        yield 'negative infinity' => [-\INF];
+        yield 'not a number' => [\NAN];
+    }
+}


### PR DESCRIPTION
Reject infinite and NaN run durations at direct construction. Wire decoding already rejects non-finite floats, but the public constructor accepted them and could produce an event that JSON cannot encode. Preserve the existing negative-duration diagnostic and add focused coverage for all non-finite forms.