### PR TITLE
test(expect): retain numeric zero subset paths

### DIFF
--- a/tests/Unit/Expect/ArraySubsetZeroKeyPathTest.php
+++ b/tests/Unit/Expect/ArraySubsetZeroKeyPathTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+
+final readonly class ArraySubsetZeroKeyPathTest
+{
+    #[Test]
+    public function nestedDifferencePathsRetainANumericZeroParentKey(): void
+    {
+        $detail = FailureProbe::detailOf(
+            static fn() => Expect::that([0 => ['actual' => true]])
+                ->toContainSubset([0 => ['missing' => true]]),
+        );
+
+        Expect::that($detail->message)
+            ->because('nested subset diagnostics MUST retain a numeric zero parent key')
+            ->toContain("(missing key '0.missing').");
+    }
+}


### PR DESCRIPTION
Nested subset diagnostics build a dotted path from each array key. A numeric zero parent is a valid path component and must not be mistaken for the empty root path.

Cover a missing nested key under index zero through the public expectation API so the complete failure diagnostic retains `0.missing`.