### PR TITLE
test(core): cover zero-offset wildcard matches

### DIFF
--- a/tests/Unit/Core/WildcardTest.php
+++ b/tests/Unit/Core/WildcardTest.php
@@ -57,6 +57,13 @@ final class WildcardTest
             true,
         ];
 
+        yield 'plain case-insensitive pattern matches at the subject start' => [
+            'InvoiceTotalsTest',
+            'invoice',
+            true,
+            true,
+        ];
+
         yield 'wildcard pattern must match the whole subject' => [
             'prefix-value-suffix',
             'value*',


### PR DESCRIPTION
## Summary

- cover a case-insensitive plain-text match at the start of its subject
- distinguish a valid zero offset from the false result returned for no match
- keep the contract in the existing wildcard data set