### PR TITLE
test(reporting): cap profiled slow tests

### DIFF
--- a/tests/Unit/Reporting/SlowTestsTest.php
+++ b/tests/Unit/Reporting/SlowTestsTest.php
@@ -59,6 +59,30 @@ final class SlowTestsTest
     }
 
     #[Test]
+    public function extendedModeCapsAtTwentyFive(): void
+    {
+        $slow = new SlowTests(extended: true);
+
+        for ($i = 1; $i <= 26; ++$i) {
+            $slow->record($this->finished(\sprintf('Acme\SlowTest::case%02d', $i), 0.5 + $i / 100));
+        }
+
+        $rendered = $slow->render(new Style(ansi: false));
+        $lines = \explode("\n", \trim($rendered));
+
+        Expect::that(\count($lines))
+            ->because('profile mode MUST list exactly the 25 slowest tests')
+            ->toBe(26)
+            ->and($lines[1])
+            ->toBe('  0.760s Acme\SlowTest::case26')
+            ->and($lines[25])
+            ->toBe('  0.520s Acme\SlowTest::case02')
+            ->and($rendered)
+            ->not()
+            ->toContain('case01');
+    }
+
+    #[Test]
     public function longRunsPruneIncrementallyWithoutLosingTheSlowestTests(): void
     {
         $slow = new SlowTests();


### PR DESCRIPTION
## Summary

- lock profile-mode slow-test output to its documented 25-entry limit
- assert descending order at both ends of the retained window
- assert that the 26th, faster entry is omitted

## Mutation proof

Changing \`EXTENDED_LIMIT\` from 25 to 24 survived all 2,240 existing tests. The new focused test kills that mutant with \`Expected 25 to be 26\` and passes against the restored source.