### PR TITLE
test(reporting): cover missing class starts

### DIFF
--- a/tests/Unit/Reporting/TtyReporterTest.php
+++ b/tests/Unit/Reporting/TtyReporterTest.php
@@ -77,6 +77,19 @@ final class TtyReporterTest
     }
 
     #[Test]
+    public function aClassFinishedEventWithoutAStartUsesAnEmptyState(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new TtyReporter($output, color: false, cursor: false);
+
+        $reporter->onEvent(new TestClassFinished('App\RecoveredTest', 1.0));
+
+        Expect::that($output->buffer())
+            ->because('a missing class-start event MUST NOT hide the class completion')
+            ->toBe("✓ App\RecoveredTest (0 tests, 0.000s)\n");
+    }
+
+    #[Test]
     public function zeroResultCategoriesAreOmittedFromTheSummary(): void
     {
         $output = new BufferOutput();


### PR DESCRIPTION
## Summary

- cover a class-finished event whose matching start event is absent
- assert append-only TTY output retains the recovered zero-test completion
- protect the reporter fallback used for partial event streams

## Mutation proof

Removing the null-coalescing fallback in \`TtyReporter::finalizeClass()\` survived all 2,240 existing tests. The new focused test kills that mutant with an undefined class key and \`TypeError\`, then passes against the restored source.