### PR TITLE
test(expect): retain duplicate-key traversable values

### DIFF
--- a/tests/Unit/Expect/ToBeInDuplicateKeyTest.php
+++ b/tests/Unit/Expect/ToBeInDuplicateKeyTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+
+final readonly class ToBeInDuplicateKeyTest
+{
+    #[Test]
+    public function traversableKeysDoNotDiscardEarlierValues(): void
+    {
+        $values = static function (): \Generator {
+            yield 'shared' => 'first';
+            yield 'shared' => 'second';
+        };
+
+        Expect::that('first')
+            ->because('toBeIn() MUST inspect every traversable value regardless of its key')
+            ->toBeIn($values());
+    }
+}


### PR DESCRIPTION
The toBeIn() matcher consumes a Traversable as a sequence of values, so repeated iterator keys must not overwrite earlier candidates.

Cover a generator that yields two values under the same key and assert that the matcher can still find the first value.