### PR TITLE
test(expect): retain iterable short-circuiting

### DIFF
--- a/tests/Unit/Expect/ToContainShortCircuitTest.php
+++ b/tests/Unit/Expect/ToContainShortCircuitTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+
+final readonly class ToContainShortCircuitTest
+{
+    #[Test]
+    public function iterableStopsAfterTheMatchingValue(): void
+    {
+        $values = static function (): \Generator {
+            yield 'target';
+
+            throw new \LogicException('The matcher consumed the iterable after it found the target.');
+        };
+
+        Expect::that($values())
+            ->because('toContain() MUST stop consuming an iterable after it finds the target')
+            ->toContain('target');
+    }
+}


### PR DESCRIPTION
The toContain() matcher can inspect a lazy or unbounded iterable, so it must stop as soon as it finds the requested value.

Cover a generator whose tail throws after yielding the match. This makes continued consumption fail immediately while preserving a focused assertion of the matcher contract.