### PR TITLE
fix(protocol): round-trip empty envelopes

### DIFF
--- a/src/Runner/Protocol/JsonFrameCodec.php
+++ b/src/Runner/Protocol/JsonFrameCodec.php
@@ -38,7 +38,10 @@ final readonly class JsonFrameCodec implements FrameCodec
     public function encode(array $envelope): string
     {
         try {
-            $json = \json_encode($envelope, \JSON_THROW_ON_ERROR | \JSON_INVALID_UTF8_SUBSTITUTE);
+            $json = \json_encode(
+                $envelope === [] ? new \stdClass() : $envelope,
+                \JSON_THROW_ON_ERROR | \JSON_INVALID_UTF8_SUBSTITUTE,
+            );
         } catch (\JsonException $e) {
             throw ProtocolError::malformedFrame('Greenlight cannot encode the payload as JSON: ' . $e->getMessage());
         }

--- a/tests/Unit/Runner/Protocol/JsonFrameCodecEmptyEnvelopeTest.php
+++ b/tests/Unit/Runner/Protocol/JsonFrameCodecEmptyEnvelopeTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Protocol;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Runner\Protocol\JsonFrameCodec;
+
+final readonly class JsonFrameCodecEmptyEnvelopeTest
+{
+    #[Test]
+    public function emptyEnvelopeSurvivesTheCodecRoundTrip(): void
+    {
+        $codec = new JsonFrameCodec();
+        $body = \substr($codec->encode([]), 4);
+
+        if ($body === '') {
+            Fail::because('Expected the encoded frame to contain a JSON body.');
+        }
+
+        Expect::that($body)
+            ->because('an empty protocol envelope MUST remain a JSON map')
+            ->toBe('{}')
+            ->and($codec->decode($body))
+            ->because('the frame codec MUST decode its empty encoded envelope')
+            ->toBe([]);
+    }
+}


### PR DESCRIPTION
## Summary

- encode an empty protocol envelope as a JSON object
- prove that the frame codec decodes its own empty encoded envelope