### PR TITLE
fix(coverage): scrub unsafe XML path characters

### DIFF
--- a/src/Coverage/Export/CloverExporter.php
+++ b/src/Coverage/Export/CloverExporter.php
@@ -28,7 +28,7 @@ final readonly class CloverExporter implements CoverageExporter
         $out .= \sprintf('  <project timestamp="%d" name="greenlight">', $this->timestamp) . "\n";
 
         foreach ($map->files() as $path => $file) {
-            $out .= \sprintf('    <file name="%s">', $this->xml($path)) . "\n";
+            $out .= \sprintf('    <file name="%s">', XmlEscaper::attribute($path)) . "\n";
 
             $counts = [];
 
@@ -69,10 +69,5 @@ final readonly class CloverExporter implements CoverageExporter
             $statements,
             $covered,
         );
-    }
-
-    private function xml(string $value): string
-    {
-        return \htmlspecialchars($value, \ENT_XML1 | \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
     }
 }

--- a/src/Coverage/Export/CoberturaExporter.php
+++ b/src/Coverage/Export/CoberturaExporter.php
@@ -46,8 +46,8 @@ final readonly class CoberturaExporter implements CoverageExporter
         foreach ($map->files() as $path => $file) {
             $out .= \sprintf(
                 '        <class name="%s" filename="%s" line-rate="%s" branch-rate="0" complexity="0">',
-                $this->xml(\ltrim($path, '/')),
-                $this->xml(\ltrim($path, '/')),
+                XmlEscaper::attribute(\ltrim($path, '/')),
+                XmlEscaper::attribute(\ltrim($path, '/')),
                 $this->rate($file->coveredLineCount(), $file->executableLineCount()),
             ) . "\n";
             $out .= '          <methods/>' . "\n";
@@ -88,10 +88,5 @@ final readonly class CoberturaExporter implements CoverageExporter
         }
 
         return \sprintf('%.4F', $covered / $executable);
-    }
-
-    private function xml(string $value): string
-    {
-        return \htmlspecialchars($value, \ENT_XML1 | \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
     }
 }

--- a/src/Coverage/Export/XmlEscaper.php
+++ b/src/Coverage/Export/XmlEscaper.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Coverage\Export;
+
+use Greenlight\Core\Wire\Utf8;
+
+/**
+ * Escapes file-system paths for XML 1.0 attributes.
+ *
+ * @internal
+ */
+final class XmlEscaper
+{
+    /** @codeCoverageIgnore */
+    private function __construct() {}
+
+    public static function attribute(string $value): string
+    {
+        $value = (string) \preg_replace(
+            '/[^\x{9}\x{A}\x{D}\x{20}-\x{D7FF}\x{E000}-\x{FFFD}\x{10000}-\x{10FFFF}]/u',
+            "\u{FFFD}",
+            Utf8::scrub($value),
+        );
+
+        $value = \htmlspecialchars($value, \ENT_XML1 | \ENT_QUOTES | \ENT_SUBSTITUTE, 'UTF-8');
+
+        return \str_replace(
+            ["\t", "\n", "\r"],
+            ['&#x9;', '&#xA;', '&#xD;'],
+            $value,
+        );
+    }
+}

--- a/tests/Unit/Coverage/XmlExporterControlCharacterPathTest.php
+++ b/tests/Unit/Coverage/XmlExporterControlCharacterPathTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Coverage\Export\CloverExporter;
+use Greenlight\Coverage\Export\CoberturaExporter;
+use Greenlight\Coverage\FileCoverage;
+use Greenlight\Expect\Expect;
+
+final readonly class XmlExporterControlCharacterPathTest
+{
+    #[Test]
+    #[DataSet('unsafePaths')]
+    public function unsafePathCharactersRemainRoundTrippable(string $path, string $expected): void
+    {
+        $map = new CoverageMap([
+            new FileCoverage($path, [1], []),
+        ]);
+
+        $clover = new \SimpleXMLElement(
+            new CloverExporter()->export($map)[CloverExporter::FILE_NAME],
+        );
+        $cloverFiles = $clover->xpath('/coverage/project/file');
+        Expect::that($cloverFiles)
+            ->because('the Clover document MUST contain exactly one file')
+            ->toHaveCount(1);
+        \assert(\is_array($cloverFiles) && isset($cloverFiles[0]));
+
+        $cobertura = new \SimpleXMLElement(
+            new CoberturaExporter()->export($map)[CoberturaExporter::FILE_NAME],
+        );
+        $coberturaClasses = $cobertura->xpath('/coverage/packages/package/classes/class');
+        Expect::that($coberturaClasses)
+            ->because('the Cobertura document MUST contain exactly one class')
+            ->toHaveCount(1);
+        \assert(\is_array($coberturaClasses) && isset($coberturaClasses[0]));
+
+        Expect::that((string) $cloverFiles[0]['name'])
+            ->because('Clover MUST produce a round-trippable file-system path')
+            ->toBe($expected)
+            ->and((string) $coberturaClasses[0]['filename'])
+            ->because('Cobertura MUST produce a round-trippable file-system path')
+            ->toBe(\ltrim($expected, '/'));
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string, non-empty-string}>
+     */
+    public static function unsafePaths(): iterable
+    {
+        yield 'XML-forbidden control character' => [
+            "/src/before\x01after.php",
+            "/src/before\u{FFFD}after.php",
+        ];
+        yield 'XML attribute whitespace' => [
+            "/src/tab\tline\nreturn\rafter.php",
+            "/src/tab\tline\nreturn\rafter.php",
+        ];
+    }
+}


### PR DESCRIPTION
Clover and Cobertura currently pass valid UTF-8 control bytes through `htmlspecialchars()`. XML 1.0 rejects those bytes, and raw tab, line-feed, and carriage-return characters in attributes do not round-trip because XML normalizes them.

Route both exporters through one XML 1.0 attribute escaper. Replace forbidden characters, encode attribute whitespace as character references, and retain the existing invalid-UTF-8 and metacharacter handling.