### PR TITLE
test(discovery): cover legacy cache dependencies

### DIFF
--- a/tests/Unit/Discovery/DiscoveryCacheEntryTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheEntryTest.php
@@ -40,6 +40,24 @@ final class DiscoveryCacheEntryTest
             ->toBe($decoded);
     }
 
+    #[Test]
+    public function aLegacyEntryWithoutDependenciesUsesTheBackwardCompatibleDefault(): void
+    {
+        $entry = DiscoveryCacheEntry::fromDecoded([
+            'mtime' => 100,
+            'size' => 200,
+            'entries' => [['class' => 'Example\Test']],
+        ]);
+
+        if (!$entry instanceof DiscoveryCacheEntry) {
+            Fail::because('Expected a legacy discovery cache entry.');
+        }
+
+        Expect::that($entry->dependencies)
+            ->because('a legacy entry without dependencies MUST use an empty dependency map')
+            ->toBe([]);
+    }
+
     /**
      * @param array<mixed> $decoded
      */


### PR DESCRIPTION
## Summary

- Cover discovery cache payloads that predate the dependency map.
- Verify that the missing field keeps the backward-compatible empty map.

## Mutation proof

Removing the missing-field fallback survived all 2,240 existing tests. The new focused test fails with an undefined \`dependencies\` key and a rejected legacy cache entry; the restored implementation passes.