### PR TITLE
refactor(cli): return sharded plan directly

### DIFF
--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -1118,7 +1118,7 @@ final readonly class Application
         $plan = new TestDiscoverer()->discover($directories, $filter, $resolved->randomSeed, DiscoveryCache::forDirectories($directories));
 
         if ($resolved->shard !== null) {
-            $plan = PlanShard::select($plan, \max(1, $resolved->shard[0]), \max(1, $resolved->shard[1]));
+            return PlanShard::select($plan, \max(1, $resolved->shard[0]), \max(1, $resolved->shard[1]));
         }
 
         return $plan;


### PR DESCRIPTION
Return the selected shard directly when sharding is active. This behavior-preserving rewrite satisfies Rector 2.6.2 and lets the pending development-dependency update rebase cleanly.