### PR TITLE
test(runner): assert scheduler state directly

### DIFF
--- a/tests/Unit/Runner/Orchestrator/DispatchDecisionTest.php
+++ b/tests/Unit/Runner/Orchestrator/DispatchDecisionTest.php
@@ -24,15 +24,12 @@ final readonly class DispatchDecisionTest
         $lease = new ResourceLease(41, $this->unit());
         $decision = DispatchDecision::assign($lease);
 
-        Expect::that([
-            'kind' => $decision->kind,
-            'lease' => $decision->lease,
-        ])
+        Expect::that($decision->kind)
+            ->because('an assignment MUST use the assign decision kind')
+            ->toBe(DispatchKind::Assign);
+        Expect::that($decision->lease)
             ->because('an assignment MUST carry the exact resource lease')
-            ->toBe([
-                'kind' => DispatchKind::Assign,
-                'lease' => $lease,
-            ]);
+            ->toBe($lease);
     }
 
     #[Test]
@@ -45,15 +42,12 @@ final readonly class DispatchDecisionTest
             default => throw new \LogicException(\sprintf('Unknown decision factory "%s".', $factory)),
         };
 
-        Expect::that([
-            'kind' => $decision->kind,
-            'lease' => $decision->lease,
-        ])
-            ->because('non-assignment decisions MUST identify their action without a lease')
-            ->toBe([
-                'kind' => $kind,
-                'lease' => null,
-            ]);
+        Expect::that($decision->kind)
+            ->because('a non-assignment decision MUST use its requested decision kind')
+            ->toBe($kind);
+        Expect::that($decision->lease)
+            ->because('a non-assignment decision MUST NOT carry a resource lease')
+            ->toBeNull();
     }
 
     /**

--- a/tests/Unit/Runner/Orchestrator/ResourceSchedulerQueuePriorityTest.php
+++ b/tests/Unit/Runner/Orchestrator/ResourceSchedulerQueuePriorityTest.php
@@ -30,17 +30,15 @@ final readonly class ResourceSchedulerQueuePriorityTest
         $staleWorkerDecision = $scheduler->dispatch(false);
         $isolatedLease = $this->assigned($scheduler, freshWorker: true);
 
-        Expect::that([
-            'first' => $pooledLease->unit->plan->classes(),
-            'staleWorker' => $staleWorkerDecision->kind,
-            'second' => $isolatedLease->unit->plan->classes(),
-        ])
-            ->because('pooled work MUST run first and isolated work MUST wait for a fresh worker')
-            ->toBe([
-                'first' => ['Acme\\PooledTest'],
-                'staleWorker' => DispatchKind::Drain,
-                'second' => ['Acme\\IsolatedTest'],
-            ]);
+        Expect::that($pooledLease->unit->plan->classes())
+            ->because('pooled work MUST run before isolated work')
+            ->toBe(['Acme\\PooledTest']);
+        Expect::that($staleWorkerDecision->kind)
+            ->because('isolated work MUST wait for a fresh worker')
+            ->toBe(DispatchKind::Drain);
+        Expect::that($isolatedLease->unit->plan->classes())
+            ->because('a fresh worker MUST receive the isolated work')
+            ->toBe(['Acme\\IsolatedTest']);
     }
 
     /**


### PR DESCRIPTION
Replace manufactured scheduler-state maps with direct expectations. Decision kind, lease state, queue order, and worker freshness now have focused diagnostics.