### PR TITLE
feat(phpstan): validate toThrow subject types

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -16,6 +16,7 @@ rules:
     - Greenlight\PhpStan\TestConstructorRule
     - Greenlight\PhpStan\TestMethodRule
     - Greenlight\PhpStan\ToThrowMessageRule
+    - Greenlight\PhpStan\ToThrowSubjectRule
 
 services:
     greenlight.matcherMapProvider:

--- a/src/PhpStan/ToThrowSubjectRule.php
+++ b/src/PhpStan/ToThrowSubjectRule.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\PhpStan;
+
+use Greenlight\Expect\ConsistentlyExpectation;
+use Greenlight\Expect\EventuallyExpectation;
+use Greenlight\Expect\Expectation;
+use Greenlight\Expect\TemporalExpectation;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\VerbosityLevel;
+
+/**
+ * Checks that `toThrow()` has a callable subject.
+ *
+ * @internal
+ *
+ * @implements Rule<MethodCall>
+ */
+final class ToThrowSubjectRule implements Rule
+{
+    #[\Override]
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    #[\Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Identifier || $node->name->toString() !== 'toThrow') {
+            return [];
+        }
+
+        $subject = $this->subjectType($scope->getType($node->var));
+
+        if (!$subject instanceof Type || $subject instanceof ErrorType || $subject instanceof MixedType) {
+            return [];
+        }
+
+        if ($subject->isCallable()->yes()) {
+            return [];
+        }
+
+        return [$this->error($subject, $node->getStartLine())];
+    }
+
+    private function subjectType(Type $receiver): ?Type
+    {
+        foreach ([
+            Expectation::class,
+            EventuallyExpectation::class,
+            ConsistentlyExpectation::class,
+            TemporalExpectation::class,
+        ] as $class) {
+            if (new ObjectType($class)->isSuperTypeOf($receiver)->yes()) {
+                return $receiver->getTemplateType($class, 'T');
+            }
+        }
+
+        return null;
+    }
+
+    private function error(Type $subject, int $line): IdentifierRuleError
+    {
+        return RuleErrorBuilder::message(\sprintf(
+            'toThrow() requires a callable subject. The subject type is %s.',
+            $subject->describe(VerbosityLevel::typeOnly()),
+        ))
+            ->identifier('greenlight.toThrow.subjectType')
+            ->line($line)
+            ->build();
+    }
+}

--- a/tests/Acceptance/PhpStanToThrowRuleTest.php
+++ b/tests/Acceptance/PhpStanToThrowRuleTest.php
@@ -16,6 +16,60 @@ final readonly class PhpStanToThrowRuleTest
     public function __construct(private TempDirectory $tempDirectory) {}
 
     #[Test]
+    public function subjectMustBeCallable(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Expect\Expect;
+
+            function greenlightGoodToThrowSubjectProbe(mixed $subject): void
+            {
+                Expect::that(static fn() => throw new DomainException('boom'))
+                    ->toThrow(DomainException::class);
+                Expect::that($subject)->toThrow(DomainException::class);
+                Expect::eventually(static fn(): Closure => static fn() => throw new DomainException('boom'))
+                    ->within(1.0)
+                    ->toThrow(DomainException::class);
+                Expect::consistently(static fn(): Closure => static fn() => throw new DomainException('boom'))
+                    ->for(0.1)
+                    ->toThrow(DomainException::class);
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Expect\Expect;
+
+            function greenlightBadToThrowSubjectProbe(): void
+            {
+                Expect::that(1)->toThrow(DomainException::class);
+                Expect::that(static fn() => null)
+                    ->and('not callable')
+                    ->toThrow(DomainException::class);
+                Expect::eventually(static fn(): int => 1)
+                    ->within(1.0)
+                    ->toThrow(DomainException::class);
+                Expect::consistently(static fn(): string => 'not callable')
+                    ->for(0.1)
+                    ->toThrow(DomainException::class);
+            }
+            PHP,
+        );
+
+        Expect::that($probe->exitCode)->because('toThrow requires a callable subject')->toBe(1)
+            ->and($probe->goodPassed)->toBeTrue()
+            ->and(\count($probe->errors))->toBe(4)
+            ->and($probe->messages())->toContain('toThrow() requires a callable subject. The subject type is');
+    }
+
+    #[Test]
     public function patternAndExactMessageConstraintsAreMutuallyExclusive(): void
     {
         $probe = PhpStanProbe::analyze(

--- a/tests/Unit/Expect/ToThrowTest.php
+++ b/tests/Unit/Expect/ToThrowTest.php
@@ -113,7 +113,7 @@ final class ToThrowTest
     public function toThrowGuardsTheSubjectTypeEvenWhenNegated(): void
     {
         $detail = FailureProbe::detailOf(
-            static fn() => Expect::that(42)->not()->toThrow(\DomainException::class),
+            static fn() => Expect::that(42)->not()->toThrow(\DomainException::class), // @phpstan-ignore greenlight.toThrow.subjectType (deliberately invalid: tests runtime validation)
         );
 
         Expect::that($detail->message)->because('toThrow() guards the subject type even when negated')


### PR DESCRIPTION
## Summary

- report known non-callable subjects passed to \`toThrow()\`
- preserve runtime validation for explicit \`mixed\` subjects
- cover immediate, fluent, eventual, and consistent expectation chains