### PR TITLE
test(protocol): remove duplicate empty map coverage

### DIFF
--- a/tests/Unit/Runner/Protocol/JsonFrameCodecTest.php
+++ b/tests/Unit/Runner/Protocol/JsonFrameCodecTest.php
@@ -122,14 +122,6 @@ final class JsonFrameCodecTest
     }
 
     #[Test]
-    public function emptyJsonObjectRemainsAValidMap(): void
-    {
-        Expect::that(new JsonFrameCodec()->decode('{}'))
-            ->because('an empty JSON object is still a protocol map')
-            ->toBe([]);
-    }
-
-    #[Test]
     public function whitespaceWrappedEmptyJsonObjectRemainsAValidMap(): void
     {
         Expect::that(new JsonFrameCodec()->decode("\n \t{}\r\n"))


### PR DESCRIPTION
Removes the plain empty-object decode test. The retained whitespace-wrapped empty-object test exercises the same object-versus-list behavior and adds the stricter JSON-whitespace condition, so it detects every relevant failure from the removed test plus incorrect trimming.