### PR TITLE
test: assert remaining subjects directly

### DIFF
--- a/tests/Unit/Artifact/ArtifactSessionTest.php
+++ b/tests/Unit/Artifact/ArtifactSessionTest.php
@@ -20,12 +20,18 @@ final readonly class ArtifactSessionTest
         $session = new ArtifactSession($stagingDirectory, $publicDirectory);
         $decoded = ArtifactSession::fromWire($session->toWire());
 
-        Expect::that([$session->stagingDirectory, $session->publicDirectory])
-            ->because('an artifact session MUST retain each non-empty storage directory')
-            ->toBe([$stagingDirectory, $publicDirectory])
-            ->and([$decoded->stagingDirectory, $decoded->publicDirectory])
-            ->because('artifact storage directories MUST survive the wire')
-            ->toBe([$stagingDirectory, $publicDirectory]);
+        Expect::that($session->stagingDirectory)
+            ->because('an artifact session MUST retain its staging directory')
+            ->toBe($stagingDirectory);
+        Expect::that($session->publicDirectory)
+            ->because('an artifact session MUST retain its public directory')
+            ->toBe($publicDirectory);
+        Expect::that($decoded->stagingDirectory)
+            ->because('the artifact staging directory MUST survive the wire')
+            ->toBe($stagingDirectory);
+        Expect::that($decoded->publicDirectory)
+            ->because('the artifact public directory MUST survive the wire')
+            ->toBe($publicDirectory);
     }
 
     #[Test]

--- a/tests/Unit/Artifact/AttachmentMediaTypeValidationTest.php
+++ b/tests/Unit/Artifact/AttachmentMediaTypeValidationTest.php
@@ -46,10 +46,13 @@ final readonly class AttachmentMediaTypeValidationTest
                     ),
                 )
                 ->and($attachments->collected())
-                ->toBe([])
-                ->and([$budget->attachments, $budget->bytes])
-                ->because('an invalid media type MUST NOT consume the shared test budget')
-                ->toBe([0, 0]);
+                ->toBe([]);
+            Expect::that($budget->attachments)
+                ->because('an invalid media type MUST NOT consume the shared attachment count')
+                ->toBe(0);
+            Expect::that($budget->bytes)
+                ->because('an invalid media type MUST NOT consume the shared byte count')
+                ->toBe(0);
         } finally {
             $store->cleanup();
         }

--- a/tests/Unit/Artifact/AttachmentNameValidationTest.php
+++ b/tests/Unit/Artifact/AttachmentNameValidationTest.php
@@ -40,9 +40,13 @@ final readonly class AttachmentNameValidationTest
                 $attachments->collected(),
             ))
                 ->because('an attachment name MAY contain 120 bytes')
-                ->toBe([$name])
-                ->and([$budget->attachments, $budget->bytes])
-                ->toBe([1, 4]);
+                ->toBe([$name]);
+            Expect::that($budget->attachments)
+                ->because('a valid attachment MUST consume one shared attachment slot')
+                ->toBe(1);
+            Expect::that($budget->bytes)
+                ->because('a valid attachment MUST consume its bytes from the shared budget')
+                ->toBe(4);
         } finally {
             $store->cleanup();
         }
@@ -72,9 +76,13 @@ final readonly class AttachmentNameValidationTest
                     ),
                 )
                 ->and($attachments->collected())
-                ->toBe([])
-                ->and([$budget->attachments, $budget->bytes])
-                ->toBe([0, 0])
+                ->toBe([]);
+            Expect::that($budget->attachments)
+                ->because('an unsafe attachment name MUST NOT consume an attachment slot')
+                ->toBe(0);
+            Expect::that($budget->bytes)
+                ->because('an unsafe attachment name MUST NOT consume the byte budget')
+                ->toBe(0)
                 ->and(\file_exists($store->session()->stagingDirectory))
                 ->toBeFalse();
         } finally {

--- a/tests/Unit/Cli/ConfigurationResolverSelectionTest.php
+++ b/tests/Unit/Cli/ConfigurationResolverSelectionTest.php
@@ -61,13 +61,15 @@ final readonly class ConfigurationResolverSelectionTest
     ): void {
         $policy = $this->resolve($overrides)->policy;
 
-        Expect::that([
-            $policy->failOnDeprecation,
-            $policy->failOnNotice,
-            $policy->failOnRisky,
-        ])
-            ->because('failure policy CLI flags MUST map to their matching policy fields')
-            ->toBe($expected);
+        Expect::that($policy->failOnDeprecation)
+            ->because('the deprecation policy flag MUST map to failOnDeprecation')
+            ->toBe($expected[0]);
+        Expect::that($policy->failOnNotice)
+            ->because('the notice policy flag MUST map to failOnNotice')
+            ->toBe($expected[1]);
+        Expect::that($policy->failOnRisky)
+            ->because('the risky-test policy flag MUST map to failOnRisky')
+            ->toBe($expected[2]);
     }
 
     /**

--- a/tests/Unit/Cli/StatChangeDetectorContentTest.php
+++ b/tests/Unit/Cli/StatChangeDetectorContentTest.php
@@ -43,10 +43,13 @@ final readonly class StatChangeDetectorContentTest
 
         \clearstatcache(true, $source);
 
-        Expect::that([\filemtime($source), \filesize($source)])
-            ->because('the rewrite MUST preserve the metadata in the original fingerprint')
-            ->toBe([$mtime, \strlen($original)])
-            ->and($detector->poll())
+        Expect::that(\filemtime($source))
+            ->because('the rewrite MUST preserve the modification time in the original fingerprint')
+            ->toBe($mtime);
+        Expect::that(\filesize($source))
+            ->because('the rewrite MUST preserve the file size in the original fingerprint')
+            ->toBe(\strlen($original));
+        Expect::that($detector->poll())
             ->because('the content fingerprint MUST report an equal-size rewrite')
             ->toBe([$source]);
     }

--- a/tests/Unit/Config/ArtifactBuilderMinimumCountsTest.php
+++ b/tests/Unit/Config/ArtifactBuilderMinimumCountsTest.php
@@ -18,11 +18,11 @@ final class ArtifactBuilderMinimumCountsTest
             ->maxRunAttachments(1)
             ->toConfiguration();
 
-        Expect::that([
-            $configuration->maxAttachmentsPerTest,
-            $configuration->maxRunAttachments,
-        ])
-            ->because('artifact limits MUST accept their documented minimum')
-            ->toBe([1, 1]);
+        Expect::that($configuration->maxAttachmentsPerTest)
+            ->because('the per-test artifact limit MUST accept its documented minimum')
+            ->toBe(1);
+        Expect::that($configuration->maxRunAttachments)
+            ->because('the per-run artifact limit MUST accept its documented minimum')
+            ->toBe(1);
     }
 }

--- a/tests/Unit/Config/ConfigurationCopyTest.php
+++ b/tests/Unit/Config/ConfigurationCopyTest.php
@@ -21,9 +21,12 @@ final class ConfigurationCopyTest
     {
         $configuration = $mutate(GreenlightConfig::create()->build());
 
-        Expect::that([$configuration->onlyTests, $configuration->excludePaths])
-            ->because('selection mutations MUST preserve selection state from earlier mutations')
-            ->toBe([['App\ExampleTest::runs'], ['/project/generated']]);
+        Expect::that($configuration->onlyTests)
+            ->because('a selection mutation MUST preserve earlier test ID selections')
+            ->toBe(['App\ExampleTest::runs']);
+        Expect::that($configuration->excludePaths)
+            ->because('a selection mutation MUST preserve earlier path exclusions')
+            ->toBe(['/project/generated']);
     }
 
     /**

--- a/tests/Unit/Config/CoverageExportTest.php
+++ b/tests/Unit/Config/CoverageExportTest.php
@@ -39,9 +39,12 @@ final class CoverageExportTest
     {
         $export = new CoverageExport($format, $target);
 
-        Expect::that([$export->format, $export->target])
-            ->because('zero-string coverage export values are not empty')
-            ->toBe([$format, $target]);
+        Expect::that($export->format)
+            ->because('a zero-string coverage export format is not empty')
+            ->toBe($format);
+        Expect::that($export->target)
+            ->because('a zero-string coverage export target is not empty')
+            ->toBe($target);
     }
 
     /**

--- a/tests/Unit/Config/GreenlightConfigTest.php
+++ b/tests/Unit/Config/GreenlightConfigTest.php
@@ -119,13 +119,15 @@ final class GreenlightConfigTest
             ->suite('0', static fn(SuiteBuilder $suite) => $suite->in('tests')->tag('fast'))
             ->build();
 
-        Expect::that([
-            $configuration->suites[0]->name,
-            $configuration->suites[0]->paths,
-            $configuration->suites[0]->tags,
-        ])
+        Expect::that($configuration->suites[0]->name)
             ->because('a zero-string suite name is not empty')
-            ->toBe(['0', ['tests'], ['fast']]);
+            ->toBe('0');
+        Expect::that($configuration->suites[0]->paths)
+            ->because('the suite MUST retain its configured paths')
+            ->toBe(['tests']);
+        Expect::that($configuration->suites[0]->tags)
+            ->because('the suite MUST retain its configured tags')
+            ->toBe(['fast']);
     }
 
     #[Test]

--- a/tests/Unit/Config/IncrementalConfiguratorTest.php
+++ b/tests/Unit/Config/IncrementalConfiguratorTest.php
@@ -61,13 +61,17 @@ final class IncrementalConfiguratorTest
             ->build()
             ->artifacts;
 
-        Expect::that([
-            $artifacts->directory,
-            $artifacts->maxAttachmentsPerTest,
-            $artifacts->maxAttachmentBytes,
-            $artifacts->maxRunAttachments,
-        ])
-            ->because('repeated artifact blocks MUST retain earlier settings')
-            ->toBe(['build/evidence', 12, 2 * 1024 * 1024, 200]);
+        Expect::that($artifacts->directory)
+            ->because('repeated artifact blocks MUST retain the earlier directory')
+            ->toBe('build/evidence');
+        Expect::that($artifacts->maxAttachmentsPerTest)
+            ->because('repeated artifact blocks MUST retain the earlier per-test limit')
+            ->toBe(12);
+        Expect::that($artifacts->maxAttachmentBytes)
+            ->because('repeated artifact blocks MUST apply the attachment size limit')
+            ->toBe(2 * 1024 * 1024);
+        Expect::that($artifacts->maxRunAttachments)
+            ->because('repeated artifact blocks MUST apply the per-run limit')
+            ->toBe(200);
     }
 }

--- a/tests/Unit/Config/SuiteBuilderTest.php
+++ b/tests/Unit/Config/SuiteBuilderTest.php
@@ -68,9 +68,12 @@ final class SuiteBuilderTest
             ->tag(...$tags)
             ->toConfiguration();
 
-        Expect::that([$suite->paths, $suite->tags])
-            ->because('zero-string suite builder values are not empty')
-            ->toBe([$paths, $tags]);
+        Expect::that($suite->paths)
+            ->because('a zero-string suite path is not empty')
+            ->toBe($paths);
+        Expect::that($suite->tags)
+            ->because('a zero-string suite tag is not empty')
+            ->toBe($tags);
     }
 
     /**

--- a/tests/Unit/Core/AttachmentWireTest.php
+++ b/tests/Unit/Core/AttachmentWireTest.php
@@ -99,9 +99,12 @@ final class AttachmentWireTest
             'retention' => AttachmentRetention::Always->value,
         ]);
 
-        Expect::that([$attachment->sizeBytes, $attachment->attempt])
-            ->because('attachment wire decoding MUST preserve its numeric bounds')
-            ->toBe([0, 1]);
+        Expect::that($attachment->sizeBytes)
+            ->because('attachment wire decoding MUST normalize a negative size to zero')
+            ->toBe(0);
+        Expect::that($attachment->attempt)
+            ->because('attachment wire decoding MUST normalize a nonpositive attempt to one')
+            ->toBe(1);
     }
 
     /**

--- a/tests/Unit/Core/ExpectationCounterTest.php
+++ b/tests/Unit/Core/ExpectationCounterTest.php
@@ -36,9 +36,18 @@ final class ExpectationCounterTest
         ExpectationCounter::increment();
         $afterResume = ExpectationCounter::count();
 
-        Expect::that([$value, $observed, $afterSuppression, $afterResume])
-            ->because('nested suppression MUST preserve the value and resume counting afterward')
-            ->toBe(['result', [1, 1], 1, 2]);
+        Expect::that($value)
+            ->because('nested suppression MUST preserve the operation value')
+            ->toBe('result');
+        Expect::that($observed)
+            ->because('nested suppression MUST keep the expectation count unchanged')
+            ->toBe([1, 1]);
+        Expect::that($afterSuppression)
+            ->because('nested suppression MUST restore the earlier expectation count')
+            ->toBe(1);
+        Expect::that($afterResume)
+            ->because('expectation counting MUST resume after nested suppression')
+            ->toBe(2);
     }
 
     #[Test]
@@ -60,8 +69,11 @@ final class ExpectationCounterTest
         ExpectationCounter::increment();
         $afterResume = ExpectationCounter::count();
 
-        Expect::that([$afterThrow, $afterResume])
-            ->because('suppression MUST be restored after an operation error')
-            ->toBe([1, 2]);
+        Expect::that($afterThrow)
+            ->because('suppression MUST restore the earlier count after an operation error')
+            ->toBe(1);
+        Expect::that($afterResume)
+            ->because('expectation counting MUST resume after an operation error')
+            ->toBe(2);
     }
 }

--- a/tests/Unit/Core/StagedAttachmentValidationTest.php
+++ b/tests/Unit/Core/StagedAttachmentValidationTest.php
@@ -68,9 +68,15 @@ final class StagedAttachmentValidationTest
             'attempt' => $attempt,
         ]);
 
-        Expect::that([$staged->sizeBytes, $staged->attempt, $staged->storageKey])
-            ->because('staged attachment wire decoding preserves its numeric bounds and coordinate')
-            ->toBe([0, 1, 'test/attempt-1/01-artifact.txt']);
+        Expect::that($staged->sizeBytes)
+            ->because('staged attachment wire decoding MUST normalize a negative size to zero')
+            ->toBe(0);
+        Expect::that($staged->attempt)
+            ->because('staged attachment wire decoding MUST normalize a nonpositive attempt to one')
+            ->toBe(1);
+        Expect::that($staged->storageKey)
+            ->because('staged attachment wire decoding MUST preserve the storage key')
+            ->toBe('test/attempt-1/01-artifact.txt');
     }
 
     /**

--- a/tests/Unit/Core/TestResultFailureTransitionTest.php
+++ b/tests/Unit/Core/TestResultFailureTransitionTest.php
@@ -40,34 +40,34 @@ final readonly class TestResultFailureTransitionTest
 
         Expect::that($original->toWire())
             ->because('a failure transition MUST NOT change the original result')
-            ->toBe($originalWire)
-            ->and([
-                'outcome' => $failed->outcome,
-                'failures' => \array_map(
-                    static fn(FailureDetail $failure): array => $failure->toWire(),
-                    $failed->failures,
-                ),
-                'transformations' => \array_map(
-                    static fn(OutcomeTransformation $transformation): array => $transformation->toWire(),
-                    $failed->transformations,
-                ),
-                'attempts' => $failed->attempts,
-                'expectations' => $failed->expectations,
-            ])
-            ->because('a failure transition MUST append evidence and provenance')
+            ->toBe($originalWire);
+        Expect::that($failed->outcome)
+            ->because('a failure transition MUST use the failed outcome')
+            ->toBe(Outcome::Failed);
+        Expect::that(\array_map(
+            static fn(FailureDetail $failure): array => $failure->toWire(),
+            $failed->failures,
+        ))
+            ->because('a failure transition MUST append failure evidence')
+            ->toBe([$earlierFailure->toWire(), $policyFailure->toWire()]);
+        Expect::that(\array_map(
+            static fn(OutcomeTransformation $transformation): array => $transformation->toWire(),
+            $failed->transformations,
+        ))
+            ->because('a failure transition MUST append provenance')
             ->toBe([
-                'outcome' => Outcome::Failed,
-                'failures' => [$earlierFailure->toWire(), $policyFailure->toWire()],
-                'transformations' => [
-                    $earlierTransformation->toWire(),
-                    new OutcomeTransformation(
-                        'result policy',
-                        Outcome::Passed,
-                        Outcome::Failed,
-                    )->toWire(),
-                ],
-                'attempts' => 2,
-                'expectations' => 3,
+                $earlierTransformation->toWire(),
+                new OutcomeTransformation(
+                    'result policy',
+                    Outcome::Passed,
+                    Outcome::Failed,
+                )->toWire(),
             ]);
+        Expect::that($failed->attempts)
+            ->because('a failure transition MUST preserve the attempt count')
+            ->toBe(2);
+        Expect::that($failed->expectations)
+            ->because('a failure transition MUST preserve the expectation count')
+            ->toBe(3);
     }
 }

--- a/tests/Unit/Core/TestResultTest.php
+++ b/tests/Unit/Core/TestResultTest.php
@@ -186,10 +186,13 @@ final class TestResultTest
             ->toBe($error)
             ->and($errored->failures)
             ->because('a later lifecycle error MUST NOT discard earlier failure evidence')
-            ->toBe([$failure])
-            ->and([$errored->attempts, $errored->expectations])
-            ->because('a later lifecycle error MUST preserve completed attempt state')
-            ->toBe([2, 3]);
+            ->toBe([$failure]);
+        Expect::that($errored->attempts)
+            ->because('a later lifecycle error MUST preserve the attempt count')
+            ->toBe(2);
+        Expect::that($errored->expectations)
+            ->because('a later lifecycle error MUST preserve the expectation count')
+            ->toBe(3);
     }
 
     #[Test]

--- a/tests/Unit/Coverage/FileDeltaTest.php
+++ b/tests/Unit/Coverage/FileDeltaTest.php
@@ -16,9 +16,15 @@ final readonly class FileDeltaTest
     {
         $delta = new FileDelta('0', 75.0, 50.0, [2, 5]);
 
-        Expect::that([$delta->file, $delta->newlyUncoveredLines, $delta->delta()])
+        Expect::that($delta->file)
             ->because('a zero-string coverage delta file path is not empty')
-            ->toBe(['0', [2, 5], -25.0]);
+            ->toBe('0');
+        Expect::that($delta->newlyUncoveredLines)
+            ->because('a coverage delta MUST retain its newly uncovered lines')
+            ->toBe([2, 5]);
+        Expect::that($delta->delta())
+            ->because('a coverage delta MUST calculate the percentage change')
+            ->toBe(-25.0);
     }
 
     /**

--- a/tests/Unit/Discovery/DiscoveryCacheContentFingerprintTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheContentFingerprintTest.php
@@ -59,10 +59,13 @@ final readonly class DiscoveryCacheContentFingerprintTest
 
             \clearstatcache(true, $source);
 
-            Expect::that([\filemtime($source), \filesize($source)])
-                ->because('the rewrite MUST preserve the cached source metadata')
-                ->toBe([$mtime, \strlen($original)])
-                ->and(DiscoveryCache::forDirectories([$directory])->lookup($source))
+            Expect::that(\filemtime($source))
+                ->because('the rewrite MUST preserve the cached source modification time')
+                ->toBe($mtime);
+            Expect::that(\filesize($source))
+                ->because('the rewrite MUST preserve the cached source file size')
+                ->toBe(\strlen($original));
+            Expect::that(DiscoveryCache::forDirectories([$directory])->lookup($source))
                 ->because('the content fingerprint MUST invalidate an equal-size rewrite')
                 ->toBeNull();
         } finally {
@@ -135,10 +138,13 @@ final readonly class DiscoveryCacheContentFingerprintTest
 
             \clearstatcache(true, $provider);
 
-            Expect::that([\filemtime($provider), \filesize($provider)])
-                ->because('the rewrite MUST preserve the cached provider metadata')
-                ->toBe([$mtime, \strlen($providerSource)])
-                ->and(DiscoveryCache::forDirectories([$directory])->lookup($source))
+            Expect::that(\filemtime($provider))
+                ->because('the rewrite MUST preserve the cached provider modification time')
+                ->toBe($mtime);
+            Expect::that(\filesize($provider))
+                ->because('the rewrite MUST preserve the cached provider file size')
+                ->toBe(\strlen($providerSource));
+            Expect::that(DiscoveryCache::forDirectories([$directory])->lookup($source))
                 ->because('the content fingerprint MUST invalidate an equal-size provider rewrite')
                 ->toBeNull();
         } finally {

--- a/tests/Unit/Doubles/ProxyOptionalReferenceTest.php
+++ b/tests/Unit/Doubles/ProxyOptionalReferenceTest.php
@@ -37,9 +37,15 @@ final readonly class ProxyOptionalReferenceTest
             $omitted = $double->supplied();
             $provided = $double->supplied($value);
 
-            Expect::that([$omitted, $provided, $value])
-                ->because('a proxy callback MUST receive only arguments that the caller supplied')
-                ->toBe([0, 1, 'changed']);
+            Expect::that($omitted)
+                ->because('a proxy callback MUST NOT receive an omitted optional argument')
+                ->toBe(0);
+            Expect::that($provided)
+                ->because('a proxy callback MUST receive a supplied optional argument')
+                ->toBe(1);
+            Expect::that($value)
+                ->because('a proxy callback MUST preserve a supplied optional reference')
+                ->toBe('changed');
         } finally {
             $doubles->dispose();
         }

--- a/tests/Unit/Doubles/ProxyVariadicReferenceTest.php
+++ b/tests/Unit/Doubles/ProxyVariadicReferenceTest.php
@@ -33,9 +33,12 @@ final readonly class ProxyVariadicReferenceTest
         try {
             $double->mutate($first, $second);
 
-            Expect::that([$first, $second])
-                ->because('a proxy callback MUST preserve every variadic reference')
-                ->toBe(['first changed', 'second changed']);
+            Expect::that($first)
+                ->because('a proxy callback MUST preserve the first variadic reference')
+                ->toBe('first changed');
+            Expect::that($second)
+                ->because('a proxy callback MUST preserve the second variadic reference')
+                ->toBe('second changed');
         } finally {
             $doubles->dispose();
         }

--- a/tests/Unit/Fixture/EnvironmentSandboxValueValidationTest.php
+++ b/tests/Unit/Fixture/EnvironmentSandboxValueValidationTest.php
@@ -23,13 +23,15 @@ final readonly class EnvironmentSandboxValueValidationTest
             ->toThrow(
                 \InvalidArgumentException::class,
                 message: 'Environment variable values cannot contain a null byte.',
-            )
-            ->and([
-                \getenv($name),
-                \array_key_exists($name, $_ENV),
-                \array_key_exists($name, $_SERVER),
-            ])
-            ->because('a rejected value MUST NOT change any environment channel')
-            ->toBe([false, false, false]);
+            );
+        Expect::that(\getenv($name))
+            ->because('a rejected value MUST NOT change the process environment')
+            ->toBeFalse();
+        Expect::that(\array_key_exists($name, $_ENV))
+            ->because('a rejected value MUST NOT change the ENV superglobal')
+            ->toBeFalse();
+        Expect::that(\array_key_exists($name, $_SERVER))
+            ->because('a rejected value MUST NOT change the SERVER superglobal')
+            ->toBeFalse();
     }
 }

--- a/tests/Unit/Harness/FallbackResolverCountTest.php
+++ b/tests/Unit/Harness/FallbackResolverCountTest.php
@@ -52,8 +52,11 @@ final class FallbackResolverCountTest
                     . 'Constructor injection resolves exact types only, and none of the 2 fallback resolver(s) supplied it.',
             );
 
-        Expect::that([$first->calls, $second->calls])
-            ->because('each reported fallback resolver MUST have received the request')
-            ->toBe([1, 1]);
+        Expect::that($first->calls)
+            ->because('the first reported fallback resolver MUST receive the request')
+            ->toBe(1);
+        Expect::that($second->calls)
+            ->because('the second reported fallback resolver MUST receive the request')
+            ->toBe(1);
     }
 }

--- a/tests/Unit/Laravel/LaravelProcessEnvironmentValidationTest.php
+++ b/tests/Unit/Laravel/LaravelProcessEnvironmentValidationTest.php
@@ -27,13 +27,15 @@ final readonly class LaravelProcessEnvironmentValidationTest
             ->toThrow(
                 \InvalidArgumentException::class,
                 message: 'Laravel environment MUST NOT contain a null byte.',
-            )
-            ->and([
-                \getenv('APP_ENV'),
-                $_ENV['APP_ENV'] ?? null,
-                $_SERVER['APP_ENV'] ?? null,
-            ])
-            ->because('a rejected Laravel environment MUST NOT change process state')
-            ->toBe(['before-laravel', 'before-laravel', 'before-laravel']);
+            );
+        Expect::that(\getenv('APP_ENV'))
+            ->because('a rejected Laravel environment MUST NOT change the process environment')
+            ->toBe('before-laravel');
+        Expect::that($_ENV['APP_ENV'] ?? null)
+            ->because('a rejected Laravel environment MUST NOT change the ENV superglobal')
+            ->toBe('before-laravel');
+        Expect::that($_SERVER['APP_ENV'] ?? null)
+            ->because('a rejected Laravel environment MUST NOT change the SERVER superglobal')
+            ->toBe('before-laravel');
     }
 }

--- a/tests/Unit/Runner/Orchestrator/ResourceLeaseIdentityTest.php
+++ b/tests/Unit/Runner/Orchestrator/ResourceLeaseIdentityTest.php
@@ -28,9 +28,12 @@ final readonly class ResourceLeaseIdentityTest
         $first = $this->assigned($scheduler);
         $second = $this->assigned($scheduler);
 
-        Expect::that([$first->id, $second->id])
-            ->because('concurrent resource leases MUST have distinct identities')
-            ->toBe([1, 2]);
+        Expect::that($first->id)
+            ->because('the first resource lease MUST use the first lease ID')
+            ->toBe(1);
+        Expect::that($second->id)
+            ->because('the second resource lease MUST use a distinct lease ID')
+            ->toBe(2);
 
         Expect::that(static function () use ($scheduler, $first, $second): void {
             $scheduler->release($first);

--- a/tests/Unit/Runner/Orchestrator/ResourceSchedulerRequeueOrderTest.php
+++ b/tests/Unit/Runner/Orchestrator/ResourceSchedulerRequeueOrderTest.php
@@ -35,15 +35,12 @@ final readonly class ResourceSchedulerRequeueOrderTest
         $scheduler->release($first);
         $second = $this->assigned($scheduler, $freshWorker);
 
-        Expect::that([
-            $first->unit->plan->classes(),
-            $second->unit->plan->classes(),
-        ])
+        Expect::that($first->unit->plan->classes())
+            ->because('pending work MUST remain first in its queue')
+            ->toBe(['Acme\\PendingTest']);
+        Expect::that($second->unit->plan->classes())
             ->because('requeued work MUST append behind pending work in its queue')
-            ->toBe([
-                ['Acme\\PendingTest'],
-                ['Acme\\RetriedTest'],
-            ]);
+            ->toBe(['Acme\\RetriedTest']);
     }
 
     /**

--- a/tests/Unit/Runner/Orchestrator/WorkerHandleTerminationTest.php
+++ b/tests/Unit/Runner/Orchestrator/WorkerHandleTerminationTest.php
@@ -65,9 +65,12 @@ final readonly class WorkerHandleTerminationTest
             $handle->channel = $channel;
             $handle->terminate();
 
-            Expect::that([$channel->isEof(), \is_resource($process)])
-                ->because('worker termination MUST close its protocol channel and process handle')
-                ->toBe([true, false]);
+            Expect::that($channel->isEof())
+                ->because('worker termination MUST close its protocol channel')
+                ->toBeTrue();
+            Expect::that(\is_resource($process))
+                ->because('worker termination MUST close its process handle')
+                ->toBeFalse();
         } finally {
             $resources = $pipes;
 

--- a/tests/Unit/Runner/PlanOrderClassIntegrityTest.php
+++ b/tests/Unit/Runner/PlanOrderClassIntegrityTest.php
@@ -30,17 +30,17 @@ final class PlanOrderClassIntegrityTest
             $ordered->entries,
         );
 
-        Expect::that([$ids, $ordered->seed])
-            ->because('class priority MUST preserve method order and the reproducible plan seed')
+        Expect::that($ids)
+            ->because('class priority MUST preserve method order')
             ->toBe([
-                [
-                    'Acme\\BetaTest::first',
-                    'Acme\\BetaTest::second',
-                    'Acme\\AlphaTest::first',
-                    'Acme\\AlphaTest::second',
-                ],
-                4242,
+                'Acme\\BetaTest::first',
+                'Acme\\BetaTest::second',
+                'Acme\\AlphaTest::first',
+                'Acme\\AlphaTest::second',
             ]);
+        Expect::that($ordered->seed)
+            ->because('class priority MUST preserve the reproducible plan seed')
+            ->toBe(4242);
     }
 
     /**

--- a/tests/Unit/Runner/PlanOrderPrioritySequenceTest.php
+++ b/tests/Unit/Runner/PlanOrderPrioritySequenceTest.php
@@ -33,17 +33,17 @@ final class PlanOrderPrioritySequenceTest
             ],
         );
 
-        Expect::that([$ordered->classes(), $ordered->seed])
+        Expect::that($ordered->classes())
             ->because('priority classes MUST retain the caller sequence before duration ordering')
             ->toBe([
-                [
-                    'Acme\\GammaTest',
-                    'Acme\\AlphaTest',
-                    'Acme\\DeltaTest',
-                    'Acme\\BetaTest',
-                ],
-                4242,
+                'Acme\\GammaTest',
+                'Acme\\AlphaTest',
+                'Acme\\DeltaTest',
+                'Acme\\BetaTest',
             ]);
+        Expect::that($ordered->seed)
+            ->because('priority ordering MUST preserve the plan seed')
+            ->toBe(4242);
     }
 
     /**

--- a/tests/Unit/Runner/PlanOrderStalePriorityTest.php
+++ b/tests/Unit/Runner/PlanOrderStalePriorityTest.php
@@ -32,13 +32,15 @@ final class PlanOrderStalePriorityTest
             $ordered->entries,
         );
 
-        Expect::that([$ids, $ordered->seed, $warning])
-            ->because('stale priority data MUST NOT change the current plan')
-            ->toBe([
-                ['Acme\\AlphaTest::probe', 'Acme\\BetaTest::probe'],
-                4242,
-                null,
-            ]);
+        Expect::that($ids)
+            ->because('stale priority data MUST NOT change the current plan entries')
+            ->toBe(['Acme\\AlphaTest::probe', 'Acme\\BetaTest::probe']);
+        Expect::that($ordered->seed)
+            ->because('stale priority data MUST NOT change the plan seed')
+            ->toBe(4242);
+        Expect::that($warning)
+            ->because('stale priority data MUST NOT cause a warning')
+            ->toBeNull();
     }
 
     /**


### PR DESCRIPTION
Complete the final sweep for tests that construct positional or associative arrays only to group independent expectation subjects.

Give each independent value to `Expect::that()` directly, with a focused reason where useful. Keep array comparisons where the behavior under test produces an array, including matcher contracts, wire payloads, and ordered sequences.