### PR TITLE
test(doubles): remove duplicate mock verification coverage

### DIFF
--- a/tests/Unit/Doubles/MockTest.php
+++ b/tests/Unit/Doubles/MockTest.php
@@ -18,19 +18,6 @@ use Greenlight\Tests\Fixture\Doubles\UntypedMethod;
 final class MockTest
 {
     #[Test]
-    public function metExpectationsPassVerification(): void
-    {
-        $doubles = new Doubles();
-        $calculator = $doubles->mock(Calculator::class, static function (MockPlan $plan): void {
-            $plan->expects('add')->with(1, 2)->once()->andReturns(3);
-        });
-
-        Expect::that($calculator->add(1, 2))->because('met expectations pass verification')->toBe(3);
-
-        $doubles->dispose();
-    }
-
-    #[Test]
     public function valueReturningCallsRequireAConfiguredAnswer(): void
     {
         $doubles = new Doubles();


### PR DESCRIPTION
Removes the ordinary met-expectation test. The retained case-insensitive method-name test performs the same mock plan, argument match, return-value assertion, cardinality verification, and disposal, while also detecting incorrect method-name canonicalization.