### PR TITLE
test(expect): remove duplicate JSON match coverage

### DIFF
--- a/tests/Unit/Expect/JsonMatchersTest.php
+++ b/tests/Unit/Expect/JsonMatchersTest.php
@@ -47,12 +47,6 @@ final class JsonMatchersTest
     }
 
     #[Test]
-    public function toMatchJsonPasses(): void
-    {
-        Expect::that('{"a": 1}')->because('toMatchJson() passes')->toMatchJson('{"a": 1}');
-    }
-
-    #[Test]
     public function toMatchJsonIgnoresObjectKeyOrder(): void
     {
         Expect::that('{"a": 1, "b": [1, 2]}')->because('toMatchJson() ignores object key order')->toMatchJson('{"b": [1, 2], "a": 1}');


### PR DESCRIPTION
Removes the one-key identical JSON success test. The retained object-key-order test exercises the same successful structural match with nested data and additionally proves that object member order is irrelevant.