### PR TITLE
test(discovery): remove duplicate plan identity coverage

### DIFF
--- a/tests/Unit/Discovery/ExecutionPlanTest.php
+++ b/tests/Unit/Discovery/ExecutionPlanTest.php
@@ -59,17 +59,6 @@ final class ExecutionPlanTest
     }
 
     #[Test]
-    public function rejectsEntryWhoseIdAndMetadataDisagree(): void
-    {
-        Expect::that(
-            static fn(): PlanEntry => new PlanEntry(
-                new TestId('App\FooTest', 'a'),
-                new TestMetadata('App\FooTest', 'b'),
-            ),
-        )->because('rejects entry whose ID and metadata disagree')->toThrow(\InvalidArgumentException::class);
-    }
-
-    #[Test]
     public function rejectsDuplicateTestIdsFromConstructionAndTheWire(): void
     {
         $entry = self::entry('App\FooTest', 'a', 'first');


### PR DESCRIPTION
Removes the generic PlanEntry identity-mismatch assertion from ExecutionPlanTest. The retained PlanEntryIdentityTest constructs the same mismatch and asserts the exact diagnostic with both the test ID and metadata identity.