### PR TITLE
test(discovery): preserve method identity coverage

### DIFF
--- a/tests/Unit/Discovery/PlanEntryIdentityTest.php
+++ b/tests/Unit/Discovery/PlanEntryIdentityTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Discovery;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Core\Test\TestMetadata;
@@ -13,16 +14,44 @@ use Greenlight\Expect\Expect;
 final readonly class PlanEntryIdentityTest
 {
     #[Test]
-    public function mismatchedIdentityNamesBothSides(): void
-    {
+    #[DataSet('identityMismatches')]
+    public function mismatchedIdentityNamesBothSides(
+        string $idClass,
+        string $idMethod,
+        string $metadataClass,
+        string $metadataMethod,
+        string $message,
+    ): void {
         Expect::that(static fn(): PlanEntry => new PlanEntry(
-            new TestId('App\PaymentTest', 'chargesCard'),
-            new TestMetadata('App\RefundTest', 'refundsCard'),
+            new TestId($idClass, $idMethod),
+            new TestMetadata($metadataClass, $metadataMethod),
         ))
             ->because('a plan identity mismatch MUST identify the test ID and its metadata')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Plan entry identity App\PaymentTest::chargesCard does not match its metadata App\RefundTest::refundsCard.',
+                message: $message,
             );
+    }
+
+    /**
+     * @return iterable<string, array{string, string, string, string, non-empty-string}>
+     */
+    public static function identityMismatches(): iterable
+    {
+        yield 'class and method' => [
+            'App\PaymentTest',
+            'chargesCard',
+            'App\RefundTest',
+            'refundsCard',
+            'Plan entry identity App\PaymentTest::chargesCard does not match its metadata App\RefundTest::refundsCard.',
+        ];
+
+        yield 'method only' => [
+            'App\FooTest',
+            'a',
+            'App\FooTest',
+            'b',
+            'Plan entry identity App\FooTest::a does not match its metadata App\FooTest::b.',
+        ];
     }
 }


### PR DESCRIPTION
Parameterizes the retained exact-diagnostic PlanEntry identity test across both constructor comparisons. The class-and-method case exercises the class mismatch, and the method-only case preserves the second OR branch that the removed generic assertion previously covered.