### PR TITLE
feat(phpstan): validate native matcher subjects

### DIFF
--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -215,3 +215,26 @@ Errors have identifiers under `greenlight.dataProvider.*` (`provider`,
 ```php
 #[DataSet('doesNotExist')] // @phpstan-ignore greenlight.dataProvider.provider (proves the runtime error path)
 ```
+
+## Native matcher subject reference
+
+Some native matchers accept only specified subject types. The extension reports
+a known incompatible subject before the test runs:
+
+| Required subject | Matchers |
+| --- | --- |
+| `string` or `iterable` | `toContain()` |
+| `Countable` or `Traversable` | `toHaveCount()` |
+| `string`, `array`, `Countable`, or `Traversable` | `toBeEmpty()` |
+| `string`, `array`, or `Countable` | `toHaveLength()` |
+| `array` or `ArrayAccess` | `toHaveKey()` |
+| `array` | `toContainSubset()` |
+| `int` or `float` | Numeric comparison matchers and `toBeWithin()` |
+| `string` | String and JSON matchers |
+
+Subject errors use the `greenlight.nativeMatcher.subjectType` identifier. A
+string subject also requires a string `toContain()` needle. This error uses
+`greenlight.toContain.needleType`.
+
+The extension does not report these errors for a `mixed` subject. Greenlight
+validates unresolved subject types at run time.

--- a/extension.neon
+++ b/extension.neon
@@ -11,6 +11,7 @@ rules:
     - Greenlight\PhpStan\AttributeArgumentRule
     - Greenlight\PhpStan\DataProviderSignatureRule
     - Greenlight\PhpStan\LifecycleMethodRule
+    - Greenlight\PhpStan\NativeMatcherSubjectRule
     - Greenlight\PhpStan\SkipUnlessConditionRule
     - Greenlight\PhpStan\TestAttributePlacementRule
     - Greenlight\PhpStan\TestConstructorRule

--- a/src/PhpStan/NativeMatcherSubjectRule.php
+++ b/src/PhpStan/NativeMatcherSubjectRule.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\PhpStan;
+
+use Greenlight\Expect\ConsistentlyExpectation;
+use Greenlight\Expect\EventuallyExpectation;
+use Greenlight\Expect\Expectation;
+use Greenlight\Expect\TemporalExpectation;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\ErrorType;
+use PHPStan\Type\FloatType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\IterableType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+use PHPStan\Type\VerbosityLevel;
+
+/**
+ * Checks the subject types for native matchers that have type requirements.
+ *
+ * @internal
+ *
+ * @implements Rule<MethodCall>
+ */
+final class NativeMatcherSubjectRule implements Rule
+{
+    /**
+     * @var array<non-empty-string, non-empty-string>
+     */
+    private const array REQUIREMENTS = [
+        'toContain' => 'a string or iterable',
+        'toHaveCount' => 'a countable or traversable',
+        'toBeEmpty' => 'a string, array, Countable, or iterable',
+        'toHaveLength' => 'a string, array, or Countable',
+        'toHaveKey' => 'an array or ArrayAccess',
+        'toContainSubset' => 'an array',
+        'toBeGreaterThan' => 'an int or float',
+        'toBeGreaterThanOrEqual' => 'an int or float',
+        'toBeLessThan' => 'an int or float',
+        'toBeLessThanOrEqual' => 'an int or float',
+        'toBeWithin' => 'an int or float',
+        'toMatch' => 'a string',
+        'toStartWith' => 'a string',
+        'toEndWith' => 'a string',
+        'toBeJson' => 'a string',
+        'toMatchJson' => 'a string',
+    ];
+
+    #[\Override]
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    #[\Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Identifier) {
+            return [];
+        }
+
+        $matcher = $node->name->toString();
+
+        if (!isset(self::REQUIREMENTS[$matcher])) {
+            return [];
+        }
+
+        $subject = $this->subjectType($scope->getType($node->var));
+
+        if (!$subject instanceof Type || $subject instanceof ErrorType || $subject instanceof MixedType) {
+            return [];
+        }
+
+        $accepted = $this->acceptedType($matcher);
+
+        if (!$accepted->accepts($subject, $scope->isDeclareStrictTypes())->no()) {
+            return $this->needleErrors($matcher, $subject, $node, $scope);
+        }
+
+        return [$this->subjectError($matcher, $subject, $node->getStartLine())];
+    }
+
+    private function subjectType(Type $receiver): ?Type
+    {
+        foreach ([
+            Expectation::class,
+            EventuallyExpectation::class,
+            ConsistentlyExpectation::class,
+            TemporalExpectation::class,
+        ] as $class) {
+            if (new ObjectType($class)->isSuperTypeOf($receiver)->yes()) {
+                return $receiver->getTemplateType($class, 'T');
+            }
+        }
+
+        return null;
+    }
+
+    private function acceptedType(string $matcher): Type
+    {
+        $mixed = new MixedType();
+        $array = new ArrayType($mixed, $mixed);
+        $iterable = new IterableType($mixed, $mixed);
+
+        return match ($matcher) {
+            'toContain' => TypeCombinator::union(new StringType(), $iterable),
+            'toHaveCount' => TypeCombinator::union($iterable, new ObjectType(\Countable::class)),
+            'toBeEmpty' => TypeCombinator::union(new StringType(), $iterable, new ObjectType(\Countable::class)),
+            'toHaveLength' => TypeCombinator::union(new StringType(), $array, new ObjectType(\Countable::class)),
+            'toHaveKey' => TypeCombinator::union($array, new ObjectType(\ArrayAccess::class)),
+            'toContainSubset' => $array,
+            'toBeGreaterThan',
+            'toBeGreaterThanOrEqual',
+            'toBeLessThan',
+            'toBeLessThanOrEqual',
+            'toBeWithin' => TypeCombinator::union(new IntegerType(), new FloatType()),
+            'toMatch',
+            'toStartWith',
+            'toEndWith',
+            'toBeJson',
+            'toMatchJson' => new StringType(),
+            default => throw new \LogicException(\sprintf(
+                'Native matcher "%s" has no subject type requirement.',
+                $matcher,
+            )),
+        };
+    }
+
+    /**
+     * @return list<IdentifierRuleError>
+     */
+    private function needleErrors(string $matcher, Type $subject, MethodCall $call, Scope $scope): array
+    {
+        if ($matcher !== 'toContain' || !new StringType()->isSuperTypeOf($subject)->yes()) {
+            return [];
+        }
+
+        $argument = $call->getArgs()[0] ?? null;
+
+        if (!$argument instanceof Node\Arg) {
+            return [];
+        }
+
+        $needle = $scope->getType($argument->value);
+
+        if ($needle instanceof ErrorType || $needle instanceof MixedType || !new StringType()->accepts($needle, true)->no()) {
+            return [];
+        }
+
+        return [RuleErrorBuilder::message(\sprintf(
+            'toContain() requires a string needle for a string subject. The needle type is %s.',
+            $needle->describe(VerbosityLevel::typeOnly()),
+        ))
+            ->identifier('greenlight.toContain.needleType')
+            ->line($call->getStartLine())
+            ->build()];
+    }
+
+    private function subjectError(string $matcher, Type $subject, int $line): IdentifierRuleError
+    {
+        return RuleErrorBuilder::message(\sprintf(
+            '%s() requires %s subject. The subject type is %s.',
+            $matcher,
+            self::REQUIREMENTS[$matcher],
+            $subject->describe(VerbosityLevel::typeOnly()),
+        ))
+            ->identifier('greenlight.nativeMatcher.subjectType')
+            ->line($line)
+            ->build();
+    }
+}

--- a/tests/Acceptance/PhpStanNativeMatcherSubjectRuleTest.php
+++ b/tests/Acceptance/PhpStanNativeMatcherSubjectRuleTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\PhpStanProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class PhpStanNativeMatcherSubjectRuleTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function nativeMatcherSubjectTypesFollowExpectationChains(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Expect\Expect;
+
+            function greenlightGoodNativeMatcherSubjectProbe(mixed $subject): void
+            {
+                Expect::that('greenlight')->toContain('light');
+                Expect::that([1, 2])->toHaveCount(2);
+                Expect::that(new ArrayIterator())->toBeEmpty();
+                Expect::that('greenlight')->toHaveLength(10);
+                Expect::that(['status' => 'green'])->toHaveKey('status');
+                Expect::that(['status' => 'green'])->toContainSubset(['status' => 'green']);
+                Expect::that(2)->toBeGreaterThan(1);
+                Expect::that('greenlight')->toStartWith('green');
+                Expect::that($subject)->toEndWith('light');
+                Expect::eventually(static fn(): string => 'greenlight')
+                    ->within(1.0)
+                    ->toMatch('/green/');
+                Expect::consistently(static fn(): int => 2)
+                    ->for(0.1)
+                    ->toBeWithin(1.0, 2.0);
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Expect\Expect;
+
+            function greenlightBadNativeMatcherSubjectProbe(): void
+            {
+                Expect::that(1)->toContain('1');
+                Expect::that('greenlight')->toContain(1);
+                Expect::that('greenlight')->toHaveCount(10);
+                Expect::that(1)->toBeEmpty();
+                Expect::that(1)->toHaveLength(1);
+                Expect::that('greenlight')->toHaveKey(0);
+                Expect::that('greenlight')->toContainSubset([]);
+                Expect::that('1')->toBeGreaterThan(0);
+                Expect::that('1')->toBeGreaterThanOrEqual(0);
+                Expect::that('1')->toBeLessThan(2);
+                Expect::that('1')->toBeLessThanOrEqual(2);
+                Expect::that('1')->toBeWithin(1.0, 1.0);
+                Expect::eventually(static fn(): int => 1)
+                    ->within(1.0)
+                    ->toMatch('/1/');
+                Expect::that(1)->toStartWith('1');
+                Expect::that(1)->toEndWith('1');
+                Expect::that([])->toBeJson();
+                Expect::consistently(static fn(): array => [])
+                    ->for(0.1)
+                    ->toMatchJson('{}');
+            }
+            PHP,
+        );
+
+        Expect::that($probe->exitCode)->because('native matchers require compatible subject types')->toBe(1)
+            ->and($probe->goodPassed)->toBeTrue()
+            ->and(\count($probe->errors))->toBe(17)
+            ->and($probe->messages())->toContain('toContain() requires a string or iterable subject')
+            ->and($probe->messages())->toContain('toContain() requires a string needle for a string subject')
+            ->and($probe->messages())->toContain('toMatchJson() requires a string subject');
+    }
+}

--- a/tests/Unit/Expect/BecauseTest.php
+++ b/tests/Unit/Expect/BecauseTest.php
@@ -104,7 +104,7 @@ final class BecauseTest
     public function aUsageFailureIgnoresThePendingReason(): void
     {
         $detail = FailureProbe::detailOf(
-            static fn() => Expect::that(42)->because('the reason applies to matcher failures only')->toContain('x'),
+            static fn() => Expect::that(42)->because('the reason applies to matcher failures only')->toContain('x'), // @phpstan-ignore greenlight.nativeMatcher.subjectType (deliberately invalid: tests runtime validation)
         );
 
         Expect::that($detail->message)->because('a usage failure ignores the pending reason')

--- a/tests/Unit/Expect/IterableMatchersTest.php
+++ b/tests/Unit/Expect/IterableMatchersTest.php
@@ -59,7 +59,7 @@ final class IterableMatchersTest
     public function toContainGuardsTheSubjectTypeEvenWhenNegated(): void
     {
         $detail = FailureProbe::detailOf(
-            static fn() => Expect::that(42)->not()->toContain(4),
+            static fn() => Expect::that(42)->not()->toContain(4), // @phpstan-ignore greenlight.nativeMatcher.subjectType (deliberately invalid: tests runtime validation)
         );
 
         Expect::that($detail->message)->because('toContain() guards the subject type even when negated')
@@ -70,7 +70,7 @@ final class IterableMatchersTest
     public function toContainGuardsTheNeedleTypeForStringSubjects(): void
     {
         $detail = FailureProbe::detailOf(
-            static fn() => Expect::that('greenlight')->toContain(4),
+            static fn() => Expect::that('greenlight')->toContain(4), // @phpstan-ignore greenlight.toContain.needleType (deliberately invalid: tests runtime validation)
         );
 
         Expect::that($detail->message)->because('toContain() guards the needle type for string subjects')
@@ -106,7 +106,7 @@ final class IterableMatchersTest
     public function toHaveCountGuardsTheSubjectType(): void
     {
         $detail = FailureProbe::detailOf(
-            static fn() => Expect::that('12')->toHaveCount(2),
+            static fn() => Expect::that('12')->toHaveCount(2), // @phpstan-ignore greenlight.nativeMatcher.subjectType (deliberately invalid: tests runtime validation)
         );
 
         Expect::that($detail->message)->because('toHaveCount() guards the subject type')
@@ -142,7 +142,7 @@ final class IterableMatchersTest
     public function toHaveKeyGuardsTheSubjectType(): void
     {
         $detail = FailureProbe::detailOf(
-            static fn() => Expect::that('abc')->toHaveKey(0),
+            static fn() => Expect::that('abc')->toHaveKey(0), // @phpstan-ignore greenlight.nativeMatcher.subjectType (deliberately invalid: tests runtime validation)
         );
 
         Expect::that($detail->message)->because('toHaveKey() guards the subject type')
@@ -190,7 +190,7 @@ final class IterableMatchersTest
     public function toBeEmptyGuardsTheSubjectType(): void
     {
         $detail = FailureProbe::detailOf(
-            static fn() => Expect::that(0)->toBeEmpty(),
+            static fn() => Expect::that(0)->toBeEmpty(), // @phpstan-ignore greenlight.nativeMatcher.subjectType (deliberately invalid: tests runtime validation)
         );
 
         Expect::that($detail->message)->because('toBeEmpty() guards the subject type')
@@ -339,7 +339,7 @@ final class IterableMatchersTest
     public function toContainSubsetGuardsTheSubjectType(): void
     {
         $detail = FailureProbe::detailOf(
-            static fn() => Expect::that('x')->toContainSubset(['a' => 1]),
+            static fn() => Expect::that('x')->toContainSubset(['a' => 1]), // @phpstan-ignore greenlight.nativeMatcher.subjectType (deliberately invalid: tests runtime validation)
         );
 
         Expect::that($detail->message)->because('toContainSubset() guards the subject type')

--- a/tests/Unit/Expect/JsonMatchersTest.php
+++ b/tests/Unit/Expect/JsonMatchersTest.php
@@ -39,7 +39,7 @@ final class JsonMatchersTest
     public function toBeJsonGuardsTheSubjectType(): void
     {
         $detail = FailureProbe::detailOf(
-            static fn() => Expect::that([])->toBeJson(),
+            static fn() => Expect::that([])->toBeJson(), // @phpstan-ignore greenlight.nativeMatcher.subjectType (deliberately invalid: tests runtime validation)
         );
 
         Expect::that($detail->message)->because('toBeJson() guards the subject type')
@@ -85,7 +85,7 @@ final class JsonMatchersTest
     public function toMatchJsonGuardsTheSubjectType(): void
     {
         $detail = FailureProbe::detailOf(
-            static fn() => Expect::that(1)->toMatchJson('{}'),
+            static fn() => Expect::that(1)->toMatchJson('{}'), // @phpstan-ignore greenlight.nativeMatcher.subjectType (deliberately invalid: tests runtime validation)
         );
 
         Expect::that($detail->message)->because('toMatchJson() guards the subject type')

--- a/tests/Unit/Expect/NumericMatchersTest.php
+++ b/tests/Unit/Expect/NumericMatchersTest.php
@@ -49,7 +49,7 @@ final class NumericMatchersTest
     public function toBeGreaterThanGuardsTheSubjectType(): void
     {
         $detail = FailureProbe::detailOf(
-            static fn() => Expect::that('3')->toBeGreaterThan(2),
+            static fn() => Expect::that('3')->toBeGreaterThan(2), // @phpstan-ignore greenlight.nativeMatcher.subjectType (deliberately invalid: tests runtime validation)
         );
 
         Expect::that($detail->message)->because('toBeGreaterThan() guards the subject type')
@@ -85,7 +85,7 @@ final class NumericMatchersTest
     public function toBeGreaterThanOrEqualGuardsTheSubjectType(): void
     {
         $detail = FailureProbe::detailOf(
-            static fn() => Expect::that('3')->toBeGreaterThanOrEqual(2),
+            static fn() => Expect::that('3')->toBeGreaterThanOrEqual(2), // @phpstan-ignore greenlight.nativeMatcher.subjectType (deliberately invalid: tests runtime validation)
         );
 
         Expect::that($detail->message)->because('toBeGreaterThanOrEqual() guards the subject type')
@@ -119,7 +119,7 @@ final class NumericMatchersTest
     public function toBeLessThanGuardsTheSubjectType(): void
     {
         $detail = FailureProbe::detailOf(
-            static fn() => Expect::that(null)->toBeLessThan(2),
+            static fn() => Expect::that(null)->toBeLessThan(2), // @phpstan-ignore greenlight.nativeMatcher.subjectType (deliberately invalid: tests runtime validation)
         );
 
         Expect::that($detail->message)->because('toBeLessThan() guards the subject type')
@@ -155,7 +155,7 @@ final class NumericMatchersTest
     public function toBeLessThanOrEqualGuardsTheSubjectType(): void
     {
         $detail = FailureProbe::detailOf(
-            static fn() => Expect::that(null)->toBeLessThanOrEqual(2),
+            static fn() => Expect::that(null)->toBeLessThanOrEqual(2), // @phpstan-ignore greenlight.nativeMatcher.subjectType (deliberately invalid: tests runtime validation)
         );
 
         Expect::that($detail->message)->because('toBeLessThanOrEqual() guards the subject type')
@@ -200,7 +200,7 @@ final class NumericMatchersTest
     public function toBeWithinGuardsTheSubjectType(): void
     {
         $detail = FailureProbe::detailOf(
-            static fn() => Expect::that('1.0')->toBeWithin(0.1, 1.0),
+            static fn() => Expect::that('1.0')->toBeWithin(0.1, 1.0), // @phpstan-ignore greenlight.nativeMatcher.subjectType (deliberately invalid: tests runtime validation)
         );
 
         Expect::that($detail->message)->because('toBeWithin() guards the subject type')

--- a/tests/Unit/Expect/StringMatchersTest.php
+++ b/tests/Unit/Expect/StringMatchersTest.php
@@ -36,7 +36,7 @@ final class StringMatchersTest
     public function toMatchGuardsTheSubjectType(): void
     {
         $detail = FailureProbe::detailOf(
-            static fn() => Expect::that(123)->toMatch('/\d+/'),
+            static fn() => Expect::that(123)->toMatch('/\d+/'), // @phpstan-ignore greenlight.nativeMatcher.subjectType (deliberately invalid: tests runtime validation)
         );
 
         Expect::that($detail->message)->because('toMatch() guards the subject type')
@@ -81,7 +81,7 @@ final class StringMatchersTest
     public function toStartWithGuardsTheSubjectType(): void
     {
         $detail = FailureProbe::detailOf(
-            static fn() => Expect::that(['green'])->toStartWith('green'),
+            static fn() => Expect::that(['green'])->toStartWith('green'), // @phpstan-ignore greenlight.nativeMatcher.subjectType (deliberately invalid: tests runtime validation)
         );
 
         Expect::that($detail->message)->because('toStartWith() guards the subject type')
@@ -114,7 +114,7 @@ final class StringMatchersTest
     public function toEndWithGuardsTheSubjectType(): void
     {
         $detail = FailureProbe::detailOf(
-            static fn() => Expect::that(null)->toEndWith('x'),
+            static fn() => Expect::that(null)->toEndWith('x'), // @phpstan-ignore greenlight.nativeMatcher.subjectType (deliberately invalid: tests runtime validation)
         );
 
         Expect::that($detail->message)->because('toEndWith() guards the subject type')
@@ -163,7 +163,7 @@ final class StringMatchersTest
     public function toHaveLengthGuardsTheSubjectType(): void
     {
         $detail = FailureProbe::detailOf(
-            static fn() => Expect::that(42)->toHaveLength(2),
+            static fn() => Expect::that(42)->toHaveLength(2), // @phpstan-ignore greenlight.nativeMatcher.subjectType (deliberately invalid: tests runtime validation)
         );
 
         Expect::that($detail->message)->because('toHaveLength() guards the subject type')


### PR DESCRIPTION
Adds early PHPStan diagnostics for native matcher calls with incompatible subject types.\n\n- Covers string, iterable, countable, array, numeric, and JSON matchers.\n- Validates string needles for string subjects.\n- Documents the supported matcher-to-subject mappings.