### PR TITLE
feat(phpstan): validate expectation arguments

### DIFF
--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -115,6 +115,21 @@ To give an IDE the same signatures, generate the helper file:
 vendor/bin/greenlight ide-helper
 ```
 
+## Constant expectation argument checks
+
+The extension reports constant expectation arguments that Greenlight cannot
+use:
+
+* `toMatch()` and the `matching:` argument of `toThrow()` require a valid
+  regular expression.
+* The expected value for `toMatchJson()` must contain valid JSON.
+* `pollEvery()` requires a finite duration of at least 0.001 seconds.
+* `within()` and `for()` require a finite duration greater than zero.
+
+Errors have identifiers under `greenlight.expectationArgument.*` (`pattern`,
+`json`, `duration`). Greenlight checks values that PHPStan cannot resolve at run
+time.
+
 ## Test method checks
 
 The extension reports a `#[Test]` method that Greenlight cannot run. A test

--- a/extension.neon
+++ b/extension.neon
@@ -10,6 +10,7 @@ parameters:
 rules:
     - Greenlight\PhpStan\AttributeArgumentRule
     - Greenlight\PhpStan\DataProviderSignatureRule
+    - Greenlight\PhpStan\ExpectationArgumentRule
     - Greenlight\PhpStan\LifecycleMethodRule
     - Greenlight\PhpStan\SkipUnlessConditionRule
     - Greenlight\PhpStan\TestAttributePlacementRule

--- a/src/PhpStan/ExpectationArgumentRule.php
+++ b/src/PhpStan/ExpectationArgumentRule.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\PhpStan;
+
+use Greenlight\Core\ErrorTrap;
+use Greenlight\Expect\ConsistentlyExpectation;
+use Greenlight\Expect\EventuallyExpectation;
+use Greenlight\Expect\Expectation;
+use Greenlight\Expect\PendingConsistently;
+use Greenlight\Expect\PendingEventually;
+use Greenlight\Expect\TemporalExpectation;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+/**
+ * Checks constant expectation arguments that have value constraints.
+ *
+ * @internal
+ *
+ * @implements Rule<MethodCall>
+ */
+final class ExpectationArgumentRule implements Rule
+{
+    #[\Override]
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    #[\Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Identifier) {
+            return [];
+        }
+
+        $method = $node->name->toString();
+
+        if ($this->isExpectation($scope->getType($node->var))) {
+            return match ($method) {
+                'toMatch' => $this->patternErrors($node, $scope, $method, 'pattern', 0),
+                'toThrow' => $this->patternErrors($node, $scope, $method, 'matching', 1),
+                'toMatchJson' => $this->jsonErrors($node, $scope),
+                default => [],
+            };
+        }
+
+        if ($method === 'within' && $this->isType($scope, $node, PendingEventually::class)) {
+            return $this->durationErrors($node, $scope, $method, 0.0, false);
+        }
+
+        if ($method === 'for' && $this->isType($scope, $node, PendingConsistently::class)) {
+            return $this->durationErrors($node, $scope, $method, 0.0, false);
+        }
+
+        if ($method === 'pollEvery'
+            && ($this->isType($scope, $node, PendingEventually::class)
+                || $this->isType($scope, $node, PendingConsistently::class))
+        ) {
+            return $this->durationErrors($node, $scope, $method, 0.001, true);
+        }
+
+        return [];
+    }
+
+    /**
+     * @return list<IdentifierRuleError>
+     */
+    private function patternErrors(
+        MethodCall $call,
+        Scope $scope,
+        string $method,
+        string $name,
+        int $position,
+    ): array {
+        $argument = $this->argument($call, $name, $position);
+
+        if (!$argument instanceof Arg) {
+            return [];
+        }
+
+        foreach ($scope->getType($argument->value)->getConstantStrings() as $pattern) {
+            if (ErrorTrap::run(static fn(): int|false => \preg_match($pattern->getValue(), ''), $warning) !== false) {
+                continue;
+            }
+
+            return [RuleErrorBuilder::message(\sprintf(
+                'Regular expression "%s" for %s() is invalid.',
+                $pattern->getValue(),
+                $method,
+            ))
+                ->identifier('greenlight.expectationArgument.pattern')
+                ->line($call->getStartLine())
+                ->build()];
+        }
+
+        return [];
+    }
+
+    /**
+     * @return list<IdentifierRuleError>
+     */
+    private function jsonErrors(MethodCall $call, Scope $scope): array
+    {
+        $argument = $this->argument($call, 'expected', 0);
+
+        if (!$argument instanceof Arg) {
+            return [];
+        }
+
+        foreach ($scope->getType($argument->value)->getConstantStrings() as $expected) {
+            if (\json_validate($expected->getValue())) {
+                continue;
+            }
+
+            return [RuleErrorBuilder::message('toMatchJson() requires valid expected JSON.')
+                ->identifier('greenlight.expectationArgument.json')
+                ->line($call->getStartLine())
+                ->build()];
+        }
+
+        return [];
+    }
+
+    /**
+     * @return list<IdentifierRuleError>
+     */
+    private function durationErrors(
+        MethodCall $call,
+        Scope $scope,
+        string $method,
+        float $minimum,
+        bool $inclusive,
+    ): array {
+        $argument = $this->argument($call, 'seconds', 0);
+
+        if (!$argument instanceof Arg) {
+            return [];
+        }
+
+        foreach ($scope->getType($argument->value)->getConstantScalarValues() as $seconds) {
+            if ((\is_int($seconds) || \is_float($seconds))
+                && \is_finite((float) $seconds)
+                && ($inclusive ? $seconds >= $minimum : $seconds > $minimum)
+            ) {
+                continue;
+            }
+
+            $constraint = $inclusive
+                ? \sprintf('at least %.3f seconds', $minimum)
+                : \sprintf('greater than %.3f seconds', $minimum);
+
+            return [RuleErrorBuilder::message(\sprintf(
+                '%s() requires a finite duration %s.',
+                $method,
+                $constraint,
+            ))
+                ->identifier('greenlight.expectationArgument.duration')
+                ->line($call->getStartLine())
+                ->build()];
+        }
+
+        return [];
+    }
+
+    private function argument(MethodCall $call, string $name, int $position): ?Arg
+    {
+        $nextPosition = 0;
+
+        foreach ($call->getArgs() as $argument) {
+            if ($argument->unpack) {
+                continue;
+            }
+
+            if ($argument->name instanceof Identifier) {
+                if ($argument->name->toString() === $name) {
+                    return $argument;
+                }
+
+                continue;
+            }
+
+            if ($nextPosition === $position) {
+                return $argument;
+            }
+
+            ++$nextPosition;
+        }
+
+        return null;
+    }
+
+    private function isExpectation(Type $receiver): bool
+    {
+        return \array_any(
+            [Expectation::class, TemporalExpectation::class, EventuallyExpectation::class, ConsistentlyExpectation::class],
+            static fn(string $class): bool => new ObjectType($class)->isSuperTypeOf($receiver)->yes(),
+        );
+    }
+
+    /**
+     * @param class-string $class
+     */
+    private function isType(Scope $scope, MethodCall $call, string $class): bool
+    {
+        return new ObjectType($class)->isSuperTypeOf($scope->getType($call->var))->yes();
+    }
+}

--- a/tests/Acceptance/PhpStanExpectationArgumentRuleTest.php
+++ b/tests/Acceptance/PhpStanExpectationArgumentRuleTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\PhpStanProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class PhpStanExpectationArgumentRuleTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function constantExpectationArgumentsMustBeValid(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Expect\Expect;
+
+            function greenlightGoodExpectationArgumentProbe(string $pattern, string $json, float $duration): void
+            {
+                Expect::that('greenlight')->toMatch('/green/');
+                Expect::that(static fn() => throw new DomainException('greenlight'))
+                    ->toThrow(DomainException::class, matching: '/green/');
+                Expect::that('{}')->toMatchJson('{}');
+                Expect::eventually(static fn(): bool => true)
+                    ->pollEvery(0.001)
+                    ->within(0.001)
+                    ->toBeTrue();
+                Expect::consistently(static fn(): bool => true)
+                    ->pollEvery(0.001)
+                    ->for(0.001)
+                    ->toBeTrue();
+                Expect::that('greenlight')->toMatch($pattern);
+                Expect::that('{}')->toMatchJson($json);
+                Expect::eventually(static fn(): bool => true)->within($duration)->toBeTrue();
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Expect\Expect;
+
+            function greenlightBadExpectationArgumentProbe(): void
+            {
+                Expect::that('greenlight')->toMatch('/[/');
+                Expect::that(static fn() => throw new DomainException('greenlight'))
+                    ->toThrow(DomainException::class, matching: '/[/');
+                Expect::that('{}')->toMatchJson('{');
+                Expect::eventually(static fn(): bool => true)->pollEvery(0.0001)->within(1.0)->toBeTrue();
+                Expect::eventually(static fn(): bool => true)->within(0.0)->toBeTrue();
+                Expect::consistently(static fn(): bool => true)->pollEvery(-1.0)->for(1.0)->toBeTrue();
+                Expect::consistently(static fn(): bool => true)->for(0.0)->toBeTrue();
+            }
+            PHP,
+        );
+
+        Expect::that($probe->exitCode)->because('constant expectation arguments must satisfy runtime constraints')->toBe(1)
+            ->and($probe->goodPassed)->toBeTrue()
+            ->and(\count($probe->errors))->toBe(7)
+            ->and($probe->messages())->toContain('Regular expression "/[/" for toMatch() is invalid')
+            ->and($probe->messages())->toContain('toMatchJson() requires valid expected JSON')
+            ->and($probe->messages())->toContain('within() requires a finite duration greater than 0.000 seconds');
+    }
+}

--- a/tests/Unit/Expect/JsonMatchersTest.php
+++ b/tests/Unit/Expect/JsonMatchersTest.php
@@ -96,7 +96,7 @@ final class JsonMatchersTest
     public function toMatchJsonGuardsTheExpectedValue(): void
     {
         $detail = FailureProbe::detailOf(
-            static fn() => Expect::that('{}')->toMatchJson('{oops'),
+            static fn() => Expect::that('{}')->toMatchJson('{oops'), // @phpstan-ignore greenlight.expectationArgument.json (deliberately invalid: tests runtime validation)
         );
 
         Expect::that($detail->message)->because('toMatchJson() guards the expected value')

--- a/tests/Unit/Expect/StringMatchersTest.php
+++ b/tests/Unit/Expect/StringMatchersTest.php
@@ -46,7 +46,7 @@ final class StringMatchersTest
     #[Test]
     public function toMatchRejectsInvalidPatterns(): void
     {
-        Expect::that(static fn() => Expect::that('abc')->toMatch('not a pattern'))->because('toMatch() rejects invalid patterns')
+        Expect::that(static fn() => Expect::that('abc')->toMatch('not a pattern'))->because('toMatch() rejects invalid patterns') // @phpstan-ignore greenlight.expectationArgument.pattern (deliberately invalid: tests runtime validation)
             ->toThrow(
                 \InvalidArgumentException::class,
                 message: 'The pattern for toMatch() is an invalid regular expression: not a pattern '

--- a/tests/Unit/Expect/TemporalExpectationTest.php
+++ b/tests/Unit/Expect/TemporalExpectationTest.php
@@ -216,7 +216,7 @@ final class TemporalExpectationTest
 
         Expect::that(static function () use ($clock, &$calls): void {
             ExpectationRuntime::withClock($clock, static function () use (&$calls): void {
-                Expect::eventually(static function () use (&$calls): string {
+                Expect::eventually(static function () use (&$calls): string { // @phpstan-ignore greenlight.expectationArgument.pattern (deliberately invalid: tests runtime validation)
                     ++$calls;
 
                     return 'value';
@@ -426,22 +426,22 @@ final class TemporalExpectationTest
     #[Test]
     public function pollingDurationsAndExceptionTypesAreValidated(): void
     {
-        Expect::that(static fn() => Expect::eventually(static fn(): int => 1)->within(0.0))->because('polling durations and exception types are validated')
+        Expect::that(static fn() => Expect::eventually(static fn(): int => 1)->within(0.0))->because('polling durations and exception types are validated') // @phpstan-ignore greenlight.expectationArgument.duration (deliberately invalid: tests runtime validation)
             ->toThrow(
                 \InvalidArgumentException::class,
                 message: 'Set Eventually duration to a finite value of at least 0.000 seconds.',
             );
-        Expect::that(static fn() => Expect::eventually(static fn(): int => 1)->pollEvery(0.0009))->because('polling durations and exception types are validated')
+        Expect::that(static fn() => Expect::eventually(static fn(): int => 1)->pollEvery(0.0009))->because('polling durations and exception types are validated') // @phpstan-ignore greenlight.expectationArgument.duration (deliberately invalid: tests runtime validation)
             ->toThrow(
                 \InvalidArgumentException::class,
                 message: 'Set Polling interval to a finite value of at least 0.001 seconds.',
             );
-        Expect::that(static fn() => Expect::consistently(static fn(): int => 1)->for(\NAN))->because('polling durations and exception types are validated')
+        Expect::that(static fn() => Expect::consistently(static fn(): int => 1)->for(\NAN))->because('polling durations and exception types are validated') // @phpstan-ignore greenlight.expectationArgument.duration (deliberately invalid: tests runtime validation)
             ->toThrow(
                 \InvalidArgumentException::class,
                 message: 'Use a finite consistency duration greater than 0.000 seconds.',
             );
-        Expect::that(static fn() => Expect::consistently(static fn(): int => 1)->pollEvery(0.0009))->because('polling durations and exception types are validated')
+        Expect::that(static fn() => Expect::consistently(static fn(): int => 1)->pollEvery(0.0009))->because('polling durations and exception types are validated') // @phpstan-ignore greenlight.expectationArgument.duration (deliberately invalid: tests runtime validation)
             ->toThrow(
                 \InvalidArgumentException::class,
                 message: 'Use a finite polling interval of at least 0.001 seconds.',

--- a/tests/Unit/Expect/ToThrowTest.php
+++ b/tests/Unit/Expect/ToThrowTest.php
@@ -126,7 +126,7 @@ final class ToThrowTest
         $invoked = false;
 
         Expect::that(function () use (&$invoked): void {
-            Expect::that(static function () use (&$invoked): void {
+            Expect::that(static function () use (&$invoked): void { // @phpstan-ignore greenlight.expectationArgument.pattern (deliberately invalid: tests runtime validation)
                 $invoked = true;
             })
                 ->toThrow(\DomainException::class, matching: 'not a pattern');


### PR DESCRIPTION
Adds PHPStan checks for invalid statically known expectation arguments.\n\n- Validates regular expressions and expected JSON strings.\n- Validates constant temporal durations and polling intervals.\n- Leaves dynamic values to existing runtime validation.