### PR TITLE
test(condition): isolate environment variable checks

### DIFF
--- a/tests/Unit/Condition/ConditionsTest.php
+++ b/tests/Unit/Condition/ConditionsTest.php
@@ -16,86 +16,123 @@ use Greenlight\Condition\OperatingSystemFamily;
 use Greenlight\Condition\PhpVersionAtLeast;
 use Greenlight\Condition\PhpVersionLessThan;
 use Greenlight\Expect\Expect;
+use Greenlight\Fixture\EnvironmentSandbox;
 
-final class ConditionsTest
+final readonly class ConditionsTest
 {
+    public function __construct(private EnvironmentSandbox $environment) {}
+
     #[Test]
     public function extensionLoadedChecksTheLoadedExtensionList(): void
     {
-        Expect::that(new ExtensionLoaded('json')->isSatisfied())->because('extension loaded checks the loaded extension list')->toBeTrue()
-            ->and(new ExtensionLoaded('greenlight_no_such_extension')->isSatisfied())->toBeFalse();
+        Expect::that(new ExtensionLoaded('json')->isSatisfied())
+            ->because('extension loaded checks the loaded extension list')
+            ->toBeTrue();
+        Expect::that(new ExtensionLoaded('greenlight_no_such_extension')->isSatisfied())
+            ->because('extension loaded checks the loaded extension list')
+            ->toBeFalse();
     }
 
     #[Test]
     public function extensionMissingIsTheInverseOfExtensionLoaded(): void
     {
-        Expect::that(new ExtensionMissing('json')->isSatisfied())->because('extension missing is the inverse of extension loaded')->toBeFalse()
-            ->and(new ExtensionMissing('greenlight_no_such_extension')->isSatisfied())->toBeTrue();
+        Expect::that(new ExtensionMissing('json')->isSatisfied())
+            ->because('extension missing is the inverse of extension loaded')
+            ->toBeFalse();
+        Expect::that(new ExtensionMissing('greenlight_no_such_extension')->isSatisfied())
+            ->because('extension missing is the inverse of extension loaded')
+            ->toBeTrue();
     }
 
     #[Test]
     public function environmentVariableSetDetectsPresence(): void
     {
-        \putenv('GREENLIGHT_CONDITION_PROBE=anything');
+        $suffix = \strtoupper(\bin2hex(\random_bytes(6)));
+        $presentName = 'GREENLIGHT_CONDITION_PRESENT_' . $suffix;
+        $absentName = 'GREENLIGHT_CONDITION_ABSENT_' . $suffix;
+        $this->environment->set($presentName, 'anything');
+        $this->environment->unset($absentName);
 
-        try {
-            Expect::that(new EnvironmentVariableSet('GREENLIGHT_CONDITION_PROBE')->isSatisfied())->toBeTrue()
-                ->and(new EnvironmentVariableSet('GREENLIGHT_CONDITION_ABSENT')->isSatisfied())->toBeFalse();
-        } finally {
-            \putenv('GREENLIGHT_CONDITION_PROBE');
-        }
+        Expect::that(new EnvironmentVariableSet($presentName)->isSatisfied())->toBeTrue();
+        Expect::that(new EnvironmentVariableSet($absentName)->isSatisfied())->toBeFalse();
     }
 
     #[Test]
     public function environmentVariableEqualsComparesTheExactValue(): void
     {
-        \putenv('GREENLIGHT_CONDITION_PROBE=expected');
+        $suffix = \strtoupper(\bin2hex(\random_bytes(6)));
+        $presentName = 'GREENLIGHT_CONDITION_PRESENT_' . $suffix;
+        $absentName = 'GREENLIGHT_CONDITION_ABSENT_' . $suffix;
+        $this->environment->set($presentName, 'expected');
+        $this->environment->unset($absentName);
 
-        try {
-            Expect::that(new EnvironmentVariableEquals('GREENLIGHT_CONDITION_PROBE', 'expected')->isSatisfied())->toBeTrue()
-                ->and(new EnvironmentVariableEquals('GREENLIGHT_CONDITION_PROBE', 'other')->isSatisfied())->toBeFalse()
-                ->and(new EnvironmentVariableEquals('GREENLIGHT_CONDITION_ABSENT', 'expected')->isSatisfied())->toBeFalse();
-        } finally {
-            \putenv('GREENLIGHT_CONDITION_PROBE');
-        }
+        Expect::that(new EnvironmentVariableEquals($presentName, 'expected')->isSatisfied())->toBeTrue();
+        Expect::that(new EnvironmentVariableEquals($presentName, 'other')->isSatisfied())->toBeFalse();
+        Expect::that(new EnvironmentVariableEquals($absentName, 'expected')->isSatisfied())->toBeFalse();
     }
 
     #[Test]
     public function operatingSystemFamilyComparesCaseInsensitively(): void
     {
-        Expect::that(new OperatingSystemFamily(\PHP_OS_FAMILY)->isSatisfied())->because('operating system family compares case insensitively')->toBeTrue()
-            ->and(new OperatingSystemFamily(\strtolower(\PHP_OS_FAMILY))->isSatisfied())->toBeTrue()
-            ->and(new OperatingSystemFamily('NotAnOperatingSystem')->isSatisfied())->toBeFalse();
+        Expect::that(new OperatingSystemFamily(\PHP_OS_FAMILY)->isSatisfied())
+            ->because('operating system family compares case insensitively')
+            ->toBeTrue();
+        Expect::that(new OperatingSystemFamily(\strtolower(\PHP_OS_FAMILY))->isSatisfied())
+            ->because('operating system family compares case insensitively')
+            ->toBeTrue();
+        Expect::that(new OperatingSystemFamily('NotAnOperatingSystem')->isSatisfied())
+            ->because('operating system family compares case insensitively')
+            ->toBeFalse();
     }
 
     #[Test]
     public function phpVersionAtLeastComparesAgainstTheRunningVersion(): void
     {
-        Expect::that(new PhpVersionAtLeast('8.0')->isSatisfied())->because('PHP version at least compares against the current PHP version')->toBeTrue()
-            ->and(new PhpVersionAtLeast(\PHP_VERSION)->isSatisfied())->toBeTrue()
-            ->and(new PhpVersionAtLeast('99.0')->isSatisfied())->toBeFalse();
+        Expect::that(new PhpVersionAtLeast('8.0')->isSatisfied())
+            ->because('PHP version at least compares against the current PHP version')
+            ->toBeTrue();
+        Expect::that(new PhpVersionAtLeast(\PHP_VERSION)->isSatisfied())
+            ->because('PHP version at least compares against the current PHP version')
+            ->toBeTrue();
+        Expect::that(new PhpVersionAtLeast('99.0')->isSatisfied())
+            ->because('PHP version at least compares against the current PHP version')
+            ->toBeFalse();
     }
 
     #[Test]
     public function phpVersionLessThanComparesAgainstTheRunningVersion(): void
     {
-        Expect::that(new PhpVersionLessThan('99.0')->isSatisfied())->because('PHP version less than compares against the current PHP version')->toBeTrue()
-            ->and(new PhpVersionLessThan('8.0')->isSatisfied())->toBeFalse()
-            ->and(new PhpVersionLessThan(\PHP_VERSION)->isSatisfied())->toBeFalse();
+        Expect::that(new PhpVersionLessThan('99.0')->isSatisfied())
+            ->because('PHP version less than compares against the current PHP version')
+            ->toBeTrue();
+        Expect::that(new PhpVersionLessThan('8.0')->isSatisfied())
+            ->because('PHP version less than compares against the current PHP version')
+            ->toBeFalse();
+        Expect::that(new PhpVersionLessThan(\PHP_VERSION)->isSatisfied())
+            ->because('PHP version less than compares against the current PHP version')
+            ->toBeFalse();
     }
 
     #[Test]
     public function functionAvailableChecksCallableFunctions(): void
     {
-        Expect::that(new FunctionAvailable('strlen')->isSatisfied())->because('function available checks callable functions')->toBeTrue()
-            ->and(new FunctionAvailable('greenlight_no_such_function')->isSatisfied())->toBeFalse();
+        Expect::that(new FunctionAvailable('strlen')->isSatisfied())
+            ->because('function available checks callable functions')
+            ->toBeTrue();
+        Expect::that(new FunctionAvailable('greenlight_no_such_function')->isSatisfied())
+            ->because('function available checks callable functions')
+            ->toBeFalse();
     }
 
     #[Test]
     public function classAvailableChecksAutoloadableClasses(): void
     {
-        Expect::that(new ClassAvailable(\stdClass::class)->isSatisfied())->because('class available checks autoloadable classes')->toBeTrue()
-            ->and(new ClassAvailable('Greenlight\NoSuchClassAnywhere')->isSatisfied())->toBeFalse();
+        Expect::that(new ClassAvailable(\stdClass::class)->isSatisfied())
+            ->because('class available checks autoloadable classes')
+            ->toBeTrue();
+        Expect::that(new ClassAvailable('Greenlight\NoSuchClassAnywhere')->isSatisfied())
+            ->because('class available checks autoloadable classes')
+            ->toBeFalse();
     }
 
     #[Test]


### PR DESCRIPTION
This change isolates condition environment-variable tests with EnvironmentSandbox. It uses collision-safe names, explicitly stages present and absent states, and gives independent subjects separate expectations.

Verification:
- php bin/greenlight run --filter=ConditionsTest
- composer static-analysis
- composer tests