### PR TITLE
test(cli): strengthen malformed shard coverage

### DIFF
--- a/tests/Acceptance/ShardingTest.php
+++ b/tests/Acceptance/ShardingTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Acceptance;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -29,20 +30,40 @@ final readonly class ShardingTest
         }
         \sort($all);
         \sort($union);
-        Expect::that($all)->because('shards reconstitute the full list exactly once')->not()->toHaveCount(0)
-            ->and($union)->toBe($all);
+        Expect::that($all)->because('shards reconstitute the full list exactly once')->not()->toHaveCount(0);
+        Expect::that($union)->because('shards reconstitute the full list exactly once')->toBe($all);
     }
 
     #[Test]
-    public function malformedShardSpecsAreUsageErrors(): void
+    #[DataSet('malformedShardSpecs')]
+    public function malformedShardSpecsAreUsageErrors(string $flag, string $diagnostic): void
     {
         $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'sharding');
-        foreach (['--shard=4/3', '--shard=0/3', '--shard=banana'] as $flag) {
-            $result = GreenlightCli::run($project->directory, ['list-tests', $flag]);
-            Expect::that($result->exitCode)->toBe(64)->and($result->output())->toContain('greenlight: --shard');
-        }
-        $result = GreenlightCli::run($project->directory, ['list-tests', '--shard=4/3']);
-        Expect::that($result->output())->because('malformed shard specs are usage errors')->toContain('Valid n values for 3 shards are 1 through 3.');
+        $result = GreenlightCli::run($project->directory, ['list-tests', $flag]);
+
+        Expect::that($result->exitCode)->because('malformed shard specs are usage errors')->toBe(64);
+        Expect::that($result->output())->because('malformed shard specs are usage errors')->toBe($diagnostic);
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string, non-empty-string}>
+     */
+    public static function malformedShardSpecs(): iterable
+    {
+        yield 'index exceeds the shard count' => [
+            '--shard=4/3',
+            'greenlight: --shard requires 1 <= n <= m. Received "4/3". '
+            . 'Valid n values for 3 shards are 1 through 3.',
+        ];
+        yield 'zero index' => [
+            '--shard=0/3',
+            'greenlight: --shard requires 1 <= n <= m. Received "0/3". '
+            . 'Valid n values for 3 shards are 1 through 3.',
+        ];
+        yield 'invalid format' => [
+            '--shard=banana',
+            'greenlight: --shard requires <n>/<m>, such as 1/4. Received "banana".',
+        ];
     }
 
     /**


### PR DESCRIPTION
## Summary

- Give each malformed shard case a named data-set identity.
- Check each complete CLI diagnostic.
- Use separate expectations for independent subjects.

## Verification

- Focused ShardingTest test IDs
- composer static-analysis
- composer tests