### PR TITLE
test(cli): assert exact selected test IDs

### DIFF
--- a/tests/Acceptance/SelectionTest.php
+++ b/tests/Acceptance/SelectionTest.php
@@ -16,17 +16,52 @@ final readonly class SelectionTest
     public function __construct(private TempDirectory $tempDirectory) {}
 
     #[Test]
-    public function filterSelectsByMethodClassAndWildcard(): void
+    public function filterSelectsByMethod(): void
     {
         $project = $this->writeProject();
         $result = $this->run($project, '--filter=alwaysPasses');
-        Expect::that($result->exitCode)->because('filter selects by method class and wildcard')->toBe(0)->and($result->output())->toContain('1 test, 1 passed');
+
+        Expect::that($result->exitCode)->because('filter selects by method')->toBe(0);
+        Expect::that($this->reportedTestIds($result))->because('filter selects by method')->toBe([
+            'SelectionProbe\SelectionProbeTest::alwaysPasses',
+        ]);
+    }
+
+    #[Test]
+    public function filterSelectsByClass(): void
+    {
+        $project = $this->writeProject();
         $result = $this->run($project, '--filter=SelectionProbeTest');
-        Expect::that($result->output())->because('filter selects by method class and wildcard')->toContain('3 tests,');
+
+        Expect::that($result->exitCode)->because('filter selects by class')->toBe(1);
+        Expect::that($this->reportedTestIds($result))->because('filter selects by class')->toBe([
+            'SelectionProbe\SelectionProbeTest::alsoPasses',
+            'SelectionProbe\SelectionProbeTest::alwaysPasses',
+            'SelectionProbe\SelectionProbeTest::breaksSometimes',
+        ]);
+    }
+
+    #[Test]
+    public function filterSelectsWithAWildcard(): void
+    {
+        $project = $this->writeProject();
         $result = $this->run($project, '--filter=*::breaks?ometimes');
-        Expect::that($result->exitCode)->because('filter selects by method class and wildcard')->toBe(1)->and($result->output())->toContain('1 test, 0 passed, 1 errored');
+
+        Expect::that($result->exitCode)->because('filter selects with a wildcard')->toBe(1);
+        Expect::that($this->reportedTestIds($result))->because('filter selects with a wildcard')->toBe([
+            'SelectionProbe\SelectionProbeTest::breaksSometimes',
+        ]);
+    }
+
+    #[Test]
+    public function filterReportsNoTestsWhenNothingMatches(): void
+    {
+        $project = $this->writeProject();
         $result = $this->run($project, '--filter=nothingMatchesThis');
-        Expect::that($result->exitCode)->because('filter selects by method class and wildcard')->toBe(1)->and($result->output())->toContain('Greenlight found no tests');
+
+        Expect::that($result->exitCode)->because('filter reports no tests when nothing matches')->toBe(1);
+        Expect::that($this->reportedTestIds($result))->because('filter reports no tests when nothing matches')->toBe([]);
+        Expect::that($result->output())->because('filter reports no tests when nothing matches')->toContain('Greenlight found no tests');
     }
 
     #[Test]
@@ -38,29 +73,46 @@ final readonly class SelectionTest
             '--test-id=SelectionProbe\SelectionProbeTest::alsoPasses',
         );
 
-        Expect::that($result->exitCode)->because('test ID selects only an exact ID')->toBe(0)
-            ->and($result->output())->toContain('1 test, 1 passed')
-            ->not()->toContain('alwaysPasses');
+        Expect::that($result->exitCode)->because('test ID selects only an exact ID')->toBe(0);
+        Expect::that($this->reportedTestIds($result))->because('test ID selects only an exact ID')->toBe([
+            'SelectionProbe\SelectionProbeTest::alsoPasses',
+        ]);
 
         $result = $this->run(
             $project,
             '--test-id=SelectionProbe\SelectionProbeTest::also',
         );
 
-        Expect::that($result->exitCode)->because('test ID selects only an exact ID')->toBe(1)
-            ->and($result->output())->toContain('Greenlight found no tests');
+        Expect::that($result->exitCode)->because('test ID selects only an exact ID')->toBe(1);
+        Expect::that($this->reportedTestIds($result))->because('test ID selects only an exact ID')->toBe([]);
+        Expect::that($result->output())->because('test ID selects only an exact ID')->toContain('Greenlight found no tests');
+    }
+
+    #[Test]
+    public function groupSelectsMatchingTests(): void
+    {
+        $project = $this->writeProject();
+        $result = $this->run($project, '--group=fast');
+
+        Expect::that($result->exitCode)->because('group selects matching tests')->toBe(0);
+        Expect::that($this->reportedTestIds($result))->because('group selects matching tests')->toBe([
+            'SelectionProbe\GroupedProbeTest::fastOne',
+        ]);
     }
 
     #[Test]
     public function excludeGroupRemovesGroupedTestsFromARun(): void
     {
         $project = $this->writeProject();
-        // The complete project has five tests. Exclusion of the slow group
-        // removes one test.
         $result = $this->run($project, '--exclude-group=slow');
-        Expect::that($result->exitCode)->because('exclude group removes grouped tests from a run')->toBe(1)->and($result->output())->toContain('4 tests,');
-        $result = $this->run($project, '--group=fast', '--exclude-group=slow');
-        Expect::that($result->exitCode)->because('exclude group removes grouped tests from a run')->toBe(0)->and($result->output())->toContain('1 test, 1 passed');
+
+        Expect::that($result->exitCode)->because('exclude group removes grouped tests from a run')->toBe(1);
+        Expect::that($this->reportedTestIds($result))->because('exclude group removes grouped tests from a run')->toBe([
+            'SelectionProbe\GroupedProbeTest::fastOne',
+            'SelectionProbe\SelectionProbeTest::alsoPasses',
+            'SelectionProbe\SelectionProbeTest::alwaysPasses',
+            'SelectionProbe\SelectionProbeTest::breaksSometimes',
+        ]);
     }
 
     #[Test]
@@ -68,7 +120,13 @@ final readonly class SelectionTest
     {
         $project = $this->writeProject();
         $result = $this->run($project, '--exclude-method=*Passes');
-        Expect::that($result->exitCode)->because('exclude method with a wildcard removes matching methods')->toBe(1)->and($result->output())->toContain('3 tests,');
+
+        Expect::that($result->exitCode)->because('exclude method with a wildcard removes matching methods')->toBe(1);
+        Expect::that($this->reportedTestIds($result))->because('exclude method with a wildcard removes matching methods')->toBe([
+            'SelectionProbe\GroupedProbeTest::fastOne',
+            'SelectionProbe\GroupedProbeTest::slowOne',
+            'SelectionProbe\SelectionProbeTest::breaksSometimes',
+        ]);
     }
 
     #[Test]
@@ -76,9 +134,22 @@ final readonly class SelectionTest
     {
         $project = $this->writeProject();
         $result = $this->run($project, '--filter=alwaysPasses', '--exclude-method=alwaysPasses');
-        Expect::that($result->exitCode)->because('exclude wins over an include filter')->toBe(1)->and($result->output())->toContain('Greenlight found no tests');
+
+        Expect::that($result->exitCode)->because('exclude wins over an include filter')->toBe(1);
+        Expect::that($this->reportedTestIds($result))->because('exclude wins over an include filter')->toBe([]);
+        Expect::that($result->output())->because('exclude wins over an include filter')->toContain('Greenlight found no tests');
+    }
+
+    #[Test]
+    public function excludedGroupWinsOverIncludedGroups(): void
+    {
+        $project = $this->writeProject();
         $result = $this->run($project, '--group=fast', '--group=slow', '--exclude-group=slow');
-        Expect::that($result->exitCode)->because('exclude wins over an include filter')->toBe(0)->and($result->output())->toContain('1 test, 1 passed');
+
+        Expect::that($result->exitCode)->because('excluded group wins over included groups')->toBe(0);
+        Expect::that($this->reportedTestIds($result))->because('excluded group wins over included groups')->toBe([
+            'SelectionProbe\GroupedProbeTest::fastOne',
+        ]);
     }
 
     #[Test]
@@ -86,17 +157,36 @@ final readonly class SelectionTest
     {
         $project = $this->writeProject();
         $result = $this->run($project, '--failed');
-        Expect::that($result->exitCode)->because('failed reruns exactly the previous failures')->toBe(64)->and($result->output())->toContain('previous run');
+        Expect::that($result->exitCode)->because('failed reruns exactly the previous failures')->toBe(64);
+        Expect::that($this->reportedTestIds($result))->because('failed reruns exactly the previous failures')->toBe([]);
+        Expect::that($result->output())->because('failed reruns exactly the previous failures')->toContain('previous run');
+
         $result = $this->run($project);
         Expect::that($result->exitCode)->because('failed reruns exactly the previous failures')->toBe(1);
+        Expect::that($this->reportedTestIds($result))->because('failed reruns exactly the previous failures')->toBe([
+            'SelectionProbe\GroupedProbeTest::fastOne',
+            'SelectionProbe\GroupedProbeTest::slowOne',
+            'SelectionProbe\SelectionProbeTest::alsoPasses',
+            'SelectionProbe\SelectionProbeTest::alwaysPasses',
+            'SelectionProbe\SelectionProbeTest::breaksSometimes',
+        ]);
+
         $result = $this->run($project, '--failed');
-        Expect::that($result->exitCode)->because('failed reruns exactly the previous failures')->toBe(1)
-            ->and($result->output())->toContain('1 test, 0 passed, 1 errored')
-            ->toContain('breaksSometimes');
+        Expect::that($result->exitCode)->because('failed reruns exactly the previous failures')->toBe(1);
+        Expect::that($this->reportedTestIds($result))->because('failed reruns exactly the previous failures')->toBe([
+            'SelectionProbe\SelectionProbeTest::breaksSometimes',
+        ]);
+
         $result = $this->run($project, '--filter=alwaysPasses');
         Expect::that($result->exitCode)->because('failed reruns exactly the previous failures')->toBe(0);
+        Expect::that($this->reportedTestIds($result))->because('failed reruns exactly the previous failures')->toBe([
+            'SelectionProbe\SelectionProbeTest::alwaysPasses',
+        ]);
+
         $result = $this->run($project, '--failed');
-        Expect::that($result->exitCode)->because('failed reruns exactly the previous failures')->toBe(0)->and($result->output())->toContain('No tests failed');
+        Expect::that($result->exitCode)->because('failed reruns exactly the previous failures')->toBe(0);
+        Expect::that($this->reportedTestIds($result))->because('failed reruns exactly the previous failures')->toBe([]);
+        Expect::that($result->output())->because('failed reruns exactly the previous failures')->toContain('No tests failed');
     }
 
     #[Test]
@@ -114,14 +204,29 @@ final readonly class SelectionTest
             ['run', '--reporter=plain', '--filter=alwaysPasses'],
             ['TMPDIR' => $project->directory . '/not-a-directory'],
         );
-        Expect::that($result->exitCode)->because('unpersistable run state warns without failing the run')->toBe(0)
-            ->and($result->output())->toContain('1 test, 1 passed')
-            ->toContain('Greenlight did not save run state');
+        Expect::that($result->exitCode)->because('unpersistable run state warns without failing the run')->toBe(0);
+        Expect::that($this->reportedTestIds($result))->because('unpersistable run state warns without failing the run')->toBe([
+            'SelectionProbe\SelectionProbeTest::alwaysPasses',
+        ]);
+        Expect::that($result->output())->because('unpersistable run state warns without failing the run')->toContain('Greenlight did not save run state');
     }
 
     private function run(AcceptanceProject $project, string ...$flags): ProcessResult
     {
         return GreenlightCli::run($project->directory, \array_values(['run', '--reporter=plain', ...$flags]));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function reportedTestIds(ProcessResult $result): array
+    {
+        $matches = [];
+        \preg_match_all('/^(?:PASS|FAIL|ERROR|SKIP) (\S+) \(\d+\.\d{3}s\)/m', $result->output(), $matches);
+        $testIds = $matches[1];
+        \sort($testIds);
+
+        return $testIds;
     }
 
     private function writeProject(): AcceptanceProject


### PR DESCRIPTION
## Summary

- Compare the exact reported test IDs for selection acceptance tests.
- Separate method, class, wildcard, group, exclusion, and precedence behavior.
- Use independent expectations for each subject.

## Verification

- php bin/greenlight run --filter=Greenlight\\Tests\\Acceptance\\SelectionTest
- composer static-analysis
- composer tests