### PR TITLE
test(coverage): use xdebug public lifecycle

### DIFF
--- a/tests/Unit/Coverage/XdebugDriverIniFallbackTest.php
+++ b/tests/Unit/Coverage/XdebugDriverIniFallbackTest.php
@@ -36,8 +36,9 @@ final class XdebugDriverIniFallbackTest
 
         Expect::that($result->exitCode)
             ->because('the isolated Xdebug availability probe MUST exit successfully')
-            ->toBe(0)
-            ->and($result->stdout)
+            ->toBe(0);
+
+        Expect::that($result->stdout)
             ->because('Xdebug availability MUST fall back to the configured INI mode')
             ->toBe("disabled\navailable");
     }

--- a/tests/Unit/Coverage/XdebugDriverNormalizationTest.php
+++ b/tests/Unit/Coverage/XdebugDriverNormalizationTest.php
@@ -4,30 +4,57 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Coverage;
 
+use Greenlight\Attribute\Isolated;
 use Greenlight\Attribute\Test;
 use Greenlight\Coverage\Driver\XdebugDriver;
+use Greenlight\Coverage\Driver\XdebugRuntime;
 use Greenlight\Expect\Expect;
 
 final class XdebugDriverNormalizationTest
 {
     #[Test]
+    #[Isolated]
     public function malformedCoverageEntriesAreDiscarded(): void
     {
-        $driver = new \ReflectionClass(XdebugDriver::class)->newInstanceWithoutConstructor();
-        $normalize = new \ReflectionMethod(XdebugDriver::class, 'normalize');
+        if (!\defined('XDEBUG_CC_UNUSED')) {
+            \define('XDEBUG_CC_UNUSED', 1);
+        }
 
-        $normalized = $normalize->invoke($driver, [
-            '/valid.php' => [
-                10 => 1,
-                11 => -1,
-                'line' => 1,
-                12 => 'covered',
-            ],
-            7 => [20 => 1],
-            '/invalid.php' => 'not line coverage',
-        ]);
+        if (!\defined('XDEBUG_CC_DEAD_CODE')) {
+            \define('XDEBUG_CC_DEAD_CODE', 2);
+        }
 
-        Expect::that($normalized)
+        $runtime = new class implements XdebugRuntime {
+            #[\Override]
+            public function start(int $flags): void {}
+
+            /**
+             * @return array<mixed>
+             */
+            #[\Override]
+            public function collect(): array
+            {
+                return [
+                    '/valid.php' => [
+                        10 => 1,
+                        11 => -1,
+                        'line' => 1,
+                        12 => 'covered',
+                    ],
+                    7 => [20 => 1],
+                    '/invalid.php' => 'not line coverage',
+                ];
+            }
+
+            #[\Override]
+            public function stop(): void {}
+        };
+
+        $driver = new XdebugDriver($runtime);
+        $driver->start();
+        $coverage = $driver->stop();
+
+        Expect::that($coverage->lines)
             ->because('Xdebug coverage MUST keep only integer statuses keyed by integer lines')
             ->toBe([
                 '/valid.php' => [

--- a/tests/Unit/Coverage/XdebugDriverTest.php
+++ b/tests/Unit/Coverage/XdebugDriverTest.php
@@ -45,9 +45,19 @@ final class XdebugDriverTest
     }
 
     #[Test]
+    #[Isolated]
     public function reportsInvalidCollectionStateExactly(): void
     {
-        $driver = new \ReflectionClass(XdebugDriver::class)->newInstanceWithoutConstructor();
+        if (!\defined('XDEBUG_CC_UNUSED')) {
+            \define('XDEBUG_CC_UNUSED', 1);
+        }
+
+        if (!\defined('XDEBUG_CC_DEAD_CODE')) {
+            \define('XDEBUG_CC_DEAD_CODE', 2);
+        }
+
+        $runtime = new FakeXdebugRuntime();
+        $driver = new XdebugDriver($runtime);
 
         Expect::that(static fn(): mixed => $driver->stop())
             ->toThrow(
@@ -55,14 +65,23 @@ final class XdebugDriverTest
                 message: 'The Xdebug collection window is not open. Call start() before stop().',
             );
 
-        $collecting = new \ReflectionProperty(XdebugDriver::class, 'collecting');
-        $collecting->setValue($driver, true);
+        Expect::that($runtime->calls)
+            ->because('an invalid stop MUST NOT use the Xdebug runtime')
+            ->toBe([]);
+
+        $driver->start();
 
         Expect::that(static fn() => $driver->start())
             ->toThrow(
                 \LogicException::class,
                 message: 'The Xdebug collection window is already open. Call stop() before start().',
             );
+
+        $driver->stop();
+
+        Expect::that($runtime->calls)
+            ->because('an invalid start MUST NOT open a second collection window')
+            ->toBe(['start', 'collect', 'stop']);
     }
 
     #[Test]
@@ -89,11 +108,13 @@ final class XdebugDriverTest
                     10 => 1,
                     11 => -1,
                 ],
-            ])
-            ->and($runtime->flags)
+            ]);
+
+        Expect::that($runtime->flags)
             ->because('Xdebug collection MUST request unused and dead code analysis')
-            ->toBe(\XDEBUG_CC_UNUSED | \XDEBUG_CC_DEAD_CODE)
-            ->and($runtime->calls)
+            ->toBe(\XDEBUG_CC_UNUSED | \XDEBUG_CC_DEAD_CODE);
+
+        Expect::that($runtime->calls)
             ->because('Xdebug collection MUST read and stop the extension before closing its window')
             ->toBe(['start', 'collect', 'stop']);
 
@@ -125,12 +146,24 @@ final class XdebugDriverTest
         $map = CoverageMap::fromRaw($raw, new PathFilter([$fixtureDir]));
         $file = $map->files()[$fixtureFile] ?? null;
 
-        Expect::that($sum)->because('collects real line coverage over the fixture')->toBe(42)
-            ->and($file)->not()->toBeNull();
+        Expect::that($sum)
+            ->because('collects real line coverage over the fixture')
+            ->toBe(42);
+
+        Expect::that($file)
+            ->because('collects real line coverage over the fixture')
+            ->not()
+            ->toBeNull();
         \assert($file !== null);
 
-        Expect::that($file->coveredLines)->because('collects real line coverage over the fixture')->toContain(Adder::ADD_RETURN_LINE)
-            ->and($file->uncoveredLines)->not()->toContain(Adder::ADD_RETURN_LINE);
+        Expect::that($file->coveredLines)
+            ->because('collects real line coverage over the fixture')
+            ->toContain(Adder::ADD_RETURN_LINE);
+
+        Expect::that($file->uncoveredLines)
+            ->because('collects real line coverage over the fixture')
+            ->not()
+            ->toContain(Adder::ADD_RETURN_LINE);
     }
 
     /**


### PR DESCRIPTION
## Summary

- Exercise malformed Xdebug coverage through the public collection lifecycle.
- Verify invalid lifecycle transitions with the deterministic runtime fake.
- Give each independent expectation subject to Expect::that().

## Verification

- php bin/greenlight run --filter=XdebugDriverNormalizationTest
- php bin/greenlight run --filter=XdebugDriverTest
- php bin/greenlight run --filter=XdebugDriverIniFallbackTest
- composer static-analysis
- composer tests