### PR TITLE
refactor(cli): extract terminal row resolver

### DIFF
--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -897,7 +897,7 @@ final readonly class Application
                     $header,
                     extendedSlowTests: $profile,
                     verbose: $arguments->has('verbose'),
-                    terminalRows: $this->terminalRows(),
+                    terminalRows: TerminalRowsResolver::resolve(),
                 ),
                 'plain' => new PlainReporter($output, $header, extendedSlowTests: $profile),
                 'junit' => new JUnitReporter($output),
@@ -913,21 +913,6 @@ final readonly class Application
         }
 
         return \count($reporters) === 1 ? $reporters[0] : new CompositeReporter($reporters);
-    }
-
-    /** Uses LINES, then tput, then 24. The reporter probes it one time when built. */
-    private function terminalRows(): int
-    {
-        $linesEnv = \getenv('LINES');
-        $lines = $linesEnv === false || $linesEnv === '' ? 0 : (int) $linesEnv;
-
-        if ($lines > 0) {
-            return $lines;
-        }
-
-        $probed = (int) ErrorTrap::run(static fn(): string|false => \exec('tput lines 2>/dev/null'));
-
-        return $probed > 0 ? $probed : 24;
     }
 
     /** Uses the loaded configuration so IDE and PHPStan signatures match. */

--- a/src/Cli/TerminalRowsResolver.php
+++ b/src/Cli/TerminalRowsResolver.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli;
+
+use Greenlight\Core\ErrorTrap;
+
+/**
+ * Uses LINES, then tput, then 24.
+ *
+ * @internal
+ */
+final class TerminalRowsResolver
+{
+    /** @codeCoverageIgnore */
+    private function __construct() {}
+
+    public static function resolve(): int
+    {
+        $linesEnv = \getenv('LINES');
+        $lines = $linesEnv === false || $linesEnv === '' ? 0 : (int) $linesEnv;
+
+        if ($lines > 0) {
+            return $lines;
+        }
+
+        $probed = (int) ErrorTrap::run(static fn(): string|false => \exec('tput lines 2>/dev/null'));
+
+        return $probed > 0 ? $probed : 24;
+    }
+}

--- a/tests/Unit/Cli/ApplicationTerminalRowsFallbackTest.php
+++ b/tests/Unit/Cli/ApplicationTerminalRowsFallbackTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Cli;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Cli\Application;
+use Greenlight\Cli\TerminalRowsResolver;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\EnvironmentSandbox;
@@ -25,7 +25,7 @@ final readonly class ApplicationTerminalRowsFallbackTest
         $this->environment->set('PATH', $this->temporaryDirectory->path());
         $this->installTput("31\n");
 
-        $rows = $this->terminalRows();
+        $rows = TerminalRowsResolver::resolve();
 
         Expect::that($rows)
             ->because('the terminal probe MUST set the reporter height when LINES is unavailable')
@@ -38,7 +38,7 @@ final readonly class ApplicationTerminalRowsFallbackTest
         $this->environment->unset('LINES');
         $this->environment->set('PATH', $this->temporaryDirectory->path());
 
-        $rows = $this->terminalRows();
+        $rows = TerminalRowsResolver::resolve();
 
         Expect::that($rows)
             ->because('the reporter MUST use 24 rows when terminal height detection fails')
@@ -53,12 +53,5 @@ final readonly class ApplicationTerminalRowsFallbackTest
         if ($written === false || !\chmod($path, 0o700)) {
             Fail::because('The test could not install its terminal probe.');
         }
-    }
-
-    private function terminalRows(): mixed
-    {
-        $application = new \ReflectionClass(Application::class)->newInstanceWithoutConstructor();
-
-        return new \ReflectionMethod(Application::class, 'terminalRows')->invoke($application);
     }
 }

--- a/tests/Unit/Cli/ApplicationTerminalRowsTest.php
+++ b/tests/Unit/Cli/ApplicationTerminalRowsTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Cli;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Cli\Application;
+use Greenlight\Cli\TerminalRowsResolver;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\EnvironmentSandbox;
 
@@ -18,8 +18,7 @@ final readonly class ApplicationTerminalRowsTest
     {
         $this->environment->set('LINES', '37');
 
-        $application = new \ReflectionClass(Application::class)->newInstanceWithoutConstructor();
-        $rows = new \ReflectionMethod(Application::class, 'terminalRows')->invoke($application);
+        $rows = TerminalRowsResolver::resolve();
 
         Expect::that($rows)
             ->because('a positive LINES value MUST set the reporter terminal height')


### PR DESCRIPTION
## Summary

- Move terminal row detection to an internal resolver.
- Make Application delegate reporter height detection to the resolver.
- Test each policy branch without private reflection.

## Verification

- php bin/greenlight run --filter=ApplicationTerminalRows
- composer static-analysis
- composer tests