### PR TITLE
refactor(cli): extract coverage settings resolver

### DIFF
--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -452,7 +452,7 @@ final readonly class Application
     ): int {
         $workers = $resolved->workers->fixed ?? CpuCores::count();
         $realBin = $binPath === null || !$this->canSpawnWorkers() ? false : \realpath($binPath);
-        $coverageSettings = $this->coverageSettings($resolved->coverage, $workingDirectory);
+        $coverageSettings = CoverageSettingsResolver::resolve($resolved->coverage, $workingDirectory);
         $detectLeaks = $arguments->has('detect-leaks');
 
         $orchestratorCollector = null;
@@ -648,7 +648,7 @@ final readonly class Application
 
         $workers = $resolved->workers->fixed ?? CpuCores::count();
         $realBin = $binPath === null || !$this->canSpawnWorkers() ? false : \realpath($binPath);
-        $coverageSettings = $this->coverageSettings($resolved->coverage, $workingDirectory);
+        $coverageSettings = CoverageSettingsResolver::resolve($resolved->coverage, $workingDirectory);
         $detectLeaks = $arguments->has('detect-leaks');
         $this->warnWhenLeakDetectionIsUnreliable($detectLeaks, $arguments->has('no-ansi'));
 
@@ -707,28 +707,6 @@ final readonly class Application
         }
 
         return $shutdown->exitCode() ?? self::EXIT_OK;
-    }
-
-    private function coverageSettings(?CoverageConfiguration $configuration, string $workingDirectory): ?CoverageSettings
-    {
-        if (!$configuration instanceof CoverageConfiguration) {
-            return null;
-        }
-
-        $include = [];
-
-        foreach ($configuration->includePaths as $path) {
-            $absolute = $this->absolutePath($path, $workingDirectory);
-            $real = \realpath($absolute);
-
-            if ($real !== false) {
-                $include[] = $real;
-            } elseif ($absolute !== '') {
-                $include[] = $absolute;
-            }
-        }
-
-        return new CoverageSettings($include, $configuration->driver);
     }
 
     private function writeCoverage(CoverageConfiguration $configuration, CoverageMap $coverage, string $workingDirectory, Style $style): bool

--- a/src/Cli/CoverageSettingsResolver.php
+++ b/src/Cli/CoverageSettingsResolver.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli;
+
+use Greenlight\Config\CoverageConfiguration;
+use Greenlight\Runner\CoverageSettings;
+
+/** Resolves CLI coverage configuration into runner settings.
+ *
+ * @internal
+ */
+final class CoverageSettingsResolver
+{
+    /** @codeCoverageIgnore */
+    private function __construct() {}
+
+    public static function resolve(?CoverageConfiguration $configuration, string $workingDirectory): ?CoverageSettings
+    {
+        if (!$configuration instanceof CoverageConfiguration) {
+            return null;
+        }
+
+        $include = [];
+
+        foreach ($configuration->includePaths as $path) {
+            $absolute = \str_starts_with($path, '/')
+                ? $path
+                : \rtrim($workingDirectory, '/') . '/' . $path;
+            $real = \realpath($absolute);
+
+            if ($real !== false) {
+                $include[] = $real;
+            } elseif ($absolute !== '') {
+                $include[] = $absolute;
+            }
+        }
+
+        return new CoverageSettings($include, $configuration->driver);
+    }
+}

--- a/tests/Unit/Cli/CoverageMissingIncludePathTest.php
+++ b/tests/Unit/Cli/CoverageMissingIncludePathTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Cli;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Cli\Application;
+use Greenlight\Cli\CoverageSettingsResolver;
 use Greenlight\Config\CoverageConfiguration;
 use Greenlight\Coverage\Driver\DriverSelector;
 use Greenlight\Expect\Expect;
@@ -19,10 +19,8 @@ final class CoverageMissingIncludePathTest
     #[Test]
     public function anUnresolvedIncludePathRemainsRestrictive(): void
     {
-        $application = new \ReflectionClass(Application::class)->newInstanceWithoutConstructor();
         $configuration = new CoverageConfiguration(['future/src'], null, []);
-        $settings = new \ReflectionMethod(Application::class, 'coverageSettings')
-            ->invoke($application, $configuration, '/project');
+        $settings = CoverageSettingsResolver::resolve($configuration, '/project');
 
         if (!$settings instanceof CoverageSettings) {
             Fail::because('Expected coverage configuration to create coverage settings.');


### PR DESCRIPTION
## Summary

- extract coverage include-path normalization into an internal CLI resolver
- delegate both Application run paths to the resolver
- test unresolved relative paths through the callable seam and retain the collector restriction assertion

## Verification

- focused coverage missing-include-path test
- composer static-analysis
- composer tests: 2,439 passed and 1 Xdebug-only test skipped; the host Datadog extension was omitted from the test PHP configuration