### PR TITLE
test(data-rows): assert exact executed IDs

### DIFF
--- a/tests/Acceptance/DataRowRunTest.php
+++ b/tests/Acceptance/DataRowRunTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Acceptance;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\TestFinished;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Support\GreenlightCli;
+use Greenlight\Tests\Support\JsonlEvents;
 use Greenlight\Tests\Support\ProcessResult;
 
 final class DataRowRunTest
@@ -15,19 +17,41 @@ final class DataRowRunTest
     public function inlineRowsRunAndFilterByLabel(): void
     {
         $result = $this->run('--workers=2');
-        Expect::that($result->exitCode)->because('inline rows run and filter by label')->toBe(0)
-            ->and($result->output())->toContain('4 tests, 4 passed')
-            ->toContain('addsUp[small]')
-            ->toContain('addsUp[#1]')
-            ->toContain('acceptsWord[from attribute]')
-            ->toContain('acceptsWord[from provider]');
+        Expect::that($result->exitCode)->because('all inline data rows MUST run')->toBe(0);
+        Expect::that($this->finishedTestIds($result))->because('all inline data rows MUST run')->toBe([
+            'Greenlight\Tests\Fixture\DataRows\InlineRowsTest::acceptsWord[from attribute]',
+            'Greenlight\Tests\Fixture\DataRows\InlineRowsTest::acceptsWord[from provider]',
+            'Greenlight\Tests\Fixture\DataRows\InlineRowsTest::addsUp[#1]',
+            'Greenlight\Tests\Fixture\DataRows\InlineRowsTest::addsUp[small]',
+        ]);
 
         $result = $this->run('--filter=*[from attribute]');
-        Expect::that($result->exitCode)->because('inline rows run and filter by label')->toBe(0)->and($result->output())->toContain('1 test, 1 passed');
+        Expect::that($result->exitCode)->because('the label filter MUST select only its row')->toBe(0);
+        Expect::that($this->finishedTestIds($result))->because('the label filter MUST select only its row')->toBe([
+            'Greenlight\Tests\Fixture\DataRows\InlineRowsTest::acceptsWord[from attribute]',
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function finishedTestIds(ProcessResult $result): array
+    {
+        $testIds = [];
+
+        foreach (JsonlEvents::from($result) as $event) {
+            if ($event instanceof TestFinished) {
+                $testIds[] = (string) $event->result->id;
+            }
+        }
+
+        \sort($testIds);
+
+        return $testIds;
     }
 
     private function run(string ...$flags): ProcessResult
     {
-        return GreenlightCli::run(\dirname(__DIR__) . '/Fixture/DataRows', ['run', '--reporter=plain', ...\array_values($flags)]);
+        return GreenlightCli::run(\dirname(__DIR__) . '/Fixture/DataRows', ['run', '--reporter=jsonl', ...\array_values($flags)]);
     }
 }


### PR DESCRIPTION
## Why

Data-row acceptance coverage used plain reporter summaries and label substrings, so it could not detect missing, duplicate, or unexpected test IDs.

## What changed

- Parse JSONL `TestFinished` events for the full inline-row run and the filtered-label run.
- Assert each exit code and canonicalized exact ID set independently.

## Verification

- `php bin/greenlight run --filter=Greenlight\\Tests\\Acceptance\\DataRowRunTest` (1 passed, 4 expectations)
- `composer static-analysis` (passed)
- `COMPOSER_PROCESS_TIMEOUT=0 composer tests` (2440 tests: 2439 passed, 1 skipped; 5969 expectations)