### PR TITLE
test: use managed doubles fixture for class interception

### DIFF
--- a/tests/Unit/Doubles/ClassMethodInterceptionTest.php
+++ b/tests/Unit/Doubles/ClassMethodInterceptionTest.php
@@ -8,27 +8,21 @@ use Greenlight\Attribute\Test;
 use Greenlight\Doubles\Doubles;
 use Greenlight\Doubles\MockPlan;
 use Greenlight\Expect\Expect;
-use Greenlight\Fixture\TempDirectory;
 use Greenlight\Tests\Fixture\Doubles\Clock;
 
 final readonly class ClassMethodInterceptionTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(private Doubles $doubles) {}
 
     #[Test]
     public function classDoublesInterceptConcreteMethods(): void
     {
-        $doubles = new Doubles($this->tempDirectory->subdirectory('proxies'));
-        $clock = $doubles->mock(Clock::class, static function (MockPlan $plan): void {
+        $clock = $this->doubles->mock(Clock::class, static function (MockPlan $plan): void {
             $plan->expects('now')->once()->andReturns('fixed-time');
         });
 
-        try {
-            Expect::that($clock->now())
-                ->because('a class double MUST use its configured answer for a concrete method')
-                ->toBe('fixed-time');
-        } finally {
-            $doubles->dispose();
-        }
+        Expect::that($clock->now())
+            ->because('a class double MUST use its configured answer for a concrete method')
+            ->toBe('fixed-time');
     }
 }


### PR DESCRIPTION
## Why

The class-method interception test created and disposed a second doubles manager instead of using the managed test fixture.

## What changed

- Use the per-test `Doubles` fixture for the class proxy.
- Remove the temporary-directory dependency and manual disposal.