### PR TITLE
test: manage method case doubles fixture

### DIFF
--- a/tests/Unit/Doubles/MockMethodCaseTest.php
+++ b/tests/Unit/Doubles/MockMethodCaseTest.php
@@ -10,20 +10,19 @@ use Greenlight\Doubles\MockPlan;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\Doubles\Calculator;
 
-final class MockMethodCaseTest
+final readonly class MockMethodCaseTest
 {
+    public function __construct(private Doubles $doubles) {}
+
     #[Test]
     public function expectationMethodNamesFollowPhpCaseInsensitivity(): void
     {
-        $doubles = new Doubles();
-        $calculator = $doubles->mock(Calculator::class, static function (MockPlan $plan): void {
+        $calculator = $this->doubles->mock(Calculator::class, static function (MockPlan $plan): void {
             $plan->expects('ADD')->with(1, 2)->once()->andReturns(3);
         });
 
         Expect::that($calculator->add(1, 2))
             ->because('mock method names MUST follow PHP case-insensitive dispatch')
             ->toBe(3);
-
-        $doubles->dispose();
     }
 }


### PR DESCRIPTION
## Summary
- inject the managed per-test Doubles fixture
- preserve case-insensitive mock method dispatch coverage
- remove manual fixture disposal

## Validation
Not run, as requested.