### PR TITLE
test(doubles): use managed fixture in answers tests

### DIFF
--- a/tests/Unit/Doubles/AnswersTest.php
+++ b/tests/Unit/Doubles/AnswersTest.php
@@ -12,31 +12,29 @@ use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\Doubles\Calculator;
 use Greenlight\Tests\Fixture\Doubles\Wide;
 
-final class AnswersTest
+final readonly class AnswersTest
 {
     private const string CONFLICTING_ANSWER = 'The expectation on add() already has an answer. '
         . 'Configure exactly one of andReturns(), andReturnsSequence(), andReturnsUsing(), or andThrows().';
 
+    public function __construct(private Doubles $doubles) {}
+
     #[Test]
     public function aSequenceReturnsItsValuesInOrder(): void
     {
-        $doubles = new Doubles();
-        $calculator = $doubles->mock(Calculator::class, static function (MockPlan $plan): void {
+        $calculator = $this->doubles->mock(Calculator::class, static function (MockPlan $plan): void {
             $plan->expects('add')->times(3)->andReturnsSequence(1, 2, 3);
         });
 
-        Expect::that($calculator->add(0, 0))->because('a sequence returns its values in order')->toBe(1)
-            ->and($calculator->add(0, 0))->toBe(2)
-            ->and($calculator->add(0, 0))->toBe(3);
-
-        $doubles->dispose();
+        Expect::that($calculator->add(0, 0))->because('a sequence returns its values in order')->toBe(1);
+        Expect::that($calculator->add(0, 0))->toBe(2);
+        Expect::that($calculator->add(0, 0))->toBe(3);
     }
 
     #[Test]
     public function aSequenceCanReturnNull(): void
     {
-        $doubles = new Doubles();
-        $wide = $doubles->mock(Wide::class, static function (MockPlan $plan): void {
+        $wide = $this->doubles->mock(Wide::class, static function (MockPlan $plan): void {
             $plan->expects('nullable')
                 ->times(2)
                 ->andReturnsSequence(null, 'ready');
@@ -44,23 +42,21 @@ final class AnswersTest
 
         Expect::that($wide->nullable('first'))
             ->because('a null sequence element MUST be consumed as a configured return value')
-            ->toBeNull()
-            ->and($wide->nullable('second'))
-            ->toBe('ready');
-
-        $doubles->dispose();
+            ->toBeNull();
+        Expect::that($wide->nullable('second'))->toBe('ready');
     }
 
     #[Test]
     public function aMatchedCallAfterSequenceExhaustionIsAnAuthoringError(): void
     {
-        $doubles = new Doubles();
-        $calculator = $doubles->mock(Calculator::class, static function (MockPlan $plan): void {
+        $calculator = $this->doubles->mock(Calculator::class, static function (MockPlan $plan): void {
             $plan->expects('add')->atLeast(1)->andReturnsSequence(5);
         });
 
-        Expect::that($calculator->add(0, 0))->because('a matched call after sequence exhaustion is an authoring error')->toBe(5)
-            ->and(static fn(): int => $calculator->add(0, 0))
+        Expect::that($calculator->add(0, 0))
+            ->because('a matched call after sequence exhaustion is an authoring error')
+            ->toBe(5);
+        Expect::that(static fn(): int => $calculator->add(0, 0))
             ->toThrow(
                 DoublesError::class,
                 message: 'The return sequence for add() has no value after 1 time. '
@@ -71,9 +67,7 @@ final class AnswersTest
     #[Test]
     public function anEmptySequenceIsRejected(): void
     {
-        $doubles = new Doubles();
-
-        Expect::that(static fn(): mixed => $doubles->mock(Calculator::class, static function (MockPlan $plan): void {
+        Expect::that(fn(): mixed => $this->doubles->mock(Calculator::class, static function (MockPlan $plan): void {
             $plan->expects('add')->andReturnsSequence();
         }))
             ->because('an empty sequence is rejected')
@@ -86,22 +80,17 @@ final class AnswersTest
     #[Test]
     public function andReturnsUsingReceivesTheCallArguments(): void
     {
-        $doubles = new Doubles();
-        $calculator = $doubles->mock(Calculator::class, static function (MockPlan $plan): void {
+        $calculator = $this->doubles->mock(Calculator::class, static function (MockPlan $plan): void {
             $plan->expects('add')->once()->andReturnsUsing(static fn(int $a, int $b): int => $a + $b);
         });
 
         Expect::that($calculator->add(19, 23))->because('andReturnsUsing() receives the call arguments')->toBe(42);
-
-        $doubles->dispose();
     }
 
     #[Test]
     public function aSecondAnswerKindOnOneExpectationIsRejected(): void
     {
-        $doubles = new Doubles();
-
-        Expect::that(static fn(): mixed => $doubles->mock(Calculator::class, static function (MockPlan $plan): void {
+        Expect::that(fn(): mixed => $this->doubles->mock(Calculator::class, static function (MockPlan $plan): void {
             $plan->expects('add')->andReturns(1)->andReturnsSequence(2, 3);
         }))
             ->because('a second answer kind on one expectation is rejected')
@@ -111,9 +100,7 @@ final class AnswersTest
     #[Test]
     public function aCallbackAfterAReturnValueIsRejected(): void
     {
-        $doubles = new Doubles();
-
-        Expect::that(static fn(): mixed => $doubles->mock(Calculator::class, static function (MockPlan $plan): void {
+        Expect::that(fn(): mixed => $this->doubles->mock(Calculator::class, static function (MockPlan $plan): void {
             $plan->expects('add')->andReturns(1)->andReturnsUsing(static fn(): int => 2);
         }))
             ->because('a callback after a return value is rejected')
@@ -123,9 +110,7 @@ final class AnswersTest
     #[Test]
     public function aReturnValueAfterASequenceIsRejected(): void
     {
-        $doubles = new Doubles();
-
-        Expect::that(static fn(): mixed => $doubles->mock(Calculator::class, static function (MockPlan $plan): void {
+        Expect::that(fn(): mixed => $this->doubles->mock(Calculator::class, static function (MockPlan $plan): void {
             $plan->expects('add')->andReturnsSequence(1)->andReturns(2);
         }))
             ->because('a return value after a sequence is rejected')
@@ -135,9 +120,7 @@ final class AnswersTest
     #[Test]
     public function aThrowableAfterAReturnValueIsRejected(): void
     {
-        $doubles = new Doubles();
-
-        Expect::that(static fn(): mixed => $doubles->mock(Calculator::class, static function (MockPlan $plan): void {
+        Expect::that(fn(): mixed => $this->doubles->mock(Calculator::class, static function (MockPlan $plan): void {
             $plan->expects('add')->andReturns(1)->andThrows(new \RuntimeException('boom'));
         }))
             ->because('a throwable after a return value is rejected')
@@ -147,9 +130,7 @@ final class AnswersTest
     #[Test]
     public function aReturnValueAfterAThrowableIsRejected(): void
     {
-        $doubles = new Doubles();
-
-        Expect::that(static fn(): mixed => $doubles->mock(Calculator::class, static function (MockPlan $plan): void {
+        Expect::that(fn(): mixed => $this->doubles->mock(Calculator::class, static function (MockPlan $plan): void {
             $plan->expects('add')->andThrows(new \RuntimeException('boom'))->andReturns(1);
         }))
             ->because('a return value after a throwable is rejected')
@@ -159,14 +140,11 @@ final class AnswersTest
     #[Test]
     public function aSequenceWithTimesStaysConsistent(): void
     {
-        $doubles = new Doubles();
-        $calculator = $doubles->mock(Calculator::class, static function (MockPlan $plan): void {
+        $calculator = $this->doubles->mock(Calculator::class, static function (MockPlan $plan): void {
             $plan->expects('add')->times(2)->andReturnsSequence(10, 20);
         });
 
-        Expect::that($calculator->add(1, 1))->because('a sequence with times stays consistent')->toBe(10)
-            ->and($calculator->add(2, 2))->toBe(20);
-
-        $doubles->dispose();
+        Expect::that($calculator->add(1, 1))->because('a sequence with times stays consistent')->toBe(10);
+        Expect::that($calculator->add(2, 2))->toBe(20);
     }
 }


### PR DESCRIPTION
## Why

The answers tests created unmanaged doubles, so failures before explicit disposal could leave verification state outside the test lifecycle.

## What changed

Inject the per-test `Doubles` fixture and express sequential results as direct expectations while preserving call order.