### PR TITLE
test(doubles): manage argument capture fixture

### DIFF
--- a/tests/Unit/Doubles/ArgumentCaptureTest.php
+++ b/tests/Unit/Doubles/ArgumentCaptureTest.php
@@ -12,31 +12,30 @@ use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Tests\Fixture\Doubles\Wide;
 
-final class ArgumentCaptureTest
+final readonly class ArgumentCaptureTest
 {
+    public function __construct(private Doubles $doubles) {}
+
     #[Test]
     public function captureArgumentIgnoresOmittedOptionalAndVariadicPositions(): void
     {
-        $doubles = new Doubles();
         $optionalCaptor = null;
         $variadicCaptor = null;
-        $wide = $doubles->mock(Wide::class, static function (MockPlan $plan) use (&$optionalCaptor, &$variadicCaptor): void {
+        $wide = $this->doubles->mock(Wide::class, static function (MockPlan $plan) use (&$optionalCaptor, &$variadicCaptor): void {
             $optionalCaptor = $plan->expects('withDefaults')->once()->andReturns('defaults')->captureArgument(1);
             $variadicCaptor = $plan->expects('variadic')->once()->andReturns([])->captureArgument(1);
         });
 
         Expect::that($wide->withDefaults())
             ->because('capture argument ignores omitted optional and variadic positions')
-            ->toBe('defaults')
-            ->and($wide->variadic('head'))->toBe([]);
+            ->toBe('defaults');
+        Expect::that($wide->variadic('head'))->toBe([]);
 
         if (!$optionalCaptor instanceof ArgumentCaptor || !$variadicCaptor instanceof ArgumentCaptor) {
             Fail::because('Expected both captureArgument() calls to return ArgumentCaptor.');
         }
 
-        Expect::that($optionalCaptor->values())->toBe([])
-            ->and($variadicCaptor->values())->toBe([]);
-
-        $doubles->dispose();
+        Expect::that($optionalCaptor->values())->toBe([]);
+        Expect::that($variadicCaptor->values())->toBe([]);
     }
 }


### PR DESCRIPTION
## Why

The argument-capture test should use the runner-managed doubles lifecycle and keep expectations scoped to one subject.

## What changed

- Inject the managed `Doubles` fixture and remove manual disposal.
- Assert mocked calls and captured values directly while preserving their execution order.