### PR TITLE
test: manage ignore scanner temporary directory

### DIFF
--- a/tests/Unit/Coverage/IgnoreScannerTest.php
+++ b/tests/Unit/Coverage/IgnoreScannerTest.php
@@ -9,8 +9,10 @@ use Greenlight\Coverage\Ignore\IgnoreScanner;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
 
-final class IgnoreScannerTest
+final readonly class IgnoreScannerTest
 {
+    public function __construct(private TempDirectory $tempDirectory) {}
+
     #[Test]
     public function unreadableFileYieldsNoIgnoredLines(): void
     {
@@ -349,18 +351,12 @@ final class IgnoreScannerTest
      */
     private function scan(string $source): array
     {
-        $directory = new TempDirectory();
+        $path = $this->tempDirectory->path() . '/fixture.php';
+        \file_put_contents($path, $source);
 
-        try {
-            $path = $directory->path() . '/fixture.php';
-            \file_put_contents($path, $source);
+        $lines = \array_keys(new IgnoreScanner()->ignoredLines($path));
+        \sort($lines);
 
-            $lines = \array_keys(new IgnoreScanner()->ignoredLines($path));
-            \sort($lines);
-
-            return $lines;
-        } finally {
-            $directory->dispose();
-        }
+        return $lines;
     }
 }


### PR DESCRIPTION
## Why

Ignore scanner tests must use the runner-managed temporary-directory lifecycle instead of disposing test resources manually.

## What changed

- Inject the per-test `TempDirectory` fixture into the scanner test.
- Reuse the managed fixture when scanner source files are written.