### PR TITLE
test(config): name watch debounce cases

### DIFF
--- a/tests/Unit/Config/WatchBuilderTest.php
+++ b/tests/Unit/Config/WatchBuilderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Config;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\InvalidConfiguration;
 use Greenlight\Config\WatchBuilder;
@@ -19,27 +20,36 @@ final class WatchBuilderTest
 
         Expect::that($default->debounceMilliseconds)
             ->because('watch mode MUST have a stable default debounce')
-            ->toBe(200)
-            ->and($configured->debounceMilliseconds)
+            ->toBe(200);
+
+        Expect::that($configured->debounceMilliseconds)
             ->because('the configured debounce MUST reach watch mode')
             ->toBe(750);
     }
 
     #[Test]
-    public function theDebounceMustBePositive(): void
+    #[DataSet('nonPositiveDebounces')]
+    public function theDebounceMustBePositive(int $milliseconds): void
     {
-        foreach ([0, -1] as $milliseconds) {
-            Expect::that(static function () use ($milliseconds): void {
-                new WatchBuilder()->debounceMilliseconds($milliseconds);
-            })
-                ->because('the watch debounce must be positive')
-                ->toThrow(
-                    InvalidConfiguration::class,
-                    message: \sprintf(
-                        'The watch debounce must be at least 1 millisecond, got %d.',
-                        $milliseconds,
-                    ),
-                );
-        }
+        Expect::that(static function () use ($milliseconds): void {
+            new WatchBuilder()->debounceMilliseconds($milliseconds);
+        })
+            ->because('the watch debounce must be positive')
+            ->toThrow(
+                InvalidConfiguration::class,
+                message: \sprintf(
+                    'The watch debounce must be at least 1 millisecond, got %d.',
+                    $milliseconds,
+                ),
+            );
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function nonPositiveDebounces(): iterable
+    {
+        yield 'zero' => [0];
+        yield 'negative' => [-1];
     }
 }


### PR DESCRIPTION
## Why

The watch debounce validation test grouped zero and negative values, which made failures less specific.

## What changed

- Use named data-set cases for zero and negative values.
- Use direct expectations for independent debounce values.