### PR TITLE
test(doubles): use managed final-method fixture

### DIFF
--- a/tests/Unit/Doubles/FinalMethodDoubleTest.php
+++ b/tests/Unit/Doubles/FinalMethodDoubleTest.php
@@ -9,24 +9,20 @@ use Greenlight\Doubles\Doubles;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\Doubles\PlanningBoundaries;
 
-final class FinalMethodDoubleTest
+final readonly class FinalMethodDoubleTest
 {
+    public function __construct(private Doubles $doubles) {}
+
     #[Test]
     public function aClassDoubleKeepsItsOriginalFinalMethods(): void
     {
-        $doubles = new Doubles();
+        $double = $this->doubles->stub(PlanningBoundaries::class);
 
-        try {
-            $double = $doubles->stub(PlanningBoundaries::class);
-
-            Expect::that(static function () use ($double): void {
-                $double->finalMethod();
-            })
-                ->because('a class double MUST keep its original final methods')
-                ->not()
-                ->toThrow(\Throwable::class);
-        } finally {
-            $doubles->dispose();
-        }
+        Expect::that(static function () use ($double): void {
+            $double->finalMethod();
+        })
+            ->because('a class double MUST keep its original final methods')
+            ->not()
+            ->toThrow(\Throwable::class);
     }
 }


### PR DESCRIPTION
## Why

The final-method test MUST use the runner-managed doubles fixture so that fixture lifecycle behavior stays consistent with the doubles test suite.

## What changed

- Inject the managed `Doubles` fixture into the test class.
- Remove manual construction and disposal while preserving the final-method behavior assertion.