### PR TITLE
test: manage callback conflict doubles fixture

### DIFF
--- a/tests/Unit/Doubles/CallbackAnswerConflictTest.php
+++ b/tests/Unit/Doubles/CallbackAnswerConflictTest.php
@@ -11,15 +11,15 @@ use Greenlight\Doubles\MockPlan;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\Doubles\Calculator;
 
-final class CallbackAnswerConflictTest
+final readonly class CallbackAnswerConflictTest
 {
+    public function __construct(private Doubles $doubles) {}
+
     #[Test]
     public function aReturnValueAfterACallbackIsRejected(): void
     {
-        $doubles = new Doubles();
-
         Expect::that(
-            static fn(): mixed => $doubles->mock(
+            fn(): mixed => $this->doubles->mock(
                 Calculator::class,
                 static function (MockPlan $plan): void {
                     $plan->expects('add')


### PR DESCRIPTION
## Why

The callback-answer conflict test MUST use Greenlight's managed per-test fixture so the runner disposes of the double after the test.

## What changed

Inject `Doubles` into the test class and use it for the existing callback-answer conflict assertion without changing the diagnostic.