### PR TITLE
test: exercise unavailable attachment types independently

### DIFF
--- a/tests/Unit/Artifact/UnavailableAttachmentsTest.php
+++ b/tests/Unit/Artifact/UnavailableAttachmentsTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Artifact;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Core\Artifact\UnavailableAttachments;
@@ -11,24 +12,42 @@ use Greenlight\Expect\Expect;
 
 final class UnavailableAttachmentsTest
 {
+    /**
+     * @param \Closure(UnavailableAttachments): void $call
+     */
     #[Test]
-    public function everyAttachmentTypeFailsOutsideAnActiveAttempt(): void
+    #[DataSet('attachmentCalls')]
+    public function everyAttachmentTypeFailsOutsideAnActiveAttempt(\Closure $call): void
     {
         $attachments = new UnavailableAttachments();
-        $calls = [
-            'value' => static fn() => $attachments->value('state', ['ready' => true]),
-            'text' => static fn() => $attachments->text('log', 'Ready.'),
-            'bytes' => static fn() => $attachments->bytes('image', "\x89PNG"),
-            'file' => static fn() => $attachments->file('report', '/tmp/report.txt'),
+
+        Expect::that(static fn() => $call($attachments))
+            ->because('attachments are unavailable outside an active attempt')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Attachments are not available outside an active test attempt.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{\Closure(UnavailableAttachments): void}>
+     */
+    public static function attachmentCalls(): iterable
+    {
+        yield 'value' => [
+            static fn(UnavailableAttachments $attachments) => $attachments->value('state', ['ready' => true]),
         ];
 
-        foreach ($calls as $type => $call) {
-            Expect::that($call)
-                ->because(\sprintf('%s attachments are unavailable outside an active attempt', $type))
-                ->toThrow(
-                    AttachmentError::class,
-                    message: 'Attachments are not available outside an active test attempt.',
-                );
-        }
+        yield 'text' => [
+            static fn(UnavailableAttachments $attachments) => $attachments->text('log', 'Ready.'),
+        ];
+
+        yield 'bytes' => [
+            static fn(UnavailableAttachments $attachments) => $attachments->bytes('image', "\x89PNG"),
+        ];
+
+        yield 'file' => [
+            static fn(UnavailableAttachments $attachments) => $attachments->file('report', '/tmp/report.txt'),
+        ];
     }
 }


### PR DESCRIPTION
## Why

The unavailable attachment contract must identify failures for each attachment API independently.

## What changed

- Replace the shared manual loop with named `value`, `text`, `bytes`, and `file` data-set cases.
- Keep one behavioral assertion with the exact `AttachmentError` diagnostic.