### PR TITLE
test(cli): give CI values independent test IDs

### DIFF
--- a/tests/Unit/Cli/TerminalCapabilitiesTest.php
+++ b/tests/Unit/Cli/TerminalCapabilitiesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Cli;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Cli\TerminalCapabilities;
 use Greenlight\Expect\Expect;
@@ -15,8 +16,8 @@ final class TerminalCapabilitiesTest
     {
         $capabilities = TerminalCapabilities::detect(stdoutIsTty: true, env: [], noAnsiFlag: false);
 
-        Expect::that($capabilities->interactive)->because('a plain TTY is interactive with color')->toBeTrue()
-            ->and($capabilities->color)->toBeTrue();
+        Expect::that($capabilities->interactive)->because('a plain TTY is interactive with color')->toBeTrue();
+        Expect::that($capabilities->color)->toBeTrue();
     }
 
     #[Test]
@@ -24,8 +25,8 @@ final class TerminalCapabilitiesTest
     {
         $capabilities = TerminalCapabilities::detect(stdoutIsTty: false, env: [], noAnsiFlag: false);
 
-        Expect::that($capabilities->interactive)->because('non TTY is never interactive')->toBeFalse()
-            ->and($capabilities->color)->toBeFalse();
+        Expect::that($capabilities->interactive)->because('non TTY is never interactive')->toBeFalse();
+        Expect::that($capabilities->color)->toBeFalse();
     }
 
     #[Test]
@@ -33,34 +34,32 @@ final class TerminalCapabilitiesTest
     {
         $capabilities = TerminalCapabilities::detect(stdoutIsTty: true, env: [], noAnsiFlag: true);
 
-        Expect::that($capabilities->interactive)->because('the no ANSI flag forces non interactive')->toBeFalse()
-            ->and($capabilities->color)->toBeFalse();
+        Expect::that($capabilities->interactive)->because('the no ANSI flag forces non interactive')->toBeFalse();
+        Expect::that($capabilities->color)->toBeFalse();
     }
 
     #[Test]
-    public function truthyCiForcesNonInteractiveEvenWithATty(): void
+    #[DataSet('truthyCiValues')]
+    public function truthyCiForcesNonInteractiveEvenWithATty(string $value): void
     {
-        foreach (['true', '1', 'yes'] as $value) {
-            $capabilities = TerminalCapabilities::detect(stdoutIsTty: true, env: ['CI' => $value], noAnsiFlag: false);
+        $capabilities = TerminalCapabilities::detect(stdoutIsTty: true, env: ['CI' => $value], noAnsiFlag: false);
 
-            Expect::that($capabilities->interactive)->toBeFalse()
-                ->and($capabilities->color)->toBeFalse();
-        }
+        Expect::that($capabilities->interactive)->toBeFalse();
+        Expect::that($capabilities->color)->toBeFalse();
     }
 
     #[Test]
-    public function falsyCiValuesDoNotDisableInteractivity(): void
+    #[DataSet('falsyCiValues')]
+    public function falsyCiValuesDoNotDisableInteractivity(string|false $value): void
     {
-        foreach (['', '0', 'false', 'FALSE', false] as $value) {
-            $capabilities = TerminalCapabilities::detect(stdoutIsTty: true, env: ['CI' => $value], noAnsiFlag: false);
+        $capabilities = TerminalCapabilities::detect(stdoutIsTty: true, env: ['CI' => $value], noAnsiFlag: false);
 
-            Expect::that($capabilities->interactive)
-                ->because('a falsey CI value MUST preserve terminal interactivity')
-                ->toBeTrue()
-                ->and($capabilities->color)
-                ->because('a falsey CI value MUST preserve terminal color')
-                ->toBeTrue();
-        }
+        Expect::that($capabilities->interactive)
+            ->because('a falsey CI value MUST preserve terminal interactivity')
+            ->toBeTrue();
+        Expect::that($capabilities->color)
+            ->because('a falsey CI value MUST preserve terminal color')
+            ->toBeTrue();
     }
 
     #[Test]
@@ -68,8 +67,8 @@ final class TerminalCapabilitiesTest
     {
         $capabilities = TerminalCapabilities::detect(stdoutIsTty: true, env: ['NO_COLOR' => '1'], noAnsiFlag: false);
 
-        Expect::that($capabilities->interactive)->because('no color strips color but keeps interactivity')->toBeTrue()
-            ->and($capabilities->color)->toBeFalse();
+        Expect::that($capabilities->interactive)->because('no color strips color but keeps interactivity')->toBeTrue();
+        Expect::that($capabilities->color)->toBeFalse();
     }
 
     #[Test]
@@ -83,9 +82,8 @@ final class TerminalCapabilitiesTest
 
         Expect::that($capabilities->interactive)
             ->because('a zero NO_COLOR value keeps interactivity but disables color')
-            ->toBeTrue()
-            ->and($capabilities->color)
-            ->toBeFalse();
+            ->toBeTrue();
+        Expect::that($capabilities->color)->toBeFalse();
     }
 
     #[Test]
@@ -94,5 +92,27 @@ final class TerminalCapabilitiesTest
         $capabilities = TerminalCapabilities::detect(stdoutIsTty: true, env: ['NO_COLOR' => ''], noAnsiFlag: false);
 
         Expect::that($capabilities->color)->because('an empty no color is ignored')->toBeTrue();
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function truthyCiValues(): iterable
+    {
+        yield 'true string' => ['true'];
+        yield 'one string' => ['1'];
+        yield 'yes string' => ['yes'];
+    }
+
+    /**
+     * @return iterable<string, array{string|false}>
+     */
+    public static function falsyCiValues(): iterable
+    {
+        yield 'empty string' => [''];
+        yield 'zero string' => ['0'];
+        yield 'lowercase false string' => ['false'];
+        yield 'uppercase false string' => ['FALSE'];
+        yield 'boolean false' => [false];
     }
 }


### PR DESCRIPTION
## Why

CI environment values share test IDs, which makes a failure difficult to isolate.

## What changed

- Give each truthy and falsy CI value a named data set.
- Give each capability subject to `Expect::that()` directly.