### PR TITLE
test: strengthen ide helper write error assertion

### DIFF
--- a/tests/Acceptance/CommandErrorsTest.php
+++ b/tests/Acceptance/CommandErrorsTest.php
@@ -141,14 +141,16 @@ final readonly class CommandErrorsTest
         $fixture = \dirname(__DIR__) . '/Fixture/PhpStanExtension';
         $readOnlyDirectory = $this->tempDirectory->subdirectory('ide-helper-read-only');
         \chmod($readOnlyDirectory, 0o555);
+        $outputPath = $readOnlyDirectory . '/helper.php';
 
         try {
             $result = GreenlightCli::run($fixture, [
                 'ide-helper',
-                '--output=' . $readOnlyDirectory . '/helper.php',
+                '--output=' . $outputPath,
             ]);
 
-            Expect::that($result->exitCode)->toBe(1)->and($result->output())->toContain('Greenlight could not write');
+            Expect::that($result->exitCode)->toBe(1);
+            Expect::that($result->output())->toContain(\sprintf('Greenlight could not write "%s":', $outputPath));
         } finally {
             \chmod($readOnlyDirectory, 0o755);
         }


### PR DESCRIPTION
## Why

The IDE helper acceptance test did not verify that a write failure identifies the requested output path.

## What changed

- Assert the exit code and output with separate expectations.
- Match the stable write-error diagnostic prefix, including the requested output path.