### PR TITLE
test: use managed fixture for untyped return

### DIFF
--- a/tests/Unit/Doubles/UntypedReturnTest.php
+++ b/tests/Unit/Doubles/UntypedReturnTest.php
@@ -10,13 +10,14 @@ use Greenlight\Doubles\MockPlan;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\Doubles\UntypedAction;
 
-final class UntypedReturnTest
+final readonly class UntypedReturnTest
 {
+    public function __construct(private Doubles $doubles) {}
+
     #[Test]
     public function aPlannedUntypedMethodNeedsNoConfiguredReturnValue(): void
     {
-        $doubles = new Doubles();
-        $action = $doubles->mock(
+        $action = $this->doubles->mock(
             UntypedAction::class,
             static function (MockPlan $plan): void {
                 $plan
@@ -31,7 +32,5 @@ final class UntypedReturnTest
         Expect::that($result)
             ->because('an untyped collaborator method can complete without a configured value')
             ->toBeNull();
-
-        $doubles->dispose();
     }
 }


### PR DESCRIPTION
## Why

The untyped return test must use the managed per-test Doubles fixture so that the harness owns fixture disposal.

## What changed

- Inject the managed `Doubles` fixture into the test class.
- Preserve the planned `once()` call and null-return contract.