### PR TITLE
test: give attribute contracts independent IDs

### DIFF
--- a/tests/Unit/Attribute/AttributesTest.php
+++ b/tests/Unit/Attribute/AttributesTest.php
@@ -6,6 +6,7 @@ namespace Greenlight\Tests\Unit\Attribute;
 
 use Greenlight\Attribute\After;
 use Greenlight\Attribute\Before;
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 
@@ -25,17 +26,29 @@ final class AttributesTest
         Expect::that($this->beforeRan)->because('before hook runs before tests')->toBeTrue();
     }
 
+    /**
+     * @param class-string<Test|Before|After> $attributeClass
+     */
     #[Test]
-    public function attributesTargetMethods(): void
+    #[DataSet('methodAttributes')]
+    public function attributesTargetMethods(string $attributeClass): void
     {
-        foreach ([Test::class, Before::class, After::class] as $attributeClass) {
-            $attributes = new \ReflectionClass($attributeClass)->getAttributes(\Attribute::class);
+        $attributes = new \ReflectionClass($attributeClass)->getAttributes(\Attribute::class);
 
-            Expect::that($attributes)->toHaveCount(1);
+        Expect::that($attributes)->toHaveCount(1);
 
-            $flags = $attributes[0]->newInstance()->flags;
+        $flags = $attributes[0]->newInstance()->flags;
 
-            Expect::that($flags)->toBe(\Attribute::TARGET_METHOD);
-        }
+        Expect::that($flags)->toBe(\Attribute::TARGET_METHOD);
+    }
+
+    /**
+     * @return iterable<string, array{class-string<Test|Before|After>}>
+     */
+    public static function methodAttributes(): iterable
+    {
+        yield 'Test' => [Test::class];
+        yield 'Before' => [Before::class];
+        yield 'After' => [After::class];
     }
 }


### PR DESCRIPTION
## Why

The method-target contracts for Test, Before, and After need independent test IDs so failures identify the affected attribute.

## What changed

- Replace the shared loop with a named data set for Test, Before, and After.
- Keep the before-hook coverage and exact target-method assertion.