### PR TITLE
test: identify repeat watch incompatibilities

### DIFF
--- a/tests/Acceptance/RepeatTest.php
+++ b/tests/Acceptance/RepeatTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Acceptance;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -20,8 +21,10 @@ final readonly class RepeatTest
     {
         $project = $this->writeProject(passing: true);
         $result = $this->run($project, [], '--repeat=3');
-        Expect::that($result->exitCode)->because('repeat runs the plan the requested number of times')->toBe(0)
-            ->and($result->output())->toContain('Repeat: iteration 1 of 3')
+        Expect::that($result->exitCode)->because('repeat runs the plan the requested number of times')->toBe(0);
+        Expect::that($result->output())
+            ->because('repeat runs the plan the requested number of times')
+            ->toContain('Repeat: iteration 1 of 3')
             ->toContain('Repeat: iteration 2 of 3')
             ->toContain('Repeat: iteration 3 of 3')
             ->toContain('Repeat: 3 iterations, all passed');
@@ -32,8 +35,10 @@ final readonly class RepeatTest
     {
         $project = $this->writeProject(passing: false);
         $result = $this->run($project, [], '--repeat=2');
-        Expect::that($result->exitCode)->because('repeat reports every failing iteration')->toBe(1)
-            ->and($result->output())->toContain('Repeat: iteration 2 of 2')
+        Expect::that($result->exitCode)->because('repeat reports every failing iteration')->toBe(1);
+        Expect::that($result->output())
+            ->because('repeat reports every failing iteration')
+            ->toContain('Repeat: iteration 2 of 2')
             ->toContain('Repeat: failed iterations: 1, 2');
     }
 
@@ -43,8 +48,10 @@ final readonly class RepeatTest
         $project = $this->writeFlakyProject();
         $state = $project->path('repeat-state');
         $result = $this->run($project, ['GREENLIGHT_REPEAT_STATE' => $state], '--repeat-until-failure');
-        Expect::that($result->exitCode)->because('repeat until failure stops at the first failing iteration')->toBe(1)
-            ->and($result->output())->toContain('Repeat: iteration 3 of at most 100')
+        Expect::that($result->exitCode)->because('repeat until failure stops at the first failing iteration')->toBe(1);
+        Expect::that($result->output())
+            ->because('repeat until failure stops at the first failing iteration')
+            ->toContain('Repeat: iteration 3 of at most 100')
             ->toContain('Repeat: failed iterations: 3')
             ->not()->toContain('Repeat: iteration 4');
     }
@@ -59,8 +66,10 @@ final readonly class RepeatTest
         // The recorded state MUST keep the intermittent failure after earlier
         // iterations pass. Thus, --failed runs only that test again.
         $result = $this->run($project, ['GREENLIGHT_REPEAT_STATE' => $state], '--failed');
-        Expect::that($result->exitCode)->because('failed reruns every test that flaked during repeat')->toBe(1)
-            ->and($result->output())->toContain('failsOnTheThirdRun')
+        Expect::that($result->exitCode)->because('failed reruns every test that flaked during repeat')->toBe(1);
+        Expect::that($result->output())
+            ->because('failed reruns every test that flaked during repeat')
+            ->toContain('failsOnTheThirdRun')
             ->toContain('1 test');
     }
 
@@ -69,19 +78,29 @@ final readonly class RepeatTest
     {
         $project = $this->writeProject(passing: true);
         $result = $this->run($project, [], '--repeat=2', '--filter=firstProbe');
-        Expect::that($result->exitCode)->because('repeat composes with filter')->toBe(0)
-            ->and($result->output())->toContain('Repeat: 2 iterations, all passed')
-            ->and(\substr_count($result->output(), '1 test, 1 passed'))->toBe(2);
+        Expect::that($result->exitCode)->because('repeat composes with filter')->toBe(0);
+        Expect::that($result->output())->because('repeat composes with filter')->toContain('Repeat: 2 iterations, all passed');
+        Expect::that(\substr_count($result->output(), '1 test, 1 passed'))->because('repeat composes with filter')->toBe(2);
     }
 
     #[Test]
-    public function watchCannotBeCombinedWithRepeat(): void
+    #[DataSet('repeatOptions')]
+    public function watchCannotBeCombinedWithRepeat(string $repeatOption): void
     {
         $project = $this->writeProject(passing: true);
-        $result = $this->run($project, [], '--watch', '--repeat=2');
-        Expect::that($result->exitCode)->because('watch cannot be combined with repeat')->toBe(64)->and($result->output())->toContain('Do not use --watch with');
-        $result = $this->run($project, [], '--watch', '--repeat-until-failure');
-        Expect::that($result->exitCode)->because('watch cannot be combined with repeat')->toBe(64)->and($result->output())->toContain('Do not use --watch with');
+        $result = $this->run($project, [], '--watch', $repeatOption);
+
+        Expect::that($result->exitCode)->because('watch cannot be combined with repeat')->toBe(64);
+        Expect::that($result->output())->because('watch cannot be combined with repeat')->toContain('Do not use --watch with');
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function repeatOptions(): iterable
+    {
+        yield 'fixed repeat count' => ['--repeat=2'];
+        yield 'repeat until failure' => ['--repeat-until-failure'];
     }
 
     /**


### PR DESCRIPTION
## Why

Watch and repeat incompatibility coverage used one test identity, which obscured case-specific failures.

## What changed

- Give fixed-count and until-failure repeat options named data-set identities.
- Use direct expectations for each result subject and retain every output assertion.
- Verify `php bin/greenlight run --filter=RepeatTest`: 7 tests, 7 passed, 23 expectations.