### PR TITLE
test(expect): assert object depth rendering

### DIFF
--- a/tests/Unit/Expect/ValueRendererTest.php
+++ b/tests/Unit/Expect/ValueRendererTest.php
@@ -130,7 +130,12 @@ final class ValueRendererTest
     {
         $inner = new Holder(new Holder(new Holder(new Holder(null))));
 
-        Expect::that(new ValueRenderer()->render($inner))->because('limits object nesting depth')->toContain('{...}');
+        Expect::that(new ValueRenderer()->render($inner))->because('limits object nesting depth')->toBe(
+            Holder::class . ' {inner: '
+            . Holder::class . ' {inner: '
+            . Holder::class . ' {inner: '
+            . Holder::class . ' {...}}}}',
+        );
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- Assert the complete nested `Holder` output at the object-depth limit.
- Detect root truncation and an incorrect object depth.

## Verification

- `php bin/greenlight run --filter=limitsObjectNestingDepth`
- `composer static-analysis`
- `composer tests`