### PR TITLE
test(coverage): give invalid imports independent test IDs

### DIFF
--- a/tests/Unit/Coverage/JsonExporterTest.php
+++ b/tests/Unit/Coverage/JsonExporterTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Coverage;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Coverage\CoverageError;
 use Greenlight\Coverage\CoverageMap;
@@ -78,41 +79,46 @@ final class JsonExporterTest
     }
 
     #[Test]
-    public function importRejectsMalformedDocuments(): void
+    #[DataSet('invalidDocuments')]
+    public function importReportsEachInvalidDocumentExactly(string $json, string $message): void
     {
-        Expect::that(static fn(): CoverageMap => JsonExporter::import('not json'))->because('import rejects malformed documents')
-            ->toThrow(CoverageError::class)
-            ->and(static fn(): CoverageMap => JsonExporter::import('{"v":2,"files":{}}'))
-            ->toThrow(CoverageError::class, '/schema version/');
+        Expect::that(static fn(): CoverageMap => JsonExporter::import($json))
+            ->because('each invalid coverage JSON document MUST give its exact diagnostic')
+            ->toThrow(CoverageError::class, message: $message);
     }
 
-    #[Test]
-    public function importReportsEachInvalidDocumentShapeExactly(): void
+    /**
+     * @return iterable<string, array{non-empty-string, non-empty-string}>
+     */
+    public static function invalidDocuments(): iterable
     {
-        Expect::that(static fn(): CoverageMap => JsonExporter::import('"invalid"'))
-            ->toThrow(
-                CoverageError::class,
-                message: 'Coverage JSON document is invalid: use an object at the top level.',
-            )
-            ->and(static fn(): CoverageMap => JsonExporter::import('{"v":1,"files":"invalid"}'))
-            ->toThrow(
-                CoverageError::class,
-                message: 'Coverage JSON document is invalid: use an object for "files".',
-            )
-            ->and(static fn(): CoverageMap => JsonExporter::import('{"v":1,"files":{"":{}}}'))
-            ->toThrow(
-                CoverageError::class,
-                message: 'Coverage JSON document is invalid: map each file path in "files" to an object.',
-            )
-            ->and(static fn(): CoverageMap => JsonExporter::import('{"v":1,"files":{"/a.php":{"covered":{"line":1},"uncovered":[]}}}'))
-            ->toThrow(
-                CoverageError::class,
-                message: 'Coverage JSON document is invalid: use a list of line numbers for "covered" in file "/a.php".',
-            )
-            ->and(static fn(): CoverageMap => JsonExporter::import('{"v":1,"files":{"/a.php":{"covered":[0],"uncovered":[]}}}'))
-            ->toThrow(
-                CoverageError::class,
-                message: 'Coverage JSON document is invalid: use only positive integers in "covered" for file "/a.php".',
-            );
+        yield 'malformed JSON' => [
+            'not json',
+            'Coverage JSON document is invalid: Syntax error',
+        ];
+        yield 'unsupported schema version' => [
+            '{"v":2,"files":{}}',
+            'Coverage JSON document is invalid: unsupported or missing schema version, expected 1.',
+        ];
+        yield 'top level is not an object' => [
+            '"invalid"',
+            'Coverage JSON document is invalid: use an object at the top level.',
+        ];
+        yield 'files is not an object' => [
+            '{"v":1,"files":"invalid"}',
+            'Coverage JSON document is invalid: use an object for "files".',
+        ];
+        yield 'file path is empty' => [
+            '{"v":1,"files":{"":{}}}',
+            'Coverage JSON document is invalid: map each file path in "files" to an object.',
+        ];
+        yield 'covered lines are not a list' => [
+            '{"v":1,"files":{"/a.php":{"covered":{"line":1},"uncovered":[]}}}',
+            'Coverage JSON document is invalid: use a list of line numbers for "covered" in file "/a.php".',
+        ];
+        yield 'covered line is not a positive integer' => [
+            '{"v":1,"files":{"/a.php":{"covered":[0],"uncovered":[]}}}',
+            'Coverage JSON document is invalid: use only positive integers in "covered" for file "/a.php".',
+        ];
     }
 }


### PR DESCRIPTION
Summary:
- Replaces chained invalid-import assertions with labeled data-set rows.
- Pins the full malformed-JSON diagnostic and each invalid-document diagnostic.

Verification:
- php bin/greenlight run --filter=JsonExporterTest::importReportsEachInvalidDocumentExactly
- composer static-analysis && composer tests (2,498 passed, 1 skipped)