### PR TITLE
test(plugin): strengthen quarantine provenance assertions

### DIFF
--- a/tests/Unit/Plugin/PluginTest.php
+++ b/tests/Unit/Plugin/PluginTest.php
@@ -77,8 +77,10 @@ final class PluginTest
         $quarantined = $byMethod['flakyAndQuarantined'];
 
         Expect::that($quarantined->outcome)->because('quarantine plugin transforms failures with provenance')->toBe(Outcome::Skipped)
+            ->and($quarantined->transformations)->toHaveCount(1)
             ->and($quarantined->transformations[0]->transformedBy)->toBe(QuarantinePlugin::class)
             ->and($quarantined->transformations[0]->from)->toBe(Outcome::Errored)
+            ->and($quarantined->transformations[0]->to)->toBe(Outcome::Skipped)
             ->and($byMethod['passes']->outcome)->toBe(Outcome::Passed);
     }
 


### PR DESCRIPTION
## Summary

- require exactly one quarantine outcome transformation
- verify that the transformation target is skipped

## Verification

- php bin/greenlight run --filter=quarantinePluginTransformsFailuresWithProvenance
- composer static-analysis
- composer tests