### PR TITLE
feat(phpstan): validate callsTo method names

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -132,7 +132,7 @@ deptrac:
     Reporting: [Core]
     Runner: [Core, Attribute, Config, Discovery, Expect, Capture, Harness, Doubles, Fixture, Coverage, Plugin, Reporting, CpuCoreCounter]
     Cli: [Core, Config, Coverage, Discovery, Reporting, Runner, PhpStan]
-    PhpStan: [Core, Attribute, Config, Expect, PhpStanFramework, PhpParserFramework]
+    PhpStan: [Core, Attribute, Config, Doubles, Expect, PhpStanFramework, PhpParserFramework]
     Rector: [Core, Attribute, Condition, Expect, PhpParserFramework, RectorFramework]
     Symfony: [Core, Harness, Plugin, SymfonyFramework]
     Laravel: [Core, Harness, Plugin, LaravelFramework]

--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -22,6 +22,23 @@ parameters:
 Use `configFiles` only for custom matcher checks. The data-provider and native
 matcher rules work without it.
 
+## Double checks
+
+The extension checks a constant method name in `Doubles::callsTo()` against the
+doubled type:
+
+```php
+$events = $doubles->spy(EventPublisher::class);
+
+$doubles->callsTo($events, 'publish'); // checked against EventPublisher
+$doubles->callsTo($events, 'publsih'); // fails analysis: unknown method
+```
+
+PHP method names are not case-sensitive. Thus, the check accepts a method name
+with different letter case. Greenlight checks a dynamic method name at run time.
+
+Method errors use the `greenlight.doubles.callsToMethod` identifier.
+
 ## Attribute argument checks
 
 The extension reports constant attribute arguments that Greenlight cannot use:

--- a/extension.neon
+++ b/extension.neon
@@ -10,6 +10,7 @@ parameters:
 rules:
     - Greenlight\PhpStan\AttributeArgumentRule
     - Greenlight\PhpStan\DataProviderSignatureRule
+    - Greenlight\PhpStan\DoublesCallRule
     - Greenlight\PhpStan\ExpectationArgumentRule
     - Greenlight\PhpStan\LifecycleMethodRule
     - Greenlight\PhpStan\NativeMatcherSubjectRule

--- a/src/PhpStan/DoublesCallRule.php
+++ b/src/PhpStan/DoublesCallRule.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\PhpStan;
+
+use Greenlight\Doubles\Doubles;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\VerbosityLevel;
+
+/**
+ * Checks constant `callsTo()` method names against the doubled type.
+ *
+ * @internal
+ *
+ * @implements Rule<MethodCall>
+ */
+final readonly class DoublesCallRule implements Rule
+{
+    #[\Override]
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    #[\Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Identifier || $node->name->toString() !== 'callsTo') {
+            return [];
+        }
+
+        $receiver = $scope->getType($node->var);
+
+        if (!new ObjectType(Doubles::class)->isSuperTypeOf($receiver)->yes()) {
+            return [];
+        }
+
+        $double = $this->argument($node, 'double', 0);
+        $method = $this->argument($node, 'method', 1);
+
+        if (!$double instanceof Arg || !$method instanceof Arg) {
+            return [];
+        }
+
+        $doubleType = $scope->getType($double->value);
+
+        if (!$doubleType->isObject()->yes()) {
+            return [];
+        }
+
+        $classes = $doubleType->getObjectClassReflections();
+
+        if (\count($classes) !== 1) {
+            return [];
+        }
+
+        $errors = [];
+
+        foreach ($scope->getType($method->value)->getConstantStrings() as $methodName) {
+            $name = $methodName->getValue();
+
+            if ($classes[0]->hasNativeMethod($name)) {
+                continue;
+            }
+
+            $errors[] = $this->error(
+                $name,
+                $doubleType->describe(VerbosityLevel::typeOnly()),
+                $node->getStartLine(),
+            );
+        }
+
+        return $errors;
+    }
+
+    private function argument(MethodCall $call, string $name, int $position): ?Arg
+    {
+        $nextPosition = 0;
+
+        foreach ($call->getArgs() as $argument) {
+            if ($argument->unpack) {
+                continue;
+            }
+
+            if ($argument->name instanceof Identifier) {
+                if ($argument->name->toString() === $name) {
+                    return $argument;
+                }
+
+                continue;
+            }
+
+            if ($nextPosition === $position) {
+                return $argument;
+            }
+
+            ++$nextPosition;
+        }
+
+        return null;
+    }
+
+    private function error(string $method, string $type, int $line): IdentifierRuleError
+    {
+        return RuleErrorBuilder::message(\sprintf(
+            'callsTo() cannot inspect "%s()" on doubled type "%s" because the method does not exist.',
+            $method,
+            $type,
+        ))
+            ->identifier('greenlight.doubles.callsToMethod')
+            ->line($line)
+            ->build();
+    }
+}

--- a/tests/Acceptance/PhpStanDoublesCallRuleTest.php
+++ b/tests/Acceptance/PhpStanDoublesCallRuleTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\PhpStanProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class PhpStanDoublesCallRuleTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function callsToRequiresAMethodOnTheDoubledType(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Doubles\Doubles;
+
+            interface GoodSpyNotifier
+            {
+                public function notify(string $message): void;
+            }
+
+            function greenlightGoodSpyCallProbe(Doubles $doubles, string $dynamicMethod): void
+            {
+                $spy = $doubles->spy(GoodSpyNotifier::class);
+
+                $doubles->callsTo($spy, 'notify');
+                $doubles->callsTo(method: 'NOTIFY', double: $spy);
+                $doubles->callsTo($spy, $dynamicMethod);
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Doubles\Doubles;
+
+            interface BadSpyNotifier
+            {
+                public function notify(string $message): void;
+            }
+
+            function greenlightBadSpyCallProbe(Doubles $doubles): void
+            {
+                $spy = $doubles->spy(BadSpyNotifier::class);
+
+                $doubles->callsTo($spy, 'notifiy');
+                $doubles->callsTo(method: 'flush', double: $spy);
+            }
+            PHP,
+        );
+
+        Expect::that($probe->exitCode)
+            ->because('PHPStan rejects method names that the doubled type does not contain')
+            ->toBe(1)
+            ->and($probe->goodPassed)->toBeTrue()
+            ->and(\count($probe->errors))->toBe(2)
+            ->and($probe->messages())
+            ->toContain('callsTo() cannot inspect "notifiy()" on doubled type "BadSpyNotifier"')
+            ->and($probe->messages())
+            ->toContain('callsTo() cannot inspect "flush()" on doubled type "BadSpyNotifier"');
+    }
+}

--- a/tests/Unit/Doubles/SpyMethodValidationTest.php
+++ b/tests/Unit/Doubles/SpyMethodValidationTest.php
@@ -18,7 +18,7 @@ final class SpyMethodValidationTest
         $doubles = new Doubles();
         $spy = $doubles->spy(Notifier::class);
 
-        Expect::that(static fn(): array => $doubles->callsTo($spy, 'notifiy'))
+        Expect::that(static fn(): array => $doubles->callsTo($spy, 'notifiy')) // @phpstan-ignore greenlight.doubles.callsToMethod (deliberately invalid: tests runtime validation)
             ->because('a misspelled method MUST NOT look like an uncalled method')
             ->toThrow(
                 DoublesError::class,

--- a/tests/Unit/Doubles/SpyTest.php
+++ b/tests/Unit/Doubles/SpyTest.php
@@ -65,7 +65,7 @@ final readonly class SpyTest
     {
         $foreign = new \stdClass();
 
-        Expect::that(fn(): array => $this->doubles->callsTo($foreign, 'add'))->because('calls to rejects foreign objects')
+        Expect::that(fn(): array => $this->doubles->callsTo($foreign, 'add'))->because('calls to rejects foreign objects') // @phpstan-ignore greenlight.doubles.callsToMethod (deliberately invalid: tests runtime validation)
             ->toThrow(
                 DoublesError::class,
                 message: 'This Doubles factory did not create the stdClass instance.',


### PR DESCRIPTION
## Summary

- check constant callsTo() method names against the doubled type
- support named arguments and PHP method-name case insensitivity
- document the rule and cover it through a real PHPStan acceptance probe