### PR TITLE
refactor(expect): remove subject-changing and()

### DIFF
--- a/docs/api-expectations.md
+++ b/docs/api-expectations.md
@@ -201,23 +201,6 @@ PHPDoc:
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L120)
 
-### `and()`
-
-Sets a new subject for the chain. The chain does not apply `not()` and
-`because()` modifiers to the new subject.
-
-```php
-public function and(mixed $value): self
-```
-
-PHPDoc:
-
-- `@template TNext`
-- `@param TNext $value`
-- `@return self<TNext>`
-
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L143)
-
 ### `toBe()`
 
 Passes when the subject and expected value are identical (===).
@@ -231,7 +214,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L155)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L140)
 
 ### `toEqual()`
 
@@ -247,7 +230,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L172)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L157)
 
 ### `toEqualCanonicalizing()`
 
@@ -263,7 +246,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L189)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L174)
 
 ### `toBeOneOf()`
 
@@ -278,7 +261,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L205)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L190)
 
 ### `toBeIn()`
 
@@ -296,7 +279,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L225)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L210)
 
 ### `toBeInstanceOf()`
 
@@ -310,7 +293,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L243)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L228)
 
 ### `toBeTrue()`
 
@@ -323,7 +306,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L257)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L242)
 
 ### `toBeFalse()`
 
@@ -336,7 +319,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L267)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L252)
 
 ### `toBeNull()`
 
@@ -349,7 +332,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L277)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L262)
 
 ### `toBeArray()`
 
@@ -362,7 +345,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L287)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L272)
 
 ### `toBeString()`
 
@@ -375,7 +358,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L302)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L287)
 
 ### `toBeInt()`
 
@@ -388,7 +371,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L317)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L302)
 
 ### `toBeFloat()`
 
@@ -401,7 +384,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L332)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L317)
 
 ### `toBeBool()`
 
@@ -414,7 +397,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L347)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L332)
 
 ### `toBeCallable()`
 
@@ -427,7 +410,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L362)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L347)
 
 ### `toBeIterable()`
 
@@ -440,7 +423,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L377)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L362)
 
 ### `toContain()`
 
@@ -457,7 +440,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L396)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L381)
 
 ### `toHaveCount()`
 
@@ -473,7 +456,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L445)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L430)
 
 ### `toBeEmpty()`
 
@@ -490,7 +473,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L475)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L460)
 
 ### `toHaveLength()`
 
@@ -507,7 +490,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L502)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L487)
 
 ### `toHaveKey()`
 
@@ -524,7 +507,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L533)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L518)
 
 ### `toContainSubset()`
 
@@ -543,7 +526,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L565)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L550)
 
 ### `toBeGreaterThan()`
 
@@ -556,7 +539,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L595)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L580)
 
 ### `toBeGreaterThanOrEqual()`
 
@@ -569,7 +552,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L609)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L594)
 
 ### `toBeLessThan()`
 
@@ -582,7 +565,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L623)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L608)
 
 ### `toBeLessThanOrEqual()`
 
@@ -595,7 +578,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L637)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L622)
 
 ### `toBeWithin()`
 
@@ -611,7 +594,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L654)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L639)
 
 ### `toMatch()`
 
@@ -625,7 +608,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L677)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L662)
 
 ### `toStartWith()`
 
@@ -638,7 +621,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L693)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L678)
 
 ### `toEndWith()`
 
@@ -651,7 +634,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L707)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L692)
 
 ### `toBeJson()`
 
@@ -667,7 +650,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L724)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L709)
 
 ### `toMatchJson()`
 
@@ -685,7 +668,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L743)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L728)
 
 ### `toThrow()`
 
@@ -708,7 +691,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L789)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L774)
 
 ## `ExpectationExtension`
 

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -15,18 +15,22 @@ them.
 
 ## Matcher chains
 
-`and()` starts a new chain from another value:
+Matchers in a chain use the same subject:
 
 ```php
-Expect::that($response->status())->toBe(200)
-    ->and($response->body())->toMatchJson('{"accepted":true}');
+Expect::that($response->body())
+    ->toBeString()
+    ->toMatchJson('{"accepted":true}');
 ```
+
+Start a separate expectation for each subject.
 
 `not()` negates the next matcher only:
 
 ```php
-Expect::that($result)->not()->toBeNull()
-    ->and($errors)->toBeEmpty();
+Expect::that($errors)
+    ->not()->toBeEmpty()
+    ->toHaveCount(1);
 ```
 
 `because()` adds a reason to the next matcher only:

--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -101,7 +101,7 @@ Expect::that(123)->toBeValidUuid();      // fails analysis: expects a string sub
 ```
 
 The first closure parameter declares the accepted subject type. PHPStan gets
-this type from `that()`, `and()`, and temporal probes.
+this type from `that()` and temporal probes.
 
 Each custom matcher returns the same typed chain. Thus, later custom matchers
 receive the same subject type.

--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -131,21 +131,6 @@ final class Expectation
     }
 
     /**
-     * Sets a new subject for the chain. The chain does not apply `not()` and
-     * `because()` modifiers to the new subject.
-     *
-     * @template TNext
-     *
-     * @param TNext $value
-     *
-     * @return self<TNext>
-     */
-    public function and(mixed $value): self
-    {
-        return new self($value, $this->renderer, $this->extensions);
-    }
-
-    /**
      * Passes when the subject and expected value are identical (===).
      *
      * @return self<T>

--- a/tests/Acceptance/AttachmentMediaTypeTest.php
+++ b/tests/Acceptance/AttachmentMediaTypeTest.php
@@ -83,13 +83,13 @@ final readonly class AttachmentMediaTypeTest
 
         Expect::that($result->exitCode)
             ->because('file attachments work without the optional fileinfo function')
-            ->toBe(0)
-            ->and($finished)
+            ->toBe(0);
+        Expect::that($finished)
             ->not()
-            ->toBeNull()
-            ->and($finished?->attachments)
-            ->toHaveCount(1)
-            ->and($finished?->attachments[0]->mediaType)
+            ->toBeNull();
+        Expect::that($finished?->attachments)
+            ->toHaveCount(1);
+        Expect::that($finished?->attachments[0]->mediaType)
             ->toBe('application/octet-stream');
     }
 }

--- a/tests/Acceptance/BailRunTest.php
+++ b/tests/Acceptance/BailRunTest.php
@@ -20,8 +20,8 @@ final readonly class BailRunTest
     {
         $project = $this->writeProject();
         $result = $this->run($project, '--bail');
-        Expect::that($result->exitCode)->because('bail with no value stops after one failure')->toBe(1)
-            ->and($result->output())->toContain('6 tests, 1 worker')
+        Expect::that($result->exitCode)->because('bail with no value stops after one failure')->toBe(1);
+        Expect::that($result->output())->toContain('6 tests, 1 worker')
             ->toContain('1 test, 0 passed, 1 errored')
             ->not()->toContain('BProbe')
             ->not()->toContain('CProbe');
@@ -34,8 +34,8 @@ final readonly class BailRunTest
         $result = $this->run($project, '--bail=2');
         // Class A causes both counted failures. Thus, later classes do not
         // start.
-        Expect::that($result->exitCode)->because('bail with an explicit count stops after that many failures')->toBe(1)
-            ->and($result->output())->toContain('6 tests, 1 worker')
+        Expect::that($result->exitCode)->because('bail with an explicit count stops after that many failures')->toBe(1);
+        Expect::that($result->output())->toContain('6 tests, 1 worker')
             ->toContain('2 tests, 0 passed, 2 errored')
             ->not()->toContain('BProbe')
             ->not()->toContain('CProbe');
@@ -46,8 +46,8 @@ final readonly class BailRunTest
     {
         $project = $this->writeProject();
         $result = $this->run($project);
-        Expect::that($result->exitCode)->because('without bail the whole plan runs')->toBe(1)
-            ->and($result->output())->toContain('6 tests, 3 passed, 3 errored');
+        Expect::that($result->exitCode)->because('without bail the whole plan runs')->toBe(1);
+        Expect::that($result->output())->toContain('6 tests, 3 passed, 3 errored');
     }
 
     private function run(AcceptanceProject $project, string ...$flags): ProcessResult

--- a/tests/Acceptance/ChannelTest.php
+++ b/tests/Acceptance/ChannelTest.php
@@ -25,9 +25,9 @@ final readonly class ChannelTest
         $result = GreenlightCli::run($project->directory, ['run', '--workers=2', '--reporter=jsonl']);
         $events = JsonlEvents::from($result);
         $channels = $this->reportedChannels($events);
-        Expect::that($result->exitCode)->because('two workers occupy channels one and two')->toBe(0)
-            ->and(\count($channels))->toBe(4)
-            ->and(\array_values(\array_unique($channels)))->toBe([1, 2]);
+        Expect::that($result->exitCode)->because('two workers occupy channels one and two')->toBe(0);
+        Expect::that(\count($channels))->toBe(4);
+        Expect::that(\array_values(\array_unique($channels)))->toBe([1, 2]);
     }
 
     #[Test]
@@ -37,9 +37,9 @@ final readonly class ChannelTest
         $result = GreenlightCli::run($project->directory, ['run', '--workers=1', '--reporter=jsonl']);
         $events = JsonlEvents::from($result);
         $channels = $this->reportedChannels($events);
-        Expect::that($result->exitCode)->because('the in process runner is channel one')->toBe(0)
-            ->and(\count($channels))->toBe(4)
-            ->and(\array_values(\array_unique($channels)))->toBe([1]);
+        Expect::that($result->exitCode)->because('the in process runner is channel one')->toBe(0);
+        Expect::that(\count($channels))->toBe(4);
+        Expect::that(\array_values(\array_unique($channels)))->toBe([1]);
     }
 
     #[Test]
@@ -51,10 +51,10 @@ final readonly class ChannelTest
         $result = GreenlightCli::run($project->directory, ['run', '--reporter=jsonl']);
         $events = JsonlEvents::from($result);
         $channels = $this->reportedChannels($events);
-        Expect::that($result->exitCode)->because('recycled workers reuse freed channels')->toBe(0)
-            ->and(\count($this->spawnedWorkers($events)))->toBeGreaterThan(2)
-            ->and(\count($channels))->toBe(4)
-            ->and(\array_values(\array_unique($channels)))->toBe([1, 2]);
+        Expect::that($result->exitCode)->because('recycled workers reuse freed channels')->toBe(0);
+        Expect::that(\count($this->spawnedWorkers($events)))->toBeGreaterThan(2);
+        Expect::that(\count($channels))->toBe(4);
+        Expect::that(\array_values(\array_unique($channels)))->toBe([1, 2]);
     }
 
     /**
@@ -154,8 +154,8 @@ final readonly class ChannelTest
 
                     echo 'channel=' . $this->channel->number;
 
-                    Expect::that((string) $this->channel->number)->toBe(\getenv('GREENLIGHT_CHANNEL'))
-                        ->and($this->channel->label())->toBe('gl-' . $this->channel->number);
+                    Expect::that((string) $this->channel->number)->toBe(\getenv('GREENLIGHT_CHANNEL'));
+                    Expect::that($this->channel->label())->toBe('gl-' . $this->channel->number);
                 }
             }
             PHP;

--- a/tests/Acceptance/CliTest.php
+++ b/tests/Acceptance/CliTest.php
@@ -66,8 +66,8 @@ final readonly class CliTest
         Expect::that($result->output())->because('help and version exit zero')->toContain('Usage:');
 
         $result = $this->runCli(['--version']);
-        Expect::that($result->exitCode)->because('help and version exit zero')->toBe(0)
-            ->and($result->outputLines())->toContain('Greenlight dev-main');
+        Expect::that($result->exitCode)->because('help and version exit zero')->toBe(0);
+        Expect::that($result->outputLines())->toContain('Greenlight dev-main');
     }
 
     #[Test]
@@ -145,8 +145,8 @@ final readonly class CliTest
 
         Expect::that($result->exitCode)
             ->because('list tests reports an explicitly missing configuration')
-            ->toBe(1)
-            ->and($result->output())
+            ->toBe(1);
+        Expect::that($result->output())
             ->toContain('Configuration file "' . $projectDirectory . '/missing.php" does not exist.');
     }
 
@@ -180,10 +180,10 @@ final readonly class CliTest
 
         Expect::that($result->exitCode)
             ->because('an invalid internal worker entry MUST stop before connection')
-            ->toBe(64)
-            ->and($result->stderr)
-            ->toBe('__worker requires <address> <workerId> <token>.')
-            ->and($result->stdout)
+            ->toBe(64);
+        Expect::that($result->stderr)
+            ->toBe('__worker requires <address> <workerId> <token>.');
+        Expect::that($result->stdout)
             ->toBe('');
     }
 
@@ -210,10 +210,10 @@ final readonly class CliTest
 
         Expect::that($result->exitCode)
             ->because('an internal worker connection failure MUST report a failed process')
-            ->toBe(1)
-            ->and($result->stderr)
-            ->toStartWith('The worker did not connect to invalid://worker:')
-            ->and($result->stdout)
+            ->toBe(1);
+        Expect::that($result->stderr)
+            ->toStartWith('The worker did not connect to invalid://worker:');
+        Expect::that($result->stdout)
             ->toBe('');
     }
 

--- a/tests/Acceptance/CommandErrorsTest.php
+++ b/tests/Acceptance/CommandErrorsTest.php
@@ -21,8 +21,8 @@ final readonly class CommandErrorsTest
     {
         $result = GreenlightCli::run(\dirname(__DIR__, 2), ['bogus-command']);
 
-        Expect::that($result->exitCode)->because('unknown command exits with a usage error')->toBe(64)
-            ->and($result->output())->toContain("Unknown command 'bogus-command'")
+        Expect::that($result->exitCode)->because('unknown command exits with a usage error')->toBe(64);
+        Expect::that($result->output())->toContain("Unknown command 'bogus-command'")
             ->toContain('greenlight --help');
     }
 
@@ -37,8 +37,8 @@ final readonly class CommandErrorsTest
 
         Expect::that($result->exitCode)
             ->because('an invalid run override MUST exit with a usage error')
-            ->toBe(64)
-            ->and($result->stderr)
+            ->toBe(64);
+        Expect::that($result->stderr)
             ->toBe('greenlight: --bail requires a positive integer. Received "0".');
     }
 
@@ -47,8 +47,8 @@ final readonly class CommandErrorsTest
     {
         $result = GreenlightCli::run(\dirname(__DIR__, 2), ['coverage:diff']);
 
-        Expect::that($result->exitCode)->because('coverage diff without baseline or current is a usage error')->toBe(64)
-            ->and($result->output())->toContain('coverage:diff requires --baseline=<path> and --current=<path>');
+        Expect::that($result->exitCode)->because('coverage diff without baseline or current is a usage error')->toBe(64);
+        Expect::that($result->output())->toContain('coverage:diff requires --baseline=<path> and --current=<path>');
     }
 
     #[Test]
@@ -58,8 +58,8 @@ final readonly class CommandErrorsTest
 
         Expect::that($result->exitCode)
             ->because('profile report without input is a usage error')
-            ->toBe(64)
-            ->and($result->stderr)
+            ->toBe(64);
+        Expect::that($result->stderr)
             ->toBe('profile:report requires --input=<path to a JSONL stream>.');
     }
 
@@ -68,8 +68,8 @@ final readonly class CommandErrorsTest
     {
         $project = AcceptanceProject::create($this->tempDirectory, 'command-errors');
         $result = GreenlightCli::run($project->directory, ['profile:report', '--input=nowhere.jsonl']);
-        Expect::that($result->exitCode)->because('profile report with a missing input file fails cleanly')->toBe(1)
-            ->and($result->output())->toContain('Greenlight could not read')
+        Expect::that($result->exitCode)->because('profile report with a missing input file fails cleanly')->toBe(1);
+        Expect::that($result->output())->toContain('Greenlight could not read')
             ->toContain('nowhere.jsonl');
     }
 
@@ -91,8 +91,8 @@ final readonly class CommandErrorsTest
 
         Expect::that($result->exitCode)
             ->because('an invalid profile stream fails cleanly')
-            ->toBe(1)
-            ->and($result->output())
+            ->toBe(1);
+        Expect::that($result->output())
             ->toContain($message);
     }
 

--- a/tests/Acceptance/CompletionTest.php
+++ b/tests/Acceptance/CompletionTest.php
@@ -19,8 +19,8 @@ final readonly class CompletionTest
     public function printsAScriptPerShellAndRejectsUnknownShells(): void
     {
         $result = $this->run('bash');
-        Expect::that($result->exitCode)->because('prints a script per shell and rejects unknown shells')->toBe(0)
-            ->and($result->stdout)->toContain('_greenlight_completions')
+        Expect::that($result->exitCode)->because('prints a script per shell and rejects unknown shells')->toBe(0);
+        Expect::that($result->stdout)->toContain('_greenlight_completions')
             ->toContain('coverage:diff')
             ->toContain('--detect-leaks')
             ->toContain('teamcity');
@@ -28,24 +28,24 @@ final readonly class CompletionTest
         $bashScript = $result->stdout;
 
         $result = $this->run('zsh');
-        Expect::that($result->exitCode)->because('prints a script per shell and rejects unknown shells')->toBe(0)
-            ->and($result->stdout)->toContain('compdef _greenlight greenlight')
+        Expect::that($result->exitCode)->because('prints a script per shell and rejects unknown shells')->toBe(0);
+        Expect::that($result->stdout)->toContain('compdef _greenlight greenlight')
             ->toContain('--detect-leaks')
             ->toContain('teamcity');
 
         $result = $this->run('fish');
-        Expect::that($result->exitCode)->because('prints a script per shell and rejects unknown shells')->toBe(0)
-            ->and($result->stdout)->toContain('complete -c greenlight')
+        Expect::that($result->exitCode)->because('prints a script per shell and rejects unknown shells')->toBe(0);
+        Expect::that($result->stdout)->toContain('complete -c greenlight')
             ->toContain('-l detect-leaks')
             ->toContain('teamcity');
 
         $result = $this->run('powershell');
-        Expect::that($result->exitCode)->because('prints a script per shell and rejects unknown shells')->toBe(64)
-            ->and($result->stderr)->toContain('Unknown shell');
+        Expect::that($result->exitCode)->because('prints a script per shell and rejects unknown shells')->toBe(64);
+        Expect::that($result->stderr)->toContain('Unknown shell');
 
         $result = $this->run();
-        Expect::that($result->exitCode)->because('prints a script per shell and rejects unknown shells')->toBe(64)
-            ->and($result->stderr)->toContain('requires a shell argument');
+        Expect::that($result->exitCode)->because('prints a script per shell and rejects unknown shells')->toBe(64);
+        Expect::that($result->stderr)->toContain('requires a shell argument');
 
         $this->syntaxCheckWhenBashIsAvailable($bashScript);
     }

--- a/tests/Acceptance/CoverageDiffErrorTest.php
+++ b/tests/Acceptance/CoverageDiffErrorTest.php
@@ -31,8 +31,8 @@ final readonly class CoverageDiffErrorTest
 
         Expect::that($result->exitCode)
             ->because('missing coverage exports name their role')
-            ->toBe(1)
-            ->and($result->output())
+            ->toBe(1);
+        Expect::that($result->output())
             ->toContain(\sprintf(
                 'Greenlight could not read the %s coverage export at "%s.json"',
                 $missingLabel,
@@ -69,8 +69,8 @@ final readonly class CoverageDiffErrorTest
 
         Expect::that($result->exitCode)
             ->because('malformed coverage exports name their role')
-            ->toBe(1)
-            ->and($result->output())
+            ->toBe(1);
+        Expect::that($result->output())
             ->toContain(\sprintf(
                 'The %s file is not a valid coverage export: '
                 . 'Coverage JSON document is invalid: use an object for "files".',
@@ -97,8 +97,8 @@ final readonly class CoverageDiffErrorTest
 
         Expect::that($result->exitCode)
             ->because('empty readable exports are malformed instead of unreadable')
-            ->toBe(1)
-            ->and($result->output())
+            ->toBe(1);
+        Expect::that($result->output())
             ->toContain(\sprintf(
                 'The %s file is not a valid coverage export: '
                 . 'Coverage JSON document is invalid: Syntax error',

--- a/tests/Acceptance/CoverageDiffOutputTest.php
+++ b/tests/Acceptance/CoverageDiffOutputTest.php
@@ -44,8 +44,8 @@ final readonly class CoverageDiffOutputTest
 
         Expect::that($result->exitCode)
             ->because('removing an uncovered file MUST NOT fail the coverage diff')
-            ->toBe(0)
-            ->and($result->output())
+            ->toBe(0);
+        Expect::that($result->output())
             ->because('a removed zero-percent file has no useful file-level delta')
             ->toBe('Coverage: baseline 50.00%, current 100.00% (+50.00)');
     }

--- a/tests/Acceptance/CoverageDiffZeroPercentageOutputTest.php
+++ b/tests/Acceptance/CoverageDiffZeroPercentageOutputTest.php
@@ -40,8 +40,8 @@ final readonly class CoverageDiffZeroPercentageOutputTest
 
         Expect::that($result->exitCode)
             ->because('a zero-percent current file MUST report a coverage regression')
-            ->toBe(1)
-            ->and($result->stdoutLines())
+            ->toBe(1);
+        Expect::that($result->stdoutLines())
             ->because('a present zero-percent file MUST NOT render as absent')
             ->toBe([
                 'Coverage: baseline 100.00%, current 0.00% (-100.00)',

--- a/tests/Acceptance/CoverageIgnoreRunTest.php
+++ b/tests/Acceptance/CoverageIgnoreRunTest.php
@@ -26,8 +26,8 @@ final readonly class CoverageIgnoreRunTest
             ['XDEBUG_MODE' => 'coverage'],
         );
 
-        Expect::that($result->exitCode)->because('ignored lines are excluded from totals and exports')->toBe(0)
-            ->and($result->output())->toContain('Coverage: 100.00%');
+        Expect::that($result->exitCode)->because('ignored lines are excluded from totals and exports')->toBe(0);
+        Expect::that($result->output())->toContain('Coverage: 100.00%');
 
         $json = \file_get_contents($outDir . '/coverage.json');
 
@@ -48,9 +48,9 @@ final readonly class CoverageIgnoreRunTest
             }
         }
 
-        Expect::that($gadget)->because('ignored lines are excluded from totals and exports')->not()->toBeNull()
-            ->and($gadget['uncovered'] ?? null)->toBe([])
-            ->and($gadget['covered'] ?? [])->not()->toHaveCount(0);
+        Expect::that($gadget)->because('ignored lines are excluded from totals and exports')->not()->toBeNull();
+        Expect::that($gadget['uncovered'] ?? null)->toBe([]);
+        Expect::that($gadget['covered'] ?? [])->not()->toHaveCount(0);
     }
 
     private function writeProject(): AcceptanceProject

--- a/tests/Acceptance/CoverageRunTest.php
+++ b/tests/Acceptance/CoverageRunTest.php
@@ -25,8 +25,8 @@ final readonly class CoverageRunTest
         $outDir = $project->path('coverage-out');
         $result = $this->runIn($project, ['run', '--workers=2', '--reporter=plain'], 'coverage');
 
-        Expect::that($result->exitCode)->because('collects and exports coverage through the process pool')->toBe(0)
-            ->and($result->output())->toContain('Coverage: 60.00% (3 of 5 lines)')
+        Expect::that($result->exitCode)->because('collects and exports coverage through the process pool')->toBe(0);
+        Expect::that($result->output())->toContain('Coverage: 60.00% (3 of 5 lines)')
             ->toContain('  json → coverage-out/coverage.json');
 
         $json = \file_get_contents($outDir . '/coverage.json');
@@ -48,9 +48,9 @@ final readonly class CoverageRunTest
             }
         }
 
-        Expect::that($mathFile)->because('collects and exports coverage through the process pool')->not()->toBeNull()
-            ->and($mathFile['covered'] ?? [])->not()->toHaveCount(0)
-            ->and($mathFile['uncovered'] ?? [])->not()->toHaveCount(0);
+        Expect::that($mathFile)->because('collects and exports coverage through the process pool')->not()->toBeNull();
+        Expect::that($mathFile['covered'] ?? [])->not()->toHaveCount(0);
+        Expect::that($mathFile['uncovered'] ?? [])->not()->toHaveCount(0);
 
         $lcov = \file_get_contents($outDir . '/lcov.info');
 
@@ -64,9 +64,9 @@ final readonly class CoverageRunTest
         $project = $this->writeProject();
         $result = $this->runIn($project, ['run', '--reporter=plain'], 'off');
 
-        Expect::that($result->exitCode)->because('missing driver warns without failing the run')->toBe(0)
-            ->and($result->output())->toContain('No worker collected the requested coverage')
-            ->and(\is_dir($project->path('coverage-out')))->toBeFalse();
+        Expect::that($result->exitCode)->because('missing driver warns without failing the run')->toBe(0);
+        Expect::that($result->output())->toContain('No worker collected the requested coverage');
+        Expect::that(\is_dir($project->path('coverage-out')))->toBeFalse();
     }
 
     #[Test]
@@ -77,10 +77,10 @@ final readonly class CoverageRunTest
 
         Expect::that($result->exitCode)
             ->because('an unknown coverage export format MUST fail the run')
-            ->toBe(1)
-            ->and($result->output())
-            ->toContain('Unknown coverage export format "sarif".')
-            ->and(\is_dir($project->path('coverage-out')))
+            ->toBe(1);
+        Expect::that($result->output())
+            ->toContain('Unknown coverage export format "sarif".');
+        Expect::that(\is_dir($project->path('coverage-out')))
             ->toBeFalse();
     }
 
@@ -95,8 +95,8 @@ final readonly class CoverageRunTest
 
         Expect::that($result->exitCode)
             ->because('a configured XML coverage export MUST complete')
-            ->toBe(0)
-            ->and($result->output())
+            ->toBe(0);
+        Expect::that($result->output())
             ->toContain(\sprintf('  %s → coverage-out/coverage.unknown', $format));
 
         $document = \file_get_contents($project->path('coverage-out/coverage.unknown'));
@@ -110,8 +110,8 @@ final readonly class CoverageRunTest
 
         Expect::that($xml->getName())
             ->because('the configured XML exporter MUST write a coverage document')
-            ->toBe('coverage')
-            ->and($children === false ? [] : $children)
+            ->toBe('coverage');
+        Expect::that($children === false ? [] : $children)
             ->not()
             ->toBe([]);
     }
@@ -134,8 +134,8 @@ final readonly class CoverageRunTest
 
         Expect::that($result->exitCode)
             ->because('a failed coverage export MUST fail the run')
-            ->toBe(1)
-            ->and($result->output())
+            ->toBe(1);
+        Expect::that($result->output())
             ->toContain('Greenlight could not write the coverage export to')
             ->toContain('coverage-out/coverage.json')
             ->not()
@@ -155,8 +155,8 @@ final readonly class CoverageRunTest
             SubprocessCoverage::INCLUDE_ENV => '',
         ]);
 
-        Expect::that($result->exitCode)->because('orchestrator process coverage is merged into the export')->toBe(0)
-            ->and($result->output())->toContain('  json → coverage-out/coverage.json');
+        Expect::that($result->exitCode)->because('orchestrator process coverage is merged into the export')->toBe(0);
+        Expect::that($result->output())->toContain('  json → coverage-out/coverage.json');
 
         $json = \file_get_contents($outDir . '/coverage.json');
 
@@ -179,8 +179,8 @@ final readonly class CoverageRunTest
 
         // Only the orchestrator process loads Orchestrator.php. Thus, covered
         // lines in that file show orchestrator coverage collection.
-        Expect::that($orchestratorFile)->because('orchestrator process coverage is merged into the export')->not()->toBeNull()
-            ->and($orchestratorFile['covered'] ?? [])->not()->toHaveCount(0);
+        Expect::that($orchestratorFile)->because('orchestrator process coverage is merged into the export')->not()->toBeNull();
+        Expect::that($orchestratorFile['covered'] ?? [])->not()->toHaveCount(0);
     }
 
     #[Test]
@@ -216,8 +216,8 @@ final readonly class CoverageRunTest
 
         Expect::that($result->exitCode)
             ->because('a failed multi-file coverage export MUST fail the run')
-            ->toBe(1)
-            ->and($result->output())
+            ->toBe(1);
+        Expect::that($result->output())
             ->toContain('Greenlight could not write the coverage export to')
             ->toContain('coverage-out/coverage.unknown/index.html')
             ->not()
@@ -240,8 +240,8 @@ final readonly class CoverageRunTest
             ['coverage:diff', '--baseline=coverage-out/coverage.json', '--current=coverage-out/coverage.json'],
         );
 
-        Expect::that($sameResult->exitCode)->because('coverage diff fails on regressions and passes when equal')->toBe(0)
-            ->and($sameResult->output())->toContain('(+0.00)');
+        Expect::that($sameResult->exitCode)->because('coverage diff fails on regressions and passes when equal')->toBe(0);
+        Expect::that($sameResult->output())->toContain('(+0.00)');
 
         $json = \file_get_contents($baseline);
 
@@ -284,8 +284,8 @@ final readonly class CoverageRunTest
             ['coverage:diff', '--baseline=coverage-out/coverage.json', '--current=coverage-out/regressed.json'],
         );
 
-        Expect::that($regressedResult->exitCode)->because('coverage diff fails on regressions and passes when equal')->toBe(1)
-            ->and($regressedResult->output())->toContain('Coverage regressed against the baseline.')
+        Expect::that($regressedResult->exitCode)->because('coverage diff fails on regressions and passes when equal')->toBe(1);
+        Expect::that($regressedResult->output())->toContain('Coverage regressed against the baseline.')
             ->toContain('newly uncovered lines: ' . $movedLine);
     }
 

--- a/tests/Acceptance/GeneratedCoveragePathTest.php
+++ b/tests/Acceptance/GeneratedCoveragePathTest.php
@@ -54,8 +54,8 @@ final readonly class GeneratedCoveragePathTest
         Expect::that($generatedFile)
             ->because('the export MUST contain the generated source')
             ->not()
-            ->toBeNull()
-            ->and($generatedFile['covered'] ?? [])
+            ->toBeNull();
+        Expect::that($generatedFile['covered'] ?? [])
             ->because('the generated source MUST contain covered lines')
             ->not()
             ->toHaveCount(0);

--- a/tests/Acceptance/IdeHelperTest.php
+++ b/tests/Acceptance/IdeHelperTest.php
@@ -21,8 +21,8 @@ final readonly class IdeHelperTest
         $target = $this->tempDirectory->path() . '/ide-helper.php';
 
         $result = GreenlightCli::run($root . '/tests/Fixture/PhpStanExtension', ['ide-helper', '--output=' . $target]);
-        Expect::that($result->exitCode)->because('writes a lintable helper and skips when nothing is configured')->toBe(0)
-            ->and($result->output())->toContain('3 matchers');
+        Expect::that($result->exitCode)->because('writes a lintable helper and skips when nothing is configured')->toBe(0);
+        Expect::that($result->output())->toContain('3 matchers');
 
         $helper = (string) \file_get_contents($target);
         Expect::that($helper)->because('writes a lintable helper and skips when nothing is configured')->toContain('@method self toHaveDigestLength(int $length)')
@@ -32,9 +32,9 @@ final readonly class IdeHelperTest
         Expect::that($lint->exitCode)->because('writes a lintable helper and skips when nothing is configured')->toBe(0);
 
         $result = GreenlightCli::run($root . '/tests/Fixture/ListTestsConfig', ['ide-helper', '--output=' . $target . '.none']);
-        Expect::that($result->exitCode)->because('writes a lintable helper and skips when nothing is configured')->toBe(0)
-            ->and($result->output())->toContain('The configuration has no extension matchers')
-            ->and(\is_file($target . '.none'))->toBeFalse();
+        Expect::that($result->exitCode)->because('writes a lintable helper and skips when nothing is configured')->toBe(0);
+        Expect::that($result->output())->toContain('The configuration has no extension matchers');
+        Expect::that(\is_file($target . '.none'))->toBeFalse();
     }
 
     #[Test]
@@ -46,8 +46,8 @@ final readonly class IdeHelperTest
 
         Expect::that($result->exitCode)
             ->because('ide-helper MUST report configuration errors before it writes output')
-            ->toBe(1)
-            ->and($result->stderr)
+            ->toBe(1);
+        Expect::that($result->stderr)
             ->toBe(
                 \sprintf(
                     'greenlight: Configuration file "%s" returned string. It must return a '
@@ -55,8 +55,8 @@ final readonly class IdeHelperTest
                     . '"return GreenlightConfig::create()->...;".',
                     $config,
                 ),
-            )
-            ->and($result->stdout)
+            );
+        Expect::that($result->stdout)
             ->toBe('');
     }
 }

--- a/tests/Acceptance/InternalWorkerArityTest.php
+++ b/tests/Acceptance/InternalWorkerArityTest.php
@@ -20,10 +20,10 @@ final class InternalWorkerArityTest
 
         Expect::that($result->exitCode)
             ->because('the internal worker entry MUST accept exactly three operands')
-            ->toBe(64)
-            ->and($result->stderr)
-            ->toBe('__worker requires <address> <workerId> <token>.')
-            ->and($result->stdout)
+            ->toBe(64);
+        Expect::that($result->stderr)
+            ->toBe('__worker requires <address> <workerId> <token>.');
+        Expect::that($result->stdout)
             ->toBe('');
     }
 }

--- a/tests/Acceptance/LaravelRunTest.php
+++ b/tests/Acceptance/LaravelRunTest.php
@@ -23,8 +23,8 @@ final readonly class LaravelRunTest
     {
         $project = $this->writeProject();
         $result = GreenlightCli::run($project->directory, ['run', '--reporter=plain']);
-        Expect::that($result->exitCode)->toBe(0)
-            ->and($result->output())->toContain('4 tests, 4 passed');
+        Expect::that($result->exitCode)->toBe(0);
+        Expect::that($result->output())->toContain('4 tests, 4 passed');
     }
 
     private function writeProject(): AcceptanceProject
@@ -107,10 +107,10 @@ final readonly class LaravelRunTest
                 {
                     $this->counter->record();
 
-                    Expect::that($this->greeter->greet('Ada'))->toBe('Hello, Ada!')
-                        ->and($this->named->greet())->toContain('fixture.named_greeter')
-                        ->and($this->app->environment())->toBe('testing')
-                        ->and($this->counter->count())->toBe(1);
+                    Expect::that($this->greeter->greet('Ada'))->toBe('Hello, Ada!');
+                    Expect::that($this->named->greet())->toContain('fixture.named_greeter');
+                    Expect::that($this->app->environment())->toBe('testing');
+                    Expect::that($this->counter->count())->toBe(1);
                 }
 
                 #[Test]

--- a/tests/Acceptance/LeakDetectionRunTest.php
+++ b/tests/Acceptance/LeakDetectionRunTest.php
@@ -17,8 +17,8 @@ final readonly class LeakDetectionRunTest
     {
         $withFlag = $this->run(['run', '--detect-leaks', '--workers=2']);
 
-        Expect::that($withFlag->exitCode)->because('leak detection names the leak and fails the run')->toBe(1)
-            ->and($withFlag->output())->toContain('Test instance leaks:')
+        Expect::that($withFlag->exitCode)->because('leak detection names the leak and fails the run')->toBe(1);
+        Expect::that($withFlag->output())->toContain('Test instance leaks:')
             ->toContain('  Greenlight\Tests\Fixture\LeakSuite\LeakyTest::passesButLeaksItself');
 
         $withoutFlag = $this->run(['run', '--workers=2']);

--- a/tests/Acceptance/ListingTest.php
+++ b/tests/Acceptance/ListingTest.php
@@ -67,8 +67,8 @@ final readonly class ListingTest
 
         Expect::that($result->exitCode)
             ->because('list tests MUST report discovery failures')
-            ->toBe(1)
-            ->and($result->stderr)
+            ->toBe(1);
+        Expect::that($result->stderr)
             ->toBe(\sprintf(
                 'greenlight: Test file "%s" does not declare a class, interface, trait, or enum.',
                 $testFile,
@@ -147,8 +147,8 @@ final readonly class ListingTest
         $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'listing');
         $result = GreenlightCli::run($project->directory, ['run', '--list-suites']);
         $output = $result->stdoutLines();
-        Expect::that($result->exitCode)->because('list suites with no suites configured prints zero')->toBe(0)
-            ->and($output)->toContain('0 suites');
+        Expect::that($result->exitCode)->because('list suites with no suites configured prints zero')->toBe(0);
+        Expect::that($output)->toContain('0 suites');
     }
 
     /**

--- a/tests/Acceptance/ParallelShardRunTest.php
+++ b/tests/Acceptance/ParallelShardRunTest.php
@@ -40,25 +40,25 @@ final readonly class ParallelShardRunTest
 
         Expect::that($all->exitCode)
             ->because('the unsharded parallel run MUST succeed')
-            ->toBe(0)
-            ->and($first->exitCode)
+            ->toBe(0);
+        Expect::that($first->exitCode)
             ->because('parallel shard one MUST succeed')
-            ->toBe(0)
-            ->and($second->exitCode)
+            ->toBe(0);
+        Expect::that($second->exitCode)
             ->because('parallel shard two MUST succeed')
-            ->toBe(0)
-            ->and($firstIds)
+            ->toBe(0);
+        Expect::that($firstIds)
             ->because('parallel shard one MUST contain tests')
             ->not()
-            ->toHaveCount(0)
-            ->and($secondIds)
+            ->toHaveCount(0);
+        Expect::that($secondIds)
             ->because('parallel shard two MUST contain tests')
             ->not()
-            ->toHaveCount(0)
-            ->and(\array_intersect($firstIds, $secondIds))
+            ->toHaveCount(0);
+        Expect::that(\array_intersect($firstIds, $secondIds))
             ->because('parallel shards MUST NOT execute the same test')
-            ->toBe([])
-            ->and($union)
+            ->toBe([]);
+        Expect::that($union)
             ->because('parallel shards MUST reconstitute the full run exactly once')
             ->toBe($allIds);
     }

--- a/tests/Acceptance/PhpStanAttributeArgumentRuleTest.php
+++ b/tests/Acceptance/PhpStanAttributeArgumentRuleTest.php
@@ -68,10 +68,10 @@ final readonly class PhpStanAttributeArgumentRuleTest
             PHP,
         );
 
-        Expect::that($probe->exitCode)->because('attribute arguments must have valid values')->toBe(1)
-            ->and($probe->goodPassed)->toBeTrue()
-            ->and(\count($probe->errors))->toBe(8)
-            ->and($probe->messages())->toContain('#[RequiresResource] name "Postgres primary" does not match')
+        Expect::that($probe->exitCode)->because('attribute arguments must have valid values')->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(8);
+        Expect::that($probe->messages())->toContain('#[RequiresResource] name "Postgres primary" does not match')
             ->toContain('#[Retry] times must be at least 1')
             ->toContain('#[SkipUnless] argument 1 must be a scalar or null')
             ->not()->toContain('#[SkipUnless] argument 0')

--- a/tests/Acceptance/PhpStanDataProviderKeyRuleTest.php
+++ b/tests/Acceptance/PhpStanDataProviderKeyRuleTest.php
@@ -114,10 +114,10 @@ final readonly class PhpStanDataProviderKeyRuleTest
             PHP,
         );
 
-        Expect::that($probe->exitCode)->because('PHPStan checks provider keys, empty providers, and duplicate row keys')->toBe(1)
-            ->and($probe->goodPassed)->toBeTrue()
-            ->and(\count($probe->errors))->toBe(4)
-            ->and($probe->messages())->toContain('#[DataRow] key "same" occurs more than once on duplicateLabels()')
+        Expect::that($probe->exitCode)->because('PHPStan checks provider keys, empty providers, and duplicate row keys')->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(4);
+        Expect::that($probe->messages())->toContain('#[DataRow] key "same" occurs more than once on duplicateLabels()')
             ->toContain('#[DataRow] key "#0" occurs more than once on duplicateGeneratedLabel()')
             ->toContain('invalidKeys() keys must be int or string. The provider returns keys of type bool')
             ->toContain('empty() must provide at least one argument array');

--- a/tests/Acceptance/PhpStanDataProviderShapeRuleTest.php
+++ b/tests/Acceptance/PhpStanDataProviderShapeRuleTest.php
@@ -237,10 +237,10 @@ final readonly class PhpStanDataProviderShapeRuleTest
             PHP,
         );
 
-        Expect::that($probe->exitCode)->because('provider and row shapes are checked against the signature')->toBe(1)
-            ->and($probe->goodPassed)->toBeTrue()
-            ->and(\count($probe->errors))->toBe(11)
-            ->and($probe->messages())->toContain('Data provider doesNotExist() for missingProvider() does not exist')
+        Expect::that($probe->exitCode)->because('provider and row shapes are checked against the signature')->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(11);
+        Expect::that($probe->messages())->toContain('Data provider doesNotExist() for missingProvider() does not exist')
             ->toContain('notStatic() must be public and static')
             ->toContain('notIterable() must return an iterable of argument arrays. It returns string')
             ->toContain('scalarRows() must provide argument arrays. The iterable has value type int')

--- a/tests/Acceptance/PhpStanExpectationArgumentRuleTest.php
+++ b/tests/Acceptance/PhpStanExpectationArgumentRuleTest.php
@@ -67,11 +67,11 @@ final readonly class PhpStanExpectationArgumentRuleTest
             PHP,
         );
 
-        Expect::that($probe->exitCode)->because('constant expectation arguments must satisfy runtime constraints')->toBe(1)
-            ->and($probe->goodPassed)->toBeTrue()
-            ->and(\count($probe->errors))->toBe(7)
-            ->and($probe->messages())->toContain('Regular expression "/[/" for toMatch() is invalid')
-            ->and($probe->messages())->toContain('toMatchJson() requires valid expected JSON')
-            ->and($probe->messages())->toContain('within() requires a finite duration greater than 0.000 seconds');
+        Expect::that($probe->exitCode)->because('constant expectation arguments must satisfy runtime constraints')->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(7);
+        Expect::that($probe->messages())->toContain('Regular expression "/[/" for toMatch() is invalid');
+        Expect::that($probe->messages())->toContain('toMatchJson() requires valid expected JSON');
+        Expect::that($probe->messages())->toContain('within() requires a finite duration greater than 0.000 seconds');
     }
 }

--- a/tests/Acceptance/PhpStanLifecycleMethodRuleTest.php
+++ b/tests/Acceptance/PhpStanLifecycleMethodRuleTest.php
@@ -81,10 +81,10 @@ final readonly class PhpStanLifecycleMethodRuleTest
             PHP,
         );
 
-        Expect::that($probe->exitCode)->because('lifecycle hooks must run without arguments')->toBe(1)
-            ->and($probe->goodPassed)->toBeTrue()
-            ->and(\count($probe->errors))->toBe(4)
-            ->and($probe->messages())->toContain('protectedBefore() cannot run because it is not public')
+        Expect::that($probe->exitCode)->because('lifecycle hooks must run without arguments')->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(4);
+        Expect::that($probe->messages())->toContain('protectedBefore() cannot run because it is not public')
             ->toContain('staticAfter() cannot run because it is static')
             ->toContain('beforeWithArgument() must not require arguments')
             ->toContain('abstractAfter() cannot run because it is abstract');

--- a/tests/Acceptance/PhpStanMatcherSignatureTest.php
+++ b/tests/Acceptance/PhpStanMatcherSignatureTest.php
@@ -29,8 +29,8 @@ final readonly class PhpStanMatcherSignatureTest
 
             function greenlightGoodProbe(): void
             {
-                Expect::that('c0ffee')->toBeHexadecimal()
-                    ->and('c0ffee')->toHaveDigestLength(6);
+                Expect::that('c0ffee')->toBeHexadecimal();
+                Expect::that('c0ffee')->toHaveDigestLength(6);
             }
             PHP,
             <<<'PHP'
@@ -42,16 +42,16 @@ final readonly class PhpStanMatcherSignatureTest
 
             function greenlightBadProbe(): void
             {
-                Expect::that('c0ffee')->toHaveDigestLength('six')
-                    ->and('c0ffee')->toBeHexadecimal(123);
+                Expect::that('c0ffee')->toHaveDigestLength('six');
+                Expect::that('c0ffee')->toBeHexadecimal(123);
             }
             PHP,
         );
 
-        Expect::that($probe->exitCode)->because('reflected matcher signatures are enforced')->toBe(1)
-            ->and($probe->goodPassed)->toBeTrue()
-            ->and(\count($probe->errors))->toBe(2)
-            ->and($probe->messages())->toContain('toHaveDigestLength() expects int, string given')
+        Expect::that($probe->exitCode)->because('reflected matcher signatures are enforced')->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(2);
+        Expect::that($probe->messages())->toContain('toHaveDigestLength() expects int, string given')
             ->toContain('invoked with 1 parameter, 0 required');
     }
 
@@ -96,10 +96,10 @@ final readonly class PhpStanMatcherSignatureTest
             PHP,
         );
 
-        Expect::that($probe->exitCode)->because('temporal matcher signatures are enforced')->toBe(1)
-            ->and($probe->goodPassed)->toBeTrue()
-            ->and(\count($probe->errors))->toBe(2)
-            ->and($probe->messages())->toContain('toHaveDigestLength() expects int, string given')
+        Expect::that($probe->exitCode)->because('temporal matcher signatures are enforced')->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(2);
+        Expect::that($probe->messages())->toContain('toHaveDigestLength() expects int, string given')
             ->toContain('invoked with 1 parameter, 0 required');
     }
 }

--- a/tests/Acceptance/PhpStanMatcherSubjectTest.php
+++ b/tests/Acceptance/PhpStanMatcherSubjectTest.php
@@ -29,10 +29,12 @@ final readonly class PhpStanMatcherSubjectTest
 
             function greenlightGoodSubjectProbe(): void
             {
-                Expect::that('c0ffee')->toBeHexadecimal()
-                    ->and(1)->toBePositive();
-                Expect::that(1)->toBePositive()
-                    ->and('c0ffee')->toHaveDigestLength(6);
+                Expect::that('c0ffee')
+                    ->toBeHexadecimal()
+                    ->toHaveDigestLength(6);
+                Expect::that(1)
+                    ->toBePositive()
+                    ->toBe(1);
             }
             PHP,
             <<<'PHP'
@@ -47,15 +49,15 @@ final readonly class PhpStanMatcherSubjectTest
                 Expect::that(1)->toBePositive()
                     ->toBeHexadecimal();
                 Expect::that('c0ffee')->toHaveDigestLength(6)
-                    ->and(1)->toBeHexadecimal();
+                    ->toBePositive();
             }
             PHP,
         );
 
-        Expect::that($probe->exitCode)->because('fluent chains preserve matcher subject types')->toBe(1)
-            ->and($probe->goodPassed)->toBeTrue()
-            ->and(\count($probe->errors))->toBe(2)
-            ->and($probe->messages())->toContain('requires subject type string, but the subject has type int');
+        Expect::that($probe->exitCode)->because('fluent chains preserve matcher subject types')->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(2);
+        Expect::that($probe->messages())->toContain('requires subject type string, but the subject has type int');
     }
 
     #[Test]
@@ -104,9 +106,9 @@ final readonly class PhpStanMatcherSubjectTest
             PHP,
         );
 
-        Expect::that($probe->exitCode)->because('temporal chains preserve matcher subject types')->toBe(1)
-            ->and($probe->goodPassed)->toBeTrue()
-            ->and(\count($probe->errors))->toBe(3)
-            ->and($probe->messages())->toContain('requires subject type string, but the subject has type int');
+        Expect::that($probe->exitCode)->because('temporal chains preserve matcher subject types')->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(3);
+        Expect::that($probe->messages())->toContain('requires subject type string, but the subject has type int');
     }
 }

--- a/tests/Acceptance/PhpStanMissingDataProviderClassTest.php
+++ b/tests/Acceptance/PhpStanMissingDataProviderClassTest.php
@@ -59,11 +59,11 @@ final readonly class PhpStanMissingDataProviderClassTest
 
         Expect::that($probe->exitCode)
             ->because('PHPStan rejects a data set that references a missing provider class')
-            ->toBe(1)
-            ->and($probe->goodPassed)->toBeTrue()
-            ->and(\count($probe->errors))->toBe(2)
-            ->and($probe->messages())->toContain(
-                'Data provider class GreenlightMissingProviderClassProbe\MissingProviders referenced by testValue() does not exist.',
-            );
+            ->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(2);
+        Expect::that($probe->messages())->toContain(
+            'Data provider class GreenlightMissingProviderClassProbe\MissingProviders referenced by testValue() does not exist.',
+        );
     }
 }

--- a/tests/Acceptance/PhpStanNativeMatcherSubjectRuleTest.php
+++ b/tests/Acceptance/PhpStanNativeMatcherSubjectRuleTest.php
@@ -80,11 +80,11 @@ final readonly class PhpStanNativeMatcherSubjectRuleTest
             PHP,
         );
 
-        Expect::that($probe->exitCode)->because('native matchers require compatible subject types')->toBe(1)
-            ->and($probe->goodPassed)->toBeTrue()
-            ->and(\count($probe->errors))->toBe(17)
-            ->and($probe->messages())->toContain('toContain() requires a string or iterable subject')
-            ->and($probe->messages())->toContain('toContain() requires a string needle for a string subject')
-            ->and($probe->messages())->toContain('toMatchJson() requires a string subject');
+        Expect::that($probe->exitCode)->because('native matchers require compatible subject types')->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(17);
+        Expect::that($probe->messages())->toContain('toContain() requires a string or iterable subject');
+        Expect::that($probe->messages())->toContain('toContain() requires a string needle for a string subject');
+        Expect::that($probe->messages())->toContain('toMatchJson() requires a string subject');
     }
 }

--- a/tests/Acceptance/PhpStanNativeMatcherTypeTest.php
+++ b/tests/Acceptance/PhpStanNativeMatcherTypeTest.php
@@ -57,12 +57,12 @@ final readonly class PhpStanNativeMatcherTypeTest
 
         Expect::that($probe->exitCode)
             ->because('native matcher types keep nullable union and intersection shapes')
-            ->toBe(1)
-            ->and($probe->goodPassed)->toBeTrue()
-            ->and($probe->errors)->toBe([
-                'Extension matcher toAcceptNullableDateTime() requires subject type DateTimeInterface|null, but the subject has type int.',
-                'Extension matcher toAcceptIntegerOrString() requires subject type int|string, but the subject has type array.',
-                'Extension matcher toAcceptSerializableString() requires subject type JsonSerializable&Stringable, but the subject has type stdClass.',
-            ]);
+            ->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that($probe->errors)->toBe([
+            'Extension matcher toAcceptNullableDateTime() requires subject type DateTimeInterface|null, but the subject has type int.',
+            'Extension matcher toAcceptIntegerOrString() requires subject type int|string, but the subject has type array.',
+            'Extension matcher toAcceptSerializableString() requires subject type JsonSerializable&Stringable, but the subject has type stdClass.',
+        ]);
     }
 }

--- a/tests/Acceptance/PhpStanSkipUnlessConditionRuleTest.php
+++ b/tests/Acceptance/PhpStanSkipUnlessConditionRuleTest.php
@@ -84,10 +84,10 @@ final readonly class PhpStanSkipUnlessConditionRuleTest
             PHP,
         );
 
-        Expect::that($probe->exitCode)->because('skip-unless arguments must match the condition constructor')->toBe(1)
-            ->and($probe->goodPassed)->toBeTrue()
-            ->and(\count($probe->errors))->toBe(3)
-            ->and($probe->messages())->toContain('#[SkipUnless] supplies 1 argument to the GreenlightSkipUnlessConditionProbe\TwoArgumentsCondition constructor, but the constructor requires 2 arguments')
+        Expect::that($probe->exitCode)->because('skip-unless arguments must match the condition constructor')->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(3);
+        Expect::that($probe->messages())->toContain('#[SkipUnless] supplies 1 argument to the GreenlightSkipUnlessConditionProbe\TwoArgumentsCondition constructor, but the constructor requires 2 arguments')
             ->toContain('#[SkipUnless] supplies 3 arguments to the GreenlightSkipUnlessConditionProbe\TwoArgumentsCondition constructor, but the constructor accepts 2 arguments')
             ->toContain('#[SkipUnless] argument #1 for GreenlightSkipUnlessConditionProbe\IntegerCondition constructor parameter $value has type string, but the parameter requires int');
     }

--- a/tests/Acceptance/PhpStanTestAttributePlacementRuleTest.php
+++ b/tests/Acceptance/PhpStanTestAttributePlacementRuleTest.php
@@ -98,10 +98,10 @@ final readonly class PhpStanTestAttributePlacementRuleTest
             PHP,
         );
 
-        Expect::that($probe->exitCode)->because('test metadata on methods requires the test attribute')->toBe(1)
-            ->and($probe->goodPassed)->toBeTrue()
-            ->and(\count($probe->errors))->toBe(10)
-            ->and($probe->messages())->toContain('#[Group] on GreenlightTestAttributePlacementProbe\BadTestAttributePlacementProbe::dataHelper() has no effect')
+        Expect::that($probe->exitCode)->because('test metadata on methods requires the test attribute')->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(10);
+        Expect::that($probe->messages())->toContain('#[Group] on GreenlightTestAttributePlacementProbe\BadTestAttributePlacementProbe::dataHelper() has no effect')
             ->toContain('#[DataRow] on GreenlightTestAttributePlacementProbe\BadTestAttributePlacementProbe::dataHelper() has no effect')
             ->toContain('#[NoExpectations] on GreenlightTestAttributePlacementProbe\BadTestAttributePlacementProbe::assertionHelper() has no effect')
             ->toContain(

--- a/tests/Acceptance/PhpStanTestConstructorRuleTest.php
+++ b/tests/Acceptance/PhpStanTestConstructorRuleTest.php
@@ -106,10 +106,10 @@ final readonly class PhpStanTestConstructorRuleTest
             PHP,
         );
 
-        Expect::that($probe->exitCode)->because('test constructors must have resolvable shapes')->toBe(1)
-            ->and($probe->goodPassed)->toBeTrue()
-            ->and(\count($probe->errors))->toBe(5)
-            ->and($probe->messages())->toContain('Greenlight cannot instantiate test class GreenlightTestConstructorProbe\PrivateConstructorProbe because its constructor is not public')
+        Expect::that($probe->exitCode)->because('test constructors must have resolvable shapes')->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(5);
+        Expect::that($probe->messages())->toContain('Greenlight cannot instantiate test class GreenlightTestConstructorProbe\PrivateConstructorProbe because its constructor is not public')
             ->toContain('Greenlight cannot resolve constructor parameter $scalar of test class GreenlightTestConstructorProbe\InvalidParametersProbe')
             ->toContain('Greenlight cannot resolve constructor parameter $union of test class GreenlightTestConstructorProbe\InvalidParametersProbe')
             ->toContain('Greenlight cannot resolve constructor parameter $object of test class GreenlightTestConstructorProbe\InvalidParametersProbe')
@@ -165,12 +165,12 @@ final readonly class PhpStanTestConstructorRuleTest
             PHP,
         );
 
-        Expect::that($probe->exitCode)->because('scalar variadic parameters cannot be resolved')->toBe(1)
-            ->and($probe->goodPassed)->toBeTrue()
-            ->and($probe->errors)->toHaveCount(1)
-            ->and($probe->messages())->toContain(
-                'Greenlight cannot resolve constructor parameter $values of test class '
+        Expect::that($probe->exitCode)->because('scalar variadic parameters cannot be resolved')->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that($probe->errors)->toHaveCount(1);
+        Expect::that($probe->messages())->toContain(
+            'Greenlight cannot resolve constructor parameter $values of test class '
                 . 'GreenlightTestConstructorVariadicProbe\ScalarVariadicConstructorProbe',
-            );
+        );
     }
 }

--- a/tests/Acceptance/PhpStanTestMethodRuleTest.php
+++ b/tests/Acceptance/PhpStanTestMethodRuleTest.php
@@ -92,10 +92,10 @@ final readonly class PhpStanTestMethodRuleTest
             PHP,
         );
 
-        Expect::that($probe->exitCode)->because('test methods must be public non static and concrete')->toBe(1)
-            ->and($probe->goodPassed)->toBeTrue()
-            ->and(\count($probe->errors))->toBe(4)
-            ->and($probe->messages())->toContain('protectedTest() cannot run because it is not public')
+        Expect::that($probe->exitCode)->because('test methods must be public non static and concrete')->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(4);
+        Expect::that($probe->messages())->toContain('protectedTest() cannot run because it is not public')
             ->toContain('staticTest() cannot run because it is static')
             ->toContain('abstractTest() cannot run because it is abstract')
             ->toContain('testWithoutDataSet() has required parameters but no #[DataRow] or #[DataSet] attribute');

--- a/tests/Acceptance/PhpStanToThrowRuleTest.php
+++ b/tests/Acceptance/PhpStanToThrowRuleTest.php
@@ -50,9 +50,7 @@ final readonly class PhpStanToThrowRuleTest
             function greenlightBadToThrowSubjectProbe(): void
             {
                 Expect::that(1)->toThrow(DomainException::class);
-                Expect::that(static fn() => null)
-                    ->and('not callable')
-                    ->toThrow(DomainException::class);
+                Expect::that('not callable')->toThrow(DomainException::class);
                 Expect::eventually(static fn(): int => 1)
                     ->within(1.0)
                     ->toThrow(DomainException::class);
@@ -63,10 +61,10 @@ final readonly class PhpStanToThrowRuleTest
             PHP,
         );
 
-        Expect::that($probe->exitCode)->because('toThrow requires a callable subject')->toBe(1)
-            ->and($probe->goodPassed)->toBeTrue()
-            ->and(\count($probe->errors))->toBe(4)
-            ->and($probe->messages())->toContain('toThrow() requires a callable subject. The subject type is');
+        Expect::that($probe->exitCode)->because('toThrow requires a callable subject')->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(4);
+        Expect::that($probe->messages())->toContain('toThrow() requires a callable subject. The subject type is');
     }
 
     #[Test]
@@ -132,9 +130,9 @@ final readonly class PhpStanToThrowRuleTest
             PHP,
         );
 
-        Expect::that($probe->exitCode)->because('pattern and exact message constraints are mutually exclusive')->toBe(1)
-            ->and($probe->goodPassed)->toBeTrue()
-            ->and(\count($probe->errors))->toBe(6)
-            ->and($probe->messages())->toContain('toThrow() accepts either matching: or message:, not both');
+        Expect::that($probe->exitCode)->because('pattern and exact message constraints are mutually exclusive')->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(6);
+        Expect::that($probe->messages())->toContain('toThrow() accepts either matching: or message:, not both');
     }
 }

--- a/tests/Acceptance/PolicyTest.php
+++ b/tests/Acceptance/PolicyTest.php
@@ -22,14 +22,14 @@ final readonly class PolicyTest
         // Without flags, all tests pass. Greenlight records deprecations but
         // does not make them fatal.
         $result = $this->run($project, '--filter=DiagnosticProbeTest');
-        Expect::that($result->exitCode)->because('deprecation and notice policies change passed tests to failed')->toBe(0)
-            ->and($result->output())->toContain('3 tests, 3 passed')
+        Expect::that($result->exitCode)->because('deprecation and notice policies change passed tests to failed')->toBe(0);
+        Expect::that($result->output())->toContain('3 tests, 3 passed')
         // Each test uses one matcher. The summary contains those expectations
         // after transfer from the worker.
             ->toContain('3 expectations');
         $result = $this->run($project, '--filter=DiagnosticProbeTest', '--fail-on-deprecation');
-        Expect::that($result->exitCode)->because('deprecation and notice policies change passed tests to failed')->toBe(1)
-            ->and($result->output())->toContain('3 tests, 2 passed, 1 failed')
+        Expect::that($result->exitCode)->because('deprecation and notice policies change passed tests to failed')->toBe(1);
+        Expect::that($result->output())->toContain('3 tests, 2 passed, 1 failed')
             ->toContain('deprecation policy changed this test from passed to failed')
             ->toContain('old api is deprecated')
         // The result change MUST NOT remove verified expectations.
@@ -37,8 +37,8 @@ final readonly class PolicyTest
         // The deprecation in the allow list does not fail the test.
             ->toContain('PASS PolicyProbe\DiagnosticProbeTest::ignorableDeprecation');
         $result = $this->run($project, '--filter=DiagnosticProbeTest', '--fail-on-notice');
-        Expect::that($result->exitCode)->because('deprecation and notice policies change passed tests to failed')->toBe(1)
-            ->and($result->output())->toContain('notice policy changed this test from passed to failed')
+        Expect::that($result->exitCode)->because('deprecation and notice policies change passed tests to failed')->toBe(1);
+        Expect::that($result->output())->toContain('notice policy changed this test from passed to failed')
             ->toContain('a probe notice');
     }
 
@@ -49,18 +49,19 @@ final readonly class PolicyTest
         $result = $this->run($project, '--filter=RiskyProbeTest');
         $output = $result->output();
         $riskyBlock = \substr($output, (int) \strpos($output, 'Risky tests:'));
-        Expect::that($result->exitCode)->because('risky tests warn by default and fail under the flag')->toBe(0)
-            ->and($riskyBlock)->toContain('Risky tests: 1')
-            ->and($riskyBlock)->toContain('These tests passed without a verified expectation.')
+        Expect::that($result->exitCode)->because('risky tests warn by default and fail under the flag')->toBe(0);
+        Expect::that($riskyBlock)->toContain('Risky tests: 1');
+        Expect::that($riskyBlock)->toContain('These tests passed without a verified expectation.')
             ->toContain('RiskyProbeTest::assertsNothing')
             ->not()->toContain('optedOut')
-            ->not()->toContain('mocksOnly')
+            ->not()->toContain('mocksOnly');
+
         // Only the mock verification adds to the count. Tests without an
         // expectation add nothing.
-            ->and($output)->toContain('1 expectation');
+        Expect::that($output)->toContain('1 expectation');
         $result = $this->run($project, '--filter=RiskyProbeTest', '--fail-on-risky');
-        Expect::that($result->exitCode)->because('risky tests warn by default and fail under the flag')->toBe(1)
-            ->and($result->output())->toContain('3 tests, 2 passed, 1 failed')
+        Expect::that($result->exitCode)->because('risky tests warn by default and fail under the flag')->toBe(1);
+        Expect::that($result->output())->toContain('3 tests, 2 passed, 1 failed')
             ->toContain('fail-on-risky policy changed this test from passed to failed');
     }
 

--- a/tests/Acceptance/ProfileRunTest.php
+++ b/tests/Acceptance/ProfileRunTest.php
@@ -30,8 +30,8 @@ final readonly class ProfileRunTest
         $output = $result->stdoutLines();
         $live = $result->stdout;
 
-        Expect::that($result->exitCode)->because('live profile and offline report agree')->toBe(0)
-            ->and($live)->toContain('Profile:')
+        Expect::that($result->exitCode)->because('live profile and offline report agree')->toBe(0);
+        Expect::that($live)->toContain('Profile:')
             ->toContain('spawned, 0 recycled')
             ->toContain('Boot latency:')
             ->toContain('Slowest classes:');
@@ -50,7 +50,7 @@ final readonly class ProfileRunTest
         // line.
         $liveBlock = \substr($live, (int) \strpos($live, 'Profile:'));
 
-        Expect::that($report->exitCode)->because('live profile and offline report agree')->toBe(0)
-            ->and($offline . "\n")->toBe($liveBlock . "\n");
+        Expect::that($report->exitCode)->because('live profile and offline report agree')->toBe(0);
+        Expect::that($offline . "\n")->toBe($liveBlock . "\n");
     }
 }

--- a/tests/Acceptance/ProseCheckBehaviorTest.php
+++ b/tests/Acceptance/ProseCheckBehaviorTest.php
@@ -62,8 +62,8 @@ final readonly class ProseCheckBehaviorTest
         );
 
         $result = $this->run('check', $root);
-        Expect::that($result->exitCode)->because('closes Markdown fences only with the opening marker')->toBe(1)
-            ->and($result->output())->toContain('sample.md:9: contraction:')
+        Expect::that($result->exitCode)->because('closes Markdown fences only with the opening marker')->toBe(1);
+        Expect::that($result->output())->toContain('sample.md:9: contraction:')
             ->toContain('sample.md:9: semicolon:')
             ->not()->toContain('sample.md:6:');
     }
@@ -79,8 +79,8 @@ final readonly class ProseCheckBehaviorTest
         );
 
         $result = $this->run('check', $root);
-        Expect::that($result->exitCode)->because('checks visible Markdown link labels but excludes destinations')->toBe(1)
-            ->and($result->output())->toContain('sample.md:1: british-spelling:')
+        Expect::that($result->exitCode)->because('checks visible Markdown link labels but excludes destinations')->toBe(1);
+        Expect::that($result->output())->toContain('sample.md:1: british-spelling:')
             ->toContain('sample.md:1: contraction:')
             ->toContain('sample.md:1: semicolon:');
     }
@@ -96,8 +96,8 @@ final readonly class ProseCheckBehaviorTest
         );
 
         $result = $this->run('check', $root);
-        Expect::that($result->exitCode)->because('checks Markdown image alt text')->toBe(1)
-            ->and($result->output())->toContain('sample.md:1: british-spelling:')
+        Expect::that($result->exitCode)->because('checks Markdown image alt text')->toBe(1);
+        Expect::that($result->output())->toContain('sample.md:1: british-spelling:')
             ->toContain('sample.md:1: contraction:');
     }
 
@@ -119,8 +119,8 @@ final readonly class ProseCheckBehaviorTest
         );
 
         $result = $this->run('check', $root);
-        Expect::that($result->exitCode)->because('checks markdown headings and tables')->toBe(1)
-            ->and($result->output())->toContain('sample.md:1: british-spelling:')
+        Expect::that($result->exitCode)->because('checks markdown headings and tables')->toBe(1);
+        Expect::that($result->output())->toContain('sample.md:1: british-spelling:')
             ->toContain('sample.md:5: contraction:');
     }
 
@@ -150,8 +150,8 @@ final readonly class ProseCheckBehaviorTest
         );
 
         $result = $this->run('check', $root);
-        Expect::that($result->exitCode)->because('checks website copy and excludes code')->toBe(1)
-            ->and($result->output())->toContain('website/src/pages/index.astro:')
+        Expect::that($result->exitCode)->because('checks website copy and excludes code')->toBe(1);
+        Expect::that($result->output())->toContain('website/src/pages/index.astro:')
             ->toContain('british-spelling')
             ->toContain('contraction')
             ->not()->toContain('codeSample');
@@ -173,8 +173,8 @@ final readonly class ProseCheckBehaviorTest
         );
 
         $result = $this->run('check', $root);
-        Expect::that($result->exitCode)->because('checks static and expression accessibility attributes')->toBe(1)
-            ->and($result->output())->toContain('website/src/pages/index.astro:1: semicolon:')
+        Expect::that($result->exitCode)->because('checks static and expression accessibility attributes')->toBe(1);
+        Expect::that($result->output())->toContain('website/src/pages/index.astro:1: semicolon:')
             ->toContain('website/src/pages/index.astro:2: contraction:');
     }
 
@@ -212,8 +212,8 @@ final readonly class ProseCheckBehaviorTest
         );
 
         $result = $this->run('check', $root);
-        Expect::that($result->exitCode)->because('checks structured descriptions and owned comments')->toBe(1)
-            ->and($result->output())->toContain('composer.json:2: british-spelling:')
+        Expect::that($result->exitCode)->because('checks structured descriptions and owned comments')->toBe(1);
+        Expect::that($result->output())->toContain('composer.json:2: british-spelling:')
             ->toContain('.github/ISSUE_TEMPLATE/feature.yml:2: british-spelling:')
             ->toContain('.github/ISSUE_TEMPLATE/feature.yml:3: contraction:')
             ->toContain('website/src/lib/docs.ts:3: british-spelling:');
@@ -252,8 +252,8 @@ final readonly class ProseCheckBehaviorTest
         );
 
         $result = $this->run('check', $root);
-        Expect::that($result->exitCode)->because('checks multiline structured and script prose')->toBe(1)
-            ->and($result->output())->toContain('composer.json:2: contraction:')
+        Expect::that($result->exitCode)->because('checks multiline structured and script prose')->toBe(1);
+        Expect::that($result->output())->toContain('composer.json:2: contraction:')
             ->toContain('composer.json:2: british-spelling:')
             ->toContain('.github/ISSUE_TEMPLATE/feature.yml:1: contraction:')
             ->toContain('.github/ISSUE_TEMPLATE/feature.yml:1: british-spelling:')
@@ -283,8 +283,8 @@ final readonly class ProseCheckBehaviorTest
         );
 
         $result = $this->run('check', $root);
-        Expect::that($result->exitCode)->because('checks script block comments')->toBe(1)
-            ->and($result->output())->toContain('website/scripts/status.mjs:6: semicolon:')
+        Expect::that($result->exitCode)->because('checks script block comments')->toBe(1);
+        Expect::that($result->output())->toContain('website/scripts/status.mjs:6: semicolon:')
             ->not()->toContain('website/scripts/status.mjs:2: contraction:');
     }
 
@@ -308,8 +308,8 @@ final readonly class ProseCheckBehaviorTest
         );
 
         $result = $this->run('check', $root);
-        Expect::that($result->exitCode)->because('joins script line-comment paragraphs')->toBe(1)
-            ->and($result->output())->toContain('website/scripts/status.mjs:5: sentence-length:')
+        Expect::that($result->exitCode)->because('joins script line-comment paragraphs')->toBe(1);
+        Expect::that($result->output())->toContain('website/scripts/status.mjs:5: sentence-length:')
             ->toContain('website/scripts/status.mjs:8: paragraph-length:')
             ->not()->toContain('website/scripts/status.mjs:2: contraction:');
     }
@@ -335,8 +335,8 @@ final readonly class ProseCheckBehaviorTest
         );
 
         $result = $this->run('review', $root);
-        Expect::that($result->exitCode)->because('excludes multiline Astro expressions')->toBe(0)
-            ->and($result->output())->toBe('');
+        Expect::that($result->exitCode)->because('excludes multiline Astro expressions')->toBe(0);
+        Expect::that($result->output())->toBe('');
     }
 
     #[Test]
@@ -350,8 +350,8 @@ final readonly class ProseCheckBehaviorTest
         );
 
         $result = $this->run('review', $root);
-        Expect::that($result->exitCode)->because('excludes registered literals')->toBe(0)
-            ->and($result->output())->toBe('');
+        Expect::that($result->exitCode)->because('excludes registered literals')->toBe(0);
+        Expect::that($result->output())->toBe('');
     }
 
     #[Test]
@@ -405,8 +405,8 @@ final readonly class ProseCheckBehaviorTest
         );
 
         $includedResult = $this->run('check', $root);
-        Expect::that($includedResult->exitCode)->because('excludes PHPDoc tags and machine directives but checks narrative comments')->toBe(1)
-            ->and($includedResult->output())->toContain('src/Narrative.php:3:')
+        Expect::that($includedResult->exitCode)->because('excludes PHPDoc tags and machine directives but checks narrative comments')->toBe(1);
+        Expect::that($includedResult->output())->toContain('src/Narrative.php:3:')
             ->toContain('british-spelling')
             ->toContain('semicolon');
     }
@@ -438,8 +438,8 @@ final readonly class ProseCheckBehaviorTest
         );
 
         $result = $this->run('check', $root);
-        Expect::that($result->exitCode)->because('checks PHPDoc tag descriptions and human-readable strings')->toBe(1)
-            ->and($result->output())->toContain('src/Message.php:6: semicolon:')
+        Expect::that($result->exitCode)->because('checks PHPDoc tag descriptions and human-readable strings')->toBe(1);
+        Expect::that($result->output())->toContain('src/Message.php:6: semicolon:')
             ->toContain('src/Message.php:6: contraction:')
             ->toContain('src/Message.php:6: british-spelling:')
             ->toContain('src/Message.php:7: contraction:')
@@ -477,8 +477,8 @@ final readonly class ProseCheckBehaviorTest
         );
 
         $result = $this->run('check', $root);
-        Expect::that($result->exitCode)->because('checks prose-bearing PHPDoc tags')->toBe(1)
-            ->and($result->output())->toContain('src/Message.php:6: contraction:')
+        Expect::that($result->exitCode)->because('checks prose-bearing PHPDoc tags')->toBe(1);
+        Expect::that($result->output())->toContain('src/Message.php:6: contraction:')
             ->toContain('src/Message.php:6: semicolon:')
             ->toContain('src/Message.php:11: contraction:')
             ->toContain('src/Message.php:11: semicolon:');
@@ -495,8 +495,8 @@ final readonly class ProseCheckBehaviorTest
         );
 
         $result = $this->run('check', $root);
-        Expect::that($result->exitCode)->because('checks the extensionless PHP entry point')->toBe(1)
-            ->and($result->output())->toContain('bin/greenlight:3: contraction:')
+        Expect::that($result->exitCode)->because('checks the extensionless PHP entry point')->toBe(1);
+        Expect::that($result->output())->toContain('bin/greenlight:3: contraction:')
             ->toContain('bin/greenlight:3: semicolon:');
     }
 
@@ -533,8 +533,8 @@ final readonly class ProseCheckBehaviorTest
         );
 
         $result = $this->run('check', $root);
-        Expect::that($result->exitCode)->because('checks multiline PHPDoc and interpolated PHP strings')->toBe(1)
-            ->and($result->output())->toContain('src/Message.php:6: semicolon:')
+        Expect::that($result->exitCode)->because('checks multiline PHPDoc and interpolated PHP strings')->toBe(1);
+        Expect::that($result->output())->toContain('src/Message.php:6: semicolon:')
             ->toContain('src/Message.php:6: contraction:')
             ->toContain('src/Message.php:6: british-spelling:')
             ->toContain('src/Message.php:11: contraction:')
@@ -561,8 +561,8 @@ final readonly class ProseCheckBehaviorTest
         );
 
         $result = $this->run('check', $root);
-        Expect::that($result->exitCode)->because('joins wrapped Markdown list items')->toBe(1)
-            ->and($result->output())->toContain('sample.md:1: sentence-length:')
+        Expect::that($result->exitCode)->because('joins wrapped Markdown list items')->toBe(1);
+        Expect::that($result->output())->toContain('sample.md:1: sentence-length:')
             ->toContain('sample.md:4: paragraph-length:');
     }
 
@@ -620,8 +620,8 @@ final readonly class ProseCheckBehaviorTest
         );
 
         $result = $this->run('check', $root);
-        Expect::that($result->exitCode)->because('joins consecutive line comments and does not create delimiter text')->toBe(1)
-            ->and($result->output())->toContain('paragraph-length')
+        Expect::that($result->exitCode)->because('joins consecutive line comments and does not create delimiter text')->toBe(1);
+        Expect::that($result->output())->toContain('paragraph-length')
             ->not()->toContain('valid description. /');
     }
 
@@ -649,8 +649,8 @@ final readonly class ProseCheckBehaviorTest
         );
 
         $result = $this->run('review', $root);
-        Expect::that($result->exitCode)->because('review reports advisories without failure')->toBe(0)
-            ->and($result->output())->toContain('procedural-sentence-length')
+        Expect::that($result->exitCode)->because('review reports advisories without failure')->toBe(0);
+        Expect::that($result->output())->toContain('procedural-sentence-length')
             ->toContain('passive-voice')
             ->toContain('verbal-ing')
             ->toContain('discouraged-word')
@@ -671,9 +671,9 @@ final readonly class ProseCheckBehaviorTest
         $checked = $this->run('check', $root);
         $reviewed = $this->run('review', $root);
 
-        Expect::that($checked->exitCode)->because('reports long instructions without blocking them')->toBe(0)
-            ->and($reviewed->exitCode)->toBe(0)
-            ->and($reviewed->output())->toContain('procedural-sentence-length');
+        Expect::that($checked->exitCode)->because('reports long instructions without blocking them')->toBe(0);
+        Expect::that($reviewed->exitCode)->toBe(0);
+        Expect::that($reviewed->output())->toContain('procedural-sentence-length');
     }
 
     #[Test]
@@ -687,8 +687,8 @@ final readonly class ProseCheckBehaviorTest
         );
 
         $result = $this->run('review', $root);
-        Expect::that($result->exitCode)->because('does not report approved normative tokens as discouraged words')->toBe(0)
-            ->and($result->output())->not()->toContain('discouraged-word');
+        Expect::that($result->exitCode)->because('does not report approved normative tokens as discouraged words')->toBe(0);
+        Expect::that($result->output())->not()->toContain('discouraged-word');
     }
 
     #[Test]
@@ -703,13 +703,13 @@ final readonly class ProseCheckBehaviorTest
         $firstPosition = \strpos($first->output(), 'a-first.md:');
         $lastPosition = \strpos($first->output(), 'z-last.md:');
 
-        Expect::that($first->exitCode)->because('output is deterministic and sorted by path')->toBe(1)
-            ->and($second->exitCode)->toBe(1)
-            ->and($second->output())->toBe($first->output())
-            ->and($first->output())->toMatch('/^a-first\.md:\d+: contraction:/m')
-            ->and($firstPosition)->not()->toBeFalse()
-            ->and($lastPosition)->not()->toBeFalse()
-            ->and((int) $firstPosition)->toBeLessThan((int) $lastPosition);
+        Expect::that($first->exitCode)->because('output is deterministic and sorted by path')->toBe(1);
+        Expect::that($second->exitCode)->toBe(1);
+        Expect::that($second->output())->toBe($first->output());
+        Expect::that($first->output())->toMatch('/^a-first\.md:\d+: contraction:/m');
+        Expect::that($firstPosition)->not()->toBeFalse();
+        Expect::that($lastPosition)->not()->toBeFalse();
+        Expect::that((int) $firstPosition)->toBeLessThan((int) $lastPosition);
     }
 
     #[Test]
@@ -781,8 +781,8 @@ final readonly class ProseCheckBehaviorTest
             '--baseline-dir=' . $root . '/baseline',
         ]);
 
-        Expect::that($result->exitCode)->because('rejects removed baseline options')->toBe(1)
-            ->and($result->stderr)->toContain('Unknown prose-check option "--baseline-dir=');
+        Expect::that($result->exitCode)->because('rejects removed baseline options')->toBe(1);
+        Expect::that($result->stderr)->toContain('Unknown prose-check option "--baseline-dir=');
     }
 
     private function workspace(string $name): string

--- a/tests/Acceptance/RectorDefaultFailureMessageTest.php
+++ b/tests/Acceptance/RectorDefaultFailureMessageTest.php
@@ -43,8 +43,8 @@ final readonly class RectorDefaultFailureMessageTest
 
         Expect::that($probe->changed)
             ->because('a PHPUnit failure without a message MUST be convertible')
-            ->toBeTrue()
-            ->and($probe->code)
+            ->toBeTrue();
+        Expect::that($probe->code)
             ->because('Greenlight failures MUST have a non-empty reason')
             ->toContain("\Greenlight\Expect\Fail::because('Test failed.');");
     }

--- a/tests/Acceptance/RectorDefaultSkipReasonTest.php
+++ b/tests/Acceptance/RectorDefaultSkipReasonTest.php
@@ -43,8 +43,8 @@ final readonly class RectorDefaultSkipReasonTest
 
         Expect::that($probe->changed)
             ->because('a PHPUnit skip without a reason MUST be convertible')
-            ->toBeTrue()
-            ->and($probe->code)
+            ->toBeTrue();
+        Expect::that($probe->code)
             ->because('Greenlight skips MUST have a non-empty reason')
             ->toContain("throw new \Greenlight\Core\Test\SkipTest('Skipped.');");
     }

--- a/tests/Acceptance/RectorDuplicateExceptionExpectationTest.php
+++ b/tests/Acceptance/RectorDuplicateExceptionExpectationTest.php
@@ -46,8 +46,8 @@ final readonly class RectorDuplicateExceptionExpectationTest
 
         Expect::that($probe->changed)
             ->because('duplicate exception expectations MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorDuplicateExceptionMessageTest.php
+++ b/tests/Acceptance/RectorDuplicateExceptionMessageTest.php
@@ -48,8 +48,8 @@ final readonly class RectorDuplicateExceptionMessageTest
 
         Expect::that($probe->changed)
             ->because('duplicate exception message constraints MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorDynamicDataProviderTest.php
+++ b/tests/Acceptance/RectorDynamicDataProviderTest.php
@@ -54,8 +54,8 @@ final readonly class RectorDynamicDataProviderTest
 
         Expect::that($probe->changed)
             ->because('a dynamic data provider reference MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorDynamicExceptionMessageTest.php
+++ b/tests/Acceptance/RectorDynamicExceptionMessageTest.php
@@ -47,8 +47,8 @@ final readonly class RectorDynamicExceptionMessageTest
 
         Expect::that($probe->changed)
             ->because('a dynamic exact exception message MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorDynamicMethodCallTest.php
+++ b/tests/Acceptance/RectorDynamicMethodCallTest.php
@@ -51,8 +51,8 @@ final readonly class RectorDynamicMethodCallTest
 
         Expect::that($probe->changed)
             ->because('a dynamic method call MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorExceptionExpectationArityTest.php
+++ b/tests/Acceptance/RectorExceptionExpectationArityTest.php
@@ -46,8 +46,8 @@ final readonly class RectorExceptionExpectationArityTest
 
         Expect::that($probe->changed)
             ->because('exception expectations with surplus arguments MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorExceptionMessageDelimiterTest.php
+++ b/tests/Acceptance/RectorExceptionMessageDelimiterTest.php
@@ -45,8 +45,8 @@ final readonly class RectorExceptionMessageDelimiterTest
 
         Expect::that($probe->changed)
             ->because('the exception expectation MUST be convertible')
-            ->toBeTrue()
-            ->and($probe->code)
+            ->toBeTrue();
+        Expect::that($probe->code)
             ->because('the generated matcher MUST escape its slash delimiter')
             ->toContain(
                 "->toThrow(\\RuntimeException::class, matching: '/path \\/tmp/');",

--- a/tests/Acceptance/RectorFirstClassCallableTest.php
+++ b/tests/Acceptance/RectorFirstClassCallableTest.php
@@ -45,8 +45,8 @@ final readonly class RectorFirstClassCallableTest
 
         Expect::that($probe->changed)
             ->because('a first-class callable reference MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorInvalidTestWithLabelTest.php
+++ b/tests/Acceptance/RectorInvalidTestWithLabelTest.php
@@ -47,8 +47,8 @@ final readonly class RectorInvalidTestWithLabelTest
 
         Expect::that($probe->changed)
             ->because('a TestWith label with an invalid name MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorMessageOnlyThrowableTest.php
+++ b/tests/Acceptance/RectorMessageOnlyThrowableTest.php
@@ -44,8 +44,8 @@ final readonly class RectorMessageOnlyThrowableTest
 
         Expect::that($probe->changed)
             ->because('the message-only exception expectation MUST be convertible')
-            ->toBeTrue()
-            ->and($probe->code)
+            ->toBeTrue();
+        Expect::that($probe->code)
             ->because('the converted expectation MUST accept all throwable values')
             ->toContain("->toThrow(\Throwable::class, matching: '/boom/');");
     }

--- a/tests/Acceptance/RectorMigrationRunTest.php
+++ b/tests/Acceptance/RectorMigrationRunTest.php
@@ -165,8 +165,8 @@ final readonly class RectorMigrationRunTest
     {
         $probe = RectorProbe::convert($this->tempDirectory, self::CONVERTIBLE, name: 'converts');
 
-        Expect::that($probe->changed)->toBeTrue()
-            ->and($probe->code)->not()->toContain('extends TestCase')
+        Expect::that($probe->changed)->toBeTrue();
+        Expect::that($probe->code)->not()->toContain('extends TestCase')
             ->toContain('#[\Greenlight\Attribute\Test]')
             ->toContain('#[\Greenlight\Attribute\Before]')
             ->toContain("#[\Greenlight\Attribute\Group('pricing')]")
@@ -187,8 +187,8 @@ final readonly class RectorMigrationRunTest
         $this->writeGreenlightConfig($probe->directory);
         $run = GreenlightCli::run($probe->directory, ['run', '--no-ansi']);
 
-        Expect::that($run->exitCode)->toBe(0)
-            ->and($run->stdout)->toContain('7 tests, 6 passed, 1 skipped')
+        Expect::that($run->exitCode)->toBe(0);
+        Expect::that($run->stdout)->toContain('7 tests, 6 passed, 1 skipped')
             ->toContain('no smtp server');
     }
 
@@ -199,8 +199,8 @@ final readonly class RectorMigrationRunTest
 
         Expect::that($probe->changed)
             ->because('the exception test MUST be convertible')
-            ->toBeTrue()
-            ->and($probe->code)
+            ->toBeTrue();
+        Expect::that($probe->code)
             ->because('the PHPUnit message pattern MUST remain the Greenlight matcher pattern')
             ->toContain(
                 "->toThrow(\\RuntimeException::class, matching: '/code=\\d+/');",
@@ -211,8 +211,8 @@ final readonly class RectorMigrationRunTest
 
         Expect::that($run->exitCode)
             ->because('the converted exception matcher MUST preserve runtime behavior')
-            ->toBe(0)
-            ->and($run->stdout)
+            ->toBe(0);
+        Expect::that($run->stdout)
             ->toContain('1 test, 1 passed');
     }
 
@@ -555,8 +555,8 @@ final readonly class RectorMigrationRunTest
             name: 'drops-messages',
         );
 
-        Expect::that($probe->changed)->toBeTrue()
-            ->and($probe->code)->toContain("\Greenlight\Expect\Expect::that('a')->toBe('a');")
+        Expect::that($probe->changed)->toBeTrue();
+        Expect::that($probe->code)->toContain("\Greenlight\Expect\Expect::that('a')->toBe('a');")
             ->not()->toContain('values must match');
     }
 
@@ -589,16 +589,16 @@ final readonly class RectorMigrationRunTest
             name: 'inline-rows',
         );
 
-        Expect::that($probe->changed)->toBeTrue()
-            ->and(\substr_count($probe->code, '#[\Greenlight\Attribute\DataRow'))->toBe(2)
-            ->and($probe->code)->toContain('#[\Greenlight\Attribute\DataRow([1])]')
+        Expect::that($probe->changed)->toBeTrue();
+        Expect::that(\substr_count($probe->code, '#[\Greenlight\Attribute\DataRow'))->toBe(2);
+        Expect::that($probe->code)->toContain('#[\Greenlight\Attribute\DataRow([1])]')
             ->toContain('#[\Greenlight\Attribute\DataRow([2])]');
 
         $this->writeGreenlightConfig($probe->directory);
         $run = GreenlightCli::run($probe->directory, ['run', '--no-ansi']);
 
-        Expect::that($run->exitCode)->toBe(0)
-            ->and($run->stdout)->toContain('2 tests, 2 passed');
+        Expect::that($run->exitCode)->toBe(0);
+        Expect::that($run->stdout)->toContain('2 tests, 2 passed');
     }
 
     #[Test]
@@ -675,15 +675,15 @@ final readonly class RectorMigrationRunTest
             name: 'assertions',
         );
 
-        Expect::that($probe->changed)->toBeTrue()
-            ->and($probe->code)->not()->toContain('->assert')
+        Expect::that($probe->changed)->toBeTrue();
+        Expect::that($probe->code)->not()->toContain('->assert')
             ->not()->toContain('::assert');
 
         $this->writeGreenlightConfig($probe->directory);
         $run = GreenlightCli::run($probe->directory, ['run', '--no-ansi']);
 
-        Expect::that($run->exitCode)->toBe(0)
-            ->and($run->stdout)->toContain('1 test, 1 passed');
+        Expect::that($run->exitCode)->toBe(0);
+        Expect::that($run->stdout)->toContain('1 test, 1 passed');
     }
 
     private function writeGreenlightConfig(string $directory): void

--- a/tests/Acceptance/RectorMissingDataProviderTest.php
+++ b/tests/Acceptance/RectorMissingDataProviderTest.php
@@ -47,8 +47,8 @@ final readonly class RectorMissingDataProviderTest
 
         Expect::that($probe->changed)
             ->because('a missing data provider MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorNamedAssertionArgumentTest.php
+++ b/tests/Acceptance/RectorNamedAssertionArgumentTest.php
@@ -45,8 +45,8 @@ final readonly class RectorNamedAssertionArgumentTest
 
         Expect::that($probe->changed)
             ->because('an assertion with named arguments MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorNamedTestWithDataTest.php
+++ b/tests/Acceptance/RectorNamedTestWithDataTest.php
@@ -47,8 +47,8 @@ final readonly class RectorNamedTestWithDataTest
 
         Expect::that($probe->changed)
             ->because('named TestWith data MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorNonStaticDataProviderTest.php
+++ b/tests/Acceptance/RectorNonStaticDataProviderTest.php
@@ -52,8 +52,8 @@ final readonly class RectorNonStaticDataProviderTest
 
         Expect::that($probe->changed)
             ->because('a non-static data provider MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorNullsafeMethodCallTest.php
+++ b/tests/Acceptance/RectorNullsafeMethodCallTest.php
@@ -50,8 +50,8 @@ final readonly class RectorNullsafeMethodCallTest
 
         Expect::that($probe->changed)
             ->because('a nullsafe method call MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorOperatingSystemRequirementTest.php
+++ b/tests/Acceptance/RectorOperatingSystemRequirementTest.php
@@ -46,8 +46,8 @@ final readonly class RectorOperatingSystemRequirementTest
 
         Expect::that($probe->changed)
             ->because('the operating-system requirement MUST be convertible')
-            ->toBeTrue()
-            ->and($probe->code)
+            ->toBeTrue();
+        Expect::that($probe->code)
             ->because('the converted condition MUST keep the requested operating-system family')
             ->toContain(
                 '#[\Greenlight\Attribute\SkipUnless('
@@ -73,8 +73,8 @@ final readonly class RectorOperatingSystemRequirementTest
 
         Expect::that($run->exitCode)
             ->because('the converted operating-system condition MUST permit the matching family')
-            ->toBe(0)
-            ->and($run->stdout)
+            ->toBe(0);
+        Expect::that($run->stdout)
             ->toContain('1 test, 1 passed');
     }
 }

--- a/tests/Acceptance/RectorParentAssertionCallTest.php
+++ b/tests/Acceptance/RectorParentAssertionCallTest.php
@@ -45,8 +45,8 @@ final readonly class RectorParentAssertionCallTest
 
         Expect::that($probe->changed)
             ->because('a parent assertion call MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorPhpUnitFunctionCallTest.php
+++ b/tests/Acceptance/RectorPhpUnitFunctionCallTest.php
@@ -45,8 +45,8 @@ final readonly class RectorPhpUnitFunctionCallTest
 
         Expect::that($probe->changed)
             ->because('a PHPUnit function call MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorPhpUnitStaticCallTest.php
+++ b/tests/Acceptance/RectorPhpUnitStaticCallTest.php
@@ -45,8 +45,8 @@ final readonly class RectorPhpUnitStaticCallTest
 
         Expect::that($probe->changed)
             ->because('a PHPUnit static call MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorPrivateDataProviderTest.php
+++ b/tests/Acceptance/RectorPrivateDataProviderTest.php
@@ -52,8 +52,8 @@ final readonly class RectorPrivateDataProviderTest
 
         Expect::that($probe->changed)
             ->because('a private data provider MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorSizeAttributeTest.php
+++ b/tests/Acceptance/RectorSizeAttributeTest.php
@@ -52,8 +52,8 @@ final readonly class RectorSizeAttributeTest
 
         Expect::that($probe->changed)
             ->because('the PHPUnit size attribute MUST be convertible')
-            ->toBeTrue()
-            ->and($probe->code)
+            ->toBeTrue();
+        Expect::that($probe->code)
             ->because('the converted size MUST remain available for group selection')
             ->toContain(\sprintf("#[\\Greenlight\\Attribute\\Group('%s')]", $group))
             ->not()

--- a/tests/Acceptance/RectorSurplusFailArgumentTest.php
+++ b/tests/Acceptance/RectorSurplusFailArgumentTest.php
@@ -45,8 +45,8 @@ final readonly class RectorSurplusFailArgumentTest
 
         Expect::that($probe->changed)
             ->because('fail() with surplus arguments MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorSurplusNoExpectationsArgumentTest.php
+++ b/tests/Acceptance/RectorSurplusNoExpectationsArgumentTest.php
@@ -45,8 +45,8 @@ final readonly class RectorSurplusNoExpectationsArgumentTest
 
         Expect::that($probe->changed)
             ->because('expectNotToPerformAssertions() with arguments MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorSurplusSkipArgumentTest.php
+++ b/tests/Acceptance/RectorSurplusSkipArgumentTest.php
@@ -45,8 +45,8 @@ final readonly class RectorSurplusSkipArgumentTest
 
         Expect::that($probe->changed)
             ->because('markTestSkipped() with surplus arguments MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorSurplusTestWithArgumentTest.php
+++ b/tests/Acceptance/RectorSurplusTestWithArgumentTest.php
@@ -47,8 +47,8 @@ final readonly class RectorSurplusTestWithArgumentTest
 
         Expect::that($probe->changed)
             ->because('a TestWith attribute with surplus arguments MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorTicketGroupTest.php
+++ b/tests/Acceptance/RectorTicketGroupTest.php
@@ -51,8 +51,8 @@ final readonly class RectorTicketGroupTest
 
         Expect::that($probe->changed)
             ->because('the ticket attribute MUST be convertible')
-            ->toBeTrue()
-            ->and($probe->code)
+            ->toBeTrue();
+        Expect::that($probe->code)
             ->because('the converted group MUST keep the ticket identifier')
             ->toContain("#[\Greenlight\Attribute\Group('GH-123')]");
 
@@ -78,8 +78,8 @@ final readonly class RectorTicketGroupTest
 
         Expect::that($run->exitCode)
             ->because('the converted ticket group MUST select its test')
-            ->toBe(0)
-            ->and($run->stdout)
+            ->toBe(0);
+        Expect::that($run->stdout)
             ->toContain('1 test, 1 passed')
             ->not()
             ->toContain('2 tests');

--- a/tests/Acceptance/RectorUnpackedAssertionArgumentTest.php
+++ b/tests/Acceptance/RectorUnpackedAssertionArgumentTest.php
@@ -47,8 +47,8 @@ final readonly class RectorUnpackedAssertionArgumentTest
 
         Expect::that($probe->changed)
             ->because('an assertion with unpacked arguments MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorUnpackedTestWithTest.php
+++ b/tests/Acceptance/RectorUnpackedTestWithTest.php
@@ -47,8 +47,8 @@ final readonly class RectorUnpackedTestWithTest
 
         Expect::that($probe->changed)
             ->because('a TestWith attribute with unpacked arguments MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorUnsupportedAssertCallTest.php
+++ b/tests/Acceptance/RectorUnsupportedAssertCallTest.php
@@ -47,8 +47,8 @@ final readonly class RectorUnsupportedAssertCallTest
 
         Expect::that($probe->changed)
             ->because('an unsupported Assert call MUST remain unsupported')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->because('an unsupported class MUST remain byte-identical')
             ->toBe($source);
     }

--- a/tests/Acceptance/RectorUnsupportedAssertionTest.php
+++ b/tests/Acceptance/RectorUnsupportedAssertionTest.php
@@ -22,7 +22,7 @@ final readonly class RectorUnsupportedAssertionTest
     {
         $probe = RectorProbe::convert($this->tempDirectory, $source, name: 'unsupported');
 
-        Expect::that($probe->changed)->toBeFalse()
-            ->and($probe->code)->toBe($source);
+        Expect::that($probe->changed)->toBeFalse();
+        Expect::that($probe->code)->toBe($source);
     }
 }

--- a/tests/Acceptance/RectorUnsupportedClassShapeTest.php
+++ b/tests/Acceptance/RectorUnsupportedClassShapeTest.php
@@ -22,7 +22,7 @@ final readonly class RectorUnsupportedClassShapeTest
     {
         $probe = RectorProbe::convert($this->tempDirectory, $source, name: 'unsupported');
 
-        Expect::that($probe->changed)->toBeFalse()
-            ->and($probe->code)->toBe($source);
+        Expect::that($probe->changed)->toBeFalse();
+        Expect::that($probe->code)->toBe($source);
     }
 }

--- a/tests/Acceptance/RectorUnsupportedFrameworkApiTest.php
+++ b/tests/Acceptance/RectorUnsupportedFrameworkApiTest.php
@@ -22,7 +22,7 @@ final readonly class RectorUnsupportedFrameworkApiTest
     {
         $probe = RectorProbe::convert($this->tempDirectory, $source, name: 'unsupported');
 
-        Expect::that($probe->changed)->toBeFalse()
-            ->and($probe->code)->toBe($source);
+        Expect::that($probe->changed)->toBeFalse();
+        Expect::that($probe->code)->toBe($source);
     }
 }

--- a/tests/Acceptance/RectorUnsupportedProcessControlTest.php
+++ b/tests/Acceptance/RectorUnsupportedProcessControlTest.php
@@ -22,7 +22,7 @@ final readonly class RectorUnsupportedProcessControlTest
     {
         $probe = RectorProbe::convert($this->tempDirectory, $source, name: 'unsupported');
 
-        Expect::that($probe->changed)->toBeFalse()
-            ->and($probe->code)->toBe($source);
+        Expect::that($probe->changed)->toBeFalse();
+        Expect::that($probe->code)->toBe($source);
     }
 }

--- a/tests/Acceptance/RectorVersionedExtensionRequirementTest.php
+++ b/tests/Acceptance/RectorVersionedExtensionRequirementTest.php
@@ -47,8 +47,8 @@ final readonly class RectorVersionedExtensionRequirementTest
 
         Expect::that($probe->changed)
             ->because('Greenlight cannot preserve an extension version constraint')
-            ->toBeFalse()
-            ->and($probe->code)
+            ->toBeFalse();
+        Expect::that($probe->code)
             ->toBe($source)
             ->toContain("#[RequiresPhpExtension('json', '>=99')]");
     }

--- a/tests/Acceptance/ReporterSelectionTest.php
+++ b/tests/Acceptance/ReporterSelectionTest.php
@@ -44,12 +44,12 @@ final readonly class ReporterSelectionTest
 
         Expect::that($result->exitCode)
             ->because('an explicitly selected TTY reporter MUST run without a terminal')
-            ->toBe(0)
-            ->and($result->stdout)
+            ->toBe(0);
+        Expect::that($result->stdout)
             ->toContain('7 tests, 7 passed')
             ->not()
-            ->toContain("\x1b[")
-            ->and($result->stderr)
+            ->toContain("\x1b[");
+        Expect::that($result->stderr)
             ->toBe('');
     }
 }

--- a/tests/Acceptance/RunDiscoveryErrorTest.php
+++ b/tests/Acceptance/RunDiscoveryErrorTest.php
@@ -39,8 +39,8 @@ final readonly class RunDiscoveryErrorTest
 
         Expect::that($result->exitCode)
             ->because('a discovery failure MUST stop the run cleanly')
-            ->toBe(1)
-            ->and($result->stderr)
+            ->toBe(1);
+        Expect::that($result->stderr)
             ->toContain('MissingProviderTest::needsData() references data-set provider')
             ->toContain('MissingProviderTest::doesNotExist(), but the provider does not exist.');
     }

--- a/tests/Acceptance/SequentialFallbackTest.php
+++ b/tests/Acceptance/SequentialFallbackTest.php
@@ -30,8 +30,8 @@ final readonly class SequentialFallbackTest
 
         Expect::that($result->exitCode)
             ->because(\sprintf('the runner uses in-process execution when PHP disables %s', $function))
-            ->toBe(0)
-            ->and($result->output())->toContain('7 tests, 7 passed')
+            ->toBe(0);
+        Expect::that($result->output())->toContain('7 tests, 7 passed')
             ->not()->toContain($function);
     }
 

--- a/tests/Acceptance/SuitePathDiscoveryTest.php
+++ b/tests/Acceptance/SuitePathDiscoveryTest.php
@@ -43,8 +43,8 @@ final readonly class SuitePathDiscoveryTest
 
         Expect::that($result->exitCode)
             ->because('test discovery MUST include top-level and named-suite paths')
-            ->toBe(0)
-            ->and($result->output())
+            ->toBe(0);
+        Expect::that($result->output())
             ->toContain('Greenlight\Tests\Fixture\DiscoveryBasic\AlphaTest::one')
             ->toContain('Greenlight\Tests\Fixture\Lifecycle\Bail\AaTest::fails')
             ->toContain('Greenlight\Tests\Fixture\Lifecycle\Bail\BbTest::wouldAlsoPass');

--- a/tests/Acceptance/SymfonyRunTest.php
+++ b/tests/Acceptance/SymfonyRunTest.php
@@ -19,8 +19,8 @@ final readonly class SymfonyRunTest
     {
         $project = $this->writeProject();
         $result = GreenlightCli::run($project->directory, ['run', '--reporter=plain']);
-        Expect::that($result->exitCode)->because('injects container services and resets state between tests')->toBe(0)
-            ->and($result->output())->toContain('4 tests, 4 passed');
+        Expect::that($result->exitCode)->because('injects container services and resets state between tests')->toBe(0);
+        Expect::that($result->output())->toContain('4 tests, 4 passed');
     }
 
     private function writeProject(): AcceptanceProject
@@ -117,10 +117,10 @@ final readonly class SymfonyRunTest
                 {
                     $this->counter->record();
 
-                    Expect::that($this->greeter->greet('Ada'))->toBe('Hello, Ada!')
-                        ->and($this->named->greet())->toContain('fixture.named_greeter')
-                        ->and($this->kernel->getEnvironment())->toBe('test')
-                        ->and($this->counter->count())->toBe(1);
+                    Expect::that($this->greeter->greet('Ada'))->toBe('Hello, Ada!');
+                    Expect::that($this->named->greet())->toContain('fixture.named_greeter');
+                    Expect::that($this->kernel->getEnvironment())->toBe('test');
+                    Expect::that($this->counter->count())->toBe(1);
                 }
 
                 #[Test]

--- a/tests/Acceptance/TeamCityRunTest.php
+++ b/tests/Acceptance/TeamCityRunTest.php
@@ -26,10 +26,10 @@ final readonly class TeamCityRunTest
         $output = $result->output();
         $class = AlphaTest::class;
         $file = (string) \realpath(\dirname(__DIR__) . '/Fixture/DiscoveryBasic/AlphaTest.php');
-        Expect::that($result->exitCode)->because('parallel run emits location hints and flow IDs')->toBe(0)
-            ->and($output)->toContain(
-                "##teamcity[testSuiteStarted name='{$class}' locationHint='php_qn://{$file}::\\{$class}' flowId='{$class}']",
-            )
+        Expect::that($result->exitCode)->because('parallel run emits location hints and flow IDs')->toBe(0);
+        Expect::that($output)->toContain(
+            "##teamcity[testSuiteStarted name='{$class}' locationHint='php_qn://{$file}::\\{$class}' flowId='{$class}']",
+        )
             ->toContain(
                 "##teamcity[testStarted name='{$class}::one' locationHint='php_qn://{$file}::\\{$class}::one' flowId='{$class}']",
             )

--- a/tests/Acceptance/TemporalExpectationRunTest.php
+++ b/tests/Acceptance/TemporalExpectationRunTest.php
@@ -114,7 +114,7 @@ final readonly class TemporalExpectationRunTest
             '--reporter=plain',
         ]);
 
-        Expect::that($result->exitCode)->because('a worker polls real asynchronous external state')->toBe(0)
-            ->and($result->output())->toContain('1 test, 1 passed, 1 expectation');
+        Expect::that($result->exitCode)->because('a worker polls real asynchronous external state')->toBe(0);
+        Expect::that($result->output())->toContain('1 test, 1 passed, 1 expectation');
     }
 }

--- a/tests/Acceptance/WatchDiscoveryErrorTest.php
+++ b/tests/Acceptance/WatchDiscoveryErrorTest.php
@@ -66,8 +66,8 @@ final readonly class WatchDiscoveryErrorTest
 
             Expect::that($result->exitCode)
                 ->because('watch mode MUST remain available after a discovery error')
-                ->toBe(0)
-                ->and($result->stderr)
+                ->toBe(0);
+            Expect::that($result->stderr)
                 ->because('watch mode MUST report the discovery error')
                 ->toContain('BrokenTest.php')
                 ->toContain('WrongName');

--- a/tests/Acceptance/WorkerFailureContainmentTest.php
+++ b/tests/Acceptance/WorkerFailureContainmentTest.php
@@ -26,9 +26,9 @@ final readonly class WorkerFailureContainmentTest
     {
         $result = $this->runIn('CrashConfig', ['run', '--workers=2']);
 
-        Expect::that($result->exitCode)->because('crashed workers are contained and the run completes')->toBe(1)
-            ->and($this->summaryLine($result->output()))->toBe('3 tests, 2 passed, 1 errored, 0 expectations')
-            ->and($result->output())->toContain('crashed during this test');
+        Expect::that($result->exitCode)->because('crashed workers are contained and the run completes')->toBe(1);
+        Expect::that($this->summaryLine($result->output()))->toBe('3 tests, 2 passed, 1 errored, 0 expectations');
+        Expect::that($result->output())->toContain('crashed during this test');
     }
 
     #[Test]
@@ -74,9 +74,9 @@ final readonly class WorkerFailureContainmentTest
             Fail::because('The crashed retry did not emit TestFinished.');
         }
 
-        Expect::that($result->exitCode)->because('a crash on a retry preserves the attempt count')->toBe(1)
-            ->and($finished->result->outcome)->toBe(Outcome::Errored)
-            ->and($finished->result->attempts)->toBe(2);
+        Expect::that($result->exitCode)->because('a crash on a retry preserves the attempt count')->toBe(1);
+        Expect::that($finished->result->outcome)->toBe(Outcome::Errored);
+        Expect::that($finished->result->attempts)->toBe(2);
     }
 
     #[Test]
@@ -92,13 +92,13 @@ final readonly class WorkerFailureContainmentTest
             Fail::because('The hard timeout did not emit TestFinished.');
         }
 
-        Expect::that($result->exitCode)->because('hanging tests are hard killed by the orchestrator')->toBe(1)
-            ->and($result->output())->toContain('time limit')
-            ->and($durationSeconds)->toBeLessThan(20.0)
-            ->and($finished->result->outcome)->toBe(Outcome::Failed)
-            ->and($finished->result->durationSeconds)->toBeGreaterThan(0.1)
-            ->and($finished->result->failures)->toHaveCount(1)
-            ->and($finished->result->error)->toBeNull();
+        Expect::that($result->exitCode)->because('hanging tests are hard killed by the orchestrator')->toBe(1);
+        Expect::that($result->output())->toContain('time limit');
+        Expect::that($durationSeconds)->toBeLessThan(20.0);
+        Expect::that($finished->result->outcome)->toBe(Outcome::Failed);
+        Expect::that($finished->result->durationSeconds)->toBeGreaterThan(0.1);
+        Expect::that($finished->result->failures)->toHaveCount(1);
+        Expect::that($finished->result->error)->toBeNull();
     }
 
     #[Test]
@@ -146,8 +146,8 @@ final readonly class WorkerFailureContainmentTest
 
         Expect::that($result->exitCode)
             ->because('a hard timeout MUST fail the run')
-            ->toBe(1)
-            ->and($failure->message)
+            ->toBe(1);
+        Expect::that($failure->message)
             ->because('a hard timeout MUST preserve the worker diagnostic output')
             ->toContain("Worker output:\nThe timed-out worker emitted diagnostics.");
     }

--- a/tests/Acceptance/WorkerProcessRunTest.php
+++ b/tests/Acceptance/WorkerProcessRunTest.php
@@ -24,10 +24,10 @@ final readonly class WorkerProcessRunTest
         $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'parallel');
         $sequential = GreenlightCli::run($project->directory, ['run', '--workers=1']);
         $parallel = GreenlightCli::run($project->directory, ['run', '--workers=3']);
-        Expect::that($sequential->exitCode)->because('parallel results match sequential results')->toBe(0)
-            ->and($parallel->exitCode)->toBe(0)
-            ->and($this->summaryLine($sequential->output()))->toBe('7 tests, 7 passed, 0 expectations')
-            ->and($this->summaryLine($parallel->output()))->toBe('7 tests, 7 passed, 0 expectations');
+        Expect::that($sequential->exitCode)->because('parallel results match sequential results')->toBe(0);
+        Expect::that($parallel->exitCode)->toBe(0);
+        Expect::that($this->summaryLine($sequential->output()))->toBe('7 tests, 7 passed, 0 expectations');
+        Expect::that($this->summaryLine($parallel->output()))->toBe('7 tests, 7 passed, 0 expectations');
     }
 
     #[Test]
@@ -35,8 +35,8 @@ final readonly class WorkerProcessRunTest
     {
         $result = $this->runIn('PluginRunConfig', ['run', '--workers=2']);
 
-        Expect::that($result->exitCode)->because('configured plugins reach workers across the process boundary')->toBe(0)
-            ->and($this->summaryLine($result->output()))->toBe('2 tests, 1 passed, 1 skipped, 0 expectations');
+        Expect::that($result->exitCode)->because('configured plugins reach workers across the process boundary')->toBe(0);
+        Expect::that($this->summaryLine($result->output()))->toBe('2 tests, 1 passed, 1 skipped, 0 expectations');
     }
 
     #[Test]
@@ -44,8 +44,8 @@ final readonly class WorkerProcessRunTest
     {
         $result = $this->runIn('RecycleConfig', ['run']);
 
-        Expect::that($result->exitCode)->because('worker recycling keeps results intact')->toBe(0)
-            ->and($this->summaryLine($result->output()))->toBe('7 tests, 7 passed, 0 expectations');
+        Expect::that($result->exitCode)->because('worker recycling keeps results intact')->toBe(0);
+        Expect::that($this->summaryLine($result->output()))->toBe('7 tests, 7 passed, 0 expectations');
     }
 
     /**

--- a/tests/Fixture/Lifecycle/HarnessFixtures/HarnessFixturesTest.php
+++ b/tests/Fixture/Lifecycle/HarnessFixtures/HarnessFixturesTest.php
@@ -27,7 +27,7 @@ final readonly class HarnessFixturesTest
 
         TraceLog::add('temp:' . $path);
 
-        Expect::that(\is_file($path . '/probe.txt'))->toBeTrue()
-            ->and(\getenv('GREENLIGHT_FIXTURE_E2E'))->toBe('inside');
+        Expect::that(\is_file($path . '/probe.txt'))->toBeTrue();
+        Expect::that(\getenv('GREENLIGHT_FIXTURE_E2E'))->toBe('inside');
     }
 }

--- a/tests/Support/ProseCheckRuleProbe.php
+++ b/tests/Support/ProseCheckRuleProbe.php
@@ -27,14 +27,14 @@ final readonly class ProseCheckRuleProbe
         \file_put_contents($sample, "# Sample\n\n" . $invalid . "\n");
 
         $invalidResult = self::run($root);
-        Expect::that($invalidResult->exitCode)->because('blocking rules reject invalid prose and accept the valid counterpart')->toBe(1)
-            ->and($invalidResult->output())->toContain($rule);
+        Expect::that($invalidResult->exitCode)->because('blocking rules reject invalid prose and accept the valid counterpart')->toBe(1);
+        Expect::that($invalidResult->output())->toContain($rule);
 
         \file_put_contents($sample, "# Sample\n\n" . $valid . "\n");
 
         $validResult = self::run($root);
-        Expect::that($validResult->exitCode)->because('blocking rules reject invalid prose and accept the valid counterpart')->toBe(0)
-            ->and($validResult->output())->not()->toContain($rule);
+        Expect::that($validResult->exitCode)->because('blocking rules reject invalid prose and accept the valid counterpart')->toBe(0);
+        Expect::that($validResult->output())->not()->toContain($rule);
     }
 
     private static function run(string $root): ProcessResult

--- a/tests/Unit/Artifact/ArtifactAttemptRecordCollisionTest.php
+++ b/tests/Unit/Artifact/ArtifactAttemptRecordCollisionTest.php
@@ -37,11 +37,11 @@ final readonly class ArtifactAttemptRecordCollisionTest
             ->toThrow(
                 AttachmentError::class,
                 matching: '/^Failed to create attachment staging subdirectory/',
-            )
-            ->and((string) \file_get_contents($testDirectory))
+            );
+        Expect::that((string) \file_get_contents($testDirectory))
             ->because('a rejected attempt record MUST preserve the existing entry')
-            ->toBe('occupied')
-            ->and(\file_exists($testDirectory . '/.attempt'))
+            ->toBe('occupied');
+        Expect::that(\file_exists($testDirectory . '/.attempt'))
             ->because('a rejected attempt record MUST not create an attempt file')
             ->toBeFalse();
     }

--- a/tests/Unit/Artifact/ArtifactCleanupSymlinkTest.php
+++ b/tests/Unit/Artifact/ArtifactCleanupSymlinkTest.php
@@ -46,11 +46,11 @@ final readonly class ArtifactCleanupSymlinkTest
 
             Expect::that(\is_dir($staging))
                 ->because('cleanup MUST remove the artifact staging directory')
-                ->toBeFalse()
-                ->and(\is_link($link))
+                ->toBeFalse();
+            Expect::that(\is_link($link))
                 ->because('cleanup MUST remove symbolic links inside artifact staging')
-                ->toBeFalse()
-                ->and(\file_get_contents($sentinel))
+                ->toBeFalse();
+            Expect::that(\file_get_contents($sentinel))
                 ->because('cleanup MUST leave symbolic link targets unchanged')
                 ->toBe('keep');
         } finally {

--- a/tests/Unit/Artifact/ArtifactCopyFlushFailureTest.php
+++ b/tests/Unit/Artifact/ArtifactCopyFlushFailureTest.php
@@ -42,8 +42,8 @@ final readonly class ArtifactCopyFlushFailureTest
                 ->toThrow(
                     AttachmentError::class,
                     message: 'Failed to flush the published attachment.',
-                )
-                ->and(UnflushableStream::closedStreams())
+                );
+            Expect::that(UnflushableStream::closedStreams())
                 ->because('a flush failure MUST close the destination stream')
                 ->toBe(1);
         } finally {

--- a/tests/Unit/Artifact/ArtifactCopyReadFailureTest.php
+++ b/tests/Unit/Artifact/ArtifactCopyReadFailureTest.php
@@ -37,8 +37,8 @@ final readonly class ArtifactCopyReadFailureTest
                 ->toThrow(
                     AttachmentError::class,
                     message: 'Failed to read attachment staging content.',
-                )
-                ->and(UnreadableCopySourceStream::closedStreams())
+                );
+            Expect::that(UnreadableCopySourceStream::closedStreams())
                 ->because('a read failure MUST close the source stream')
                 ->toBe(1);
         } finally {

--- a/tests/Unit/Artifact/ArtifactIntermittentReadTest.php
+++ b/tests/Unit/Artifact/ArtifactIntermittentReadTest.php
@@ -53,10 +53,10 @@ final readonly class ArtifactIntermittentReadTest
 
             Expect::that(\file_get_contents($stagedPath))
                 ->because('a transient empty source read MUST not truncate the staged attachment')
-                ->toBe('evidence')
-                ->and($attachment->sizeBytes)
-                ->toBe(8)
-                ->and($attachment->sha256)
+                ->toBe('evidence');
+            Expect::that($attachment->sizeBytes)
+                ->toBe(8);
+            Expect::that($attachment->sha256)
                 ->toBe(\hash('sha256', 'evidence'));
         } finally {
             $store?->cleanup();

--- a/tests/Unit/Artifact/ArtifactMetadataCollisionTest.php
+++ b/tests/Unit/Artifact/ArtifactMetadataCollisionTest.php
@@ -49,11 +49,11 @@ final readonly class ArtifactMetadataCollisionTest
             ->toThrow(
                 AttachmentError::class,
                 message: 'Failed to finalize attachment recovery metadata.',
-            )
-            ->and(\is_dir($metadata))
+            );
+        Expect::that(\is_dir($metadata))
             ->because('rollback MUST preserve pre-existing metadata blockers')
-            ->toBeTrue()
-            ->and(\file_exists($staging . '/' . $storageKey))
+            ->toBeTrue();
+        Expect::that(\file_exists($staging . '/' . $storageKey))
             ->because('rollback MUST remove attachment content without completed metadata')
             ->toBeFalse();
 

--- a/tests/Unit/Artifact/ArtifactOutputEntryTest.php
+++ b/tests/Unit/Artifact/ArtifactOutputEntryTest.php
@@ -50,11 +50,11 @@ final readonly class ArtifactOutputEntryTest
                 ->toThrow(
                     AttachmentError::class,
                     message: 'Attachment output path contains a non-directory entry.',
-                )
-                ->and((string) \file_get_contents($blocker))
+                );
+            Expect::that((string) \file_get_contents($blocker))
                 ->because('a rejected publication MUST NOT replace the blocking entry')
-                ->toBe('keep')
-                ->and(\is_file($store->session()->stagingDirectory . '/' . $staged->storageKey))
+                ->toBe('keep');
+            Expect::that(\is_file($store->session()->stagingDirectory . '/' . $staged->storageKey))
                 ->because('rejected evidence remains available for recovery')
                 ->toBeTrue();
         } finally {

--- a/tests/Unit/Artifact/ArtifactOutputPermissionTest.php
+++ b/tests/Unit/Artifact/ArtifactOutputPermissionTest.php
@@ -56,8 +56,8 @@ final readonly class ArtifactOutputPermissionTest
                 ->toThrow(
                     AttachmentError::class,
                     matching: '/^Failed to create attachment output directory/',
-                )
-                ->and(\is_file($store->session()->stagingDirectory . '/' . $staged->storageKey))
+                );
+            Expect::that(\is_file($store->session()->stagingDirectory . '/' . $staged->storageKey))
                 ->because('rejected evidence MUST remain available for recovery')
                 ->toBeTrue();
         } finally {

--- a/tests/Unit/Artifact/ArtifactOutputSafetyTest.php
+++ b/tests/Unit/Artifact/ArtifactOutputSafetyTest.php
@@ -67,11 +67,11 @@ final readonly class ArtifactOutputSafetyTest
                 ->toThrow(
                     AttachmentError::class,
                     message: 'Attachment output directory contains a symbolic link.',
-                )
-                ->and(\glob($outside . '/*'))
+                );
+            Expect::that(\glob($outside . '/*'))
                 ->because('a rejected publication MUST NOT write outside its output directory')
-                ->toBe([])
-                ->and(\is_file($store->session()->stagingDirectory . '/' . $staged->storageKey))
+                ->toBe([]);
+            Expect::that(\is_file($store->session()->stagingDirectory . '/' . $staged->storageKey))
                 ->because('rejected evidence remains available for recovery')
                 ->toBeTrue();
         } finally {

--- a/tests/Unit/Artifact/ArtifactPostCopyIntegrityTest.php
+++ b/tests/Unit/Artifact/ArtifactPostCopyIntegrityTest.php
@@ -48,11 +48,11 @@ final readonly class ArtifactPostCopyIntegrityTest
                 ->toThrow(
                     AttachmentError::class,
                     message: 'Published attachment content does not match its metadata.',
-                )
-                ->and(\is_file($staged->path))
+                );
+            Expect::that(\is_file($staged->path))
                 ->because('a rejected publication MUST NOT leave the final attachment')
-                ->toBeFalse()
-                ->and(\glob($staged->path . '.part-*'))
+                ->toBeFalse();
+            Expect::that(\glob($staged->path . '.part-*'))
                 ->because('a rejected publication MUST remove its partial attachment')
                 ->toBe([]);
         } finally {

--- a/tests/Unit/Artifact/ArtifactQuotaTest.php
+++ b/tests/Unit/Artifact/ArtifactQuotaTest.php
@@ -44,8 +44,8 @@ final readonly class ArtifactQuotaTest
             ->toThrow(
                 AttachmentError::class,
                 message: 'Attachment quota path is unsafe.',
-            )
-            ->and((string) \file_get_contents($outside))
+            );
+        Expect::that((string) \file_get_contents($outside))
             ->because('a rejected quota path MUST NOT change its target')
             ->toBe('untouched');
     }
@@ -74,8 +74,8 @@ final readonly class ArtifactQuotaTest
             ->toThrow(
                 AttachmentError::class,
                 message: 'Attachment quota metadata is corrupt.',
-            )
-            ->and(\glob($staging . '/*/attempt-*'))
+            );
+        Expect::that(\glob($staging . '/*/attempt-*'))
             ->because('a rejected quota reservation MUST NOT leave staging data')
             ->toBe([]);
     }

--- a/tests/Unit/Artifact/ArtifactRecoveryAttemptFloorTest.php
+++ b/tests/Unit/Artifact/ArtifactRecoveryAttemptFloorTest.php
@@ -39,12 +39,12 @@ final readonly class ArtifactRecoveryAttemptFloorTest
 
             Expect::that($recovered->attempts)
                 ->because('stale recovery metadata MUST NOT reduce a reported attempt count')
-                ->toBe(10)
-                ->and($recovered->attachments)
-                ->toHaveCount(1)
-                ->and($recovered->attachments[0]->name)
-                ->toBe('evidence.txt')
-                ->and((string) \file_get_contents($recovered->attachments[0]->path))
+                ->toBe(10);
+            Expect::that($recovered->attachments)
+                ->toHaveCount(1);
+            Expect::that($recovered->attachments[0]->name)
+                ->toBe('evidence.txt');
+            Expect::that((string) \file_get_contents($recovered->attachments[0]->path))
                 ->toBe('completed evidence');
         } finally {
             $store->cleanup();

--- a/tests/Unit/Artifact/ArtifactRecoveryOrderTest.php
+++ b/tests/Unit/Artifact/ArtifactRecoveryOrderTest.php
@@ -42,11 +42,11 @@ final readonly class ArtifactRecoveryOrderTest
 
             Expect::that($recovered->attachments)
                 ->because('crash recovery orders evidence by numeric attempt')
-                ->toHaveCount(2)
-                ->and(\array_map(
-                    static fn($attachment): array => [$attachment->attempt, $attachment->name],
-                    $recovered->attachments,
-                ))
+                ->toHaveCount(2);
+            Expect::that(\array_map(
+                static fn($attachment): array => [$attachment->attempt, $attachment->name],
+                $recovered->attachments,
+            ))
                 ->toBe([
                     [2, 'second.txt'],
                     [10, 'tenth.txt'],

--- a/tests/Unit/Artifact/ArtifactSourceMutationTest.php
+++ b/tests/Unit/Artifact/ArtifactSourceMutationTest.php
@@ -60,8 +60,8 @@ final readonly class ArtifactSourceMutationTest
 
             Expect::that($attachments->collected())
                 ->because('a rejected source releases its run quota')
-                ->toHaveCount(1)
-                ->and($attachments->collected()[0]->name)
+                ->toHaveCount(1);
+            Expect::that($attachments->collected()[0]->name)
                 ->toBe('replacement.txt');
         } finally {
             $store?->cleanup();
@@ -106,11 +106,11 @@ final readonly class ArtifactSourceMutationTest
 
             Expect::that(\file_exists($failedPath))
                 ->because('a failed source read MUST remove the incomplete staging file')
-                ->toBeFalse()
-                ->and(\file_exists($failedPath . '.part'))
+                ->toBeFalse();
+            Expect::that(\file_exists($failedPath . '.part'))
                 ->because('a failed source read MUST remove the partial staging file')
-                ->toBeFalse()
-                ->and(\file_exists($failedPath . '.meta.json'))
+                ->toBeFalse();
+            Expect::that(\file_exists($failedPath . '.meta.json'))
                 ->because('a failed source read MUST not leave recovery metadata')
                 ->toBeFalse();
 
@@ -118,8 +118,8 @@ final readonly class ArtifactSourceMutationTest
 
             Expect::that($attachments->collected())
                 ->because('a failed source read MUST release its run quota')
-                ->toHaveCount(1)
-                ->and($attachments->collected()[0]->name)
+                ->toHaveCount(1);
+            Expect::that($attachments->collected()[0]->name)
                 ->toBe('replacement.txt');
         } finally {
             $store?->cleanup();

--- a/tests/Unit/Artifact/ArtifactStagingCollisionTest.php
+++ b/tests/Unit/Artifact/ArtifactStagingCollisionTest.php
@@ -39,8 +39,8 @@ final readonly class ArtifactStagingCollisionTest
             ->toThrow(
                 AttachmentError::class,
                 message: 'Greenlight did not create the attachment staging file.',
-            )
-            ->and((string) \file_get_contents($part))
+            );
+        Expect::that((string) \file_get_contents($part))
             ->because('a rejected file attachment MUST NOT delete the existing staging part')
             ->toBe('occupied');
 
@@ -80,8 +80,8 @@ final readonly class ArtifactStagingCollisionTest
             ->toThrow(
                 AttachmentError::class,
                 message: 'Greenlight did not create the attachment staging file.',
-            )
-            ->and((string) \file_get_contents($part))
+            );
+        Expect::that((string) \file_get_contents($part))
             ->because('a rejected byte attachment MUST NOT delete the existing staging part')
             ->toBe('occupied');
 
@@ -122,8 +122,8 @@ final readonly class ArtifactStagingCollisionTest
             ->toThrow(
                 AttachmentError::class,
                 message: 'Attachment staging path already exists.',
-            )
-            ->and((string) \file_get_contents($path))
+            );
+        Expect::that((string) \file_get_contents($path))
             ->because('a rejected attachment MUST NOT replace the existing staging file')
             ->toBe('occupied');
 

--- a/tests/Unit/Artifact/ArtifactStagingDirectoryCollisionTest.php
+++ b/tests/Unit/Artifact/ArtifactStagingDirectoryCollisionTest.php
@@ -51,8 +51,8 @@ final readonly class ArtifactStagingDirectoryCollisionTest
             ->toThrow(
                 AttachmentError::class,
                 matching: '/^Failed to create attachment staging subdirectory/',
-            )
-            ->and((string) \file_get_contents($blocker))
+            );
+        Expect::that((string) \file_get_contents($blocker))
             ->because('a rejected attachment MUST preserve the existing entry')
             ->toBe('occupied');
 

--- a/tests/Unit/Artifact/ArtifactStagingParentTest.php
+++ b/tests/Unit/Artifact/ArtifactStagingParentTest.php
@@ -49,8 +49,8 @@ final readonly class ArtifactStagingParentTest
             ->toThrow(
                 AttachmentError::class,
                 message: 'Failed to create attachment staging subdirectory: mkdir(): File exists.',
-            )
-            ->and((string) \file_get_contents($blocker))
+            );
+        Expect::that((string) \file_get_contents($blocker))
             ->because('a rejected attachment MUST NOT replace the blocking entry')
             ->toBe('keep');
 

--- a/tests/Unit/Artifact/ArtifactStagingRootCollisionTest.php
+++ b/tests/Unit/Artifact/ArtifactStagingRootCollisionTest.php
@@ -47,11 +47,11 @@ final readonly class ArtifactStagingRootCollisionTest
             ->toThrow(
                 AttachmentError::class,
                 matching: '/^Failed to create attachment staging directory/',
-            )
-            ->and((string) \file_get_contents($blocker))
+            );
+        Expect::that((string) \file_get_contents($blocker))
             ->because('a rejected staging root MUST preserve the existing entry')
-            ->toBe('occupied')
-            ->and(\is_dir($staging))
+            ->toBe('occupied');
+        Expect::that(\is_dir($staging))
             ->because('a rejected staging root MUST not create a directory')
             ->toBeFalse();
 

--- a/tests/Unit/Artifact/ArtifactStoreIntegrityTest.php
+++ b/tests/Unit/Artifact/ArtifactStoreIntegrityTest.php
@@ -103,8 +103,8 @@ final readonly class ArtifactStoreIntegrityTest
                 ->toThrow(
                     AttachmentError::class,
                     message: 'Attachment metadata contains an unsafe storage key.',
-                )
-                ->and(\file_exists($root . '/escaped.txt'))
+                );
+            Expect::that(\file_exists($root . '/escaped.txt'))
                 ->toBeFalse();
         } finally {
             $store->cleanup();

--- a/tests/Unit/Artifact/ArtifactStreamPartialWriteTest.php
+++ b/tests/Unit/Artifact/ArtifactStreamPartialWriteTest.php
@@ -33,8 +33,8 @@ final class ArtifactStreamPartialWriteTest
 
             Expect::that(PartialWriteStream::$written)
                 ->because('a partial write MUST continue from the first unwritten byte')
-                ->toBe('evidence')
-                ->and(PartialWriteStream::$writes)
+                ->toBe('evidence');
+            Expect::that(PartialWriteStream::$writes)
                 ->because('the fixture accepts at most two bytes from each write')
                 ->toBe(4);
         } finally {

--- a/tests/Unit/Artifact/ArtifactTestDirectoryCollisionTest.php
+++ b/tests/Unit/Artifact/ArtifactTestDirectoryCollisionTest.php
@@ -49,15 +49,15 @@ final readonly class ArtifactTestDirectoryCollisionTest
 
             Expect::that($first->attachments)
                 ->because('test IDs with the same filesystem slug MUST keep distinct evidence')
-                ->toHaveCount(1)
-                ->and($second->attachments)
-                ->toHaveCount(1)
-                ->and($first->attachments[0]->path)
+                ->toHaveCount(1);
+            Expect::that($second->attachments)
+                ->toHaveCount(1);
+            Expect::that($first->attachments[0]->path)
                 ->not()
-                ->toBe($second->attachments[0]->path)
-                ->and((string) \file_get_contents($first->attachments[0]->path))
-                ->toBe('spaced data-set key')
-                ->and((string) \file_get_contents($second->attachments[0]->path))
+                ->toBe($second->attachments[0]->path);
+            Expect::that((string) \file_get_contents($first->attachments[0]->path))
+                ->toBe('spaced data-set key');
+            Expect::that((string) \file_get_contents($second->attachments[0]->path))
                 ->toBe('hyphenated data-set key');
         } finally {
             $store->cleanup();

--- a/tests/Unit/Artifact/ArtifactTransformedOutcomeRetentionTest.php
+++ b/tests/Unit/Artifact/ArtifactTransformedOutcomeRetentionTest.php
@@ -39,10 +39,10 @@ final readonly class ArtifactTransformedOutcomeRetentionTest
 
             Expect::that($published->attachments)
                 ->because('a passing transformation MUST retain evidence from its failed source')
-                ->toHaveCount(1)
-                ->and($published->attachments[0]->name)
-                ->toBe('failure.txt')
-                ->and((string) \file_get_contents($published->attachments[0]->path))
+                ->toHaveCount(1);
+            Expect::that($published->attachments[0]->name)
+                ->toBe('failure.txt');
+            Expect::that((string) \file_get_contents($published->attachments[0]->path))
                 ->toBe('original failure evidence');
         } finally {
             $store->cleanup();
@@ -70,8 +70,8 @@ final readonly class ArtifactTransformedOutcomeRetentionTest
 
             Expect::that($published->attachments)
                 ->because('a transformation between successful outcomes MUST discard on-failure evidence')
-                ->toBe([])
-                ->and(\file_exists($store->publicDirectory()))
+                ->toBe([]);
+            Expect::that(\file_exists($store->publicDirectory()))
                 ->toBeFalse();
         } finally {
             $store->cleanup();

--- a/tests/Unit/Artifact/AttachmentMediaTypeValidationTest.php
+++ b/tests/Unit/Artifact/AttachmentMediaTypeValidationTest.php
@@ -44,8 +44,8 @@ final readonly class AttachmentMediaTypeValidationTest
                         'Attachment media type "%s" is invalid.',
                         $mediaType,
                     ),
-                )
-                ->and($attachments->collected())
+                );
+            Expect::that($attachments->collected())
                 ->toBe([]);
             Expect::that($budget->attachments)
                 ->because('an invalid media type MUST NOT consume the shared attachment count')

--- a/tests/Unit/Artifact/AttachmentNameValidationTest.php
+++ b/tests/Unit/Artifact/AttachmentNameValidationTest.php
@@ -74,16 +74,16 @@ final readonly class AttachmentNameValidationTest
                         'Attachment name "%s" is not a safe non-empty name.',
                         $name,
                     ),
-                )
-                ->and($attachments->collected())
+                );
+            Expect::that($attachments->collected())
                 ->toBe([]);
             Expect::that($budget->attachments)
                 ->because('an unsafe attachment name MUST NOT consume an attachment slot')
                 ->toBe(0);
             Expect::that($budget->bytes)
                 ->because('an unsafe attachment name MUST NOT consume the byte budget')
-                ->toBe(0)
-                ->and(\file_exists($store->session()->stagingDirectory))
+                ->toBe(0);
+            Expect::that(\file_exists($store->session()->stagingDirectory))
                 ->toBeFalse();
         } finally {
             $store->cleanup();

--- a/tests/Unit/Artifact/AttachmentsTest.php
+++ b/tests/Unit/Artifact/AttachmentsTest.php
@@ -120,8 +120,8 @@ final readonly class AttachmentsTest
             attachments: $attachments->seal(),
         ));
 
-        Expect::that($published->attachments)->because('output directory is created only when evidence is published')->toBe([])
-            ->and(\file_exists($output))->toBeFalse();
+        Expect::that($published->attachments)->because('output directory is created only when evidence is published')->toBe([]);
+        Expect::that(\file_exists($output))->toBeFalse();
 
         $store->cleanup();
     }
@@ -516,9 +516,9 @@ final readonly class AttachmentsTest
 
         $recovered = $store->recover(new TestResult($id, Outcome::Errored, 0.0, 0));
 
-        Expect::that($recovered->attachments)->because('completed evidence can be recovered after a worker crash')->toHaveCount(1)
-            ->and($recovered->attachments[0]->name)->toBe('last-response.txt')
-            ->and(\is_file($recovered->attachments[0]->path))->toBeTrue();
+        Expect::that($recovered->attachments)->because('completed evidence can be recovered after a worker crash')->toHaveCount(1);
+        Expect::that($recovered->attachments[0]->name)->toBe('last-response.txt');
+        Expect::that(\is_file($recovered->attachments[0]->path))->toBeTrue();
 
         $store->cleanup();
     }
@@ -538,10 +538,10 @@ final readonly class AttachmentsTest
 
         Expect::that($recovered->attachments)
             ->because('corrupt recovery metadata MUST NOT hide completed evidence')
-            ->toHaveCount(1)
-            ->and($recovered->attachments[0]->name)
-            ->toBe('completed.txt')
-            ->and(\is_file($recovered->attachments[0]->path))
+            ->toHaveCount(1);
+        Expect::that($recovered->attachments[0]->name)
+            ->toBe('completed.txt');
+        Expect::that(\is_file($recovered->attachments[0]->path))
             ->toBeTrue();
 
         $store->cleanup();
@@ -561,9 +561,9 @@ final readonly class AttachmentsTest
 
         $recovered = $store->recover(new TestResult($id, Outcome::Errored, 0.0, 0));
 
-        Expect::that($recovered->attempts)->because('crash recovery restores the latest attempt without an attachment')->toBe(2)
-            ->and($recovered->attachments)->toHaveCount(1)
-            ->and($recovered->attachments[0]->attempt)->toBe(1);
+        Expect::that($recovered->attempts)->because('crash recovery restores the latest attempt without an attachment')->toBe(2);
+        Expect::that($recovered->attachments)->toHaveCount(1);
+        Expect::that($recovered->attachments[0]->attempt)->toBe(1);
 
         $store->cleanup();
     }

--- a/tests/Unit/Artifact/PublishingEventSinkTest.php
+++ b/tests/Unit/Artifact/PublishingEventSinkTest.php
@@ -48,8 +48,8 @@ final readonly class PublishingEventSinkTest
 
             Expect::that($inner->sequence())
                 ->because('the publishing sink MUST preserve event order')
-                ->toBe(['RunStarted', 'TestFinished'])
-                ->and($inner->events[0])
+                ->toBe(['RunStarted', 'TestFinished']);
+            Expect::that($inner->events[0])
                 ->because('events without test results MUST pass through unchanged')
                 ->toBe($started);
 
@@ -64,18 +64,18 @@ final readonly class PublishingEventSinkTest
             Expect::that($finished->result)
                 ->because('a completed event MUST replace its staged result with the published result')
                 ->not()
-                ->toBe($result)
-                ->and($finished->occurredAt)
+                ->toBe($result);
+            Expect::that($finished->occurredAt)
                 ->because('publishing MUST preserve the event timestamp')
-                ->toBe(11.0)
-                ->and($finished->result->attachments)
+                ->toBe(11.0);
+            Expect::that($finished->result->attachments)
                 ->because('the inner sink MUST receive published attachment metadata')
-                ->toHaveCount(1)
-                ->and($finished->result->attachments[0]->path)
-                ->toContain('run-publishing-sink')
-                ->and((string) \file_get_contents(
-                    \str_starts_with($publishedPath, '/') ? $publishedPath : $root . '/' . $publishedPath,
-                ))
+                ->toHaveCount(1);
+            Expect::that($finished->result->attachments[0]->path)
+                ->toContain('run-publishing-sink');
+            Expect::that((string) \file_get_contents(
+                \str_starts_with($publishedPath, '/') ? $publishedPath : $root . '/' . $publishedPath,
+            ))
                 ->toBe('published evidence');
         } finally {
             $store->cleanup();

--- a/tests/Unit/Attribute/AttributeContractTest.php
+++ b/tests/Unit/Attribute/AttributeContractTest.php
@@ -60,10 +60,10 @@ final class AttributeContractTest
         $local = new DataSet('rows');
         $external = new DataSet(self::class, 'rows');
 
-        Expect::that($local->provider)->because('data set accepts local and external providers')->toBe('rows')
-            ->and($local->providerClass)->toBeNull()
-            ->and($external->provider)->toBe('rows')
-            ->and($external->providerClass)->toBe(self::class);
+        Expect::that($local->provider)->because('data set accepts local and external providers')->toBe('rows');
+        Expect::that($local->providerClass)->toBeNull();
+        Expect::that($external->provider)->toBe('rows');
+        Expect::that($external->providerClass)->toBe(self::class);
     }
 
     /**

--- a/tests/Unit/Capture/CapturedOutputTest.php
+++ b/tests/Unit/Capture/CapturedOutputTest.php
@@ -26,14 +26,14 @@ final class CapturedOutputTest
 
         $restored = CapturedOutput::fromWire(JsonWire::roundTrip($original->toWire()));
 
-        Expect::that($restored->stdout)->because('survives a JSON round trip')->toBe('some output')
-            ->and($restored->stdoutTruncated)->toBeTrue()
-            ->and($restored->diagnosticsTruncated)->toBeFalse()
-            ->and($restored->diagnostics)->toHaveCount(1)
-            ->and($restored->diagnostics[0]->severity)->toBe(DiagnosticSeverity::Warning)
-            ->and($restored->diagnostics[0]->message)->toBe('careful')
-            ->and($restored->diagnostics[0]->file)->toBe('/tmp/UserTest.php')
-            ->and($restored->diagnostics[0]->line)->toBe(42);
+        Expect::that($restored->stdout)->because('survives a JSON round trip')->toBe('some output');
+        Expect::that($restored->stdoutTruncated)->toBeTrue();
+        Expect::that($restored->diagnosticsTruncated)->toBeFalse();
+        Expect::that($restored->diagnostics)->toHaveCount(1);
+        Expect::that($restored->diagnostics[0]->severity)->toBe(DiagnosticSeverity::Warning);
+        Expect::that($restored->diagnostics[0]->message)->toBe('careful');
+        Expect::that($restored->diagnostics[0]->file)->toBe('/tmp/UserTest.php');
+        Expect::that($restored->diagnostics[0]->line)->toBe(42);
     }
 
     #[Test]
@@ -48,10 +48,10 @@ final class CapturedOutputTest
 
         Expect::that($restored->stdout)->because('wire serialization replaces invalid bytes')->toMatch('//u')
             ->toContain('stdout with')
-            ->toContain('1')
-            ->and(\preg_match('//u', $restored->diagnostics[0]->message))->toBe(1)
-            ->and($restored->diagnostics[0]->message)->toContain('message with')
-            ->and(\preg_match('//u', $restored->diagnostics[0]->file))->toBe(1);
+            ->toContain('1');
+        Expect::that(\preg_match('//u', $restored->diagnostics[0]->message))->toBe(1);
+        Expect::that($restored->diagnostics[0]->message)->toContain('message with');
+        Expect::that(\preg_match('//u', $restored->diagnostics[0]->file))->toBe(1);
     }
 
     #[Test]
@@ -59,10 +59,10 @@ final class CapturedOutputTest
     {
         $restored = CapturedOutput::fromWire(JsonWire::roundTrip(new CapturedOutput('')->toWire()));
 
-        Expect::that($restored->stdout)->because('wire serialization preserves an empty capture')->toBe('')
-            ->and($restored->diagnostics)->toBe([])
-            ->and($restored->stdoutTruncated)->toBeFalse()
-            ->and($restored->diagnosticsTruncated)->toBeFalse();
+        Expect::that($restored->stdout)->because('wire serialization preserves an empty capture')->toBe('');
+        Expect::that($restored->diagnostics)->toBe([]);
+        Expect::that($restored->stdoutTruncated)->toBeFalse();
+        Expect::that($restored->diagnosticsTruncated)->toBeFalse();
     }
 
     #[Test]

--- a/tests/Unit/Capture/OutputCaptureBufferReplacementTest.php
+++ b/tests/Unit/Capture/OutputCaptureBufferReplacementTest.php
@@ -28,14 +28,14 @@ final readonly class OutputCaptureBufferReplacementTest
 
         Expect::that($captured->stdout)
             ->because('closing the capture buffer MUST preserve the output collected before replacement')
-            ->toBe('captured')
-            ->and($levelAfterStop)
+            ->toBe('captured');
+        Expect::that($levelAfterStop)
             ->because('stop MUST leave a replacement buffer at the captured stack level open')
-            ->toBe($baseline + 1)
-            ->and($replacement)
+            ->toBe($baseline + 1);
+        Expect::that($replacement)
             ->because('stop MUST preserve content in the replacement buffer')
-            ->toBe('replacement')
-            ->and(\ob_get_level())
+            ->toBe('replacement');
+        Expect::that(\ob_get_level())
             ->because('the test MUST restore the output-buffer baseline')
             ->toBe($baseline);
     }

--- a/tests/Unit/Capture/OutputCaptureClosedBufferReuseTest.php
+++ b/tests/Unit/Capture/OutputCaptureClosedBufferReuseTest.php
@@ -18,11 +18,11 @@ final readonly class OutputCaptureClosedBufferReuseTest
 
         Expect::that($first->stdout)
             ->because('closing the first capture buffer MUST preserve its output')
-            ->toBe('first')
-            ->and($second->stdout)
+            ->toBe('first');
+        Expect::that($second->stdout)
             ->because('a reused capture MUST collect output in its second window')
-            ->toBe('second')
-            ->and($levelAfterSecondStop)
+            ->toBe('second');
+        Expect::that($levelAfterSecondStop)
             ->because('the second stop MUST restore the original output-buffer level')
             ->toBe($baseline);
     }

--- a/tests/Unit/Capture/OutputCaptureClosedBufferTest.php
+++ b/tests/Unit/Capture/OutputCaptureClosedBufferTest.php
@@ -24,8 +24,8 @@ final readonly class OutputCaptureClosedBufferTest
 
         Expect::that($captured->stdout)
             ->because('stop MUST preserve output after user code closes the capture buffer')
-            ->toBe('captured before close')
-            ->and(\ob_get_level())
+            ->toBe('captured before close');
+        Expect::that(\ob_get_level())
             ->because('stop MUST preserve the output-buffer baseline')
             ->toBe($baseline);
     }

--- a/tests/Unit/Capture/OutputCaptureMinimumDiagnosticsTest.php
+++ b/tests/Unit/Capture/OutputCaptureMinimumDiagnosticsTest.php
@@ -25,10 +25,10 @@ final class OutputCaptureMinimumDiagnosticsTest
 
         Expect::that($captured->diagnostics)
             ->because('the minimum diagnostic bound MUST retain only the first entry')
-            ->toHaveCount(1)
-            ->and($captured->diagnostics[0]->message)
-            ->toBe('first diagnostic')
-            ->and($captured->diagnosticsTruncated)
+            ->toHaveCount(1);
+        Expect::that($captured->diagnostics[0]->message)
+            ->toBe('first diagnostic');
+        Expect::that($captured->diagnosticsTruncated)
             ->toBeTrue();
     }
 }

--- a/tests/Unit/Capture/OutputCaptureTest.php
+++ b/tests/Unit/Capture/OutputCaptureTest.php
@@ -29,9 +29,9 @@ final class OutputCaptureTest
             \ob_end_clean();
         }
 
-        Expect::that($captured->stdout)->because('echo inside the window is captured and does not reach the outer stream')->toBe('hello from the test')
-            ->and($captured->stdoutTruncated)->toBeFalse()
-            ->and($leaked)->toBe('');
+        Expect::that($captured->stdout)->because('echo inside the window is captured and does not reach the outer stream')->toBe('hello from the test');
+        Expect::that($captured->stdoutTruncated)->toBeFalse();
+        Expect::that($leaked)->toBe('');
     }
 
     #[Test]
@@ -61,8 +61,8 @@ final class OutputCaptureTest
 
         $captured = $capture->stop();
 
-        Expect::that($inner)->because('user code nesting its own output buffers keeps working')->toBe('inner')
-            ->and($captured->stdout)->toBe('ab');
+        Expect::that($inner)->because('user code nesting its own output buffers keeps working')->toBe('inner');
+        Expect::that($captured->stdout)->toBe('ab');
     }
 
     #[Test]
@@ -79,8 +79,8 @@ final class OutputCaptureTest
 
         $captured = $capture->stop();
 
-        Expect::that($captured->stdout)->because('a user buffer left open is flushed into the capture')->toBe('head leftover')
-            ->and(\ob_get_level())->toBe($baseline);
+        Expect::that($captured->stdout)->because('a user buffer left open is flushed into the capture')->toBe('head leftover');
+        Expect::that(\ob_get_level())->toBe($baseline);
     }
 
     #[Test]
@@ -95,17 +95,17 @@ final class OutputCaptureTest
 
         $captured = $capture->stop();
 
-        Expect::that($captured->diagnostics)->because('notices warnings and deprecations are recorded with file and line')->toHaveCount(3)
-            ->and($captured->stdout)->toBe('');
+        Expect::that($captured->diagnostics)->because('notices warnings and deprecations are recorded with file and line')->toHaveCount(3);
+        Expect::that($captured->stdout)->toBe('');
 
         [$notice, $warning, $deprecation] = $captured->diagnostics;
 
-        Expect::that($notice->severity)->because('notices warnings and deprecations are recorded with file and line')->toBe(DiagnosticSeverity::Notice)
-            ->and($notice->message)->toBe('a notice')
-            ->and($notice->file)->toBe(__FILE__)
-            ->and($notice->line)->toBeGreaterThan(0)
-            ->and($warning->severity)->toBe(DiagnosticSeverity::Warning)
-            ->and($deprecation->severity)->toBe(DiagnosticSeverity::Deprecation);
+        Expect::that($notice->severity)->because('notices warnings and deprecations are recorded with file and line')->toBe(DiagnosticSeverity::Notice);
+        Expect::that($notice->message)->toBe('a notice');
+        Expect::that($notice->file)->toBe(__FILE__);
+        Expect::that($notice->line)->toBeGreaterThan(0);
+        Expect::that($warning->severity)->toBe(DiagnosticSeverity::Warning);
+        Expect::that($deprecation->severity)->toBe(DiagnosticSeverity::Deprecation);
     }
 
     #[Test]
@@ -141,8 +141,8 @@ final class OutputCaptureTest
 
         Expect::that($handled)
             ->because('PHP MUST handle diagnostic levels that Greenlight does not capture')
-            ->toBeFalse()
-            ->and($captured->diagnostics)
+            ->toBeFalse();
+        Expect::that($captured->diagnostics)
             ->because('unsupported diagnostic levels MUST NOT become test diagnostics')
             ->toBe([]);
     }
@@ -186,8 +186,8 @@ final class OutputCaptureTest
 
         $captured = $capture->stop();
 
-        Expect::that($captured->stdout)->because('truncation keeps the head and sets the flag')->toBe('01234567')
-            ->and($captured->stdoutTruncated)->toBeTrue();
+        Expect::that($captured->stdout)->because('truncation keeps the head and sets the flag')->toBe('01234567');
+        Expect::that($captured->stdoutTruncated)->toBeTrue();
     }
 
     #[Test]
@@ -200,8 +200,8 @@ final class OutputCaptureTest
 
         $captured = $capture->stop();
 
-        Expect::that($captured->stdout)->because('output exactly at the bound is not flagged as truncated')->toBe('full')
-            ->and($captured->stdoutTruncated)->toBeFalse();
+        Expect::that($captured->stdout)->because('output exactly at the bound is not flagged as truncated')->toBe('full');
+        Expect::that($captured->stdoutTruncated)->toBeFalse();
     }
 
     #[Test]
@@ -216,9 +216,9 @@ final class OutputCaptureTest
 
         $captured = $capture->stop();
 
-        Expect::that($captured->diagnostics)->because('diagnostics beyond the bound are dropped and flagged')->toHaveCount(2)
-            ->and($captured->diagnostics[0]->message)->toBe('one')
-            ->and($captured->diagnosticsTruncated)->toBeTrue();
+        Expect::that($captured->diagnostics)->because('diagnostics beyond the bound are dropped and flagged')->toHaveCount(2);
+        Expect::that($captured->diagnostics[0]->message)->toBe('one');
+        Expect::that($captured->diagnosticsTruncated)->toBeTrue();
     }
 
     #[Test]
@@ -234,8 +234,8 @@ final class OutputCaptureTest
 
         Expect::that($captured->diagnostics)
             ->because('diagnostics at the retention bound MUST remain complete')
-            ->toHaveCount(2)
-            ->and($captured->diagnosticsTruncated)
+            ->toHaveCount(2);
+        Expect::that($captured->diagnosticsTruncated)
             ->toBeFalse();
     }
 
@@ -273,9 +273,9 @@ final class OutputCaptureTest
             $captured = $capture->stop();
         }
 
-        Expect::that($thrown)->because('stop in a finally block restores everything when user code throws')->toBeInstanceOf(\RuntimeException::class)
-            ->and($captured->stdout)->toBe('before the throw')
-            ->and(\ob_get_level())->toBe($baseline);
+        Expect::that($thrown)->because('stop in a finally block restores everything when user code throws')->toBeInstanceOf(\RuntimeException::class);
+        Expect::that($captured->stdout)->toBe('before the throw');
+        Expect::that(\ob_get_level())->toBe($baseline);
     }
 
     #[Test]
@@ -292,10 +292,10 @@ final class OutputCaptureTest
         \trigger_error('only in the second window', \E_USER_NOTICE);
         $second = $capture->stop();
 
-        Expect::that($first->stdout)->because('the capture is reusable across windows')->toBe('first')
-            ->and($first->diagnostics)->toBe([])
-            ->and($second->stdout)->toBe('second')
-            ->and($second->diagnostics)->toHaveCount(1);
+        Expect::that($first->stdout)->because('the capture is reusable across windows')->toBe('first');
+        Expect::that($first->diagnostics)->toBe([]);
+        Expect::that($second->stdout)->toBe('second');
+        Expect::that($second->diagnostics)->toHaveCount(1);
     }
 
     #[Test]

--- a/tests/Unit/Cli/ArgumentParserTest.php
+++ b/tests/Unit/Cli/ArgumentParserTest.php
@@ -55,12 +55,12 @@ final class ArgumentParserTest
 
         Expect::that($parsed->command)
             ->because('option position MUST NOT change the selected command')
-            ->toBe('run')
-            ->and($parsed->value('workers'))
-            ->toBe('4')
-            ->and($parsed->values('group'))
-            ->toBe(['slow'])
-            ->and($parsed->value('seed'))
+            ->toBe('run');
+        Expect::that($parsed->value('workers'))
+            ->toBe('4');
+        Expect::that($parsed->values('group'))
+            ->toBe(['slow']);
+        Expect::that($parsed->value('seed'))
             ->toBe('123');
     }
 

--- a/tests/Unit/Cli/CliOverridesTest.php
+++ b/tests/Unit/Cli/CliOverridesTest.php
@@ -64,20 +64,20 @@ final class CliOverridesTest
 
         Expect::that($overrides->groups)
             ->because('a zero string MUST remain a group selection')
-            ->toBe(['0'])
-            ->and($overrides->filters)
+            ->toBe(['0']);
+        Expect::that($overrides->filters)
             ->because('a zero string MUST remain a filter selection')
-            ->toBe(['0'])
-            ->and($overrides->excludeGroups)
+            ->toBe(['0']);
+        Expect::that($overrides->excludeGroups)
             ->because('a zero string MUST remain an excluded group selection')
-            ->toBe(['0'])
-            ->and($overrides->excludeClasses)
+            ->toBe(['0']);
+        Expect::that($overrides->excludeClasses)
             ->because('a zero string MUST remain an excluded class selection')
-            ->toBe(['0'])
-            ->and($overrides->excludeMethods)
+            ->toBe(['0']);
+        Expect::that($overrides->excludeMethods)
             ->because('a zero string MUST remain an excluded method selection')
-            ->toBe(['0'])
-            ->and($overrides->excludePaths)
+            ->toBe(['0']);
+        Expect::that($overrides->excludePaths)
             ->because('a zero string MUST remain an excluded path selection')
             ->toBe(['0']);
     }

--- a/tests/Unit/Cli/CompletionScriptsTest.php
+++ b/tests/Unit/Cli/CompletionScriptsTest.php
@@ -80,14 +80,14 @@ final class CompletionScriptsTest
 
         Expect::that($scripts->render('bash'))
             ->because('Bash MUST complete the automatic worker count for the workers flag')
-            ->toContain('--workers=*)')
-            ->and($scripts->render('bash'))
+            ->toContain('--workers=*)');
+        Expect::that($scripts->render('bash'))
             ->toContain('compgen -W "auto" -P "--workers="');
 
         Expect::that($scripts->render('zsh'))
             ->because('Zsh MUST complete the automatic worker count for the workers flag')
-            ->toContain("compset -P '--workers='")
-            ->and($scripts->render('zsh'))
+            ->toContain("compset -P '--workers='");
+        Expect::that($scripts->render('zsh'))
             ->toContain('compadd -- auto');
 
         Expect::that($scripts->render('fish'))

--- a/tests/Unit/Cli/FailedTestsTapTest.php
+++ b/tests/Unit/Cli/FailedTestsTapTest.php
@@ -27,10 +27,10 @@ final class FailedTestsTapTest
 
         Expect::that($inner->events)
             ->because('the tap MUST forward lifecycle events unchanged')
-            ->toBe([$event])
-            ->and($tap->failedTests())
-            ->toBe([])
-            ->and($tap->classSeconds())
+            ->toBe([$event]);
+        Expect::that($tap->failedTests())
+            ->toBe([]);
+        Expect::that($tap->classSeconds())
             ->toBe([]);
     }
 
@@ -56,14 +56,14 @@ final class FailedTestsTapTest
             ->toBe([
                 'App\AlphaTest::fails',
                 'App\BetaTest::errors',
-            ])
-            ->and($tap->classSeconds())
+            ]);
+        Expect::that($tap->classSeconds())
             ->because('scheduling history MUST accumulate every result duration by class')
             ->toBe([
                 'App\AlphaTest' => 11.0,
                 'App\BetaTest' => 20.0,
-            ])
-            ->and($inner->events)
+            ]);
+        Expect::that($inner->events)
             ->because('the tap MUST forward every event unchanged')
             ->toBe($events);
     }

--- a/tests/Unit/Cli/ParsedArgumentsTest.php
+++ b/tests/Unit/Cli/ParsedArgumentsTest.php
@@ -32,13 +32,13 @@ final class ParsedArgumentsTest
 
         Expect::that($arguments->values('option'))
             ->because('repeatable values retain input order and omit absent values')
-            ->toBe(['first', 'last'])
-            ->and($arguments->has('flag'))
+            ->toBe(['first', 'last']);
+        Expect::that($arguments->has('flag'))
             ->because('a flag with no value is still present')
-            ->toBeTrue()
-            ->and($arguments->value('flag'))
-            ->toBeNull()
-            ->and($arguments->has('missing'))
+            ->toBeTrue();
+        Expect::that($arguments->value('flag'))
+            ->toBeNull();
+        Expect::that($arguments->has('missing'))
             ->toBeFalse();
     }
 
@@ -51,8 +51,8 @@ final class ParsedArgumentsTest
 
         Expect::that($arguments->values('option'))
             ->because('repeatable option values MUST remove only absent null entries')
-            ->toBe(['', '0'])
-            ->and($arguments->value('option'))
+            ->toBe(['', '0']);
+        Expect::that($arguments->value('option'))
             ->because('a singular option lookup MUST preserve a final zero string')
             ->toBe('0');
     }

--- a/tests/Unit/Cli/PlanFormatterTest.php
+++ b/tests/Unit/Cli/PlanFormatterTest.php
@@ -76,8 +76,8 @@ final class PlanFormatterTest
 
         Expect::that($formatted)
             ->because('the plan names runtime seed selection and configured plugins')
-            ->toContain('  order: random (seed chosen at run time)')
-            ->and($formatted)
+            ->toContain('  order: random (seed chosen at run time)');
+        Expect::that($formatted)
             ->toContain('  plugins: ' . NamedFakePlugin::class);
     }
 

--- a/tests/Unit/Cli/SignalHandlersTest.php
+++ b/tests/Unit/Cli/SignalHandlersTest.php
@@ -33,8 +33,8 @@ final class SignalHandlersTest
 
         Expect::that($shutdown->requested())
             ->because('each supported signal MUST request graceful shutdown on first delivery')
-            ->toBeTrue()
-            ->and($shutdown->exitCode())
+            ->toBeTrue();
+        Expect::that($shutdown->exitCode())
             ->toBe(128 + $signal);
     }
 
@@ -48,11 +48,11 @@ final class SignalHandlersTest
 
         Expect::that($operations->asyncEnabled)
             ->because('unavailable signal operations do not enable asynchronous signals')
-            ->toBeFalse()
-            ->and($operations->registrations)
+            ->toBeFalse();
+        Expect::that($operations->registrations)
             ->because('unavailable signal operations do not register handlers')
-            ->toBe([])
-            ->and($shutdown->requested())->toBeFalse();
+            ->toBe([]);
+        Expect::that($shutdown->requested())->toBeFalse();
     }
 
     #[Test]
@@ -65,8 +65,8 @@ final class SignalHandlersTest
 
         Expect::that($operations->asyncEnabled)
             ->because('available signal operations enable asynchronous signals')
-            ->toBeTrue()
-            ->and(\array_column($operations->registrations, 'signal'))
+            ->toBeTrue();
+        Expect::that(\array_column($operations->registrations, 'signal'))
             ->because('SIGINT and SIGTERM handlers are registered')
             ->toBe([\SIGINT, \SIGTERM]);
 
@@ -80,12 +80,12 @@ final class SignalHandlersTest
 
         Expect::that($shutdown->requested())
             ->because('the first signal requests graceful shutdown')
-            ->toBeTrue()
-            ->and($shutdown->exitCode())->toBe(128 + \SIGTERM)
-            ->and($operations->registrations[2] ?? null)
+            ->toBeTrue();
+        Expect::that($shutdown->exitCode())->toBe(128 + \SIGTERM);
+        Expect::that($operations->registrations[2] ?? null)
             ->because('the first signal restores the default SIGINT handler')
-            ->toBe(['signal' => \SIGINT, 'handler' => \SIG_DFL])
-            ->and($operations->registrations[3] ?? null)
+            ->toBe(['signal' => \SIGINT, 'handler' => \SIG_DFL]);
+        Expect::that($operations->registrations[3] ?? null)
             ->because('the first signal restores the default SIGTERM handler')
             ->toBe(['signal' => \SIGTERM, 'handler' => \SIG_DFL]);
     }

--- a/tests/Unit/Cli/StdinKeyInputTest.php
+++ b/tests/Unit/Cli/StdinKeyInputTest.php
@@ -56,8 +56,8 @@ final class StdinKeyInputTest
 
         Expect::that($blocking)
             ->because('terminal input becomes non-blocking')
-            ->toBe([false])
-            ->and($commands)
+            ->toBe([false]);
+        Expect::that($commands)
             ->because('terminal input enables raw mode')
             ->toBe(['stty -icanon -echo < /dev/tty 2> /dev/null']);
 
@@ -94,8 +94,8 @@ final class StdinKeyInputTest
 
         Expect::that($blocking)
             ->because('non-terminal input MUST remain non-blocking')
-            ->toBe([false])
-            ->and($commands)
+            ->toBe([false]);
+        Expect::that($commands)
             ->because('non-terminal input does not change terminal mode')
             ->toBe([]);
     }

--- a/tests/Unit/Cli/SystemSignalOperationsTest.php
+++ b/tests/Unit/Cli/SystemSignalOperationsTest.php
@@ -36,8 +36,8 @@ final class SystemSignalOperationsTest
 
             Expect::that(\pcntl_async_signals())
                 ->because('native signal operations MUST enable asynchronous delivery')
-                ->toBeTrue()
-                ->and(\pcntl_signal_get_handler(\SIGUSR1))
+                ->toBeTrue();
+            Expect::that(\pcntl_signal_get_handler(\SIGUSR1))
                 ->because('native signal operations MUST register the exact handler')
                 ->toBe($handler);
         } finally {
@@ -68,11 +68,11 @@ final class SystemSignalOperationsTest
 
         Expect::that($result->exitCode)
             ->because(\sprintf('the capability check runs with %s disabled', $function))
-            ->toBe(0)
-            ->and($result->stdout)
+            ->toBe(0);
+        Expect::that($result->stdout)
             ->because(\sprintf('native signal handling requires %s', $function))
-            ->toBe('unavailable')
-            ->and($result->stderr)
+            ->toBe('unavailable');
+        Expect::that($result->stderr)
             ->toBe('');
     }
 

--- a/tests/Unit/Cli/TerminalTest.php
+++ b/tests/Unit/Cli/TerminalTest.php
@@ -26,11 +26,11 @@ final class TerminalTest
 
             Expect::that(Terminal::isTty($stream))
                 ->because('an in-memory stream is not a TTY')
-                ->toBeFalse()
-                ->and(\stream_get_contents($stream))
+                ->toBeFalse();
+            Expect::that(\stream_get_contents($stream))
                 ->because('the terminal probe MUST leave stream content unchanged')
-                ->toBe('sentinel')
-                ->and(\is_resource($stream))
+                ->toBe('sentinel');
+            Expect::that(\is_resource($stream))
                 ->because('the terminal probe MUST leave the stream open')
                 ->toBeTrue();
         } finally {

--- a/tests/Unit/Cli/Watch/ClassFailureTapSkippedTest.php
+++ b/tests/Unit/Cli/Watch/ClassFailureTapSkippedTest.php
@@ -34,8 +34,8 @@ final class ClassFailureTapSkippedTest
 
         Expect::that($tap->failedClasses())
             ->because('a skipped test MUST NOT select its class for a failed watch rerun')
-            ->toBe([])
-            ->and($inner->events)
+            ->toBe([]);
+        Expect::that($inner->events)
             ->because('the skipped result MUST still reach the configured event sink')
             ->toBe([$event]);
     }

--- a/tests/Unit/Cli/Watch/ClassFailureTapTest.php
+++ b/tests/Unit/Cli/Watch/ClassFailureTapTest.php
@@ -27,8 +27,8 @@ final class ClassFailureTapTest
 
         Expect::that($inner->events)
             ->because('the watch tap MUST forward lifecycle events unchanged')
-            ->toBe([$event])
-            ->and($tap->failedClasses())
+            ->toBe([$event]);
+        Expect::that($tap->failedClasses())
             ->toBe([]);
     }
 
@@ -45,8 +45,8 @@ final class ClassFailureTapTest
 
         Expect::that($tap->failedClasses())
             ->because('failed classes are deduplicated while every result is forwarded')
-            ->toBe(['App\AlphaTest', 'App\BetaTest'])
-            ->and($inner->results())
+            ->toBe(['App\AlphaTest', 'App\BetaTest']);
+        Expect::that($inner->results())
             ->toHaveCount(4);
     }
 

--- a/tests/Unit/Cli/Watch/WatchLoopIdleTest.php
+++ b/tests/Unit/Cli/Watch/WatchLoopIdleTest.php
@@ -68,8 +68,8 @@ final class WatchLoopIdleTest
 
         Expect::that($clock->sleeps)
             ->because('an idle watch loop MUST sleep between polls')
-            ->toBe([0.1])
-            ->and($runs)
+            ->toBe([0.1]);
+        Expect::that($runs)
             ->because('idle polling MUST NOT start another test run')
             ->toBe(1);
     }

--- a/tests/Unit/Condition/ClassAvailableAutoloadTest.php
+++ b/tests/Unit/Condition/ClassAvailableAutoloadTest.php
@@ -18,11 +18,11 @@ final readonly class ClassAvailableAutoloadTest
     {
         Expect::that(\class_exists(AutoloadableConditionProbe::class, false))
             ->because('the fixture MUST start unloaded so the test covers autoloading')
-            ->toBeFalse()
-            ->and(new ClassAvailable(AutoloadableConditionProbe::class)->isSatisfied())
+            ->toBeFalse();
+        Expect::that(new ClassAvailable(AutoloadableConditionProbe::class)->isSatisfied())
             ->because('class availability MUST include classes that the autoloader can load')
-            ->toBeTrue()
-            ->and(\class_exists(AutoloadableConditionProbe::class, false))
+            ->toBeTrue();
+        Expect::that(\class_exists(AutoloadableConditionProbe::class, false))
             ->because('the successful condition MUST load the available class')
             ->toBeTrue();
     }

--- a/tests/Unit/Condition/EnvironmentVariableAbsenceTest.php
+++ b/tests/Unit/Condition/EnvironmentVariableAbsenceTest.php
@@ -22,8 +22,8 @@ final readonly class EnvironmentVariableAbsenceTest
 
         Expect::that(new EnvironmentVariableSet($name)->isSatisfied())
             ->because('an absent environment variable MUST remain absent')
-            ->toBeFalse()
-            ->and(new EnvironmentVariableEquals($name, '')->isSatisfied())
+            ->toBeFalse();
+        Expect::that(new EnvironmentVariableEquals($name, '')->isSatisfied())
             ->because('absence MUST remain distinct from an empty environment variable value')
             ->toBeFalse();
     }

--- a/tests/Unit/Condition/EnvironmentVariableConditionTest.php
+++ b/tests/Unit/Condition/EnvironmentVariableConditionTest.php
@@ -24,11 +24,11 @@ final readonly class EnvironmentVariableConditionTest
 
         Expect::that(new EnvironmentVariableSet($name)->isSatisfied())
             ->because('falsey values MUST remain distinct from missing environment variables')
-            ->toBeTrue()
-            ->and(new EnvironmentVariableEquals($name, $value)->isSatisfied())
+            ->toBeTrue();
+        Expect::that(new EnvironmentVariableEquals($name, $value)->isSatisfied())
             ->because('environment variable comparisons MUST preserve the exact falsey value')
-            ->toBeTrue()
-            ->and(new EnvironmentVariableEquals($name, 'different')->isSatisfied())
+            ->toBeTrue();
+        Expect::that(new EnvironmentVariableEquals($name, 'different')->isSatisfied())
             ->toBeFalse();
     }
 

--- a/tests/Unit/Condition/EnvironmentVariableConditionValidationTest.php
+++ b/tests/Unit/Condition/EnvironmentVariableConditionValidationTest.php
@@ -19,8 +19,8 @@ final readonly class EnvironmentVariableConditionValidationTest
             ->toThrow(
                 \InvalidArgumentException::class,
                 message: 'Environment variable name MUST NOT be empty.',
-            )
-            ->and(static fn(): EnvironmentVariableEquals => new EnvironmentVariableEquals('', 'value'))
+            );
+        Expect::that(static fn(): EnvironmentVariableEquals => new EnvironmentVariableEquals('', 'value'))
             ->because('an equality condition MUST identify the environment variable')
             ->toThrow(
                 \InvalidArgumentException::class,

--- a/tests/Unit/Config/ConfigLoaderThrowableTest.php
+++ b/tests/Unit/Config/ConfigLoaderThrowableTest.php
@@ -25,8 +25,8 @@ final readonly class ConfigLoaderThrowableTest
                 ->toBe(
                     'Configuration file "' . $directory . '/greenlight.php" threw '
                     . 'TypeError: config type exploded',
-                )
-                ->and($error->getPrevious())
+                );
+            Expect::that($error->getPrevious())
                 ->because('the wrapped configuration error MUST remain available as the cause')
                 ->toBeInstanceOf(\TypeError::class);
 

--- a/tests/Unit/Config/ConfigurationCopyStateTest.php
+++ b/tests/Unit/Config/ConfigurationCopyStateTest.php
@@ -40,11 +40,11 @@ final class ConfigurationCopyStateTest
         Expect::that($copy)
             ->because('a configuration copy MUST be a new value')
             ->not()
-            ->toBe($original)
-            ->and(\get_object_vars($copy))
+            ->toBe($original);
+        Expect::that(\get_object_vars($copy))
             ->because('a configuration copy MUST change only its requested selection')
-            ->toBe($expectedState)
-            ->and(\get_object_vars($original))
+            ->toBe($expectedState);
+        Expect::that(\get_object_vars($original))
             ->because('a configuration copy MUST leave its source unchanged')
             ->toBe($originalState);
     }

--- a/tests/Unit/Config/GreenlightConfigTest.php
+++ b/tests/Unit/Config/GreenlightConfigTest.php
@@ -174,11 +174,11 @@ final class GreenlightConfigTest
 
         Expect::that($configuration->workers->fixed)
             ->because('a rejected worker configuration retains the prior worker count')
-            ->toBe(2)
-            ->and($configuration->recycleAfterTests)
+            ->toBe(2);
+        Expect::that($configuration->recycleAfterTests)
             ->because('a rejected worker configuration retains the prior test limit')
-            ->toBe(10)
-            ->and($configuration->recycleAboveMemoryBytes)
+            ->toBe(10);
+        Expect::that($configuration->recycleAboveMemoryBytes)
             ->because('a rejected worker configuration retains the prior memory limit')
             ->toBe(64 * 1024 * 1024);
     }
@@ -221,14 +221,14 @@ final class GreenlightConfigTest
 
         Expect::that($configuration->coverage?->includePaths)
             ->because('a rejected coverage configuration retains the prior include paths')
-            ->toBe(['src'])
-            ->and($configuration->coverage?->driver)
+            ->toBe(['src']);
+        Expect::that($configuration->coverage?->driver)
             ->because('a rejected coverage configuration retains the prior driver')
-            ->toBe('pcov')
-            ->and($configuration->watch->debounceMilliseconds)
+            ->toBe('pcov');
+        Expect::that($configuration->watch->debounceMilliseconds)
             ->because('a rejected watch configuration retains the prior debounce')
-            ->toBe(500)
-            ->and($configuration->artifacts->directory)
+            ->toBe(500);
+        Expect::that($configuration->artifacts->directory)
             ->because('a rejected artifact configuration retains the prior directory')
             ->toBe('build/original');
     }

--- a/tests/Unit/Config/IncrementalConfiguratorTest.php
+++ b/tests/Unit/Config/IncrementalConfiguratorTest.php
@@ -35,13 +35,13 @@ final class IncrementalConfiguratorTest
 
         Expect::that($coverage->includePaths)
             ->because('repeated coverage blocks MUST retain earlier settings')
-            ->toBe(['src', 'packages'])
-            ->and($coverage->driver)
-            ->toBe('pcov')
-            ->and(\array_map(
-                static fn(CoverageExport $export): array => [$export->format, $export->target],
-                $coverage->exports,
-            ))
+            ->toBe(['src', 'packages']);
+        Expect::that($coverage->driver)
+            ->toBe('pcov');
+        Expect::that(\array_map(
+            static fn(CoverageExport $export): array => [$export->format, $export->target],
+            $coverage->exports,
+        ))
             ->toBe([
                 ['lcov', 'build/coverage.lcov'],
                 ['html', 'build/html'],

--- a/tests/Unit/Config/SuiteBuilderTest.php
+++ b/tests/Unit/Config/SuiteBuilderTest.php
@@ -49,8 +49,8 @@ final class SuiteBuilderTest
 
         Expect::that($configuration->paths)
             ->because('a rejected path call retains the prior paths')
-            ->toBe(['tests/Existing'])
-            ->and($configuration->tags)
+            ->toBe(['tests/Existing']);
+        Expect::that($configuration->tags)
             ->because('a rejected tag call retains the prior tags')
             ->toBe(['existing']);
     }

--- a/tests/Unit/Config/SuiteConfigurationTest.php
+++ b/tests/Unit/Config/SuiteConfigurationTest.php
@@ -36,11 +36,11 @@ final class SuiteConfigurationTest
 
         Expect::that($suite->name)
             ->because('a zero-string suite name is not empty')
-            ->toBe('0')
-            ->and($suite->paths)
+            ->toBe('0');
+        Expect::that($suite->paths)
             ->because('a zero-string suite path is not empty')
-            ->toBe(['0'])
-            ->and($suite->tags)
+            ->toBe(['0']);
+        Expect::that($suite->tags)
             ->because('a zero-string suite tag is not empty')
             ->toBe(['0']);
     }

--- a/tests/Unit/Config/WorkerCountMinimumTest.php
+++ b/tests/Unit/Config/WorkerCountMinimumTest.php
@@ -17,10 +17,10 @@ final readonly class WorkerCountMinimumTest
 
         Expect::that($workers->fixed)
             ->because('a fixed runner MUST support the minimum worker count')
-            ->toBe(1)
-            ->and($workers->isAuto())
-            ->toBeFalse()
-            ->and($workers->describe())
+            ->toBe(1);
+        Expect::that($workers->isAuto())
+            ->toBeFalse();
+        Expect::that($workers->describe())
             ->toBe('1');
     }
 }

--- a/tests/Unit/Core/AtomicFileEmptyWriteTest.php
+++ b/tests/Unit/Core/AtomicFileEmptyWriteTest.php
@@ -23,8 +23,8 @@ final readonly class AtomicFileEmptyWriteTest
 
         Expect::that(\file_get_contents($path))
             ->because('an empty atomic write MUST replace the target')
-            ->toBe('')
-            ->and(\glob($path . '.tmp-*'))
+            ->toBe('');
+        Expect::that(\glob($path . '.tmp-*'))
             ->because('an empty atomic write MUST leave no temporary file')
             ->toBe([]);
     }

--- a/tests/Unit/Core/AtomicFileTest.php
+++ b/tests/Unit/Core/AtomicFileTest.php
@@ -29,8 +29,8 @@ final readonly class AtomicFileTest
 
         Expect::that(\file_get_contents($path))
             ->because('an atomic write replaces the target with the exact bytes')
-            ->toBe("\x00new\n")
-            ->and(\glob($path . '.tmp-*'))
+            ->toBe("\x00new\n");
+        Expect::that(\glob($path . '.tmp-*'))
             ->because('a successful atomic write leaves no temporary file')
             ->toBe([]);
     }
@@ -90,8 +90,8 @@ final readonly class AtomicFileTest
 
         Expect::that($capture->error?->getPrevious())
             ->because('the temporary-name failure MUST preserve its original cause')
-            ->toBe($cause)
-            ->and(\file_exists($path))
+            ->toBe($cause);
+        Expect::that(\file_exists($path))
             ->because('an entropy failure MUST NOT create the target file')
             ->toBeFalse();
     }
@@ -125,20 +125,20 @@ final readonly class AtomicFileTest
 
         Expect::that($name->getMessage())
             ->because('the random-name diagnostic includes the target and original message')
-            ->toBe('Cannot generate a temporary name for "/state.json": entropy unavailable')
-            ->and($name->getPrevious())
+            ->toBe('Cannot generate a temporary name for "/state.json": entropy unavailable');
+        Expect::that($name->getPrevious())
             ->because('the random-name diagnostic preserves the original error')
-            ->toBe($previous)
-            ->and($write->getMessage())
+            ->toBe($previous);
+        Expect::that($write->getMessage())
             ->because('the temporary-write diagnostic includes its warning')
-            ->toBe('Cannot write temporary file "/state.json.tmp-1-abcd": disk full.')
-            ->and($writeWithoutReason->getMessage())
+            ->toBe('Cannot write temporary file "/state.json.tmp-1-abcd": disk full.');
+        Expect::that($writeWithoutReason->getMessage())
             ->because('the temporary-write diagnostic omits punctuation for a missing warning')
-            ->toBe('Cannot write temporary file "/state.json.tmp-1-abcd".')
-            ->and($rename->getMessage())
+            ->toBe('Cannot write temporary file "/state.json.tmp-1-abcd".');
+        Expect::that($rename->getMessage())
             ->because('the rename diagnostic includes both paths and its warning')
-            ->toBe('Cannot rename "/state.json.tmp-1-abcd" to "/state.json": permission denied.')
-            ->and($renameWithoutReason->getMessage())
+            ->toBe('Cannot rename "/state.json.tmp-1-abcd" to "/state.json": permission denied.');
+        Expect::that($renameWithoutReason->getMessage())
             ->because('the rename diagnostic omits punctuation for a missing warning')
             ->toBe('Cannot rename "/state.json.tmp-1-abcd" to "/state.json".');
     }

--- a/tests/Unit/Core/AttachmentValidMediaTypeTest.php
+++ b/tests/Unit/Core/AttachmentValidMediaTypeTest.php
@@ -29,8 +29,8 @@ final readonly class AttachmentValidMediaTypeTest
 
         Expect::that($attachment->mediaType)
             ->because('attachment construction MUST preserve a valid media type')
-            ->toBe($mediaType)
-            ->and($restored->mediaType)
+            ->toBe($mediaType);
+        Expect::that($restored->mediaType)
             ->because('attachment wire decoding MUST preserve a valid media type')
             ->toBe($mediaType);
     }

--- a/tests/Unit/Core/AttachmentWireEnumContractTest.php
+++ b/tests/Unit/Core/AttachmentWireEnumContractTest.php
@@ -21,8 +21,8 @@ final class AttachmentWireEnumContractTest
                 'Text' => 'text',
                 'Binary' => 'binary',
                 'File' => 'file',
-            ])
-            ->and(\array_column(AttachmentRetention::cases(), 'value', 'name'))
+            ]);
+        Expect::that(\array_column(AttachmentRetention::cases(), 'value', 'name'))
             ->because('attachment retention MUST keep its published wire values')
             ->toBe([
                 'OnFailure' => 'on-failure',

--- a/tests/Unit/Core/AttachmentWireTest.php
+++ b/tests/Unit/Core/AttachmentWireTest.php
@@ -33,8 +33,8 @@ final class AttachmentWireTest
 
         Expect::that($payload['retention'])
             ->because('explicit attachment retention survives the wire round-trip')
-            ->toBe(AttachmentRetention::Always->value)
-            ->and($decoded)
+            ->toBe(AttachmentRetention::Always->value);
+        Expect::that($decoded)
             ->toEqual($attachment);
     }
 
@@ -79,8 +79,8 @@ final class AttachmentWireTest
 
         Expect::that($attachment->retention)
             ->because('older attachment payloads use on-failure retention')
-            ->toBe(AttachmentRetention::OnFailure)
-            ->and($staged->retention)
+            ->toBe(AttachmentRetention::OnFailure);
+        Expect::that($staged->retention)
             ->toBe(AttachmentRetention::OnFailure);
     }
 

--- a/tests/Unit/Core/ClassLifecycleWorkerWireTest.php
+++ b/tests/Unit/Core/ClassLifecycleWorkerWireTest.php
@@ -29,8 +29,8 @@ final readonly class ClassLifecycleWorkerWireTest
 
         Expect::that($event->workerId)
             ->because('class lifecycle events MUST preserve their worker attribution')
-            ->toBe('worker-2')
-            ->and($event->toWire())
+            ->toBe('worker-2');
+        Expect::that($event->toWire())
             ->toBe($payload);
     }
 

--- a/tests/Unit/Core/ClassLifecycleZeroWorkerWireTest.php
+++ b/tests/Unit/Core/ClassLifecycleZeroWorkerWireTest.php
@@ -27,8 +27,8 @@ final readonly class ClassLifecycleZeroWorkerWireTest
 
         Expect::that($event->workerId)
             ->because('class lifecycle events MUST retain non-empty zero-string worker IDs')
-            ->toBe('0')
-            ->and($event->toWire()['workerId'])
+            ->toBe('0');
+        Expect::that($event->toWire()['workerId'])
             ->toBe('0');
     }
 

--- a/tests/Unit/Core/ErrorTrapTest.php
+++ b/tests/Unit/Core/ErrorTrapTest.php
@@ -56,8 +56,8 @@ final class ErrorTrapTest
 
             Expect::that($warning)
                 ->because('the trap MUST retain the diagnostic for its caller')
-                ->toBe('trapped warning')
-                ->and($handled)
+                ->toBe('trapped warning');
+            Expect::that($handled)
                 ->because('the trap MUST NOT send the diagnostic to the host error handler')
                 ->toBe([]);
         } finally {
@@ -80,8 +80,8 @@ final class ErrorTrapTest
 
         Expect::that($innerWarning)
             ->because('the inner trap MUST capture its own diagnostic')
-            ->toBe('inner warning')
-            ->and($outerWarning)
+            ->toBe('inner warning');
+        Expect::that($outerWarning)
             ->because('the outer trap MUST resume after the inner trap')
             ->toBe('outer after inner');
     }

--- a/tests/Unit/Core/EventsTest.php
+++ b/tests/Unit/Core/EventsTest.php
@@ -155,11 +155,11 @@ final class EventsTest
 
         Expect::that($started->workerId)
             ->because('legacy class-started events have no worker attribution')
-            ->toBe('')
-            ->and($finished->workerId)
+            ->toBe('');
+        Expect::that($finished->workerId)
             ->because('legacy class-finished events have no worker attribution')
-            ->toBe('')
-            ->and($run->artifactsDirectory)
+            ->toBe('');
+        Expect::that($run->artifactsDirectory)
             ->because('legacy run-started events have no artifacts directory')
             ->toBeNull();
     }

--- a/tests/Unit/Core/OutcomeTransformationTest.php
+++ b/tests/Unit/Core/OutcomeTransformationTest.php
@@ -20,13 +20,13 @@ final readonly class OutcomeTransformationTest
 
         Expect::that($transformation->transformedBy)
             ->because('an outcome transformation MUST retain each non-empty source')
-            ->toBe('0')
-            ->and($decoded->transformedBy)
+            ->toBe('0');
+        Expect::that($decoded->transformedBy)
             ->because('the transformation source MUST survive the wire')
-            ->toBe('0')
-            ->and($decoded->from)
-            ->toBe(Outcome::Failed)
-            ->and($decoded->to)
+            ->toBe('0');
+        Expect::that($decoded->from)
+            ->toBe(Outcome::Failed);
+        Expect::that($decoded->to)
             ->toBe(Outcome::Skipped);
     }
 

--- a/tests/Unit/Core/ResourceNameTest.php
+++ b/tests/Unit/Core/ResourceNameTest.php
@@ -41,8 +41,8 @@ final class ResourceNameTest
     {
         Expect::that(ResourceName::isValid($name))
             ->because('noncanonical resource names MUST be rejected')
-            ->toBeFalse()
-            ->and(static fn() => ResourceName::assertValid($name))
+            ->toBeFalse();
+        Expect::that(static fn() => ResourceName::assertValid($name))
             ->because('assertValid() MUST report the rejected resource name')
             ->toThrow(
                 \InvalidArgumentException::class,

--- a/tests/Unit/Core/ResultPolicyTest.php
+++ b/tests/Unit/Core/ResultPolicyTest.php
@@ -153,17 +153,17 @@ final class ResultPolicyTest
 
         Expect::that($result->outcome)
             ->because('each deprecation MUST be evaluated independently')
-            ->toBe(Outcome::Failed)
-            ->and($result->failures)
-            ->toHaveCount(1)
-            ->and($result->failures[0]->message)
+            ->toBe(Outcome::Failed);
+        Expect::that($result->failures)
+            ->toHaveCount(1);
+        Expect::that($result->failures[0]->message)
             ->toBe(
                 'The deprecation policy changed this test from passed to failed: '
                 . 'old api is deprecated at /src/api.php:7',
-            )
-            ->and($result->transformations)
-            ->toHaveCount(1)
-            ->and($result->transformations[0]->transformedBy)
+            );
+        Expect::that($result->transformations)
+            ->toHaveCount(1);
+        Expect::that($result->transformations[0]->transformedBy)
             ->toBe('fail-on-diagnostic policy');
     }
 
@@ -176,8 +176,8 @@ final class ResultPolicyTest
 
         Expect::that($policy->apply($matching))
             ->because('a wildcard ignore MUST match without case sensitivity')
-            ->toBe($matching)
-            ->and($policy->apply($prefixed)->outcome)
+            ->toBe($matching);
+        Expect::that($policy->apply($prefixed)->outcome)
             ->because('a wildcard ignore MUST match the complete deprecation message')
             ->toBe(Outcome::Failed);
     }
@@ -220,10 +220,10 @@ final class ResultPolicyTest
 
         Expect::that($result->outcome)
             ->because('the notice policy does not make warnings fatal')
-            ->toBe(Outcome::Failed)
-            ->and($result->failures)
-            ->toHaveCount(1)
-            ->and($result->failures[0]->message)
+            ->toBe(Outcome::Failed);
+        Expect::that($result->failures)
+            ->toHaveCount(1);
+        Expect::that($result->failures[0]->message)
             ->toBe('The notice policy changed this test from passed to failed: a notice at /src/a.php:3');
     }
 
@@ -254,26 +254,26 @@ final class ResultPolicyTest
 
         Expect::that($result->outcome)
             ->because('diagnostic failures aggregate before the risky policy')
-            ->toBe(Outcome::Failed)
-            ->and($result->failures)
-            ->toHaveCount(2)
-            ->and($result->failures[0]->message)
+            ->toBe(Outcome::Failed);
+        Expect::that($result->failures)
+            ->toHaveCount(2);
+        Expect::that($result->failures[0]->message)
             ->toBe(
                 'The deprecation policy changed this test from passed to failed: old api at /src/old.php:4',
-            )
-            ->and($result->failures[1]->message)
+            );
+        Expect::that($result->failures[1]->message)
             ->toBe(
                 'The notice policy changed this test from passed to failed: notice too at /src/notice.php:6',
-            )
-            ->and($result->transformations)
-            ->toHaveCount(1)
-            ->and($result->transformations[0]->transformedBy)
-            ->toBe('fail-on-diagnostic policy')
-            ->and($result->expectations)
-            ->toBe(5)
-            ->and($result->attempts)
-            ->toBe(2)
-            ->and($result->durationSeconds)
+            );
+        Expect::that($result->transformations)
+            ->toHaveCount(1);
+        Expect::that($result->transformations[0]->transformedBy)
+            ->toBe('fail-on-diagnostic policy');
+        Expect::that($result->expectations)
+            ->toBe(5);
+        Expect::that($result->attempts)
+            ->toBe(2);
+        Expect::that($result->durationSeconds)
             ->toBe(0.25);
     }
 
@@ -292,10 +292,10 @@ final class ResultPolicyTest
 
         Expect::that($result->outcome)
             ->because('the risky policy fails a passed result without expectations')
-            ->toBe(Outcome::Failed)
-            ->and($result->transformations[0]->transformedBy)
-            ->toBe('fail-on-risky policy')
-            ->and($result->failures[0]->message)
+            ->toBe(Outcome::Failed);
+        Expect::that($result->transformations[0]->transformedBy)
+            ->toBe('fail-on-risky policy');
+        Expect::that($result->failures[0]->message)
             ->toBe('The fail-on-risky policy changed this test from passed to failed because it verified no expectations.');
     }
 

--- a/tests/Unit/Core/ResultSummaryOutcomeTest.php
+++ b/tests/Unit/Core/ResultSummaryOutcomeTest.php
@@ -23,8 +23,8 @@ final class ResultSummaryOutcomeTest
 
         Expect::that($original->add($outcome)->toWire())
             ->because('adding an outcome MUST increment only its matching summary count')
-            ->toBe($expected)
-            ->and($original->toWire())
+            ->toBe($expected);
+        Expect::that($original->toWire())
             ->because('adding an outcome MUST leave the original summary unchanged')
             ->toBe([
                 'passed' => 1,

--- a/tests/Unit/Core/ResultWireEnumContractTest.php
+++ b/tests/Unit/Core/ResultWireEnumContractTest.php
@@ -21,8 +21,8 @@ final class ResultWireEnumContractTest
                 'Failed' => 'failed',
                 'Errored' => 'errored',
                 'Skipped' => 'skipped',
-            ])
-            ->and(\array_column(DiagnosticSeverity::cases(), 'value', 'name'))
+            ]);
+        Expect::that(\array_column(DiagnosticSeverity::cases(), 'value', 'name'))
             ->because('diagnostic severities MUST keep their published wire values')
             ->toBe([
                 'Notice' => 'notice',

--- a/tests/Unit/Core/RunEventValidationTest.php
+++ b/tests/Unit/Core/RunEventValidationTest.php
@@ -29,8 +29,8 @@ final readonly class RunEventValidationTest
 
         Expect::that($event->runId)
             ->because('a run event MUST retain each non-empty run ID')
-            ->toBe('0')
-            ->and($decoded->runId)
+            ->toBe('0');
+        Expect::that($decoded->runId)
             ->because('the run ID MUST survive the wire')
             ->toBe('0');
     }

--- a/tests/Unit/Core/SkipTestTest.php
+++ b/tests/Unit/Core/SkipTestTest.php
@@ -25,8 +25,8 @@ final class SkipTestTest
 
         Expect::that($skip->reason)
             ->because('a skip signal MUST preserve a zero-string reason')
-            ->toBe('0')
-            ->and($skip->getMessage())
+            ->toBe('0');
+        Expect::that($skip->getMessage())
             ->toBe('0');
     }
 }

--- a/tests/Unit/Core/SourceLocationTest.php
+++ b/tests/Unit/Core/SourceLocationTest.php
@@ -20,11 +20,11 @@ final class SourceLocationTest
 
         Expect::that((string) $location)
             ->because('diagnostics MUST render a conventional file and line location')
-            ->toBe('/project/tests/PaymentTest.php:42')
-            ->and($restored->file)
+            ->toBe('/project/tests/PaymentTest.php:42');
+        Expect::that($restored->file)
             ->because('the file MUST survive the wire')
-            ->toBe('/project/tests/PaymentTest.php')
-            ->and($restored->line)
+            ->toBe('/project/tests/PaymentTest.php');
+        Expect::that($restored->line)
             ->because('the line MUST survive the wire')
             ->toBe(42);
     }
@@ -37,8 +37,8 @@ final class SourceLocationTest
 
         Expect::that((string) $location)
             ->because('a zero-string source file is not empty')
-            ->toBe('0:1')
-            ->and($restored->file)
+            ->toBe('0:1');
+        Expect::that($restored->file)
             ->because('the zero-string source file MUST survive the wire')
             ->toBe('0');
     }

--- a/tests/Unit/Core/StagedAttachmentPublicationTest.php
+++ b/tests/Unit/Core/StagedAttachmentPublicationTest.php
@@ -32,8 +32,8 @@ final class StagedAttachmentPublicationTest
 
         Expect::that($published::class)
             ->because('published metadata MUST remove the private staging coordinate')
-            ->toBe(Attachment::class)
-            ->and($published)
+            ->toBe(Attachment::class);
+        Expect::that($published)
             ->because('published metadata MUST preserve every public attachment field')
             ->toEqual(new Attachment(
                 name: 'response.json',

--- a/tests/Unit/Core/SuiteEventValidationTest.php
+++ b/tests/Unit/Core/SuiteEventValidationTest.php
@@ -39,8 +39,8 @@ final readonly class SuiteEventValidationTest
 
         Expect::that($event->suite)
             ->because('a suite lifecycle event MUST retain each non-empty suite name')
-            ->toBe('0')
-            ->and($decoded->suite)
+            ->toBe('0');
+        Expect::that($decoded->suite)
             ->because('the suite name MUST survive the wire')
             ->toBe('0');
     }

--- a/tests/Unit/Core/TestChannelMinimumNumberTest.php
+++ b/tests/Unit/Core/TestChannelMinimumNumberTest.php
@@ -17,8 +17,8 @@ final readonly class TestChannelMinimumNumberTest
 
         Expect::that($channel->number)
             ->because('in-process runs MUST use the first valid test channel')
-            ->toBe(1)
-            ->and($channel->label())
+            ->toBe(1);
+        Expect::that($channel->label())
             ->toBe('gl-1');
     }
 }

--- a/tests/Unit/Core/TestChannelTest.php
+++ b/tests/Unit/Core/TestChannelTest.php
@@ -16,8 +16,8 @@ final readonly class TestChannelTest
     {
         $channel = new TestChannel(3);
 
-        Expect::that($channel->number)->because('exposes the slot number and a prefixed label')->toBe(3)
-            ->and($channel->label())->toBe('gl-3');
+        Expect::that($channel->number)->because('exposes the slot number and a prefixed label')->toBe(3);
+        Expect::that($channel->label())->toBe('gl-3');
     }
 
     #[Test]

--- a/tests/Unit/Core/TestClassEventZeroNameTest.php
+++ b/tests/Unit/Core/TestClassEventZeroNameTest.php
@@ -24,8 +24,8 @@ final readonly class TestClassEventZeroNameTest
 
         Expect::that($event->class)
             ->because('class lifecycle events MUST retain non-empty zero-string class names')
-            ->toBe('0')
-            ->and($restored->class)
+            ->toBe('0');
+        Expect::that($restored->class)
             ->toBe('0');
     }
 

--- a/tests/Unit/Core/TestMetadataCaptureWireTest.php
+++ b/tests/Unit/Core/TestMetadataCaptureWireTest.php
@@ -23,8 +23,8 @@ final class TestMetadataCaptureWireTest
 
         Expect::that($payload['capture'])
             ->because('worker metadata MUST preserve disabled output capture')
-            ->toBeFalse()
-            ->and($restored->capture)
+            ->toBeFalse();
+        Expect::that($restored->capture)
             ->toBeFalse();
     }
 }

--- a/tests/Unit/Core/TestMetadataZeroGroupTest.php
+++ b/tests/Unit/Core/TestMetadataZeroGroupTest.php
@@ -19,8 +19,8 @@ final readonly class TestMetadataZeroGroupTest
 
         Expect::that($metadata->groups)
             ->because('test metadata MUST retain each non-empty group name')
-            ->toBe(['0'])
-            ->and($decoded->groups)
+            ->toBe(['0']);
+        Expect::that($decoded->groups)
             ->because('the group name MUST survive the wire')
             ->toBe(['0']);
     }

--- a/tests/Unit/Core/TestMetadataZeroSkipReasonTest.php
+++ b/tests/Unit/Core/TestMetadataZeroSkipReasonTest.php
@@ -19,8 +19,8 @@ final readonly class TestMetadataZeroSkipReasonTest
 
         Expect::that($metadata->skipReason)
             ->because('test metadata MUST retain each non-empty skip reason')
-            ->toBe('0')
-            ->and($decoded->skipReason)
+            ->toBe('0');
+        Expect::that($decoded->skipReason)
             ->because('the skip reason MUST survive the wire')
             ->toBe('0');
     }

--- a/tests/Unit/Core/TestResultAttachmentWireTest.php
+++ b/tests/Unit/Core/TestResultAttachmentWireTest.php
@@ -56,11 +56,11 @@ final class TestResultAttachmentWireTest
             $restored->attachments,
         ))
             ->because('test result wire decoding MUST preserve concrete attachment types')
-            ->toBe([Attachment::class, StagedAttachment::class])
-            ->and($restored->attachments)
+            ->toBe([Attachment::class, StagedAttachment::class]);
+        Expect::that($restored->attachments)
             ->because('test result wire decoding MUST preserve exact attachment metadata')
-            ->toEqual([$attachment, $staged])
-            ->and($restored->attachments[1] instanceof StagedAttachment
+            ->toEqual([$attachment, $staged]);
+        Expect::that($restored->attachments[1] instanceof StagedAttachment
                 ? $restored->attachments[1]->storageKey
                 : null)
             ->because('the staged attachment storage key MUST survive the test result wire boundary')

--- a/tests/Unit/Core/TestResultCopyTest.php
+++ b/tests/Unit/Core/TestResultCopyTest.php
@@ -36,11 +36,11 @@ final class TestResultCopyTest
         Expect::that($replacement)
             ->because('a result mutation MUST produce a replacement result')
             ->not()
-            ->toBe($original)
-            ->and($original->toWire())
+            ->toBe($original);
+        Expect::that($original->toWire())
             ->because('a result mutation MUST NOT change the original result')
-            ->toBe($originalWire)
-            ->and($replacement->toWire())
+            ->toBe($originalWire);
+        Expect::that($replacement->toWire())
             ->because('a result mutation MUST preserve all state that it does not replace')
             ->toBe($expected);
     }
@@ -83,11 +83,11 @@ final class TestResultCopyTest
         Expect::that($recovered)
             ->because('recovering an attempt count MUST produce a replacement result')
             ->not()
-            ->toBe($original)
-            ->and($original->attempts)
+            ->toBe($original);
+        Expect::that($original->attempts)
             ->because('recovering an attempt count MUST NOT change the original result')
-            ->toBe(2)
-            ->and($recovered->toWire())
+            ->toBe(2);
+        Expect::that($recovered->toWire())
             ->because('the replacement MUST preserve all result state except the recovered attempt count')
             ->toBe($expected);
     }

--- a/tests/Unit/Core/TestResultExpectationValidationTest.php
+++ b/tests/Unit/Core/TestResultExpectationValidationTest.php
@@ -19,14 +19,14 @@ final class TestResultExpectationValidationTest
 
         Expect::that(new TestResult($id, Outcome::Passed, 0.1, 0, expectations: 0)->expectations)
             ->because('a result MAY contain no verified expectations')
-            ->toBe(0)
-            ->and(static fn(): TestResult => new TestResult(
-                $id,
-                Outcome::Passed,
-                0.1,
-                0,
-                expectations: -1,
-            ))
+            ->toBe(0);
+        Expect::that(static fn(): TestResult => new TestResult(
+            $id,
+            Outcome::Passed,
+            0.1,
+            0,
+            expectations: -1,
+        ))
             ->because('a result MUST NOT contain a negative expectation count')
             ->toThrow(
                 \InvalidArgumentException::class,

--- a/tests/Unit/Core/TestResultFailedByEvidenceTest.php
+++ b/tests/Unit/Core/TestResultFailedByEvidenceTest.php
@@ -32,17 +32,17 @@ final readonly class TestResultFailedByEvidenceTest
 
         Expect::that($result->outcome)
             ->because('a later failure transition MUST retain earlier failure evidence')
-            ->toBe(Outcome::Failed)
-            ->and($result->failures)
-            ->toBe([$earlier, $later])
-            ->and(\array_map(
-                static fn(OutcomeTransformation $transformation): array => [
-                    $transformation->transformedBy,
-                    $transformation->from,
-                    $transformation->to,
-                ],
-                $result->transformations,
-            ))
+            ->toBe(Outcome::Failed);
+        Expect::that($result->failures)
+            ->toBe([$earlier, $later]);
+        Expect::that(\array_map(
+            static fn(OutcomeTransformation $transformation): array => [
+                $transformation->transformedBy,
+                $transformation->from,
+                $transformation->to,
+            ],
+            $result->transformations,
+        ))
             ->toBe([
                 ['quarantine-plugin', Outcome::Failed, Outcome::Passed],
                 ['result-policy', Outcome::Passed, Outcome::Failed],

--- a/tests/Unit/Core/TestResultTest.php
+++ b/tests/Unit/Core/TestResultTest.php
@@ -94,18 +94,18 @@ final class TestResultTest
             ]);
         Expect::that($restored->output?->stdout)
             ->because('captured output and truncation state survive the wire')
-            ->toBe("first line\nsecond line")
-            ->and($restored->output?->diagnostics[0]->severity)
-            ->toBe(DiagnosticSeverity::Warning)
-            ->and($restored->output?->diagnostics[0]->message)
-            ->toBe('deprecated call')
-            ->and($restored->output?->diagnostics[0]->file)
-            ->toBe('/app/src/Foo.php')
-            ->and($restored->output?->diagnostics[0]->line)
-            ->toBe(21)
-            ->and($restored->output?->stdoutTruncated)
-            ->toBeTrue()
-            ->and($restored->output?->diagnosticsTruncated)
+            ->toBe("first line\nsecond line");
+        Expect::that($restored->output?->diagnostics[0]->severity)
+            ->toBe(DiagnosticSeverity::Warning);
+        Expect::that($restored->output?->diagnostics[0]->message)
+            ->toBe('deprecated call');
+        Expect::that($restored->output?->diagnostics[0]->file)
+            ->toBe('/app/src/Foo.php');
+        Expect::that($restored->output?->diagnostics[0]->line)
+            ->toBe(21);
+        Expect::that($restored->output?->stdoutTruncated)
+            ->toBeTrue();
+        Expect::that($restored->output?->diagnosticsTruncated)
             ->toBeTrue();
         Expect::that($restored->risky)->because('survives the wire with full payload')->toBeTrue();
         Expect::that($restored->expectations)->because('survives the wire with full payload')->toBe(7);
@@ -180,11 +180,11 @@ final class TestResultTest
 
         Expect::that($errored->outcome)
             ->because('a later lifecycle error MUST replace the final outcome')
-            ->toBe(Outcome::Errored)
-            ->and($errored->error)
+            ->toBe(Outcome::Errored);
+        Expect::that($errored->error)
             ->because('the lifecycle error MUST remain available for diagnostics')
-            ->toBe($error)
-            ->and($errored->failures)
+            ->toBe($error);
+        Expect::that($errored->failures)
             ->because('a later lifecycle error MUST NOT discard earlier failure evidence')
             ->toBe([$failure]);
         Expect::that($errored->attempts)

--- a/tests/Unit/Core/ThrowableDetailTest.php
+++ b/tests/Unit/Core/ThrowableDetailTest.php
@@ -65,8 +65,8 @@ final class ThrowableDetailTest
 
         Expect::that($detail->stackFrames)
             ->because('deep throwable traces are bounded with a truncation marker')
-            ->toHaveCount(33)
-            ->and($detail->stackFrames[32])
+            ->toHaveCount(33);
+        Expect::that($detail->stackFrames[32])
             ->toBe('... (trace truncated)');
     }
 

--- a/tests/Unit/Core/Utf8Test.php
+++ b/tests/Unit/Core/Utf8Test.php
@@ -56,14 +56,14 @@ final class Utf8Test
 
         Expect::that($restored->severity)
             ->because('the diagnostic severity MUST survive the wire')
-            ->toBe(DiagnosticSeverity::Warning)
-            ->and($restored->message)
+            ->toBe(DiagnosticSeverity::Warning);
+        Expect::that($restored->message)
             ->because('the diagnostic message MUST replace invalid bytes')
-            ->toBe("warning: \u{FFFD} details")
-            ->and($restored->file)
+            ->toBe("warning: \u{FFFD} details");
+        Expect::that($restored->file)
             ->because('the diagnostic file MUST replace invalid bytes')
-            ->toBe("/src/\u{FFFD}.php")
-            ->and($restored->line)
+            ->toBe("/src/\u{FFFD}.php");
+        Expect::that($restored->line)
             ->because('the diagnostic line MUST survive the wire')
             ->toBe(42);
     }

--- a/tests/Unit/Core/WireTest.php
+++ b/tests/Unit/Core/WireTest.php
@@ -106,14 +106,14 @@ final class WireTest
             ->toThrow(
                 InvalidWirePayload::class,
                 message: 'Wire payload key "field" must be a map, got array.',
-            )
-            ->and(static fn(): ?array => Wire::nullableMap($list, 'field'))
+            );
+        Expect::that(static fn(): ?array => Wire::nullableMap($list, 'field'))
             ->because('a nullable wire map MUST validate its non-null shape')
             ->toThrow(
                 InvalidWirePayload::class,
                 message: 'Wire payload key "field" must be a map, got array.',
-            )
-            ->and(static fn(): array => Wire::listOfMaps($listOfLists, 'field'))
+            );
+        Expect::that(static fn(): array => Wire::listOfMaps($listOfLists, 'field'))
             ->because('each item in a wire list of maps MUST be a map')
             ->toThrow(
                 InvalidWirePayload::class,
@@ -128,10 +128,10 @@ final class WireTest
 
         Expect::that(Wire::map($emptyMap, 'field'))
             ->because('an empty decoded JSON object is a valid wire map')
-            ->toBe([])
-            ->and(Wire::nullableMap($emptyMap, 'field'))
-            ->toBe([])
-            ->and(Wire::listOfMaps(['field' => [[]]], 'field'))
+            ->toBe([]);
+        Expect::that(Wire::nullableMap($emptyMap, 'field'))
+            ->toBe([]);
+        Expect::that(Wire::listOfMaps(['field' => [[]]], 'field'))
             ->toBe([[]]);
     }
 
@@ -146,14 +146,14 @@ final class WireTest
             ->toThrow(
                 InvalidWirePayload::class,
                 message: 'Wire payload key "field" must be a map with string keys, got array.',
-            )
-            ->and(static fn(): ?array => Wire::nullableMap($map, 'field'))
+            );
+        Expect::that(static fn(): ?array => Wire::nullableMap($map, 'field'))
             ->because('nullable wire maps MUST validate non-null keys')
             ->toThrow(
                 InvalidWirePayload::class,
                 message: 'Wire payload key "field" must be a map with string keys, got array.',
-            )
-            ->and(static fn(): array => Wire::listOfMaps($listOfMaps, 'field'))
+            );
+        Expect::that(static fn(): array => Wire::listOfMaps($listOfMaps, 'field'))
             ->because('each wire map in a list MUST have string keys')
             ->toThrow(
                 InvalidWirePayload::class,
@@ -172,8 +172,8 @@ final class WireTest
             ->toThrow(
                 InvalidWirePayload::class,
                 message: 'Wire payload key "durationSeconds" must be a finite float, got float.',
-            )
-            ->and(static fn(): ?float => Wire::nullableFloat($payload, 'durationSeconds'))
+            );
+        Expect::that(static fn(): ?float => Wire::nullableFloat($payload, 'durationSeconds'))
             ->because('nullable protocol floats MUST reject non-finite values')
             ->toThrow(
                 InvalidWirePayload::class,

--- a/tests/Unit/Core/WorkerEventValidationTest.php
+++ b/tests/Unit/Core/WorkerEventValidationTest.php
@@ -29,8 +29,8 @@ final readonly class WorkerEventValidationTest
 
         Expect::that($event->workerId)
             ->because('a worker event MUST retain each non-empty worker ID')
-            ->toBe('0')
-            ->and($decoded->workerId)
+            ->toBe('0');
+        Expect::that($decoded->workerId)
             ->because('the worker ID MUST survive the wire')
             ->toBe('0');
     }
@@ -43,8 +43,8 @@ final readonly class WorkerEventValidationTest
             ->toThrow(
                 \InvalidArgumentException::class,
                 message: 'Worker ID MUST NOT be empty.',
-            )
-            ->and(static fn(): WorkerRecycled => new WorkerRecycled('', RecycleReason::TestCount, 1.0))
+            );
+        Expect::that(static fn(): WorkerRecycled => new WorkerRecycled('', RecycleReason::TestCount, 1.0))
             ->because('a recycled-worker event MUST identify its worker')
             ->toThrow(
                 \InvalidArgumentException::class,

--- a/tests/Unit/Core/WorkerLifecycleWireContractTest.php
+++ b/tests/Unit/Core/WorkerLifecycleWireContractTest.php
@@ -21,8 +21,8 @@ final class WorkerLifecycleWireContractTest
                 'workerId' => 'worker-7',
                 'pid' => 321,
                 'occurredAt' => 123.5,
-            ])
-            ->and(new WorkerRecycled('worker-7', RecycleReason::Crash, 124.5)->toWire())
+            ]);
+        Expect::that(new WorkerRecycled('worker-7', RecycleReason::Crash, 124.5)->toWire())
             ->because('worker-recycled payloads MUST keep their published field names and values')
             ->toBe([
                 'workerId' => 'worker-7',

--- a/tests/Unit/Coverage/BaselineDiffTest.php
+++ b/tests/Unit/Coverage/BaselineDiffTest.php
@@ -19,9 +19,9 @@ final class BaselineDiffTest
 
         $report = BaselineDiff::between($map, $map);
 
-        Expect::that($report->fileDeltas)->because('comparing a map against itself reports no changes')->toBe([])
-            ->and($report->totalDelta())->toBe(0.0)
-            ->and($report->hasRegressions())->toBeFalse();
+        Expect::that($report->fileDeltas)->because('comparing a map against itself reports no changes')->toBe([]);
+        Expect::that($report->totalDelta())->toBe(0.0);
+        Expect::that($report->hasRegressions())->toBeFalse();
     }
 
     #[Test]
@@ -33,13 +33,13 @@ final class BaselineDiffTest
         $report = BaselineDiff::between($baseline, $current);
         $delta = $report->fileDeltas['/src/A.php'];
 
-        Expect::that($delta->baselinePercentage)->because('reports per file and total percentage deltas')->toBe(100.0)
-            ->and($delta->currentPercentage)->toBe(50.0)
-            ->and($delta->delta())->toBeWithin(0.001, -50.0)
-            ->and($report->baselinePercentage)->toBe(100.0)
-            ->and($report->currentPercentage)->toBe(50.0)
-            ->and($report->totalDelta())->toBeWithin(0.001, -50.0)
-            ->and($report->hasRegressions())->toBeTrue();
+        Expect::that($delta->baselinePercentage)->because('reports per file and total percentage deltas')->toBe(100.0);
+        Expect::that($delta->currentPercentage)->toBe(50.0);
+        Expect::that($delta->delta())->toBeWithin(0.001, -50.0);
+        Expect::that($report->baselinePercentage)->toBe(100.0);
+        Expect::that($report->currentPercentage)->toBe(50.0);
+        Expect::that($report->totalDelta())->toBeWithin(0.001, -50.0);
+        Expect::that($report->hasRegressions())->toBeTrue();
     }
 
     #[Test]
@@ -61,10 +61,10 @@ final class BaselineDiffTest
 
         $report = BaselineDiff::between($baseline, $current);
 
-        Expect::that(\array_keys($report->fileDeltas))->because('files only in one map appear with a null side')->toBe(['/src/Gone.php', '/src/New.php'])
-            ->and($report->fileDeltas['/src/Gone.php']->currentPercentage)->toBeNull()
-            ->and($report->fileDeltas['/src/New.php']->baselinePercentage)->toBeNull()
-            ->and($report->fileDeltas['/src/New.php']->newlyUncoveredLines)->toBe([2]);
+        Expect::that(\array_keys($report->fileDeltas))->because('files only in one map appear with a null side')->toBe(['/src/Gone.php', '/src/New.php']);
+        Expect::that($report->fileDeltas['/src/Gone.php']->currentPercentage)->toBeNull();
+        Expect::that($report->fileDeltas['/src/New.php']->baselinePercentage)->toBeNull();
+        Expect::that($report->fileDeltas['/src/New.php']->newlyUncoveredLines)->toBe([2]);
     }
 
     #[Test]
@@ -75,8 +75,8 @@ final class BaselineDiffTest
 
         $report = BaselineDiff::between($baseline, $current);
 
-        Expect::that($report->totalDelta())->because('improved coverage is not a regression')->toBeWithin(0.001, 50.0)
-            ->and($report->hasRegressions())->toBeFalse();
+        Expect::that($report->totalDelta())->because('improved coverage is not a regression')->toBeWithin(0.001, 50.0);
+        Expect::that($report->hasRegressions())->toBeFalse();
     }
 
     #[Test]
@@ -94,11 +94,11 @@ final class BaselineDiffTest
 
         Expect::that($report->totalDelta())
             ->because('the added covered file MUST produce an overall coverage gain')
-            ->toBeGreaterThan(0.0)
-            ->and($report->fileDeltas['/src/A.php']->newlyUncoveredLines)
+            ->toBeGreaterThan(0.0);
+        Expect::that($report->fileDeltas['/src/A.php']->newlyUncoveredLines)
             ->because('the diff MUST preserve the line-level regression')
-            ->toBe([1])
-            ->and($report->hasRegressions())
+            ->toBe([1]);
+        Expect::that($report->hasRegressions())
             ->because('an overall gain MUST NOT hide a newly uncovered line')
             ->toBeTrue();
     }

--- a/tests/Unit/Coverage/CoverageMapTest.php
+++ b/tests/Unit/Coverage/CoverageMapTest.php
@@ -24,8 +24,8 @@ final class CoverageMapTest
 
         $file = $map->files()['/src/A.php'];
 
-        Expect::that($file->coveredLines)->because('from raw splits statuses and drops dead code')->toBe([3, 6])
-            ->and($file->uncoveredLines)->toBe([4]);
+        Expect::that($file->coveredLines)->because('from raw splits statuses and drops dead code')->toBe([3, 6]);
+        Expect::that($file->uncoveredLines)->toBe([4]);
     }
 
     #[Test]
@@ -58,8 +58,8 @@ final class CoverageMapTest
 
         Expect::that($map->files()['/src/A.php']->coveredLines)
             ->because('raw coverage drops non-positive line numbers')
-            ->toBe([1])
-            ->and($map->files()['/src/A.php']->uncoveredLines)
+            ->toBe([1]);
+        Expect::that($map->files()['/src/A.php']->uncoveredLines)
             ->toBe([]);
     }
 
@@ -129,8 +129,8 @@ final class CoverageMapTest
 
         $file = $sawItUncovered->merge($sawItCovered)->files()['/src/A.php'];
 
-        Expect::that($file->coveredLines)->because('covered wins over uncovered across merges')->toBe([10])
-            ->and($file->uncoveredLines)->toBe([]);
+        Expect::that($file->coveredLines)->because('covered wins over uncovered across merges')->toBe([10]);
+        Expect::that($file->uncoveredLines)->toBe([]);
     }
 
     #[Test]
@@ -141,9 +141,9 @@ final class CoverageMapTest
             new FileCoverage('/src/B.php', [1], [2, 3, 4]),
         ]);
 
-        Expect::that($map->coveredLineTotal())->because('percentages aggregate across files')->toBe(4)
-            ->and($map->executableLineTotal())->toBe(8)
-            ->and($map->totalPercentage())->toBeWithin(0.001, 50.0);
+        Expect::that($map->coveredLineTotal())->because('percentages aggregate across files')->toBe(4);
+        Expect::that($map->executableLineTotal())->toBe(8);
+        Expect::that($map->totalPercentage())->toBeWithin(0.001, 50.0);
     }
 
     #[Test]

--- a/tests/Unit/Coverage/DriverSelectorTest.php
+++ b/tests/Unit/Coverage/DriverSelectorTest.php
@@ -19,8 +19,8 @@ final class DriverSelectorTest
     {
         $selection = new DriverSelector([])->select();
 
-        Expect::that($selection->driver)->because('empty candidate list yields no driver and a reason')->toBeNull()
-            ->and($selection->reason)->toBe('No coverage driver is configured.');
+        Expect::that($selection->driver)->because('empty candidate list yields no driver and a reason')->toBeNull();
+        Expect::that($selection->reason)->toBe('No coverage driver is configured.');
     }
 
     #[Test]
@@ -28,8 +28,8 @@ final class DriverSelectorTest
     {
         $selection = new DriverSelector([UnavailableFakeDriver::class, AvailableFakeDriver::class])->select();
 
-        Expect::that($selection->driver)->because('an available candidate is selected with no reason')->toBeInstanceOf(AvailableFakeDriver::class)
-            ->and($selection->reason)->toBeNull();
+        Expect::that($selection->driver)->because('an available candidate is selected with no reason')->toBeInstanceOf(AvailableFakeDriver::class);
+        Expect::that($selection->reason)->toBeNull();
     }
 
     #[Test]
@@ -39,8 +39,8 @@ final class DriverSelectorTest
 
         Expect::that($selection->driver)
             ->because('candidate order determines coverage-driver preference')
-            ->toBeInstanceOf(RecordingFakeDriver::class)
-            ->and($selection->reason)
+            ->toBeInstanceOf(RecordingFakeDriver::class);
+        Expect::that($selection->reason)
             ->toBeNull();
     }
 
@@ -49,11 +49,11 @@ final class DriverSelectorTest
     {
         $selection = new DriverSelector([UnavailableFakeDriver::class])->select();
 
-        Expect::that($selection->driver)->because('no available candidate yields no driver and a named reason')->toBeNull()
-            ->and($selection->reason)->toBe(
-                'No coverage driver is available. Greenlight tried UnavailableFakeDriver. Install pcov or enable Xdebug coverage mode. '
+        Expect::that($selection->driver)->because('no available candidate yields no driver and a named reason')->toBeNull();
+        Expect::that($selection->reason)->toBe(
+            'No coverage driver is available. Greenlight tried UnavailableFakeDriver. Install pcov or enable Xdebug coverage mode. '
                 . 'Set xdebug.mode to "coverage", or set the XDEBUG_MODE environment variable.',
-            );
+        );
     }
 
     #[Test]

--- a/tests/Unit/Coverage/FileCoverageTest.php
+++ b/tests/Unit/Coverage/FileCoverageTest.php
@@ -30,11 +30,11 @@ final class FileCoverageTest
 
         Expect::that($merged->file)
             ->because('a zero-string coverage file path is not empty')
-            ->toBe('0')
-            ->and($merged->coveredLines)
+            ->toBe('0');
+        Expect::that($merged->coveredLines)
             ->because('coverage for the zero-string path MUST merge normally')
-            ->toBe([1, 2])
-            ->and($merged->percentage())
+            ->toBe([1, 2]);
+        Expect::that($merged->percentage())
             ->toBe(100.0);
     }
 
@@ -43,8 +43,8 @@ final class FileCoverageTest
     {
         $file = new FileCoverage('/src/A.php', [9, 3, 3, 5], [12, 7, 12]);
 
-        Expect::that($file->coveredLines)->because('line lists are sorted and deduplicated')->toBe([3, 5, 9])
-            ->and($file->uncoveredLines)->toBe([7, 12]);
+        Expect::that($file->coveredLines)->because('line lists are sorted and deduplicated')->toBe([3, 5, 9]);
+        Expect::that($file->uncoveredLines)->toBe([7, 12]);
     }
 
     #[Test]
@@ -52,8 +52,8 @@ final class FileCoverageTest
     {
         $file = new FileCoverage('/src/A.php', [3, 5], [3, 7]);
 
-        Expect::that($file->coveredLines)->because('covered wins when a line appears in both sets')->toBe([3, 5])
-            ->and($file->uncoveredLines)->toBe([7]);
+        Expect::that($file->coveredLines)->because('covered wins when a line appears in both sets')->toBe([3, 5]);
+        Expect::that($file->uncoveredLines)->toBe([7]);
     }
 
     #[Test]
@@ -61,9 +61,9 @@ final class FileCoverageTest
     {
         $file = new FileCoverage('/src/A.php', [1, 2, 3], [4]);
 
-        Expect::that($file->percentage())->because('percentage is covered over executable')->toBeWithin(0.001, 75.0)
-            ->and($file->executableLineCount())->toBe(4)
-            ->and($file->coveredLineCount())->toBe(3);
+        Expect::that($file->percentage())->because('percentage is covered over executable')->toBeWithin(0.001, 75.0);
+        Expect::that($file->executableLineCount())->toBe(4);
+        Expect::that($file->coveredLineCount())->toBe(3);
     }
 
     #[Test]
@@ -80,8 +80,8 @@ final class FileCoverageTest
 
         $merged = $a->merge($b);
 
-        Expect::that($merged->coveredLines)->because('merge unions coverage and covered wins')->toBe([3, 5])
-            ->and($merged->uncoveredLines)->toBe([7, 9]);
+        Expect::that($merged->coveredLines)->because('merge unions coverage and covered wins')->toBe([3, 5]);
+        Expect::that($merged->uncoveredLines)->toBe([7, 9]);
     }
 
     #[Test]

--- a/tests/Unit/Coverage/HtmlExporterEmptySourceTest.php
+++ b/tests/Unit/Coverage/HtmlExporterEmptySourceTest.php
@@ -28,8 +28,8 @@ final readonly class HtmlExporterEmptySourceTest
 
         Expect::that(\is_readable($path))
             ->because('the empty source MUST be readable')
-            ->toBeTrue()
-            ->and($page)
+            ->toBeTrue();
+        Expect::that($page)
             ->because('an empty source MUST retain a valid empty source block')
             ->toContain("<pre>\n</pre>")
             ->not()

--- a/tests/Unit/Coverage/HtmlExporterInvalidUtf8PathTest.php
+++ b/tests/Unit/Coverage/HtmlExporterInvalidUtf8PathTest.php
@@ -27,8 +27,8 @@ final readonly class HtmlExporterInvalidUtf8PathTest
         Expect::that($index)
             ->because('the HTML index MUST scrub invalid UTF-8 in file-system paths')
             ->toContain($scrubbed)
-            ->toMatch('//u')
-            ->and($file)
+            ->toMatch('//u');
+        Expect::that($file)
             ->because('the HTML file page MUST scrub invalid UTF-8 in its title')
             ->toContain('<h1>' . $scrubbed . '</h1>')
             ->toMatch('//u');

--- a/tests/Unit/Coverage/HtmlExporterPathEscapingTest.php
+++ b/tests/Unit/Coverage/HtmlExporterPathEscapingTest.php
@@ -27,8 +27,8 @@ final readonly class HtmlExporterPathEscapingTest
             ->because('coverage file paths MUST remain text in the HTML index')
             ->toContain('>' . $escaped . '</a>')
             ->not()
-            ->toContain('<script>coverage</script>')
-            ->and($file)
+            ->toContain('<script>coverage</script>');
+        Expect::that($file)
             ->because('coverage file paths MUST remain text in the HTML file page')
             ->toContain('<title>' . $escaped . '</title>')
             ->toContain('<h1>' . $escaped . '</h1>')

--- a/tests/Unit/Coverage/HtmlExporterSourceFailureTest.php
+++ b/tests/Unit/Coverage/HtmlExporterSourceFailureTest.php
@@ -42,8 +42,8 @@ final readonly class HtmlExporterSourceFailureTest
             Expect::that($warning ?? '')
                 ->because('the source becomes unreadable when the exporter opens it')
                 ->toContain('file_get_contents(' . $path . ')')
-                ->toContain('Failed to open stream')
-                ->and($page)
+                ->toContain('Failed to open stream');
+            Expect::that($page)
                 ->because('a late read failure shows only coverage line numbers')
                 ->toContain('<span class="cov"><span class="num">2</span></span>')
                 ->toContain('<span class="unc"><span class="num">4</span></span>');

--- a/tests/Unit/Coverage/HtmlExporterTest.php
+++ b/tests/Unit/Coverage/HtmlExporterTest.php
@@ -129,8 +129,8 @@ final readonly class HtmlExporterTest
 
         Expect::that($index)->because('paths are shown relative to the project root')->toContain('>src/A.php<')
             ->not()->toContain('/proj/src/A.php')
-            ->toContain(HtmlExporter::pageName('/proj/src/A.php'))
-            ->and($filePage)->toContain('<h1>src/A.php</h1>');
+            ->toContain(HtmlExporter::pageName('/proj/src/A.php'));
+        Expect::that($filePage)->toContain('<h1>src/A.php</h1>');
     }
 
     #[Test]

--- a/tests/Unit/Coverage/HtmlExporterUnreadableSourceTest.php
+++ b/tests/Unit/Coverage/HtmlExporterUnreadableSourceTest.php
@@ -28,8 +28,8 @@ final readonly class HtmlExporterUnreadableSourceTest
 
             Expect::that(\is_file($path))
                 ->because('the fixture MUST be a regular file')
-                ->toBeTrue()
-                ->and(\is_readable($path))
+                ->toBeTrue();
+            Expect::that(\is_readable($path))
                 ->because('the fixture MUST reject reads')
                 ->toBeFalse();
 
@@ -41,8 +41,8 @@ final readonly class HtmlExporterUnreadableSourceTest
             Expect::that($page)
                 ->because('an unreadable source shows only coverage line numbers')
                 ->toContain('<span class="cov"><span class="num">2</span></span>')
-                ->toContain('<span class="unc"><span class="num">4</span></span>')
-                ->and(UnreadableSourceStream::$openCalls)
+                ->toContain('<span class="unc"><span class="num">4</span></span>');
+            Expect::that(UnreadableSourceStream::$openCalls)
                 ->because('the exporter rejects an unreadable source before opening it')
                 ->toBe(0);
         } finally {

--- a/tests/Unit/Coverage/JsonExporterCompatibilityTest.php
+++ b/tests/Unit/Coverage/JsonExporterCompatibilityTest.php
@@ -48,8 +48,8 @@ final readonly class JsonExporterCompatibilityTest
                 'files' => [
                     '/src/A.php' => [[3], [5]],
                 ],
-            ])
-            ->and($exported)
+            ]);
+        Expect::that($exported)
             ->because('coverage JSON readers MUST recalculate derived values')
             ->toBe([
                 'v' => 1,

--- a/tests/Unit/Coverage/PathFilterTest.php
+++ b/tests/Unit/Coverage/PathFilterTest.php
@@ -21,10 +21,10 @@ final class PathFilterTest
     {
         $filter = new PathFilter(['/project/src', '/project/lib/']);
 
-        Expect::that($filter->accepts('/project/src/A.php'))->because('accepts files under an include directory')->toBeTrue()
-            ->and($filter->accepts('/project/src/Deep/Nested/B.php'))->toBeTrue()
-            ->and($filter->accepts('/project/lib/C.php'))->toBeTrue()
-            ->and($filter->accepts('/project/vendor/D.php'))->toBeFalse();
+        Expect::that($filter->accepts('/project/src/A.php'))->because('accepts files under an include directory')->toBeTrue();
+        Expect::that($filter->accepts('/project/src/Deep/Nested/B.php'))->toBeTrue();
+        Expect::that($filter->accepts('/project/lib/C.php'))->toBeTrue();
+        Expect::that($filter->accepts('/project/vendor/D.php'))->toBeFalse();
     }
 
     #[Test]
@@ -42,8 +42,8 @@ final class PathFilterTest
 
         Expect::that($filter->accepts('/project/src/A.php'))
             ->because('the filesystem root MUST remain a valid coverage include directory')
-            ->toBeTrue()
-            ->and($filter->accepts('relative.php'))
+            ->toBeTrue();
+        Expect::that($filter->accepts('relative.php'))
             ->toBeFalse();
     }
 
@@ -54,8 +54,8 @@ final class PathFilterTest
 
         Expect::that($filter->accepts('0/Covered.php'))
             ->because('a zero-string include directory is not empty')
-            ->toBeTrue()
-            ->and($filter->accepts('01/NotCovered.php'))
+            ->toBeTrue();
+        Expect::that($filter->accepts('01/NotCovered.php'))
             ->because('relative include directories MUST match by path segment')
             ->toBeFalse();
     }

--- a/tests/Unit/Coverage/PcovDriverFailureTest.php
+++ b/tests/Unit/Coverage/PcovDriverFailureTest.php
@@ -26,8 +26,8 @@ final class PcovDriverFailureTest
             ->toThrow(
                 \RuntimeException::class,
                 message: 'PCOV start failed.',
-            )
-            ->and($runtime->calls)
+            );
+        Expect::that($runtime->calls)
             ->because('a PCOV start failure MUST stop before collection begins')
             ->toBe(['start']);
 
@@ -52,8 +52,8 @@ final class PcovDriverFailureTest
             ->toThrow(
                 \RuntimeException::class,
                 message: 'PCOV collection failed.',
-            )
-            ->and($runtime->calls)
+            );
+        Expect::that($runtime->calls)
             ->because('a PCOV collection failure MUST still stop and clear extension state')
             ->toBe(['start', 'collect', 'stop', 'clear']);
 
@@ -90,8 +90,8 @@ final class PcovDriverFailureTest
             ->toThrow(
                 \RuntimeException::class,
                 message: $message,
-            )
-            ->and($runtime->calls)
+            );
+        Expect::that($runtime->calls)
             ->because('PCOV cleanup MUST attempt clear even if stop fails')
             ->toBe(['start', 'collect', 'stop', 'clear']);
 

--- a/tests/Unit/Coverage/PcovDriverTest.php
+++ b/tests/Unit/Coverage/PcovDriverTest.php
@@ -73,8 +73,8 @@ final class PcovDriverTest
                     10 => 1,
                     11 => -1,
                 ],
-            ])
-            ->and($runtime->calls)
+            ]);
+        Expect::that($runtime->calls)
             ->because('PCOV collection MUST stop and clear extension state after reading it')
             ->toBe(['start', 'collect', 'stop', 'clear']);
     }

--- a/tests/Unit/Coverage/XmlExporterControlCharacterPathTest.php
+++ b/tests/Unit/Coverage/XmlExporterControlCharacterPathTest.php
@@ -42,8 +42,8 @@ final readonly class XmlExporterControlCharacterPathTest
 
         Expect::that((string) $cloverFiles[0]['name'])
             ->because('Clover MUST produce a round-trippable file-system path')
-            ->toBe($expected)
-            ->and((string) $coberturaClasses[0]['filename'])
+            ->toBe($expected);
+        Expect::that((string) $coberturaClasses[0]['filename'])
             ->because('Cobertura MUST produce a round-trippable file-system path')
             ->toBe(\ltrim($expected, '/'));
     }

--- a/tests/Unit/Coverage/XmlExporterInvalidUtf8PathTest.php
+++ b/tests/Unit/Coverage/XmlExporterInvalidUtf8PathTest.php
@@ -40,8 +40,8 @@ final readonly class XmlExporterInvalidUtf8PathTest
 
         Expect::that((string) $cloverFiles[0]['name'])
             ->because('Clover MUST scrub invalid UTF-8 in file-system paths')
-            ->toBe("/src/\u{FFFD}.php")
-            ->and((string) $coberturaClasses[0]['filename'])
+            ->toBe("/src/\u{FFFD}.php");
+        Expect::that((string) $coberturaClasses[0]['filename'])
             ->because('Cobertura MUST scrub invalid UTF-8 in file-system paths')
             ->toBe("src/\u{FFFD}.php");
     }

--- a/tests/Unit/Coverage/XmlExporterPathTest.php
+++ b/tests/Unit/Coverage/XmlExporterPathTest.php
@@ -31,19 +31,19 @@ final readonly class XmlExporterPathTest
 
         Expect::that($cloverDocument)
             ->because('Clover file paths MUST be escaped as XML attributes')
-            ->toContain('A&amp;B&quot;&apos;&lt;Coverage&gt;.php')
-            ->and($cloverFiles)
+            ->toContain('A&amp;B&quot;&apos;&lt;Coverage&gt;.php');
+        Expect::that($cloverFiles)
             ->because('the Clover document MUST contain exactly one file')
             ->toHaveCount(1);
         \assert(\is_array($cloverFiles) && isset($cloverFiles[0]));
 
         Expect::that((string) $cloverFiles[0]['name'])
             ->because('the parsed Clover path MUST equal the original path')
-            ->toBe($path)
-            ->and($coberturaDocument)
+            ->toBe($path);
+        Expect::that($coberturaDocument)
             ->because('Cobertura file paths MUST be escaped as XML attributes')
-            ->toContain('A&amp;B&quot;&apos;&lt;Coverage&gt;.php')
-            ->and($coberturaClasses)
+            ->toContain('A&amp;B&quot;&apos;&lt;Coverage&gt;.php');
+        Expect::that($coberturaClasses)
             ->because('the Cobertura document MUST contain exactly one class')
             ->toHaveCount(1);
         \assert(\is_array($coberturaClasses) && isset($coberturaClasses[0]));

--- a/tests/Unit/Discovery/ClassDeclarationTest.php
+++ b/tests/Unit/Discovery/ClassDeclarationTest.php
@@ -18,8 +18,8 @@ final class ClassDeclarationTest
 
         Expect::that($global->fqcn())
             ->because('the fully qualified name handles global and named namespaces')
-            ->toBe('GlobalTest')
-            ->and($namespaced->fqcn())
+            ->toBe('GlobalTest');
+        Expect::that($namespaced->fqcn())
             ->toBe('Example\Tests\NamespacedTest');
     }
 }

--- a/tests/Unit/Discovery/ClassFileParserEmptyFileTest.php
+++ b/tests/Unit/Discovery/ClassFileParserEmptyFileTest.php
@@ -21,8 +21,8 @@ final readonly class ClassFileParserEmptyFileTest
 
         Expect::that(\is_readable($file))
             ->because('the empty test file MUST be readable')
-            ->toBeTrue()
-            ->and(ClassFileParser::declarationsIn($file))
+            ->toBeTrue();
+        Expect::that(ClassFileParser::declarationsIn($file))
             ->because('an empty test file MUST contain no declarations')
             ->toBe([]);
     }

--- a/tests/Unit/Discovery/DataRowTest.php
+++ b/tests/Unit/Discovery/DataRowTest.php
@@ -23,9 +23,9 @@ final class DataRowTest
     {
         $rows = new DataSetExpander()->rowsFor(new \ReflectionClass(InlineRowsTest::class), 'addsUp', null, 5.0);
 
-        Expect::that(\array_keys($rows))->because('inline rows expand with labels and positions')->toBe(['small', '#1'])
-            ->and($rows['small'])->toBe([1, 2, 3])
-            ->and($rows['#1'])->toBe([10, 20, 30]);
+        Expect::that(\array_keys($rows))->because('inline rows expand with labels and positions')->toBe(['small', '#1']);
+        Expect::that($rows['small'])->toBe([1, 2, 3]);
+        Expect::that($rows['#1'])->toBe([10, 20, 30]);
     }
 
     #[Test]

--- a/tests/Unit/Discovery/DataSetExpansionTest.php
+++ b/tests/Unit/Discovery/DataSetExpansionTest.php
@@ -183,8 +183,8 @@ final class DataSetExpansionTest
 
         Expect::that($message)
             ->because('a non-public data-set provider MUST fail discovery')
-            ->toContain('Declare the provider as public and static')
-            ->and($message)
+            ->toContain('Declare the provider as public and static');
+        Expect::that($message)
             ->toContain('privateProvider');
     }
 
@@ -213,8 +213,8 @@ final class DataSetExpansionTest
 
         Expect::that($message)
             ->because('provider that throws during iteration fails discovery with the cause')
-            ->toContain('iteration exploded')
-            ->and($message)
+            ->toContain('iteration exploded');
+        Expect::that($message)
             ->toContain('rows');
     }
 

--- a/tests/Unit/Discovery/DiscoveryCacheContentFingerprintTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheContentFingerprintTest.php
@@ -124,8 +124,8 @@ final readonly class DiscoveryCacheContentFingerprintTest
         try {
             Expect::that($cache->persist())
                 ->because('the discovery cache MUST persist the provider fingerprint')
-                ->toBeTrue()
-                ->and(DiscoveryCache::forDirectories([$directory])->lookup($source))
+                ->toBeTrue();
+            Expect::that(DiscoveryCache::forDirectories([$directory])->lookup($source))
                 ->because('unchanged provider content MUST keep the cached plan entry')
                 ->not()
                 ->toBeNull();

--- a/tests/Unit/Discovery/DiscoveryCacheCorruptPlanTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheCorruptPlanTest.php
@@ -43,8 +43,8 @@ final readonly class DiscoveryCacheCorruptPlanTest
 
             Expect::that($cache->persist())
                 ->because('discarding a corrupt plan entry MUST leave no cache data to persist')
-                ->toBeTrue()
-                ->and(\is_file($cacheFile))
+                ->toBeTrue();
+            Expect::that(\is_file($cacheFile))
                 ->because('persistence MUST NOT recreate a discarded corrupt plan entry')
                 ->toBeFalse();
         } finally {

--- a/tests/Unit/Discovery/DiscoveryCacheDirectoryOrderTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheDirectoryOrderTest.php
@@ -38,8 +38,8 @@ final readonly class DiscoveryCacheDirectoryOrderTest
 
             Expect::that($cache->persist())
                 ->because('the initial directory order MUST write the discovery cache')
-                ->toBeTrue()
-                ->and(DiscoveryCache::forDirectories(\array_reverse($directories))->lookup($source))
+                ->toBeTrue();
+            Expect::that(DiscoveryCache::forDirectories(\array_reverse($directories))->lookup($source))
                 ->because('directory order MUST NOT change the discovery-cache identity')
                 ->toEqual([$entry]);
         } finally {

--- a/tests/Unit/Discovery/DiscoveryCacheEmptyPlanTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheEmptyPlanTest.php
@@ -31,8 +31,8 @@ final readonly class DiscoveryCacheEmptyPlanTest
 
             Expect::that($cache->persist())
                 ->because('an empty execution plan MUST be persisted')
-                ->toBeTrue()
-                ->and(DiscoveryCache::forDirectories([$directory])->lookup($source))
+                ->toBeTrue();
+            Expect::that(DiscoveryCache::forDirectories([$directory])->lookup($source))
                 ->because('an empty execution plan is a valid cache hit, not corrupt data')
                 ->toBe([]);
         } finally {

--- a/tests/Unit/Discovery/DiscoveryCacheInternalProviderTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheInternalProviderTest.php
@@ -52,8 +52,8 @@ final readonly class DiscoveryCacheInternalProviderTest
 
             Expect::that(new \ReflectionMethod($providerClass, 'listAbbreviations')->getFileName())
                 ->because('the inherited provider method belongs to the PHP runtime')
-                ->toBeFalse()
-                ->and($cache->persist())
+                ->toBeFalse();
+            Expect::that($cache->persist())
                 ->because('an internal provider method MUST NOT block cache persistence')
                 ->toBeTrue();
 

--- a/tests/Unit/Discovery/DiscoveryCachePersistenceTest.php
+++ b/tests/Unit/Discovery/DiscoveryCachePersistenceTest.php
@@ -33,8 +33,8 @@ final readonly class DiscoveryCachePersistenceTest
         try {
             Expect::that($cache->persist())
                 ->because('unencodable metadata MUST make cache persistence fail safely')
-                ->toBeFalse()
-                ->and(\is_file($cacheFile))
+                ->toBeFalse();
+            Expect::that(\is_file($cacheFile))
                 ->because('a failed cache encoding MUST not write a cache file')
                 ->toBeFalse();
         } finally {

--- a/tests/Unit/Discovery/DiscoveryCacheRuntimeProviderTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheRuntimeProviderTest.php
@@ -56,8 +56,8 @@ final class DiscoveryCacheRuntimeProviderTest
 
             Expect::that($cache->persist())
                 ->because('a runtime provider has no dependency file')
-                ->toBeTrue()
-                ->and(DiscoveryCache::forDirectories([$directory])->lookup($source))
+                ->toBeTrue();
+            Expect::that(DiscoveryCache::forDirectories([$directory])->lookup($source))
                 ->because('the entry remains available from the cache')
                 ->not()
                 ->toBeNull();

--- a/tests/Unit/Discovery/DiscoveryCacheTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheTest.php
@@ -96,8 +96,8 @@ final class DiscoveryCacheTest
 
             Expect::that($plan->count())
                 ->because('an invalid cache document becomes a cache miss')
-                ->toBe(2)
-                ->and($rewritten)
+                ->toBe(2);
+            Expect::that($rewritten)
                 ->toContain('"version":3')
                 ->toContain($className . '.php');
         } finally {
@@ -167,8 +167,8 @@ final class DiscoveryCacheTest
 
             Expect::that($plan->count())
                 ->because('a corrupt cached plan entry becomes a cache miss')
-                ->toBe(2)
-                ->and($rewritten)
+                ->toBe(2);
+            Expect::that($rewritten)
                 ->because('discovery replaces the corrupt plan entry')
                 ->not()
                 ->toContain('"entries":[[]]');
@@ -384,8 +384,8 @@ final class DiscoveryCacheTest
 
             Expect::that($cache->persist())
                 ->because('a vanished discovery source MUST not make cache persistence fail')
-                ->toBeTrue()
-                ->and(\is_file($cacheFile))
+                ->toBeTrue();
+            Expect::that(\is_file($cacheFile))
                 ->because('a vanished source MUST not create an empty cache document')
                 ->toBeFalse();
         } finally {
@@ -410,8 +410,8 @@ final class DiscoveryCacheTest
 
             Expect::that($cache->persist())
                 ->because('an unencodable source path MUST disable advisory cache persistence cleanly')
-                ->toBeFalse()
-                ->and(\is_file($cacheFile))
+                ->toBeFalse();
+            Expect::that(\is_file($cacheFile))
                 ->because('failed cache encoding MUST not leave a cache document')
                 ->toBeFalse();
         } finally {

--- a/tests/Unit/Discovery/NameFilterCaseTest.php
+++ b/tests/Unit/Discovery/NameFilterCaseTest.php
@@ -22,8 +22,8 @@ final readonly class NameFilterCaseTest
 
         Expect::that($canonical->accepts($class, $method, [], '/tests/InvoiceTest.php'))
             ->because('a class or method filter MUST accept the canonical letter case')
-            ->toBeTrue()
-            ->and($caseOnlyDifference->accepts($class, $method, [], '/tests/InvoiceTest.php'))
+            ->toBeTrue();
+        Expect::that($caseOnlyDifference->accepts($class, $method, [], '/tests/InvoiceTest.php'))
             ->because('class and method filters MUST use the same letter case')
             ->toBeFalse();
     }

--- a/tests/Unit/Doubles/ArgumentMatchingTest.php
+++ b/tests/Unit/Doubles/ArgumentMatchingTest.php
@@ -90,8 +90,8 @@ final class ArgumentMatchingTest
         } catch (ExpectationFailed $failure) {
             $detail = $failure->detail();
 
-            Expect::that($detail->expected)->toContain('type(int)')
-                ->and($detail->actual)->toBe("record('not an int')");
+            Expect::that($detail->expected)->toContain('type(int)');
+            Expect::that($detail->actual)->toBe("record('not an int')");
 
             return;
         }
@@ -214,8 +214,8 @@ final class ArgumentMatchingTest
         $calculator->add(1, 7);
         $calculator->add(999, 7);
 
-        Expect::that($captor->values())->because('a captor in with collects values in call order')->toEqual([1, 999])
-            ->and($captor->value())->toBe(999);
+        Expect::that($captor->values())->because('a captor in with collects values in call order')->toEqual([1, 999]);
+        Expect::that($captor->value())->toBe(999);
 
         $doubles->dispose();
     }
@@ -308,8 +308,8 @@ final class ArgumentMatchingTest
         $calculator->add(1, 10);
         $calculator->add(2, 20);
 
-        Expect::that($first->values())->because('captors only see calls their own expectation matched')->toEqual([10])
-            ->and($second->values())->toEqual([20]);
+        Expect::that($first->values())->because('captors only see calls their own expectation matched')->toEqual([10]);
+        Expect::that($second->values())->toEqual([20]);
 
         $doubles->dispose();
     }

--- a/tests/Unit/Doubles/HarnessIntegrationTest.php
+++ b/tests/Unit/Doubles/HarnessIntegrationTest.php
@@ -55,8 +55,8 @@ final class HarnessIntegrationTest
 
         $failures = $container->dispose();
 
-        Expect::that($failures)->because('registered as a per test service it verifies at scope close')->toHaveCount(1)
-            ->and($failures[0])->toBeInstanceOf(ExpectationFailed::class);
+        Expect::that($failures)->because('registered as a per test service it verifies at scope close')->toHaveCount(1);
+        Expect::that($failures[0])->toBeInstanceOf(ExpectationFailed::class);
 
         $failure = $failures[0];
 
@@ -76,11 +76,11 @@ final class HarnessIntegrationTest
         $wire = $doubles->stub(WireSerializable::class);
         $events = $doubles->spy(EventSink::class);
 
-        Expect::that($condition)->because('every greenlight interface can be doubled')->toBeInstanceOf(Condition::class)
-            ->and($disposable)->toBeInstanceOf(Disposable::class)
-            ->and($wire)->toBeInstanceOf(WireSerializable::class)
-            ->and($extension)->toBeInstanceOf(ExpectationExtension::class)
-            ->and($events)->toBeInstanceOf(EventSink::class);
+        Expect::that($condition)->because('every greenlight interface can be doubled')->toBeInstanceOf(Condition::class);
+        Expect::that($disposable)->toBeInstanceOf(Disposable::class);
+        Expect::that($wire)->toBeInstanceOf(WireSerializable::class);
+        Expect::that($extension)->toBeInstanceOf(ExpectationExtension::class);
+        Expect::that($events)->toBeInstanceOf(EventSink::class);
 
         $doubles->dispose();
     }

--- a/tests/Unit/Doubles/MockTest.php
+++ b/tests/Unit/Doubles/MockTest.php
@@ -70,9 +70,9 @@ final class MockTest
             Expect::that($detail->message)->toBe(
                 'Calls to Greenlight\Tests\Fixture\Doubles\Calculator::add(): 1 time. '
                 . 'The expectation requires exactly 2 times.',
-            )
-                ->and($detail->expected)->toBe('add(all arguments) exactly 2 times')
-                ->and($detail->actual)->toBe('add(1, 2)');
+            );
+            Expect::that($detail->expected)->toBe('add(all arguments) exactly 2 times');
+            Expect::that($detail->actual)->toBe('add(1, 2)');
 
             return;
         }
@@ -169,9 +169,9 @@ final class MockTest
             $detail = $failure->detail();
 
             Expect::that($detail->message)->toContain('unexpected call')
-                ->toContain('add')
-                ->and($detail->actual)->toBe('add(4, 5)')
-                ->and($detail->expected)->toContain('no calls to add()');
+                ->toContain('add');
+            Expect::that($detail->actual)->toBe('add(4, 5)');
+            Expect::that($detail->expected)->toContain('no calls to add()');
 
             return;
         }
@@ -193,8 +193,8 @@ final class MockTest
         } catch (ExpectationFailed $failure) {
             $detail = $failure->detail();
 
-            Expect::that($detail->expected)->toContain("describe('expected label') exactly 1 time")
-                ->and($detail->actual)->toBe("describe('other label')");
+            Expect::that($detail->expected)->toContain("describe('expected label') exactly 1 time");
+            Expect::that($detail->actual)->toBe("describe('other label')");
 
             return;
         }
@@ -223,8 +223,8 @@ final class MockTest
             $plan->expects('add')->with(MockPlan::any(), 7)->times(2)->andReturns(7);
         });
 
-        Expect::that($calculator->add(1, 7))->because('any() accepts each value at its position')->toBe(7)
-            ->and($calculator->add(999, 7))->toBe(7);
+        Expect::that($calculator->add(1, 7))->because('any() accepts each value at its position')->toBe(7);
+        Expect::that($calculator->add(999, 7))->toBe(7);
 
         $doubles->dispose();
     }
@@ -243,8 +243,8 @@ final class MockTest
 
             Fail::because('Expected add(1, 1) to fail because add() was configured with never().');
         } catch (ExpectationFailed $failure) {
-            Expect::that($failure->detail()->message)->toContain('unexpected call')
-                ->and($failure->detail()->expected)->toContain('never');
+            Expect::that($failure->detail()->message)->toContain('unexpected call');
+            Expect::that($failure->detail()->expected)->toContain('never');
         }
 
         // Greenlight keeps the call failure. Thus, verification reports it
@@ -290,7 +290,7 @@ final class MockTest
             $plan->expects('add')->once()->andThrows(new \RuntimeException('gateway down'));
         });
 
-        Expect::that(static fn(): int => $calculator->add(1, 2))->because('and() throws raises the configured throwable')
+        Expect::that(static fn(): int => $calculator->add(1, 2))->because('andThrows() raises the configured throwable')
             ->toThrow(\RuntimeException::class, '/gateway down/');
 
         $doubles->dispose();

--- a/tests/Unit/Doubles/ProxyGlobalConstantDefaultTest.php
+++ b/tests/Unit/Doubles/ProxyGlobalConstantDefaultTest.php
@@ -29,10 +29,10 @@ final readonly class ProxyGlobalConstantDefaultTest
 
             Expect::that($parameter->getDefaultValueConstantName())
                 ->because('a generated method MUST preserve its global default constant')
-                ->toBe('PHP_INT_MAX')
-                ->and($parameter->getDefaultValue())
-                ->toBe(\PHP_INT_MAX)
-                ->and($answer)
+                ->toBe('PHP_INT_MAX');
+            Expect::that($parameter->getDefaultValue())
+                ->toBe(\PHP_INT_MAX);
+            Expect::that($answer)
                 ->toBe(42);
         } finally {
             $doubles->dispose();

--- a/tests/Unit/Doubles/ProxyParentConstantDefaultTest.php
+++ b/tests/Unit/Doubles/ProxyParentConstantDefaultTest.php
@@ -30,10 +30,10 @@ final readonly class ProxyParentConstantDefaultTest
 
             Expect::that($parameter->getDefaultValueConstantName())
                 ->because('a generated method MUST resolve a parent constant against the parent type')
-                ->toBe(ParentConstantDefaultBase::class . '::MODE')
-                ->and($parameter->getDefaultValue())
-                ->toBe('inherited')
-                ->and($answer)
+                ->toBe(ParentConstantDefaultBase::class . '::MODE');
+            Expect::that($parameter->getDefaultValue())
+                ->toBe('inherited');
+            Expect::that($answer)
                 ->toBe('answered');
         } finally {
             $doubles->dispose();

--- a/tests/Unit/Doubles/ProxyProtectedPropertyTest.php
+++ b/tests/Unit/Doubles/ProxyProtectedPropertyTest.php
@@ -25,8 +25,8 @@ final readonly class ProxyProtectedPropertyTest
 
             Expect::that($property->isProtected())
                 ->because('a proxy property MUST preserve protected visibility')
-                ->toBeTrue()
-                ->and((string) $property->getType())
+                ->toBeTrue();
+            Expect::that((string) $property->getType())
                 ->toBe('string');
         } finally {
             $doubles->dispose();

--- a/tests/Unit/Doubles/ProxyReferenceReturnTest.php
+++ b/tests/Unit/Doubles/ProxyReferenceReturnTest.php
@@ -28,8 +28,8 @@ final readonly class ProxyReferenceReturnTest
 
             Expect::that($method->returnsReference())
                 ->because('a proxy method MUST preserve its by-reference return signature')
-                ->toBeTrue()
-                ->and($double->value())
+                ->toBeTrue();
+            Expect::that($double->value())
                 ->toBe('answer');
         } finally {
             $doubles->dispose();

--- a/tests/Unit/Doubles/TypeRendererTest.php
+++ b/tests/Unit/Doubles/TypeRendererTest.php
@@ -56,11 +56,11 @@ final class TypeRendererTest
 
         Expect::that(TypeRenderer::render($nullableClass, $context))
             ->because('nullable class names MUST retain valid PHP syntax')
-            ->toBe('?\ArrayObject')
-            ->and(TypeRenderer::render($mixed, $context))
+            ->toBe('?\ArrayObject');
+        Expect::that(TypeRenderer::render($mixed, $context))
             ->because('mixed MUST NOT gain a nullable prefix')
-            ->toBe('mixed')
-            ->and(TypeRenderer::render($null, $context))
+            ->toBe('mixed');
+        Expect::that(TypeRenderer::render($null, $context))
             ->because('null MUST NOT gain a nullable prefix')
             ->toBe('null');
     }

--- a/tests/Unit/Expect/BecauseTest.php
+++ b/tests/Unit/Expect/BecauseTest.php
@@ -67,16 +67,6 @@ final class BecauseTest
     }
 
     #[Test]
-    public function andDoesNotCarryAPendingReason(): void
-    {
-        $detail = FailureProbe::detailOf(
-            static fn() => Expect::that(1)->because('the reason stays with the first subject')->and(2)->toBe(3),
-        );
-
-        Expect::that($detail->message)->because('and() does not carry a pending reason')->toBe('Expected 2 to be 3.');
-    }
-
-    #[Test]
     public function becauseTrimsTheReason(): void
     {
         $detail = FailureProbe::detailOf(

--- a/tests/Unit/Expect/ExpectTest.php
+++ b/tests/Unit/Expect/ExpectTest.php
@@ -13,16 +13,9 @@ use Greenlight\Tests\Fixture\Expect\EvenNumbersExtension;
 final class ExpectTest
 {
     #[Test]
-    public function andReAnchorsTheChainOnANewSubject(): void
-    {
-        Expect::that(1)->because('and() re anchors the chain on a new subject')->toBe(1)->and('x')->toBe('x')->and([1])->toHaveCount(1);
-    }
-
-    #[Test]
     public function notAppliesOnlyToTheNextMatcher(): void
     {
         Expect::that(1)->because('not() applies only to the next matcher')->not()->toBe(2)->toBe(1);
-        Expect::that(1)->because('not() applies only to the next matcher')->not()->toBe(2)->and(3)->toBe(3);
     }
 
     #[Test]

--- a/tests/Unit/Expect/ExpectationFailedSingleDetailTest.php
+++ b/tests/Unit/Expect/ExpectationFailedSingleDetailTest.php
@@ -24,10 +24,10 @@ final class ExpectationFailedSingleDetailTest
 
         Expect::that($failure->getMessage())
             ->because('one detail MUST use the singular diagnostic')
-            ->toBe('Expected values to match. (at /tests/ExampleTest.php:12)')
-            ->and($failure->details)
-            ->toBe([$detail])
-            ->and($failure->detail())
+            ->toBe('Expected values to match. (at /tests/ExampleTest.php:12)');
+        Expect::that($failure->details)
+            ->toBe([$detail]);
+        Expect::that($failure->detail())
             ->toBe($detail);
     }
 }

--- a/tests/Unit/Expect/ExpectationFailedTest.php
+++ b/tests/Unit/Expect/ExpectationFailedTest.php
@@ -29,10 +29,10 @@ final class ExpectationFailedTest
                 "2 expectations failed:\n"
                 . "1) Expected the value to be ready. (at /project/tests/ProbeTest.php:12)\n"
                 . '2) Expected the callback to run.',
-            )
-            ->and($failure->details)
-            ->toBe([$first, $second])
-            ->and($failure->detail())
+            );
+        Expect::that($failure->details)
+            ->toBe([$first, $second]);
+        Expect::that($failure->detail())
             ->toBe($first);
     }
 }

--- a/tests/Unit/Expect/ExpectationRuntimeTest.php
+++ b/tests/Unit/Expect/ExpectationRuntimeTest.php
@@ -39,10 +39,10 @@ final class ExpectationRuntimeTest
 
         Expect::that($thrown)
             ->because('withClock propagates the operation exception')
-            ->toBe($expected)
-            ->and($afterInner)
-            ->toBe($outer)
-            ->and(ExpectationRuntime::clock())
+            ->toBe($expected);
+        Expect::that($afterInner)
+            ->toBe($outer);
+        Expect::that(ExpectationRuntime::clock())
             ->toBe($baseline);
     }
 }

--- a/tests/Unit/Expect/ObservationLogTest.php
+++ b/tests/Unit/Expect/ObservationLogTest.php
@@ -23,8 +23,8 @@ final class ObservationLogTest
 
         Expect::that($log->count())
             ->because('the observation count includes compressed and omitted values')
-            ->toBe(6)
-            ->and($log->render())
+            ->toBe(6);
+        Expect::that($log->render())
             ->because('the history keeps the first observation and the latest three value groups')
             ->toBe(
                 "+0.0ms same (×2)\n"
@@ -45,8 +45,8 @@ final class ObservationLogTest
 
         Expect::that($log->count())
             ->because('the observation count includes repeated tail values')
-            ->toBe(3)
-            ->and($log->render())
+            ->toBe(3);
+        Expect::that($log->render())
             ->because('consecutive tail values are one group with a repeat count')
             ->toBe("+0.0ms first\n+1.0ms changed (×2)");
     }

--- a/tests/Unit/Expect/TemporalExpectationTest.php
+++ b/tests/Unit/Expect/TemporalExpectationTest.php
@@ -43,8 +43,8 @@ final class TemporalExpectationTest
                 ->toBe('ready');
         });
 
-        Expect::that($calls)->because('eventually() stops at the first matching observation')->toBe(3)
-            ->and($clock->sleeps)->toEqual([0.010, 0.010]);
+        Expect::that($calls)->because('eventually() stops at the first matching observation')->toBe(3);
+        Expect::that($clock->sleeps)->toEqual([0.010, 0.010]);
     }
 
     #[Test]
@@ -68,8 +68,8 @@ final class TemporalExpectationTest
 
         Expect::that($calls)
             ->because('eventually() reuses a one-shot iterable across retries')
-            ->toBe(2)
-            ->and($clock->sleeps)
+            ->toBe(2);
+        Expect::that($clock->sleeps)
             ->toEqual([0.010]);
     }
 
@@ -95,10 +95,10 @@ final class TemporalExpectationTest
             'The eventually() expectation did not pass within 0.030 seconds after 4 observations. '
             . 'Last failure: Expected 4 to equal 99. Observations: '
             . "+0.0ms 1\n+10.0ms 2\n+20.0ms 3\n+30.0ms 4.",
-        )
-            ->and($detail->expected)->toBe('99')
-            ->and($detail->actual)->toBe('4')
-            ->and($detail->location?->file)->toBe(__FILE__);
+        );
+        Expect::that($detail->expected)->toBe('99');
+        Expect::that($detail->actual)->toBe('4');
+        Expect::that($detail->location?->file)->toBe(__FILE__);
     }
 
     #[Test]
@@ -201,10 +201,10 @@ final class TemporalExpectationTest
             ->toBe(
                 'The eventually() expectation did not pass within 0.020 seconds after 3 observations. '
                 . "Observations: +0.0ms {$rendered} (×3).",
-            )
-            ->and($detail->expected)
-            ->toBeNull()
-            ->and($detail->actual)
+            );
+        Expect::that($detail->expected)
+            ->toBeNull();
+        Expect::that($detail->actual)
             ->toBe($rendered);
     }
 
@@ -287,14 +287,14 @@ final class TemporalExpectationTest
             });
         });
 
-        Expect::that($calls)->because('consistently() fails on the first violation')->toBe(3)
-            ->and($detail->message)->toBe(
-                'The consistently() expectation failed after 0.020 seconds and 3 observations. '
+        Expect::that($calls)->because('consistently() fails on the first violation')->toBe(3);
+        Expect::that($detail->message)->toBe(
+            'The consistently() expectation failed after 0.020 seconds and 3 observations. '
                 . "Last failure: Expected 'changed' to be 'stable'. Observations: "
                 . "+0.0ms 'stable' (×2)\n+20.0ms 'changed'.",
-            )
-            ->and($detail->expected)->toBe("'stable'")
-            ->and($detail->actual)->toBe("'changed'");
+        );
+        Expect::that($detail->expected)->toBe("'stable'");
+        Expect::that($detail->actual)->toBe("'changed'");
     }
 
     #[Test]

--- a/tests/Unit/Expect/TemporalRetryCompositionTest.php
+++ b/tests/Unit/Expect/TemporalRetryCompositionTest.php
@@ -42,8 +42,8 @@ final readonly class TemporalRetryCompositionTest
 
         Expect::that($calls)
             ->because('repeated retry configuration MUST accumulate exception types')
-            ->toBe(3)
-            ->and($clock->sleeps)
+            ->toBe(3);
+        Expect::that($clock->sleeps)
             ->toBe([0.010, 0.010]);
     }
 }

--- a/tests/Unit/Expect/TemporalToThrowTest.php
+++ b/tests/Unit/Expect/TemporalToThrowTest.php
@@ -42,8 +42,8 @@ final class TemporalToThrowTest
 
         Expect::that($calls)
             ->because('eventually() MUST retry until the returned callable satisfies toThrow()')
-            ->toBe(2)
-            ->and($clock->sleeps)
+            ->toBe(2);
+        Expect::that($clock->sleeps)
             ->toBe([0.010]);
     }
 

--- a/tests/Unit/Expect/TemporalZeroBecauseReasonTest.php
+++ b/tests/Unit/Expect/TemporalZeroBecauseReasonTest.php
@@ -29,8 +29,8 @@ final readonly class TemporalZeroBecauseReasonTest
                 'The consistently() expectation failed on the first observation. '
                 . 'Last failure: Expected false to be true because 0. '
                 . 'Observations: +0.0ms false.',
-            )
-            ->and($clock->sleeps)
+            );
+        Expect::that($clock->sleeps)
             ->because('a first-observation failure MUST NOT wait')
             ->toBe([]);
     }

--- a/tests/Unit/Expect/ToThrowZeroMessageTest.php
+++ b/tests/Unit/Expect/ToThrowZeroMessageTest.php
@@ -30,10 +30,10 @@ final readonly class ToThrowZeroMessageTest
             ->toBe(
                 "Expected a callable that threw RuntimeException with message 'other' "
                 . "to throw RuntimeException with message '0'.",
-            )
-            ->and($detail->expected)
-            ->toBe(\RuntimeException::class)
-            ->and($detail->actual)
+            );
+        Expect::that($detail->expected)
+            ->toBe(\RuntimeException::class);
+        Expect::that($detail->actual)
             ->toBe("a callable that threw RuntimeException with message 'other'");
     }
 }

--- a/tests/Unit/Fixture/EnvironmentBackupNullServerTest.php
+++ b/tests/Unit/Fixture/EnvironmentBackupNullServerTest.php
@@ -28,12 +28,12 @@ final readonly class EnvironmentBackupNullServerTest
 
             Expect::that(\getenv($name))
                 ->because('restore MUST preserve explicit null presence in the server environment')
-                ->toBe('process-original')
-                ->and($_ENV[$name] ?? null)
-                ->toBe('env-original')
-                ->and(\array_key_exists($name, $_SERVER))
-                ->toBeTrue()
-                ->and($_SERVER[$name])
+                ->toBe('process-original');
+            Expect::that($_ENV[$name] ?? null)
+                ->toBe('env-original');
+            Expect::that(\array_key_exists($name, $_SERVER))
+                ->toBeTrue();
+            Expect::that($_SERVER[$name])
                 ->toBeNull();
         } finally {
             \putenv($name);

--- a/tests/Unit/Fixture/EnvironmentSandboxReuseTest.php
+++ b/tests/Unit/Fixture/EnvironmentSandboxReuseTest.php
@@ -29,10 +29,10 @@ final readonly class EnvironmentSandboxReuseTest
 
             Expect::that(\getenv($name))
                 ->because('use after disposal MUST capture the new environment baseline')
-                ->toBe('new baseline')
-                ->and($_ENV[$name] ?? null)
-                ->toBe('new baseline')
-                ->and($_SERVER[$name] ?? null)
+                ->toBe('new baseline');
+            Expect::that($_ENV[$name] ?? null)
+                ->toBe('new baseline');
+            Expect::that($_SERVER[$name] ?? null)
                 ->toBe('new baseline');
         } finally {
             $sandbox->dispose();

--- a/tests/Unit/Fixture/EnvironmentSandboxTest.php
+++ b/tests/Unit/Fixture/EnvironmentSandboxTest.php
@@ -19,15 +19,15 @@ final class EnvironmentSandboxTest
 
         $sandbox->set($name, 'value');
 
-        Expect::that(\getenv($name))->because('set makes the variable visible everywhere')->toBe('value')
-            ->and($this->envValue($name))->toBe('value')
-            ->and($this->serverValue($name))->toBe('value');
+        Expect::that(\getenv($name))->because('set makes the variable visible everywhere')->toBe('value');
+        Expect::that($this->envValue($name))->toBe('value');
+        Expect::that($this->serverValue($name))->toBe('value');
 
         $sandbox->dispose();
 
-        Expect::that(\getenv($name))->because('set makes the variable visible everywhere')->toBeFalse()
-            ->and($this->envHas($name))->toBeFalse()
-            ->and($this->serverHas($name))->toBeFalse();
+        Expect::that(\getenv($name))->because('set makes the variable visible everywhere')->toBeFalse();
+        Expect::that($this->envHas($name))->toBeFalse();
+        Expect::that($this->serverHas($name))->toBeFalse();
     }
 
     #[Test]
@@ -43,9 +43,9 @@ final class EnvironmentSandboxTest
             $sandbox->set($name, 'changed');
             $sandbox->dispose();
 
-            Expect::that(\getenv($name))->toBe('original')
-                ->and($this->envValue($name))->toBe('original')
-                ->and($this->serverValue($name))->toBe('original');
+            Expect::that(\getenv($name))->toBe('original');
+            Expect::that($this->envValue($name))->toBe('original');
+            Expect::that($this->serverValue($name))->toBe('original');
         } finally {
             \putenv($name);
             unset($_ENV[$name], $_SERVER[$name]);
@@ -67,14 +67,14 @@ final class EnvironmentSandboxTest
 
             Expect::that(\getenv($name))
                 ->because('dispose MUST distinguish present falsey values from absent values')
-                ->toBe('')
-                ->and($this->envHas($name))
-                ->toBeTrue()
-                ->and($this->envValue($name))
-                ->toBeNull()
-                ->and($this->serverHas($name))
-                ->toBeTrue()
-                ->and($this->serverValue($name))
+                ->toBe('');
+            Expect::that($this->envHas($name))
+                ->toBeTrue();
+            Expect::that($this->envValue($name))
+                ->toBeNull();
+            Expect::that($this->serverHas($name))
+                ->toBeTrue();
+            Expect::that($this->serverValue($name))
                 ->toBeFalse();
         } finally {
             \putenv($name);
@@ -105,16 +105,16 @@ final class EnvironmentSandboxTest
 
             Expect::that(\getenv($processAndServer))
                 ->because('dispose restores each environment channel independently')
-                ->toBe('process-original')
-                ->and($this->envHas($processAndServer))
-                ->toBeFalse()
-                ->and($this->serverValue($processAndServer))
-                ->toBe('server-original')
-                ->and(\getenv($envOnly))
-                ->toBeFalse()
-                ->and($this->envValue($envOnly))
-                ->toBe('env-original')
-                ->and($this->serverHas($envOnly))
+                ->toBe('process-original');
+            Expect::that($this->envHas($processAndServer))
+                ->toBeFalse();
+            Expect::that($this->serverValue($processAndServer))
+                ->toBe('server-original');
+            Expect::that(\getenv($envOnly))
+                ->toBeFalse();
+            Expect::that($this->envValue($envOnly))
+                ->toBe('env-original');
+            Expect::that($this->serverHas($envOnly))
                 ->toBeFalse();
         } finally {
             $sandbox->dispose();
@@ -141,15 +141,15 @@ final class EnvironmentSandboxTest
             $sandbox = new EnvironmentSandbox();
             $sandbox->unset($name);
 
-            Expect::that(\getenv($name))->toBeFalse()
-                ->and($this->envHas($name))->toBeFalse()
-                ->and($this->serverHas($name))->toBeFalse();
+            Expect::that(\getenv($name))->toBeFalse();
+            Expect::that($this->envHas($name))->toBeFalse();
+            Expect::that($this->serverHas($name))->toBeFalse();
 
             $sandbox->dispose();
 
-            Expect::that(\getenv($name))->toBe('present')
-                ->and($this->envValue($name))->toBe('present')
-                ->and($this->serverValue($name))->toBe('present');
+            Expect::that(\getenv($name))->toBe('present');
+            Expect::that($this->envValue($name))->toBe('present');
+            Expect::that($this->serverValue($name))->toBe('present');
         } finally {
             \putenv($name);
             unset($_ENV[$name], $_SERVER[$name]);
@@ -171,9 +171,9 @@ final class EnvironmentSandboxTest
             $sandbox->unset($name);
             $sandbox->dispose();
 
-            Expect::that(\getenv($name))->toBe('first')
-                ->and($this->envValue($name))->toBe('first')
-                ->and($this->serverValue($name))->toBe('first');
+            Expect::that(\getenv($name))->toBe('first');
+            Expect::that($this->envValue($name))->toBe('first');
+            Expect::that($this->serverValue($name))->toBe('first');
         } finally {
             \putenv($name);
             unset($_ENV[$name], $_SERVER[$name]);
@@ -198,10 +198,10 @@ final class EnvironmentSandboxTest
 
         Expect::that(\getenv())
             ->because('set rejects invalid names before it changes the environment')
-            ->toBe($processBefore)
-            ->and($_ENV)
-            ->toBe($envBefore)
-            ->and($_SERVER)
+            ->toBe($processBefore);
+        Expect::that($_ENV)
+            ->toBe($envBefore);
+        Expect::that($_SERVER)
             ->toBe($serverBefore);
     }
 
@@ -223,10 +223,10 @@ final class EnvironmentSandboxTest
 
         Expect::that(\getenv())
             ->because('unset rejects invalid names before it changes the environment')
-            ->toBe($processBefore)
-            ->and($_ENV)
-            ->toBe($envBefore)
-            ->and($_SERVER)
+            ->toBe($processBefore);
+        Expect::that($_ENV)
+            ->toBe($envBefore);
+        Expect::that($_SERVER)
             ->toBe($serverBefore);
     }
 

--- a/tests/Unit/Fixture/TempDirectoryReuseTest.php
+++ b/tests/Unit/Fixture/TempDirectoryReuseTest.php
@@ -28,8 +28,8 @@ final readonly class TempDirectoryReuseTest
         try {
             Expect::that($second)
                 ->because('use after disposal MUST create a fresh temp directory')
-                ->not()->toBe($first)
-                ->and(\is_dir($second))
+                ->not()->toBe($first);
+            Expect::that(\is_dir($second))
                 ->toBeTrue();
         } finally {
             $directory->dispose();

--- a/tests/Unit/Fixture/TempDirectoryRootSymbolicLinkTest.php
+++ b/tests/Unit/Fixture/TempDirectoryRootSymbolicLinkTest.php
@@ -36,8 +36,8 @@ final class TempDirectoryRootSymbolicLinkTest
 
             Expect::that(\is_link($root))
                 ->because('disposal MUST remove the root symbolic link')
-                ->toBeFalse()
-                ->and(\file_get_contents($sentinel))
+                ->toBeFalse();
+            Expect::that(\file_get_contents($sentinel))
                 ->because('disposal MUST leave the root symbolic link target unchanged')
                 ->toBe('keep');
         } finally {

--- a/tests/Unit/Fixture/TempDirectorySubdirectoryLinkTest.php
+++ b/tests/Unit/Fixture/TempDirectorySubdirectoryLinkTest.php
@@ -48,8 +48,8 @@ final class TempDirectorySubdirectoryLinkTest
 
             Expect::that(\file_get_contents($sentinel))
                 ->because('a rejected symbolic link MUST leave its target unchanged')
-                ->toBe('keep')
-                ->and(\is_dir($targetPath . '/created'))
+                ->toBe('keep');
+            Expect::that(\is_dir($targetPath . '/created'))
                 ->toBeFalse();
         } finally {
             $directory->dispose();

--- a/tests/Unit/Fixture/TempDirectoryTest.php
+++ b/tests/Unit/Fixture/TempDirectoryTest.php
@@ -33,10 +33,10 @@ final class TempDirectoryTest
 
         $path = $directory->path();
 
-        Expect::that(\is_dir($path))->because('path creates a writable directory and memoizes it')->toBeTrue()
-            ->and(\is_writable($path))->toBeTrue()
-            ->and(\realpath($path))->toBe($path)
-            ->and($directory->path())->toBe($path);
+        Expect::that(\is_dir($path))->because('path creates a writable directory and memoizes it')->toBeTrue();
+        Expect::that(\is_writable($path))->toBeTrue();
+        Expect::that(\realpath($path))->toBe($path);
+        Expect::that($directory->path())->toBe($path);
 
         $directory->dispose();
     }
@@ -80,8 +80,8 @@ final class TempDirectoryTest
 
             Expect::that($result->exitCode)
                 ->because('a blocked temp root MUST fail directory creation')
-                ->toBe(23)
-                ->and($result->stdout)
+                ->toBe(23);
+            Expect::that($result->stdout)
                 ->because('the failure MUST identify the generated directory and cause')
                 ->toMatch(
                     '/\AFailed to create temp directory "'
@@ -112,8 +112,8 @@ final class TempDirectoryTest
 
         $nested = $directory->subdirectory('a/b');
 
-        Expect::that($nested)->because('subdirectory creates nested directories')->toBe($directory->path() . '/a/b')
-            ->and(\is_dir($nested))->toBeTrue();
+        Expect::that($nested)->because('subdirectory creates nested directories')->toBe($directory->path() . '/a/b');
+        Expect::that(\is_dir($nested))->toBeTrue();
 
         $directory->dispose();
     }
@@ -286,11 +286,11 @@ final class TempDirectoryTest
 
             Expect::that(\is_link($link))
                 ->because('disposal MUST remove the symbolic link')
-                ->toBeFalse()
-                ->and(\is_dir($target->path()))
+                ->toBeFalse();
+            Expect::that(\is_dir($target->path()))
                 ->because('disposal MUST leave the symbolic link target unchanged')
-                ->toBeTrue()
-                ->and(\file_get_contents($sentinel))
+                ->toBeTrue();
+            Expect::that(\file_get_contents($sentinel))
                 ->toBe('keep');
         } finally {
             $directory->dispose();
@@ -308,8 +308,8 @@ final class TempDirectoryTest
         // path() call still creates a new writable directory.
         $path = $directory->path();
 
-        Expect::that(\is_dir($path))->because('dispose without use is a no-op')->toBeTrue()
-            ->and(\is_writable($path))->toBeTrue();
+        Expect::that(\is_dir($path))->because('dispose without use is a no-op')->toBeTrue();
+        Expect::that(\is_writable($path))->toBeTrue();
 
         $directory->dispose();
     }

--- a/tests/Unit/Harness/HarnessRegistryTest.php
+++ b/tests/Unit/Harness/HarnessRegistryTest.php
@@ -34,8 +34,8 @@ final class HarnessRegistryTest
             ->toThrow(
                 \LogicException::class,
                 message: 'A harness service for ArrayObject is already registered.',
-            )
-            ->and($registry->find(\ArrayObject::class))
+            );
+        Expect::that($registry->find(\ArrayObject::class))
             ->because('a rejected duplicate does not replace the registered definition')
             ->toBe($registered);
     }

--- a/tests/Unit/Harness/HarnessScopesCloseRunTest.php
+++ b/tests/Unit/Harness/HarnessScopesCloseRunTest.php
@@ -54,8 +54,8 @@ final class HarnessScopesCloseRunTest
             $failures,
         ))
             ->because('suite cleanup MUST finish before run cleanup and retain both failures')
-            ->toBe(['suite disposal failed', 'run disposal failed'])
-            ->and($scopes->closeRun())
+            ->toBe(['suite disposal failed', 'run disposal failed']);
+        Expect::that($scopes->closeRun())
             ->because('failed cleanup MUST still empty both long-lived scopes')
             ->toBe([]);
     }

--- a/tests/Unit/Harness/HarnessScopesTest.php
+++ b/tests/Unit/Harness/HarnessScopesTest.php
@@ -99,9 +99,9 @@ final class HarnessScopesTest
         $scopes = new HarnessScopes(new HarnessRegistry(), [$resolver]);
         $resolved = $scopes->resolve(\ArrayObject::class, 'test', [$marker]);
 
-        Expect::that($resolved)->because('fallback resolvers receive the type and attributes')->toBeInstanceOf(\ArrayObject::class)
-            ->and($resolver->type)->toBe(\ArrayObject::class)
-            ->and($resolver->attributes)->toBe([$marker]);
+        Expect::that($resolved)->because('fallback resolvers receive the type and attributes')->toBeInstanceOf(\ArrayObject::class);
+        Expect::that($resolver->type)->toBe(\ArrayObject::class);
+        Expect::that($resolver->attributes)->toBe([$marker]);
     }
 
     #[Test]
@@ -161,10 +161,10 @@ final class HarnessScopesTest
 
         Expect::that($resolved)
             ->because('the resolver retains ownership of the service lifecycle')
-            ->toBe($service)
-            ->and($service->disposeCalls)
-            ->toBe(0)
-            ->and($failures)
+            ->toBe($service);
+        Expect::that($service->disposeCalls)
+            ->toBe(0);
+        Expect::that($failures)
             ->toBe([]);
     }
 
@@ -219,8 +219,8 @@ final class HarnessScopesTest
 
         Expect::that($scopes->closeTest())
             ->because('closing an inactive test scope MUST be a safe no-op')
-            ->toBe([])
-            ->and($scopes->closeClass())
+            ->toBe([]);
+        Expect::that($scopes->closeClass())
             ->because('closing an inactive class scope MUST be a safe no-op')
             ->toBe([]);
     }

--- a/tests/Unit/Harness/ScopeContainerFailedLazyFactoryDisposalTest.php
+++ b/tests/Unit/Harness/ScopeContainerFailedLazyFactoryDisposalTest.php
@@ -45,11 +45,11 @@ final class ScopeContainerFailedLazyFactoryDisposalTest
 
         Expect::that($factoryCalls)
             ->because('scope disposal MUST NOT retry a failed lazy factory')
-            ->toBe(1)
-            ->and($failures)
+            ->toBe(1);
+        Expect::that($failures)
             ->because('an uninitialized service has nothing to dispose')
-            ->toBe([])
-            ->and(LazyDisposableFactoryProbe::disposals())
+            ->toBe([]);
+        Expect::that(LazyDisposableFactoryProbe::disposals())
             ->toBe(0);
     }
 }

--- a/tests/Unit/Harness/ScopeContainerFailureContinuationTest.php
+++ b/tests/Unit/Harness/ScopeContainerFailureContinuationTest.php
@@ -43,12 +43,12 @@ final class ScopeContainerFailureContinuationTest
 
         Expect::that($failures)
             ->because('a disposal failure MUST NOT prevent disposal of the remaining services')
-            ->toHaveCount(1)
-            ->and($failures[0]->getMessage())
-            ->toBe('disposal broke')
-            ->and(FailingDisposable::disposals())
-            ->toBe(1)
-            ->and(RecordingDisposable::disposals())
+            ->toHaveCount(1);
+        Expect::that($failures[0]->getMessage())
+            ->toBe('disposal broke');
+        Expect::that(FailingDisposable::disposals())
+            ->toBe(1);
+        Expect::that(RecordingDisposable::disposals())
             ->toBe(1);
     }
 }

--- a/tests/Unit/Harness/ScopeContainerLazyFactoryTest.php
+++ b/tests/Unit/Harness/ScopeContainerLazyFactoryTest.php
@@ -42,8 +42,8 @@ final class ScopeContainerLazyFactoryTest
 
         Expect::that(static fn() => $service->value())
             ->because('the lazy factory failure MUST propagate from the first service use')
-            ->toThrow(\RuntimeException::class, message: 'factory broke')
-            ->and($factoryCalls)
+            ->toThrow(\RuntimeException::class, message: 'factory broke');
+        Expect::that($factoryCalls)
             ->toBe(1);
     }
 }

--- a/tests/Unit/Harness/ScopeContainerTest.php
+++ b/tests/Unit/Harness/ScopeContainerTest.php
@@ -42,7 +42,8 @@ final class ScopeContainerTest
         $container->get($definition);
         $failures = $container->dispose();
 
-        Expect::that($failures)->because('an untouched lazy service is never constructed nor disposed')->toBe([])->and(TraceLog::drain())->toBe([]);
+        Expect::that($failures)->because('an untouched lazy service is never constructed nor disposed')->toBe([]);
+        Expect::that(TraceLog::drain())->toBe([]);
     }
 
     #[Test]
@@ -77,11 +78,11 @@ final class ScopeContainerTest
 
         Expect::that($firstFailures)
             ->because('disposing touched services succeeds')
-            ->toBe([])
-            ->and($secondFailures)
+            ->toBe([]);
+        Expect::that($secondFailures)
             ->because('a disposed scope does not dispose its services twice')
-            ->toBe([])
-            ->and(TraceLog::drain())
+            ->toBe([]);
+        Expect::that(TraceLog::drain())
             ->because('touched services dispose in reverse creation order')
             ->toBe([
                 'probe1:created',
@@ -115,8 +116,8 @@ final class ScopeContainerTest
         $probe->touch();
         $failures = $container->dispose();
 
-        Expect::that($failures)->because('disposal failures are collected not thrown')->toHaveCount(1)
-            ->and($failures[0]->getMessage())->toBe('disposal broke');
+        Expect::that($failures)->because('disposal failures are collected not thrown')->toHaveCount(1);
+        Expect::that($failures[0]->getMessage())->toBe('disposal broke');
     }
 
     #[Test]
@@ -145,13 +146,13 @@ final class ScopeContainerTest
 
         Expect::that($first)
             ->because('the first disposal reports the service failure')
-            ->toHaveCount(1)
-            ->and($first[0]->getMessage())
-            ->toBe('disposal broke')
-            ->and($second)
+            ->toHaveCount(1);
+        Expect::that($first[0]->getMessage())
+            ->toBe('disposal broke');
+        Expect::that($second)
             ->because('a failed disposal MUST still leave the scope empty')
-            ->toBe([])
-            ->and(FailingDisposable::disposals())
+            ->toBe([]);
+        Expect::that(FailingDisposable::disposals())
             ->toBe(1);
     }
 }

--- a/tests/Unit/Laravel/LaravelFrameworkUnavailableTest.php
+++ b/tests/Unit/Laravel/LaravelFrameworkUnavailableTest.php
@@ -54,8 +54,8 @@ final readonly class LaravelFrameworkUnavailableTest
 
         Expect::that($result->exitCode)
             ->because('the public framework probe MUST reject an installation without Laravel')
-            ->toBe(0)
-            ->and($result->stdout)
+            ->toBe(0);
+        Expect::that($result->stdout)
             ->because('the error MUST explain how to install the required Laravel framework')
             ->toBe(
                 'The Laravel framework is not available. LaravelPlugin requires the complete '

--- a/tests/Unit/Laravel/LaravelOnceStateResetTest.php
+++ b/tests/Unit/Laravel/LaravelOnceStateResetTest.php
@@ -22,8 +22,8 @@ final class LaravelOnceStateResetTest
         try {
             Expect::that($this->memoizedValue())
                 ->because('Laravel once() MUST memoize a value before the reset')
-                ->toBe(1)
-                ->and($this->memoizedValue())
+                ->toBe(1);
+            Expect::that($this->memoizedValue())
                 ->toBe(1);
 
             LaravelStateResetter::reset();

--- a/tests/Unit/Laravel/LaravelPluginTest.php
+++ b/tests/Unit/Laravel/LaravelPluginTest.php
@@ -149,10 +149,10 @@ final class LaravelPluginTest
 
         Expect::that(static function () use ($plugin): void {
             $plugin->resolve(Greeter::class, []);
-        })->toThrow(LaravelBridgeError::class, matching: '/does not exist.*bootstrap\/app\.php/s')
-            ->and(\getenv('APP_ENV'))->toBe('before-laravel')
-            ->and($_ENV['APP_ENV'] ?? null)->toBe('before-laravel')
-            ->and($_SERVER['APP_ENV'] ?? null)->toBe('before-laravel');
+        })->toThrow(LaravelBridgeError::class, matching: '/does not exist.*bootstrap\/app\.php/s');
+        Expect::that(\getenv('APP_ENV'))->toBe('before-laravel');
+        Expect::that($_ENV['APP_ENV'] ?? null)->toBe('before-laravel');
+        Expect::that($_SERVER['APP_ENV'] ?? null)->toBe('before-laravel');
     }
 
     #[Test]
@@ -228,11 +228,11 @@ final class LaravelPluginTest
 
         Expect::that(static function () use ($plugin): void {
             $plugin->resolve(Greeter::class, []);
-        })->toThrow(\RuntimeException::class, matching: '/could not bootstrap/')
-            ->and(Container::getInstance())->toBe($container)
-            ->and(\getenv('APP_ENV'))->toBe('before-laravel')
-            ->and($_ENV['APP_ENV'] ?? null)->toBe('before-laravel')
-            ->and($_SERVER['APP_ENV'] ?? null)->toBe('before-laravel');
+        })->toThrow(\RuntimeException::class, matching: '/could not bootstrap/');
+        Expect::that(Container::getInstance())->toBe($container);
+        Expect::that(\getenv('APP_ENV'))->toBe('before-laravel');
+        Expect::that($_ENV['APP_ENV'] ?? null)->toBe('before-laravel');
+        Expect::that($_SERVER['APP_ENV'] ?? null)->toBe('before-laravel');
     }
 
     #[Test]
@@ -251,10 +251,10 @@ final class LaravelPluginTest
             ));
         }
 
-        Expect::that($definitions)->toHaveCount(1)
-            ->and($definition->type)->toBe(Application::class)
-            ->and($definition->scope)->toBe(Scope::PerTest)
-            ->and(($definition->factory)())->toBe($first);
+        Expect::that($definitions)->toHaveCount(1);
+        Expect::that($definition->type)->toBe(Application::class);
+        Expect::that($definition->scope)->toBe(Scope::PerTest);
+        Expect::that(($definition->factory)())->toBe($first);
     }
 
     #[Test]
@@ -327,9 +327,9 @@ final class LaravelPluginTest
             ));
         }
 
-        Expect::that($returned)->toBe($result)
-            ->and($second->count())->toBe(0)
-            ->and($second === $counter)->toBe(false);
+        Expect::that($returned)->toBe($result);
+        Expect::that($second->count())->toBe(0);
+        Expect::that($second === $counter)->toBe(false);
     }
 
     #[Test]
@@ -352,8 +352,8 @@ final class LaravelPluginTest
         $counter->record();
         $plugin->afterTest($this->context(), $this->result());
 
-        Expect::that($counter->count())->toBe(1)
-            ->and($plugin->resolve(VisitCounter::class, []))->toBe($counter);
+        Expect::that($counter->count())->toBe(1);
+        Expect::that($plugin->resolve(VisitCounter::class, []))->toBe($counter);
     }
 
     #[Test]
@@ -369,7 +369,8 @@ final class LaravelPluginTest
         $result = $this->result();
         $returned = $plugin->afterTest($this->context(), $result);
 
-        Expect::that($booted)->toBe(false)->and($returned)->toBe($result);
+        Expect::that($booted)->toBe(false);
+        Expect::that($returned)->toBe($result);
     }
 
     #[Test]
@@ -380,16 +381,16 @@ final class LaravelPluginTest
         $plugin = $this->plugin();
         $app = ($plugin->services()[0]->factory)();
 
-        Expect::that(Facade::getFacadeApplication())->toBe($app)
-            ->and(Container::getInstance())->toBe($app);
+        Expect::that(Facade::getFacadeApplication())->toBe($app);
+        Expect::that(Container::getInstance())->toBe($app);
 
         $plugin->afterTest($this->context(), $this->result());
 
-        Expect::that(Facade::getFacadeApplication())->toBeNull()
-            ->and(Container::getInstance())->toBe($container)
-            ->and(\getenv('APP_ENV'))->toBe('before-laravel')
-            ->and($_ENV['APP_ENV'] ?? null)->toBe('before-laravel')
-            ->and($_SERVER['APP_ENV'] ?? null)->toBe('before-laravel');
+        Expect::that(Facade::getFacadeApplication())->toBeNull();
+        Expect::that(Container::getInstance())->toBe($container);
+        Expect::that(\getenv('APP_ENV'))->toBe('before-laravel');
+        Expect::that($_ENV['APP_ENV'] ?? null)->toBe('before-laravel');
+        Expect::that($_SERVER['APP_ENV'] ?? null)->toBe('before-laravel');
     }
 
     #[Test]
@@ -402,20 +403,20 @@ final class LaravelPluginTest
 
         Expect::that(\getenv('APP_ENV'))
             ->because('Laravel boot MUST set the configured application environment')
-            ->toBe('testing')
-            ->and($_ENV['APP_ENV'] ?? null)
-            ->toBe('testing')
-            ->and($_SERVER['APP_ENV'] ?? null)
+            ->toBe('testing');
+        Expect::that($_ENV['APP_ENV'] ?? null)
+            ->toBe('testing');
+        Expect::that($_SERVER['APP_ENV'] ?? null)
             ->toBe('testing');
 
         $plugin->afterTest($this->context(), $this->result());
 
         Expect::that(\getenv('APP_ENV'))
             ->because('application release MUST remove an environment that was initially absent')
-            ->toBeFalse()
-            ->and(\array_key_exists('APP_ENV', $_ENV))
-            ->toBeFalse()
-            ->and(\array_key_exists('APP_ENV', $_SERVER))
+            ->toBeFalse();
+        Expect::that(\array_key_exists('APP_ENV', $_ENV))
+            ->toBeFalse();
+        Expect::that(\array_key_exists('APP_ENV', $_SERVER))
             ->toBeFalse();
     }
 
@@ -435,9 +436,9 @@ final class LaravelPluginTest
         $exceptionAfter = \set_exception_handler(null);
         \restore_exception_handler();
 
-        Expect::that($errorAfter)->toBe($errorBefore)
-            ->and($exceptionAfter)->toBe($exceptionBefore)
-            ->and(\error_reporting())->toBe($reportingBefore);
+        Expect::that($errorAfter)->toBe($errorBefore);
+        Expect::that($exceptionAfter)->toBe($exceptionBefore);
+        Expect::that(\error_reporting())->toBe($reportingBefore);
     }
 
     #[Test]

--- a/tests/Unit/Laravel/LaravelProcessNullEnvironmentTest.php
+++ b/tests/Unit/Laravel/LaravelProcessNullEnvironmentTest.php
@@ -31,14 +31,14 @@ final readonly class LaravelProcessNullEnvironmentTest
 
             Expect::that(\getenv('APP_ENV'))
                 ->because('restore MUST preserve present null environment values')
-                ->toBe('process-original')
-                ->and(\array_key_exists('APP_ENV', $_ENV))
-                ->toBeTrue()
-                ->and($_ENV['APP_ENV'])
-                ->toBeNull()
-                ->and(\array_key_exists('APP_ENV', $_SERVER))
-                ->toBeTrue()
-                ->and($_SERVER['APP_ENV'])
+                ->toBe('process-original');
+            Expect::that(\array_key_exists('APP_ENV', $_ENV))
+                ->toBeTrue();
+            Expect::that($_ENV['APP_ENV'])
+                ->toBeNull();
+            Expect::that(\array_key_exists('APP_ENV', $_SERVER))
+                ->toBeTrue();
+            Expect::that($_SERVER['APP_ENV'])
                 ->toBeNull();
         } finally {
             $state?->restore();

--- a/tests/Unit/Laravel/LaravelProcessZeroEnvironmentTest.php
+++ b/tests/Unit/Laravel/LaravelProcessZeroEnvironmentTest.php
@@ -31,10 +31,10 @@ final readonly class LaravelProcessZeroEnvironmentTest
 
             Expect::that(\getenv('APP_ENV'))
                 ->because('restore MUST preserve a zero process environment')
-                ->toBe('0')
-                ->and($_ENV['APP_ENV'])
-                ->toBe('environment-original')
-                ->and($_SERVER['APP_ENV'])
+                ->toBe('0');
+            Expect::that($_ENV['APP_ENV'])
+                ->toBe('environment-original');
+            Expect::that($_SERVER['APP_ENV'])
                 ->toBe('server-original');
         } finally {
             $state?->restore();

--- a/tests/Unit/PhpStan/ExtensionMatcherDispatchTest.php
+++ b/tests/Unit/PhpStan/ExtensionMatcherDispatchTest.php
@@ -21,8 +21,8 @@ final class ExtensionMatcherDispatchTest
 
         try {
             Expect::that('c0ffee')->toBeHexadecimal()
-                ->toHaveDigestLength(6)
-                ->and('not hex!')->not()->toBeHexadecimal();
+                ->toHaveDigestLength(6);
+            Expect::that('not hex!')->not()->toBeHexadecimal();
         } finally {
             Expect::install([]);
         }

--- a/tests/Unit/PhpStan/ExtensionMatcherParameterTest.php
+++ b/tests/Unit/PhpStan/ExtensionMatcherParameterTest.php
@@ -26,16 +26,16 @@ final class ExtensionMatcherParameterTest
 
         Expect::that($parameter->getName())
             ->because('extension matcher parameters MUST preserve their reflected signature')
-            ->toBe($name)
-            ->and($parameter->isOptional())
-            ->toBe($optional)
-            ->and($parameter->isVariadic())
-            ->toBe($variadic)
-            ->and($parameter->getType()->describe(VerbosityLevel::typeOnly()))
-            ->toBe($type)
-            ->and($parameter->passedByReference()->no())
-            ->toBeTrue()
-            ->and($parameter->getDefaultValue())
+            ->toBe($name);
+        Expect::that($parameter->isOptional())
+            ->toBe($optional);
+        Expect::that($parameter->isVariadic())
+            ->toBe($variadic);
+        Expect::that($parameter->getType()->describe(VerbosityLevel::typeOnly()))
+            ->toBe($type);
+        Expect::that($parameter->passedByReference()->no())
+            ->toBeTrue();
+        Expect::that($parameter->getDefaultValue())
             ->toBeNull();
     }
 

--- a/tests/Unit/PhpStan/MatcherMapPluginFilteringTest.php
+++ b/tests/Unit/PhpStan/MatcherMapPluginFilteringTest.php
@@ -23,8 +23,8 @@ final class MatcherMapPluginFilteringTest
                 'toBeHexadecimal',
                 'toHaveDigestLength',
                 'toBePositive',
-            ])
-            ->and($map->has('toHaveDigestLength'))
+            ]);
+        Expect::that($map->has('toHaveDigestLength'))
             ->because('matcher discovery MUST retain expectation extensions from a mixed plugin configuration')
             ->toBeTrue();
     }

--- a/tests/Unit/PhpStan/MatcherMapProviderTest.php
+++ b/tests/Unit/PhpStan/MatcherMapProviderTest.php
@@ -18,8 +18,8 @@ final class MatcherMapProviderTest
 
         Expect::that($provider->get())
             ->because('PHPStan extensions MUST share one lazily loaded matcher map')
-            ->toBe($first)
-            ->and($first->names())
+            ->toBe($first);
+        Expect::that($first->names())
             ->toBe([]);
     }
 }

--- a/tests/Unit/PhpStan/MatcherMapTest.php
+++ b/tests/Unit/PhpStan/MatcherMapTest.php
@@ -27,14 +27,14 @@ final class MatcherMapTest
         $lengthType = $lengthParameters[0]->getType();
         $subjectType = $map->subjectParameter('toHaveDigestLength')?->getType();
 
-        Expect::that($map->has('toBeHexadecimal'))->because('collects matchers with subject stripped')->toBeTrue()
-            ->and($map->has('toHaveDigestLength'))->toBeTrue()
-            ->and($map->has('toBeSomethingElse'))->toBeFalse()
-            ->and($map->parameters('toBeHexadecimal'))->toBe([])
-            ->and(\count($lengthParameters))->toBe(1)
-            ->and($lengthParameters[0]->getName())->toBe('length')
-            ->and($lengthType instanceof \ReflectionNamedType ? $lengthType->getName() : null)->toBe('int')
-            ->and($subjectType instanceof \ReflectionNamedType ? $subjectType->getName() : null)->toBe('string');
+        Expect::that($map->has('toBeHexadecimal'))->because('collects matchers with subject stripped')->toBeTrue();
+        Expect::that($map->has('toHaveDigestLength'))->toBeTrue();
+        Expect::that($map->has('toBeSomethingElse'))->toBeFalse();
+        Expect::that($map->parameters('toBeHexadecimal'))->toBe([]);
+        Expect::that(\count($lengthParameters))->toBe(1);
+        Expect::that($lengthParameters[0]->getName())->toBe('length');
+        Expect::that($lengthType instanceof \ReflectionNamedType ? $lengthType->getName() : null)->toBe('int');
+        Expect::that($subjectType instanceof \ReflectionNamedType ? $subjectType->getName() : null)->toBe('string');
     }
 
     #[Test]

--- a/tests/Unit/PhpStan/NativeTypeTest.php
+++ b/tests/Unit/PhpStan/NativeTypeTest.php
@@ -34,8 +34,8 @@ final class NativeTypeTest
 
         Expect::that($mapped->isObject()->yes())
             ->because('reflected object types stay object types')
-            ->toBeTrue()
-            ->and($mapped->getObjectClassNames())
+            ->toBeTrue();
+        Expect::that($mapped->getObjectClassNames())
             ->because('reflected object types keep every required class')
             ->toBe($expected);
     }
@@ -49,8 +49,8 @@ final class NativeTypeTest
 
         Expect::that($mapped::class)
             ->because('literal native booleans map to PHPStan boolean constants')
-            ->toBe(ConstantBooleanType::class)
-            ->and($mapped->describe(VerbosityLevel::typeOnly()))
+            ->toBe(ConstantBooleanType::class);
+        Expect::that($mapped->describe(VerbosityLevel::typeOnly()))
             ->toBe($expected ? 'true' : 'false');
     }
 

--- a/tests/Unit/Plugin/AfterTestSubscriberIsolationTest.php
+++ b/tests/Unit/Plugin/AfterTestSubscriberIsolationTest.php
@@ -70,8 +70,8 @@ final readonly class AfterTestSubscriberIsolationTest
             ->toBe([
                 'broken:after',
                 'observer:after:errored',
-            ])
-            ->and($sink->results()[0]->outcome)
+            ]);
+        Expect::that($sink->results()[0]->outcome)
             ->because('the later subscriber MUST receive the errored result')
             ->toBe(Outcome::Errored);
     }

--- a/tests/Unit/Plugin/PluginRegistryTest.php
+++ b/tests/Unit/Plugin/PluginRegistryTest.php
@@ -20,14 +20,14 @@ final class PluginRegistryTest
 
         Expect::that($registry->testSubscribers())
             ->because('an empty registry MUST expose no plugin capabilities or harness services')
-            ->toBe([])
-            ->and($registry->retryDeciders())
-            ->toBe([])
-            ->and($registry->runSubscribers())
-            ->toBe([])
-            ->and($registry->harnessServices())
-            ->toBe([])
-            ->and($registry->serviceResolvers())
+            ->toBe([]);
+        Expect::that($registry->retryDeciders())
+            ->toBe([]);
+        Expect::that($registry->runSubscribers())
+            ->toBe([]);
+        Expect::that($registry->harnessServices())
+            ->toBe([]);
+        Expect::that($registry->serviceResolvers())
             ->toBe([]);
     }
 
@@ -44,10 +44,10 @@ final class PluginRegistryTest
 
         Expect::that($registry->testSubscribers())
             ->because('capability accessors filter plugins and keep stable priority order')
-            ->toBe($expected)
-            ->and($registry->retryDeciders())->toBe($expected)
-            ->and($registry->runSubscribers())->toBe($expected)
-            ->and($registry->serviceResolvers())->toBe($expected)
-            ->and($registry->ofType(NamedFakePlugin::class))->toBe([$unrelated]);
+            ->toBe($expected);
+        Expect::that($registry->retryDeciders())->toBe($expected);
+        Expect::that($registry->runSubscribers())->toBe($expected);
+        Expect::that($registry->serviceResolvers())->toBe($expected);
+        Expect::that($registry->ofType(NamedFakePlugin::class))->toBe([$unrelated]);
     }
 }

--- a/tests/Unit/Plugin/PluginTest.php
+++ b/tests/Unit/Plugin/PluginTest.php
@@ -76,10 +76,10 @@ final class PluginTest
 
         $quarantined = $byMethod['flakyAndQuarantined'];
 
-        Expect::that($quarantined->outcome)->because('quarantine plugin transforms failures with provenance')->toBe(Outcome::Skipped)
-            ->and($quarantined->transformations[0]->transformedBy)->toBe(QuarantinePlugin::class)
-            ->and($quarantined->transformations[0]->from)->toBe(Outcome::Errored)
-            ->and($byMethod['passes']->outcome)->toBe(Outcome::Passed);
+        Expect::that($quarantined->outcome)->because('quarantine plugin transforms failures with provenance')->toBe(Outcome::Skipped);
+        Expect::that($quarantined->transformations[0]->transformedBy)->toBe(QuarantinePlugin::class);
+        Expect::that($quarantined->transformations[0]->from)->toBe(Outcome::Errored);
+        Expect::that($byMethod['passes']->outcome)->toBe(Outcome::Passed);
     }
 
     #[Test]
@@ -107,8 +107,8 @@ final class PluginTest
 
         Expect::that($results[0]->outcome)
             ->because('unattributed outcome changes error the test naming the plugin')
-            ->toBe(Outcome::Errored)
-            ->and($results[0]->error?->message)
+            ->toBe(Outcome::Errored);
+        Expect::that($results[0]->error?->message)
             ->toBe($message);
     }
 
@@ -137,10 +137,10 @@ final class PluginTest
 
         Expect::that((string) $result->id)
             ->because('afterTest() MUST NOT replace the executed test identity')
-            ->toBe($expectedId)
-            ->and($result->outcome)
-            ->toBe(Outcome::Errored)
-            ->and($result->error?->message)
+            ->toBe($expectedId);
+        Expect::that($result->outcome)
+            ->toBe(Outcome::Errored);
+        Expect::that($result->error?->message)
             ->toBe(\sprintf(
                 'Plugin "%s" changed the test identity during afterTest() from "%s" to "Rogue\\InjectedTest::wrong".',
                 $rogue::class,
@@ -173,8 +173,8 @@ final class PluginTest
 
         Expect::that($results[0]->outcome)
             ->because('throwing before test errors the test naming the plugin')
-            ->toBe(Outcome::Errored)
-            ->and($results[0]->error?->message)
+            ->toBe(Outcome::Errored);
+        Expect::that($results[0]->error?->message)
             ->toBe($message);
     }
 
@@ -207,8 +207,8 @@ final class PluginTest
         // The passed test becomes an error that names the plugin.
         Expect::that($byMethod['passes']->outcome)
             ->because('throwing after test keeps the outcome and records the plugin failure')
-            ->toBe(Outcome::Errored)
-            ->and($byMethod['passes']->error?->message)
+            ->toBe(Outcome::Errored);
+        Expect::that($byMethod['passes']->error?->message)
             ->toBe($pluginFailure);
 
         // The test keeps its original error. Greenlight records the plugin
@@ -216,10 +216,10 @@ final class PluginTest
         $errored = $byMethod['explodes'];
         Expect::that($errored->outcome)
             ->because('throwing after test keeps the outcome and records the plugin failure')
-            ->toBe(Outcome::Errored)
-            ->and($errored->error?->message)
-            ->toContain('intentional boom')
-            ->and($errored->failures[0]->message ?? '')
+            ->toBe(Outcome::Errored);
+        Expect::that($errored->error?->message)
+            ->toContain('intentional boom');
+        Expect::that($errored->failures[0]->message ?? '')
             ->toBe($pluginFailure);
 
         // The test keeps its assertion failure. Greenlight adds the plugin
@@ -228,14 +228,14 @@ final class PluginTest
         $failed = $failedResults[0];
         Expect::that($failed->outcome)
             ->because('a plugin failure MUST NOT replace an assertion failure')
-            ->toBe(Outcome::Failed)
-            ->and($failed->error)
-            ->toBe(null)
-            ->and($failed->failures)
-            ->toHaveCount(2)
-            ->and($failed->failures[0]->message)
-            ->toContain('intentional assertion failure')
-            ->and($failed->failures[1]->message)
+            ->toBe(Outcome::Failed);
+        Expect::that($failed->error)
+            ->toBe(null);
+        Expect::that($failed->failures)
+            ->toHaveCount(2);
+        Expect::that($failed->failures[0]->message)
+            ->toContain('intentional assertion failure');
+        Expect::that($failed->failures[1]->message)
             ->toBe($pluginFailure);
     }
 
@@ -264,11 +264,11 @@ final class PluginTest
 
         Expect::that($byMethod['passes']->outcome)
             ->because('a retry decider MUST NOT run after a successful test')
-            ->toBe(Outcome::Passed)
-            ->and($byMethod['explodes']->outcome)
+            ->toBe(Outcome::Passed);
+        Expect::that($byMethod['explodes']->outcome)
             ->because('a retry decider failure MUST error the unsuccessful test')
-            ->toBe(Outcome::Errored)
-            ->and($byMethod['explodes']->error?->message)
+            ->toBe(Outcome::Errored);
+        Expect::that($byMethod['explodes']->error?->message)
             ->toBe('retry decision failed');
     }
 
@@ -291,8 +291,8 @@ final class PluginTest
 
         [$summary, $results] = $this->runSuite('Lifecycle/Order', [$skipper]);
 
-        Expect::that($summary->skipped)->because('context skip from before test skips the test')->toBe(1)
-            ->and($results[0]->skipReason)->toBe('flaky on this platform');
+        Expect::that($summary->skipped)->because('context skip from before test skips the test')->toBe(1);
+        Expect::that($results[0]->skipReason)->toBe('flaky on this platform');
     }
 
     #[Test]
@@ -320,8 +320,8 @@ final class PluginTest
 
         Expect::that($summary->skipped)
             ->because('the plugin skip stops test execution')
-            ->toBe(1)
-            ->and(TraceLog::drain())
+            ->toBe(1);
+        Expect::that(TraceLog::drain())
             ->because('the plugin skip MUST preserve fixture and subscriber teardown order')
             ->toBe(['construct', 'after2', 'after1', 'plugin-after']);
     }
@@ -345,8 +345,8 @@ final class PluginTest
 
         [$summary, $results] = $this->runSuite('Lifecycle/Order', [$skipper]);
 
-        Expect::that($summary->skipped)->because('skip signal from before test skips the test')->toBe(1)
-            ->and($results[0]->skipReason)->toBe('quarantined environment');
+        Expect::that($summary->skipped)->because('skip signal from before test skips the test')->toBe(1);
+        Expect::that($results[0]->skipReason)->toBe('quarantined environment');
     }
 
     #[Test]
@@ -409,8 +409,8 @@ final class PluginTest
 
         [$summary] = $this->runSuite('Lifecycle/Services', [new ProbeProvider()]);
 
-        Expect::that($summary->passed)->because('harness providers contribute injectable services')->toBe(2)
-            ->and(TraceLog::drain())->toContain('probe1:disposed');
+        Expect::that($summary->passed)->because('harness providers contribute injectable services')->toBe(2);
+        Expect::that(TraceLog::drain())->toContain('probe1:disposed');
     }
 
     #[Test]

--- a/tests/Unit/Plugin/TestContextTest.php
+++ b/tests/Unit/Plugin/TestContextTest.php
@@ -35,8 +35,8 @@ final class TestContextTest
 
         Expect::that($service)
             ->because('the plugin context resolves a registered harness service')
-            ->toBeInstanceOf(\ArrayObject::class)
-            ->and($service->getArrayCopy())->toBe(['ready']);
+            ->toBeInstanceOf(\ArrayObject::class);
+        Expect::that($service->getArrayCopy())->toBe(['ready']);
     }
 
     #[Test]

--- a/tests/Unit/Rector/AssertionMapTest.php
+++ b/tests/Unit/Rector/AssertionMapTest.php
@@ -38,11 +38,11 @@ final class AssertionMapTest
             Fail::because(\sprintf('Expected a conversion for PHPUnit assertion "%s".', $method));
         }
 
-        Expect::that($conversion->matcher)->because('lookup preserves conversion metadata')->toBe($expected['matcher'])
-            ->and($conversion->subject)->toBe($expected['subject'])
-            ->and($conversion->matcherArguments)->toBe($expected['matcherArguments'])
-            ->and($conversion->arity)->toBe($expected['arity'])
-            ->and($conversion->negated)->toBe($expected['negated']);
+        Expect::that($conversion->matcher)->because('lookup preserves conversion metadata')->toBe($expected['matcher']);
+        Expect::that($conversion->subject)->toBe($expected['subject']);
+        Expect::that($conversion->matcherArguments)->toBe($expected['matcherArguments']);
+        Expect::that($conversion->arity)->toBe($expected['arity']);
+        Expect::that($conversion->negated)->toBe($expected['negated']);
     }
 
     /**

--- a/tests/Unit/Rector/PhpUnitAttributesTest.php
+++ b/tests/Unit/Rector/PhpUnitAttributesTest.php
@@ -28,21 +28,21 @@ final class PhpUnitAttributesTest
                 'RunInSeparateProcess' => Isolated::class,
                 'RunTestsInSeparateProcesses' => Isolated::class,
                 'DoesNotPerformAssertions' => NoExpectations::class,
-            ])
-            ->and(PhpUnitAttributes::SIZE_GROUPS)
+            ]);
+        Expect::that(PhpUnitAttributes::SIZE_GROUPS)
             ->toBe([
                 'Small' => 'small',
                 'Medium' => 'medium',
                 'Large' => 'large',
-            ])
-            ->and(PhpUnitAttributes::SKIP_UNLESS_CONDITIONS)
+            ]);
+        Expect::that(PhpUnitAttributes::SKIP_UNLESS_CONDITIONS)
             ->toBe([
                 'RequiresPhpExtension' => ExtensionLoaded::class,
                 'RequiresOperatingSystemFamily' => OperatingSystemFamily::class,
-            ])
-            ->and(PhpUnitAttributes::STRUCTURAL)
-            ->toBe(['Test', 'Before', 'After'])
-            ->and(PhpUnitAttributes::TEST_WITH)
+            ]);
+        Expect::that(PhpUnitAttributes::STRUCTURAL)
+            ->toBe(['Test', 'Before', 'After']);
+        Expect::that(PhpUnitAttributes::TEST_WITH)
             ->toBe('TestWith');
     }
 

--- a/tests/Unit/Reporting/AttachmentFormatBoundaryTest.php
+++ b/tests/Unit/Reporting/AttachmentFormatBoundaryTest.php
@@ -44,8 +44,8 @@ final class AttachmentFormatBoundaryTest
             ->because('the exact attachment display limit MUST NOT report an empty remainder')
             ->toContain('attachment-10.txt')
             ->not()
-            ->toContain('and 0 more')
-            ->and(AttachmentFormat::paths($attachments))
+            ->toContain('and 0 more');
+        Expect::that(AttachmentFormat::paths($attachments))
             ->because('the exact attachment path limit MUST NOT report an empty remainder')
             ->toContain('attachment-10.txt')
             ->not()

--- a/tests/Unit/Reporting/AttachmentReporterTest.php
+++ b/tests/Unit/Reporting/AttachmentReporterTest.php
@@ -65,8 +65,8 @@ final class AttachmentReporterTest
             'build/greenlight-artifacts/run-1/response.json',
         ))
             ->because('successful attachment metadata MUST be rendered exactly once')
-            ->toBe(1)
-            ->and($output->buffer())
+            ->toBe(1);
+        Expect::that($output->buffer())
             ->because('reporters MUST NOT inline attachment content')
             ->not()
             ->toContain('secret response body');
@@ -95,8 +95,8 @@ final class AttachmentReporterTest
             ->because('successful attachments are written before the result is released')
             ->toContain('PASS Example\AttachmentTest::fails')
             ->toContain('response.json')
-            ->toContain('build/greenlight-artifacts/run-1/response.json')
-            ->and($reference->get())
+            ->toContain('build/greenlight-artifacts/run-1/response.json');
+        Expect::that($reference->get())
             ->because('the plain reporter does not retain successful results')
             ->toBeNull();
     }

--- a/tests/Unit/Reporting/CompositeReporterTest.php
+++ b/tests/Unit/Reporting/CompositeReporterTest.php
@@ -22,10 +22,10 @@ final class CompositeReporterTest
 
         $expected = \count(CannedStream::events());
 
-        Expect::that($first->eventCount)->because('every reporter sees every event and finish')->toBe($expected)
-            ->and($second->eventCount)->toBe($expected)
-            ->and($first->finished)->toBeTrue()
-            ->and($second->finished)->toBeTrue();
+        Expect::that($first->eventCount)->because('every reporter sees every event and finish')->toBe($expected);
+        Expect::that($second->eventCount)->toBe($expected);
+        Expect::that($first->finished)->toBeTrue();
+        Expect::that($second->finished)->toBeTrue();
     }
 
     #[Test]
@@ -44,8 +44,8 @@ final class CompositeReporterTest
             new GithubReporter($compositeGithub),
         ]));
 
-        Expect::that($compositePlain->buffer())->because('fan out matches running each reporter alone')->toBe($alonePlain->buffer())
-            ->and($compositeGithub->buffer())->toBe($aloneGithub->buffer());
+        Expect::that($compositePlain->buffer())->because('fan out matches running each reporter alone')->toBe($alonePlain->buffer());
+        Expect::that($compositeGithub->buffer())->toBe($aloneGithub->buffer());
     }
 
     #[Test]
@@ -56,7 +56,7 @@ final class CompositeReporterTest
 
         new CompositeReporter([$plain, $live])->tick(1.5);
 
-        Expect::that($live->ticks)->because('ticks reach only ticking reporters')->toBe([1.5])
-            ->and($plain->eventCount)->toBe(0);
+        Expect::that($live->ticks)->because('ticks reach only ticking reporters')->toBe([1.5]);
+        Expect::that($plain->eventCount)->toBe(0);
     }
 }

--- a/tests/Unit/Reporting/JUnitReporterTest.php
+++ b/tests/Unit/Reporting/JUnitReporterTest.php
@@ -66,15 +66,15 @@ final class JUnitReporterTest
             return;
         }
 
-        Expect::that((string) $document['tests'])->because('XML parses and counts match the stream')->toBe('6')
-            ->and((string) $document['failures'])->toBe('1')
-            ->and((string) $document['errors'])->toBe('1')
-            ->and((string) $document['skipped'])->toBe('1')
-            ->and($document->xpath('//testcase'))->toHaveCount(6)
-            ->and($document->xpath('//testsuite'))->toHaveCount(2)
-            ->and($document->xpath('//failure'))->toHaveCount(1)
-            ->and($document->xpath('//error'))->toHaveCount(1)
-            ->and($document->xpath('//skipped'))->toHaveCount(1);
+        Expect::that((string) $document['tests'])->because('XML parses and counts match the stream')->toBe('6');
+        Expect::that((string) $document['failures'])->toBe('1');
+        Expect::that((string) $document['errors'])->toBe('1');
+        Expect::that((string) $document['skipped'])->toBe('1');
+        Expect::that($document->xpath('//testcase'))->toHaveCount(6);
+        Expect::that($document->xpath('//testsuite'))->toHaveCount(2);
+        Expect::that($document->xpath('//failure'))->toHaveCount(1);
+        Expect::that($document->xpath('//error'))->toHaveCount(1);
+        Expect::that($document->xpath('//skipped'))->toHaveCount(1);
     }
 
     #[Test]
@@ -109,8 +109,8 @@ final class JUnitReporterTest
 
         Expect::that((string) $document['failures'])
             ->because('one failed test contributes one suite failure')
-            ->toBe('1')
-            ->and($failures)
+            ->toBe('1');
+        Expect::that($failures)
             ->because('each failure detail remains visible to JUnit consumers')
             ->toHaveCount(2);
 
@@ -120,8 +120,8 @@ final class JUnitReporterTest
 
         Expect::that((string) $failures[0]['message'])
             ->because('failure details retain their encounter order')
-            ->toBe('first failure')
-            ->and((string) $failures[1]['message'])
+            ->toBe('first failure');
+        Expect::that((string) $failures[1]['message'])
             ->toBe('second failure');
     }
 
@@ -224,11 +224,11 @@ final class JUnitReporterTest
 
         Expect::that((string) $case['name'])
             ->because('forbidden characters in test names are replaced')
-            ->toBe("fails[case\u{FFFD}]")
-            ->and((string) $failure['message'])
+            ->toBe("fails[case\u{FFFD}]");
+        Expect::that((string) $failure['message'])
             ->because('forbidden characters in diagnostic attributes are replaced')
-            ->toBe("message\u{FFFD}")
-            ->and((string) $failure)
+            ->toBe("message\u{FFFD}");
+        Expect::that((string) $failure)
             ->because('forbidden characters in diagnostic text are replaced')
             ->toBe(
                 "expected: expected\u{FFFD}\n"

--- a/tests/Unit/Reporting/JsonLinesReporterTest.php
+++ b/tests/Unit/Reporting/JsonLinesReporterTest.php
@@ -47,9 +47,9 @@ final class JsonLinesReporterTest
                 flags: \JSON_THROW_ON_ERROR,
             );
 
-            Expect::that($decoded['v'])->toBe(2)
-                ->and($decoded['event'])->toBe(\array_search($event::class, $tags, true))
-                ->and($decoded['data'])->toEqual($expectedData);
+            Expect::that($decoded['v'])->toBe(2);
+            Expect::that($decoded['event'])->toBe(\array_search($event::class, $tags, true));
+            Expect::that($decoded['data'])->toEqual($expectedData);
         }
     }
 
@@ -69,8 +69,8 @@ final class JsonLinesReporterTest
             $class = $classesByTag[$decoded['event']];
             $restored = $class::fromWire($decoded['data']);
 
-            Expect::that($restored::class)->toBe($events[$index]::class)
-                ->and($restored->occurredAt)->toBe($events[$index]->occurredAt);
+            Expect::that($restored::class)->toBe($events[$index]::class);
+            Expect::that($restored->occurredAt)->toBe($events[$index]->occurredAt);
         }
     }
 

--- a/tests/Unit/Reporting/JsonlSchemaTest.php
+++ b/tests/Unit/Reporting/JsonlSchemaTest.php
@@ -37,8 +37,8 @@ final class JsonlSchemaTest
             }
         }
 
-        Expect::that($violations)->because('every canned line validates against the shipped schema')->toBe([])
-            ->and(\array_keys($seenTags))->toEqualCanonicalizing(\array_keys(EventTags::all()));
+        Expect::that($violations)->because('every canned line validates against the shipped schema')->toBe([]);
+        Expect::that(\array_keys($seenTags))->toEqualCanonicalizing(\array_keys(EventTags::all()));
     }
 
     #[Test]

--- a/tests/Unit/Reporting/PluralTest.php
+++ b/tests/Unit/Reporting/PluralTest.php
@@ -13,17 +13,17 @@ final class PluralTest
     #[Test]
     public function countPluralizesRegularNouns(): void
     {
-        Expect::that(Plural::count(1, 'test'))->because('count pluralizes regular nouns')->toBe('1 test')
-            ->and(Plural::count(2, 'test'))->toBe('2 tests')
-            ->and(Plural::count(0, 'expectation'))->toBe('0 expectations')
-            ->and(Plural::count(1, 'expectation'))->toBe('1 expectation')
-            ->and(Plural::count(11, 'worker'))->toBe('11 workers');
+        Expect::that(Plural::count(1, 'test'))->because('count pluralizes regular nouns')->toBe('1 test');
+        Expect::that(Plural::count(2, 'test'))->toBe('2 tests');
+        Expect::that(Plural::count(0, 'expectation'))->toBe('0 expectations');
+        Expect::that(Plural::count(1, 'expectation'))->toBe('1 expectation');
+        Expect::that(Plural::count(11, 'worker'))->toBe('11 workers');
     }
 
     #[Test]
     public function countUsesTheIrregularPluralWhenGiven(): void
     {
-        Expect::that(Plural::count(1, 'class', 'classes'))->because('count uses the irregular plural when given')->toBe('1 class')
-            ->and(Plural::count(3, 'class', 'classes'))->toBe('3 classes');
+        Expect::that(Plural::count(1, 'class', 'classes'))->because('count uses the irregular plural when given')->toBe('1 class');
+        Expect::that(Plural::count(3, 'class', 'classes'))->toBe('3 classes');
     }
 }

--- a/tests/Unit/Reporting/ProfileAggregatorTest.php
+++ b/tests/Unit/Reporting/ProfileAggregatorTest.php
@@ -171,8 +171,8 @@ final class ProfileAggregatorTest
 
         Expect::that($aggregator->render(new Style(ansi: false)))
             ->because('the summary counts every spawned worker')
-            ->toContain('Workers: 2 requested, 2 spawned, 0 recycled')
-            ->and($aggregator->render(new Style(ansi: false)))
+            ->toContain('Workers: 2 requested, 2 spawned, 0 recycled');
+        Expect::that($aggregator->render(new Style(ansi: false)))
             ->because('an idle worker has no class statistics to report')
             ->toContain("\n  active        1  0.500s")
             ->not()

--- a/tests/Unit/Reporting/RunHeaderTest.php
+++ b/tests/Unit/Reporting/RunHeaderTest.php
@@ -54,8 +54,8 @@ final class RunHeaderTest
         $header = new RunHeader('dev-main', null, null, phpVersion: '8.4.0');
 
         Expect::that($header->render(1, new Style(ansi: false)))->because('flags a missing configuration file')
-            ->toBe("Greenlight dev-main\nPHP 8.4.0 | configuration: (none) | workers: 1")
-            ->and($header->render(1, new Style(ansi: true)))
+            ->toBe("Greenlight dev-main\nPHP 8.4.0 | configuration: (none) | workers: 1");
+        Expect::that($header->render(1, new Style(ansi: true)))
             ->toContain("\x1b[33mconfiguration: (none)\x1b[0m");
     }
 
@@ -65,8 +65,8 @@ final class RunHeaderTest
         $header = new RunHeader('dev-main', 'greenlight.php', null, phpVersion: '8.4.0', workerFallback: true);
 
         Expect::that($header->render(1, new Style(ansi: true)))->because('flags the worker fallback')
-            ->toContain("\x1b[33mworkers: 1\x1b[0m")
-            ->and($header->render(1, new Style(ansi: false)))
+            ->toContain("\x1b[33mworkers: 1\x1b[0m");
+        Expect::that($header->render(1, new Style(ansi: false)))
             ->toContain('workers: 1');
     }
 

--- a/tests/Unit/Reporting/SlowTestsTest.php
+++ b/tests/Unit/Reporting/SlowTestsTest.php
@@ -39,11 +39,11 @@ final class SlowTestsTest
             static fn(string $line): bool => $line !== '',
         ));
 
-        Expect::that($lines[0])->because('renders slowest first and caps at five')->toBe('Slowest tests:')
-            ->and(\count($lines))->toBe(6)
-            ->and($lines[1])->toBe('  0.580s Acme\SlowTest::case08')
-            ->and($lines[5])->toBe('  0.540s Acme\SlowTest::case04')
-            ->and($rendered)->not()->toContain('case03');
+        Expect::that($lines[0])->because('renders slowest first and caps at five')->toBe('Slowest tests:');
+        Expect::that(\count($lines))->toBe(6);
+        Expect::that($lines[1])->toBe('  0.580s Acme\SlowTest::case08');
+        Expect::that($lines[5])->toBe('  0.540s Acme\SlowTest::case04');
+        Expect::that($rendered)->not()->toContain('case03');
     }
 
     #[Test]
@@ -72,12 +72,12 @@ final class SlowTestsTest
 
         Expect::that(\count($lines))
             ->because('profile mode MUST list exactly the 25 slowest tests')
-            ->toBe(26)
-            ->and($lines[1])
-            ->toBe('  0.760s Acme\SlowTest::case26')
-            ->and($lines[25])
-            ->toBe('  0.520s Acme\SlowTest::case02')
-            ->and($rendered)
+            ->toBe(26);
+        Expect::that($lines[1])
+            ->toBe('  0.760s Acme\SlowTest::case26');
+        Expect::that($lines[25])
+            ->toBe('  0.520s Acme\SlowTest::case02');
+        Expect::that($rendered)
             ->not()
             ->toContain('case01');
     }

--- a/tests/Unit/Reporting/StyleTest.php
+++ b/tests/Unit/Reporting/StyleTest.php
@@ -16,12 +16,12 @@ final class StyleTest
         $ansi = new Style(ansi: true);
         $plain = new Style(ansi: false);
 
-        Expect::that($ansi->ok('fine'))->because('colors apply only with ANSI')->toBe("\x1b[32mfine\x1b[0m")
-            ->and($ansi->error('bad'))->toBe("\x1b[31mbad\x1b[0m")
-            ->and($ansi->warn('uh oh'))->toBe("\x1b[33muh oh\x1b[0m")
-            ->and($plain->ok('fine'))->toBe('fine')
-            ->and($plain->error('bad'))->toBe('bad')
-            ->and($plain->warn('uh oh'))->toBe('uh oh');
+        Expect::that($ansi->ok('fine'))->because('colors apply only with ANSI')->toBe("\x1b[32mfine\x1b[0m");
+        Expect::that($ansi->error('bad'))->toBe("\x1b[31mbad\x1b[0m");
+        Expect::that($ansi->warn('uh oh'))->toBe("\x1b[33muh oh\x1b[0m");
+        Expect::that($plain->ok('fine'))->toBe('fine');
+        Expect::that($plain->error('bad'))->toBe('bad');
+        Expect::that($plain->warn('uh oh'))->toBe('uh oh');
     }
 
     #[Test]
@@ -29,9 +29,9 @@ final class StyleTest
     {
         $ansi = new Style(ansi: true);
 
-        Expect::that($ansi->duration(0.123))->because('durations color by severity')->toBe('0.123s')
-            ->and($ansi->duration(1.5))->toBe("\x1b[33m1.500s\x1b[0m")
-            ->and($ansi->duration(6.0))->toBe("\x1b[31m6.000s\x1b[0m");
+        Expect::that($ansi->duration(0.123))->because('durations color by severity')->toBe('0.123s');
+        Expect::that($ansi->duration(1.5))->toBe("\x1b[33m1.500s\x1b[0m");
+        Expect::that($ansi->duration(6.0))->toBe("\x1b[31m6.000s\x1b[0m");
     }
 
     #[Test]
@@ -41,13 +41,13 @@ final class StyleTest
 
         Expect::that($ansi->duration(0.999))
             ->because('durations below one second remain uncolored')
-            ->toBe('0.999s')
-            ->and($ansi->duration(1.0))
+            ->toBe('0.999s');
+        Expect::that($ansi->duration(1.0))
             ->because('one second enters the warning band')
-            ->toBe("\x1b[33m1.000s\x1b[0m")
-            ->and($ansi->duration(4.999))
-            ->toBe("\x1b[33m4.999s\x1b[0m")
-            ->and($ansi->duration(5.0))
+            ->toBe("\x1b[33m1.000s\x1b[0m");
+        Expect::that($ansi->duration(4.999))
+            ->toBe("\x1b[33m4.999s\x1b[0m");
+        Expect::that($ansi->duration(5.0))
             ->because('five seconds enters the error band')
             ->toBe("\x1b[31m5.000s\x1b[0m");
     }
@@ -57,7 +57,7 @@ final class StyleTest
     {
         $plain = new Style(ansi: false);
 
-        Expect::that($plain->duration(1.5))->because('durations stay plain without ANSI')->toBe('1.500s')
-            ->and($plain->duration(6.0))->toBe('6.000s');
+        Expect::that($plain->duration(1.5))->because('durations stay plain without ANSI')->toBe('1.500s');
+        Expect::that($plain->duration(6.0))->toBe('6.000s');
     }
 }

--- a/tests/Unit/Reporting/SummaryFormatTest.php
+++ b/tests/Unit/Reporting/SummaryFormatTest.php
@@ -155,8 +155,8 @@ final class SummaryFormatTest
     {
         $block = SummaryFormat::leaks([new TestId('App\AlphaTest', 'one')], new Style(ansi: true));
 
-        Expect::that($block)->because('leaks color the header red and nothing without leaks')->toContain("\x1b[31mTest instance leaks:\x1b[0m")
-            ->and(SummaryFormat::leaks([], new Style(ansi: true)))->toBe('');
+        Expect::that($block)->because('leaks color the header red and nothing without leaks')->toContain("\x1b[31mTest instance leaks:\x1b[0m");
+        Expect::that(SummaryFormat::leaks([], new Style(ansi: true)))->toBe('');
     }
 
     #[Test]

--- a/tests/Unit/Reporting/TeamCityReporterAutoloadCacheTest.php
+++ b/tests/Unit/Reporting/TeamCityReporterAutoloadCacheTest.php
@@ -38,8 +38,8 @@ final readonly class TeamCityReporterAutoloadCacheTest
 
         Expect::that($autoloadCalls)
             ->because('a failed optional location lookup MUST not rerun the autoloader for each event')
-            ->toBe(1)
-            ->and($output->buffer())
+            ->toBe(1);
+        Expect::that($output->buffer())
             ->because('cached lookup failure MUST not stop later report events')
             ->toBe(
                 "##teamcity[testSuiteStarted name='{$class}' flowId='{$class}']\n"

--- a/tests/Unit/Reporting/TerminalEmulatorTest.php
+++ b/tests/Unit/Reporting/TerminalEmulatorTest.php
@@ -82,8 +82,8 @@ final class TerminalEmulatorTest
 
         $terminal->write("\x1b[?25lhidden");
 
-        Expect::that($terminal->isCursorHidden())->because('cursor visibility toggles without affecting the grid')->toBeTrue()
-            ->and($terminal->visibleLines())->toBe(['hidden']);
+        Expect::that($terminal->isCursorHidden())->because('cursor visibility toggles without affecting the grid')->toBeTrue();
+        Expect::that($terminal->visibleLines())->toBe(['hidden']);
 
         $terminal->write("\x1b[?25h");
 

--- a/tests/Unit/Reporting/TtyReporterTest.php
+++ b/tests/Unit/Reporting/TtyReporterTest.php
@@ -279,8 +279,8 @@ final class TtyReporterTest
 
         // A blank line separates the first permanent line from the header. The
         // second permanent line occurs directly below the first.
-        Expect::that($lines[$gammaLine - 1] ?? null)->because('the first permanent line gets a gap and later ones stack')->toBe('')
-            ->and($deltaLine)->toBe($gammaLine + 1);
+        Expect::that($lines[$gammaLine - 1] ?? null)->because('the first permanent line gets a gap and later ones stack')->toBe('');
+        Expect::that($deltaLine)->toBe($gammaLine + 1);
     }
 
     #[Test]
@@ -371,9 +371,9 @@ final class TtyReporterTest
     #[Test]
     public function windowCapacityClampsToTerminalHeightWithAFloor(): void
     {
-        Expect::that(TtyReporter::windowCapacity(50))->because('window capacity clamps to terminal height with a floor')->toBe(10)
-            ->and(TtyReporter::windowCapacity(12))->toBe(7)
-            ->and(TtyReporter::windowCapacity(6))->toBe(3);
+        Expect::that(TtyReporter::windowCapacity(50))->because('window capacity clamps to terminal height with a floor')->toBe(10);
+        Expect::that(TtyReporter::windowCapacity(12))->toBe(7);
+        Expect::that(TtyReporter::windowCapacity(6))->toBe(3);
     }
 
     #[Test]

--- a/tests/Unit/Reporting/WorkerProfileTest.php
+++ b/tests/Unit/Reporting/WorkerProfileTest.php
@@ -25,25 +25,25 @@ final class WorkerProfileTest
 
         Expect::that($profile->classFinished(15.75))
             ->because('the second class duration is measured')
-            ->toBe(1.75)
-            ->and($profile->busy)
+            ->toBe(1.75);
+        Expect::that($profile->busy)
             ->because('busy time accumulates every completed class')
-            ->toBe(3.0)
-            ->and($profile->classes)
-            ->toBe(2)
-            ->and($profile->openAt)
-            ->toBeNull()
-            ->and($profile->spawnedAt)
-            ->toBe(10.0)
-            ->and($profile->firstClassAt)
-            ->toBe(12.0)
-            ->and($profile->lastFinishAt)
-            ->toBe(15.75)
-            ->and($profile->bootLatency())
-            ->toBe(2.0)
-            ->and($profile->window())
-            ->toBe(5.75)
-            ->and($profile->utilizationPercent())
+            ->toBe(3.0);
+        Expect::that($profile->classes)
+            ->toBe(2);
+        Expect::that($profile->openAt)
+            ->toBeNull();
+        Expect::that($profile->spawnedAt)
+            ->toBe(10.0);
+        Expect::that($profile->firstClassAt)
+            ->toBe(12.0);
+        Expect::that($profile->lastFinishAt)
+            ->toBe(15.75);
+        Expect::that($profile->bootLatency())
+            ->toBe(2.0);
+        Expect::that($profile->window())
+            ->toBe(5.75);
+        Expect::that($profile->utilizationPercent())
             ->because('utilization is rounded from accumulated busy time')
             ->toBe(52);
     }
@@ -60,14 +60,14 @@ final class WorkerProfileTest
 
         Expect::that($profile->spawnedAt)
             ->because('repeated lifecycle events MUST NOT replace the first worker spawn time')
-            ->toBe(10.0)
-            ->and($profile->firstClassAt)
+            ->toBe(10.0);
+        Expect::that($profile->firstClassAt)
             ->because('repeated lifecycle events MUST NOT replace the first class start time')
-            ->toBe(12.0)
-            ->and($profile->bootLatency())
+            ->toBe(12.0);
+        Expect::that($profile->bootLatency())
             ->because('boot latency MUST use the first observed lifecycle timestamps')
-            ->toBe(2.0)
-            ->and($profile->window())
+            ->toBe(2.0);
+        Expect::that($profile->window())
             ->because('the worker window MUST start at the first observed spawn')
             ->toBe(5.0);
     }
@@ -79,10 +79,10 @@ final class WorkerProfileTest
 
         Expect::that($profile->bootLatency())
             ->because('incomplete timing data does not invent metrics')
-            ->toBeNull()
-            ->and($profile->window())
-            ->toBe(0.0)
-            ->and($profile->utilizationPercent())
+            ->toBeNull();
+        Expect::that($profile->window())
+            ->toBe(0.0);
+        Expect::that($profile->utilizationPercent())
             ->toBeNull();
     }
 
@@ -96,10 +96,10 @@ final class WorkerProfileTest
 
         Expect::that($profile->bootLatency())
             ->because('worker clock skew MUST NOT produce negative boot latency')
-            ->toBe(0.0)
-            ->and($profile->window())
-            ->toBe(10.0)
-            ->and($profile->utilizationPercent())
+            ->toBe(0.0);
+        Expect::that($profile->window())
+            ->toBe(10.0);
+        Expect::that($profile->utilizationPercent())
             ->because('worker utilization MUST stay within its percentage range')
             ->toBe(100);
     }
@@ -114,11 +114,11 @@ final class WorkerProfileTest
 
         Expect::that($profile->busy)
             ->because('a reversed class timestamp MUST NOT produce negative busy time')
-            ->toBe(0.0)
-            ->and($profile->window())
+            ->toBe(0.0);
+        Expect::that($profile->window())
             ->because('a reversed worker period MUST NOT produce a negative window')
-            ->toBe(0.0)
-            ->and($profile->utilizationPercent())
+            ->toBe(0.0);
+        Expect::that($profile->utilizationPercent())
             ->toBeNull();
     }
 }

--- a/tests/Unit/Reporting/WorkerProfileZeroTimestampTest.php
+++ b/tests/Unit/Reporting/WorkerProfileZeroTimestampTest.php
@@ -19,10 +19,10 @@ final readonly class WorkerProfileZeroTimestampTest
 
         Expect::that($profile->classFinished(0.5))
             ->because('a zero class-start timestamp is known timing data')
-            ->toBe(0.5)
-            ->and($profile->busy)->toBe(0.5)
-            ->and($profile->bootLatency())->toBe(0.0)
-            ->and($profile->window())->toBe(0.5)
-            ->and($profile->utilizationPercent())->toBe(100);
+            ->toBe(0.5);
+        Expect::that($profile->busy)->toBe(0.5);
+        Expect::that($profile->bootLatency())->toBe(0.0);
+        Expect::that($profile->window())->toBe(0.5);
+        Expect::that($profile->utilizationPercent())->toBe(100);
     }
 }

--- a/tests/Unit/Runner/CoverageCollectorTest.php
+++ b/tests/Unit/Runner/CoverageCollectorTest.php
@@ -40,12 +40,12 @@ final class CoverageCollectorTest
 
         Expect::that(RecordingFakeDriver::started())
             ->because('the collector stops the selected driver')
-            ->toBeFalse()
-            ->and(\array_keys($files))
+            ->toBeFalse();
+        Expect::that(\array_keys($files))
             ->because('the collector filters raw coverage to the included paths')
-            ->toBe(['/project/src/Included.php'])
-            ->and($files['/project/src/Included.php']->coveredLines)->toBe([10])
-            ->and($files['/project/src/Included.php']->uncoveredLines)->toBe([11]);
+            ->toBe(['/project/src/Included.php']);
+        Expect::that($files['/project/src/Included.php']->coveredLines)->toBe([10]);
+        Expect::that($files['/project/src/Included.php']->uncoveredLines)->toBe([11]);
     }
 
     #[Test]
@@ -62,11 +62,11 @@ final class CoverageCollectorTest
 
         Expect::that($collector)
             ->because('an unavailable driver does not create a collector')
-            ->toBeNull()
-            ->and($reason)->toBe(
-                'No coverage driver is available. Greenlight tried UnavailableFakeDriver. Install pcov or enable Xdebug coverage mode. '
+            ->toBeNull();
+        Expect::that($reason)->toBe(
+            'No coverage driver is available. Greenlight tried UnavailableFakeDriver. Install pcov or enable Xdebug coverage mode. '
                 . 'Set xdebug.mode to "coverage", or set the XDEBUG_MODE environment variable.',
-            );
+        );
     }
 
     #[Test]
@@ -124,9 +124,9 @@ final class CoverageCollectorTest
 
             Expect::that($collector)
                 ->because($setting . ' selects only its configured coverage driver')
-                ->toBeNull()
-                ->and($reason)->toContain('Greenlight tried ' . $expectedName . '.')
-                ->and(\str_contains($reason, $otherName))->toBeFalse();
+                ->toBeNull();
+            Expect::that($reason)->toContain('Greenlight tried ' . $expectedName . '.');
+            Expect::that(\str_contains($reason, $otherName))->toBeFalse();
 
             return;
         }

--- a/tests/Unit/Runner/CpuCoresTest.php
+++ b/tests/Unit/Runner/CpuCoresTest.php
@@ -25,8 +25,8 @@ final class CpuCoresTest
 
         Expect::that(CpuCores::count())
             ->because('the optional CPU counter supplies the worker count')
-            ->toBe(7)
-            ->and(FakeCpuCoreCounter::$calls)
+            ->toBe(7);
+        Expect::that(FakeCpuCoreCounter::$calls)
             ->because('the optional CPU counter runs once')
             ->toBe(1);
     }
@@ -39,8 +39,8 @@ final class CpuCoresTest
 
         Expect::that(CpuCores::count())
             ->because('the typed not-found error falls through to the built-in probe')
-            ->toBeGreaterThan(0)
-            ->and(FakeCpuCoreCounter::$calls)
+            ->toBeGreaterThan(0);
+        Expect::that(FakeCpuCoreCounter::$calls)
             ->because('the fallback follows one optional attempt')
             ->toBe(1);
     }
@@ -81,8 +81,8 @@ final class CpuCoresTest
 
         Expect::that($result->exitCode)
             ->because('the built-in CPU probe runs without the optional package')
-            ->toBe(0)
-            ->and($result->stdout)
+            ->toBe(0);
+        Expect::that($result->stdout)
             ->because('the built-in CPU probe returns a positive integer')
             ->toMatch('/^[1-9]\d*$/D');
     }

--- a/tests/Unit/Runner/InProcessRunnerTest.php
+++ b/tests/Unit/Runner/InProcessRunnerTest.php
@@ -40,8 +40,8 @@ final readonly class InProcessRunnerTest
         Expect::that($subscriber->sequence())
             ->because('the subscriber observes both run boundaries')
             ->toContain('RunStarted')
-            ->toContain('RunFinished')
-            ->and($result->summary->passed)
+            ->toContain('RunFinished');
+        Expect::that($result->summary->passed)
             ->toBe(7);
     }
 
@@ -59,10 +59,10 @@ final readonly class InProcessRunnerTest
 
         Expect::that($first->seed)
             ->because('the run result MUST report its explicit random seed')
-            ->toBe(4242)
-            ->and($second->seed)
-            ->toBe(4242)
-            ->and($this->resultIds($firstSink))
+            ->toBe(4242);
+        Expect::that($second->seed)
+            ->toBe(4242);
+        Expect::that($this->resultIds($firstSink))
             ->because('the same explicit seed MUST reproduce the in-process run order')
             ->toBe($this->resultIds($secondSink));
     }
@@ -90,8 +90,8 @@ final readonly class InProcessRunnerTest
 
             Expect::that($result->plannedTests)
                 ->because('each in-process shard reports the number of tests it executes')
-                ->toBe(\count($ids))
-                ->and($result->summary->total())
+                ->toBe(\count($ids));
+            Expect::that($result->summary->total())
                 ->toBe(\count($ids));
 
             $shardedIds = [...$shardedIds, ...$ids];

--- a/tests/Unit/Runner/Orchestrator/ChannelAllocatorMinimumBoundTest.php
+++ b/tests/Unit/Runner/Orchestrator/ChannelAllocatorMinimumBoundTest.php
@@ -17,8 +17,8 @@ final readonly class ChannelAllocatorMinimumBoundTest
 
         Expect::that($allocator->allocate())
             ->because('a single worker channel MUST be a valid allocation bound')
-            ->toBe(1)
-            ->and(static fn(): int => $allocator->allocate())
+            ->toBe(1);
+        Expect::that(static fn(): int => $allocator->allocate())
             ->toThrow(
                 \LogicException::class,
                 message: 'All 1 worker channels are in use. A worker finished without releasing its channel.',

--- a/tests/Unit/Runner/Orchestrator/ChannelAllocatorTest.php
+++ b/tests/Unit/Runner/Orchestrator/ChannelAllocatorTest.php
@@ -37,10 +37,10 @@ final readonly class ChannelAllocatorTest
     {
         $allocator = new ChannelAllocator(4);
 
-        Expect::that($allocator->allocate())->because('allocates the lowest free channel first')->toBe(1)
-            ->and($allocator->allocate())->toBe(2)
-            ->and($allocator->allocate())->toBe(3)
-            ->and($allocator->allocate())->toBe(4);
+        Expect::that($allocator->allocate())->because('allocates the lowest free channel first')->toBe(1);
+        Expect::that($allocator->allocate())->toBe(2);
+        Expect::that($allocator->allocate())->toBe(3);
+        Expect::that($allocator->allocate())->toBe(4);
     }
 
     #[Test]

--- a/tests/Unit/Runner/Orchestrator/DistributorTest.php
+++ b/tests/Unit/Runner/Orchestrator/DistributorTest.php
@@ -30,24 +30,24 @@ final class DistributorTest
             ->because(
                 'pooled entries stay grouped by class and isolated entries each get a unit',
             )
-            ->toHaveCount(2)
-            ->and((string) $pooled[0]->plan->entries[0]->id)
-            ->toBe('ExampleTest::pooled')
-            ->and((string) $pooled[1]->plan->entries[0]->id)
-            ->toBe('OtherTest::pooled')
-            ->and($isolated)
-            ->toHaveCount(2)
-            ->and($isolated[0]->plan->entries)
-            ->toHaveCount(1)
-            ->and((string) $isolated[0]->plan->entries[0]->id)
-            ->toBe('ExampleTest::isolatedOne')
-            ->and($isolated[0]->plan->seed)
-            ->toBe(42)
-            ->and($isolated[1]->plan->entries)
-            ->toHaveCount(1)
-            ->and((string) $isolated[1]->plan->entries[0]->id)
-            ->toBe('ExampleTest::isolatedTwo')
-            ->and($isolated[1]->plan->seed)
+            ->toHaveCount(2);
+        Expect::that((string) $pooled[0]->plan->entries[0]->id)
+            ->toBe('ExampleTest::pooled');
+        Expect::that((string) $pooled[1]->plan->entries[0]->id)
+            ->toBe('OtherTest::pooled');
+        Expect::that($isolated)
+            ->toHaveCount(2);
+        Expect::that($isolated[0]->plan->entries)
+            ->toHaveCount(1);
+        Expect::that((string) $isolated[0]->plan->entries[0]->id)
+            ->toBe('ExampleTest::isolatedOne');
+        Expect::that($isolated[0]->plan->seed)
+            ->toBe(42);
+        Expect::that($isolated[1]->plan->entries)
+            ->toHaveCount(1);
+        Expect::that((string) $isolated[1]->plan->entries[0]->id)
+            ->toBe('ExampleTest::isolatedTwo');
+        Expect::that($isolated[1]->plan->seed)
             ->toBe(42);
     }
 

--- a/tests/Unit/Runner/Orchestrator/OrchestratorIsolatedRemainderTest.php
+++ b/tests/Unit/Runner/Orchestrator/OrchestratorIsolatedRemainderTest.php
@@ -51,8 +51,8 @@ final class OrchestratorIsolatedRemainderTest
 
         Expect::that($summary)
             ->because('the replacement worker MUST execute the requeued isolated test')
-            ->toEqual(new ResultSummary(passed: 1))
-            ->and($workers)
+            ->toEqual(new ResultSummary(passed: 1));
+        Expect::that($workers)
             ->toBe(['w-2']);
     }
 }

--- a/tests/Unit/Runner/Orchestrator/OrchestratorTest.php
+++ b/tests/Unit/Runner/Orchestrator/OrchestratorTest.php
@@ -109,10 +109,10 @@ final class OrchestratorTest
 
         Expect::that($summary->passed)
             ->because('a legitimate worker MUST complete the plan after an invalid hello token')
-            ->toBe(1)
-            ->and($summary->isSuccessful())->toBeTrue()
-            ->and($results)->toHaveCount(1)
-            ->and((string) $results[0]->id)
+            ->toBe(1);
+        Expect::that($summary->isSuccessful())->toBeTrue();
+        Expect::that($results)->toHaveCount(1);
+        Expect::that((string) $results[0]->id)
             ->toBe(CleanTest::class . '::passesAndIsCollectable');
     }
 
@@ -143,8 +143,8 @@ final class OrchestratorTest
 
         Expect::that($summary->passed)
             ->because('a replacement worker MUST complete the undelivered assignment')
-            ->toBe(1)
-            ->and($workers)
+            ->toBe(1);
+        Expect::that($workers)
             ->because('the disconnected worker MUST NOT start the test class')
             ->toBe(['w-2']);
     }
@@ -435,11 +435,11 @@ final class OrchestratorTest
 
         Expect::that($summary->passed)
             ->because('the worker completes both assignments before it reaches its cumulative test budget')
-            ->toBe(2)
-            ->and($recycled)
+            ->toBe(2);
+        Expect::that($recycled)
             ->because('the cumulative test budget recycles the worker after its second assignment')
-            ->toHaveCount(1)
-            ->and($recycled[0]->reason)
+            ->toHaveCount(1);
+        Expect::that($recycled[0]->reason)
             ->toBe(RecycleReason::TestCount);
     }
 
@@ -460,12 +460,12 @@ final class OrchestratorTest
 
         Expect::that($summary->total())
             ->because('the failure limit MUST stop before the queued class assignment runs')
-            ->toBe(1)
-            ->and($summary->errored)
-            ->toBe(1)
-            ->and($results)
-            ->toHaveCount(1)
-            ->and((string) $results[0]->id)
+            ->toBe(1);
+        Expect::that($summary->errored)
+            ->toBe(1);
+        Expect::that($results)
+            ->toHaveCount(1);
+        Expect::that((string) $results[0]->id)
             ->toBe(AaTest::class . '::fails');
     }
 
@@ -485,10 +485,10 @@ final class OrchestratorTest
 
         Expect::that($summary->errored)
             ->because('a worker crash MUST produce one synthetic error result')
-            ->toBe(1)
-            ->and($results)
-            ->toHaveCount(1)
-            ->and($results[0]->error?->message)
+            ->toBe(1);
+        Expect::that($results)
+            ->toHaveCount(1);
+        Expect::that($results[0]->error?->message)
             ->because('the synthetic error MUST preserve the worker diagnostic output')
             ->toBe(
                 "Worker \"w-1\" crashed during this test: the worker process exited unexpectedly.\n"

--- a/tests/Unit/Runner/Orchestrator/ResourceSchedulerPendingTest.php
+++ b/tests/Unit/Runner/Orchestrator/ResourceSchedulerPendingTest.php
@@ -40,17 +40,17 @@ final class ResourceSchedulerPendingTest
 
         Expect::that($scheduler->pendingCount())
             ->because('clear pending MUST remove both queues')
-            ->toBe(0)
-            ->and($scheduler->dispatch(true)->kind)->toBe(DispatchKind::Drain);
+            ->toBe(0);
+        Expect::that($scheduler->dispatch(true)->kind)->toBe(DispatchKind::Drain);
 
         $scheduler->release($lease);
         $scheduler->requeue($queued);
 
         Expect::that($scheduler->pendingCount())
             ->because('pooled work can be requeued after pending work is cleared')
-            ->toBe(1)
-            ->and($this->assigned($scheduler, fresh: false)->unit)->toBe($queued)
-            ->and($scheduler->pendingCount())->toBe(0);
+            ->toBe(1);
+        Expect::that($this->assigned($scheduler, fresh: false)->unit)->toBe($queued);
+        Expect::that($scheduler->pendingCount())->toBe(0);
     }
 
     /**

--- a/tests/Unit/Runner/Orchestrator/ServerSocketTest.php
+++ b/tests/Unit/Runner/Orchestrator/ServerSocketTest.php
@@ -27,8 +27,8 @@ final class ServerSocketTest
 
             Expect::that($socket->address)
                 ->because('the orchestrator MUST use TCP when its Unix socket cannot open')
-                ->toStartWith('tcp://127.0.0.1:')
-                ->and(\is_resource($socket->stream()))
+                ->toStartWith('tcp://127.0.0.1:');
+            Expect::that(\is_resource($socket->stream()))
                 ->toBeTrue();
         } finally {
             $socket?->close();

--- a/tests/Unit/Runner/Orchestrator/WorkerSpawnBudgetTest.php
+++ b/tests/Unit/Runner/Orchestrator/WorkerSpawnBudgetTest.php
@@ -28,8 +28,8 @@ final readonly class WorkerSpawnBudgetTest
 
         Expect::that($last)
             ->because('the replacement budget permits the final bounded worker')
-            ->toBe('w-25')
-            ->and($budget->nextWorkerId(...))
+            ->toBe('w-25');
+        Expect::that($budget->nextWorkerId(...))
             ->because('the replacement budget MUST stop a worker loop')
             ->toThrow(
                 ProtocolError::class,

--- a/tests/Unit/Runner/ParallelRunnerTest.php
+++ b/tests/Unit/Runner/ParallelRunnerTest.php
@@ -42,8 +42,8 @@ final readonly class ParallelRunnerTest
         Expect::that($subscriber->sequence())
             ->because('the parallel subscriber observes both run boundaries')
             ->toContain('RunStarted')
-            ->toContain('RunFinished')
-            ->and($result->summary->passed)
+            ->toContain('RunFinished');
+        Expect::that($result->summary->passed)
             ->toBe(7);
     }
 }

--- a/tests/Unit/Runner/PlanOrderTest.php
+++ b/tests/Unit/Runner/PlanOrderTest.php
@@ -47,8 +47,8 @@ final class PlanOrderTest
 
         Expect::that($this->classes($ordered))
             ->because('priority inputs MUST preserve each planned test exactly once')
-            ->toBe(['Acme\B', 'Acme\A'])
-            ->and($ordered->count())
+            ->toBe(['Acme\B', 'Acme\A']);
+        Expect::that($ordered->count())
             ->toBe(2);
     }
 

--- a/tests/Unit/Runner/Protocol/ExactFrameLimitTest.php
+++ b/tests/Unit/Runner/Protocol/ExactFrameLimitTest.php
@@ -38,8 +38,8 @@ final class ExactFrameLimitTest
 
         Expect::that($codec->decode($body))
             ->because('the exact-limit frame MUST survive the protocol round trip')
-            ->toBe($envelope)
-            ->and($buffer->hasPendingBytes())
+            ->toBe($envelope);
+        Expect::that($buffer->hasPendingBytes())
             ->toBeFalse();
     }
 
@@ -67,8 +67,8 @@ final class ExactFrameLimitTest
 
         Expect::that(new JsonFrameCodec(self::LIMIT)->decode($decodedBody))
             ->because('frame lengths MUST count Unicode bytes, not characters')
-            ->toBe($envelope)
-            ->and($buffer->hasPendingBytes())
+            ->toBe($envelope);
+        Expect::that($buffer->hasPendingBytes())
             ->toBeFalse();
     }
 }

--- a/tests/Unit/Runner/Protocol/FrameMinimumSizeTest.php
+++ b/tests/Unit/Runner/Protocol/FrameMinimumSizeTest.php
@@ -20,8 +20,8 @@ final readonly class FrameMinimumSizeTest
 
         Expect::that($codec->maxFrameBytes)
             ->because('the protocol MUST support the smallest valid frame')
-            ->toBe(1)
-            ->and($buffer->next())
+            ->toBe(1);
+        Expect::that($buffer->next())
             ->toBe('x');
     }
 }

--- a/tests/Unit/Runner/Protocol/HelloTest.php
+++ b/tests/Unit/Runner/Protocol/HelloTest.php
@@ -21,11 +21,11 @@ final class HelloTest
 
         Expect::that($hello->workerId)
             ->because('a worker introduction MUST retain each non-empty worker ID')
-            ->toBe($workerId)
-            ->and($hello->token)
+            ->toBe($workerId);
+        Expect::that($hello->token)
             ->because('a worker introduction MUST retain each non-empty authentication token')
-            ->toBe($token)
-            ->and($decoded->toWire())
+            ->toBe($token);
+        Expect::that($decoded->toWire())
             ->because('the worker introduction MUST survive the wire')
             ->toBe($hello->toWire());
     }

--- a/tests/Unit/Runner/Protocol/JsonFrameCodecEmptyEnvelopeTest.php
+++ b/tests/Unit/Runner/Protocol/JsonFrameCodecEmptyEnvelopeTest.php
@@ -23,8 +23,8 @@ final readonly class JsonFrameCodecEmptyEnvelopeTest
 
         Expect::that($body)
             ->because('an empty protocol envelope MUST remain a JSON map')
-            ->toBe('{}')
-            ->and($codec->decode($body))
+            ->toBe('{}');
+        Expect::that($codec->decode($body))
             ->because('the frame codec MUST decode its empty encoded envelope')
             ->toBe([]);
     }

--- a/tests/Unit/Runner/Protocol/JsonFrameCodecTest.php
+++ b/tests/Unit/Runner/Protocol/JsonFrameCodecTest.php
@@ -34,15 +34,15 @@ final class JsonFrameCodecTest
 
         Expect::that($length)
             ->because('the frame prefix MUST contain the substituted JSON body length')
-            ->toBe(\strlen($body))
-            ->and($message)
+            ->toBe(\strlen($body));
+        Expect::that($message)
             ->because('the substituted protocol value remains a string')
             ->toBeString();
 
         Expect::that(\preg_match('//u', $message))
             ->because('the protocol value MUST contain valid UTF-8')
-            ->toBe(1)
-            ->and($message)
+            ->toBe(1);
+        Expect::that($message)
             ->because('UTF-8 substitution preserves readable surrounding text')
             ->toStartWith('query failed: ')
             ->toEndWith(' row 1');

--- a/tests/Unit/Runner/Protocol/ProtocolTest.php
+++ b/tests/Unit/Runner/Protocol/ProtocolTest.php
@@ -111,15 +111,15 @@ final class ProtocolTest
             artifactConfiguration: new ArtifactConfiguration(maxRunAttachments: 123),
         )->toWire());
 
-        Expect::that($assign->slice->seed)->because('assign carries the plan intact')->toBe(42)
-            ->and($assign->recycleAfterTests)->toBe(10)
-            ->and($assign->recycleAboveMemoryBytes)->toBeNull()
-            ->and($assign->artifactSession?->stagingDirectory)->toBe('/tmp/staging')
-            ->and($assign->artifactSession?->publicDirectory)->toBe('build/artifacts/run-1')
-            ->and($assign->artifactConfiguration?->maxRunAttachments)->toBe(123)
-            ->and($assign->slice->entries[0]->id->dataSetKey)->toBe('data set one')
-            ->and($assign->slice->entries[0]->metadata->isolated)->toBeTrue()
-            ->and($assign->slice->entries[0]->metadata->resources)->toBe(['postgres']);
+        Expect::that($assign->slice->seed)->because('assign carries the plan intact')->toBe(42);
+        Expect::that($assign->recycleAfterTests)->toBe(10);
+        Expect::that($assign->recycleAboveMemoryBytes)->toBeNull();
+        Expect::that($assign->artifactSession?->stagingDirectory)->toBe('/tmp/staging');
+        Expect::that($assign->artifactSession?->publicDirectory)->toBe('build/artifacts/run-1');
+        Expect::that($assign->artifactConfiguration?->maxRunAttachments)->toBe(123);
+        Expect::that($assign->slice->entries[0]->id->dataSetKey)->toBe('data set one');
+        Expect::that($assign->slice->entries[0]->metadata->isolated)->toBeTrue();
+        Expect::that($assign->slice->entries[0]->metadata->resources)->toBe(['postgres']);
     }
 
     #[Test]
@@ -147,8 +147,8 @@ final class ProtocolTest
 
         Expect::that($assign->artifactSession)
             ->because('legacy assignments have no artifact session')
-            ->toBeNull()
-            ->and($assign->artifactConfiguration)
+            ->toBeNull();
+        Expect::that($assign->artifactConfiguration)
             ->because('legacy assignments have no artifact configuration')
             ->toBeNull();
     }

--- a/tests/Unit/Runner/Protocol/SocketChannelInterruptedReceiveTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelInterruptedReceiveTest.php
@@ -73,20 +73,20 @@ final readonly class SocketChannelInterruptedReceiveTest
 
         Expect::that($received)
             ->because('a signal-interrupted select MUST end the receive attempt')
-            ->toBeNull()
-            ->and($eof)
+            ->toBeNull();
+        Expect::that($eof)
             ->because('an interrupted select MUST not claim that the peer closed')
-            ->toBeFalse()
-            ->and($waited)
+            ->toBeFalse();
+        Expect::that($waited)
             ->because('the signal helper MUST finish before the test exits')
-            ->toBe($childPid)
-            ->and($stopped)
+            ->toBe($childPid);
+        Expect::that($stopped)
             ->because('the signal helper MUST remain active until the receive attempt ends')
-            ->toBeTrue()
-            ->and(\pcntl_wifsignaled($status))
+            ->toBeTrue();
+        Expect::that(\pcntl_wifsignaled($status))
             ->because('the test MUST stop the signal helper after the receive attempt ends')
-            ->toBeTrue()
-            ->and(\pcntl_wtermsig($status))
+            ->toBeTrue();
+        Expect::that(\pcntl_wtermsig($status))
             ->toBe(\SIGTERM);
     }
 }

--- a/tests/Unit/Runner/Protocol/SocketChannelTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelTest.php
@@ -26,8 +26,8 @@ final class SocketChannelTest
         try {
             Expect::that($receiver->receive(0.0))
                 ->because('an empty receive can reach its deadline')
-                ->toBeNull()
-                ->and($receiver->isEof())
+                ->toBeNull();
+            Expect::that($receiver->isEof())
                 ->because('a receive deadline MUST NOT mark an open channel as EOF')
                 ->toBeFalse();
 
@@ -55,11 +55,11 @@ final class SocketChannelTest
 
             Expect::that($receiver->poll())
                 ->because('a complete final frame MUST be delivered before peer EOF')
-                ->toBeInstanceOf(Drain::class)
-                ->and($receiver->poll())
+                ->toBeInstanceOf(Drain::class);
+            Expect::that($receiver->poll())
                 ->because('the channel reaches clean EOF after the final frame')
-                ->toBeNull()
-                ->and($receiver->isEof())
+                ->toBeNull();
+            Expect::that($receiver->isEof())
                 ->toBeTrue();
         } finally {
             $sender->close();
@@ -114,10 +114,10 @@ final class SocketChannelTest
 
             Expect::that($channel->poll())
                 ->because('polling an externally closed stream reaches EOF')
-                ->toBeNull()
-                ->and($channel->isEof())
-                ->toBeTrue()
-                ->and($channel->poll())
+                ->toBeNull();
+            Expect::that($channel->isEof())
+                ->toBeTrue();
+            Expect::that($channel->poll())
                 ->toBeNull();
 
             Expect::that(static function () use ($channel): void {
@@ -150,8 +150,8 @@ final class SocketChannelTest
         try {
             Expect::that($channel->receive(1.0))
                 ->because('a stream-select failure MUST end the receive wait')
-                ->toBeNull()
-                ->and($channel->isEof())
+                ->toBeNull();
+            Expect::that($channel->isEof())
                 ->because('a stream-select failure MUST NOT mark the channel as EOF')
                 ->toBeFalse();
         } finally {

--- a/tests/Unit/Runner/Protocol/WorkerMessageWireTest.php
+++ b/tests/Unit/Runner/Protocol/WorkerMessageWireTest.php
@@ -76,12 +76,12 @@ final class WorkerMessageWireTest
 
         Expect::that($withoutRecycle->peakMemoryBytes)
             ->because('decoded peak memory MUST NOT be negative')
-            ->toBe(0)
-            ->and($withoutRecycle->wantsRecycle)->toBeNull();
+            ->toBe(0);
+        Expect::that($withoutRecycle->wantsRecycle)->toBeNull();
         Expect::that($withRecycle->peakMemoryBytes)
             ->because('valid Done fields MUST survive decoding')
-            ->toBe(2048)
-            ->and($withRecycle->wantsRecycle)->toBe(RecycleReason::TestCount);
+            ->toBe(2048);
+        Expect::that($withRecycle->wantsRecycle)->toBe(RecycleReason::TestCount);
     }
 
     #[Test]

--- a/tests/Unit/Runner/SelectionFilterTest.php
+++ b/tests/Unit/Runner/SelectionFilterTest.php
@@ -24,54 +24,54 @@ final class SelectionFilterTest
             '/project/tests/FastTest.php',
         ))
             ->because('a test that satisfies every configured selection dimension MUST be accepted')
-            ->toBeTrue()
-            ->and($filter->accepts(
-                'Acme\FastTest',
-                'works',
-                ['slow'],
-                '/project/tests/FastTest.php',
-            ))
+            ->toBeTrue();
+        Expect::that($filter->accepts(
+            'Acme\FastTest',
+            'works',
+            ['slow'],
+            '/project/tests/FastTest.php',
+        ))
             ->because('the configured include group MUST restrict selection')
-            ->toBeFalse()
-            ->and($filter->accepts(
-                'Acme\FastTest',
-                'works',
-                ['fast', 'quarantined'],
-                '/project/tests/FastTest.php',
-            ))
+            ->toBeFalse();
+        Expect::that($filter->accepts(
+            'Acme\FastTest',
+            'works',
+            ['fast', 'quarantined'],
+            '/project/tests/FastTest.php',
+        ))
             ->because('the configured exclude group MUST override the include group')
-            ->toBeFalse()
-            ->and($filter->accepts(
-                'Acme\LegacyTest',
-                'works',
-                ['fast'],
-                '/project/tests/LegacyTest.php',
-            ))
+            ->toBeFalse();
+        Expect::that($filter->accepts(
+            'Acme\LegacyTest',
+            'works',
+            ['fast'],
+            '/project/tests/LegacyTest.php',
+        ))
             ->because('the configured class exclusion MUST restrict selection')
-            ->toBeFalse()
-            ->and($filter->accepts(
-                'Acme\FastTest',
-                'manualCheck',
-                ['fast'],
-                '/project/tests/FastTest.php',
-            ))
+            ->toBeFalse();
+        Expect::that($filter->accepts(
+            'Acme\FastTest',
+            'manualCheck',
+            ['fast'],
+            '/project/tests/FastTest.php',
+        ))
             ->because('the configured method exclusion MUST restrict selection')
-            ->toBeFalse()
-            ->and($filter->accepts(
-                'Acme\FastTest',
-                'works',
-                ['fast'],
-                '/vendor/tests/FastTest.php',
-            ))
+            ->toBeFalse();
+        Expect::that($filter->accepts(
+            'Acme\FastTest',
+            'works',
+            ['fast'],
+            '/vendor/tests/FastTest.php',
+        ))
             ->because('the configured path exclusion MUST restrict selection')
-            ->toBeFalse()
-            ->and($filter->acceptsId('Acme\FastTest::worksNow'))
+            ->toBeFalse();
+        Expect::that($filter->acceptsId('Acme\FastTest::worksNow'))
             ->because('the configured test ID pattern MUST select matching IDs')
-            ->toBeTrue()
-            ->and($filter->acceptsId('Acme\ExactTest::only'))
+            ->toBeTrue();
+        Expect::that($filter->acceptsId('Acme\ExactTest::only'))
             ->because('the configured exact test ID MUST select that complete ID')
-            ->toBeTrue()
-            ->and($filter->acceptsId('Acme\FastTest::other'))
+            ->toBeTrue();
+        Expect::that($filter->acceptsId('Acme\FastTest::other'))
             ->because('configured test IDs MUST reject an ID that matches neither form')
             ->toBeFalse();
     }

--- a/tests/Unit/Runner/SubprocessCoverageTest.php
+++ b/tests/Unit/Runner/SubprocessCoverageTest.php
@@ -37,16 +37,16 @@ final readonly class SubprocessCoverageTest
 
             $directory = \getenv(SubprocessCoverage::DIRECTORY_ENV);
 
-            Expect::that(\is_string($directory) && $directory !== '/outer/dir')->toBeTrue()
-                ->and(\is_string($directory) && \is_dir($directory))->toBeTrue()
-                ->and(\getenv(SubprocessCoverage::INCLUDE_ENV))->toBe('/project/src' . \PATH_SEPARATOR . '/project/lib')
-                ->and(SubprocessCoverage::requested())->toBeTrue();
+            Expect::that(\is_string($directory) && $directory !== '/outer/dir')->toBeTrue();
+            Expect::that(\is_string($directory) && \is_dir($directory))->toBeTrue();
+            Expect::that(\getenv(SubprocessCoverage::INCLUDE_ENV))->toBe('/project/src' . \PATH_SEPARATOR . '/project/lib');
+            Expect::that(SubprocessCoverage::requested())->toBeTrue();
 
             Expect::that($shared->drain())->toBeNull();
 
-            Expect::that(\getenv(SubprocessCoverage::DIRECTORY_ENV))->toBe('/outer/dir')
-                ->and(\getenv(SubprocessCoverage::INCLUDE_ENV))->toBeFalse()
-                ->and(\is_string($directory) && \is_dir($directory))->toBeFalse();
+            Expect::that(\getenv(SubprocessCoverage::DIRECTORY_ENV))->toBe('/outer/dir');
+            Expect::that(\getenv(SubprocessCoverage::INCLUDE_ENV))->toBeFalse();
+            Expect::that(\is_string($directory) && \is_dir($directory))->toBeFalse();
         } finally {
             $sandbox->dispose();
         }
@@ -105,11 +105,11 @@ final readonly class SubprocessCoverageTest
 
         Expect::that($result->exitCode)
             ->because('coverage setup MUST fail before it exports a nonexistent relay directory')
-            ->toBe(0)
-            ->and($result->stdout)
+            ->toBe(0);
+        Expect::that($result->stdout)
             ->because('the child MUST emit success only after the exact coverage error matches')
-            ->toBe('matched')
-            ->and($result->stderr)
+            ->toBe('matched');
+        Expect::that($result->stderr)
             ->toBe('');
     }
 
@@ -147,11 +147,11 @@ final readonly class SubprocessCoverageTest
 
             $files = $merged->files();
 
-            Expect::that(\array_keys($files))->toBe(['/app/a.php', '/app/b.php'])
-                ->and($files['/app/a.php']->coveredLines)->toBe([1, 2, 3])
-                ->and($files['/app/a.php']->uncoveredLines)->toBe([])
-                ->and($files['/app/b.php']->coveredLines)->toBe([7])
-                ->and(\is_dir($directory))->toBeFalse();
+            Expect::that(\array_keys($files))->toBe(['/app/a.php', '/app/b.php']);
+            Expect::that($files['/app/a.php']->coveredLines)->toBe([1, 2, 3]);
+            Expect::that($files['/app/a.php']->uncoveredLines)->toBe([]);
+            Expect::that($files['/app/b.php']->coveredLines)->toBe([7]);
+            Expect::that(\is_dir($directory))->toBeFalse();
         } finally {
             $sandbox->dispose();
         }
@@ -180,17 +180,17 @@ final readonly class SubprocessCoverageTest
 
             Expect::that($shared->drain())
                 ->because('drain skips unreadable coverage dumps')
-                ->toBeNull()
-                ->and(\is_link($unreadable))
+                ->toBeNull();
+            Expect::that(\is_link($unreadable))
                 ->because('drain removes unreadable coverage dumps')
-                ->toBeFalse()
-                ->and(\is_dir($directory))
+                ->toBeFalse();
+            Expect::that(\is_dir($directory))
                 ->because('drain removes the empty relay directory')
-                ->toBeFalse()
-                ->and(\getenv(SubprocessCoverage::DIRECTORY_ENV))
+                ->toBeFalse();
+            Expect::that(\getenv(SubprocessCoverage::DIRECTORY_ENV))
                 ->because('drain restores the previous relay directory')
-                ->toBe('/outer/dir')
-                ->and(\getenv(SubprocessCoverage::INCLUDE_ENV))
+                ->toBe('/outer/dir');
+            Expect::that(\getenv(SubprocessCoverage::INCLUDE_ENV))
                 ->because('drain restores an unset include-path variable')
                 ->toBeFalse();
         } finally {
@@ -205,8 +205,8 @@ final readonly class SubprocessCoverageTest
         $sandbox->unset(SubprocessCoverage::DIRECTORY_ENV);
 
         try {
-            Expect::that(SubprocessCoverage::requested())->toBeFalse()
-                ->and(SubprocessCoverage::begin())->toBeNull();
+            Expect::that(SubprocessCoverage::requested())->toBeFalse();
+            Expect::that(SubprocessCoverage::begin())->toBeNull();
         } finally {
             $sandbox->dispose();
         }
@@ -227,8 +227,8 @@ final readonly class SubprocessCoverageTest
 
             Expect::that(SubprocessCoverage::requested())
                 ->because('a non-empty falsey directory MUST request subprocess coverage')
-                ->toBeTrue()
-                ->and(RecordingFakeDriver::started())
+                ->toBeTrue();
+            Expect::that(RecordingFakeDriver::started())
                 ->because('a non-empty falsey directory MUST start the selected coverage driver')
                 ->toBeTrue();
 
@@ -282,10 +282,10 @@ final readonly class SubprocessCoverageTest
 
             Expect::that(\array_keys($files))
                 ->because('empty include segments are ignored and the configured path filters the dump')
-                ->toBe(['/project/src/Included.php'])
-                ->and($files['/project/src/Included.php']->coveredLines)
-                ->toBe([10])
-                ->and($files['/project/src/Included.php']->uncoveredLines)
+                ->toBe(['/project/src/Included.php']);
+            Expect::that($files['/project/src/Included.php']->coveredLines)
+                ->toBe([10]);
+            Expect::that($files['/project/src/Included.php']->uncoveredLines)
                 ->toBe([11]);
         } finally {
             $sandbox->dispose();
@@ -311,8 +311,8 @@ final readonly class SubprocessCoverageTest
 
             Expect::that(RecordingFakeDriver::started())
                 ->because('a failed relay write MUST still stop the coverage driver')
-                ->toBeFalse()
-                ->and(\file_exists($directory))
+                ->toBeFalse();
+            Expect::that(\file_exists($directory))
                 ->because('a failed relay write MUST NOT create an incomplete relay directory')
                 ->toBeFalse();
         } finally {
@@ -356,8 +356,8 @@ final readonly class SubprocessCoverageTest
         try {
             Expect::that(SubprocessCoverage::begin(new DriverSelector([UnavailableFakeDriver::class])))
                 ->because('a missing coverage driver does not fail a subprocess run')
-                ->toBeNull()
-                ->and(\glob($directory . '/*.json'))
+                ->toBeNull();
+            Expect::that(\glob($directory . '/*.json'))
                 ->toBe([]);
         } finally {
             $sandbox->dispose();
@@ -377,8 +377,8 @@ final readonly class SubprocessCoverageTest
 
             Expect::that(\getenv(SubprocessCoverage::DIRECTORY_ENV))
                 ->because('drain MUST restore falsey relay values exactly')
-                ->toBe('0')
-                ->and(\getenv(SubprocessCoverage::INCLUDE_ENV))
+                ->toBe('0');
+            Expect::that(\getenv(SubprocessCoverage::INCLUDE_ENV))
                 ->toBe('0');
         } finally {
             $sandbox->dispose();

--- a/tests/Unit/Runner/Worker/ClassContextTest.php
+++ b/tests/Unit/Runner/Worker/ClassContextTest.php
@@ -67,11 +67,11 @@ final class ClassContextTest
 
         Expect::that($first)
             ->because('the class context MUST return the first cached data row')
-            ->toBe(['alpha'])
-            ->and($second)
+            ->toBe(['alpha']);
+        Expect::that($second)
             ->because('the class context MUST return another row from the same cache')
-            ->toBe(['beta'])
-            ->and(CachedDataSetProbe::$providerCalls)
+            ->toBe(['beta']);
+        Expect::that(CachedDataSetProbe::$providerCalls)
             ->because('the class context MUST evaluate its data provider only once')
             ->toBe(1);
     }

--- a/tests/Unit/Runner/Worker/LeakDetectorTest.php
+++ b/tests/Unit/Runner/Worker/LeakDetectorTest.php
@@ -19,8 +19,8 @@ final class LeakDetectorTest
             ->toBe(
                 'Warning: Xdebug develop mode keeps caught exceptions in memory. Thus, leak detection reports '
                 . 'false positives. Rerun with XDEBUG_MODE=off to get correct results.',
-            )
-            ->and(LeakDetector::environmentWarning(['coverage']))
+            );
+        Expect::that(LeakDetector::environmentWarning(['coverage']))
             ->because('Xdebug modes without develop MUST NOT warn about leak detection')
             ->toBeNull();
     }
@@ -40,8 +40,8 @@ final class LeakDetectorTest
 
         Expect::that($detector->sweep())
             ->because('a sweep MUST report only instances that remain alive')
-            ->toBe([$retainedId])
-            ->and($detector->sweep())
+            ->toBe([$retainedId]);
+        Expect::that($detector->sweep())
             ->because('a leak MUST be reported one time')
             ->toBe([]);
     }

--- a/tests/Unit/Runner/Worker/LeakDetectorWhitespaceIniModeTest.php
+++ b/tests/Unit/Runner/Worker/LeakDetectorWhitespaceIniModeTest.php
@@ -39,10 +39,10 @@ final readonly class LeakDetectorWhitespaceIniModeTest
 
         Expect::that($result->exitCode)
             ->because('the fallback process MUST accept comma-separated Xdebug modes')
-            ->toBe(0)
-            ->and($result->stderr)
-            ->toBe('')
-            ->and($result->stdout)
+            ->toBe(0);
+        Expect::that($result->stderr)
+            ->toBe('');
+        Expect::that($result->stdout)
             ->because('the fallback MUST detect develop mode after separator whitespace')
             ->toBe(
                 'Warning: Xdebug develop mode keeps caught exceptions in memory. Thus, leak detection reports '

--- a/tests/Unit/Runner/Worker/RetryDeciderAttachmentTest.php
+++ b/tests/Unit/Runner/Worker/RetryDeciderAttachmentTest.php
@@ -61,13 +61,13 @@ final readonly class RetryDeciderAttachmentTest
 
             Expect::that($decider->results)
                 ->because('a retry decider MUST receive the unsuccessful attempt result')
-                ->toHaveCount(1)
-                ->and($decider->results[0]->attachments)
+                ->toHaveCount(1);
+            Expect::that($decider->results[0]->attachments)
                 ->because('a retry decider MUST receive attachment metadata before it decides')
-                ->toHaveCount(1)
-                ->and($decider->results[0]->attachments[0]->name)
-                ->toBe('failure.txt')
-                ->and($decider->results[0]->attachments[0]->sizeBytes)
+                ->toHaveCount(1);
+            Expect::that($decider->results[0]->attachments[0]->name)
+                ->toBe('failure.txt');
+            Expect::that($decider->results[0]->attachments[0]->sizeBytes)
                 ->toBe(14);
         } finally {
             $store->cleanup();

--- a/tests/Unit/Runner/Worker/WorkerArtifactSessionTest.php
+++ b/tests/Unit/Runner/Worker/WorkerArtifactSessionTest.php
@@ -141,8 +141,8 @@ final readonly class WorkerArtifactSessionTest
 
         Expect::that($workerExit)
             ->because('a worker with artifact settings MUST complete its assignment')
-            ->toBe(0)
-            ->and($serverExit)
+            ->toBe(0);
+        Expect::that($serverExit)
             ->because('the worker MUST stage evidence in the assigned artifact session')
             ->toBe(0);
     }

--- a/tests/Unit/Runner/Worker/WorkerBudgetTest.php
+++ b/tests/Unit/Runner/Worker/WorkerBudgetTest.php
@@ -19,14 +19,14 @@ final readonly class WorkerBudgetTest
 
         Expect::that($disabled->exhaustedByCount(\PHP_INT_MAX))
             ->because('an unset test-count budget MUST remain disabled')
-            ->toBeFalse()
-            ->and($limited->exhaustedByCount(2))
+            ->toBeFalse();
+        Expect::that($limited->exhaustedByCount(2))
             ->because('the worker MUST continue below its test-count budget')
-            ->toBeFalse()
-            ->and($limited->exhaustedByCount(3))
+            ->toBeFalse();
+        Expect::that($limited->exhaustedByCount(3))
             ->because('the worker MUST recycle when it reaches its test-count budget')
-            ->toBeTrue()
-            ->and($limited->exhaustedByCount(4))
+            ->toBeTrue();
+        Expect::that($limited->exhaustedByCount(4))
             ->because('the test-count budget MUST remain exhausted above its boundary')
             ->toBeTrue();
     }

--- a/tests/Unit/Runner/Worker/WorkerProcessFatalSendFailureTest.php
+++ b/tests/Unit/Runner/Worker/WorkerProcessFatalSendFailureTest.php
@@ -154,8 +154,8 @@ final class WorkerProcessFatalSendFailureTest
 
             Expect::that($workerExit)
                 ->because('a failed final report MUST not escape the worker process')
-                ->toBe(1)
-                ->and($serverResult->exitCode)
+                ->toBe(1);
+            Expect::that($serverResult->exitCode)
                 ->because('the protocol fixture MUST reset the channel before it releases the assignment failure')
                 ->toBe(0);
         } finally {

--- a/tests/Unit/Runner/Worker/WorkerProcessTest.php
+++ b/tests/Unit/Runner/Worker/WorkerProcessTest.php
@@ -39,8 +39,8 @@ final class WorkerProcessTest
 
         Expect::that($result->exitCode)
             ->because('a worker connection failure MUST fail startup')
-            ->toBe(1)
-            ->and($result->stderr)
+            ->toBe(1);
+        Expect::that($result->stderr)
             ->toContain('The worker did not connect to ' . $address . ':');
     }
 
@@ -109,11 +109,11 @@ final class WorkerProcessTest
 
             Expect::that($workerExit)
                 ->because('an assignment setup failure MUST stop the worker abnormally')
-                ->toBe(1)
-                ->and($serverResult->exitCode)
+                ->toBe(1);
+            Expect::that($serverResult->exitCode)
                 ->because('the orchestrator fixture MUST receive the worker fatal message')
-                ->toBe(0)
-                ->and($serverResult->stdout)
+                ->toBe(0);
+            Expect::that($serverResult->stdout)
                 ->toContain("Greenlight\\Config\\ConfigFileError\n")
                 ->toContain('Configuration file "' . $missingConfig . '" does not exist.');
         } finally {
@@ -127,8 +127,8 @@ final class WorkerProcessTest
     {
         [$workerExit, $serverExit] = $this->runScenario('idle-then-drain');
 
-        Expect::that($workerExit)->toBe(0)
-            ->and($serverExit)->toBe(0);
+        Expect::that($workerExit)->toBe(0);
+        Expect::that($serverExit)->toBe(0);
     }
 
     #[Test]
@@ -139,8 +139,8 @@ final class WorkerProcessTest
 
         Expect::that($workerExit)
             ->because('an empty assignment MUST complete and leave the worker available to drain')
-            ->toBe(0)
-            ->and($serverExit)
+            ->toBe(0);
+        Expect::that($serverExit)
             ->because('the protocol fixture MUST receive the empty completion before it drains the worker')
             ->toBe(0);
     }
@@ -153,8 +153,8 @@ final class WorkerProcessTest
 
         Expect::that($workerExit)
             ->because('a worker above its memory threshold MUST exit cleanly')
-            ->toBe(0)
-            ->and($serverExit)
+            ->toBe(0);
+        Expect::that($serverExit)
             ->because('the protocol fixture MUST receive the memory recycle request')
             ->toBe(0);
     }
@@ -167,8 +167,8 @@ final class WorkerProcessTest
 
         Expect::that($workerExit)
             ->because('a worker that reaches its test-count budget MUST exit cleanly')
-            ->toBe(0)
-            ->and($serverExit)
+            ->toBe(0);
+        Expect::that($serverExit)
             ->because('the protocol fixture MUST receive the completed result and recycle reason')
             ->toBe(0);
     }
@@ -181,8 +181,8 @@ final class WorkerProcessTest
 
         Expect::that($workerExit)
             ->because('a worker that reaches its cumulative test-count budget MUST exit cleanly')
-            ->toBe(0)
-            ->and($serverExit)
+            ->toBe(0);
+        Expect::that($serverExit)
             ->because('the protocol fixture MUST receive both completions before recycling')
             ->toBe(0);
     }
@@ -196,8 +196,8 @@ final class WorkerProcessTest
 
         Expect::that($workerExit)
             ->because('a control-channel ending MUST stop the worker cleanly')
-            ->toBe(0)
-            ->and($serverExit)
+            ->toBe(0);
+        Expect::that($serverExit)
             ->toBe(0);
     }
 

--- a/tests/Unit/Runner/WorkerTest.php
+++ b/tests/Unit/Runner/WorkerTest.php
@@ -46,8 +46,8 @@ final class WorkerTest
         [, $results] = $this->runFixture('Order');
 
         Expect::that(TraceLog::drain())->because('lifecycle runs in the frozen order')
-            ->toBe(['construct', 'before1', 'before2', 'test', 'after2', 'after1'])
-            ->and($results[0]->outcome)->toBe(Outcome::Passed);
+            ->toBe(['construct', 'before1', 'before2', 'test', 'after2', 'after1']);
+        Expect::that($results[0]->outcome)->toBe(Outcome::Passed);
     }
 
     #[Test]
@@ -56,9 +56,9 @@ final class WorkerTest
         TraceLog::drain();
         [, $results] = $this->runFixture('BeforeFails');
 
-        Expect::that(TraceLog::drain())->because('failing before hook skips the method but runs after hooks')->toBe(['before', 'after'])
-            ->and($results[0]->outcome)->toBe(Outcome::Errored)
-            ->and($results[0]->error?->message)->toBe('before broke');
+        Expect::that(TraceLog::drain())->because('failing before hook skips the method but runs after hooks')->toBe(['before', 'after']);
+        Expect::that($results[0]->outcome)->toBe(Outcome::Errored);
+        Expect::that($results[0]->error?->message)->toBe('before broke');
     }
 
     #[Test]
@@ -66,8 +66,8 @@ final class WorkerTest
     {
         [, $results] = $this->runFixture('AfterFails');
 
-        Expect::that($results[0]->outcome)->because('throwing after hook errors a passing test')->toBe(Outcome::Errored)
-            ->and($results[0]->error?->message)->toBe('after broke');
+        Expect::that($results[0]->outcome)->because('throwing after hook errors a passing test')->toBe(Outcome::Errored);
+        Expect::that($results[0]->error?->message)->toBe('after broke');
     }
 
     #[Test]
@@ -78,10 +78,10 @@ final class WorkerTest
 
         Expect::that(TraceLog::drain())
             ->because('later cleanup MUST run after an earlier after-hook throws')
-            ->toBe(['test', 'failing cleanup', 'final cleanup'])
-            ->and($results[0]->outcome)
-            ->toBe(Outcome::Errored)
-            ->and($results[0]->error?->message)
+            ->toBe(['test', 'failing cleanup', 'final cleanup']);
+        Expect::that($results[0]->outcome)
+            ->toBe(Outcome::Errored);
+        Expect::that($results[0]->error?->message)
             ->because('the first teardown error MUST remain primary')
             ->toBe('after broke');
     }
@@ -92,8 +92,8 @@ final class WorkerTest
         RetriesTest::$attempts = 0;
         [, $results] = $this->runFixture('Retries');
 
-        Expect::that($results[0]->outcome)->because('retries until passing and records attempts')->toBe(Outcome::Passed)
-            ->and($results[0]->attempts)->toBe(3);
+        Expect::that($results[0]->outcome)->because('retries until passing and records attempts')->toBe(Outcome::Passed);
+        Expect::that($results[0]->attempts)->toBe(3);
     }
 
     #[Test]
@@ -102,9 +102,9 @@ final class WorkerTest
         RetryFilterTest::$attempts = 0;
         [, $results] = $this->runFixture('RetryFilter');
 
-        Expect::that($results[0]->outcome)->because('retry only on does not retry other throwables')->toBe(Outcome::Errored)
-            ->and($results[0]->attempts)->toBe(1)
-            ->and(RetryFilterTest::$attempts)->toBe(1);
+        Expect::that($results[0]->outcome)->because('retry only on does not retry other throwables')->toBe(Outcome::Errored);
+        Expect::that($results[0]->attempts)->toBe(1);
+        Expect::that(RetryFilterTest::$attempts)->toBe(1);
     }
 
     #[Test]
@@ -113,9 +113,9 @@ final class WorkerTest
         TemporalRetryTest::$attempts = 0;
         [, $results] = $this->runFixture('TemporalRetry');
 
-        Expect::that($results[0]->outcome)->because('temporal expectations receive a fresh deadline on retry')->toBe(Outcome::Passed)
-            ->and($results[0]->attempts)->toBe(2)
-            ->and($results[0]->expectations)->toBe(1);
+        Expect::that($results[0]->outcome)->because('temporal expectations receive a fresh deadline on retry')->toBe(Outcome::Passed);
+        Expect::that($results[0]->attempts)->toBe(2);
+        Expect::that($results[0]->expectations)->toBe(1);
     }
 
     #[Test]
@@ -123,8 +123,8 @@ final class WorkerTest
     {
         [, $results] = $this->runFixture('SlowTimeout');
 
-        Expect::that($results[0]->outcome)->because('timeout fails a slow test after the fact')->toBe(Outcome::Failed)
-            ->and($results[0]->failures[0]->message)->toContain('configured time limit');
+        Expect::that($results[0]->outcome)->because('timeout fails a slow test after the fact')->toBe(Outcome::Failed);
+        Expect::that($results[0]->failures[0]->message)->toContain('configured time limit');
     }
 
     #[Test]
@@ -132,8 +132,8 @@ final class WorkerTest
     {
         [$summary, $results] = $this->runFixture('RuntimeSkip');
 
-        Expect::that($summary->skipped)->because('runtime skip signal reports skipped with the reason')->toBe(1)
-            ->and($results[0]->skipReason)->toBe('the fixture backend is unreachable');
+        Expect::that($summary->skipped)->because('runtime skip signal reports skipped with the reason')->toBe(1);
+        Expect::that($results[0]->skipReason)->toBe('the fixture backend is unreachable');
     }
 
     #[Test]
@@ -148,11 +148,11 @@ final class WorkerTest
             $byMethod[$result->id->method] = $result;
         }
 
-        Expect::that($summary->skipped)->because('skips run nothing and conditions are evaluated')->toBe(2)
-            ->and($summary->passed)->toBe(1)
-            ->and($byMethod['skippedUnconditionally']->skipReason)->toBe('not today')
-            ->and($byMethod['skippedByCondition']->skipReason)->toContain('NeverCondition')
-            ->and(TraceLog::drain())->toBe(['construct', 'satisfied']);
+        Expect::that($summary->skipped)->because('skips run nothing and conditions are evaluated')->toBe(2);
+        Expect::that($summary->passed)->toBe(1);
+        Expect::that($byMethod['skippedUnconditionally']->skipReason)->toBe('not today');
+        Expect::that($byMethod['skippedByCondition']->skipReason)->toContain('NeverCondition');
+        Expect::that(TraceLog::drain())->toBe(['construct', 'satisfied']);
     }
 
     #[Test]
@@ -168,8 +168,8 @@ final class WorkerTest
     {
         [, $results] = $this->runFixture('UnknownDep');
 
-        Expect::that($results[0]->outcome)->because('unknown constructor dependencies error the test naming the type')->toBe(Outcome::Errored)
-            ->and($results[0]->error?->message)->toContain('SplStack');
+        Expect::that($results[0]->outcome)->because('unknown constructor dependencies error the test naming the type')->toBe(Outcome::Errored);
+        Expect::that($results[0]->error?->message)->toContain('SplStack');
     }
 
     #[Test]
@@ -187,8 +187,8 @@ final class WorkerTest
 
         Expect::that($result->outcome)
             ->because('optional built-in constructor parameters use their defaults')
-            ->toBe(Outcome::Passed)
-            ->and($result->expectations)
+            ->toBe(Outcome::Passed);
+        Expect::that($result->expectations)
             ->toBe(1);
     }
 
@@ -207,8 +207,8 @@ final class WorkerTest
 
         Expect::that($result->outcome)
             ->because('unsupported constructor parameters error the test with guidance')
-            ->toBe(Outcome::Errored)
-            ->and($result->error?->message)
+            ->toBe(Outcome::Errored);
+        Expect::that($result->error?->message)
             ->toBe(\sprintf(
                 'Constructor parameter $value of "%s" has no resolvable type. '
                 . 'A test constructor can declare only harness service types.',
@@ -230,12 +230,12 @@ final class WorkerTest
 
         Expect::that($outcome->summary->errored)
             ->because('an unloadable plan class MUST become a contained test error')
-            ->toBe(1)
-            ->and($result->outcome)
-            ->toBe(Outcome::Errored)
-            ->and($result->error?->message)
-            ->toBe('This process cannot load test class "Missing\ExampleTest" from the execution plan.')
-            ->and($sink->sequence())
+            ->toBe(1);
+        Expect::that($result->outcome)
+            ->toBe(Outcome::Errored);
+        Expect::that($result->error?->message)
+            ->toBe('This process cannot load test class "Missing\ExampleTest" from the execution plan.');
+        Expect::that($sink->sequence())
             ->toBe([
                 'TestClassStarted',
                 'TestStarted',
@@ -254,10 +254,10 @@ final class WorkerTest
             static fn(TestResult $result): bool => $result->outcome === Outcome::Errored,
         ));
 
-        Expect::that($summary->total())->because('data set arguments reach the method per key')->toBe(3)
-            ->and($summary->passed)->toBe(2)
-            ->and(\count($failed))->toBe(1)
-            ->and($failed[0]->id->dataSetKey)->toBe('broken row');
+        Expect::that($summary->total())->because('data set arguments reach the method per key')->toBe(3);
+        Expect::that($summary->passed)->toBe(2);
+        Expect::that(\count($failed))->toBe(1);
+        Expect::that($failed[0]->id->dataSetKey)->toBe('broken row');
     }
 
     #[Test]
@@ -265,8 +265,8 @@ final class WorkerTest
     {
         [$summary] = $this->runFixture('ExternalDataSets');
 
-        Expect::that($summary->total())->because('data set providers can be declared on another class')->toBe(2)
-            ->and($summary->passed)->toBe(2);
+        Expect::that($summary->total())->because('data set providers can be declared on another class')->toBe(2);
+        Expect::that($summary->passed)->toBe(2);
     }
 
     #[Test]
@@ -317,9 +317,9 @@ final class WorkerTest
 
         [, $results] = $this->runFixture('DisposeFails', $registry);
 
-        Expect::that($results[0]->outcome)->because('class scope teardown failure is attributed to the last test')->toBe(Outcome::Passed)
-            ->and($results[1]->outcome)->toBe(Outcome::Errored)
-            ->and($results[1]->error?->message)->toBe('disposal broke');
+        Expect::that($results[0]->outcome)->because('class scope teardown failure is attributed to the last test')->toBe(Outcome::Passed);
+        Expect::that($results[1]->outcome)->toBe(Outcome::Errored);
+        Expect::that($results[1]->error?->message)->toBe('disposal broke');
     }
 
     #[Test]
@@ -336,8 +336,8 @@ final class WorkerTest
 
         Expect::that($results[0]->outcome)
             ->because('a per-test teardown failure is attributed to the current test')
-            ->toBe(Outcome::Errored)
-            ->and($results[0]->error?->message)
+            ->toBe(Outcome::Errored);
+        Expect::that($results[0]->error?->message)
             ->toBe('per-test disposal broke');
     }
 
@@ -353,9 +353,9 @@ final class WorkerTest
 
         [, $results] = $this->runFixture('VerifyOnDispose', $registry);
 
-        Expect::that($results[0]->outcome)->because('disposal expectation failures fail the test with diffs')->toBe(Outcome::Failed)
-            ->and($results[0]->error)->toBeNull()
-            ->and($results[0]->failures[0]->message)->toContain('2');
+        Expect::that($results[0]->outcome)->because('disposal expectation failures fail the test with diffs')->toBe(Outcome::Failed);
+        Expect::that($results[0]->error)->toBeNull();
+        Expect::that($results[0]->failures[0]->message)->toContain('2');
     }
 
     #[Test]
@@ -363,8 +363,8 @@ final class WorkerTest
     {
         [$summary] = $this->runFixture('Bail', stopAfterFailures: 1);
 
-        Expect::that($summary->total())->because('bail stops the run after the threshold')->toBe(1)
-            ->and($summary->errored)->toBe(1);
+        Expect::that($summary->total())->because('bail stops the run after the threshold')->toBe(1);
+        Expect::that($summary->errored)->toBe(1);
     }
 
     #[Test]
@@ -381,10 +381,10 @@ final class WorkerTest
         $noisy = $byMethod['echoesAndFails'];
         $optedOut = $byMethod['optsOutOfCapture'];
 
-        Expect::that($noisy->outcome)->because('output is captured per test and attached to the result')->toBe(Outcome::Errored)
-            ->and($noisy->output?->stdout)->toContain('noisy diagnostic output')
-            ->and($noisy->output?->diagnostics[0]->message)->toContain('old api')
-            ->and($optedOut->output)->toBeNull();
+        Expect::that($noisy->outcome)->because('output is captured per test and attached to the result')->toBe(Outcome::Errored);
+        Expect::that($noisy->output?->stdout)->toContain('noisy diagnostic output');
+        Expect::that($noisy->output?->diagnostics[0]->message)->toContain('old api');
+        Expect::that($optedOut->output)->toBeNull();
     }
 
     #[Test]
@@ -400,10 +400,10 @@ final class WorkerTest
             budget: new WorkerBudget(maxTests: 1),
         );
 
-        Expect::that($outcome->recycleReason)->because('test count budget stops the worker and reports the remainder')->toBe(RecycleReason::TestCount)
-            ->and($outcome->summary->total())->toBe(1)
-            ->and(\count($outcome->remaining))->toBe(2)
-            ->and((string) $outcome->remaining[0])->toContain('AaTest::wouldPass');
+        Expect::that($outcome->recycleReason)->because('test count budget stops the worker and reports the remainder')->toBe(RecycleReason::TestCount);
+        Expect::that($outcome->summary->total())->toBe(1);
+        Expect::that(\count($outcome->remaining))->toBe(2);
+        Expect::that((string) $outcome->remaining[0])->toContain('AaTest::wouldPass');
     }
 
     #[Test]
@@ -421,10 +421,10 @@ final class WorkerTest
 
         Expect::that($outcome->recycleReason)
             ->because('memory budget stops the worker and reports the remainder')
-            ->toBe(RecycleReason::Memory)
-            ->and($outcome->summary->total())->toBe(1)
-            ->and(\count($outcome->remaining))->toBe(2)
-            ->and((string) $outcome->remaining[0])->toContain('AaTest::wouldPass');
+            ->toBe(RecycleReason::Memory);
+        Expect::that($outcome->summary->total())->toBe(1);
+        Expect::that(\count($outcome->remaining))->toBe(2);
+        Expect::that((string) $outcome->remaining[0])->toContain('AaTest::wouldPass');
     }
 
     #[Test]
@@ -440,9 +440,9 @@ final class WorkerTest
             drainRequested: static fn(): bool => true,
         );
 
-        Expect::that($outcome->drained)->because('drain request stops between tests')->toBeTrue()
-            ->and($outcome->summary->total())->toBe(1)
-            ->and($outcome->recycleReason)->toBeNull();
+        Expect::that($outcome->drained)->because('drain request stops between tests')->toBeTrue();
+        Expect::that($outcome->summary->total())->toBe(1);
+        Expect::that($outcome->recycleReason)->toBeNull();
     }
 
     #[Test]
@@ -459,8 +459,8 @@ final class WorkerTest
 
         $leakedIds = \array_map(static fn($id): string => (string) $id, $outcome->leaks);
 
-        Expect::that($outcome->leaks)->because('leak detection names the test that retained its instance')->toHaveCount(1)
-            ->and($leakedIds[0])->toContain('LeakyTest::passesButLeaksItself');
+        Expect::that($outcome->leaks)->because('leak detection names the test that retained its instance')->toHaveCount(1);
+        Expect::that($leakedIds[0])->toContain('LeakyTest::passesButLeaksItself');
 
         LeakyTest::$retained = [];
     }

--- a/tests/Unit/Support/AcceptanceProjectTest.php
+++ b/tests/Unit/Support/AcceptanceProjectTest.php
@@ -21,9 +21,9 @@ final readonly class AcceptanceProjectTest
         $project = AcceptanceProject::create($this->workspace, 'project');
         $project->writeFile('nested/example.txt', 'contents');
 
-        Expect::that($project->directory)->because('creates a project and writes nested files')->toBe($this->workspace->path() . '/project')
-            ->and($project->path('nested/example.txt'))->toBe($project->directory . '/nested/example.txt')
-            ->and(\file_get_contents($project->path('nested/example.txt')))->toBe('contents');
+        Expect::that($project->directory)->because('creates a project and writes nested files')->toBe($this->workspace->path() . '/project');
+        Expect::that($project->path('nested/example.txt'))->toBe($project->directory . '/nested/example.txt');
+        Expect::that(\file_get_contents($project->path('nested/example.txt')))->toBe('contents');
     }
 
     #[Test]
@@ -62,10 +62,10 @@ final readonly class AcceptanceProjectTest
             ));
         }
 
-        Expect::that(\file_get_contents($project->path('loaded.txt')))->because('configures the project with test files and the requested worker count')->toBe('firstsecond')
-            ->and($configuration->paths)->toBe([$testsDirectory])
-            ->and($configuration->workers->fixed)->toBe(3)
-            ->and($configuration->randomizeOrder)->toBeFalse();
+        Expect::that(\file_get_contents($project->path('loaded.txt')))->because('configures the project with test files and the requested worker count')->toBe('firstsecond');
+        Expect::that($configuration->paths)->toBe([$testsDirectory]);
+        Expect::that($configuration->workers->fixed)->toBe(3);
+        Expect::that($configuration->randomizeOrder)->toBeFalse();
     }
 
     #[Test]

--- a/tests/Unit/Support/JsonlEventsTest.php
+++ b/tests/Unit/Support/JsonlEventsTest.php
@@ -30,9 +30,9 @@ final class JsonlEventsTest
 
         $events = JsonlEvents::from($result);
 
-        Expect::that($events)->because('restores typed events in order from stdout only')->toHaveCount(2)
-            ->and($events[0])->toBeInstanceOf(WorkerSpawned::class)
-            ->and($events[1])->toBeInstanceOf(TestClassStarted::class);
+        Expect::that($events)->because('restores typed events in order from stdout only')->toHaveCount(2);
+        Expect::that($events[0])->toBeInstanceOf(WorkerSpawned::class);
+        Expect::that($events[1])->toBeInstanceOf(TestClassStarted::class);
 
         $restoredSpawned = $events[0];
         $restoredStarted = $events[1];
@@ -45,10 +45,10 @@ final class JsonlEventsTest
             ));
         }
 
-        Expect::that($restoredSpawned->workerId)->because('restores typed events in order from stdout only')->toBe('worker-2')
-            ->and($restoredSpawned->pid)->toBe(42)
-            ->and($restoredStarted->class)->toBe('ExampleTest')
-            ->and($restoredStarted->workerId)->toBe('worker-2');
+        Expect::that($restoredSpawned->workerId)->because('restores typed events in order from stdout only')->toBe('worker-2');
+        Expect::that($restoredSpawned->pid)->toBe(42);
+        Expect::that($restoredStarted->class)->toBe('ExampleTest');
+        Expect::that($restoredStarted->workerId)->toBe('worker-2');
     }
 
     #[Test]

--- a/tests/Unit/Support/ProcessResultTest.php
+++ b/tests/Unit/Support/ProcessResultTest.php
@@ -19,10 +19,10 @@ final class ProcessResultTest
             stderr: "warning\nerror",
         );
 
-        Expect::that($result->exitCode)->because('exposes individual and combined output lines')->toBe(17)
-            ->and($result->stdoutLines())->toBe(['first', 'second'])
-            ->and($result->output())->toBe("first\nsecond\nwarning\nerror")
-            ->and($result->outputLines())->toBe(['first', 'second', 'warning', 'error']);
+        Expect::that($result->exitCode)->because('exposes individual and combined output lines')->toBe(17);
+        Expect::that($result->stdoutLines())->toBe(['first', 'second']);
+        Expect::that($result->output())->toBe("first\nsecond\nwarning\nerror");
+        Expect::that($result->outputLines())->toBe(['first', 'second', 'warning', 'error']);
     }
 
     #[Test]
@@ -32,9 +32,9 @@ final class ProcessResultTest
         $stderrOnly = new ProcessResult(1, '', 'error');
         $empty = new ProcessResult(0, '', '');
 
-        Expect::that($stdoutOnly->output())->because('combines empty streams without adding separators')->toBe('output')
-            ->and($stderrOnly->output())->toBe('error')
-            ->and($empty->output())->toBe('')
-            ->and($empty->outputLines())->toBe([]);
+        Expect::that($stdoutOnly->output())->because('combines empty streams without adding separators')->toBe('output');
+        Expect::that($stderrOnly->output())->toBe('error');
+        Expect::that($empty->output())->toBe('');
+        Expect::that($empty->outputLines())->toBe([]);
     }
 }

--- a/tests/Unit/Support/SubprocessTest.php
+++ b/tests/Unit/Support/SubprocessTest.php
@@ -40,9 +40,9 @@ final readonly class SubprocessTest
             ));
         }
 
-        Expect::that($result->exitCode)->because('run captures the result and honors its execution context')->toBe(7)
-            ->and($result->stdout)->toBe($workingDirectory . "\nenvironment")
-            ->and($result->stderr)->toBe('warning');
+        Expect::that($result->exitCode)->because('run captures the result and honors its execution context')->toBe(7);
+        Expect::that($result->stdout)->toBe($workingDirectory . "\nenvironment");
+        Expect::that($result->stderr)->toBe('warning');
     }
 
     #[Test]
@@ -60,8 +60,8 @@ final readonly class SubprocessTest
             ],
         );
 
-        Expect::that($result->stdout)->because('run drains large outputs from both streams')->toHaveLength(131072)
-            ->and($result->stderr)->toHaveLength(131072);
+        Expect::that($result->stdout)->because('run drains large outputs from both streams')->toHaveLength(131072);
+        Expect::that($result->stderr)->toHaveLength(131072);
     }
 
     #[Test]
@@ -88,10 +88,10 @@ final readonly class SubprocessTest
             $process->write("payload\n");
             $result = $process->wait(2.0);
 
-            Expect::that($ready)->toBe("ready\n")
-                ->and($result->exitCode)->toBe(3)
-                ->and($result->stdout)->toBe("ready\nreceived:payload")
-                ->and($result->stderr)->toBe('note');
+            Expect::that($ready)->toBe("ready\n");
+            Expect::that($result->exitCode)->toBe(3);
+            Expect::that($result->stdout)->toBe("ready\nreceived:payload");
+            Expect::that($result->stderr)->toBe('note');
         } finally {
             $process->terminate();
         }
@@ -108,8 +108,8 @@ final readonly class SubprocessTest
         try {
             $result = $process->complete();
 
-            Expect::that($result->exitCode)->toBe(9)
-                ->and($result->stderr)->toBe('failed');
+            Expect::that($result->exitCode)->toBe(9);
+            Expect::that($result->stderr)->toBe('failed');
 
             Expect::that(static fn(): string => $process->readStdoutUntil('ready', 2.0))
                 ->toThrow(\RuntimeException::class, '/Process exited before stdout contained/');

--- a/tests/Unit/Symfony/SymfonyPluginTest.php
+++ b/tests/Unit/Symfony/SymfonyPluginTest.php
@@ -160,11 +160,11 @@ final class SymfonyPluginTest
             ));
         }
 
-        Expect::that($definitions)->because('the kernel is a per run harness service and boots once')->toHaveCount(1)
-            ->and($definition->type)->toBe(KernelInterface::class)
-            ->and($definition->scope)->toBe(Scope::PerRun)
-            ->and($first->getEnvironment())->toBe('test')
-            ->and(($definition->factory)())->toBe($first);
+        Expect::that($definitions)->because('the kernel is a per run harness service and boots once')->toHaveCount(1);
+        Expect::that($definition->type)->toBe(KernelInterface::class);
+        Expect::that($definition->scope)->toBe(Scope::PerRun);
+        Expect::that($first->getEnvironment())->toBe('test');
+        Expect::that(($definition->factory)())->toBe($first);
     }
 
     #[Test]
@@ -203,7 +203,8 @@ final class SymfonyPluginTest
         $result = $this->result();
         $returned = $plugin->afterTest($this->context(), $result);
 
-        Expect::that($counter->count())->because('after test resets stateful container services')->toBe(0)->and($returned)->toBe($result);
+        Expect::that($counter->count())->because('after test resets stateful container services')->toBe(0);
+        Expect::that($returned)->toBe($result);
     }
 
     #[Test]
@@ -236,7 +237,8 @@ final class SymfonyPluginTest
         $result = $this->result();
         $returned = $plugin->afterTest($this->context(), $result);
 
-        Expect::that($booted)->because('after test without a booted kernel is a no-op')->toBe(false)->and($returned)->toBe($result);
+        Expect::that($booted)->because('after test without a booted kernel is a no-op')->toBe(false);
+        Expect::that($returned)->toBe($result);
     }
 
     private function plugin(): SymfonyPlugin

--- a/tests/Unit/Tools/RuntimeMessageTest.php
+++ b/tests/Unit/Tools/RuntimeMessageTest.php
@@ -24,17 +24,17 @@ final readonly class RuntimeMessageTest
             ['GITHUB_STEP_SUMMARY' => $summary],
         );
 
-        Expect::that($result->exitCode)->toBe(1)
-            ->and($result->stderr)->toContain(
-                \sprintf(
-                    'Greenlight did not find the coverage export at %s/build/coverage/coverage.json. Run `composer tests:coverage` first.',
-                    (string) \realpath($root),
-                ),
-            )
-            ->and((string) \file_get_contents($summary))->toBe(
-                "## Code coverage\n\n"
+        Expect::that($result->exitCode)->toBe(1);
+        Expect::that($result->stderr)->toContain(
+            \sprintf(
+                'Greenlight did not find the coverage export at %s/build/coverage/coverage.json. Run `composer tests:coverage` first.',
+                (string) \realpath($root),
+            ),
+        );
+        Expect::that((string) \file_get_contents($summary))->toBe(
+            "## Code coverage\n\n"
                 . "**Coverage unavailable.** Greenlight did not produce the coverage export.\n\n",
-            );
+        );
     }
 
     #[Test]
@@ -48,10 +48,10 @@ final readonly class RuntimeMessageTest
             ['GITHUB_STEP_SUMMARY' => $summaryDirectory],
         );
 
-        Expect::that($result->exitCode)->toBe(1)
-            ->and($result->stderr)->toContain(
-                'Warning: Greenlight did not write the GitHub Actions job summary.',
-            );
+        Expect::that($result->exitCode)->toBe(1);
+        Expect::that($result->stderr)->toContain(
+            'Warning: Greenlight did not write the GitHub Actions job summary.',
+        );
     }
 
     #[Test]
@@ -60,10 +60,10 @@ final readonly class RuntimeMessageTest
         [$missingRoot, $missingScript] = $this->toolSandbox('phpstan-missing', 'extract-phpstan-api.php');
         $missing = Subprocess::run($missingRoot, [\PHP_BINARY, $missingScript]);
 
-        Expect::that($missing->exitCode)->toBe(0)
-            ->and($missing->stdout)->toBe(
-                'The tool cannot extract the PHPStan API stubs because phpstan.phar is not installed.',
-            );
+        Expect::that($missing->exitCode)->toBe(0);
+        Expect::that($missing->stdout)->toBe(
+            'The tool cannot extract the PHPStan API stubs because phpstan.phar is not installed.',
+        );
 
         [$successRoot, $successScript] = $this->toolSandbox('phpstan-success', 'extract-phpstan-api.php');
         $pharPath = $successRoot . '/vendor/phpstan/phpstan/phpstan.phar';
@@ -91,14 +91,14 @@ final readonly class RuntimeMessageTest
         $success = Subprocess::run($successRoot, [\PHP_BINARY, $successScript]);
         $target = \realpath($successRoot) . '/.phpstan-api-stubs';
 
-        Expect::that($success->exitCode)->toBe(0)
-            ->and($success->stdout)->toBe(
-                \sprintf(
-                    'Greenlight extracted the PHPStan API sources to %s. Editors can index these sources.',
-                    $target,
-                ),
-            )
-            ->and(\is_file($target . '/src/Fixture.php'))->toBeTrue();
+        Expect::that($success->exitCode)->toBe(0);
+        Expect::that($success->stdout)->toBe(
+            \sprintf(
+                'Greenlight extracted the PHPStan API sources to %s. Editors can index these sources.',
+                $target,
+            ),
+        );
+        Expect::that(\is_file($target . '/src/Fixture.php'))->toBeTrue();
     }
 
     #[Test]
@@ -119,10 +119,10 @@ final readonly class RuntimeMessageTest
             '--root=' . $root,
         ]);
 
-        Expect::that($sentence->exitCode)->toBe(1)
-            ->and($sentence->stdout)->toContain(
-                'sample.md:3: sentence-length: Write no more than 25 words in a descriptive sentence. Found 27 words.',
-            );
+        Expect::that($sentence->exitCode)->toBe(1);
+        Expect::that($sentence->stdout)->toContain(
+            'sample.md:3: sentence-length: Write no more than 25 words in a descriptive sentence. Found 27 words.',
+        );
 
         \file_put_contents($root . '/sample.md', "# Sample\n\nThe worker stops.\n");
         $removedOption = Subprocess::run($root, [
@@ -133,8 +133,8 @@ final readonly class RuntimeMessageTest
             '--baseline-dir=' . $root . '/baseline',
         ]);
 
-        Expect::that($removedOption->exitCode)->toBe(1)
-            ->and($removedOption->stderr)->toContain('Unknown prose-check option "--baseline-dir=');
+        Expect::that($removedOption->exitCode)->toBe(1);
+        Expect::that($removedOption->stderr)->toContain('Unknown prose-check option "--baseline-dir=');
     }
 
     #[Test]
@@ -143,10 +143,10 @@ final readonly class RuntimeMessageTest
         [$missingRoot, $missingScript] = $this->toolSandbox('memory-missing', 'memory-gate.php');
         $missing = Subprocess::run($missingRoot, [\PHP_BINARY, $missingScript]);
 
-        Expect::that($missing->exitCode)->toBe(1)
-            ->and($missing->stderr)->toContain(
-                'The memory probe wrote no samples. The run did not reach the sample points.',
-            );
+        Expect::that($missing->exitCode)->toBe(1);
+        Expect::that($missing->stderr)->toContain(
+            'The memory probe wrote no samples. The run did not reach the sample points.',
+        );
 
         [$successRoot, $successScript] = $this->toolSandbox('memory-success', 'memory-gate.php');
         $binDirectory = $this->tempDirectory->subdirectory('memory-success/bin');
@@ -167,11 +167,11 @@ final readonly class RuntimeMessageTest
 
         $success = Subprocess::run($successRoot, [\PHP_BINARY, $successScript]);
 
-        Expect::that($success->exitCode)->toBe(0)
-            ->and($success->stdout)->toContain(
-                'Memory after 2000 tests: 1.00 MiB. Memory after 10000 tests: 1.50 MiB. '
+        Expect::that($success->exitCode)->toBe(0);
+        Expect::that($success->stdout)->toContain(
+            'Memory after 2000 tests: 1.00 MiB. Memory after 10000 tests: 1.50 MiB. '
                 . 'Drift: +524288 bytes. Limit: 1048576 bytes.',
-            );
+        );
     }
 
     #[Test]
@@ -187,8 +187,8 @@ final readonly class RuntimeMessageTest
             $script,
         ]);
 
-        Expect::that($result->exitCode)->toBe(255)
-            ->and($result->stderr)->toContain('Greenlight did not create directory "')
+        Expect::that($result->exitCode)->toBe(255);
+        Expect::that($result->stderr)->toContain('Greenlight did not create directory "')
             ->toContain('/suite".');
     }
 
@@ -208,10 +208,10 @@ final readonly class RuntimeMessageTest
             '--runs=1',
         ]);
 
-        Expect::that($directoryFailure->exitCode)->toBe(1)
-            ->and($directoryFailure->stderr)->toContain(
-                'Greenlight did not create the benchmark project directory.',
-            );
+        Expect::that($directoryFailure->exitCode)->toBe(1);
+        Expect::that($directoryFailure->stderr)->toContain(
+            'Greenlight did not create the benchmark project directory.',
+        );
 
         $fakeBin = $this->tempDirectory->subdirectory('benchmark-composer/bin');
         \file_put_contents(
@@ -237,10 +237,10 @@ final readonly class RuntimeMessageTest
             ['PATH' => $fakeBin . \PATH_SEPARATOR . (\is_string($path) ? $path : '')],
         );
 
-        Expect::that($composerFailure->exitCode)->toBe(1)
-            ->and($composerFailure->stderr)->toContain(
-                "Composer did not install PHPUnit and ParaTest:\nfixture composer failure",
-            );
+        Expect::that($composerFailure->exitCode)->toBe(1);
+        Expect::that($composerFailure->stderr)->toContain(
+            "Composer did not install PHPUnit and ParaTest:\nfixture composer failure",
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary

- Remove Expectation::and() so each matcher chain retains one subject.
- Migrate repository expectations and embedded fixtures to explicit Expect::that() statements.
- Refresh the expectation guide, PHPStan guidance, and generated interface reference.

This makes subject changes explicit and removes the modifier-reset semantics that callers had to learn.