### PR TITLE
feat(phpstan): infer callsTo argument types

### DIFF
--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -39,6 +39,17 @@ with different letter case. Greenlight checks a dynamic method name at run time.
 
 Method errors use the `greenlight.doubles.callsToMethod` identifier.
 
+For a constant method name, the extension also supplies the declared argument
+types for each recorded call:
+
+```php
+$calls = $doubles->callsTo($events, 'publish');
+$event = $calls[0][0]; // the declared type of EventPublisher::publish() argument 1
+```
+
+The result keeps optional parameters and variadic parameters. A dynamic method
+name keeps the documented `list<list<mixed>>` return type.
+
 ## Attribute argument checks
 
 The extension reports constant attribute arguments that Greenlight cannot use:

--- a/extension.neon
+++ b/extension.neon
@@ -23,6 +23,10 @@ rules:
     - Greenlight\PhpStan\ToThrowSubjectRule
 
 services:
+    greenlight.doublesCallsToReturnTypeExtension:
+        class: Greenlight\PhpStan\DoublesCallsToReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
     greenlight.matcherMapProvider:
         class: Greenlight\PhpStan\MatcherMapProvider
         arguments:

--- a/src/PhpStan/DoublesCallsToReturnTypeExtension.php
+++ b/src/PhpStan/DoublesCallsToReturnTypeExtension.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\PhpStan;
+
+use Greenlight\Doubles\Doubles;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Accessory\AccessoryArrayListType;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\Constant\ConstantArrayTypeBuilder;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+/**
+ * Gets the recorded argument types for a constant `callsTo()` method name.
+ *
+ * @internal
+ */
+final readonly class DoublesCallsToReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    #[\Override]
+    public function getClass(): string
+    {
+        return Doubles::class;
+    }
+
+    #[\Override]
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'callsTo';
+    }
+
+    #[\Override]
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
+    {
+        $double = $this->argument($methodCall, 'double', 0);
+        $method = $this->argument($methodCall, 'method', 1);
+
+        if (!$double instanceof Arg || !$method instanceof Arg) {
+            return null;
+        }
+
+        $doubleType = $scope->getType($double->value);
+        $methodNames = $scope->getType($method->value)->getConstantStrings();
+
+        if (\count($methodNames) !== 1) {
+            return null;
+        }
+
+        $methodName = $methodNames[0]->getValue();
+
+        if (!$doubleType->hasMethod($methodName)->yes()) {
+            return null;
+        }
+
+        $argumentTypes = [];
+
+        foreach ($doubleType->getMethod($methodName, $scope)->getVariants() as $variant) {
+            $builder = ConstantArrayTypeBuilder::createEmpty();
+
+            foreach ($variant->getParameters() as $parameter) {
+                if ($parameter->isVariadic()) {
+                    $builder->makeUnsealed(new IntegerType(), $parameter->getType());
+
+                    continue;
+                }
+
+                $builder->setOffsetValueType(
+                    null,
+                    $parameter->getType(),
+                    $parameter->isOptional(),
+                );
+            }
+
+            $argumentTypes[] = $builder->getArray();
+        }
+
+        if ($argumentTypes === []) {
+            return null;
+        }
+
+        $calls = new ArrayType(
+            new IntegerType(),
+            TypeCombinator::union(...$argumentTypes),
+        );
+
+        return TypeCombinator::intersect($calls, new AccessoryArrayListType());
+    }
+
+    private function argument(MethodCall $call, string $name, int $position): ?Arg
+    {
+        $nextPosition = 0;
+
+        foreach ($call->getArgs() as $argument) {
+            if ($argument->unpack) {
+                continue;
+            }
+
+            if ($argument->name instanceof Identifier) {
+                if ($argument->name->toString() === $name) {
+                    return $argument;
+                }
+
+                continue;
+            }
+
+            if ($nextPosition === $position) {
+                return $argument;
+            }
+
+            ++$nextPosition;
+        }
+
+        return null;
+    }
+}

--- a/tests/Acceptance/PhpStanDoublesCallsToReturnTypeExtensionTest.php
+++ b/tests/Acceptance/PhpStanDoublesCallsToReturnTypeExtensionTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\PhpStanProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class PhpStanDoublesCallsToReturnTypeExtensionTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function callsToReturnsTheSelectedMethodsArgumentTypes(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Doubles\Doubles;
+
+            interface TypedCallSpy
+            {
+                public function notify(string $message, int $priority = 0): void;
+
+                public function tag(string $name, int ...$values): void;
+            }
+
+            /** @param list<array{0: string, 1?: int}> $calls */
+            function acceptNotifyCalls(array $calls): void {}
+
+            /** @param list<non-empty-list<int|string>> $calls */
+            function acceptTagCalls(array $calls): void {}
+
+            /** @param list<list<mixed>> $calls */
+            function acceptDynamicCalls(array $calls): void {}
+
+            function greenlightTypedCallProbe(Doubles $doubles, string $dynamicMethod): void
+            {
+                $spy = $doubles->spy(TypedCallSpy::class);
+
+                acceptNotifyCalls($doubles->callsTo($spy, 'notify'));
+                acceptTagCalls($doubles->callsTo(method: 'tag', double: $spy));
+                acceptDynamicCalls($doubles->callsTo($spy, $dynamicMethod));
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Doubles\Doubles;
+
+            interface MistypedCallSpy
+            {
+                public function notify(string $message): void;
+            }
+
+            /** @param list<array{int}> $calls */
+            function acceptMistypedCalls(array $calls): void {}
+
+            function greenlightMistypedCallProbe(Doubles $doubles): void
+            {
+                $spy = $doubles->spy(MistypedCallSpy::class);
+
+                acceptMistypedCalls($doubles->callsTo($spy, 'notify'));
+            }
+            PHP,
+        );
+
+        Expect::that($probe->exitCode)
+            ->because('PHPStan rejects an incompatible asserted callsTo() result type')
+            ->toBe(1);
+        Expect::that($probe->goodPassed)
+            ->because('PHPStan messages: ' . $probe->messages())
+            ->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(1);
+        Expect::that($probe->messages())->toContain('expects list<array{int}>, list<array{string}> given');
+    }
+}


### PR DESCRIPTION
Infer recorded-call argument shapes from the selected doubled method when callsTo receives a constant method name. Preserve optional and variadic parameters, with the documented mixed fallback for dynamic names. Add acceptance coverage and PHPStan documentation.