### PR TITLE
feat(doubles): type-check mock plan arguments

### DIFF
--- a/docs/api-doubles.md
+++ b/docs/api-doubles.md
@@ -205,7 +205,7 @@ PHPDoc:
 
 - `@template T of object`
 - `@param class-string<T> $type`
-- `@param \Closure(MockPlan): void|null $plan`
+- `@param \Closure(MockPlan<T>): void|null $plan`
 - `@return T`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L87)
@@ -306,7 +306,11 @@ scope closes.
 final readonly class MockPlan
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/MockPlan.php#L14)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/MockPlan.php#L16)
+
+PHPDoc:
+
+- `@template TTarget of object = object`
 
 ### `any()`
 
@@ -316,7 +320,7 @@ Returns the `with()` wildcard that accepts all values in its position.
 public static function any(): Any
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/MockPlan.php#L24)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/MockPlan.php#L31)
 
 ### `expects()`
 
@@ -326,6 +330,8 @@ public function expects(string $method): MethodExpectation
 
 PHPDoc:
 
-- `@param non-empty-string $method`
+- `@template TMethod of non-empty-string`
+- `@param TMethod $method`
+- `@return MethodExpectation<TTarget, TMethod>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/MockPlan.php#L32)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/MockPlan.php#L43)

--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -80,6 +80,25 @@ This call causes the `greenlight.toThrow.subjectType` error. The extension
 does not report the error for a `mixed` subject. Greenlight validates unresolved
 subject types at run time.
 
+## Mock plan checks
+
+The extension keeps the doubled type through the `MockPlan` configurator. It
+checks constant method names before a test runs.
+
+The extension reports these mock plan errors:
+
+* The planned method does not exist or Greenlight cannot intercept it.
+* `withNoArguments()` cannot satisfy the required parameter count.
+* `with()` supplies too few or too many arguments.
+* A value in `with()` has a type that the method parameter does not accept.
+
+Argument matchers do not have to match the declared parameter type. They
+describe the values that the mock accepts at run time.
+
+Errors use the `greenlight.mockPlan.*` identifiers (`method`, `arity`, and
+`argument`). Greenlight validates each plan at run time when PHPStan cannot
+resolve a method name or argument list.
+
 ## Custom matcher checks
 
 These checks apply when a plugin adds matchers through `ExpectationExtension`.

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -70,6 +70,10 @@ A call that does not match an expectation fails immediately. At teardown, an
 unmet expectation fails the test. Greenlight reports all unmet expectations
 together.
 
+Without an argument constraint, an expectation accepts each argument list that
+the method declaration permits. Greenlight rejects arguments that the method
+does not declare.
+
 ## Mock responses
 
 Each mock method that returns a value needs an explicit response:
@@ -98,6 +102,15 @@ Bare values passed to `with()` use the same deep equality as `toEqual()`:
 ```php
 $plan->expects('save')->with($expectedOrder);
 ```
+
+Use `withNoArguments()` to require a call that supplies no arguments:
+
+```php
+$plan->expects('loadDefaults')->withNoArguments();
+```
+
+This constraint is useful when a method has optional or variadic parameters.
+`with()` requires at least one value or argument matcher.
 
 Use `Argument` matchers for broader constraints:
 

--- a/extension.neon
+++ b/extension.neon
@@ -10,6 +10,7 @@ parameters:
 rules:
     - Greenlight\PhpStan\AttributeArgumentRule
     - Greenlight\PhpStan\DataProviderSignatureRule
+    - Greenlight\PhpStan\DoublePlanRule
     - Greenlight\PhpStan\DoublesCallRule
     - Greenlight\PhpStan\ExpectationArgumentRule
     - Greenlight\PhpStan\LifecycleMethodRule

--- a/src/Doubles/CallHandler.php
+++ b/src/Doubles/CallHandler.php
@@ -27,10 +27,14 @@ final readonly class CallHandler
     ) {}
 
     /**
+     * @param non-empty-string $method
      * @param list<mixed> $arguments
      */
     public function invoke(object $double, string $method, array $arguments): mixed
     {
+        MethodCallContract::from($this->state->type, $method)
+            ->assertCallArgumentCount(\count($arguments));
+
         $this->state->recordedCalls[$method][] = $arguments;
 
         return match ($this->state->kind) {

--- a/src/Doubles/Doubles.php
+++ b/src/Doubles/Doubles.php
@@ -80,7 +80,7 @@ final class Doubles implements Disposable
      * @template T of object
      *
      * @param class-string<T> $type
-     * @param \Closure(MockPlan): void|null $plan
+     * @param \Closure(MockPlan<T>): void|null $plan
      *
      * @return T
      */
@@ -185,7 +185,7 @@ final class Doubles implements Disposable
      * @template T of object
      *
      * @param class-string<T> $type
-     * @param \Closure(MockPlan): void|null $plan
+     * @param \Closure(MockPlan<T>): void|null $plan
      *
      * @return T
      */
@@ -194,7 +194,7 @@ final class Doubles implements Disposable
         $state = new DoubleState($type, $kind);
 
         if ($plan instanceof \Closure) {
-            $plan(new MockPlan($state));
+            $plan(new MockPlan($state, $type));
         }
 
         $proxyClass = $this->generator->proxyClass($type);

--- a/src/Doubles/DoublesError.php
+++ b/src/Doubles/DoublesError.php
@@ -191,6 +191,74 @@ final class DoublesError extends \LogicException
         return new self(\sprintf('atLeast(%d) requires a count of one or more.', $count));
     }
 
+    /**
+     * @param class-string $type
+     */
+    public static function tooFewPlannedArguments(
+        string $selector,
+        string $type,
+        string $method,
+        int $actual,
+        int $required,
+    ): self {
+        return new self(\sprintf(
+            '%s() supplies %s for %s::%s(), but the method requires %s.',
+            $selector,
+            self::argumentCount($actual),
+            $type,
+            $method,
+            self::argumentCount($required),
+        ));
+    }
+
+    /**
+     * @param class-string $type
+     */
+    public static function tooManyPlannedArguments(
+        string $selector,
+        string $type,
+        string $method,
+        int $actual,
+        int $maximum,
+    ): self {
+        return new self(\sprintf(
+            '%s() supplies %s for %s::%s(), but the method accepts at most %s.',
+            $selector,
+            self::argumentCount($actual),
+            $type,
+            $method,
+            self::argumentCount($maximum),
+        ));
+    }
+
+    /**
+     * @param class-string $type
+     */
+    public static function tooFewCallArguments(string $type, string $method, int $actual, int $required): self
+    {
+        return new self(\sprintf(
+            'The call to %s::%s() supplies %s, but the method requires %s.',
+            $type,
+            $method,
+            self::argumentCount($actual),
+            self::argumentCount($required),
+        ));
+    }
+
+    /**
+     * @param class-string $type
+     */
+    public static function tooManyCallArguments(string $type, string $method, int $actual, int $maximum): self
+    {
+        return new self(\sprintf(
+            'The call to %s::%s() supplies %s, but the method accepts at most %s.',
+            $type,
+            $method,
+            self::argumentCount($actual),
+            self::argumentCount($maximum),
+        ));
+    }
+
     public static function conflictingAnswers(string $method): self
     {
         return new self(\sprintf(
@@ -227,5 +295,10 @@ final class DoublesError extends \LogicException
     public static function invalidArgumentType(): self
     {
         return new self('Argument::type() requires a type name that contains a non-space character.');
+    }
+
+    private static function argumentCount(int $count): string
+    {
+        return \sprintf('%d argument%s', $count, $count === 1 ? '' : 's');
     }
 }

--- a/src/Doubles/MethodCallContract.php
+++ b/src/Doubles/MethodCallContract.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Doubles;
+
+/**
+ * Defines the permitted argument count for one doubled method.
+ *
+ * @internal
+ *
+ * @template TTarget of object = object
+ * @template TMethod of non-empty-string = non-empty-string
+ */
+final readonly class MethodCallContract
+{
+    /**
+     * @param class-string<TTarget> $type
+     * @param TMethod $requestedMethod
+     */
+    private function __construct(
+        public string $type,
+        public string $method,
+        private int $requiredArguments,
+        private ?int $maximumArguments,
+        public string $requestedMethod,
+    ) {}
+
+    /**
+     * @template TRequestedTarget of object
+     * @template TRequestedMethod of non-empty-string
+     *
+     * @param class-string<TRequestedTarget> $type
+     * @param TRequestedMethod $method
+     *
+     * @return self<TRequestedTarget, TRequestedMethod>
+     */
+    public static function from(string $type, string $method): self
+    {
+        return self::fromReflection($type, $method, new \ReflectionMethod($type, $method));
+    }
+
+    /**
+     * @template TRequestedTarget of object
+     * @template TRequestedMethod of non-empty-string
+     *
+     * @param class-string<TRequestedTarget> $type
+     * @param TRequestedMethod $method
+     *
+     * @return self<TRequestedTarget, TRequestedMethod>
+     */
+    public static function fromReflection(string $type, string $method, \ReflectionMethod $reflection): self
+    {
+        return new self(
+            $type,
+            $reflection->getName(),
+            $reflection->getNumberOfRequiredParameters(),
+            $reflection->isVariadic() ? null : $reflection->getNumberOfParameters(),
+            $method,
+        );
+    }
+
+    public function assertPlannedArgumentCount(string $selector, int $count): void
+    {
+        if ($count < $this->requiredArguments) {
+            throw DoublesError::tooFewPlannedArguments(
+                $selector,
+                $this->type,
+                $this->requestedMethod,
+                $count,
+                $this->requiredArguments,
+            );
+        }
+
+        if ($this->maximumArguments !== null && $count > $this->maximumArguments) {
+            throw DoublesError::tooManyPlannedArguments(
+                $selector,
+                $this->type,
+                $this->requestedMethod,
+                $count,
+                $this->maximumArguments,
+            );
+        }
+    }
+
+    public function assertCallArgumentCount(int $count): void
+    {
+        if ($count < $this->requiredArguments) {
+            throw DoublesError::tooFewCallArguments(
+                $this->type,
+                $this->method,
+                $count,
+                $this->requiredArguments,
+            );
+        }
+
+        if ($this->maximumArguments !== null && $count > $this->maximumArguments) {
+            throw DoublesError::tooManyCallArguments(
+                $this->type,
+                $this->method,
+                $count,
+                $this->maximumArguments,
+            );
+        }
+    }
+}

--- a/src/Doubles/MethodExpectation.php
+++ b/src/Doubles/MethodExpectation.php
@@ -16,6 +16,9 @@ use Greenlight\Expect\ValueRenderer;
  * @internal
  *
  * Argument values compare with the same deep equality as Expect's toEqual().
+ *
+ * @template TTarget of object = object
+ * @template TMethod of non-empty-string = non-empty-string
  */
 final class MethodExpectation
 {
@@ -53,16 +56,35 @@ final class MethodExpectation
      */
     private array $registeredCaptors = [];
 
+    public readonly string $method;
+
     /**
      * @internal Only MockPlan::expects() constructs this object.
      *
-     * @param non-empty-string $method
+     * @param MethodCallContract<TTarget, TMethod> $contract
      */
-    public function __construct(public readonly string $method) {}
-
-    public function with(mixed ...$arguments): self
+    public function __construct(private readonly MethodCallContract $contract)
     {
-        $this->arguments = \array_values($arguments);
+        $this->method = $contract->method;
+    }
+
+    public function withNoArguments(): self
+    {
+        return $this->withArguments([], 'withNoArguments');
+    }
+
+    public function with(mixed $first, mixed ...$rest): self
+    {
+        return $this->withArguments([$first, ...\array_values($rest)], 'with');
+    }
+
+    /**
+     * @param list<mixed> $arguments
+     */
+    private function withArguments(array $arguments, string $selector): self
+    {
+        $this->contract->assertPlannedArgumentCount($selector, \count($arguments));
+        $this->arguments = $arguments;
 
         return $this;
     }

--- a/src/Doubles/MockPlan.php
+++ b/src/Doubles/MockPlan.php
@@ -10,13 +10,20 @@ namespace Greenlight\Doubles;
  * Use the fluent methods to declare call patterns. The default cardinality is
  * at least one call. The verifier checks each declared pattern when the test
  * scope closes.
+ *
+ * @template TTarget of object = object
  */
 final readonly class MockPlan
 {
     /**
      * @internal Only the Doubles factory constructs this object.
+     *
+     * @param class-string<TTarget> $target
      */
-    public function __construct(private DoubleState $state) {}
+    public function __construct(
+        private DoubleState $state,
+        private string $target,
+    ) {}
 
     /**
      * Returns the `with()` wildcard that accepts all values in its position.
@@ -27,26 +34,32 @@ final readonly class MockPlan
     }
 
     /**
-     * @param non-empty-string $method
+     * @template TMethod of non-empty-string
+     *
+     * @param TMethod $method
+     *
+     * @return MethodExpectation<TTarget, TMethod>
      */
     public function expects(string $method): MethodExpectation
     {
-        $method = $this->assertPlannable($method);
+        $contract = $this->assertPlannable($method);
 
-        $expectation = new MethodExpectation($method);
+        $expectation = new MethodExpectation($contract);
         $this->state->expectations[] = $expectation;
 
         return $expectation;
     }
 
     /**
-     * @param non-empty-string $method
+     * @template TMethod of non-empty-string
      *
-     * @return non-empty-string
+     * @param TMethod $method
+     *
+     * @return MethodCallContract<TTarget, TMethod>
      */
-    private function assertPlannable(string $method): string
+    private function assertPlannable(string $method): MethodCallContract
     {
-        $reflection = new \ReflectionClass($this->state->type);
+        $reflection = new \ReflectionClass($this->target);
 
         if (!$reflection->hasMethod($method)) {
             throw DoublesError::noSuchMethod($this->state->type, $method);
@@ -66,6 +79,6 @@ final readonly class MockPlan
             throw DoublesError::finalMethod($this->state->type, $method);
         }
 
-        return $declared->getName();
+        return MethodCallContract::fromReflection($this->target, $method, $declared);
     }
 }

--- a/src/PhpStan/DoublePlanRule.php
+++ b/src/PhpStan/DoublePlanRule.php
@@ -1,0 +1,252 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\PhpStan;
+
+use Greenlight\Doubles\ArgumentMatcher;
+use Greenlight\Doubles\MethodExpectation;
+use Greenlight\Doubles\MockPlan;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\ExtendedMethodReflection;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Reflection\ParametersAcceptor;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\VerbosityLevel;
+
+/**
+ * Checks mock plan methods and their argument constraints.
+ *
+ * @internal
+ *
+ * @implements Rule<MethodCall>
+ */
+final readonly class DoublePlanRule implements Rule
+{
+    public function __construct(private ReflectionProvider $reflectionProvider) {}
+
+    #[\Override]
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    #[\Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Identifier) {
+            return [];
+        }
+
+        return match ($node->name->toString()) {
+            'expects' => $this->expectsErrors($node, $scope),
+            'with', 'withNoArguments' => $this->argumentErrors($node, $scope),
+            default => [],
+        };
+    }
+
+    /**
+     * @return list<IdentifierRuleError>
+     */
+    private function expectsErrors(MethodCall $call, Scope $scope): array
+    {
+        $receiver = $scope->getType($call->var);
+
+        if (!new ObjectType(MockPlan::class)->isSuperTypeOf($receiver)->yes()) {
+            return [];
+        }
+
+        $target = $this->targetClass($receiver, MockPlan::class, 'TTarget');
+        $methodArgument = $call->getArgs()[0] ?? null;
+
+        if (!$target instanceof ClassReflection || !$methodArgument instanceof Node\Arg) {
+            return [];
+        }
+
+        $methodNames = $scope->getType($methodArgument->value)->getConstantStrings();
+
+        if (\count($methodNames) !== 1) {
+            return [];
+        }
+
+        $method = $methodNames[0]->getValue();
+
+        if (!$target->hasNativeMethod($method)) {
+            return [$this->error(
+                \sprintf('Mock plan method %s::%s() does not exist.', $target->getDisplayName(), $method),
+                'method',
+                $call->getStartLine(),
+            )];
+        }
+
+        $reflection = $target->getNativeMethod($method);
+
+        if (!$reflection->isPublic() || $reflection->isStatic() || $this->isFinal($reflection)) {
+            return [$this->error(
+                \sprintf('Mock plan method %s::%s() must be public, non-static, and non-final.', $target->getDisplayName(), $method),
+                'method',
+                $call->getStartLine(),
+            )];
+        }
+
+        return [];
+    }
+
+    /**
+     * @return list<IdentifierRuleError>
+     */
+    private function argumentErrors(MethodCall $call, Scope $scope): array
+    {
+        $receiver = $scope->getType($call->var);
+
+        if (!new ObjectType(MethodExpectation::class)->isSuperTypeOf($receiver)->yes()) {
+            return [];
+        }
+
+        $target = $this->targetClass($receiver, MethodExpectation::class, 'TTarget');
+        $methodType = $receiver->getTemplateType(MethodExpectation::class, 'TMethod');
+        $methodNames = $methodType->getConstantStrings();
+
+        if (!$target instanceof ClassReflection || \count($methodNames) !== 1) {
+            return [];
+        }
+
+        $method = $methodNames[0]->getValue();
+
+        if (!$target->hasNativeMethod($method)) {
+            return [];
+        }
+
+        $acceptor = $this->singleAcceptor($target->getNativeMethod($method)->getVariants());
+
+        if (!$acceptor instanceof ParametersAcceptor || \array_any($call->getArgs(), static fn(Node\Arg $argument): bool => $argument->unpack)) {
+            return [];
+        }
+
+        $arguments = $call->getArgs();
+        $selector = $call->name instanceof Identifier ? $call->name->toString() : '';
+
+        if (($selector === 'with' && $arguments === [])
+            || ($selector === 'withNoArguments' && $arguments !== [])
+        ) {
+            return [];
+        }
+
+        $parameters = $acceptor->getParameters();
+        $required = \count(\array_filter(
+            $parameters,
+            static fn(ParameterReflection $parameter): bool => !$parameter->isOptional() && !$parameter->isVariadic(),
+        ));
+        $variadic = $parameters !== [] && $parameters[\array_key_last($parameters)]->isVariadic();
+        $actual = \count($arguments);
+        if ($actual < $required) {
+            return [$this->error(
+                \sprintf(
+                    '%s() supplies %s for %s::%s(), but the method requires %s.',
+                    $selector,
+                    $this->argumentCount($actual),
+                    $target->getDisplayName(),
+                    $method,
+                    $this->argumentCount($required),
+                ),
+                'arity',
+                $call->getStartLine(),
+            )];
+        }
+
+        if (!$variadic && $actual > \count($parameters)) {
+            return [$this->error(
+                \sprintf(
+                    '%s() supplies %s for %s::%s(), but the method accepts at most %s.',
+                    $selector,
+                    $this->argumentCount($actual),
+                    $target->getDisplayName(),
+                    $method,
+                    $this->argumentCount(\count($parameters)),
+                ),
+                'arity',
+                $call->getStartLine(),
+            )];
+        }
+
+        $errors = [];
+        $matcher = new ObjectType(ArgumentMatcher::class);
+
+        foreach ($arguments as $index => $argument) {
+            $parameter = $parameters[\min($index, \count($parameters) - 1)];
+            $argumentType = $scope->getType($argument->value);
+
+            if (!$matcher->isSuperTypeOf($argumentType)->no()
+                || !$parameter->getType()->accepts($argumentType, $scope->isDeclareStrictTypes())->no()
+            ) {
+                continue;
+            }
+
+            $errors[] = $this->error(
+                \sprintf(
+                    '%s() argument #%d for %s::%s() parameter $%s has type %s, but the parameter requires %s.',
+                    $selector,
+                    $index + 1,
+                    $target->getDisplayName(),
+                    $method,
+                    $parameter->getName(),
+                    $argumentType->describe(VerbosityLevel::typeOnly()),
+                    $parameter->getType()->describe(VerbosityLevel::typeOnly()),
+                ),
+                'argument',
+                $argument->getStartLine(),
+            );
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @param class-string $genericClass
+     */
+    private function targetClass(Type $receiver, string $genericClass, string $template): ?ClassReflection
+    {
+        $classes = $receiver->getTemplateType($genericClass, $template)->getObjectClassNames();
+
+        if (\count($classes) !== 1 || !$this->reflectionProvider->hasClass($classes[0])) {
+            return null;
+        }
+
+        return $this->reflectionProvider->getClass($classes[0]);
+    }
+
+    /**
+     * @param list<ParametersAcceptor> $acceptors
+     */
+    private function singleAcceptor(array $acceptors): ?ParametersAcceptor
+    {
+        return \count($acceptors) === 1 ? $acceptors[0] : null;
+    }
+
+    private function isFinal(ExtendedMethodReflection $method): bool
+    {
+        return $method->isFinal()->yes();
+    }
+
+    private function argumentCount(int $count): string
+    {
+        return \sprintf('%d argument%s', $count, $count === 1 ? '' : 's');
+    }
+
+    private function error(string $message, string $identifier, int $line): IdentifierRuleError
+    {
+        return RuleErrorBuilder::message($message)
+            ->identifier('greenlight.mockPlan.' . $identifier)
+            ->line($line)
+            ->build();
+    }
+}

--- a/tests/Acceptance/PhpStanDoublePlanRuleTest.php
+++ b/tests/Acceptance/PhpStanDoublePlanRuleTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\PhpStanProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class PhpStanDoublePlanRuleTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function mockPlanArgumentsMustSatisfyTheDoubledMethod(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Doubles\Argument;
+            use Greenlight\Doubles\Doubles;
+            use Greenlight\Doubles\MockPlan;
+            use Greenlight\Tests\Fixture\Doubles\Wide;
+
+            /** @param non-empty-string $method */
+            function greenlightGoodDoublePlanProbe(Doubles $doubles, string $method): void
+            {
+                $doubles->mock(Wide::class, static function (MockPlan $plan) use ($method): void {
+                    $plan->expects('withDefaults')->withNoArguments();
+                    $plan->expects('unionType')->with(1);
+                    $plan->expects('unionType')->with(Argument::any());
+                    $plan->expects('variadic')->with('head', 1, 2);
+                    $plan->expects($method)->withNoArguments();
+                });
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Doubles\Doubles;
+            use Greenlight\Doubles\MockPlan;
+            use Greenlight\Tests\Fixture\Doubles\Wide;
+
+            function greenlightBadDoublePlanProbe(Doubles $doubles): void
+            {
+                $doubles->mock(Wide::class, static function (MockPlan $plan): void {
+                    $plan->expects('missing');
+                    $plan->expects('unionType')->withNoArguments();
+                    $plan->expects('returnsVoid')->with(1);
+                    $plan->expects('withDefaults')->with('eleven');
+                    $plan->expects('variadic')->with('head', 'not-an-int');
+                    $plan->expects('withDefaults')->with();
+                });
+            }
+            PHP,
+        );
+
+        Expect::that($probe->exitCode)->because('mock plans must satisfy their doubled methods')->toBe(1)
+            ->and($probe->goodPassed)->toBeTrue()
+            ->and(\count($probe->errors))->toBe(6)
+            ->and($probe->messages())->toContain('Mock plan method Greenlight\\Tests\\Fixture\\Doubles\\Wide::missing() does not exist')
+            ->and($probe->messages())->toContain('withNoArguments() supplies 0 arguments')
+            ->and($probe->messages())->toContain('with() supplies 1 argument')
+            ->and($probe->messages())->toContain('parameter $limit has type string, but the parameter requires int')
+            ->and($probe->messages())->toContain('parameter $rest has type string, but the parameter requires int');
+    }
+}

--- a/tests/Unit/Doubles/BoundaryTest.php
+++ b/tests/Unit/Doubles/BoundaryTest.php
@@ -114,8 +114,14 @@ final readonly class BoundaryTest
     public function planningAMissingMethodIsAnAuthoringError(): void
     {
         Expect::that(fn(): object => $this->doubles->mock(Calculator::class, static function (MockPlan $plan): void {
-            $plan->expects('subtract');
+            $plan->expects(self::missingMethod());
         }))->because('planning a missing method is an authoring error')->toThrow(DoublesError::class, '/has no method subtract\(\)/');
+    }
+
+    /** @return non-empty-string */
+    private static function missingMethod(): string
+    {
+        return 'subtract';
     }
 
     /**

--- a/tests/Unit/Doubles/EmptyArgumentConstraintTest.php
+++ b/tests/Unit/Doubles/EmptyArgumentConstraintTest.php
@@ -11,15 +11,17 @@ use Greenlight\Expect\Expect;
 use Greenlight\Expect\ExpectationFailed;
 use Greenlight\Tests\Fixture\Doubles\Wide;
 
-final class EmptyArgumentConstraintTest
+final readonly class EmptyArgumentConstraintTest
 {
+    public function __construct(private Doubles $doubles) {}
+
     #[Test]
     public function anExplicitEmptyConstraintRejectsSuppliedOptionalArguments(): void
     {
         $doubles = new Doubles();
         $wide = $doubles->mock(Wide::class, static function (MockPlan $plan): void {
             $plan->expects('withDefaults')
-                ->with()
+                ->withNoArguments()
                 ->once()
                 ->andReturns('default');
         });
@@ -27,5 +29,22 @@ final class EmptyArgumentConstraintTest
         Expect::that(static fn(): string => $wide->withDefaults(11))
             ->because('an explicit empty argument constraint MUST reject supplied optional arguments')
             ->toThrow(ExpectationFailed::class, '/unexpected call/');
+
+        Expect::that(static fn() => $doubles->dispose())
+            ->because('verification MUST report the unexpected call')
+            ->toThrow(ExpectationFailed::class, '/unexpected call/');
+    }
+
+    #[Test]
+    public function anExplicitEmptyConstraintAcceptsNoArguments(): void
+    {
+        $wide = $this->doubles->mock(Wide::class, static function (MockPlan $plan): void {
+            $plan->expects('withDefaults')
+                ->withNoArguments()
+                ->once()
+                ->andReturns('default');
+        });
+
+        Expect::that($wide->withDefaults())->toBe('default');
     }
 }

--- a/tests/Unit/Doubles/MethodArgumentContractTest.php
+++ b/tests/Unit/Doubles/MethodArgumentContractTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\DoublesError;
+use Greenlight\Doubles\MockPlan;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Doubles\Wide;
+
+final readonly class MethodArgumentContractTest
+{
+    public function __construct(private Doubles $doubles) {}
+
+    #[Test]
+    public function plannedArgumentsMustSatisfyTheMethodDeclaration(): void
+    {
+        Expect::that(fn(): Wide => $this->doubles->mock(Wide::class, static function (MockPlan $plan): void {
+            $plan->expects(self::requiredMethod())->withNoArguments();
+        }))->toThrow(
+            DoublesError::class,
+            '/withNoArguments\(\) supplies 0 arguments .* but the method requires 1 argument/',
+        );
+
+        Expect::that(fn(): Wide => $this->doubles->mock(Wide::class, static function (MockPlan $plan): void {
+            $plan->expects(self::emptyMethod())->with(1);
+        }))->toThrow(
+            DoublesError::class,
+            '/with\(\) supplies 1 argument .* but the method accepts at most 0 arguments/',
+        );
+    }
+
+    #[Test]
+    public function aDoubleRejectsArgumentsThatTheMethodDoesNotDeclare(): void
+    {
+        $doubles = new Doubles();
+        $wide = $doubles->mock(Wide::class, static function (MockPlan $plan): void {
+            $plan->expects('returnsVoid')->never();
+        });
+
+        Expect::that(static fn(): mixed => new \ReflectionMethod($wide, 'returnsVoid')->invokeArgs($wide, [1]))
+            ->toThrow(
+                DoublesError::class,
+                '/accepts at most 0 arguments/',
+            );
+
+        $doubles->dispose();
+    }
+
+    /** @return non-empty-string */
+    private static function requiredMethod(): string
+    {
+        return 'unionType';
+    }
+
+    /** @return non-empty-string */
+    private static function emptyMethod(): string
+    {
+        return 'returnsVoid';
+    }
+}


### PR DESCRIPTION
## Why

The fluent mock-plan API could express an exact empty argument list with an unclear zero-argument with() call. PHP also permits surplus arguments for user-defined methods, and PHPStan could not connect a string method name to its doubled declaration.

## What changed

- Add withNoArguments() and require at least one constraint in with().
- Enforce declared argument counts when Greenlight builds a plan and handles a call.
- Preserve the doubled type and constant method name through the fluent chain so the PHPStan extension checks method names, arity, and value types.
- Document the interface and include the zero-argument coverage explored in #1181.