### PR TITLE
feat(phpstan): validate doubleable types

### DIFF
--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -50,6 +50,12 @@ $event = $calls[0][0]; // the declared type of EventPublisher::publish() argumen
 The result keeps optional parameters and variadic parameters. A dynamic method
 name keeps the documented `list<list<mixed>>` return type.
 
+The extension also checks known types in `mock()`, `stub()`, and `spy()`.
+Final classes, readonly classes, enums, and traits cause analysis errors. Use
+an interface or a non-final class.
+
+Factory type errors use the `greenlight.doubles.doubleableType` identifier.
+
 ## Attribute argument checks
 
 The extension reports constant attribute arguments that Greenlight cannot use:

--- a/extension.neon
+++ b/extension.neon
@@ -11,6 +11,7 @@ rules:
     - Greenlight\PhpStan\AttributeArgumentRule
     - Greenlight\PhpStan\DataProviderSignatureRule
     - Greenlight\PhpStan\DoublePlanRule
+    - Greenlight\PhpStan\DoubleableTypeRule
     - Greenlight\PhpStan\DoublesCallRule
     - Greenlight\PhpStan\ExpectationArgumentRule
     - Greenlight\PhpStan\LifecycleMethodRule

--- a/src/PhpStan/DoubleableTypeRule.php
+++ b/src/PhpStan/DoubleableTypeRule.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\PhpStan;
+
+use Greenlight\Doubles\Doubles;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+
+/**
+ * Checks that a known type can have a double proxy.
+ *
+ * @internal
+ *
+ * @implements Rule<MethodCall>
+ */
+final readonly class DoubleableTypeRule implements Rule
+{
+    #[\Override]
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    #[\Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Identifier
+            || !\in_array($node->name->toString(), ['mock', 'stub', 'spy'], true)
+        ) {
+            return [];
+        }
+
+        if (!new ObjectType(Doubles::class)->isSuperTypeOf($scope->getType($node->var))->yes()) {
+            return [];
+        }
+
+        $type = $this->argument($node, 'type', 0);
+
+        if (!$type instanceof Arg) {
+            return [];
+        }
+
+        $errors = [];
+
+        foreach ($scope->getType($type->value)->getClassStringObjectType()->getObjectClassReflections() as $class) {
+            $reason = $this->unsupportedReason($class);
+
+            if ($reason === null) {
+                continue;
+            }
+
+            $errors[] = RuleErrorBuilder::message(\sprintf(
+                'Doubles::%s() cannot double %s because %s.',
+                $node->name->toString(),
+                $class->getDisplayName(),
+                $reason,
+            ))
+                ->identifier('greenlight.doubles.doubleableType')
+                ->line($node->getStartLine())
+                ->build();
+        }
+
+        return $errors;
+    }
+
+    private function unsupportedReason(ClassReflection $class): ?string
+    {
+        if ($class->isInterface()) {
+            return null;
+        }
+
+        if ($class->isEnum()) {
+            return 'it is an enum. Use an interface that the enum implements';
+        }
+
+        if ($class->isReadOnly()) {
+            return 'it is a readonly class. Use an interface instead';
+        }
+
+        if ($class->isFinal()) {
+            return 'it is final. Use an interface instead';
+        }
+
+        if ($class->isTrait()) {
+            return 'it is a trait. Use a class or interface that uses it';
+        }
+
+        return null;
+    }
+
+    private function argument(MethodCall $call, string $name, int $position): ?Arg
+    {
+        $nextPosition = 0;
+
+        foreach ($call->getArgs() as $argument) {
+            if ($argument->unpack) {
+                continue;
+            }
+
+            if ($argument->name instanceof Identifier) {
+                if ($argument->name->toString() === $name) {
+                    return $argument;
+                }
+
+                continue;
+            }
+
+            if ($nextPosition === $position) {
+                return $argument;
+            }
+
+            ++$nextPosition;
+        }
+
+        return null;
+    }
+}

--- a/tests/Acceptance/PhpStanDoubleableTypeRuleTest.php
+++ b/tests/Acceptance/PhpStanDoubleableTypeRuleTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\PhpStanProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class PhpStanDoubleableTypeRuleTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function factoriesRequireTypesThatCanHaveAProxy(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Doubles\Doubles;
+
+            interface DoubleablePort {}
+
+            class DoubleableService {}
+
+            /** @param class-string<object> $dynamicType */
+            function greenlightDoubleableTypeProbe(Doubles $doubles, string $dynamicType): void
+            {
+                $doubles->mock(DoubleablePort::class);
+                $doubles->stub(type: DoubleableService::class);
+                $doubles->spy($dynamicType);
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Doubles\Doubles;
+
+            final class FinalService {}
+
+            readonly class ReadonlyService {}
+
+            enum ServiceState
+            {
+                case Ready;
+            }
+
+            trait ServiceBehavior {}
+
+            function greenlightNonDoubleableTypeProbe(Doubles $doubles): void
+            {
+                $doubles->mock(FinalService::class);
+                $doubles->stub(type: ReadonlyService::class);
+                $doubles->spy(ServiceState::class);
+                $doubles->mock(ServiceBehavior::class);
+            }
+            PHP,
+        );
+
+        Expect::that($probe->exitCode)
+            ->because('PHPStan rejects types that cannot have a proxy')
+            ->toBe(1);
+        Expect::that($probe->goodPassed)
+            ->because('PHPStan messages: ' . $probe->messages())
+            ->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(4);
+        Expect::that($probe->messages())->toContain('Doubles::mock() cannot double FinalService because it is final');
+        Expect::that($probe->messages())->toContain('Doubles::stub() cannot double ReadonlyService because it is a readonly class');
+        Expect::that($probe->messages())->toContain('Doubles::spy() cannot double ServiceState because it is an enum');
+        Expect::that($probe->messages())->toContain('Doubles::mock() cannot double ServiceBehavior because it is a trait');
+    }
+}

--- a/tests/Unit/Doubles/BoundaryTest.php
+++ b/tests/Unit/Doubles/BoundaryTest.php
@@ -28,21 +28,21 @@ final readonly class BoundaryTest
     #[Test]
     public function finalClassesCannotBeDoubled(): void
     {
-        Expect::that(fn(): object => $this->doubles->mock(FinalService::class))->because('final classes cannot be doubled')
+        Expect::that(fn(): object => $this->doubles->mock(FinalService::class))->because('final classes cannot be doubled') // @phpstan-ignore greenlight.doubles.doubleableType (deliberately invalid: tests runtime validation)
             ->toThrow(DoublesError::class, '/is final.*proxy subclass.*interface/');
     }
 
     #[Test]
     public function readonlyClassesCannotBeDoubled(): void
     {
-        Expect::that(fn(): object => $this->doubles->mock(ReadonlyService::class))->because('readonly classes cannot be doubled')
+        Expect::that(fn(): object => $this->doubles->mock(ReadonlyService::class))->because('readonly classes cannot be doubled') // @phpstan-ignore greenlight.doubles.doubleableType (deliberately invalid: tests runtime validation)
             ->toThrow(DoublesError::class, '/readonly class.*interface/');
     }
 
     #[Test]
     public function enumsCannotBeDoubled(): void
     {
-        Expect::that(fn(): object => $this->doubles->mock(Suit::class))->because('enums cannot be doubled')
+        Expect::that(fn(): object => $this->doubles->mock(Suit::class))->because('enums cannot be doubled') // @phpstan-ignore greenlight.doubles.doubleableType (deliberately invalid: tests runtime validation)
             ->toThrow(
                 DoublesError::class,
                 message: 'Greenlight\Tests\Fixture\Doubles\Suit is an enum. '
@@ -53,7 +53,7 @@ final readonly class BoundaryTest
     #[Test]
     public function traitsCannotBeDoubled(): void
     {
-        Expect::that(fn(): object => $this->doubles->mock(ReusableBehavior::class))
+        Expect::that(fn(): object => $this->doubles->mock(ReusableBehavior::class)) // @phpstan-ignore greenlight.doubles.doubleableType (deliberately invalid: tests runtime validation)
             ->because('a trait cannot supply an object type for a generated proxy')
             ->toThrow(
                 DoublesError::class,


### PR DESCRIPTION
Reject known final classes, readonly classes, enums, and traits at analysis time when code passes them to mock, stub, or spy. Preserve runtime boundary coverage through a dynamic helper, and document the new diagnostic identifier.