### PR TITLE
test(doubles): cover missing call arguments

### DIFF
--- a/tests/Unit/Doubles/MethodArgumentContractTest.php
+++ b/tests/Unit/Doubles/MethodArgumentContractTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Unit\Doubles;
 use Greenlight\Attribute\Test;
 use Greenlight\Doubles\Doubles;
 use Greenlight\Doubles\DoublesError;
+use Greenlight\Doubles\MethodCallContract;
 use Greenlight\Doubles\MockPlan;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\Doubles\Wide;
@@ -48,6 +49,18 @@ final readonly class MethodArgumentContractTest
             );
 
         $doubles->dispose();
+    }
+
+    #[Test]
+    public function theCallContractRejectsMissingRequiredArguments(): void
+    {
+        $contract = MethodCallContract::from(Wide::class, 'unionType');
+
+        Expect::that(static fn() => $contract->assertCallArgumentCount(0))
+            ->toThrow(
+                DoublesError::class,
+                '/supplies 0 arguments, but the method requires 1 argument/',
+            );
     }
 
     /** @return non-empty-string */


### PR DESCRIPTION
## Why

The Codecov report on #1205 identified seven uncovered lines in the defensive too-few-call-arguments path.

## What changed

Add a focused call-contract test that reaches the fallback guard directly and verifies its diagnostic. Generated proxies normally let PHP reject missing required arguments before this internal guard runs.