### PR TITLE
feat(phpstan): validate mock plan results

### DIFF
--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -102,13 +102,18 @@ The extension reports these mock plan errors:
 * `withNoArguments()` cannot satisfy the required parameter count.
 * `with()` supplies too few or too many arguments.
 * A value in `with()` has a type that the method parameter does not accept.
+* A cardinality or capture position is outside its permitted range.
+* A configured result does not match the method return type.
+* An answer closure does not accept the method arguments or return its type.
+* A return sequence has no values.
 
 Argument matchers do not have to match the declared parameter type. They
 describe the values that the mock accepts at run time.
 
-Errors use the `greenlight.mockPlan.*` identifiers (`method`, `arity`, and
-`argument`). Greenlight validates each plan at run time when PHPStan cannot
-resolve a method name or argument list.
+Errors use the `greenlight.mockPlan.*` identifiers. The final identifier part
+is `method`, `arity`, `argument`, `cardinality`, `answer`, or `capturePosition`.
+Greenlight validates each plan at run time when PHPStan cannot resolve a method
+name or argument list.
 
 ## Custom matcher checks
 

--- a/src/PhpStan/DoublePlanRule.php
+++ b/src/PhpStan/DoublePlanRule.php
@@ -19,7 +19,10 @@ use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\CallableType;
+use PHPStan\Type\MixedType;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\StaticType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
 
@@ -50,6 +53,9 @@ final readonly class DoublePlanRule implements Rule
         return match ($node->name->toString()) {
             'expects' => $this->expectsErrors($node, $scope),
             'with', 'withNoArguments' => $this->argumentErrors($node, $scope),
+            'times', 'atLeast' => $this->cardinalityErrors($node, $scope),
+            'andReturns', 'andReturnsSequence', 'andReturnsUsing' => $this->answerErrors($node, $scope),
+            'captureArgument' => $this->captureErrors($node, $scope),
             default => [],
         };
     }
@@ -106,31 +112,13 @@ final readonly class DoublePlanRule implements Rule
      */
     private function argumentErrors(MethodCall $call, Scope $scope): array
     {
-        $receiver = $scope->getType($call->var);
+        $selected = $this->selectedMethod($scope->getType($call->var));
 
-        if (!new ObjectType(MethodExpectation::class)->isSuperTypeOf($receiver)->yes()) {
+        if ($selected === null || \array_any($call->getArgs(), static fn(Node\Arg $argument): bool => $argument->unpack)) {
             return [];
         }
 
-        $target = $this->targetClass($receiver, MethodExpectation::class, 'TTarget');
-        $methodType = $receiver->getTemplateType(MethodExpectation::class, 'TMethod');
-        $methodNames = $methodType->getConstantStrings();
-
-        if (!$target instanceof ClassReflection || \count($methodNames) !== 1) {
-            return [];
-        }
-
-        $method = $methodNames[0]->getValue();
-
-        if (!$target->hasNativeMethod($method)) {
-            return [];
-        }
-
-        $acceptor = $this->singleAcceptor($target->getNativeMethod($method)->getVariants());
-
-        if (!$acceptor instanceof ParametersAcceptor || \array_any($call->getArgs(), static fn(Node\Arg $argument): bool => $argument->unpack)) {
-            return [];
-        }
+        [$target, $method, $acceptor] = $selected;
 
         $arguments = $call->getArgs();
         $selector = $call->name instanceof Identifier ? $call->name->toString() : '';
@@ -208,6 +196,257 @@ final readonly class DoublePlanRule implements Rule
         }
 
         return $errors;
+    }
+
+    /**
+     * @return list<IdentifierRuleError>
+     */
+    private function cardinalityErrors(MethodCall $call, Scope $scope): array
+    {
+        if (!$this->isMethodExpectation($scope->getType($call->var))) {
+            return [];
+        }
+
+        $count = $this->argument($call, 'count', 0);
+
+        if (!$count instanceof Node\Arg) {
+            return [];
+        }
+
+        $selector = $call->name instanceof Identifier ? $call->name->toString() : '';
+        $minimum = $selector === 'times' ? 0 : 1;
+        $errors = [];
+
+        foreach ($scope->getType($count->value)->getConstantScalarValues() as $value) {
+            if (!\is_int($value) || $value >= $minimum) {
+                continue;
+            }
+
+            $errors[] = $this->error(
+                \sprintf(
+                    '%s(%d) requires a count of %s or more.',
+                    $selector,
+                    $value,
+                    $minimum === 0 ? 'zero' : 'one',
+                ),
+                'cardinality',
+                $count->getStartLine(),
+            );
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @return list<IdentifierRuleError>
+     */
+    private function answerErrors(MethodCall $call, Scope $scope): array
+    {
+        $selected = $this->selectedMethod($scope->getType($call->var));
+
+        if ($selected === null) {
+            return [];
+        }
+
+        [$target, $method, $acceptor] = $selected;
+        $selector = $call->name instanceof Identifier ? $call->name->toString() : '';
+        $arguments = $call->getArgs();
+        $returnType = $acceptor->getReturnType();
+
+        if ($selector === 'andReturnsSequence' && $arguments === []) {
+            return [$this->error(
+                \sprintf('andReturnsSequence() on %s::%s() requires at least one value.', $target->getDisplayName(), $method),
+                'answer',
+                $call->getStartLine(),
+            )];
+        }
+
+        if ($selector === 'andReturnsUsing') {
+            $answer = $this->argument($call, 'answer', 0);
+
+            if (!$answer instanceof Node\Arg) {
+                return [];
+            }
+
+            $expected = new CallableType(
+                $acceptor->getParameters(),
+                $returnType instanceof StaticType ? new MixedType() : $returnType,
+                $acceptor->isVariadic(),
+            );
+            $actual = $scope->getType($answer->value);
+
+            if (!$expected->accepts($actual, $scope->isDeclareStrictTypes())->no()) {
+                return [];
+            }
+
+            return [$this->error(
+                \sprintf(
+                    'andReturnsUsing() answer for %s::%s() has type %s, but it requires %s.',
+                    $target->getDisplayName(),
+                    $method,
+                    $actual->describe(VerbosityLevel::typeOnly()),
+                    $expected->describe(VerbosityLevel::typeOnly()),
+                ),
+                'answer',
+                $answer->getStartLine(),
+            )];
+        }
+
+        if ($returnType instanceof StaticType) {
+            return [];
+        }
+
+        $errors = [];
+
+        foreach ($arguments as $index => $argument) {
+            if ($argument->unpack) {
+                continue;
+            }
+
+            $actual = $scope->getType($argument->value);
+
+            if (!$returnType->accepts($actual, $scope->isDeclareStrictTypes())->no()) {
+                continue;
+            }
+
+            $errors[] = $this->error(
+                \sprintf(
+                    '%s() value #%d for %s::%s() has type %s, but the method returns %s.',
+                    $selector,
+                    $index + 1,
+                    $target->getDisplayName(),
+                    $method,
+                    $actual->describe(VerbosityLevel::typeOnly()),
+                    $returnType->describe(VerbosityLevel::typeOnly()),
+                ),
+                'answer',
+                $argument->getStartLine(),
+            );
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @return list<IdentifierRuleError>
+     */
+    private function captureErrors(MethodCall $call, Scope $scope): array
+    {
+        $selected = $this->selectedMethod($scope->getType($call->var));
+
+        if ($selected === null) {
+            return [];
+        }
+
+        [$target, $method, $acceptor] = $selected;
+        $positionArgument = $this->argument($call, 'position', 0);
+        $positions = $positionArgument instanceof Node\Arg
+            ? $scope->getType($positionArgument->value)->getConstantScalarValues()
+            : [0];
+        $parameters = $acceptor->getParameters();
+        $variadic = $parameters !== [] && $parameters[\array_key_last($parameters)]->isVariadic();
+        $errors = [];
+
+        foreach ($positions as $position) {
+            if (!\is_int($position)) {
+                continue;
+            }
+
+            if ($position >= 0 && ($variadic || $position < \count($parameters))) {
+                continue;
+            }
+
+            if ($parameters === []) {
+                $errors[] = $this->error(
+                    \sprintf(
+                        'captureArgument(%d) cannot select an argument on %s::%s() because the method has no parameters.',
+                        $position,
+                        $target->getDisplayName(),
+                        $method,
+                    ),
+                    'capturePosition',
+                    $positionArgument?->getStartLine() ?? $call->getStartLine(),
+                );
+
+                continue;
+            }
+
+            $requirement = $variadic
+                ? 'a position of zero or more'
+                : \sprintf('a position from zero to %d', \count($parameters) - 1);
+            $errors[] = $this->error(
+                \sprintf(
+                    'captureArgument(%d) for %s::%s() requires %s.',
+                    $position,
+                    $target->getDisplayName(),
+                    $method,
+                    $requirement,
+                ),
+                'capturePosition',
+                $positionArgument?->getStartLine() ?? $call->getStartLine(),
+            );
+        }
+
+        return $errors;
+    }
+
+    private function isMethodExpectation(Type $receiver): bool
+    {
+        return new ObjectType(MethodExpectation::class)->isSuperTypeOf($receiver)->yes();
+    }
+
+    /**
+     * @return array{ClassReflection, string, ParametersAcceptor}|null
+     */
+    private function selectedMethod(Type $receiver): ?array
+    {
+        if (!$this->isMethodExpectation($receiver)) {
+            return null;
+        }
+
+        $target = $this->targetClass($receiver, MethodExpectation::class, 'TTarget');
+        $methodNames = $receiver->getTemplateType(MethodExpectation::class, 'TMethod')->getConstantStrings();
+
+        if (!$target instanceof ClassReflection || \count($methodNames) !== 1) {
+            return null;
+        }
+
+        $method = $methodNames[0]->getValue();
+
+        if (!$target->hasNativeMethod($method)) {
+            return null;
+        }
+
+        $acceptor = $this->singleAcceptor($target->getNativeMethod($method)->getVariants());
+
+        return $acceptor instanceof ParametersAcceptor ? [$target, $method, $acceptor] : null;
+    }
+
+    private function argument(MethodCall $call, string $name, int $position): ?Node\Arg
+    {
+        $nextPosition = 0;
+
+        foreach ($call->getArgs() as $argument) {
+            if ($argument->unpack) {
+                continue;
+            }
+
+            if ($argument->name instanceof Identifier) {
+                if ($argument->name->toString() === $name) {
+                    return $argument;
+                }
+
+                continue;
+            }
+
+            if ($nextPosition === $position) {
+                return $argument;
+            }
+
+            ++$nextPosition;
+        }
+
+        return null;
     }
 
     /**

--- a/tests/Acceptance/PhpStanDoublePlanResultRuleTest.php
+++ b/tests/Acceptance/PhpStanDoublePlanResultRuleTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\PhpStanProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class PhpStanDoublePlanResultRuleTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function mockPlanResultsAndLimitsFollowTheSelectedMethod(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Doubles\Doubles;
+            use Greenlight\Doubles\MockPlan;
+
+            interface ValidResultPlan
+            {
+                public function add(int $left, int $right): int;
+
+                /** @return list<int> */
+                public function collect(string $name, int ...$values): array;
+            }
+
+            function greenlightValidResultPlanProbe(Doubles $doubles): void
+            {
+                $doubles->mock(ValidResultPlan::class, static function (MockPlan $plan): void {
+                    $plan->expects('add')->times(0)->andReturns(1);
+                    $plan->expects('add')->atLeast(1)->andReturnsSequence(1, 2);
+                    $plan->expects('add')->andReturnsUsing(static fn(int $left, int $right): int => $left + $right);
+                    $plan->expects('add')->captureArgument(1);
+                    $plan->expects('collect')->andReturns([])->captureArgument(99);
+                });
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Doubles\Doubles;
+            use Greenlight\Doubles\MockPlan;
+
+            interface InvalidResultPlan
+            {
+                public function add(int $left, int $right): int;
+
+                public function ping(): void;
+            }
+
+            function greenlightInvalidResultPlanProbe(Doubles $doubles): void
+            {
+                $doubles->mock(InvalidResultPlan::class, static function (MockPlan $plan): void {
+                    $plan->expects('add')->times(-1);
+                    $plan->expects('add')->atLeast(0);
+                    $plan->expects('add')->andReturnsSequence();
+                    $plan->expects('add')->andReturns('wrong');
+                    $plan->expects('add')->andReturnsSequence(1, 'wrong');
+                    $plan->expects('add')->andReturnsUsing(static fn(string $value): string => $value);
+                    $plan->expects('add')->captureArgument(-1);
+                    $plan->expects('add')->captureArgument(2);
+                    $plan->expects('ping')->captureArgument();
+                });
+            }
+            PHP,
+        );
+
+        Expect::that($probe->exitCode)
+            ->because('PHPStan rejects invalid mock plan results and limits')
+            ->toBe(1);
+        Expect::that($probe->goodPassed)
+            ->because('PHPStan messages: ' . $probe->messages())
+            ->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(9);
+        Expect::that($probe->messages())->toContain('times(-1) requires a count of zero or more');
+        Expect::that($probe->messages())->toContain('atLeast(0) requires a count of one or more');
+        Expect::that($probe->messages())->toContain('andReturnsSequence() on InvalidResultPlan::add() requires at least one value');
+        Expect::that($probe->messages())->toContain('andReturns() value #1 for InvalidResultPlan::add() has type string, but the method returns int');
+        Expect::that($probe->messages())->toContain('andReturnsUsing() answer for InvalidResultPlan::add()');
+        Expect::that($probe->messages())->toContain('captureArgument(2) for InvalidResultPlan::add() requires a position from zero to 1');
+    }
+}

--- a/tests/Unit/Doubles/AnswersTest.php
+++ b/tests/Unit/Doubles/AnswersTest.php
@@ -68,7 +68,7 @@ final readonly class AnswersTest
     public function anEmptySequenceIsRejected(): void
     {
         Expect::that(fn(): mixed => $this->doubles->mock(Calculator::class, static function (MockPlan $plan): void {
-            $plan->expects('add')->andReturnsSequence();
+            $plan->expects('add')->andReturnsSequence(); // @phpstan-ignore greenlight.mockPlan.answer (deliberately invalid: tests runtime validation)
         }))
             ->because('an empty sequence is rejected')
             ->toThrow(

--- a/tests/Unit/Doubles/ArgumentMatchingTest.php
+++ b/tests/Unit/Doubles/ArgumentMatchingTest.php
@@ -289,7 +289,7 @@ final class ArgumentMatchingTest
         $doubles = new Doubles();
 
         Expect::that(static fn(): mixed => $doubles->mock(Calculator::class, static function (MockPlan $plan): void {
-            $plan->expects('add')->captureArgument(-1);
+            $plan->expects('add')->captureArgument(-1); // @phpstan-ignore greenlight.mockPlan.capturePosition (deliberately invalid: tests runtime validation)
         }))->because('capture argument rejects negative positions')
             ->toThrow(DoublesError::class, message: 'captureArgument(-1) requires a position of zero or more.');
     }

--- a/tests/Unit/Doubles/ProxyGenerationTest.php
+++ b/tests/Unit/Doubles/ProxyGenerationTest.php
@@ -193,7 +193,7 @@ final readonly class ProxyGenerationTest
     public function aNeverReturningMethodRejectsAConfiguredReturnValue(): void
     {
         $wide = $this->doubles->mock(Wide::class, static function (MockPlan $plan): void {
-            $plan->expects('returnsNever')->andReturns(null);
+            $plan->expects('returnsNever')->andReturns(null); // @phpstan-ignore greenlight.mockPlan.answer (deliberately invalid: tests runtime validation)
         });
 
         Expect::that(static fn() => $wide->returnsNever())->because('a never returning method requires andThrows()')


### PR DESCRIPTION
Extend the generic mock-plan rule to validate constant cardinalities, capture positions, return values, return sequences, and answer closure signatures against the selected doubled method. Keep unresolved method names and static proxy return values on their runtime fallback paths, and document the new diagnostics.