### PR TITLE
feat(phpstan): infer captured argument types

### DIFF
--- a/docs/api-doubles.md
+++ b/docs/api-doubles.md
@@ -85,7 +85,11 @@ candidate expectations cannot add values to a captor.
 final class ArgumentCaptor implements ArgumentMatcher
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/ArgumentCaptor.php#L15)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/ArgumentCaptor.php#L17)
+
+PHPDoc:
+
+- `@template TValue = mixed`
 
 ### `matches()`
 
@@ -93,7 +97,7 @@ final class ArgumentCaptor implements ArgumentMatcher
 public function matches(mixed $value): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/ArgumentCaptor.php#L22)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/ArgumentCaptor.php#L24)
 
 ### `describe()`
 
@@ -101,7 +105,7 @@ public function matches(mixed $value): bool
 public function describe(): string
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/ArgumentCaptor.php#L27)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/ArgumentCaptor.php#L29)
 
 ### `values()`
 
@@ -111,9 +115,9 @@ public function values(): array
 
 PHPDoc:
 
-- `@return list<mixed>`
+- `@return list<TValue>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/ArgumentCaptor.php#L41)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/ArgumentCaptor.php#L47)
 
 ### `value()`
 
@@ -121,7 +125,11 @@ PHPDoc:
 public function value(): mixed
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/ArgumentCaptor.php#L46)
+PHPDoc:
+
+- `@return TValue`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/ArgumentCaptor.php#L53)
 
 ## `ArgumentMatcher`
 

--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -121,6 +121,10 @@ is `method`, `arity`, `argument`, `cardinality`, `answer`, or `capturePosition`.
 Greenlight validates each plan at run time when PHPStan cannot resolve a method
 name or argument list.
 
+For a constant method name and capture position, `captureArgument()` keeps the
+selected parameter type. Its `value()` and `values()` results use that type.
+A dynamic method name or position keeps the documented `mixed` value type.
+
 ## Custom matcher checks
 
 These checks apply when a plugin adds matchers through `ExpectationExtension`.

--- a/extension.neon
+++ b/extension.neon
@@ -24,6 +24,10 @@ rules:
     - Greenlight\PhpStan\ToThrowSubjectRule
 
 services:
+    greenlight.captureArgumentReturnTypeExtension:
+        class: Greenlight\PhpStan\CaptureArgumentReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicMethodReturnTypeExtension
     greenlight.doublesCallsToReturnTypeExtension:
         class: Greenlight\PhpStan\DoublesCallsToReturnTypeExtension
         tags:

--- a/src/Doubles/ArgumentCaptor.php
+++ b/src/Doubles/ArgumentCaptor.php
@@ -11,11 +11,13 @@ namespace Greenlight\Doubles;
  * `matches()` always accepts the value and does not record it. Only the
  * expectation selected for the call can record an argument. Thus, checks of
  * candidate expectations cannot add values to a captor.
+ *
+ * @template TValue = mixed
  */
 final class ArgumentCaptor implements ArgumentMatcher
 {
     /**
-     * @var list<mixed>
+     * @var list<TValue>
      */
     private array $captured = [];
 
@@ -29,20 +31,25 @@ final class ArgumentCaptor implements ArgumentMatcher
         return 'captor()';
     }
 
-    /** @internal */
+    /**
+     * @param TValue $value
+     *
+     * @internal
+     */
     public function capture(mixed $value): void
     {
         $this->captured[] = $value;
     }
 
     /**
-     * @return list<mixed>
+     * @return list<TValue>
      */
     public function values(): array
     {
         return $this->captured;
     }
 
+    /** @return TValue */
     public function value(): mixed
     {
         if ($this->captured === []) {

--- a/src/Doubles/MethodExpectation.php
+++ b/src/Doubles/MethodExpectation.php
@@ -185,6 +185,8 @@ final class MethodExpectation
      * expectation for a call. The method returns the captor and ends the
      * fluent chain. Before you call this method, configure the cardinality. If
      * the doubled method returns a value, configure its result first.
+     *
+     * @return ArgumentCaptor<mixed>
      */
     public function captureArgument(int $position = 0): ArgumentCaptor
     {

--- a/src/PhpStan/CaptureArgumentReturnTypeExtension.php
+++ b/src/PhpStan/CaptureArgumentReturnTypeExtension.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\PhpStan;
+
+use Greenlight\Doubles\ArgumentCaptor;
+use Greenlight\Doubles\MethodExpectation;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Reflection\ReflectionProvider;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+/**
+ * Gets the selected method parameter type for `captureArgument()`.
+ *
+ * @internal
+ */
+final readonly class CaptureArgumentReturnTypeExtension implements DynamicMethodReturnTypeExtension
+{
+    public function __construct(private ReflectionProvider $reflectionProvider) {}
+
+    #[\Override]
+    public function getClass(): string
+    {
+        return MethodExpectation::class;
+    }
+
+    #[\Override]
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'captureArgument';
+    }
+
+    #[\Override]
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
+    {
+        $receiver = $scope->getType($methodCall->var);
+
+        if (!new ObjectType(MethodExpectation::class)->isSuperTypeOf($receiver)->yes()) {
+            return null;
+        }
+
+        $targets = $receiver->getTemplateType(MethodExpectation::class, 'TTarget')->getObjectClassNames();
+        $methods = $receiver->getTemplateType(MethodExpectation::class, 'TMethod')->getConstantStrings();
+
+        if (\count($targets) !== 1
+            || \count($methods) !== 1
+            || !$this->reflectionProvider->hasClass($targets[0])
+        ) {
+            return null;
+        }
+
+        $target = $this->reflectionProvider->getClass($targets[0]);
+        $method = $methods[0]->getValue();
+
+        if (!$target->hasNativeMethod($method)) {
+            return null;
+        }
+
+        $variants = $target->getNativeMethod($method)->getVariants();
+
+        if (\count($variants) !== 1) {
+            return null;
+        }
+
+        $position = $this->position($methodCall, $scope);
+        $parameters = $variants[0]->getParameters();
+
+        if ($position === null || $position < 0 || $parameters === []) {
+            return null;
+        }
+
+        $last = \array_key_last($parameters);
+
+        if ($position > $last && !$parameters[$last]->isVariadic()) {
+            return null;
+        }
+
+        $parameter = $parameters[\min($position, $last)];
+
+        return new GenericObjectType(ArgumentCaptor::class, [$parameter->getType()]);
+    }
+
+    private function position(MethodCall $call, Scope $scope): ?int
+    {
+        $argument = $this->argument($call, 'position', 0);
+
+        if (!$argument instanceof Arg) {
+            return 0;
+        }
+
+        $values = \array_values(\array_filter(
+            $scope->getType($argument->value)->getConstantScalarValues(),
+            \is_int(...),
+        ));
+
+        return \count($values) === 1 ? $values[0] : null;
+    }
+
+    private function argument(MethodCall $call, string $name, int $position): ?Arg
+    {
+        $nextPosition = 0;
+
+        foreach ($call->getArgs() as $argument) {
+            if ($argument->unpack) {
+                continue;
+            }
+
+            if ($argument->name instanceof Identifier) {
+                if ($argument->name->toString() === $name) {
+                    return $argument;
+                }
+
+                continue;
+            }
+
+            if ($nextPosition === $position) {
+                return $argument;
+            }
+
+            ++$nextPosition;
+        }
+
+        return null;
+    }
+}

--- a/tests/Acceptance/PhpStanCaptureArgumentReturnTypeExtensionTest.php
+++ b/tests/Acceptance/PhpStanCaptureArgumentReturnTypeExtensionTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\PhpStanProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class PhpStanCaptureArgumentReturnTypeExtensionTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function captureArgumentUsesTheSelectedParameterType(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Doubles\Doubles;
+            use Greenlight\Doubles\MockPlan;
+
+            interface TypedCapturePlan
+            {
+                public function record(int $id, string $message): void;
+
+                public function collect(string $name, int ...$values): void;
+            }
+
+            function acceptCapturedString(string $value): void {}
+
+            /** @param list<string> $values */
+            function acceptCapturedStrings(array $values): void {}
+
+            function acceptCapturedInt(int $value): void {}
+
+            function acceptCapturedMixed(mixed $value): void {}
+
+            function greenlightTypedCaptureProbe(Doubles $doubles, int $dynamicPosition): void
+            {
+                $doubles->mock(TypedCapturePlan::class, static function (MockPlan $plan) use ($dynamicPosition): void {
+                    $message = $plan->expects('record')->captureArgument(position: 1);
+                    acceptCapturedString($message->value());
+                    acceptCapturedStrings($message->values());
+
+                    $value = $plan->expects('collect')->captureArgument(99);
+                    acceptCapturedInt($value->value());
+
+                    $dynamic = $plan->expects('record')->captureArgument($dynamicPosition);
+                    acceptCapturedMixed($dynamic->value());
+                });
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Doubles\Doubles;
+            use Greenlight\Doubles\MockPlan;
+
+            interface MistypedCapturePlan
+            {
+                public function record(int $id, string $message): void;
+            }
+
+            function acceptMistypedCapture(int $value): void {}
+
+            function greenlightMistypedCaptureProbe(Doubles $doubles): void
+            {
+                $doubles->mock(MistypedCapturePlan::class, static function (MockPlan $plan): void {
+                    $message = $plan->expects('record')->captureArgument(1);
+                    acceptMistypedCapture($message->value());
+                });
+            }
+            PHP,
+        );
+
+        Expect::that($probe->exitCode)
+            ->because('PHPStan rejects a captor value used as the wrong parameter type')
+            ->toBe(1);
+        Expect::that($probe->goodPassed)
+            ->because('PHPStan messages: ' . $probe->messages())
+            ->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(1);
+        Expect::that($probe->messages())->toContain('expects int, string given');
+    }
+}


### PR DESCRIPTION
Make ArgumentCaptor generic and infer captureArgument return values from the selected doubled method parameter. Preserve mixed for dynamic method names or positions, type variadic tail captures correctly, and update the generated API reference and PHPStan documentation.