### PR TITLE
fix(expect): replace removed subject-changing chain

### DIFF
--- a/tests/Acceptance/PhpStanDoublePlanRuleTest.php
+++ b/tests/Acceptance/PhpStanDoublePlanRuleTest.php
@@ -65,13 +65,14 @@ final readonly class PhpStanDoublePlanRuleTest
             PHP,
         );
 
-        Expect::that($probe->exitCode)->because('mock plans must satisfy their doubled methods')->toBe(1)
-            ->and($probe->goodPassed)->toBeTrue()
-            ->and(\count($probe->errors))->toBe(6)
-            ->and($probe->messages())->toContain('Mock plan method Greenlight\\Tests\\Fixture\\Doubles\\Wide::missing() does not exist')
-            ->and($probe->messages())->toContain('withNoArguments() supplies 0 arguments')
-            ->and($probe->messages())->toContain('with() supplies 1 argument')
-            ->and($probe->messages())->toContain('parameter $limit has type string, but the parameter requires int')
-            ->and($probe->messages())->toContain('parameter $rest has type string, but the parameter requires int');
+        Expect::that($probe->exitCode)->because('mock plans must satisfy their doubled methods')->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(6);
+        Expect::that($probe->messages())
+            ->toContain('Mock plan method Greenlight\\Tests\\Fixture\\Doubles\\Wide::missing() does not exist');
+        Expect::that($probe->messages())->toContain('withNoArguments() supplies 0 arguments');
+        Expect::that($probe->messages())->toContain('with() supplies 1 argument');
+        Expect::that($probe->messages())->toContain('parameter $limit has type string, but the parameter requires int');
+        Expect::that($probe->messages())->toContain('parameter $rest has type string, but the parameter requires int');
     }
 }


### PR DESCRIPTION
Replace the stale subject-changing and() chain in PhpStanDoublePlanRuleTest with independent expectations. This aligns the test merged in #1205 with the expectation API removal merged in #1203 and restores CI on main.