### PR TITLE
feat(expect): support typed throwable callbacks

### DIFF
--- a/docs/api-expectations.md
+++ b/docs/api-expectations.md
@@ -698,12 +698,13 @@ public function toThrow(
 
 PHPDoc:
 
-- `@param class-string<\Throwable>|\Closure $throwable`
+- `@template TThrowable of \Throwable`
+- `@param class-string<TThrowable>|\Closure(TThrowable): void $throwable`
 - `@return self<T>`
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L782)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L784)
 
 ## `ExpectationExtension`
 

--- a/docs/api-expectations.md
+++ b/docs/api-expectations.md
@@ -674,34 +674,36 @@ PHPDoc:
 
 The subject must be callable. The matcher calls it with no arguments.
 It passes when the subject throws an instance of the specified class.
-The optional `matching:` argument can be a message regular expression
-or a callback. Greenlight gives the caught throwable to the callback
-after its type matches. The callback matches when it returns without an
-expectation failure.
 
-The `message:` argument checks the exact message.
+The throwable can instead be a callback with one typed Throwable
+parameter. Its parameter type specifies the expected throwable class.
+Greenlight gives the caught throwable to the callback after its type
+matches. The callback matches when it returns without an expectation
+failure.
+
+The optional `matching:` argument checks the message with a regular
+expression. The `message:` argument checks the exact message. Do not use
+these arguments with a throwable callback.
 
 With `not()`, a throwable that does not satisfy both conditions makes the
 matcher pass.
 
 ```php
 public function toThrow(
-    string $throwable,
-    string|\Closure|null $matching = null,
+    string|\Closure $throwable,
+    ?string $matching = null,
     ?string $message = null,
 ): self
 ```
 
 PHPDoc:
 
-- `@template TThrowable of \Throwable`
-- `@param class-string<TThrowable> $throwable`
-- `@param (\Closure(TThrowable): void)|string|null $matching`
+- `@param class-string<\Throwable>|\Closure $throwable`
 - `@return self<T>`
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L781)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L782)
 
 ## `ExpectationExtension`
 

--- a/docs/api-expectations.md
+++ b/docs/api-expectations.md
@@ -674,24 +674,34 @@ PHPDoc:
 
 The subject must be callable. The matcher calls it with no arguments.
 It passes when the subject throws an instance of the specified class.
-The message must satisfy the optional regular expression or exact-text
-constraint.
+The optional `matching:` argument can be a message regular expression
+or a callback. Greenlight gives the caught throwable to the callback
+after its type matches. The callback matches when it returns without an
+expectation failure.
+
+The `message:` argument checks the exact message.
 
 With `not()`, a throwable that does not satisfy both conditions makes the
 matcher pass.
 
 ```php
-public function toThrow(string $throwable, ?string $matching = null, ?string $message = null): self
+public function toThrow(
+    string $throwable,
+    string|\Closure|null $matching = null,
+    ?string $message = null,
+): self
 ```
 
 PHPDoc:
 
-- `@param class-string<\Throwable> $throwable`
+- `@template TThrowable of \Throwable`
+- `@param class-string<TThrowable> $throwable`
+- `@param (\Closure(TThrowable): void)|string|null $matching`
 - `@return self<T>`
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L774)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L781)
 
 ## `ExpectationExtension`
 

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -154,6 +154,30 @@ Expect::that($callback)->toThrow(
 
 `message:` and `matching:` are mutually exclusive.
 
+The `matching:` argument also accepts a callback. Greenlight runs the callback
+only after the throwable type matches:
+
+```php
+Expect::that(fn() => $fixtureManager->start())
+    ->toThrow(
+        IntegrationFixtureError::class,
+        matching: static function (IntegrationFixtureError $error): void {
+            Expect::that($error->getPrevious())
+                ->toBeInstanceOf(LengthException::class);
+        },
+    );
+```
+
+The callback must accept the configured throwable type and return `void`.
+PHPStan infers its parameter type from the class-string argument.
+
+The callback can contain ordinary expectations. A failed callback expectation
+keeps its diagnostic. An `eventually()` expectation retries this failure.
+
+With `not()`, a failed callback expectation means that the throwable does not
+match. Thus, the negated `toThrow()` expectation passes. Other callback
+throwables stop the matcher.
+
 ## Asynchronous state
 
 `Expect::eventually()` calls a probe immediately. It then polls until its

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -152,31 +152,32 @@ Expect::that($callback)->toThrow(
 );
 ```
 
-`message:` and `matching:` are mutually exclusive.
+`message:` and `matching:` are mutually exclusive. Use them only with a
+throwable class-string.
 
-The `matching:` argument also accepts a callback. Greenlight runs the callback
-only after the throwable type matches:
+A typed callback can specify the throwable type and check the caught
+throwable. Greenlight runs it only after the throwable type matches:
 
 ```php
 Expect::that(fn() => $fixtureManager->start())
     ->toThrow(
-        IntegrationFixtureError::class,
-        matching: static function (IntegrationFixtureError $error): void {
+        static function (IntegrationFixtureError $error): void {
             Expect::that($error->getPrevious())
                 ->toBeInstanceOf(LengthException::class);
         },
     );
 ```
 
-The callback must accept the configured throwable type and return `void`.
-PHPStan infers its parameter type from the class-string argument.
+The callback MUST declare one named, non-null Throwable parameter type by
+value. It MUST return `void`. The parameter type specifies the expected
+throwable class.
 
 The callback can contain ordinary expectations. A failed callback expectation
 keeps its diagnostic. An `eventually()` expectation retries this failure.
 
 With `not()`, a failed callback expectation means that the throwable does not
-match. Thus, the negated `toThrow()` expectation passes. Other callback
-throwables stop the matcher.
+match. Thus, the negated `toThrow()` expectation passes. Other throwables from
+the callback stop the matcher.
 
 ## Asynchronous state
 

--- a/docs/migrating-from-phpunit.md
+++ b/docs/migrating-from-phpunit.md
@@ -152,10 +152,49 @@ These differences are important:
 * `toThrow()` accepts a callable subject and an optional message constraint.
   * Use `message:` for exact equality.
   * Use `matching:` for a regular expression.
+  * Use a typed `matching:` callback to check the caught throwable.
   * Do not use `message:` and `matching:` in one call.
 * `Fail::because()` replaces `$this->fail()` and supports explicit type guards.
 * `Fail::because()` counts as an expectation and reports the guard location.
 * A failed matcher throws immediately. Greenlight has no soft-assertion mode.
+
+A matching callback removes manual exception capture. It can check the message,
+the previous throwable, and other throwable state.
+
+Replace this pattern:
+
+```php
+$error = null;
+
+try {
+    $fixtureManager->start();
+} catch (IntegrationFixtureError $caught) {
+    $error = $caught;
+}
+
+if (!$error instanceof IntegrationFixtureError) {
+    Fail::because('Expected the fixture manager to fail.');
+}
+
+Expect::that($error->getPrevious())
+    ->toBeInstanceOf(LengthException::class);
+```
+
+Use this expectation:
+
+```php
+Expect::that(fn() => $fixtureManager->start())
+    ->toThrow(
+        IntegrationFixtureError::class,
+        matching: static function (IntegrationFixtureError $error): void {
+            Expect::that($error->getPrevious())
+                ->toBeInstanceOf(LengthException::class);
+        },
+    );
+```
+
+The callback runs only after the throwable type matches. PHPStan infers
+`IntegrationFixtureError` from the first argument.
 
 Replace manual `sleep()` calls or retry loops with `eventually()`:
 

--- a/docs/migrating-from-phpunit.md
+++ b/docs/migrating-from-phpunit.md
@@ -152,14 +152,15 @@ These differences are important:
 * `toThrow()` accepts a callable subject and an optional message constraint.
   * Use `message:` for exact equality.
   * Use `matching:` for a regular expression.
-  * Use a typed `matching:` callback to check the caught throwable.
+  * Use a typed throwable callback to check the caught throwable.
   * Do not use `message:` and `matching:` in one call.
 * `Fail::because()` replaces `$this->fail()` and supports explicit type guards.
 * `Fail::because()` counts as an expectation and reports the guard location.
 * A failed matcher throws immediately. Greenlight has no soft-assertion mode.
 
-A matching callback removes manual exception capture. It can check the message,
-the previous throwable, and other throwable state.
+A throwable callback removes manual exception capture. Its parameter type
+specifies the expected throwable class. Its body can check the message, the
+previous throwable, and other throwable state.
 
 Replace this pattern:
 
@@ -185,16 +186,14 @@ Use this expectation:
 ```php
 Expect::that(fn() => $fixtureManager->start())
     ->toThrow(
-        IntegrationFixtureError::class,
-        matching: static function (IntegrationFixtureError $error): void {
+        static function (IntegrationFixtureError $error): void {
             Expect::that($error->getPrevious())
                 ->toBeInstanceOf(LengthException::class);
         },
     );
 ```
 
-The callback runs only after the throwable type matches. PHPStan infers
-`IntegrationFixtureError` from the first argument.
+The callback runs only after the throwable type matches.
 
 Replace manual `sleep()` calls or retry loops with `eventually()`:
 

--- a/docs/migrating-from-phpunit.md
+++ b/docs/migrating-from-phpunit.md
@@ -165,20 +165,15 @@ previous throwable, and other throwable state.
 Replace this pattern:
 
 ```php
-$error = null;
-
 try {
     $fixtureManager->start();
-} catch (IntegrationFixtureError $caught) {
-    $error = $caught;
+    $this->fail('Expected the fixture manager to fail.');
+} catch (IntegrationFixtureError $error) {
+    $this->assertInstanceOf(
+        LengthException::class,
+        $error->getPrevious(),
+    );
 }
-
-if (!$error instanceof IntegrationFixtureError) {
-    Fail::because('Expected the fixture manager to fail.');
-}
-
-Expect::that($error->getPrevious())
-    ->toBeInstanceOf(LengthException::class);
 ```
 
 Use this expectation:

--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -74,17 +74,28 @@ parameter.
 
 ## Native matcher constraints
 
-`toThrow()` can constrain the exception message with either an exact string or
-a regular expression:
+`toThrow()` can constrain the exception message with an exact string, regular
+expression, or typed callback:
 
 ```php
 Expect::that($callback)->toThrow(DomainException::class, message: 'Exact message');
 Expect::that($callback)->toThrow(DomainException::class, matching: '/message/i');
+Expect::that($callback)->toThrow(
+    DomainException::class,
+    matching: static function (DomainException $error): void {
+        Expect::that($error->getPrevious())->toBeInstanceOf(LengthException::class);
+    },
+);
 ```
 
 A call that supplies both `message:` and `matching:` causes the
 `greenlight.toThrow.messageConstraint` error. Greenlight also rejects the call
 at run time. Thus, the constraint does not depend on PHPStan.
+
+The throwable class-string supplies the matching callback parameter type.
+PHPStan reports an incompatible parameter or return type. The
+`greenlight.toThrow.matchingCallback` error reports an invalid argument count
+or a reference parameter.
 
 The subject for `toThrow()` must be callable. The extension reports a known
 incompatible subject before the test runs:

--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -74,15 +74,14 @@ parameter.
 
 ## Native matcher constraints
 
-`toThrow()` can constrain the exception message with an exact string, regular
-expression, or typed callback:
+`toThrow()` can constrain the exception message with an exact string or a
+regular expression. A typed callback can specify and check the throwable:
 
 ```php
 Expect::that($callback)->toThrow(DomainException::class, message: 'Exact message');
 Expect::that($callback)->toThrow(DomainException::class, matching: '/message/i');
 Expect::that($callback)->toThrow(
-    DomainException::class,
-    matching: static function (DomainException $error): void {
+    static function (DomainException $error): void {
         Expect::that($error->getPrevious())->toBeInstanceOf(LengthException::class);
     },
 );
@@ -92,10 +91,10 @@ A call that supplies both `message:` and `matching:` causes the
 `greenlight.toThrow.messageConstraint` error. Greenlight also rejects the call
 at run time. Thus, the constraint does not depend on PHPStan.
 
-The throwable class-string supplies the matching callback parameter type.
-PHPStan reports an incompatible parameter or return type. The
-`greenlight.toThrow.matchingCallback` error reports an invalid argument count
-or a reference parameter.
+A call that supplies a message constraint with a throwable callback causes the
+`greenlight.toThrow.callbackConstraint` error. The
+`greenlight.toThrow.callback` error reports an invalid callback parameter or
+return type. Greenlight applies the same checks at run time.
 
 The subject for `toThrow()` must be callable. The extension reports a known
 incompatible subject before the test runs:

--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -92,9 +92,10 @@ A call that supplies both `message:` and `matching:` causes the
 at run time. Thus, the constraint does not depend on PHPStan.
 
 A call that supplies a message constraint with a throwable callback causes the
-`greenlight.toThrow.callbackConstraint` error. The
-`greenlight.toThrow.callback` error reports an invalid callback parameter or
-return type. Greenlight applies the same checks at run time.
+`greenlight.toThrow.callbackConstraint` error. The generic closure signature
+reports incompatible parameter and return types. The
+`greenlight.toThrow.callback` error reports constraints that the signature
+cannot express. Greenlight applies all callback checks at run time.
 
 The subject for `toThrow()` must be callable. The extension reports a known
 incompatible subject before the test runs:

--- a/extension.neon
+++ b/extension.neon
@@ -20,6 +20,7 @@ rules:
     - Greenlight\PhpStan\TestAttributePlacementRule
     - Greenlight\PhpStan\TestConstructorRule
     - Greenlight\PhpStan\TestMethodRule
+    - Greenlight\PhpStan\ToThrowMatchingCallbackRule
     - Greenlight\PhpStan\ToThrowMessageRule
     - Greenlight\PhpStan\ToThrowSubjectRule
 

--- a/extension.neon
+++ b/extension.neon
@@ -20,8 +20,8 @@ rules:
     - Greenlight\PhpStan\TestAttributePlacementRule
     - Greenlight\PhpStan\TestConstructorRule
     - Greenlight\PhpStan\TestMethodRule
-    - Greenlight\PhpStan\ToThrowMatchingCallbackRule
-    - Greenlight\PhpStan\ToThrowMessageRule
+    - Greenlight\PhpStan\ToThrowCallbackRule
+    - Greenlight\PhpStan\ToThrowConstraintRule
     - Greenlight\PhpStan\ToThrowSubjectRule
 
 services:

--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -758,20 +758,21 @@ final class Expectation
     /**
      * The subject must be callable. The matcher calls it with no arguments.
      * It passes when the subject throws an instance of the specified class.
-     * The optional `matching:` argument can be a message regular expression
-     * or a callback. Greenlight gives the caught throwable to the callback
-     * after its type matches. The callback matches when it returns without an
-     * expectation failure.
      *
-     * The `message:` argument checks the exact message.
+     * The throwable can instead be a callback with one typed Throwable
+     * parameter. Its parameter type specifies the expected throwable class.
+     * Greenlight gives the caught throwable to the callback after its type
+     * matches. The callback matches when it returns without an expectation
+     * failure.
+     *
+     * The optional `matching:` argument checks the message with a regular
+     * expression. The `message:` argument checks the exact message. Do not use
+     * these arguments with a throwable callback.
      *
      * With `not()`, a throwable that does not satisfy both conditions makes the
      * matcher pass.
      *
-     * @template TThrowable of \Throwable
-     *
-     * @param class-string<TThrowable> $throwable
-     * @param (\Closure(TThrowable): void)|string|null $matching
+     * @param class-string<\Throwable>|\Closure $throwable
      *
      * @return self<T>
      *
@@ -779,19 +780,27 @@ final class Expectation
      * @throws ExpectationFailed
      */
     public function toThrow(
-        string $throwable,
-        string|\Closure|null $matching = null,
+        string|\Closure $throwable,
+        ?string $matching = null,
         ?string $message = null,
     ): self {
+        $callback = $throwable instanceof \Closure ? $throwable : null;
+
+        if ($callback instanceof \Closure && ($matching !== null || $message !== null)) {
+            $this->usageFailure('Do not specify matching: or message: when the throwable is a callback.');
+        }
+
         if ($matching !== null && $message !== null) {
             $this->usageFailure('Specify matching: or message: for toThrow(). Do not specify both.');
         }
 
-        if (\is_string($matching)) {
+        if ($matching !== null) {
             $this->requireValidPattern($matching, 'toThrow');
-        } elseif ($matching instanceof \Closure) {
-            $this->requireThrowableCallback($matching, $throwable);
         }
+
+        $expectedThrowable = $callback instanceof \Closure
+            ? $this->requireThrowableCallback($callback)
+            : $throwable;
 
         if (!\is_callable($this->subject)) {
             $this->usageFailure(\sprintf(
@@ -808,13 +817,13 @@ final class Expectation
             $thrown = $caught;
         }
 
-        $matched = $thrown instanceof $throwable;
+        $matched = $thrown instanceof $expectedThrowable;
 
-        if ($matched && \is_string($matching)) {
+        if ($matched && $matching !== null) {
             $matched = \preg_match($matching, $thrown->getMessage()) === 1;
-        } elseif ($matched && $matching instanceof \Closure) {
+        } elseif ($matched && $callback instanceof \Closure) {
             try {
-                $result = $this->invokeThrowableCallback($matching, $thrown);
+                $result = $this->invokeThrowableCallback($callback, $thrown);
             } catch (ExpectationFailed $failure) {
                 if (!$this->negated) {
                     $this->negated = false;
@@ -829,7 +838,7 @@ final class Expectation
 
             if ($result !== null) {
                 $this->usageFailure(\sprintf(
-                    'The matching callback for toThrow() must return void. It returned %s.',
+                    'The throwable callback for toThrow() MUST return void. It returned %s.',
                     \get_debug_type($result),
                 ));
             }
@@ -839,12 +848,12 @@ final class Expectation
             $matched = $thrown instanceof \Throwable && $thrown->getMessage() === $message;
         }
 
-        $description = 'to throw ' . $throwable;
+        $description = 'to throw ' . $expectedThrowable;
 
-        if (\is_string($matching)) {
+        if ($matching !== null) {
             $description .= ' with message matching ' . $matching;
-        } elseif ($matching instanceof \Closure) {
-            $description .= ' with a throwable that satisfies the matching callback';
+        } elseif ($callback instanceof \Closure) {
+            $description .= ' and satisfy the throwable callback';
         } elseif ($message !== null) {
             $description .= ' with message ' . $this->renderer->render($message);
         }
@@ -857,7 +866,7 @@ final class Expectation
             )
             : 'a callable that did not throw';
 
-        return $this->verify($matched, $description, $throwable, $actual);
+        return $this->verify($matched, $description, $expectedThrowable, $actual);
     }
 
     /**
@@ -957,24 +966,27 @@ final class Expectation
     }
 
     /**
-     * Confirms that a matching callback can accept one configured throwable.
+     * Returns the Throwable class declared by a throwable callback.
      *
-     * @param class-string<\Throwable> $throwable
+     * @return class-string<\Throwable>
      *
      * @throws ExpectationFailed
      */
-    private function requireThrowableCallback(\Closure $callback, string $throwable): void
+    private function requireThrowableCallback(\Closure $callback): string
     {
         $reflection = new \ReflectionFunction($callback);
         $parameters = $reflection->getParameters();
         $parameter = $parameters[0] ?? null;
 
-        if (!$parameter instanceof \ReflectionParameter || $reflection->getNumberOfRequiredParameters() > 1) {
-            $this->usageFailure('The matching callback for toThrow() must accept one throwable argument.');
+        if (!$parameter instanceof \ReflectionParameter
+            || $parameter->isVariadic()
+            || $reflection->getNumberOfRequiredParameters() > 1
+        ) {
+            $this->usageFailure('The throwable callback for toThrow() MUST accept one typed Throwable argument.');
         }
 
         if ($parameter->isPassedByReference()) {
-            $this->usageFailure('The matching callback for toThrow() must accept its throwable argument by value.');
+            $this->usageFailure('The throwable callback for toThrow() MUST accept its argument by value.');
         }
 
         $returnType = $reflection->getReturnType();
@@ -984,72 +996,41 @@ final class Expectation
                 || ($returnType->getName() !== 'void' && $returnType->getName() !== 'never'))
         ) {
             $this->usageFailure(\sprintf(
-                'The matching callback for toThrow() must return void. Its return type is %s.',
+                'The throwable callback for toThrow() MUST return void. Its return type is %s.',
                 $this->renderReflectionType($returnType),
             ));
         }
 
         $type = $parameter->getType();
 
-        if ($type instanceof \ReflectionType && !$this->reflectionTypeAcceptsClass($type, $throwable, $reflection)) {
+        if (!$type instanceof \ReflectionNamedType || $type->isBuiltin() || $type->allowsNull()) {
             $this->usageFailure(\sprintf(
-                'The matching callback for toThrow() must accept %s. Its parameter type is %s.',
-                $throwable,
-                $this->renderReflectionType($type),
+                'The throwable callback for toThrow() MUST declare one named, non-null Throwable parameter type. Its parameter type is %s.',
+                $type instanceof \ReflectionType ? $this->renderReflectionType($type) : 'missing',
             ));
         }
+
+        $scope = $reflection->getClosureScopeClass();
+        $parent = $scope?->getParentClass();
+        $throwable = match ($type->getName()) {
+            'self', 'static' => $scope?->getName() ?? $type->getName(),
+            'parent' => $parent instanceof \ReflectionClass ? $parent->getName() : $type->getName(),
+            default => $type->getName(),
+        };
+
+        if (!\is_a($throwable, \Throwable::class, true)) {
+            $this->usageFailure(\sprintf(
+                'The throwable callback for toThrow() MUST declare a Throwable parameter type. Its parameter type is %s.',
+                $type->getName(),
+            ));
+        }
+
+        return $throwable;
     }
 
     private function invokeThrowableCallback(\Closure $callback, \Throwable $throwable): mixed
     {
         return $callback($throwable);
-    }
-
-    /**
-     * @param class-string $class
-     */
-    private function reflectionTypeAcceptsClass(
-        \ReflectionType $type,
-        string $class,
-        \ReflectionFunction $callback,
-    ): bool {
-        if ($type instanceof \ReflectionUnionType) {
-            return \array_any(
-                $type->getTypes(),
-                fn(\ReflectionType $member): bool => $this->reflectionTypeAcceptsClass($member, $class, $callback),
-            );
-        }
-
-        if ($type instanceof \ReflectionIntersectionType) {
-            return \array_all(
-                $type->getTypes(),
-                fn(\ReflectionType $member): bool => $this->reflectionTypeAcceptsClass($member, $class, $callback),
-            );
-        }
-
-        if (!$type instanceof \ReflectionNamedType) {
-            return false; // @codeCoverageIgnore
-        }
-
-        $name = $type->getName();
-
-        if ($name === 'mixed' || $name === 'object') {
-            return true;
-        }
-
-        if ($type->isBuiltin()) {
-            return false;
-        }
-
-        $scope = $callback->getClosureScopeClass();
-        $parent = $scope?->getParentClass();
-        $name = match ($name) {
-            'self', 'static' => $scope?->getName() ?? $name,
-            'parent' => $parent instanceof \ReflectionClass ? $parent->getName() : $name,
-            default => $name,
-        };
-
-        return \is_a($class, $name, true);
     }
 
     private function renderReflectionType(\ReflectionType $type): string

--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -772,7 +772,9 @@ final class Expectation
      * With `not()`, a throwable that does not satisfy both conditions makes the
      * matcher pass.
      *
-     * @param class-string<\Throwable>|\Closure $throwable
+     * @template TThrowable of \Throwable
+     *
+     * @param class-string<TThrowable>|\Closure(TThrowable): void $throwable
      *
      * @return self<T>
      *

--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -758,27 +758,39 @@ final class Expectation
     /**
      * The subject must be callable. The matcher calls it with no arguments.
      * It passes when the subject throws an instance of the specified class.
-     * The message must satisfy the optional regular expression or exact-text
-     * constraint.
+     * The optional `matching:` argument can be a message regular expression
+     * or a callback. Greenlight gives the caught throwable to the callback
+     * after its type matches. The callback matches when it returns without an
+     * expectation failure.
+     *
+     * The `message:` argument checks the exact message.
      *
      * With `not()`, a throwable that does not satisfy both conditions makes the
      * matcher pass.
      *
-     * @param class-string<\Throwable> $throwable
+     * @template TThrowable of \Throwable
+     *
+     * @param class-string<TThrowable> $throwable
+     * @param (\Closure(TThrowable): void)|string|null $matching
      *
      * @return self<T>
      *
      * @throws \InvalidArgumentException when the match pattern is not a valid regular expression
      * @throws ExpectationFailed
      */
-    public function toThrow(string $throwable, ?string $matching = null, ?string $message = null): self
-    {
+    public function toThrow(
+        string $throwable,
+        string|\Closure|null $matching = null,
+        ?string $message = null,
+    ): self {
         if ($matching !== null && $message !== null) {
             $this->usageFailure('Specify matching: or message: for toThrow(). Do not specify both.');
         }
 
-        if ($matching !== null) {
+        if (\is_string($matching)) {
             $this->requireValidPattern($matching, 'toThrow');
+        } elseif ($matching instanceof \Closure) {
+            $this->requireThrowableCallback($matching, $throwable);
         }
 
         if (!\is_callable($this->subject)) {
@@ -796,14 +808,43 @@ final class Expectation
             $thrown = $caught;
         }
 
-        $matched = $thrown instanceof $throwable
-            && ($matching === null || \preg_match($matching, $thrown->getMessage()) === 1)
-            && ($message === null || $thrown->getMessage() === $message);
+        $matched = $thrown instanceof $throwable;
+
+        if ($matched && \is_string($matching)) {
+            $matched = \preg_match($matching, $thrown->getMessage()) === 1;
+        } elseif ($matched && $matching instanceof \Closure) {
+            try {
+                $result = $this->invokeThrowableCallback($matching, $thrown);
+            } catch (ExpectationFailed $failure) {
+                if (!$this->negated) {
+                    $this->negated = false;
+                    $this->reason = null;
+
+                    throw $failure;
+                }
+
+                $matched = false;
+                $result = null;
+            }
+
+            if ($result !== null) {
+                $this->usageFailure(\sprintf(
+                    'The matching callback for toThrow() must return void. It returned %s.',
+                    \get_debug_type($result),
+                ));
+            }
+        }
+
+        if ($matched && $message !== null) {
+            $matched = $thrown instanceof \Throwable && $thrown->getMessage() === $message;
+        }
 
         $description = 'to throw ' . $throwable;
 
-        if ($matching !== null) {
+        if (\is_string($matching)) {
             $description .= ' with message matching ' . $matching;
+        } elseif ($matching instanceof \Closure) {
+            $description .= ' with a throwable that satisfies the matching callback';
         } elseif ($message !== null) {
             $description .= ' with message ' . $this->renderer->render($message);
         }
@@ -913,6 +954,126 @@ final class Expectation
             $this->renderer->render($this->subject),
             CallSite::capture(),
         ));
+    }
+
+    /**
+     * Confirms that a matching callback can accept one configured throwable.
+     *
+     * @param class-string<\Throwable> $throwable
+     *
+     * @throws ExpectationFailed
+     */
+    private function requireThrowableCallback(\Closure $callback, string $throwable): void
+    {
+        $reflection = new \ReflectionFunction($callback);
+        $parameters = $reflection->getParameters();
+        $parameter = $parameters[0] ?? null;
+
+        if (!$parameter instanceof \ReflectionParameter || $reflection->getNumberOfRequiredParameters() > 1) {
+            $this->usageFailure('The matching callback for toThrow() must accept one throwable argument.');
+        }
+
+        if ($parameter->isPassedByReference()) {
+            $this->usageFailure('The matching callback for toThrow() must accept its throwable argument by value.');
+        }
+
+        $returnType = $reflection->getReturnType();
+
+        if ($returnType instanceof \ReflectionType
+            && (!$returnType instanceof \ReflectionNamedType
+                || ($returnType->getName() !== 'void' && $returnType->getName() !== 'never'))
+        ) {
+            $this->usageFailure(\sprintf(
+                'The matching callback for toThrow() must return void. Its return type is %s.',
+                $this->renderReflectionType($returnType),
+            ));
+        }
+
+        $type = $parameter->getType();
+
+        if ($type instanceof \ReflectionType && !$this->reflectionTypeAcceptsClass($type, $throwable, $reflection)) {
+            $this->usageFailure(\sprintf(
+                'The matching callback for toThrow() must accept %s. Its parameter type is %s.',
+                $throwable,
+                $this->renderReflectionType($type),
+            ));
+        }
+    }
+
+    private function invokeThrowableCallback(\Closure $callback, \Throwable $throwable): mixed
+    {
+        return $callback($throwable);
+    }
+
+    /**
+     * @param class-string $class
+     */
+    private function reflectionTypeAcceptsClass(
+        \ReflectionType $type,
+        string $class,
+        \ReflectionFunction $callback,
+    ): bool {
+        if ($type instanceof \ReflectionUnionType) {
+            return \array_any(
+                $type->getTypes(),
+                fn(\ReflectionType $member): bool => $this->reflectionTypeAcceptsClass($member, $class, $callback),
+            );
+        }
+
+        if ($type instanceof \ReflectionIntersectionType) {
+            return \array_all(
+                $type->getTypes(),
+                fn(\ReflectionType $member): bool => $this->reflectionTypeAcceptsClass($member, $class, $callback),
+            );
+        }
+
+        if (!$type instanceof \ReflectionNamedType) {
+            return false;
+        }
+
+        $name = $type->getName();
+
+        if ($name === 'mixed' || $name === 'object') {
+            return true;
+        }
+
+        if ($type->isBuiltin()) {
+            return false;
+        }
+
+        $scope = $callback->getClosureScopeClass();
+        $parent = $scope?->getParentClass();
+        $name = match ($name) {
+            'self', 'static' => $scope?->getName() ?? $name,
+            'parent' => $parent instanceof \ReflectionClass ? $parent->getName() : $name,
+            default => $name,
+        };
+
+        return \is_a($class, $name, true);
+    }
+
+    private function renderReflectionType(\ReflectionType $type): string
+    {
+        if ($type instanceof \ReflectionUnionType) {
+            return \implode('|', \array_map(
+                $this->renderReflectionType(...),
+                $type->getTypes(),
+            ));
+        }
+
+        if ($type instanceof \ReflectionIntersectionType) {
+            return \implode('&', \array_map(
+                $this->renderReflectionType(...),
+                $type->getTypes(),
+            ));
+        }
+
+        if (!$type instanceof \ReflectionNamedType) {
+            return 'unknown';
+        }
+
+        return ($type->allowsNull() && $type->getName() !== 'mixed' && $type->getName() !== 'null' ? '?' : '')
+            . $type->getName();
     }
 
     /**

--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -1028,7 +1028,7 @@ final class Expectation
         }
 
         if (!$type instanceof \ReflectionNamedType) {
-            return false;
+            return false; // @codeCoverageIgnore
         }
 
         $name = $type->getName();
@@ -1069,7 +1069,7 @@ final class Expectation
         }
 
         if (!$type instanceof \ReflectionNamedType) {
-            return 'unknown';
+            return 'unknown'; // @codeCoverageIgnore
         }
 
         return ($type->allowsNull() && $type->getName() !== 'mixed' && $type->getName() !== 'null' ? '?' : '')

--- a/src/Expect/TemporalExpectation.php
+++ b/src/Expect/TemporalExpectation.php
@@ -295,12 +295,18 @@ abstract class TemporalExpectation
     }
 
     /**
-     * @param class-string<\Throwable> $throwable
+     * @template TThrowable of \Throwable
+     *
+     * @param class-string<TThrowable> $throwable
+     * @param (\Closure(TThrowable): void)|string|null $matching
      *
      * @return Expectation<T>
      */
-    final public function toThrow(string $throwable, ?string $matching = null, ?string $message = null): Expectation
-    {
+    final public function toThrow(
+        string $throwable,
+        string|\Closure|null $matching = null,
+        ?string $message = null,
+    ): Expectation {
         if ($matching !== null && $message !== null) {
             throw ExpectationFailed::fromDetail(new FailureDetail(
                 'Specify matching: or message: for toThrow(). Do not specify both.',

--- a/src/Expect/TemporalExpectation.php
+++ b/src/Expect/TemporalExpectation.php
@@ -295,18 +295,22 @@ abstract class TemporalExpectation
     }
 
     /**
-     * @template TThrowable of \Throwable
-     *
-     * @param class-string<TThrowable> $throwable
-     * @param (\Closure(TThrowable): void)|string|null $matching
+     * @param class-string<\Throwable>|\Closure $throwable
      *
      * @return Expectation<T>
      */
     final public function toThrow(
-        string $throwable,
-        string|\Closure|null $matching = null,
+        string|\Closure $throwable,
+        ?string $matching = null,
         ?string $message = null,
     ): Expectation {
+        if ($throwable instanceof \Closure && ($matching !== null || $message !== null)) {
+            throw ExpectationFailed::fromDetail(new FailureDetail(
+                'Do not specify matching: or message: when the throwable is a callback.',
+                location: CallSite::capture(),
+            ));
+        }
+
         if ($matching !== null && $message !== null) {
             throw ExpectationFailed::fromDetail(new FailureDetail(
                 'Specify matching: or message: for toThrow(). Do not specify both.',
@@ -316,6 +320,10 @@ abstract class TemporalExpectation
 
         return $this->apply(
             static function (Expectation $expectation) use ($throwable, $matching, $message): Expectation {
+                if ($throwable instanceof \Closure) {
+                    return $expectation->toThrow($throwable);
+                }
+
                 if ($matching !== null) {
                     return $expectation->toThrow($throwable, matching: $matching);
                 }

--- a/src/Expect/TemporalExpectation.php
+++ b/src/Expect/TemporalExpectation.php
@@ -295,7 +295,9 @@ abstract class TemporalExpectation
     }
 
     /**
-     * @param class-string<\Throwable>|\Closure $throwable
+     * @template TThrowable of \Throwable
+     *
+     * @param class-string<TThrowable>|\Closure(TThrowable): void $throwable
      *
      * @return Expectation<T>
      */

--- a/src/PhpStan/ToThrowCallbackRule.php
+++ b/src/PhpStan/ToThrowCallbackRule.php
@@ -17,17 +17,19 @@ use PHPStan\Reflection\ParameterReflection;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ClosureType;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
+use PHPStan\Type\VerbosityLevel;
 
 /**
- * Checks the argument count and reference mode of a `toThrow()` matching
- * callback. The method PHPDoc checks its parameter and return types.
+ * Checks the parameter and return type of a `toThrow()` throwable callback.
  *
  * @internal
  *
  * @implements Rule<MethodCall>
  */
-final class ToThrowMatchingCallbackRule implements Rule
+final class ToThrowCallbackRule implements Rule
 {
     #[\Override]
     public function getNodeType(): string
@@ -52,7 +54,7 @@ final class ToThrowMatchingCallbackRule implements Rule
             return [];
         }
 
-        $argument = $this->matchingArgument($node);
+        $argument = $this->throwableArgument($node);
 
         if (!$argument instanceof Arg) {
             return [];
@@ -60,7 +62,7 @@ final class ToThrowMatchingCallbackRule implements Rule
 
         $type = $scope->getType($argument->value);
 
-        if (!new ObjectType(\Closure::class)->isSuperTypeOf($type)->yes()) {
+        if (!$type instanceof ClosureType) {
             return [];
         }
 
@@ -75,28 +77,22 @@ final class ToThrowMatchingCallbackRule implements Rule
         return [];
     }
 
-    private function matchingArgument(MethodCall $call): ?Arg
+    private function throwableArgument(MethodCall $call): ?Arg
     {
-        $position = 0;
-
         foreach ($call->getArgs() as $argument) {
             if ($argument->unpack) {
                 continue;
             }
 
             if ($argument->name instanceof Identifier) {
-                if ($argument->name->toString() === 'matching') {
+                if ($argument->name->toString() === 'throwable') {
                     return $argument;
                 }
 
                 continue;
             }
 
-            if ($position === 1) {
-                return $argument;
-            }
-
-            ++$position;
+            return $argument;
         }
 
         return null;
@@ -110,18 +106,38 @@ final class ToThrowMatchingCallbackRule implements Rule
             static fn(ParameterReflection $parameter): bool => !$parameter->isOptional() && !$parameter->isVariadic(),
         );
 
-        if ($parameters === [] || \count($required) > 1) {
+        if ($parameters === [] || $parameters[0]->isVariadic() || \count($required) > 1) {
             return $this->error(
-                'The matching callback for toThrow() must accept one throwable argument.',
+                'The throwable callback for toThrow() MUST accept one typed Throwable argument.',
                 $line,
             );
         }
 
         if ($parameters[0]->passedByReference()->yes()) {
             return $this->error(
-                'The matching callback for toThrow() must accept its throwable argument by value.',
+                'The throwable callback for toThrow() MUST accept its argument by value.',
                 $line,
             );
+        }
+
+        $parameterType = $parameters[0]->getType();
+
+        if (\count($parameterType->getObjectClassNames()) !== 1
+            || !new ObjectType(\Throwable::class)->isSuperTypeOf($parameterType)->yes()
+        ) {
+            return $this->error(\sprintf(
+                'The throwable callback for toThrow() MUST declare one named, non-null Throwable parameter type. Its parameter type is %s.',
+                $parameterType->describe(VerbosityLevel::typeOnly()),
+            ), $line);
+        }
+
+        $returnType = $callback->getReturnType();
+
+        if (!$returnType->isVoid()->yes() && !$returnType instanceof NeverType) {
+            return $this->error(\sprintf(
+                'The throwable callback for toThrow() MUST return void. Its return type is %s.',
+                $returnType->describe(VerbosityLevel::typeOnly()),
+            ), $line);
         }
 
         return null;
@@ -130,7 +146,7 @@ final class ToThrowMatchingCallbackRule implements Rule
     private function error(string $message, int $line): IdentifierRuleError
     {
         return RuleErrorBuilder::message($message)
-            ->identifier('greenlight.toThrow.matchingCallback')
+            ->identifier('greenlight.toThrow.callback')
             ->line($line)
             ->build();
     }

--- a/src/PhpStan/ToThrowCallbackRule.php
+++ b/src/PhpStan/ToThrowCallbackRule.php
@@ -18,12 +18,11 @@ use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\ClosureType;
-use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\VerbosityLevel;
 
 /**
- * Checks the parameter and return type of a `toThrow()` throwable callback.
+ * Checks throwable callback constraints that the generic signature cannot express.
  *
  * @internal
  *
@@ -106,11 +105,15 @@ final class ToThrowCallbackRule implements Rule
             static fn(ParameterReflection $parameter): bool => !$parameter->isOptional() && !$parameter->isVariadic(),
         );
 
-        if ($parameters === [] || $parameters[0]->isVariadic() || \count($required) > 1) {
+        if ($parameters === [] || $parameters[0]->isVariadic()) {
             return $this->error(
                 'The throwable callback for toThrow() MUST accept one typed Throwable argument.',
                 $line,
             );
+        }
+
+        if (\count($required) > 1) {
+            return null;
         }
 
         if ($parameters[0]->passedByReference()->yes()) {
@@ -121,22 +124,22 @@ final class ToThrowCallbackRule implements Rule
         }
 
         $parameterType = $parameters[0]->getType();
+        $classNames = $parameterType->getObjectClassNames();
+        $throwable = new ObjectType(\Throwable::class);
 
-        if (\count($parameterType->getObjectClassNames()) !== 1
-            || !new ObjectType(\Throwable::class)->isSuperTypeOf($parameterType)->yes()
+        if ($parameterType->isObject()->no()
+            || (\count($classNames) === 1
+                && !$throwable->isSuperTypeOf(new ObjectType($classNames[0]))->yes())
+        ) {
+            return null;
+        }
+
+        if (\count($classNames) !== 1
+            || !$throwable->isSuperTypeOf($parameterType)->yes()
         ) {
             return $this->error(\sprintf(
                 'The throwable callback for toThrow() MUST declare one named, non-null Throwable parameter type. Its parameter type is %s.',
                 $parameterType->describe(VerbosityLevel::typeOnly()),
-            ), $line);
-        }
-
-        $returnType = $callback->getReturnType();
-
-        if (!$returnType->isVoid()->yes() && !$returnType instanceof NeverType) {
-            return $this->error(\sprintf(
-                'The throwable callback for toThrow() MUST return void. Its return type is %s.',
-                $returnType->describe(VerbosityLevel::typeOnly()),
             ), $line);
         }
 

--- a/src/PhpStan/ToThrowConstraintRule.php
+++ b/src/PhpStan/ToThrowConstraintRule.php
@@ -19,15 +19,13 @@ use PHPStan\Type\ObjectType;
 use PHPStan\Type\Type;
 
 /**
- * For compatibility, the `toThrow()` signature keeps the pattern and
- * exact-message arguments nullable. A call-site rule makes these arguments
- * mutually exclusive.
+ * Checks the mutually exclusive `toThrow()` throwable constraints.
  *
  * @internal
  *
  * @implements Rule<MethodCall>
  */
-final class ToThrowMessageRule implements Rule
+final class ToThrowConstraintRule implements Rule
 {
     #[\Override]
     public function getNodeType(): string
@@ -53,12 +51,20 @@ final class ToThrowMessageRule implements Rule
         }
 
         foreach ($this->constraintStates($node, $scope) as $state) {
+            if ($state['throwable'] instanceof Type
+                && new ObjectType(\Closure::class)->isSuperTypeOf($state['throwable'])->yes()
+                && (($state['matching'] instanceof Type && !$state['matching']->isNull()->yes())
+                    || ($state['message'] instanceof Type && !$state['message']->isNull()->yes()))
+            ) {
+                return [$this->callbackConstraintError($node->getStartLine())];
+            }
+
             if ($state['matching'] instanceof Type
                 && $state['message'] instanceof Type
                 && !$state['matching']->isNull()->yes()
                 && !$state['message']->isNull()->yes()
             ) {
-                return [$this->error($node->getStartLine())];
+                return [$this->messageConstraintError($node->getStartLine())];
             }
         }
 
@@ -70,11 +76,12 @@ final class ToThrowMessageRule implements Rule
      *
      * Greenlight validates dynamic unpack operations at run time.
      *
-     * @return list<array{matching: ?Type, message: ?Type, nextPosition: int}>
+     * @return list<array{throwable: ?Type, matching: ?Type, message: ?Type, nextPosition: int}>
      */
     private function constraintStates(MethodCall $call, Scope $scope): array
     {
         $states = [[
+            'throwable' => null,
             'matching' => null,
             'message' => null,
             'nextPosition' => 0,
@@ -129,13 +136,15 @@ final class ToThrowMessageRule implements Rule
     }
 
     /**
-     * @param array{matching: ?Type, message: ?Type, nextPosition: int} $state
+     * @param array{throwable: ?Type, matching: ?Type, message: ?Type, nextPosition: int} $state
      *
-     * @return array{matching: ?Type, message: ?Type, nextPosition: int}
+     * @return array{throwable: ?Type, matching: ?Type, message: ?Type, nextPosition: int}
      */
     private function withArgument(array $state, Type $type, ?string $name): array
     {
-        if ($name === 'matching' || ($name === null && $state['nextPosition'] === 1)) {
+        if ($name === 'throwable' || ($name === null && $state['nextPosition'] === 0)) {
+            $state['throwable'] = $type;
+        } elseif ($name === 'matching' || ($name === null && $state['nextPosition'] === 1)) {
             $state['matching'] = $type;
         } elseif ($name === 'message' || ($name === null && $state['nextPosition'] === 2)) {
             $state['message'] = $type;
@@ -148,10 +157,20 @@ final class ToThrowMessageRule implements Rule
         return $state;
     }
 
-    private function error(int $line): IdentifierRuleError
+    private function messageConstraintError(int $line): IdentifierRuleError
     {
         return RuleErrorBuilder::message('toThrow() accepts either matching: or message:, not both.')
             ->identifier('greenlight.toThrow.messageConstraint')
+            ->line($line)
+            ->build();
+    }
+
+    private function callbackConstraintError(int $line): IdentifierRuleError
+    {
+        return RuleErrorBuilder::message(
+            'Do not specify matching: or message: when the throwable is a callback.',
+        )
+            ->identifier('greenlight.toThrow.callbackConstraint')
             ->line($line)
             ->build();
     }

--- a/src/PhpStan/ToThrowMatchingCallbackRule.php
+++ b/src/PhpStan/ToThrowMatchingCallbackRule.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\PhpStan;
+
+use Greenlight\Expect\ConsistentlyExpectation;
+use Greenlight\Expect\EventuallyExpectation;
+use Greenlight\Expect\Expectation;
+use PhpParser\Node;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\Callables\CallableParametersAcceptor;
+use PHPStan\Reflection\ParameterReflection;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+
+/**
+ * Checks the argument count and reference mode of a `toThrow()` matching
+ * callback. The method PHPDoc checks its parameter and return types.
+ *
+ * @internal
+ *
+ * @implements Rule<MethodCall>
+ */
+final class ToThrowMatchingCallbackRule implements Rule
+{
+    #[\Override]
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    #[\Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Identifier || $node->name->toString() !== 'toThrow') {
+            return [];
+        }
+
+        $receiver = $scope->getType($node->var);
+        $supported = \array_any(
+            [Expectation::class, EventuallyExpectation::class, ConsistentlyExpectation::class],
+            static fn(string $class): bool => new ObjectType($class)->isSuperTypeOf($receiver)->yes(),
+        );
+
+        if (!$supported) {
+            return [];
+        }
+
+        $argument = $this->matchingArgument($node);
+
+        if (!$argument instanceof Arg) {
+            return [];
+        }
+
+        $type = $scope->getType($argument->value);
+
+        if (!new ObjectType(\Closure::class)->isSuperTypeOf($type)->yes()) {
+            return [];
+        }
+
+        foreach ($type->getCallableParametersAcceptors($scope) as $acceptor) {
+            $error = $this->callbackError($acceptor, $node->getStartLine());
+
+            if ($error instanceof IdentifierRuleError) {
+                return [$error];
+            }
+        }
+
+        return [];
+    }
+
+    private function matchingArgument(MethodCall $call): ?Arg
+    {
+        $position = 0;
+
+        foreach ($call->getArgs() as $argument) {
+            if ($argument->unpack) {
+                continue;
+            }
+
+            if ($argument->name instanceof Identifier) {
+                if ($argument->name->toString() === 'matching') {
+                    return $argument;
+                }
+
+                continue;
+            }
+
+            if ($position === 1) {
+                return $argument;
+            }
+
+            ++$position;
+        }
+
+        return null;
+    }
+
+    private function callbackError(CallableParametersAcceptor $callback, int $line): ?IdentifierRuleError
+    {
+        $parameters = $callback->getParameters();
+        $required = \array_filter(
+            $parameters,
+            static fn(ParameterReflection $parameter): bool => !$parameter->isOptional() && !$parameter->isVariadic(),
+        );
+
+        if ($parameters === [] || \count($required) > 1) {
+            return $this->error(
+                'The matching callback for toThrow() must accept one throwable argument.',
+                $line,
+            );
+        }
+
+        if ($parameters[0]->passedByReference()->yes()) {
+            return $this->error(
+                'The matching callback for toThrow() must accept its throwable argument by value.',
+                $line,
+            );
+        }
+
+        return null;
+    }
+
+    private function error(string $message, int $line): IdentifierRuleError
+    {
+        return RuleErrorBuilder::message($message)
+            ->identifier('greenlight.toThrow.matchingCallback')
+            ->line($line)
+            ->build();
+    }
+}

--- a/tests/Acceptance/PhpStanToThrowRuleTest.php
+++ b/tests/Acceptance/PhpStanToThrowRuleTest.php
@@ -126,18 +126,32 @@ final readonly class PhpStanToThrowRuleTest
                 Expect::consistently(static fn(): Closure => static fn() => throw new DomainException('boom'))
                     ->for(0.1)
                     ->toThrow(DomainException::class, matching: '/boom/', message: 'boom');
+                Expect::that(static fn() => throw new DomainException('boom'))
+                    ->toThrow(
+                        static function (DomainException $error): void {},
+                        matching: '/boom/',
+                    );
+                Expect::eventually(static fn(): Closure => static fn() => throw new DomainException('boom'))
+                    ->within(1.0)
+                    ->toThrow(
+                        static function (DomainException $error): void {},
+                        message: 'boom',
+                    );
             }
             PHP,
         );
 
         Expect::that($probe->exitCode)->because('pattern and exact message constraints are mutually exclusive')->toBe(1);
         Expect::that($probe->goodPassed)->toBeTrue();
-        Expect::that(\count($probe->errors))->toBe(6);
+        Expect::that(\count($probe->errors))->toBe(8);
         Expect::that($probe->messages())->toContain('toThrow() accepts either matching: or message:, not both');
+        Expect::that($probe->messages())->toContain(
+            'Do not specify matching: or message: when the throwable is a callback.',
+        );
     }
 
     #[Test]
-    public function matchingCallbackParameterUsesTheConfiguredThrowableType(): void
+    public function throwableCallbackDeclaresTheExpectedThrowableType(): void
     {
         $probe = PhpStanProbe::analyze(
             $this->tempDirectory,
@@ -152,21 +166,18 @@ final readonly class PhpStanToThrowRuleTest
             {
                 Expect::that(static fn() => throw new DomainException('boom'))
                     ->toThrow(
-                        DomainException::class,
-                        matching: static function (DomainException $error): void {
+                        static function (DomainException $error): void {
                             Expect::that($error->getPrevious())->toBeNull();
                         },
                     );
                 Expect::that(static fn() => throw new DomainException('boom'))
                     ->toThrow(
-                        DomainException::class,
-                        matching: static function (Throwable $error): void {},
+                        throwable: static function (Throwable $error): void {},
                     );
                 Expect::eventually(static fn(): Closure => static fn() => throw new DomainException('boom'))
                     ->within(1.0)
                     ->toThrow(
-                        DomainException::class,
-                        matching: static function (DomainException $error): void {},
+                        static function (DomainException $error): void {},
                     );
             }
             PHP,
@@ -181,24 +192,32 @@ final readonly class PhpStanToThrowRuleTest
             {
                 Expect::that(static fn() => throw new DomainException('boom'))
                     ->toThrow(
-                        DomainException::class,
-                        matching: static function (LengthException $error): void {},
+                        static function (): void {},
                     );
                 Expect::that(static fn() => throw new DomainException('boom'))
                     ->toThrow(
-                        DomainException::class,
-                        matching: static function (): void {},
+                        static function (string $error): void {},
                     );
                 Expect::eventually(static fn(): Closure => static fn() => throw new DomainException('boom'))
                     ->within(1.0)
                     ->toThrow(
-                        DomainException::class,
-                        matching: static function (LengthException $error): void {},
+                        static function (DomainException &$error): void {},
                     );
                 Expect::that(static fn() => throw new DomainException('boom'))
                     ->toThrow(
-                        DomainException::class,
-                        matching: static fn(DomainException $error): int => 1,
+                        static function (DomainException $error, string $context): void {},
+                    );
+                Expect::that(static fn() => throw new DomainException('boom'))
+                    ->toThrow(
+                        static function (DomainException ...$error): void {},
+                    );
+                Expect::that(static fn() => throw new DomainException('boom'))
+                    ->toThrow(
+                        static fn(DomainException $error): int => 1,
+                    );
+                Expect::that(static fn() => throw new DomainException('boom'))
+                    ->toThrow(
+                        static function (?DomainException $error): void {},
                     );
             }
             PHP,
@@ -206,13 +225,15 @@ final readonly class PhpStanToThrowRuleTest
 
         Expect::that($probe->exitCode)->toBe(1);
         Expect::that($probe->goodPassed)->toBeTrue();
-        Expect::that(\count($probe->errors))->toBe(4);
+        Expect::that(\count($probe->errors))->toBe(7);
         Expect::that($probe->messages())->toContain(
-            'Parameter $matching of method Greenlight\\Expect\\Expectation<Closure>::toThrow() expects',
+            'The throwable callback for toThrow() MUST accept one typed Throwable argument.',
         );
-        Expect::that($probe->messages())->toContain('Closure(DomainException): void');
         Expect::that($probe->messages())->toContain(
-            'The matching callback for toThrow() must accept one throwable argument.',
+            'The throwable callback for toThrow() MUST declare one named, non-null Throwable parameter type.',
+        );
+        Expect::that($probe->messages())->toContain(
+            'The throwable callback for toThrow() MUST return void.',
         );
     }
 }

--- a/tests/Acceptance/PhpStanToThrowRuleTest.php
+++ b/tests/Acceptance/PhpStanToThrowRuleTest.php
@@ -233,7 +233,7 @@ final readonly class PhpStanToThrowRuleTest
             'The throwable callback for toThrow() MUST declare one named, non-null Throwable parameter type.',
         );
         Expect::that($probe->messages())->toContain(
-            'The throwable callback for toThrow() MUST return void.',
+            'Parameter #1 $throwable of method Greenlight\\Expect\\Expectation<Closure>::toThrow() expects',
         );
     }
 }

--- a/tests/Acceptance/PhpStanToThrowRuleTest.php
+++ b/tests/Acceptance/PhpStanToThrowRuleTest.php
@@ -135,4 +135,84 @@ final readonly class PhpStanToThrowRuleTest
         Expect::that(\count($probe->errors))->toBe(6);
         Expect::that($probe->messages())->toContain('toThrow() accepts either matching: or message:, not both');
     }
+
+    #[Test]
+    public function matchingCallbackParameterUsesTheConfiguredThrowableType(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Expect\Expect;
+
+            function greenlightGoodToThrowCallbackProbe(): void
+            {
+                Expect::that(static fn() => throw new DomainException('boom'))
+                    ->toThrow(
+                        DomainException::class,
+                        matching: static function (DomainException $error): void {
+                            Expect::that($error->getPrevious())->toBeNull();
+                        },
+                    );
+                Expect::that(static fn() => throw new DomainException('boom'))
+                    ->toThrow(
+                        DomainException::class,
+                        matching: static function (Throwable $error): void {},
+                    );
+                Expect::eventually(static fn(): Closure => static fn() => throw new DomainException('boom'))
+                    ->within(1.0)
+                    ->toThrow(
+                        DomainException::class,
+                        matching: static function (DomainException $error): void {},
+                    );
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Expect\Expect;
+
+            function greenlightBadToThrowCallbackProbe(): void
+            {
+                Expect::that(static fn() => throw new DomainException('boom'))
+                    ->toThrow(
+                        DomainException::class,
+                        matching: static function (LengthException $error): void {},
+                    );
+                Expect::that(static fn() => throw new DomainException('boom'))
+                    ->toThrow(
+                        DomainException::class,
+                        matching: static function (): void {},
+                    );
+                Expect::eventually(static fn(): Closure => static fn() => throw new DomainException('boom'))
+                    ->within(1.0)
+                    ->toThrow(
+                        DomainException::class,
+                        matching: static function (LengthException $error): void {},
+                    );
+                Expect::that(static fn() => throw new DomainException('boom'))
+                    ->toThrow(
+                        DomainException::class,
+                        matching: static fn(DomainException $error): int => 1,
+                    );
+            }
+            PHP,
+        );
+
+        Expect::that($probe->exitCode)->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(4);
+        Expect::that($probe->messages())->toContain(
+            'Parameter $matching of method Greenlight\\Expect\\Expectation<Closure>::toThrow() expects',
+        );
+        Expect::that($probe->messages())->toContain('Closure(DomainException): void');
+        Expect::that($probe->messages())->toContain(
+            'The matching callback for toThrow() must accept one throwable argument.',
+        );
+    }
 }

--- a/tests/Unit/Core/ThrowableDetailTest.php
+++ b/tests/Unit/Core/ThrowableDetailTest.php
@@ -7,67 +7,48 @@ namespace Greenlight\Tests\Unit\Core;
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Result\ThrowableDetail;
-use Greenlight\Doubles\Fake;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
 
 final class ThrowableDetailTest
 {
     #[Test]
     public function rendersNormalInstanceMethodStackFrames(): void
     {
-        $threw = null;
+        $callLine = __LINE__ + 2;
 
-        try {
-            $callLine = __LINE__ + 1;
-            $this->throwFromInstanceMethod();
-        } catch (\RuntimeException $exception) {
-            $threw = $exception;
-        }
-
-        Expect::that(ThrowableDetail::fromThrowable($threw)->stackFrames[0])
-            ->because('a throwable detail MUST identify the method and source of each stack frame')
-            ->toBe(
-                self::class
-                . '->throwFromInstanceMethod at '
-                . __FILE__
-                . ':'
-                . $callLine,
-            );
+        Expect::that(fn() => $this->throwFromInstanceMethod())->toThrow(
+            \RuntimeException::class,
+            matching: static function (\RuntimeException $threw) use ($callLine): void {
+                Expect::that(ThrowableDetail::fromThrowable($threw)->stackFrames[0])
+                    ->because('a throwable detail MUST identify the method and source of each stack frame')
+                    ->toBe(
+                        self::class
+                        . '->throwFromInstanceMethod at '
+                        . __FILE__
+                        . ':'
+                        . $callLine,
+                    );
+            },
+        );
     }
 
     #[Test]
     public function deepTracesAreBoundedWithATruncationMarker(): void
     {
-        $capture = new class implements Fake {
-            public ?\RuntimeException $exception = null;
-        };
+        Expect::that(fn() => $this->throwAtDepth(40))->toThrow(
+            \RuntimeException::class,
+            matching: static function (\RuntimeException $threw): void {
+                Expect::that($threw->getMessage())->toBe('bottom');
 
-        Expect::that(function () use ($capture): void {
-            try {
-                $this->throwAtDepth(40);
-            } catch (\RuntimeException $exception) {
-                $capture->exception = $exception;
+                $detail = ThrowableDetail::fromThrowable($threw);
 
-                throw $exception;
-            }
-        })
-            ->because('the recursive helper MUST throw at its terminal depth')
-            ->toThrow(\RuntimeException::class, message: 'bottom');
-
-        $threw = $capture->exception;
-
-        if (!$threw instanceof \RuntimeException) {
-            Fail::because('Expected to capture the recursive helper exception.');
-        }
-
-        $detail = ThrowableDetail::fromThrowable($threw);
-
-        Expect::that($detail->stackFrames)
-            ->because('deep throwable traces are bounded with a truncation marker')
-            ->toHaveCount(33);
-        Expect::that($detail->stackFrames[32])
-            ->toBe('... (trace truncated)');
+                Expect::that($detail->stackFrames)
+                    ->because('deep throwable traces are bounded with a truncation marker')
+                    ->toHaveCount(33);
+                Expect::that($detail->stackFrames[32])
+                    ->toBe('... (trace truncated)');
+            },
+        );
     }
 
     #[Test]

--- a/tests/Unit/Core/ThrowableDetailTest.php
+++ b/tests/Unit/Core/ThrowableDetailTest.php
@@ -17,8 +17,7 @@ final class ThrowableDetailTest
         $callLine = __LINE__ + 2;
 
         Expect::that(fn() => $this->throwFromInstanceMethod())->toThrow(
-            \RuntimeException::class,
-            matching: static function (\RuntimeException $threw) use ($callLine): void {
+            static function (\RuntimeException $threw) use ($callLine): void {
                 Expect::that(ThrowableDetail::fromThrowable($threw)->stackFrames[0])
                     ->because('a throwable detail MUST identify the method and source of each stack frame')
                     ->toBe(
@@ -36,8 +35,7 @@ final class ThrowableDetailTest
     public function deepTracesAreBoundedWithATruncationMarker(): void
     {
         Expect::that(fn() => $this->throwAtDepth(40))->toThrow(
-            \RuntimeException::class,
-            matching: static function (\RuntimeException $threw): void {
+            static function (\RuntimeException $threw): void {
                 Expect::that($threw->getMessage())->toBe('bottom');
 
                 $detail = ThrowableDetail::fromThrowable($threw);

--- a/tests/Unit/Discovery/MetadataFactoryResourceErrorTest.php
+++ b/tests/Unit/Discovery/MetadataFactoryResourceErrorTest.php
@@ -8,7 +8,6 @@ use Greenlight\Attribute\Test;
 use Greenlight\Discovery\DiscoveryError;
 use Greenlight\Discovery\MetadataFactory;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
 use Greenlight\Tests\Fixture\DiscoveryAttributeArgumentsInvalid\WrongResourceTypeTest;
 
 final readonly class MetadataFactoryResourceErrorTest
@@ -17,37 +16,22 @@ final readonly class MetadataFactoryResourceErrorTest
     public function invalidResourceArgumentsAreWrappedWithTheirLocationAndCause(): void
     {
         $class = $this->fixtureClass();
-        $capture = new class {
-            public ?DiscoveryError $error = null;
-        };
-        $attempt = static function () use ($capture, $class): array {
-            try {
-                return new MetadataFactory()->forClass(new \ReflectionClass($class));
-            } catch (DiscoveryError $error) {
-                $capture->error = $error;
 
-                throw $error;
-            }
-        };
-
-        Expect::that($attempt)
+        Expect::that(static fn(): array => new MetadataFactory()->forClass(new \ReflectionClass($class)))
             ->because('discovery MUST wrap an invalid resource attribute with its method location')
             ->toThrow(
                 DiscoveryError::class,
-                matching: '/^Attribute on '
-                    . \preg_quote($class . '::neverDiscovered()', '/')
-                    . ' is invalid:/',
+                matching: static function (DiscoveryError $error) use ($class): void {
+                    Expect::that($error->getMessage())->toMatch(
+                        '/^Attribute on '
+                        . \preg_quote($class . '::neverDiscovered()', '/')
+                        . ' is invalid:/',
+                    );
+                    Expect::that($error->getPrevious())
+                        ->because('the discovery error MUST preserve the invalid resource attribute cause')
+                        ->toBeInstanceOf(\TypeError::class);
+                },
             );
-
-        $error = $capture->error;
-
-        if (!$error instanceof DiscoveryError) {
-            Fail::because('Expected discovery to throw the captured resource attribute error.');
-        }
-
-        Expect::that($error->getPrevious())
-            ->because('the discovery error MUST preserve the invalid resource attribute cause')
-            ->toBeInstanceOf(\TypeError::class);
     }
 
     /**

--- a/tests/Unit/Discovery/MetadataFactoryResourceErrorTest.php
+++ b/tests/Unit/Discovery/MetadataFactoryResourceErrorTest.php
@@ -20,8 +20,7 @@ final readonly class MetadataFactoryResourceErrorTest
         Expect::that(static fn(): array => new MetadataFactory()->forClass(new \ReflectionClass($class)))
             ->because('discovery MUST wrap an invalid resource attribute with its method location')
             ->toThrow(
-                DiscoveryError::class,
-                matching: static function (DiscoveryError $error) use ($class): void {
+                static function (DiscoveryError $error) use ($class): void {
                     Expect::that($error->getMessage())->toMatch(
                         '/^Attribute on '
                         . \preg_quote($class . '::neverDiscovered()', '/')

--- a/tests/Unit/Discovery/MetadataFactoryTest.php
+++ b/tests/Unit/Discovery/MetadataFactoryTest.php
@@ -25,8 +25,7 @@ final class MetadataFactoryTest
         Expect::that(static fn(): array => new MetadataFactory()->forClass(new \ReflectionClass($class)))
             ->because('discovery wraps invalid attribute arguments with their location')
             ->toThrow(
-                DiscoveryError::class,
-                matching: static function (DiscoveryError $error) use ($class): void {
+                static function (DiscoveryError $error) use ($class): void {
                     Expect::that($error->getMessage())->toMatch(
                         '/^Attribute on '
                         . \preg_quote($class . '::neverDiscovered()', '/')
@@ -47,8 +46,7 @@ final class MetadataFactoryTest
         Expect::that(static fn(): array => new MetadataFactory()->forClass(new \ReflectionClass($class)))
             ->because('discovery wraps invalid group arguments with their method location')
             ->toThrow(
-                DiscoveryError::class,
-                matching: static function (DiscoveryError $error) use ($class): void {
+                static function (DiscoveryError $error) use ($class): void {
                     Expect::that($error->getMessage())->toMatch(
                         '/^Attribute on '
                         . \preg_quote($class . '::neverDiscovered()', '/')

--- a/tests/Unit/Discovery/MetadataFactoryTest.php
+++ b/tests/Unit/Discovery/MetadataFactoryTest.php
@@ -9,7 +9,6 @@ use Greenlight\Attribute\Test;
 use Greenlight\Discovery\DiscoveryError;
 use Greenlight\Discovery\MetadataFactory;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
 use Greenlight\Tests\Fixture\DiscoveryAttributeArgumentsInvalid\WrongCaptureTypeTest;
 use Greenlight\Tests\Fixture\DiscoveryAttributeArgumentsInvalid\WrongGroupTypeTest;
 use Greenlight\Tests\Fixture\DiscoveryInvalidMethods\AbstractMethodTest;
@@ -22,74 +21,44 @@ final class MetadataFactoryTest
     public function invalidAttributeArgumentsAreWrappedWithTheirLocationAndCause(): void
     {
         $class = $this->wrongCaptureTypeClass();
-        $capture = new class {
-            public ?DiscoveryError $error = null;
-        };
-        $attempt = static function () use ($capture, $class): array {
-            try {
-                return new MetadataFactory()->forClass(new \ReflectionClass($class));
-            } catch (DiscoveryError $error) {
-                $capture->error = $error;
 
-                throw $error;
-            }
-        };
-
-        Expect::that($attempt)
+        Expect::that(static fn(): array => new MetadataFactory()->forClass(new \ReflectionClass($class)))
             ->because('discovery wraps invalid attribute arguments with their location')
             ->toThrow(
                 DiscoveryError::class,
-                matching: '/^Attribute on '
-                    . \preg_quote($class . '::neverDiscovered()', '/')
-                    . ' is invalid:/',
+                matching: static function (DiscoveryError $error) use ($class): void {
+                    Expect::that($error->getMessage())->toMatch(
+                        '/^Attribute on '
+                        . \preg_quote($class . '::neverDiscovered()', '/')
+                        . ' is invalid:/',
+                    );
+                    Expect::that($error->getPrevious())
+                        ->because('the discovery error preserves the invalid attribute cause')
+                        ->toBeInstanceOf(\TypeError::class);
+                },
             );
-
-        $error = $capture->error;
-
-        if (!$error instanceof DiscoveryError) {
-            Fail::because('Expected discovery to throw the captured DiscoveryError.');
-        }
-
-        Expect::that($error->getPrevious())
-            ->because('the discovery error preserves the invalid attribute cause')
-            ->toBeInstanceOf(\TypeError::class);
     }
 
     #[Test]
     public function invalidGroupArgumentsAreWrappedWithTheirLocationAndCause(): void
     {
         $class = $this->wrongGroupTypeClass();
-        $capture = new class {
-            public ?DiscoveryError $error = null;
-        };
-        $attempt = static function () use ($capture, $class): array {
-            try {
-                return new MetadataFactory()->forClass(new \ReflectionClass($class));
-            } catch (DiscoveryError $error) {
-                $capture->error = $error;
 
-                throw $error;
-            }
-        };
-
-        Expect::that($attempt)
+        Expect::that(static fn(): array => new MetadataFactory()->forClass(new \ReflectionClass($class)))
             ->because('discovery wraps invalid group arguments with their method location')
             ->toThrow(
                 DiscoveryError::class,
-                matching: '/^Attribute on '
-                    . \preg_quote($class . '::neverDiscovered()', '/')
-                    . ' is invalid:/',
+                matching: static function (DiscoveryError $error) use ($class): void {
+                    Expect::that($error->getMessage())->toMatch(
+                        '/^Attribute on '
+                        . \preg_quote($class . '::neverDiscovered()', '/')
+                        . ' is invalid:/',
+                    );
+                    Expect::that($error->getPrevious())
+                        ->because('the discovery error preserves the invalid group cause')
+                        ->toBeInstanceOf(\TypeError::class);
+                },
             );
-
-        $error = $capture->error;
-
-        if (!$error instanceof DiscoveryError) {
-            Fail::because('Expected discovery to throw the captured DiscoveryError.');
-        }
-
-        Expect::that($error->getPrevious())
-            ->because('the discovery error preserves the invalid group cause')
-            ->toBeInstanceOf(\TypeError::class);
     }
 
     /**

--- a/tests/Unit/Doubles/ProxyStorageTest.php
+++ b/tests/Unit/Doubles/ProxyStorageTest.php
@@ -64,8 +64,7 @@ final readonly class ProxyStorageTest
         Expect::that(static fn(): object => $doubles->stub(ProxyStorageContract::class))
             ->because('a directory at the proxy file path MUST produce a typed file error')
             ->toThrow(
-                DoublesError::class,
-                matching: static function (DoublesError $error) use ($file): void {
+                static function (DoublesError $error) use ($file): void {
                     Expect::that($error->getMessage())
                         ->toBe('Doubles could not write the proxy file ' . $file . '.');
                     Expect::that($error->getPrevious())

--- a/tests/Unit/Doubles/ProxyStorageTest.php
+++ b/tests/Unit/Doubles/ProxyStorageTest.php
@@ -60,35 +60,19 @@ final readonly class ProxyStorageTest
         }
 
         $doubles = new Doubles($blockedDirectory);
-        $capture = new class {
-            public ?DoublesError $error = null;
-        };
-        $attempt = static function () use ($capture, $doubles): object {
-            try {
-                return $doubles->stub(ProxyStorageContract::class);
-            } catch (DoublesError $error) {
-                $capture->error = $error;
 
-                throw $error;
-            }
-        };
-
-        Expect::that($attempt)
+        Expect::that(static fn(): object => $doubles->stub(ProxyStorageContract::class))
             ->because('a directory at the proxy file path MUST produce a typed file error')
             ->toThrow(
                 DoublesError::class,
-                message: 'Doubles could not write the proxy file ' . $file . '.',
+                matching: static function (DoublesError $error) use ($file): void {
+                    Expect::that($error->getMessage())
+                        ->toBe('Doubles could not write the proxy file ' . $file . '.');
+                    Expect::that($error->getPrevious())
+                        ->because('the proxy error preserves the atomic file failure')
+                        ->toBeInstanceOf(AtomicFileError::class);
+                },
             );
-
-        $error = $capture->error;
-
-        if (!$error instanceof DoublesError) {
-            Fail::because('Expected proxy generation to throw the captured DoublesError.');
-        }
-
-        Expect::that($error->getPrevious())
-            ->because('the proxy error preserves the atomic file failure')
-            ->toBeInstanceOf(AtomicFileError::class);
     }
 
     /**

--- a/tests/Unit/Expect/TemporalToThrowTest.php
+++ b/tests/Unit/Expect/TemporalToThrowTest.php
@@ -56,4 +56,56 @@ final class TemporalToThrowTest
         yield 'message pattern' => ['pattern'];
         yield 'exact message' => ['message'];
     }
+
+    #[Test]
+    public function eventuallyRetriesWhenTheMatchingCallbackExpectationFails(): void
+    {
+        $clock = new FakePollingClock();
+        $calls = 0;
+
+        ExpectationRuntime::withClock($clock, static function () use (&$calls): void {
+            Expect::eventually(static fn(): \Closure => static fn() => throw new \RuntimeException('ready'))
+                ->pollEvery(0.010)
+                ->within(0.100)
+                ->toThrow(
+                    \RuntimeException::class,
+                    matching: static function (\RuntimeException $error) use (&$calls): void {
+                        ++$calls;
+                        Expect::that($calls)->toBe(2);
+                        Expect::that($error->getMessage())->toBe('ready');
+                    },
+                );
+        });
+
+        Expect::that($calls)->toBe(2);
+        Expect::that($clock->sleeps)->toBe([0.010]);
+    }
+
+    #[Test]
+    public function eventuallyReportsTheFinalMatchingCallbackFailure(): void
+    {
+        $clock = new FakePollingClock();
+
+        $detail = FailureProbe::detailOf(static fn() => ExpectationRuntime::withClock(
+            $clock,
+            static fn() => Expect::eventually(
+                static fn(): \Closure => static fn() => throw new \RuntimeException('not ready'),
+            )
+                ->pollEvery(0.010)
+                ->within(0.020)
+                ->toThrow(
+                    \RuntimeException::class,
+                    matching: static function (\RuntimeException $error): void {
+                        Expect::that($error->getMessage())->toBe('ready');
+                    },
+                ),
+        ));
+
+        Expect::that($detail->message)->toContain(
+            "Last failure: Expected 'not ready' to be 'ready'.",
+        );
+        Expect::that($detail->expected)->toBe("'ready'");
+        Expect::that($detail->actual)->toBe("'not ready'");
+        Expect::that($clock->sleeps)->toBe([0.010, 0.010]);
+    }
 }

--- a/tests/Unit/Expect/TemporalToThrowTest.php
+++ b/tests/Unit/Expect/TemporalToThrowTest.php
@@ -58,7 +58,35 @@ final class TemporalToThrowTest
     }
 
     #[Test]
-    public function eventuallyRetriesWhenTheMatchingCallbackExpectationFails(): void
+    public function temporalToThrowRejectsAConstraintWithAThrowableCallbackBeforePolling(): void
+    {
+        $calls = 0;
+        $eventually = Expect::eventually(static function () use (&$calls): \Closure {
+            ++$calls;
+
+            return static fn() => throw new \RuntimeException('boom');
+        })->within(0.100);
+
+        $detail = FailureProbe::detailOf(
+            static function () use ($eventually): void {
+                new \ReflectionMethod($eventually, 'toThrow')->invokeArgs(
+                    $eventually,
+                    [
+                        'throwable' => static function (\RuntimeException $error): void {},
+                        'message' => 'boom',
+                    ],
+                );
+            },
+        );
+
+        Expect::that($detail->message)->toBe(
+            'Do not specify matching: or message: when the throwable is a callback.',
+        );
+        Expect::that($calls)->toBe(0);
+    }
+
+    #[Test]
+    public function eventuallyRetriesWhenTheThrowableCallbackExpectationFails(): void
     {
         $clock = new FakePollingClock();
         $calls = 0;
@@ -68,8 +96,7 @@ final class TemporalToThrowTest
                 ->pollEvery(0.010)
                 ->within(0.100)
                 ->toThrow(
-                    \RuntimeException::class,
-                    matching: static function (\RuntimeException $error) use (&$calls): void {
+                    static function (\RuntimeException $error) use (&$calls): void {
                         ++$calls;
                         Expect::that($calls)->toBe(2);
                         Expect::that($error->getMessage())->toBe('ready');
@@ -82,7 +109,7 @@ final class TemporalToThrowTest
     }
 
     #[Test]
-    public function eventuallyReportsTheFinalMatchingCallbackFailure(): void
+    public function eventuallyReportsTheFinalThrowableCallbackFailure(): void
     {
         $clock = new FakePollingClock();
 
@@ -94,8 +121,7 @@ final class TemporalToThrowTest
                 ->pollEvery(0.010)
                 ->within(0.020)
                 ->toThrow(
-                    \RuntimeException::class,
-                    matching: static function (\RuntimeException $error): void {
+                    static function (\RuntimeException $error): void {
                         Expect::that($error->getMessage())->toBe('ready');
                     },
                 ),

--- a/tests/Unit/Expect/ToThrowTest.php
+++ b/tests/Unit/Expect/ToThrowTest.php
@@ -303,6 +303,60 @@ final class ToThrowTest
             static function (\LengthException $error): void {},
             'The matching callback for toThrow() must accept DomainException. Its parameter type is LengthException.',
         ];
+        yield 'built-in parameter type' => [
+            static function (string $error): void {},
+            'The matching callback for toThrow() must accept DomainException. Its parameter type is string.',
+        ];
+        yield 'union parameter type' => [
+            static function (\LengthException|\OutOfBoundsException $error): void {},
+            'The matching callback for toThrow() must accept DomainException. Its parameter type is LengthException|OutOfBoundsException.',
+        ];
+        yield 'intersection parameter type' => [
+            static function (\Throwable&\Countable $error): void {},
+            'The matching callback for toThrow() must accept DomainException. Its parameter type is Throwable&Countable.',
+        ];
+    }
+
+    #[Test]
+    public function toThrowAcceptsBroadAndScopedMatchingCallbackParameterTypes(): void
+    {
+        Expect::that(static fn() => throw new \DomainException('object'))
+            ->toThrow(
+                \DomainException::class,
+                matching: static function (object $error): void {
+                    Expect::that($error)->toBeInstanceOf(\DomainException::class);
+                },
+            );
+
+        $selfScopedError = new class ('self') extends \DomainException {
+            public function matchingCallback(): \Closure
+            {
+                return static function (self $error): void {
+                    Expect::that($error)->toBeInstanceOf(self::class);
+                };
+            }
+        };
+
+        $expectation = Expect::that(static fn() => throw $selfScopedError);
+        new \ReflectionMethod($expectation, 'toThrow')->invokeArgs(
+            $expectation,
+            [$selfScopedError::class, $selfScopedError->matchingCallback()],
+        );
+
+        $parentScopedCallback = new class ('parent') extends \Exception {
+            public function matchingCallback(): \Closure
+            {
+                return static function (parent $error): void {
+                    Expect::that($error)->toBeInstanceOf(\Exception::class);
+                };
+            }
+        };
+
+        $expectation = Expect::that(static fn() => throw new \DomainException('parent'));
+        new \ReflectionMethod($expectation, 'toThrow')->invokeArgs(
+            $expectation,
+            [\DomainException::class, $parentScopedCallback->matchingCallback()],
+        );
     }
 
     #[Test]

--- a/tests/Unit/Expect/ToThrowTest.php
+++ b/tests/Unit/Expect/ToThrowTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Expect;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 
@@ -28,6 +29,60 @@ final class ToThrowTest
     {
         Expect::that(static fn() => throw new \DomainException('insufficient funds'))->because('toThrow() passes on an exact message')
             ->toThrow(\LogicException::class, message: 'insufficient funds');
+    }
+
+    #[Test]
+    public function toThrowPassesTheTypedThrowableToAMatchingCallback(): void
+    {
+        $previous = new \LengthException('too short');
+
+        Expect::that(static fn() => throw new \DomainException('invalid value', previous: $previous))
+            ->toThrow(
+                \DomainException::class,
+                matching: static function (\DomainException $error) use ($previous): void {
+                    Expect::that($error->getPrevious())->toBe($previous);
+                },
+            );
+    }
+
+    #[Test]
+    public function toThrowRunsTheCallbackOnlyAfterTheThrowableTypeMatches(): void
+    {
+        $called = false;
+
+        $detail = FailureProbe::detailOf(
+            static fn() => Expect::that(static fn() => throw new \RuntimeException('boom'))
+                ->toThrow(
+                    \DomainException::class,
+                    matching: static function (\DomainException $error) use (&$called): void {
+                        $called = true;
+                    },
+                ),
+        );
+
+        Expect::that($called)->toBeFalse();
+        Expect::that($detail->message)->toBe(
+            "Expected a callable that threw RuntimeException with message 'boom' "
+            . 'to throw DomainException with a throwable that satisfies the matching callback.',
+        );
+    }
+
+    #[Test]
+    public function toThrowPreservesAMatchingCallbackExpectationFailure(): void
+    {
+        $detail = FailureProbe::detailOf(
+            static fn() => Expect::that(static fn() => throw new \DomainException('boom'))
+                ->toThrow(
+                    \DomainException::class,
+                    matching: static function (\DomainException $error): void {
+                        Expect::that($error->getMessage())->toBe('expected message');
+                    },
+                ),
+        );
+
+        Expect::that($detail->message)->toBe("Expected 'boom' to be 'expected message'.");
+        Expect::that($detail->expected)->toBe("'expected message'");
+        Expect::that($detail->actual)->toBe("'boom'");
     }
 
     #[Test]
@@ -110,6 +165,39 @@ final class ToThrowTest
     }
 
     #[Test]
+    public function notToThrowPassesWhenTheMatchingCallbackExpectationFails(): void
+    {
+        Expect::that(static fn() => throw new \DomainException('boom'))
+            ->not()
+            ->toThrow(
+                \DomainException::class,
+                matching: static function (\DomainException $error): void {
+                    Expect::that($error->getMessage())->toBe('different');
+                },
+            );
+    }
+
+    #[Test]
+    public function notToThrowFailsWhenTheMatchingCallbackPasses(): void
+    {
+        $detail = FailureProbe::detailOf(
+            static fn() => Expect::that(static fn() => throw new \DomainException('boom'))
+                ->not()
+                ->toThrow(
+                    \DomainException::class,
+                    matching: static function (\DomainException $error): void {
+                        Expect::that($error->getMessage())->toBe('boom');
+                    },
+                ),
+        );
+
+        Expect::that($detail->message)->toBe(
+            "Expected a callable that threw DomainException with message 'boom' "
+            . 'not to throw DomainException with a throwable that satisfies the matching callback.',
+        );
+    }
+
+    #[Test]
     public function toThrowGuardsTheSubjectTypeEvenWhenNegated(): void
     {
         $detail = FailureProbe::detailOf(
@@ -160,5 +248,79 @@ final class ToThrowTest
             'Specify matching: or message: for toThrow(). Do not specify both.',
         );
         Expect::that($invoked)->because('toThrow() rejects pattern and exact message before invoking the subject')->toBeFalse();
+    }
+
+    /**
+     * @param \Closure(): mixed $matching
+     */
+    #[Test]
+    #[DataSet('invalidMatchingCallbacks')]
+    public function toThrowRejectsAnInvalidMatchingCallbackBeforeInvokingTheSubject(
+        \Closure $matching,
+        string $message,
+    ): void {
+        $invoked = false;
+
+        $detail = FailureProbe::detailOf(
+            static function () use (&$invoked, $matching): void {
+                $expectation = Expect::that(static function () use (&$invoked): void {
+                    $invoked = true;
+                });
+
+                new \ReflectionMethod($expectation, 'toThrow')->invokeArgs(
+                    $expectation,
+                    [\DomainException::class, $matching],
+                );
+            },
+        );
+
+        Expect::that($detail->message)->toBe($message);
+        Expect::that($invoked)->toBeFalse();
+    }
+
+    /**
+     * @return iterable<string, array{\Closure, non-empty-string}>
+     */
+    public static function invalidMatchingCallbacks(): iterable
+    {
+        yield 'no throwable parameter' => [
+            static function (): void {},
+            'The matching callback for toThrow() must accept one throwable argument.',
+        ];
+        yield 'too many required parameters' => [
+            static function (\DomainException $error, string $context): void {},
+            'The matching callback for toThrow() must accept one throwable argument.',
+        ];
+        yield 'parameter by reference' => [
+            static function (\DomainException &$error): void {},
+            'The matching callback for toThrow() must accept its throwable argument by value.',
+        ];
+        yield 'declared return value' => [
+            static fn(\DomainException $error): int => 1,
+            'The matching callback for toThrow() must return void. Its return type is int.',
+        ];
+        yield 'incompatible throwable parameter' => [
+            static function (\LengthException $error): void {},
+            'The matching callback for toThrow() must accept DomainException. Its parameter type is LengthException.',
+        ];
+    }
+
+    #[Test]
+    public function toThrowRejectsAMatchingCallbackReturnValue(): void
+    {
+        $detail = FailureProbe::detailOf(
+            static function (): void {
+                $expectation = Expect::that(static fn() => throw new \DomainException('boom'));
+
+                new \ReflectionMethod($expectation, 'toThrow')->invokeArgs(
+                    $expectation,
+                    [\DomainException::class, static fn(\DomainException $error) => 1],
+                );
+            },
+        );
+
+        Expect::that($detail->message)->toBe(
+            'The matching callback for toThrow() must return void. It returned int.',
+        );
     }
 }

--- a/tests/Unit/Expect/ToThrowTest.php
+++ b/tests/Unit/Expect/ToThrowTest.php
@@ -32,14 +32,13 @@ final class ToThrowTest
     }
 
     #[Test]
-    public function toThrowPassesTheTypedThrowableToAMatchingCallback(): void
+    public function toThrowPassesTheTypedThrowableToACallback(): void
     {
         $previous = new \LengthException('too short');
 
         Expect::that(static fn() => throw new \DomainException('invalid value', previous: $previous))
             ->toThrow(
-                \DomainException::class,
-                matching: static function (\DomainException $error) use ($previous): void {
+                static function (\DomainException $error) use ($previous): void {
                     Expect::that($error->getPrevious())->toBe($previous);
                 },
             );
@@ -53,8 +52,7 @@ final class ToThrowTest
         $detail = FailureProbe::detailOf(
             static fn() => Expect::that(static fn() => throw new \RuntimeException('boom'))
                 ->toThrow(
-                    \DomainException::class,
-                    matching: static function (\DomainException $error) use (&$called): void {
+                    static function (\DomainException $error) use (&$called): void {
                         $called = true;
                     },
                 ),
@@ -63,18 +61,17 @@ final class ToThrowTest
         Expect::that($called)->toBeFalse();
         Expect::that($detail->message)->toBe(
             "Expected a callable that threw RuntimeException with message 'boom' "
-            . 'to throw DomainException with a throwable that satisfies the matching callback.',
+            . 'to throw DomainException and satisfy the throwable callback.',
         );
     }
 
     #[Test]
-    public function toThrowPreservesAMatchingCallbackExpectationFailure(): void
+    public function toThrowPreservesAThrowableCallbackExpectationFailure(): void
     {
         $detail = FailureProbe::detailOf(
             static fn() => Expect::that(static fn() => throw new \DomainException('boom'))
                 ->toThrow(
-                    \DomainException::class,
-                    matching: static function (\DomainException $error): void {
+                    static function (\DomainException $error): void {
                         Expect::that($error->getMessage())->toBe('expected message');
                     },
                 ),
@@ -165,27 +162,25 @@ final class ToThrowTest
     }
 
     #[Test]
-    public function notToThrowPassesWhenTheMatchingCallbackExpectationFails(): void
+    public function notToThrowPassesWhenTheThrowableCallbackExpectationFails(): void
     {
         Expect::that(static fn() => throw new \DomainException('boom'))
             ->not()
             ->toThrow(
-                \DomainException::class,
-                matching: static function (\DomainException $error): void {
+                static function (\DomainException $error): void {
                     Expect::that($error->getMessage())->toBe('different');
                 },
             );
     }
 
     #[Test]
-    public function notToThrowFailsWhenTheMatchingCallbackPasses(): void
+    public function notToThrowFailsWhenTheThrowableCallbackPasses(): void
     {
         $detail = FailureProbe::detailOf(
             static fn() => Expect::that(static fn() => throw new \DomainException('boom'))
                 ->not()
                 ->toThrow(
-                    \DomainException::class,
-                    matching: static function (\DomainException $error): void {
+                    static function (\DomainException $error): void {
                         Expect::that($error->getMessage())->toBe('boom');
                     },
                 ),
@@ -193,7 +188,7 @@ final class ToThrowTest
 
         Expect::that($detail->message)->toBe(
             "Expected a callable that threw DomainException with message 'boom' "
-            . 'not to throw DomainException with a throwable that satisfies the matching callback.',
+            . 'not to throw DomainException and satisfy the throwable callback.',
         );
     }
 
@@ -250,26 +245,53 @@ final class ToThrowTest
         Expect::that($invoked)->because('toThrow() rejects pattern and exact message before invoking the subject')->toBeFalse();
     }
 
-    /**
-     * @param \Closure(): mixed $matching
-     */
     #[Test]
-    #[DataSet('invalidMatchingCallbacks')]
-    public function toThrowRejectsAnInvalidMatchingCallbackBeforeInvokingTheSubject(
-        \Closure $matching,
-        string $message,
-    ): void {
+    public function toThrowRejectsAConstraintWithAThrowableCallbackBeforeInvokingTheSubject(): void
+    {
         $invoked = false;
 
         $detail = FailureProbe::detailOf(
-            static function () use (&$invoked, $matching): void {
+            static function () use (&$invoked): void {
                 $expectation = Expect::that(static function () use (&$invoked): void {
                     $invoked = true;
                 });
 
                 new \ReflectionMethod($expectation, 'toThrow')->invokeArgs(
                     $expectation,
-                    [\DomainException::class, $matching],
+                    [
+                        'throwable' => static function (\DomainException $error): void {},
+                        'matching' => '/boom/',
+                    ],
+                );
+            },
+        );
+
+        Expect::that($detail->message)->toBe(
+            'Do not specify matching: or message: when the throwable is a callback.',
+        );
+        Expect::that($invoked)->toBeFalse();
+    }
+
+    /**
+     * @param \Closure(): mixed $throwable
+     */
+    #[Test]
+    #[DataSet('invalidThrowableCallbacks')]
+    public function toThrowRejectsAnInvalidThrowableCallbackBeforeInvokingTheSubject(
+        \Closure $throwable,
+        string $message,
+    ): void {
+        $invoked = false;
+
+        $detail = FailureProbe::detailOf(
+            static function () use (&$invoked, $throwable): void {
+                $expectation = Expect::that(static function () use (&$invoked): void {
+                    $invoked = true;
+                });
+
+                new \ReflectionMethod($expectation, 'toThrow')->invokeArgs(
+                    $expectation,
+                    [$throwable],
                 );
             },
         );
@@ -281,55 +303,59 @@ final class ToThrowTest
     /**
      * @return iterable<string, array{\Closure, non-empty-string}>
      */
-    public static function invalidMatchingCallbacks(): iterable
+    public static function invalidThrowableCallbacks(): iterable
     {
         yield 'no throwable parameter' => [
             static function (): void {},
-            'The matching callback for toThrow() must accept one throwable argument.',
+            'The throwable callback for toThrow() MUST accept one typed Throwable argument.',
         ];
         yield 'too many required parameters' => [
             static function (\DomainException $error, string $context): void {},
-            'The matching callback for toThrow() must accept one throwable argument.',
+            'The throwable callback for toThrow() MUST accept one typed Throwable argument.',
+        ];
+        yield 'variadic throwable parameter' => [
+            static function (\DomainException ...$error): void {},
+            'The throwable callback for toThrow() MUST accept one typed Throwable argument.',
         ];
         yield 'parameter by reference' => [
             static function (\DomainException &$error): void {},
-            'The matching callback for toThrow() must accept its throwable argument by value.',
+            'The throwable callback for toThrow() MUST accept its argument by value.',
         ];
         yield 'declared return value' => [
             static fn(\DomainException $error): int => 1,
-            'The matching callback for toThrow() must return void. Its return type is int.',
+            'The throwable callback for toThrow() MUST return void. Its return type is int.',
         ];
-        yield 'incompatible throwable parameter' => [
-            static function (\LengthException $error): void {},
-            'The matching callback for toThrow() must accept DomainException. Its parameter type is LengthException.',
+        yield 'missing parameter type' => [
+            static function ($error): void {},
+            'The throwable callback for toThrow() MUST declare one named, non-null Throwable parameter type. Its parameter type is missing.',
         ];
         yield 'built-in parameter type' => [
             static function (string $error): void {},
-            'The matching callback for toThrow() must accept DomainException. Its parameter type is string.',
+            'The throwable callback for toThrow() MUST declare one named, non-null Throwable parameter type. Its parameter type is string.',
+        ];
+        yield 'nullable parameter type' => [
+            static function (?\DomainException $error): void {},
+            'The throwable callback for toThrow() MUST declare one named, non-null Throwable parameter type. Its parameter type is ?DomainException.',
         ];
         yield 'union parameter type' => [
             static function (\LengthException|\OutOfBoundsException $error): void {},
-            'The matching callback for toThrow() must accept DomainException. Its parameter type is LengthException|OutOfBoundsException.',
+            'The throwable callback for toThrow() MUST declare one named, non-null Throwable parameter type. Its parameter type is LengthException|OutOfBoundsException.',
         ];
         yield 'intersection parameter type' => [
             static function (\Throwable&\Countable $error): void {},
-            'The matching callback for toThrow() must accept DomainException. Its parameter type is Throwable&Countable.',
+            'The throwable callback for toThrow() MUST declare one named, non-null Throwable parameter type. Its parameter type is Throwable&Countable.',
+        ];
+        yield 'non-throwable class parameter type' => [
+            static function (\stdClass $error): void {},
+            'The throwable callback for toThrow() MUST declare a Throwable parameter type. Its parameter type is stdClass.',
         ];
     }
 
     #[Test]
-    public function toThrowAcceptsBroadAndScopedMatchingCallbackParameterTypes(): void
+    public function toThrowAcceptsScopedThrowableCallbackParameterTypes(): void
     {
-        Expect::that(static fn() => throw new \DomainException('object'))
-            ->toThrow(
-                \DomainException::class,
-                matching: static function (object $error): void {
-                    Expect::that($error)->toBeInstanceOf(\DomainException::class);
-                },
-            );
-
         $selfScopedError = new class ('self') extends \DomainException {
-            public function matchingCallback(): \Closure
+            public function throwableCallback(): \Closure
             {
                 return static function (self $error): void {
                     Expect::that($error)->toBeInstanceOf(self::class);
@@ -337,14 +363,11 @@ final class ToThrowTest
             }
         };
 
-        $expectation = Expect::that(static fn() => throw $selfScopedError);
-        new \ReflectionMethod($expectation, 'toThrow')->invokeArgs(
-            $expectation,
-            [$selfScopedError::class, $selfScopedError->matchingCallback()],
-        );
+        Expect::that(static fn() => throw $selfScopedError)
+            ->toThrow($selfScopedError->throwableCallback());
 
         $parentScopedCallback = new class ('parent') extends \Exception {
-            public function matchingCallback(): \Closure
+            public function throwableCallback(): \Closure
             {
                 return static function (parent $error): void {
                     Expect::that($error)->toBeInstanceOf(\Exception::class);
@@ -352,15 +375,12 @@ final class ToThrowTest
             }
         };
 
-        $expectation = Expect::that(static fn() => throw new \DomainException('parent'));
-        new \ReflectionMethod($expectation, 'toThrow')->invokeArgs(
-            $expectation,
-            [\DomainException::class, $parentScopedCallback->matchingCallback()],
-        );
+        Expect::that(static fn() => throw new \DomainException('parent'))
+            ->toThrow($parentScopedCallback->throwableCallback());
     }
 
     #[Test]
-    public function toThrowRejectsAMatchingCallbackReturnValue(): void
+    public function toThrowRejectsAThrowableCallbackReturnValue(): void
     {
         $detail = FailureProbe::detailOf(
             static function (): void {
@@ -368,13 +388,13 @@ final class ToThrowTest
 
                 new \ReflectionMethod($expectation, 'toThrow')->invokeArgs(
                     $expectation,
-                    [\DomainException::class, static fn(\DomainException $error) => 1],
+                    [static fn(\DomainException $error) => 1],
                 );
             },
         );
 
         Expect::that($detail->message)->toBe(
-            'The matching callback for toThrow() must return void. It returned int.',
+            'The throwable callback for toThrow() MUST return void. It returned int.',
         );
     }
 }


### PR DESCRIPTION
Allows `toThrow()` to accept a typed closure instead of a throwable class-string. The closure parameter declares the expected throwable type, and the closure body can use ordinary Greenlight expectations to inspect the throwable, including `getPrevious()`.

Greenlight validates the closure shape before it runs the subject and invokes the closure only after the thrown type matches. Callback expectation failures keep their diagnostics, participate in temporal retries, and act as a mismatch under `not()`.

Class-string calls remain backward compatible: `matching:` continues to check the message with a regular expression, and `message:` continues to check it exactly. Runtime validation, PHPStan rules, API documentation, and migration examples cover both forms.