### PR TITLE
ci: add OpenSSF Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,43 @@
+name: "OpenSSF Scorecard"
+
+on:
+  push:
+    branches:
+      - "main"
+  schedule:
+    - cron: "30 1 * * 6"
+
+permissions: "read-all"
+
+jobs:
+  analysis:
+    name: "Scorecard analysis"
+    runs-on: "ubuntu-latest"
+    permissions:
+      security-events: "write"
+      id-token: "write"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: "Run Scorecard analysis"
+        uses: "ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc" # v2.4.4
+        with:
+          results_file: "results.sarif"
+          results_format: "sarif"
+          publish_results: true
+
+      - name: "Upload SARIF artifact"
+        uses: "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" # v7.0.1
+        with:
+          name: "SARIF file"
+          path: "results.sarif"
+          retention-days: 5
+
+      - name: "Upload SARIF to code scanning"
+        uses: "github/codeql-action/upload-sarif@f205ea1c3313d32999d8d6a48b4f6530d4437b38" # v4.37.4
+        with:
+          sarif_file: "results.sarif"


### PR DESCRIPTION
Adds the official OpenSSF Scorecard workflow for weekly and main-branch scans.

The workflow publishes public results through OIDC. It uploads SARIF results to GitHub code scanning and retains the artifact for five days.

The workflow does not run for pull requests and does not join the required-checks job.