### PR TITLE
ci: check external documentation links

### DIFF
--- a/.github/workflows/external-links.yml
+++ b/.github/workflows/external-links.yml
@@ -1,0 +1,38 @@
+name: "External links"
+
+on:
+  schedule:
+    - cron: "17 5 * * 1"
+  workflow_dispatch: ~
+
+concurrency:
+  group: "external-links"
+  cancel-in-progress: true
+
+permissions:
+  contents: "read"
+
+jobs:
+  external-links:
+    name: "External documentation links"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 15
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7
+        with:
+          persist-credentials: false
+
+      - name: "Check external links"
+        uses: "docker://lycheeverse/lychee:0.24.2@sha256:e2d19e57cf6ab037026f20b8e449a1f30d9d7f81eef4194763aab2eab20bd28d"
+        with:
+          args: >-
+            --config .lychee.toml
+            README.md
+            CONTRIBUTING.md
+            SECURITY.md
+            'docs/**/*.md'
+            'website/src/**/*.astro'
+        env:
+          GITHUB_TOKEN: "${{ github.token }}"

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,23 @@
+# Check only external destinations. The built-site check validates internal targets.
+scheme = ["https", "http"]
+extensions = ["md", "astro"]
+
+# Retry temporary failures and limit the request rate for each service.
+max_retries = 3
+retry_wait_time = 2
+timeout = 30
+max_concurrency = 16
+host_concurrency = 4
+host_request_interval = "100ms"
+
+# Some services deny automated requests or rate-limit them after authentication.
+accept = ["100..=103", "200..=299", "403", "429"]
+
+# Dynamic badge images are not documentation destinations.
+exclude = [
+    '^https://codecov\.io/.+/badge\.svg',
+    '^https://github\.com/.+/badge\.svg',
+    '^https://img\.shields\.io/',
+]
+
+no_progress = true


### PR DESCRIPTION
Adds a weekly and manually dispatchable external-link check for repository and website documentation. Uses digest-pinned Lychee with reviewable retry, throttling, rate-limit, and dynamic-badge policies, and keeps the network check separate from pull-request CI.