### PR TITLE
ci: add PHP 8.6 compatibility lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -323,6 +323,39 @@ jobs:
             --filter=TerminalTest \
             --filter=WorkerProcessRunTest
 
+  php-next:
+    name: "PHP 8.6 pre-release compatibility"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 30
+    continue-on-error: true # Allow failures until PHP 8.6 is stable.
+    permissions:
+      contents: "read"
+    env:
+      XDEBUG_MODE: "off"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7
+        with:
+          persist-credentials: false
+
+      - name: "Set up PHP"
+        uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # v2
+        with:
+          php-version: "8.6"
+          extensions: "pcntl, sockets"
+          coverage: "xdebug"
+          ini-values: "memory_limit=-1"
+
+      - name: "Install dependencies"
+        uses: "ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda" # 4.0.0
+        with:
+          composer-options: "--ignore-platform-req=php+"
+          dependency-versions: "locked"
+
+      - name: "Tests"
+        run: "composer tests"
+
   memory:
     name: "Flat-memory gate (10,000 tests, one worker)"
     runs-on: "ubuntu-latest"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,7 +327,6 @@ jobs:
     name: "PHP 8.6 pre-release compatibility"
     runs-on: "ubuntu-latest"
     timeout-minutes: 30
-    continue-on-error: true # Allow failures until PHP 8.6 is stable.
     permissions:
       contents: "read"
     env:
@@ -354,7 +353,19 @@ jobs:
           dependency-versions: "locked"
 
       - name: "Tests"
+        id: "compatibility-tests"
+        continue-on-error: true # Allow failures until PHP 8.6 is stable.
         run: "composer tests"
+
+      - name: "Report compatibility failure"
+        if: "steps.compatibility-tests.outcome == 'failure'"
+        run: |
+          echo "::warning title=PHP 8.6 compatibility failure::The PHP 8.6 test suite failed. Review the Tests step."
+          {
+            echo "### PHP 8.6 compatibility failure"
+            echo
+            echo "The PHP 8.6 test suite failed. Review the Tests step."
+          } >> "${GITHUB_STEP_SUMMARY}"
 
   memory:
     name: "Flat-memory gate (10,000 tests, one worker)"

--- a/tests/Unit/Coverage/HtmlExporterSourceFailureTest.php
+++ b/tests/Unit/Coverage/HtmlExporterSourceFailureTest.php
@@ -41,7 +41,9 @@ final readonly class HtmlExporterSourceFailureTest
 
             Expect::that($warning ?? '')
                 ->because('the source becomes unreadable when the exporter opens it')
-                ->toContain('file_get_contents(' . $path . ')')
+                // PHP 8.5 includes the path in this warning, but PHP 8.6 omits it.
+                // Require file_get_contents() when PHP 8.6 is the minimum version.
+                ->toContain('file_get_contents')
                 ->toContain('Failed to open stream');
             Expect::that($page)
                 ->because('a late read failure shows only coverage line numbers')

--- a/tests/Unit/Coverage/JsonExporterTest.php
+++ b/tests/Unit/Coverage/JsonExporterTest.php
@@ -87,15 +87,24 @@ final class JsonExporterTest
             ->toThrow(CoverageError::class, message: $message);
     }
 
+    #[Test]
+    public function importReportsMalformedJsonWithOptionalPhpLocation(): void
+    {
+        Expect::that(static fn(): CoverageMap => JsonExporter::import('not json'))
+            ->because('malformed coverage JSON MUST include the PHP syntax error')
+            ->toThrow(
+                CoverageError::class,
+                // PHP 8.5 omits the location, but PHP 8.6 adds it.
+                // Remove the PHP 8.5 form when PHP 8.6 is the minimum version.
+                matching: '/^Coverage JSON document is invalid: Syntax error(?: near location 1:1)?$/',
+            );
+    }
+
     /**
      * @return iterable<string, array{non-empty-string, non-empty-string}>
      */
     public static function invalidDocuments(): iterable
     {
-        yield 'malformed JSON' => [
-            'not json',
-            'Coverage JSON document is invalid: Syntax error',
-        ];
         yield 'unsupported schema version' => [
             '{"v":2,"files":{}}',
             'Coverage JSON document is invalid: unsupported or missing schema version, expected 1.',

--- a/tests/Unit/Fixture/TempDirectoryRootSymbolicLinkTest.php
+++ b/tests/Unit/Fixture/TempDirectoryRootSymbolicLinkTest.php
@@ -75,10 +75,12 @@ final class TempDirectoryRootSymbolicLinkTest
                 ->because('fixture cleanup MUST report a root symbolic link that it cannot remove')
                 ->toThrow(
                     \RuntimeException::class,
-                    message: \sprintf(
-                        'Failed to remove temp directory symbolic link "%s": unlink(%s): Permission denied.',
-                        $root,
-                        $root,
+                    // PHP 8.5 includes the path argument.
+                    // Remove the PHP 8.5 form when PHP 8.6 is the minimum version.
+                    matching: \sprintf(
+                        '/^Failed to remove temp directory symbolic link "%s": unlink\((?:%s)?\): Permission denied\.$/',
+                        \preg_quote($root, '/'),
+                        \preg_quote($root, '/'),
                     ),
                 );
         } finally {

--- a/tests/Unit/Fixture/TempDirectoryTest.php
+++ b/tests/Unit/Fixture/TempDirectoryTest.php
@@ -255,10 +255,12 @@ final class TempDirectoryTest
                 ->because('fixture cleanup MUST report a root that it cannot remove')
                 ->toThrow(
                     \RuntimeException::class,
-                    message: \sprintf(
-                        'Failed to remove temp directory "%s": rmdir(%s): Permission denied.',
-                        $path,
-                        $path,
+                    // PHP 8.5 includes the path argument.
+                    // Remove the PHP 8.5 form when PHP 8.6 is the minimum version.
+                    matching: \sprintf(
+                        '/^Failed to remove temp directory "%s": rmdir\((?:%s)?\): Permission denied\.$/',
+                        \preg_quote($path, '/'),
+                        \preg_quote($path, '/'),
                     ),
                 );
         } finally {


### PR DESCRIPTION
Adds a separate PHP 8.6 pre-release lane that:

- runs the full suite with locked dependencies on the PHP 8.6 nightly build
- ignores only dependency PHP upper bounds during Composer installation
- allows pre-release failures without changing the required PHP 8.4 and 8.5 matrix