### PR TITLE
docs: link private vulnerability reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,8 +9,7 @@ We will review this policy after we release version 1.0.
 
 Do not open a public issue for a security problem.
 
-Report the problem privately through GitHub Security Advisories in this
-repository. On the Security tab, select "Report a vulnerability".
+[Report the problem privately through a GitHub security advisory](https://github.com/ben-challis/greenlight/security/advisories/new).
 
 We will acknowledge your report. We will coordinate a fix or mitigation plan
 with you before public disclosure.


### PR DESCRIPTION
Links the security policy directly to GitHub's private vulnerability report form.

Private vulnerability reporting is now enabled for the repository. Reporters can use the documented confidential path instead of a public issue. This change also supplies the linked content that the OpenSSF Security-Policy check requires.