### PR TITLE
ci: declare Bash for stress campaign

### DIFF
--- a/.github/workflows/parallel-runner-stress.yml
+++ b/.github/workflows/parallel-runner-stress.yml
@@ -41,6 +41,7 @@ jobs:
           dependency-versions: "locked"
 
       - name: "Run the stress campaign"
+        shell: "bash"
         run: |
           set -euo pipefail
 


### PR DESCRIPTION
Declare Bash explicitly for the scheduled stress script so its array syntax and strict pipeline behavior do not depend on the runner default shell.