### PR TITLE
chore: define repository code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ben-challis @marmichalski


### PR DESCRIPTION
Defines @ben-challis and @marmichalski as the default owners for all repository files.