### PR TITLE
ci: harden workflow shell checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,8 +97,10 @@ jobs:
 
       - name: "Run actionlint"
         uses: "docker://rhysd/actionlint:1.7.12@sha256:b1934ee5f1c509618f2508e6eb47ee0d3520686341fec936f3b79331f9315667"
+        env:
+          SHELLCHECK_OPTS: "--enable=add-default-case,avoid-nullary-conditions,check-extra-masked-returns,check-set-e-suppressed,deprecate-which,require-double-brackets"
         with:
-          args: "-color"
+          args: "-color -shellcheck=shellcheck"
 
   installed-package:
     name: "Installed package"
@@ -131,7 +133,8 @@ jobs:
           cd "${RUNNER_TEMP}/greenlight-consumer"
           composer install --no-interaction --no-progress --prefer-dist
           test ! -L vendor/greenlight/greenlight
-          test "$(composer show --name-only)" = "greenlight/greenlight"
+          package_name="$(composer show --name-only)"
+          test "${package_name}" = "greenlight/greenlight"
           # shellcheck disable=SC2016
           php -r '$metadata = json_decode(file_get_contents("vendor/greenlight/greenlight/composer.json"), true, flags: JSON_THROW_ON_ERROR); exit(array_diff(array_keys($metadata["require"] ?? []), ["php"]) === [] ? 0 : 1);'
           vendor/bin/greenlight --version | grep -Eq '^Greenlight [^[:space:]]+$'
@@ -204,6 +207,7 @@ jobs:
       # composer.json.
       - name: "Set up Symfony Flex"
         if: "matrix.symfony-version"
+        shell: "bash"
         run: |
           composer global config --no-plugins allow-plugins.symfony/flex true
           composer global require --no-progress --no-scripts --no-plugins symfony/flex
@@ -266,6 +270,7 @@ jobs:
 
       - name: "Tests with JUnit output"
         if: "matrix.analytics == true"
+        shell: "bash"
         run: |
           mkdir -p build/test-results
           php bin/greenlight run --reporter=junit > build/test-results/greenlight.junit.xml
@@ -310,6 +315,7 @@ jobs:
           dependency-versions: "locked"
 
       - name: "Run the portability smoke tests"
+        shell: "bash"
         run: |
           php bin/greenlight run \
             --filter=CpuCoresTest \
@@ -359,6 +365,7 @@ jobs:
 
       - name: "Report compatibility failure"
         if: "steps.compatibility-tests.outcome == 'failure'"
+        shell: "bash"
         run: |
           echo "::warning title=PHP 8.6 compatibility failure::The PHP 8.6 test suite failed. Review the Tests step."
           {
@@ -547,6 +554,7 @@ jobs:
           PCOV_RESULT: "${{ needs.pcov.result }}"
           RENOVATE_CONFIG_RESULT: "${{ needs.renovate-config.result }}"
           ZIZMOR_RESULT: "${{ needs.zizmor.result }}"
+        shell: "bash"
         run: |
           test "${DOCUMENTATION_RESULT}" = "success"
           test "${RENOVATE_CONFIG_RESULT}" = "success"

--- a/composer.json
+++ b/composer.json
@@ -93,12 +93,14 @@
             "@composer normalize --dry-run",
             "@lint",
             "@prose:check",
+            "@workflow-shell:check",
             "@code-style:check",
             "@phpstan",
             "@rector:check",
             "@deptrac"
         ],
         "tests": "@php bin/greenlight run",
-        "tests:coverage": "XDEBUG_MODE=coverage php bin/greenlight run --config=greenlight.coverage.php"
+        "tests:coverage": "XDEBUG_MODE=coverage php bin/greenlight run --config=greenlight.coverage.php",
+        "workflow-shell:check": "@php tools/workflow-shell-check.php"
     }
 }

--- a/tests/Acceptance/WorkflowShellCheckTest.php
+++ b/tests/Acceptance/WorkflowShellCheckTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\ProcessResult;
+use Greenlight\Tests\Support\Subprocess;
+
+final readonly class WorkflowShellCheckTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function acceptsExplicitBashForMultilineRunSteps(): void
+    {
+        $root = $this->workspace('explicit-bash');
+        $this->writeWorkflow(
+            $root,
+            <<<'YAML'
+            name: Shell contract
+            on: push
+            jobs:
+              check:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: "Run checks"
+                    run: |
+                      first-command | second-command
+                    shell: bash
+            YAML,
+        );
+
+        $result = $this->run($root);
+
+        Expect::that($result->exitCode)->because('accepts an explicit Bash shell')->toBe(0);
+        Expect::that($result->stdout)->toBe('Workflow shell contracts passed.');
+    }
+
+    #[Test]
+    public function rejectsMultilineRunStepsWithoutExplicitBash(): void
+    {
+        $root = $this->workspace('implicit-shell');
+        $this->writeWorkflow(
+            $root,
+            <<<'YAML'
+            name: Shell contract
+            on: push
+            jobs:
+              check:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: "Run checks"
+                    run: |
+                      first-command | second-command
+            YAML,
+        );
+
+        $result = $this->run($root);
+
+        Expect::that($result->exitCode)->because('rejects an implicit shell')->toBe(1);
+        Expect::that($result->stderr)->toContain('workflow.yml:8: Multiline run step "Run checks" does not set `shell: bash`.')
+            ->toContain('Set `shell: bash` on each multiline `run` step.');
+    }
+
+    #[Test]
+    public function rejectsFoldedMultilineRunStepsWithoutExplicitBash(): void
+    {
+        $root = $this->workspace('folded-implicit-shell');
+        $this->writeWorkflow(
+            $root,
+            <<<'YAML'
+            name: Shell contract
+            on: push
+            jobs:
+              check:
+                runs-on: ubuntu-latest
+                steps:
+                  - name: "Run folded checks"
+                    run: >-
+                      first-command |
+                      second-command
+            YAML,
+        );
+
+        $result = $this->run($root);
+
+        Expect::that($result->exitCode)->because('rejects a folded block with an implicit shell')->toBe(1);
+        Expect::that($result->stderr)->toContain('Multiline run step "Run folded checks" does not set `shell: bash`.');
+    }
+
+    private function workspace(string $name): string
+    {
+        return $this->tempDirectory->subdirectory($name);
+    }
+
+    private function writeWorkflow(string $root, string $contents): void
+    {
+        \file_put_contents($root . '/workflow.yml', $contents . "\n");
+    }
+
+    private function run(string $root): ProcessResult
+    {
+        return Subprocess::run($root, [
+            \PHP_BINARY,
+            \dirname(__DIR__, 2) . '/tools/workflow-shell-check.php',
+            'workflow.yml',
+        ]);
+    }
+}

--- a/tools/workflow-shell-check.php
+++ b/tools/workflow-shell-check.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+$root = \dirname(__DIR__);
+$workflowFiles = [];
+
+foreach (\array_slice($argv, 1) as $argument) {
+    if (\str_starts_with($argument, '-')) {
+        \fwrite(\STDERR, \sprintf("Unknown workflow shell check option \"%s\".\n", $argument));
+
+        exit(2);
+    }
+
+    $workflowFiles[] = $argument;
+}
+
+if ($workflowFiles === []) {
+    $yamlFiles = \glob($root . '/.github/workflows/*.yaml');
+    $ymlFiles = \glob($root . '/.github/workflows/*.yml');
+    $workflowFiles = [
+        ...($yamlFiles === false ? [] : $yamlFiles),
+        ...($ymlFiles === false ? [] : $ymlFiles),
+    ];
+}
+
+try {
+    $violations = [];
+
+    foreach ($workflowFiles as $workflowFile) {
+        $displayPath = \displayWorkflowPath($workflowFile, $root);
+
+        foreach (\multilineRunSteps($workflowFile) as $step) {
+            if ($step['usesBash']) {
+                continue;
+            }
+
+            $violations[] = \sprintf(
+                '%s:%d: Multiline run step "%s" does not set `shell: bash`.',
+                $displayPath,
+                $step['line'],
+                $step['name'],
+            );
+        }
+    }
+} catch (RuntimeException $error) {
+    \fwrite(\STDERR, $error->getMessage() . "\n");
+
+    exit(2);
+}
+
+if ($violations !== []) {
+    foreach ($violations as $violation) {
+        \fwrite(\STDERR, $violation . "\n");
+    }
+
+    \fwrite(\STDERR, "Set `shell: bash` on each multiline `run` step.\n");
+
+    exit(1);
+}
+
+echo "Workflow shell contracts passed.\n";
+
+/**
+ * @return list<array{name: string, line: int, usesBash: bool}>
+ */
+function multilineRunSteps(string $path): array
+{
+    $contents = \file_get_contents($path);
+
+    if ($contents === false) {
+        throw new RuntimeException(\sprintf('Could not read workflow "%s".', $path));
+    }
+
+    $lines = \preg_split('/\R/', $contents);
+
+    if ($lines === false) {
+        throw new RuntimeException(\sprintf('Could not split workflow "%s" into lines.', $path));
+    }
+
+    $steps = [];
+
+    foreach ($lines as $index => $line) {
+        if (\preg_match('/\A( *)(- )?run:\s*[|>](?:[1-9][+-]?|[+-][1-9]?)?\s*(?:#.*)?\z/', $line, $match) !== 1) {
+            continue;
+        }
+
+        $runStartsStep = isset($match[2]);
+        $keyIndent = \strlen($match[1]) + ($runStartsStep ? 2 : 0);
+        [$stepStart, $stepEnd, $stepIndent] = \stepBounds($lines, $index, $keyIndent, $runStartsStep);
+        $name = \stepName($lines, $stepStart, $stepEnd, $keyIndent, $stepIndent, $index + 1);
+        $usesBash = \stepUsesBash($lines, $stepStart, $stepEnd, $keyIndent, $stepIndent);
+
+        $steps[] = [
+            'name' => $name,
+            'line' => $index + 1,
+            'usesBash' => $usesBash,
+        ];
+    }
+
+    return $steps;
+}
+
+/**
+ * @param list<string> $lines
+ *
+ * @return array{int, int, int}
+ */
+function stepBounds(array $lines, int $runIndex, int $keyIndent, bool $runStartsStep): array
+{
+    $stepStart = $runIndex;
+    $stepIndent = $runStartsStep ? $keyIndent - 2 : -1;
+
+    if (!$runStartsStep) {
+        for ($index = $runIndex - 1; $index >= 0; --$index) {
+            if (\preg_match('/\A( *)-\s+/', $lines[$index], $match) !== 1) {
+                continue;
+            }
+
+            $candidateIndent = \strlen($match[1]);
+
+            if ($candidateIndent < $keyIndent) {
+                $stepStart = $index;
+                $stepIndent = $candidateIndent;
+
+                break;
+            }
+        }
+    }
+
+    if ($stepIndent < 0) {
+        throw new RuntimeException(\sprintf('Could not find the step for multiline run block on line %d.', $runIndex + 1));
+    }
+
+    $stepEnd = \count($lines);
+    $lineCount = \count($lines);
+
+    for ($index = $stepStart + 1; $index < $lineCount; ++$index) {
+        $line = $lines[$index];
+
+        if ($line === '') {
+            continue;
+        }
+
+        $indent = \strlen($line) - \strlen(\ltrim($line, ' '));
+
+        if ($indent < $stepIndent || ($indent === $stepIndent && \preg_match('/\A *-\s+/', $line) === 1)) {
+            $stepEnd = $index;
+
+            break;
+        }
+    }
+
+    return [$stepStart, $stepEnd, $stepIndent];
+}
+
+/**
+ * @param list<string> $lines
+ */
+function stepName(array $lines, int $start, int $end, int $keyIndent, int $stepIndent, int $line): string
+{
+    $keyPattern = '/\A {' . $keyIndent . '}name:\s*(.*?)\s*\z/';
+    $inlinePattern = '/\A {' . $stepIndent . '}-\s+name:\s*(.*?)\s*\z/';
+
+    for ($index = $start; $index < $end; ++$index) {
+        if (
+            \preg_match($keyPattern, $lines[$index], $match) !== 1
+            && \preg_match($inlinePattern, $lines[$index], $match) !== 1
+        ) {
+            continue;
+        }
+
+        $name = $match[1];
+
+        if (\strlen($name) >= 2 && (($name[0] === '"' && $name[-1] === '"') || ($name[0] === "'" && $name[-1] === "'"))) {
+            return \substr($name, 1, -1);
+        }
+
+        return $name;
+    }
+
+    return 'line ' . $line;
+}
+
+/**
+ * @param list<string> $lines
+ */
+function stepUsesBash(array $lines, int $start, int $end, int $keyIndent, int $stepIndent): bool
+{
+    $keyPattern = '/\A {' . $keyIndent . '}shell:\s*(?:bash|"bash"|\'bash\')\s*(?:#.*)?\z/';
+    $inlinePattern = '/\A {' . $stepIndent . '}-\s+shell:\s*(?:bash|"bash"|\'bash\')\s*(?:#.*)?\z/';
+
+    for ($index = $start; $index < $end; ++$index) {
+        if (\preg_match($keyPattern, $lines[$index]) === 1 || \preg_match($inlinePattern, $lines[$index]) === 1) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+function displayWorkflowPath(string $path, string $root): string
+{
+    $absolutePath = \realpath($path);
+
+    if ($absolutePath === false) {
+        throw new RuntimeException(\sprintf('Workflow "%s" does not exist.', $path));
+    }
+
+    if (!\str_starts_with($path, \DIRECTORY_SEPARATOR)) {
+        return $path;
+    }
+
+    $rootPrefix = $root . \DIRECTORY_SEPARATOR;
+
+    return \str_starts_with($absolutePath, $rootPrefix)
+        ? \substr($absolutePath, \strlen($rootPrefix))
+        : $absolutePath;
+}


### PR DESCRIPTION
Require every multiline GitHub Actions run step to declare Bash so GitHub invokes it with errexit and pipefail. Add a repository check with focused acceptance coverage and run it from Composer static analysis. All existing multiline steps now comply; there is no baseline or exception mechanism.

Keep inline scripts in workflows because actionlint reliably passes them to ShellCheck. Make a missing ShellCheck executable a CI failure and enable curated optional checks for incomplete case statements, ambiguous conditions, masked returns, suppressed errexit, deprecated command lookup, and single-bracket Bash conditions.

The stricter profile exposed a masked composer show failure in the installed-package check. Capture its output before asserting the package name so the command failure propagates.