### PR TITLE
test(config): inspect loader errors with toThrow

### DIFF
--- a/tests/Unit/Config/ConfigLoaderTest.php
+++ b/tests/Unit/Config/ConfigLoaderTest.php
@@ -9,7 +9,6 @@ use Greenlight\Config\ConfigFileError;
 use Greenlight\Config\ConfigLoader;
 use Greenlight\Config\GreenlightConfig;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
 
 final class ConfigLoaderTest
 {
@@ -57,36 +56,28 @@ final class ConfigLoaderTest
     #[Test]
     public function fileReturningTheWrongTypeIsRejectedWithTheActualType(): void
     {
-        try {
-            new ConfigLoader()->loadFromDirectory(self::fixtureDir('WrongReturn'));
-        } catch (ConfigFileError $error) {
-            Expect::that($error->getMessage())->toContain('must return a Greenlight\Config\GreenlightConfig instance');
-            Expect::that($error->getMessage())->toContain('returned string');
-
-            return;
-        }
-
-        Fail::because(
-            'Expected ConfigLoader::loadFromDirectory() to throw ConfigFileError when greenlight.php returns a string.',
-        );
+        Expect::that(static fn(): GreenlightConfig => new ConfigLoader()->loadFromDirectory(self::fixtureDir('WrongReturn')))
+            ->toThrow(
+                static function (ConfigFileError $error): void {
+                    Expect::that($error->getMessage())
+                        ->toContain('must return a Greenlight\Config\GreenlightConfig instance');
+                    Expect::that($error->getMessage())->toContain('returned string');
+                },
+            );
     }
 
     #[Test]
     public function throwingConfigFileIsWrappedWithTheOriginalMessage(): void
     {
-        try {
-            new ConfigLoader()->loadFromDirectory(self::fixtureDir('Throwing'));
-        } catch (ConfigFileError $error) {
-            Expect::that($error->getMessage())->toContain('config exploded');
-            Expect::that($error->getMessage())->toContain('RuntimeException');
-            Expect::that($error->getPrevious())->toBeInstanceOf(\RuntimeException::class);
-
-            return;
-        }
-
-        Fail::because(
-            'Expected ConfigLoader::loadFromDirectory() to wrap the configuration RuntimeException in ConfigFileError.',
-        );
+        Expect::that(static fn(): GreenlightConfig => new ConfigLoader()->loadFromDirectory(self::fixtureDir('Throwing')))
+            ->toThrow(
+                static function (ConfigFileError $error): void {
+                    Expect::that($error->getMessage())->toContain('config exploded');
+                    Expect::that($error->getMessage())->toContain('RuntimeException');
+                    Expect::that($error->getPrevious())->toBeInstanceOf(\RuntimeException::class);
+                    Expect::that($error->getPrevious()?->getMessage())->toBe('config exploded');
+                },
+            );
     }
 
     private static function fixtureDir(string $name): string

--- a/tests/Unit/Config/ConfigLoaderThrowableTest.php
+++ b/tests/Unit/Config/ConfigLoaderThrowableTest.php
@@ -8,7 +8,6 @@ use Greenlight\Attribute\Test;
 use Greenlight\Config\ConfigFileError;
 use Greenlight\Config\ConfigLoader;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
 
 final readonly class ConfigLoaderThrowableTest
 {
@@ -17,22 +16,20 @@ final readonly class ConfigLoaderThrowableTest
     {
         $directory = \dirname(__DIR__, 2) . '/Fixture/ConfigFiles/ThrowingError';
 
-        try {
-            new ConfigLoader()->loadFromDirectory($directory);
-        } catch (ConfigFileError $error) {
-            Expect::that($error->getMessage())
-                ->because('configuration errors MUST retain their type, source file, and message')
-                ->toBe(
-                    'Configuration file "' . $directory . '/greenlight.php" threw '
-                    . 'TypeError: config type exploded',
-                );
-            Expect::that($error->getPrevious())
-                ->because('the wrapped configuration error MUST remain available as the cause')
-                ->toBeInstanceOf(\TypeError::class);
-
-            return;
-        }
-
-        Fail::because('Expected ConfigLoader to wrap the TypeError from the configuration file.');
+        Expect::that(static fn() => new ConfigLoader()->loadFromDirectory($directory))
+            ->toThrow(
+                static function (ConfigFileError $error) use ($directory): void {
+                    Expect::that($error->getMessage())
+                        ->because('configuration errors MUST retain their type, source file, and message')
+                        ->toBe(
+                            'Configuration file "' . $directory . '/greenlight.php" threw '
+                            . 'TypeError: config type exploded',
+                        );
+                    Expect::that($error->getPrevious())
+                        ->because('the wrapped configuration error MUST remain available as the cause')
+                        ->toBeInstanceOf(\TypeError::class);
+                    Expect::that($error->getPrevious()?->getMessage())->toBe('config type exploded');
+                },
+            );
     }
 }


### PR DESCRIPTION
Replace manual ConfigFileError catches with typed toThrow callbacks in the configuration loader tests.

Assert the wrapped RuntimeException and TypeError causes, including their original messages, through the callback. Remove the obsolete Fail guards.