### PR TITLE
test: assert pass-through throwable identity

### DIFF
--- a/tests/Unit/Cli/ReporterSinkTest.php
+++ b/tests/Unit/Cli/ReporterSinkTest.php
@@ -42,11 +42,14 @@ final class ReporterSinkTest
     #[Test]
     public function reporterFailuresPropagateToTheEmitter(): void
     {
-        $reporter = new class implements Reporter, Fake {
+        $failure = ReportingError::writeFailed();
+        $reporter = new readonly class ($failure) implements Reporter, Fake {
+            public function __construct(private ReportingError $failure) {}
+
             #[\Override]
             public function onEvent(Event $event): never
             {
-                throw ReportingError::writeFailed();
+                throw $this->failure;
             }
 
             #[\Override]
@@ -59,8 +62,9 @@ final class ReporterSinkTest
         })
             ->because('a reporter failure MUST stop event delivery')
             ->toThrow(
-                ReportingError::class,
-                message: 'Greenlight did not write reporter output to the stream.',
+                static function (ReportingError $caught) use ($failure): void {
+                    Expect::that($caught)->toBe($failure);
+                },
             );
     }
 }

--- a/tests/Unit/Core/ErrorTrapTest.php
+++ b/tests/Unit/Core/ErrorTrapTest.php
@@ -90,6 +90,7 @@ final class ErrorTrapTest
     public function restoresThePreviousHandlerWhenTheOperationThrows(): void
     {
         $handled = null;
+        $failure = new \RuntimeException('operation failed');
 
         \set_error_handler(static function (int $severity, string $message) use (&$handled): bool {
             $handled = [$severity, $message];
@@ -99,10 +100,14 @@ final class ErrorTrapTest
 
         try {
             Expect::that(static fn(): mixed => ErrorTrap::run(
-                static fn(): never => throw new \RuntimeException('operation failed'),
+                static fn(): never => throw $failure,
             ))
                 ->because('the trap MUST propagate an operation error')
-                ->toThrow(\RuntimeException::class, message: 'operation failed');
+                ->toThrow(
+                    static function (\RuntimeException $caught) use ($failure): void {
+                        Expect::that($caught)->toBe($failure);
+                    },
+                );
 
             \trigger_error('after trap', \E_USER_WARNING);
 

--- a/tests/Unit/Expect/ExpectationRuntimeTest.php
+++ b/tests/Unit/Expect/ExpectationRuntimeTest.php
@@ -19,29 +19,25 @@ final class ExpectationRuntimeTest
         $inner = new FakePollingClock();
         $expected = new \RuntimeException('clock operation failed');
 
-        [$thrown, $afterInner] = ExpectationRuntime::withClock(
+        ExpectationRuntime::withClock(
             $outer,
-            static function () use ($inner, $expected): array {
-                $thrown = null;
-
-                try {
-                    ExpectationRuntime::withClock(
-                        $inner,
-                        static fn(): never => throw $expected,
+            static function () use ($inner, $outer, $expected): void {
+                Expect::that(static fn(): mixed => ExpectationRuntime::withClock(
+                    $inner,
+                    static fn(): never => throw $expected,
+                ))
+                    ->because('withClock propagates the operation exception')
+                    ->toThrow(
+                        static function (\RuntimeException $caught) use ($expected): void {
+                            Expect::that($caught)->toBe($expected);
+                        },
                     );
-                } catch (\RuntimeException $caught) {
-                    $thrown = $caught;
-                }
 
-                return [$thrown, ExpectationRuntime::clock()];
+                Expect::that(ExpectationRuntime::clock())
+                    ->toBe($outer);
             },
         );
 
-        Expect::that($thrown)
-            ->because('withClock propagates the operation exception')
-            ->toBe($expected);
-        Expect::that($afterInner)
-            ->toBe($outer);
         Expect::that(ExpectationRuntime::clock())
             ->toBe($baseline);
     }

--- a/tests/Unit/Expect/TemporalExpectationTest.php
+++ b/tests/Unit/Expect/TemporalExpectationTest.php
@@ -150,13 +150,18 @@ final class TemporalExpectationTest
     public function probeExceptionsPropagateUnlessExplicitlyRetryable(): void
     {
         $clock = new FakePollingClock();
+        $failure = new TransientProbeFailure('not ready');
 
         Expect::that(static fn() => ExpectationRuntime::withClock(
             $clock,
             static fn() => Expect::eventually(
-                static fn(): never => throw new TransientProbeFailure('not ready'),
+                static fn(): never => throw $failure,
             )->within(0.100)->toBe('ready'),
-        ))->because('probe exceptions propagate unless explicitly retryable')->toThrow(TransientProbeFailure::class, message: 'not ready');
+        ))->because('probe exceptions propagate unless explicitly retryable')->toThrow(
+            static function (TransientProbeFailure $caught) use ($failure): void {
+                Expect::that($caught)->toBe($failure);
+            },
+        );
 
         $calls = 0;
         ExpectationRuntime::withClock($clock, static function () use (&$calls): void {
@@ -213,6 +218,7 @@ final class TemporalExpectationTest
     {
         $clock = new FakePollingClock();
         $calls = 0;
+        $failure = new \Error('programming error');
 
         Expect::that(static function () use ($clock, &$calls): void {
             ExpectationRuntime::withClock($clock, static function () use (&$calls): void {
@@ -229,18 +235,22 @@ final class TemporalExpectationTest
 
         Expect::that($calls)->because('errors and matcher misuse are never retried')->toBe(1);
 
-        Expect::that(static function () use ($clock, &$calls): void {
-            ExpectationRuntime::withClock($clock, static function () use (&$calls): void {
-                Expect::eventually(static function () use (&$calls): never {
+        Expect::that(static function () use ($clock, &$calls, $failure): void {
+            ExpectationRuntime::withClock($clock, static function () use (&$calls, $failure): void {
+                Expect::eventually(static function () use (&$calls, $failure): never {
                     ++$calls;
 
-                    throw new \Error('programming error');
+                    throw $failure;
                 })
                     ->retryOnException(\Exception::class)
                     ->within(0.100)
                     ->toBe('unreachable');
             });
-        })->because('errors and matcher misuse are never retried')->toThrow(\Error::class, message: 'programming error');
+        })->because('errors and matcher misuse are never retried')->toThrow(
+            static function (\Error $caught) use ($failure): void {
+                Expect::that($caught)->toBe($failure);
+            },
+        );
 
         Expect::that($calls)->because('errors and matcher misuse are never retried')->toBe(2);
     }

--- a/tests/Unit/Harness/ScopeContainerLazyFactoryTest.php
+++ b/tests/Unit/Harness/ScopeContainerLazyFactoryTest.php
@@ -18,14 +18,15 @@ final class ScopeContainerLazyFactoryTest
     public function aLazyFactoryFailureIsDeferredAndPropagated(): void
     {
         $factoryCalls = 0;
+        $failure = new \RuntimeException('factory broke');
         $container = new ScopeContainer();
         $service = $container->get(new ServiceDefinition(
             LazyFactoryProbe::class,
             Scope::PerTest,
-            static function () use (&$factoryCalls): LazyFactoryProbe {
+            static function () use (&$factoryCalls, $failure): LazyFactoryProbe {
                 ++$factoryCalls;
 
-                throw new \RuntimeException('factory broke');
+                throw $failure;
             },
         ));
 
@@ -42,7 +43,11 @@ final class ScopeContainerLazyFactoryTest
 
         Expect::that(static fn() => $service->value())
             ->because('the lazy factory failure MUST propagate from the first service use')
-            ->toThrow(\RuntimeException::class, message: 'factory broke');
+            ->toThrow(
+                static function (\RuntimeException $caught) use ($failure): void {
+                    Expect::that($caught)->toBe($failure);
+                },
+            );
         Expect::that($factoryCalls)
             ->toBe(1);
     }

--- a/tests/Unit/Runner/PluginEventSinkTest.php
+++ b/tests/Unit/Runner/PluginEventSinkTest.php
@@ -73,11 +73,14 @@ final class PluginEventSinkTest
     #[Test]
     public function aSubscriberFailurePropagatesBeforeTheInnerSinkReceivesTheEvent(): void
     {
-        $subscriber = new class implements RunLifecycleSubscriber, Fake {
+        $failure = new \RuntimeException('subscriber broke');
+        $subscriber = new readonly class ($failure) implements RunLifecycleSubscriber, Fake {
+            public function __construct(private \RuntimeException $failure) {}
+
             #[\Override]
             public function onRunEvent(Event $event): never
             {
-                throw new \RuntimeException('subscriber broke');
+                throw $this->failure;
             }
         };
         $inner = new CollectingEventSink();
@@ -91,7 +94,11 @@ final class PluginEventSinkTest
             $sink->emit($event);
         })
             ->because('an orchestrator subscriber failure MUST fail event delivery')
-            ->toThrow(\RuntimeException::class, message: 'subscriber broke');
+            ->toThrow(
+                static function (\RuntimeException $caught) use ($failure): void {
+                    Expect::that($caught)->toBe($failure);
+                },
+            );
 
         Expect::that($inner->events)
             ->because('the inner sink MUST not observe an event rejected by a subscriber')


### PR DESCRIPTION
Use typed toThrow callbacks where components are expected to propagate a configured throwable unchanged. Assert exact object identity while retaining the existing delivery, retry, handler-restoration, and clock-restoration contracts.