### PR TITLE
test(doubles): assert aggregate failure details

### DIFF
--- a/tests/Unit/Doubles/DoublesDisposalAggregationTest.php
+++ b/tests/Unit/Doubles/DoublesDisposalAggregationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Doubles;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\FailureDetail;
 use Greenlight\Doubles\Doubles;
 use Greenlight\Doubles\MockPlan;
 use Greenlight\Expect\Expect;
@@ -31,13 +32,29 @@ final class DoublesDisposalAggregationTest
             ->because(
                 'disposal MUST report unmet expectations from every mock in creation order',
             )
-            ->toThrow(
-                ExpectationFailed::class,
-                message: "2 expectations failed:\n"
+            ->toThrow(static function (ExpectationFailed $failure): void {
+                Expect::that($failure->getMessage())->toBe(
+                    "2 expectations failed:\n"
                     . '1) Calls to ' . Calculator::class . '::add(): 0 times. '
                     . "The expectation requires exactly 1 time.\n"
                     . '2) Calls to ' . Recorder::class . '::record(): 0 times. '
                     . 'The expectation requires exactly 1 time.',
-            );
+                );
+
+                Expect::that($failure->details)->toEqual([
+                    new FailureDetail(
+                        'Calls to ' . Calculator::class . '::add(): 0 times. '
+                            . 'The expectation requires exactly 1 time.',
+                        'add(all arguments) exactly 1 time',
+                        'never called',
+                    ),
+                    new FailureDetail(
+                        'Calls to ' . Recorder::class . '::record(): 0 times. '
+                            . 'The expectation requires exactly 1 time.',
+                        'record(all arguments) exactly 1 time',
+                        'never called',
+                    ),
+                ]);
+            });
     }
 }

--- a/tests/Unit/Doubles/MockTest.php
+++ b/tests/Unit/Doubles/MockTest.php
@@ -6,6 +6,7 @@ namespace Greenlight\Tests\Unit\Doubles;
 
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\FailureDetail;
 use Greenlight\Doubles\Doubles;
 use Greenlight\Doubles\DoublesError;
 use Greenlight\Doubles\MockPlan;
@@ -86,14 +87,30 @@ final class MockTest
 
         Expect::that(static fn() => $doubles->dispose())
             ->because('disposal MUST report every unmet expectation in plan order')
-            ->toThrow(
-                ExpectationFailed::class,
-                message: "2 expectations failed:\n"
+            ->toThrow(static function (ExpectationFailed $failure): void {
+                Expect::that($failure->getMessage())->toBe(
+                    "2 expectations failed:\n"
                     . '1) Calls to ' . Calculator::class . '::add(): 0 times. '
                     . "The expectation requires exactly 1 time.\n"
                     . '2) Calls to ' . Calculator::class . '::describe(): 0 times. '
                     . 'The expectation requires exactly 1 time.',
-            );
+                );
+
+                Expect::that($failure->details)->toEqual([
+                    new FailureDetail(
+                        'Calls to ' . Calculator::class . '::add(): 0 times. '
+                            . 'The expectation requires exactly 1 time.',
+                        'add(all arguments) exactly 1 time',
+                        'never called',
+                    ),
+                    new FailureDetail(
+                        'Calls to ' . Calculator::class . '::describe(): 0 times. '
+                            . 'The expectation requires exactly 1 time.',
+                        'describe(all arguments) exactly 1 time',
+                        'never called',
+                    ),
+                ]);
+            });
     }
 
     #[Test]


### PR DESCRIPTION
Updates the doubles disposal aggregation tests to inspect the thrown ExpectationFailed through typed callbacks. Asserts each ordered FailureDetail message, expected value, and actual value while retaining the aggregate diagnostic contract.