### PR TITLE
build: enforce checked exception documentation

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -7,6 +7,12 @@ includes:
 parameters:
     level: max
     tmpDir: build/cache/phpstan
+    exceptions:
+        checkedExceptionClasses:
+            - Greenlight\Core\Test\SkipTest
+            - Greenlight\Expect\ExpectationFailed
+        check:
+            missingCheckedExceptionInThrows: true
     paths:
         - src
         - tests
@@ -21,3 +27,7 @@ parameters:
     greenlight:
         configFiles:
             - tests/Fixture/PhpStanExtension/greenlight.php
+
+services:
+    exceptionTypeResolver!:
+        class: Greenlight\Tests\Support\TestCodeExceptionTypeResolver

--- a/tests/Acceptance/PhpStanCheckedExceptionTest.php
+++ b/tests/Acceptance/PhpStanCheckedExceptionTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\PhpStanProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class PhpStanCheckedExceptionTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function controlSignalsNeedThrowsTagsOutsideTestCode(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace Greenlight\Tests\Probe;
+
+            use Greenlight\Core\Result\FailureDetail;
+            use Greenlight\Expect\ExpectationFailed;
+
+            function undocumentedTestHelper(): void
+            {
+                throw ExpectationFailed::fromDetail(new FailureDetail('Expected test failure.'));
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace Greenlight\Probe;
+
+            use Greenlight\Core\Result\FailureDetail;
+            use Greenlight\Expect\ExpectationFailed;
+
+            function undocumentedProductionHelper(): void
+            {
+                throw ExpectationFailed::fromDetail(new FailureDetail('Expected production failure.'));
+            }
+            PHP,
+            \dirname(__DIR__, 2) . '/phpstan.dist.neon',
+        );
+
+        Expect::that($probe->exitCode)
+            ->because('PHPStan MUST reject an undocumented production control signal')
+            ->toBe(1);
+        Expect::that($probe->goodPassed)
+            ->because('PHPStan MUST not require throws tags in test code')
+            ->toBeTrue();
+        Expect::that($probe->errors)->toHaveCount(1);
+        Expect::that($probe->messages())->toContain(
+            'throws checked exception Greenlight\\Expect\\ExpectationFailed but it\'s missing from the PHPDoc @throws tag.',
+        );
+    }
+}

--- a/tests/Support/TestCodeExceptionTypeResolver.php
+++ b/tests/Support/TestCodeExceptionTypeResolver.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Support;
+
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\Exceptions\DefaultExceptionTypeResolver;
+use PHPStan\Rules\Exceptions\ExceptionTypeResolver;
+
+/**
+ * Makes exceptions unchecked in Greenlight test code.
+ *
+ * @internal
+ */
+final readonly class TestCodeExceptionTypeResolver implements ExceptionTypeResolver
+{
+    public function __construct(private DefaultExceptionTypeResolver $defaultResolver) {}
+
+    #[\Override]
+    public function isCheckedException(string $className, Scope $scope): bool
+    {
+        $namespace = $scope->getNamespace();
+        $testDirectory = \dirname(__DIR__) . \DIRECTORY_SEPARATOR;
+
+        if (
+            $namespace === 'Greenlight\\Tests'
+            || \str_starts_with($namespace ?? '', 'Greenlight\\Tests\\')
+            || \str_starts_with($scope->getFile(), $testDirectory)
+        ) {
+            return false;
+        }
+
+        return $this->defaultResolver->isCheckedException($className, $scope);
+    }
+}


### PR DESCRIPTION
## Summary

- Treat `ExpectationFailed` and `SkipTest` as checked control signals in PHPStan.
- Fail static analysis when production code omits their `@throws` declarations.
- Keep test code exempt through a scoped exception resolver.
- Prove the production/test boundary with an acceptance test.

## Stack

Depends on #1243.