### PR TITLE
test(worker): remove release signal race

### DIFF
--- a/tests/Unit/Runner/Worker/WorkerProcessFatalSendFailureTest.php
+++ b/tests/Unit/Runner/Worker/WorkerProcessFatalSendFailureTest.php
@@ -118,7 +118,7 @@ final readonly class WorkerProcessFatalSendFailureTest
 
             $channel->close();
 
-            if (!touch($release)) {
+            if (file_put_contents($release, 'release') === false) {
                 exit(8);
             }
 


### PR DESCRIPTION
Replace the touch-based release signal in the worker fatal-send fixture with a payload write. The worker removes the release path as soon as it sees the signal, which can make touch report failure after the worker has already consumed the signal.