### PR TITLE
build: enforce core exception contracts

### DIFF
--- a/docs/api-artifacts.md
+++ b/docs/api-artifacts.md
@@ -226,7 +226,11 @@ public function value(
 ): void;
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachments.php#L15)
+PHPDoc:
+
+- `@throws AttachmentError when the attachment cannot be accepted`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachments.php#L18)
 
 ### `text()`
 
@@ -239,7 +243,11 @@ public function text(
 ): void;
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachments.php#L21)
+PHPDoc:
+
+- `@throws AttachmentError when the attachment cannot be accepted`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachments.php#L27)
 
 ### `bytes()`
 
@@ -252,7 +260,11 @@ public function bytes(
 ): void;
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachments.php#L28)
+PHPDoc:
+
+- `@throws AttachmentError when the attachment cannot be accepted`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachments.php#L37)
 
 ### `file()`
 
@@ -265,4 +277,8 @@ public function file(
 ): void;
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachments.php#L35)
+PHPDoc:
+
+- `@throws AttachmentError when the attachment cannot be accepted`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachments.php#L47)

--- a/docs/api-configuration.md
+++ b/docs/api-configuration.md
@@ -24,7 +24,11 @@ final class ArtifactBuilder
 public function directory(string $directory): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L19)
+PHPDoc:
+
+- `@throws InvalidConfiguration`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L22)
 
 ### `maxAttachmentsPerTest()`
 
@@ -32,7 +36,11 @@ public function directory(string $directory): self
 public function maxAttachmentsPerTest(int $count): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L34)
+PHPDoc:
+
+- `@throws InvalidConfiguration`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L40)
 
 ### `maxAttachmentSize()`
 
@@ -40,7 +48,11 @@ public function maxAttachmentsPerTest(int $count): self
 public function maxAttachmentSize(string $size): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L45)
+PHPDoc:
+
+- `@throws InvalidConfiguration`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L54)
 
 ### `maxTestSize()`
 
@@ -48,7 +60,11 @@ public function maxAttachmentSize(string $size): self
 public function maxTestSize(string $size): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L52)
+PHPDoc:
+
+- `@throws InvalidConfiguration`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L64)
 
 ### `maxRunAttachments()`
 
@@ -56,7 +72,11 @@ public function maxTestSize(string $size): self
 public function maxRunAttachments(int $count): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L59)
+PHPDoc:
+
+- `@throws InvalidConfiguration`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L74)
 
 ### `maxRunSize()`
 
@@ -64,7 +84,11 @@ public function maxRunAttachments(int $count): self
 public function maxRunSize(string $size): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L70)
+PHPDoc:
+
+- `@throws InvalidConfiguration`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L88)
 
 ## `CoverageBuilder`
 
@@ -287,7 +311,11 @@ or "?" matches the complete message. Multiple calls add patterns.
 public function ignoreDeprecationsMatching(string ...$patterns): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L275)
+PHPDoc:
+
+- `@throws InvalidConfiguration`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L276)
 
 ### `plugins()`
 
@@ -295,7 +323,7 @@ public function ignoreDeprecationsMatching(string ...$patterns): self
 public function plugins(Plugin ...$plugins): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L292)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L293)
 
 ### `failFast()`
 
@@ -303,7 +331,7 @@ public function plugins(Plugin ...$plugins): self
 public function failFast(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L301)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L302)
 
 ### `randomizeOrder()`
 
@@ -313,7 +341,7 @@ If the seed is null, Greenlight generates and prints a seed at run time.
 public function randomizeOrder(?int $seed = null): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L309)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L310)
 
 ### `build()`
 
@@ -321,7 +349,11 @@ public function randomizeOrder(?int $seed = null): self
 public function build(): Configuration
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L337)
+PHPDoc:
+
+- `@throws InvalidConfiguration`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L342)
 
 ## `SuiteBuilder`
 

--- a/docs/api-test-contracts.md
+++ b/docs/api-test-contracts.md
@@ -407,6 +407,7 @@ public static function fromWire(array $payload): static;
 PHPDoc:
 
 - `@param array<string, mixed> $payload`
+- `@throws \InvalidArgumentException when a decoded value violates a domain invariant`
 - `@throws InvalidWirePayload`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Wire/WireSerializable.php#L26)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Wire/WireSerializable.php#L27)

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -9,10 +9,20 @@ parameters:
     tmpDir: build/cache/phpstan
     exceptions:
         checkedExceptionClasses:
+            - Greenlight\Capture\CaptureError
+            - Greenlight\Cli\CliError
+            - Greenlight\Config\ConfigFileError
+            - Greenlight\Config\InvalidConfiguration
+            - Greenlight\Core\Artifact\AttachmentError
+            - Greenlight\Core\AtomicFileError
             - Greenlight\Core\Test\SkipTest
+            - Greenlight\Core\Wire\InvalidWirePayload
+            - Greenlight\Coverage\CoverageError
+            - Greenlight\Discovery\DiscoveryError
             - Greenlight\Expect\ExpectationFailed
         check:
             missingCheckedExceptionInThrows: true
+            throwTypeCovariance: true
     paths:
         - src
         - tests

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -23,6 +23,7 @@ use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Event\EventTags;
 use Greenlight\Core\GracefulShutdown;
 use Greenlight\Core\Wire\InvalidWirePayload;
+use Greenlight\Coverage\CoverageError;
 use Greenlight\Coverage\CoverageMap;
 use Greenlight\Coverage\Diff\BaselineDiff;
 use Greenlight\Coverage\Export\CloverExporter;
@@ -172,6 +173,7 @@ final readonly class Application
 
     /**
      * @param list<string> $argv the arguments after the script name
+     * @throws CoverageError
      */
     public function run(array $argv, string $workingDirectory, ?string $binPath = null): int
     {
@@ -206,6 +208,7 @@ final readonly class Application
 
     /**
      * @param list<string> $argv the arguments after the script name
+     * @throws CoverageError
      */
     private function dispatch(array $argv, string $workingDirectory, ?string $binPath): int
     {
@@ -263,6 +266,9 @@ final readonly class Application
         return self::EXIT_USAGE;
     }
 
+    /**
+     * @throws CoverageError
+     */
     private function runCommand(ParsedArguments $arguments, string $workingDirectory, ?string $binPath = null): int
     {
         try {
@@ -437,6 +443,7 @@ final readonly class Application
      *
      * @param list<non-empty-string> $priorityClasses
      * @param array<string, float> $classSeconds
+     * @throws CoverageError
      */
     private function executeRun(
         ParsedArguments $arguments,

--- a/src/Cli/ArgumentParser.php
+++ b/src/Cli/ArgumentParser.php
@@ -115,6 +115,7 @@ final class ArgumentParser
 
     /**
      * @param array<string, list<string|null>> $options
+     * @throws CliError
      */
     private function record(array &$options, OptionSpec $spec, ?string $value): void
     {

--- a/src/Cli/CliOverrides.php
+++ b/src/Cli/CliOverrides.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Cli;
 
+use Greenlight\Config\InvalidConfiguration;
 use Greenlight\Config\WorkerCount;
 use Greenlight\Core\DecimalInteger;
 use Greenlight\Core\Test\ResourceName;
@@ -55,6 +56,7 @@ final readonly class CliOverrides
 
     /**
      * @throws CliError
+     * @throws InvalidConfiguration
      */
     public static function fromArguments(ParsedArguments $arguments): self
     {
@@ -225,6 +227,7 @@ final readonly class CliOverrides
 
     /**
      * @return positive-int
+     * @throws CliError
      */
     private static function positiveInt(string $raw, string $flag): int
     {

--- a/src/Config/ArtifactBuilder.php
+++ b/src/Config/ArtifactBuilder.php
@@ -16,6 +16,9 @@ final class ArtifactBuilder
     private int $maxRunAttachments = ArtifactConfiguration::DEFAULT_MAX_RUN_ATTACHMENTS;
     private int $maxRunBytes = ArtifactConfiguration::DEFAULT_MAX_RUN_BYTES;
 
+    /**
+     * @throws InvalidConfiguration
+     */
     public function directory(string $directory): self
     {
         if ($directory === '') {
@@ -31,6 +34,9 @@ final class ArtifactBuilder
         return $this;
     }
 
+    /**
+     * @throws InvalidConfiguration
+     */
     public function maxAttachmentsPerTest(int $count): self
     {
         if ($count < 1) {
@@ -42,6 +48,9 @@ final class ArtifactBuilder
         return $this;
     }
 
+    /**
+     * @throws InvalidConfiguration
+     */
     public function maxAttachmentSize(string $size): self
     {
         $this->maxAttachmentBytes = MemorySize::parseToBytes($size);
@@ -49,6 +58,9 @@ final class ArtifactBuilder
         return $this;
     }
 
+    /**
+     * @throws InvalidConfiguration
+     */
     public function maxTestSize(string $size): self
     {
         $this->maxTestBytes = MemorySize::parseToBytes($size);
@@ -56,6 +68,9 @@ final class ArtifactBuilder
         return $this;
     }
 
+    /**
+     * @throws InvalidConfiguration
+     */
     public function maxRunAttachments(int $count): self
     {
         if ($count < 1) {
@@ -67,6 +82,9 @@ final class ArtifactBuilder
         return $this;
     }
 
+    /**
+     * @throws InvalidConfiguration
+     */
     public function maxRunSize(string $size): self
     {
         $this->maxRunBytes = MemorySize::parseToBytes($size);

--- a/src/Config/GreenlightConfig.php
+++ b/src/Config/GreenlightConfig.php
@@ -271,6 +271,7 @@ final class GreenlightConfig
      * Exempts deprecation messages from `failOnDeprecation()`. A pattern matches
      * part of a message without case sensitivity. A pattern that contains "*"
      * or "?" matches the complete message. Multiple calls add patterns.
+     * @throws InvalidConfiguration
      */
     public function ignoreDeprecationsMatching(string ...$patterns): self
     {
@@ -317,6 +318,7 @@ final class GreenlightConfig
     /**
      * Uses a wider parameter type than the public contract. This gives callers
      * without static analysis a clear runtime error for invalid strings.
+     * @throws InvalidConfiguration
      */
     private function workerCount(int|string $count): WorkerCount
     {
@@ -334,6 +336,9 @@ final class GreenlightConfig
         ));
     }
 
+    /**
+     * @throws InvalidConfiguration
+     */
     public function build(): Configuration
     {
         return new Configuration(

--- a/src/Config/WatchBuilder.php
+++ b/src/Config/WatchBuilder.php
@@ -30,6 +30,7 @@ final class WatchBuilder
 
     /**
      * @internal
+     * @throws InvalidConfiguration
      */
     public function toConfiguration(): WatchConfiguration
     {

--- a/src/Core/Artifact/Attachments.php
+++ b/src/Core/Artifact/Attachments.php
@@ -12,12 +12,18 @@ namespace Greenlight\Core\Artifact;
  */
 interface Attachments
 {
+    /**
+     * @throws AttachmentError when the attachment cannot be accepted
+     */
     public function value(
         string $name,
         mixed $value,
         AttachmentRetention $retention = AttachmentRetention::OnFailure,
     ): void;
 
+    /**
+     * @throws AttachmentError when the attachment cannot be accepted
+     */
     public function text(
         string $name,
         string $text,
@@ -25,6 +31,9 @@ interface Attachments
         AttachmentRetention $retention = AttachmentRetention::OnFailure,
     ): void;
 
+    /**
+     * @throws AttachmentError when the attachment cannot be accepted
+     */
     public function bytes(
         string $name,
         string $bytes,
@@ -32,6 +41,9 @@ interface Attachments
         AttachmentRetention $retention = AttachmentRetention::OnFailure,
     ): void;
 
+    /**
+     * @throws AttachmentError when the attachment cannot be accepted
+     */
     public function file(
         string $name,
         string $sourcePath,

--- a/src/Core/Artifact/UnavailableAttachments.php
+++ b/src/Core/Artifact/UnavailableAttachments.php
@@ -11,6 +11,9 @@ namespace Greenlight\Core\Artifact;
  */
 final class UnavailableAttachments implements Attachments
 {
+    /**
+     * @throws AttachmentError
+     */
     #[\Override]
     public function value(
         string $name,
@@ -20,6 +23,9 @@ final class UnavailableAttachments implements Attachments
         throw AttachmentError::unavailable();
     }
 
+    /**
+     * @throws AttachmentError
+     */
     #[\Override]
     public function text(
         string $name,
@@ -30,6 +36,9 @@ final class UnavailableAttachments implements Attachments
         throw AttachmentError::unavailable();
     }
 
+    /**
+     * @throws AttachmentError
+     */
     #[\Override]
     public function bytes(
         string $name,
@@ -40,6 +49,9 @@ final class UnavailableAttachments implements Attachments
         throw AttachmentError::unavailable();
     }
 
+    /**
+     * @throws AttachmentError
+     */
     #[\Override]
     public function file(
         string $name,

--- a/src/Core/Wire/Wire.php
+++ b/src/Core/Wire/Wire.php
@@ -316,6 +316,7 @@ final class Wire
 
     /**
      * @param array<string, mixed> $payload
+     * @throws InvalidWirePayload
      */
     private static function require(array $payload, string $key): mixed
     {

--- a/src/Core/Wire/WireSerializable.php
+++ b/src/Core/Wire/WireSerializable.php
@@ -21,6 +21,7 @@ interface WireSerializable
     /**
      * @param array<string, mixed> $payload
      *
+     * @throws \InvalidArgumentException when a decoded value violates a domain invariant
      * @throws InvalidWirePayload
      */
     public static function fromWire(array $payload): static;

--- a/src/Coverage/CoverageMap.php
+++ b/src/Coverage/CoverageMap.php
@@ -181,6 +181,7 @@ final readonly class CoverageMap implements WireSerializable
 
     /**
      * @return list<int>
+     * @throws InvalidWirePayload
      */
     private static function lineList(mixed $value): array
     {

--- a/src/Coverage/Driver/PcovDriver.php
+++ b/src/Coverage/Driver/PcovDriver.php
@@ -22,6 +22,9 @@ final class PcovDriver implements CoverageDriver
 
     private readonly PcovRuntime $runtime;
 
+    /**
+     * @throws CoverageError
+     */
     public function __construct(?PcovRuntime $runtime = null)
     {
         if (!$runtime instanceof PcovRuntime && !self::isAvailable()) {

--- a/src/Coverage/Driver/XdebugDriver.php
+++ b/src/Coverage/Driver/XdebugDriver.php
@@ -22,6 +22,9 @@ final class XdebugDriver implements CoverageDriver
 
     private readonly XdebugRuntime $runtime;
 
+    /**
+     * @throws CoverageError
+     */
     public function __construct(
         ?XdebugRuntime $runtime = null,
         private readonly ?int $flags = null,

--- a/src/Coverage/Export/JsonExporter.php
+++ b/src/Coverage/Export/JsonExporter.php
@@ -51,6 +51,7 @@ final readonly class JsonExporter implements CoverageExporter
     /**
      * Reads a document from export() into a CoverageMap. The method calculates
      * totals and percentages because export() derives these values.
+     * @throws CoverageError
      */
     public static function import(string $json): CoverageMap
     {
@@ -96,6 +97,7 @@ final readonly class JsonExporter implements CoverageExporter
      * @param array<mixed> $entry
      *
      * @return list<int>
+     * @throws CoverageError
      */
     private static function lineList(array $entry, string $key, string $path): array
     {

--- a/src/Discovery/DataSetExpander.php
+++ b/src/Discovery/DataSetExpander.php
@@ -187,6 +187,9 @@ final readonly class DataSetExpander
         return $dataSets;
     }
 
+    /**
+     * @throws DiscoveryError
+     */
     private function deriveKey(string $class, string $provider, mixed $key): string
     {
         if (\is_int($key)) {

--- a/src/Discovery/ExecutionPlan.php
+++ b/src/Discovery/ExecutionPlan.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Discovery;
 
+use Greenlight\Core\Wire\InvalidWirePayload;
 use Greenlight\Core\Wire\Wire;
 use Greenlight\Core\Wire\WireSerializable;
 
@@ -120,6 +121,7 @@ final readonly class ExecutionPlan implements WireSerializable, \Countable
 
     /**
      * @throws \InvalidArgumentException when entries are not grouped by class or contain duplicate test IDs
+     * @throws InvalidWirePayload
      */
     #[\Override]
     public static function fromWire(array $payload): static

--- a/src/Discovery/MetadataFactory.php
+++ b/src/Discovery/MetadataFactory.php
@@ -132,6 +132,7 @@ final class MetadataFactory
      * @param \ReflectionClass<object>|\ReflectionMethod $reflector
      *
      * @return list<non-empty-string>
+     * @throws DiscoveryError
      */
     private function groupNames(\ReflectionClass|\ReflectionMethod $reflector, string $where): array
     {
@@ -152,6 +153,7 @@ final class MetadataFactory
      * @param \ReflectionClass<object>|\ReflectionMethod $reflector
      *
      * @return list<non-empty-string>
+     * @throws DiscoveryError
      */
     private function resourceNames(\ReflectionClass|\ReflectionMethod $reflector, string $where): array
     {
@@ -175,6 +177,7 @@ final class MetadataFactory
      * @param class-string<T> $attribute
      *
      * @return T|null
+     * @throws DiscoveryError
      */
     private function attributeInstance(\ReflectionClass|\ReflectionMethod $reflector, string $attribute, string $where): ?object
     {

--- a/src/Discovery/TestDiscoverer.php
+++ b/src/Discovery/TestDiscoverer.php
@@ -113,6 +113,7 @@ final readonly class TestDiscoverer
      * @param non-empty-string $file
      *
      * @return list<PlanEntry>
+     * @throws DiscoveryError
      */
     private function entriesForFile(string $file): array
     {
@@ -185,6 +186,7 @@ final readonly class TestDiscoverer
      * @param non-empty-string $file
      *
      * @return class-string|null
+     * @throws DiscoveryError
      */
     private function resolveClass(string $file): ?string
     {

--- a/src/PhpStan/ExpectationMethodsExtension.php
+++ b/src/PhpStan/ExpectationMethodsExtension.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Greenlight\PhpStan;
 
+use Greenlight\Config\ConfigFileError;
+use Greenlight\Config\InvalidConfiguration;
 use Greenlight\Expect\ConsistentlyExpectation;
 use Greenlight\Expect\EventuallyExpectation;
 use Greenlight\Expect\Expectation;
@@ -27,6 +29,10 @@ final readonly class ExpectationMethodsExtension implements MethodsClassReflecti
 {
     public function __construct(private MatcherMapProvider $matcherMap) {}
 
+    /**
+     * @throws ConfigFileError
+     * @throws InvalidConfiguration
+     */
     #[\Override]
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
     {
@@ -39,6 +45,10 @@ final readonly class ExpectationMethodsExtension implements MethodsClassReflecti
             && $this->matcherMap->get()->has($methodName);
     }
 
+    /**
+     * @throws ConfigFileError
+     * @throws InvalidConfiguration
+     */
     #[\Override]
     public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection
     {

--- a/src/PhpStan/ExtensionMatcherSubjectRule.php
+++ b/src/PhpStan/ExtensionMatcherSubjectRule.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Greenlight\PhpStan;
 
+use Greenlight\Config\ConfigFileError;
+use Greenlight\Config\InvalidConfiguration;
 use Greenlight\Expect\Expectation;
 use Greenlight\Expect\TemporalExpectation;
 use PhpParser\Node;
@@ -36,6 +38,10 @@ final readonly class ExtensionMatcherSubjectRule implements Rule
         return MethodCall::class;
     }
 
+    /**
+     * @throws ConfigFileError
+     * @throws InvalidConfiguration
+     */
     #[\Override]
     public function processNode(Node $node, Scope $scope): array
     {

--- a/src/PhpStan/MatcherMap.php
+++ b/src/PhpStan/MatcherMap.php
@@ -6,6 +6,7 @@ namespace Greenlight\PhpStan;
 
 use Greenlight\Config\ConfigFileError;
 use Greenlight\Config\ConfigLoader;
+use Greenlight\Config\InvalidConfiguration;
 use Greenlight\Expect\ExpectationExtension;
 
 /**
@@ -35,6 +36,7 @@ final readonly class MatcherMap
      *
      * @throws ConfigFileError
      * @throws MatcherMapError
+     * @throws InvalidConfiguration
      */
     public static function fromConfigFiles(array $configFiles): self
     {

--- a/src/PhpStan/MatcherMapProvider.php
+++ b/src/PhpStan/MatcherMapProvider.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace Greenlight\PhpStan;
 
+use Greenlight\Config\ConfigFileError;
+use Greenlight\Config\InvalidConfiguration;
+
 /**
  * Loads one matcher map for all PHPStan expectation extensions.
  *
@@ -19,6 +22,10 @@ final class MatcherMapProvider
      */
     public function __construct(private readonly array $configFiles) {}
 
+    /**
+     * @throws ConfigFileError
+     * @throws InvalidConfiguration
+     */
     public function get(): MatcherMap
     {
         return $this->map ??= MatcherMap::fromConfigFiles($this->configFiles);

--- a/src/Runner/Artifact/ArtifactStore.php
+++ b/src/Runner/Artifact/ArtifactStore.php
@@ -32,6 +32,9 @@ final class ArtifactStore
         private readonly FileCopier $fileCopier,
     ) {}
 
+    /**
+     * @throws AttachmentError
+     */
     public static function open(
         ArtifactConfiguration $configuration,
         string $workingDirectory,
@@ -96,6 +99,9 @@ final class ArtifactStore
         return $this->session->publicDirectory;
     }
 
+    /**
+     * @throws AttachmentError
+     */
     public function forAttempt(TestId $id, int $attempt, TestArtifactBudget $budget): StagedAttachments
     {
         $attemptRecorded = \is_dir(
@@ -125,6 +131,9 @@ final class ArtifactStore
         return $slug . '-' . \substr(\hash('sha256', $raw), 0, 12);
     }
 
+    /**
+     * @throws AttachmentError
+     */
     public function stageBytes(
         string $bytes,
         string $name,
@@ -190,6 +199,9 @@ final class ArtifactStore
         }
     }
 
+    /**
+     * @throws AttachmentError
+     */
     public function stageFile(
         string $sourcePath,
         string $name,
@@ -302,6 +314,9 @@ final class ArtifactStore
         }
     }
 
+    /**
+     * @throws AttachmentError
+     */
     public function discard(StagedAttachment $attachment): void
     {
         $storageKey = $attachment->storageKey;
@@ -311,6 +326,9 @@ final class ArtifactStore
         $this->release($attachment->sizeBytes);
     }
 
+    /**
+     * @throws AttachmentError
+     */
     public function publish(TestResult $result): TestResult
     {
         if ($result->attachments === []) {
@@ -390,6 +408,7 @@ final class ArtifactStore
     /**
      * Recovers evidence that completed atomically from a worker that stopped
      * before TestFinished.
+     * @throws AttachmentError
      */
     public function recover(TestResult $result): TestResult
     {
@@ -476,6 +495,9 @@ final class ArtifactStore
         @\rmdir($directory);
     }
 
+    /**
+     * @throws AttachmentError
+     */
     private function validateSize(int $size, ArtifactConfiguration $configuration): void
     {
         if ($size < 0) {
@@ -491,6 +513,9 @@ final class ArtifactStore
         }
     }
 
+    /**
+     * @throws AttachmentError
+     */
     private function preparePath(string $storageKey): string
     {
         $this->ensureStaging();
@@ -508,6 +533,9 @@ final class ArtifactStore
         return $path;
     }
 
+    /**
+     * @throws AttachmentError
+     */
     private function reserve(int $bytes): void
     {
         $this->updateQuota(function (int $count, int $used) use ($bytes): array {
@@ -529,6 +557,9 @@ final class ArtifactStore
         });
     }
 
+    /**
+     * @throws AttachmentError
+     */
     private function release(int $bytes): void
     {
         $this->updateQuota(static fn(int $count, int $used): array => [
@@ -539,6 +570,7 @@ final class ArtifactStore
 
     /**
      * @param \Closure(int, int): array{int, int} $update
+     * @throws AttachmentError
      */
     private function updateQuota(\Closure $update): void
     {
@@ -610,6 +642,9 @@ final class ArtifactStore
         }
     }
 
+    /**
+     * @throws AttachmentError
+     */
     private function writeMetadata(StagedAttachment $attachment): void
     {
         $storageKey = $attachment->storageKey;
@@ -635,6 +670,9 @@ final class ArtifactStore
         }
     }
 
+    /**
+     * @throws AttachmentError
+     */
     public function recordAttempt(TestId $id, int $attempt): void
     {
         $this->ensureStaging();
@@ -665,6 +703,9 @@ final class ArtifactStore
         }
     }
 
+    /**
+     * @throws AttachmentError
+     */
     private function ensureStaging(): void
     {
         $directory = $this->session->stagingDirectory;
@@ -683,6 +724,9 @@ final class ArtifactStore
         \chmod($directory, 0o700);
     }
 
+    /**
+     * @throws AttachmentError
+     */
     private function rollbackStagedAttachment(
         string $storageKey,
         ?string $path,
@@ -701,6 +745,9 @@ final class ArtifactStore
         }
     }
 
+    /**
+     * @throws AttachmentError
+     */
     private function removeFile(string $path, string $description): void
     {
         if (!\file_exists($path) && !\is_link($path)) {
@@ -717,6 +764,9 @@ final class ArtifactStore
         return $this->session->stagingDirectory . '/' . $storageKey . '.meta.json';
     }
 
+    /**
+     * @throws AttachmentError
+     */
     private function assertSafeStorageKey(string $storageKey): void
     {
         if ($storageKey === '' || \str_starts_with($storageKey, '/') || \str_contains($storageKey, '\\')) {
@@ -731,6 +781,9 @@ final class ArtifactStore
         }
     }
 
+    /**
+     * @throws AttachmentError
+     */
     private function createDirectorySafely(string $directory): void
     {
         $absolute = \str_starts_with($directory, '/');

--- a/src/Runner/Artifact/FileCopier.php
+++ b/src/Runner/Artifact/FileCopier.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Greenlight\Runner\Artifact;
 
+use Greenlight\Core\Artifact\AttachmentError;
+
 /**
  * Copies attachment files into their output directory.
  *
@@ -11,5 +13,8 @@ namespace Greenlight\Runner\Artifact;
  */
 interface FileCopier
 {
+    /**
+     * @throws AttachmentError when the file cannot be copied
+     */
     public function copy(string $sourcePath, string $destinationPath): void;
 }

--- a/src/Runner/Artifact/NativeFileCopier.php
+++ b/src/Runner/Artifact/NativeFileCopier.php
@@ -11,6 +11,9 @@ final readonly class NativeFileCopier implements FileCopier
 {
     private const int COPY_CHUNK_BYTES = 1024 * 1024;
 
+    /**
+     * @throws AttachmentError
+     */
     #[\Override]
     public function copy(string $sourcePath, string $destinationPath): void
     {

--- a/src/Runner/Artifact/PublishingEventSink.php
+++ b/src/Runner/Artifact/PublishingEventSink.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Runner\Artifact;
 
+use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Core\Event\Event;
 use Greenlight\Core\Event\TestFinished;
 use Greenlight\Runner\Worker\EventSink;
@@ -20,6 +21,9 @@ final readonly class PublishingEventSink implements EventSink
         private EventSink $inner,
     ) {}
 
+    /**
+     * @throws AttachmentError
+     */
     #[\Override]
     public function emit(Event $event): void
     {

--- a/src/Runner/Artifact/StagedAttachments.php
+++ b/src/Runner/Artifact/StagedAttachments.php
@@ -40,6 +40,9 @@ final class StagedAttachments implements Attachments
         private bool $attemptRecorded = false,
     ) {}
 
+    /**
+     * @throws AttachmentError
+     */
     #[\Override]
     public function value(
         string $name,
@@ -59,6 +62,9 @@ final class StagedAttachments implements Attachments
         $this->stage($name, $encoded . "\n", 'application/json', AttachmentKind::Value, $retention);
     }
 
+    /**
+     * @throws AttachmentError
+     */
     #[\Override]
     public function text(
         string $name,
@@ -69,6 +75,9 @@ final class StagedAttachments implements Attachments
         $this->stage($name, $text, $mediaType, AttachmentKind::Text, $retention);
     }
 
+    /**
+     * @throws AttachmentError
+     */
     #[\Override]
     public function bytes(
         string $name,
@@ -79,6 +88,9 @@ final class StagedAttachments implements Attachments
         $this->stage($name, $bytes, $mediaType, AttachmentKind::Binary, $retention);
     }
 
+    /**
+     * @throws AttachmentError
+     */
     #[\Override]
     public function file(
         string $name,
@@ -135,6 +147,9 @@ final class StagedAttachments implements Attachments
         return $this->attachments;
     }
 
+    /**
+     * @throws AttachmentError
+     */
     private function stage(
         string $name,
         string $bytes,
@@ -158,6 +173,9 @@ final class StagedAttachments implements Attachments
         $this->record($attachment);
     }
 
+    /**
+     * @throws AttachmentError
+     */
     private function recordAttempt(): void
     {
         if ($this->attemptRecorded) {
@@ -168,6 +186,9 @@ final class StagedAttachments implements Attachments
         $this->attemptRecorded = true;
     }
 
+    /**
+     * @throws AttachmentError
+     */
     private function record(StagedAttachment $attachment): void
     {
         if ($this->budget->bytes + $attachment->sizeBytes > $this->configuration->maxTestBytes) {
@@ -184,6 +205,9 @@ final class StagedAttachments implements Attachments
         $this->attachments[] = $attachment;
     }
 
+    /**
+     * @throws AttachmentError
+     */
     private function guard(string $name, string $mediaType): void
     {
         if ($this->sealed) {

--- a/src/Runner/Artifact/StreamWriter.php
+++ b/src/Runner/Artifact/StreamWriter.php
@@ -16,6 +16,7 @@ final class StreamWriter
 {
     /**
      * @param resource $stream
+     * @throws AttachmentError
      */
     public static function writeFully($stream, string $bytes): void
     {

--- a/src/Runner/InProcessRunner.php
+++ b/src/Runner/InProcessRunner.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Runner;
 
 use Greenlight\Config\Configuration;
+use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Core\Event\RunFinished;
 use Greenlight\Core\Event\RunStarted;
 use Greenlight\Core\GracefulShutdown;
@@ -43,6 +44,7 @@ final readonly class InProcessRunner
      * @param array<string, float> $classSeconds Recorded class durations for longest-first ordering. Seeded runs ignore this value.
      *
      * @throws DiscoveryError
+     * @throws AttachmentError
      */
     public function run(
         Configuration $configuration,
@@ -191,6 +193,7 @@ final readonly class InProcessRunner
 
     /**
      * @param list<non-empty-string> $directories
+     * @throws DiscoveryError
      */
     private function discover(Configuration $configuration, array $directories, ?int $seed): ExecutionPlan
     {

--- a/src/Runner/Orchestrator/Orchestrator.php
+++ b/src/Runner/Orchestrator/Orchestrator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Runner\Orchestrator;
 
 use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Event\Event;
 use Greenlight\Core\Event\RecycleReason;
@@ -20,6 +21,7 @@ use Greenlight\Core\Result\ResultSummary;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Core\Result\ThrowableDetail;
 use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Wire\InvalidWirePayload;
 use Greenlight\Coverage\CoverageMap;
 use Greenlight\Discovery\ExecutionPlan;
 use Greenlight\Discovery\PlanEntry;
@@ -168,6 +170,8 @@ final class Orchestrator
      * @param positive-int $workerCount
      *
      * @throws ProtocolError
+     * @throws AttachmentError
+     * @throws InvalidWirePayload
      */
     public function run(ExecutionPlan $plan, EventSink $sink, int $workerCount): ResultSummary
     {
@@ -318,6 +322,8 @@ final class Orchestrator
     /**
      * @param resource $server
      * @param non-empty-string $token
+     * @throws AttachmentError
+     * @throws InvalidWirePayload
      */
     private function tick(mixed $server, string $token, EventSink $sink): void
     {
@@ -354,6 +360,8 @@ final class Orchestrator
 
     /**
      * @param non-empty-string $token
+     * @throws InvalidWirePayload
+     * @throws AttachmentError
      */
     private function processHellos(string $token, EventSink $sink): void
     {
@@ -401,6 +409,7 @@ final class Orchestrator
      *
      * If no suitable work remains, drains the worker. A worker can remain
      * connected without an assignment while a resource lease is unavailable.
+     * @throws AttachmentError
      */
     private function assignNext(WorkerHandle $handle, EventSink $sink): void
     {
@@ -459,6 +468,10 @@ final class Orchestrator
         }
     }
 
+    /**
+     * @throws AttachmentError
+     * @throws InvalidWirePayload
+     */
     private function pumpChannels(EventSink $sink): void
     {
         foreach ($this->handles as $handle) {
@@ -552,6 +565,9 @@ final class Orchestrator
 
     }
 
+    /**
+     * @throws AttachmentError
+     */
     private function openInitialBarrier(EventSink $sink): void
     {
         $ready = 0;
@@ -577,6 +593,9 @@ final class Orchestrator
         }
     }
 
+    /**
+     * @throws AttachmentError
+     */
     private function onEvent(WorkerHandle $handle, Event $event, EventSink $sink): void
     {
         if ($event instanceof TestFinished && $this->artifactStore instanceof ArtifactStore) {
@@ -655,6 +674,9 @@ final class Orchestrator
         }
     }
 
+    /**
+     * @throws AttachmentError
+     */
     private function detectCrashes(EventSink $sink): void
     {
         foreach ($this->handles as $handle) {
@@ -703,6 +725,9 @@ final class Orchestrator
         }
     }
 
+    /**
+     * @throws AttachmentError
+     */
     private function enforceTimeouts(EventSink $sink): void
     {
         foreach ($this->handles as $handle) {
@@ -753,6 +778,9 @@ final class Orchestrator
         }
     }
 
+    /**
+     * @throws AttachmentError
+     */
     private function containTimeout(WorkerHandle $handle, EventSink $sink, float $budget): void
     {
         $inFlight = $handle->inFlight;
@@ -783,6 +811,9 @@ final class Orchestrator
         $this->retireFailedWorker($handle, $sink);
     }
 
+    /**
+     * @throws AttachmentError
+     */
     private function containCrash(WorkerHandle $handle, EventSink $sink, string $reason): void
     {
         $handle->drainPipes();
@@ -808,6 +839,9 @@ final class Orchestrator
         $this->retireFailedWorker($handle, $sink);
     }
 
+    /**
+     * @throws AttachmentError
+     */
     private function recordSyntheticResult(WorkerHandle $handle, EventSink $sink, TestResult $result): void
     {
         $result = $result->withAttempts(\max($result->attempts, $handle->inFlightAttempt));
@@ -904,6 +938,9 @@ final class Orchestrator
         $this->retryWaitingWorkers = true;
     }
 
+    /**
+     * @throws AttachmentError
+     */
     private function assignWaiting(EventSink $sink): void
     {
         if (!$this->retryWaitingWorkers) {

--- a/src/Runner/ParallelRunner.php
+++ b/src/Runner/ParallelRunner.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Runner;
 
 use Greenlight\Config\Configuration;
+use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Core\Event\RunFinished;
 use Greenlight\Core\Event\RunStarted;
 use Greenlight\Core\GracefulShutdown;
@@ -44,6 +45,7 @@ final readonly class ParallelRunner
      * @param array<string, float> $classSeconds Recorded class durations for longest-first ordering. Seeded runs ignore this value.
      *
      * @throws DiscoveryError
+     * @throws AttachmentError
      */
     public function run(
         Configuration $configuration,

--- a/src/Runner/Protocol/EventRegistry.php
+++ b/src/Runner/Protocol/EventRegistry.php
@@ -7,6 +7,7 @@ namespace Greenlight\Runner\Protocol;
 use Greenlight\Attribute\CoverageIgnore;
 use Greenlight\Core\Event\Event;
 use Greenlight\Core\Event\EventTags;
+use Greenlight\Core\Wire\InvalidWirePayload;
 use Greenlight\Core\Wire\Wire;
 
 /** @internal */
@@ -33,6 +34,7 @@ final class EventRegistry
      * @param array<string, mixed> $tagged
      *
      * @throws ProtocolError
+     * @throws InvalidWirePayload
      */
     public static function fromTagged(array $tagged): Event
     {

--- a/src/Runner/Protocol/MessageRegistry.php
+++ b/src/Runner/Protocol/MessageRegistry.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Runner\Protocol;
 
 use Greenlight\Attribute\CoverageIgnore;
+use Greenlight\Core\Wire\InvalidWirePayload;
 use Greenlight\Core\Wire\Wire;
 use Greenlight\Runner\Protocol\Messages\Assign;
 use Greenlight\Runner\Protocol\Messages\AttemptStarted;
@@ -64,6 +65,7 @@ final class MessageRegistry
      * @param array<string, mixed> $envelope
      *
      * @throws ProtocolError
+     * @throws InvalidWirePayload
      */
     public static function open(array $envelope): Message
     {

--- a/src/Runner/Protocol/SocketChannel.php
+++ b/src/Runner/Protocol/SocketChannel.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Runner\Protocol;
 
 use Greenlight\Core\ErrorTrap;
+use Greenlight\Core\Wire\InvalidWirePayload;
 
 /**
  * Sends framed messages through one stream socket.
@@ -77,6 +78,7 @@ final class SocketChannel
      * unless the buffer already contains a complete frame.
      *
      * @throws ProtocolError
+     * @throws InvalidWirePayload
      */
     public function receive(float $timeoutSeconds): ?Message
     {
@@ -120,6 +122,7 @@ final class SocketChannel
      * Returns the next complete message or null.
      *
      * @throws ProtocolError
+     * @throws InvalidWirePayload
      */
     public function poll(): ?Message
     {

--- a/src/Runner/SharedCoverageDirectory.php
+++ b/src/Runner/SharedCoverageDirectory.php
@@ -23,6 +23,9 @@ final readonly class SharedCoverageDirectory
         private string|false $previousInclude,
     ) {}
 
+    /**
+     * @throws CoverageError
+     */
     public static function open(CoverageSettings $settings): self
     {
         $directory = \rtrim(\sys_get_temp_dir(), '/') . '/greenlight-coverage-' . \bin2hex(\random_bytes(6));

--- a/src/Runner/Worker/TestExecutor.php
+++ b/src/Runner/Worker/TestExecutor.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Greenlight\Runner\Worker;
 
+use Greenlight\Capture\CaptureError;
 use Greenlight\Capture\OutputCapture;
+use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Core\Artifact\Attachments;
 use Greenlight\Core\Artifact\UnavailableAttachments;
 use Greenlight\Core\Condition;
@@ -65,6 +67,10 @@ final readonly class TestExecutor
         private ?\Closure $attemptStarted = null,
     ) {}
 
+    /**
+     * @throws CaptureError
+     * @throws AttachmentError
+     */
     public function execute(PlanEntry $entry): TestResult
     {
         $metadata = $entry->metadata;
@@ -144,6 +150,8 @@ final readonly class TestExecutor
 
     /**
      * @return array{TestResult, ?\Throwable, ?StagedAttachments}
+     * @throws CaptureError
+     * @throws AttachmentError
      */
     private function attempt(PlanEntry $entry, int $attempt, TestArtifactBudget $artifactBudget): array
     {

--- a/tests/Acceptance/PhpStanCheckedExceptionTest.php
+++ b/tests/Acceptance/PhpStanCheckedExceptionTest.php
@@ -43,11 +43,17 @@ final readonly class PhpStanCheckedExceptionTest
             namespace Greenlight\Probe;
 
             use Greenlight\Core\Result\FailureDetail;
+            use Greenlight\Coverage\CoverageError;
             use Greenlight\Expect\ExpectationFailed;
 
             function undocumentedProductionHelper(): void
             {
                 throw ExpectationFailed::fromDetail(new FailureDetail('Expected production failure.'));
+            }
+
+            function undocumentedOperationalError(): void
+            {
+                throw CoverageError::driverUnavailable('probe', 'Expected operational failure.');
             }
             PHP,
             \dirname(__DIR__, 2) . '/phpstan.dist.neon',
@@ -59,9 +65,80 @@ final readonly class PhpStanCheckedExceptionTest
         Expect::that($probe->goodPassed)
             ->because('PHPStan MUST not require throws tags in test code')
             ->toBeTrue();
-        Expect::that($probe->errors)->toHaveCount(1);
+        Expect::that($probe->errors)->toHaveCount(2);
         Expect::that($probe->messages())->toContain(
             'throws checked exception Greenlight\\Expect\\ExpectationFailed but it\'s missing from the PHPDoc @throws tag.',
         );
+        Expect::that($probe->messages())->toContain(
+            'throws checked exception Greenlight\\Coverage\\CoverageError but it\'s missing from the PHPDoc @throws tag.',
+        );
+    }
+
+    #[Test]
+    public function throwsTagsMustBeCovariant(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace Greenlight\Probe\Covariant;
+
+            use Greenlight\Coverage\CoverageError;
+
+            interface ParentContract
+            {
+                /** @throws CoverageError */
+                public function run(): void;
+            }
+
+            final class GoodChild implements ParentContract
+            {
+                /** @throws CoverageError */
+                public function run(): void
+                {
+                    throw CoverageError::driverUnavailable('probe', 'Expected operational failure.');
+                }
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace Greenlight\Probe\NotCovariant;
+
+            use Greenlight\Core\Result\FailureDetail;
+            use Greenlight\Coverage\CoverageError;
+            use Greenlight\Expect\ExpectationFailed;
+
+            interface ParentContract
+            {
+                /** @throws ExpectationFailed */
+                public function run(): void;
+            }
+
+            final class BadChild implements ParentContract
+            {
+                /** @throws CoverageError */
+                public function run(): void
+                {
+                    throw CoverageError::driverUnavailable('probe', 'Expected operational failure.');
+                }
+            }
+            PHP,
+            \dirname(__DIR__, 2) . '/phpstan.dist.neon',
+        );
+
+        Expect::that($probe->exitCode)
+            ->because('PHPStan MUST reject a wider implementation throws contract')
+            ->toBe(1);
+        Expect::that($probe->goodPassed)
+            ->because('PHPStan MUST accept a covariant implementation throws contract')
+            ->toBeTrue();
+        Expect::that($probe->errors)->toHaveCount(1);
+        Expect::that($probe->messages())->toContain('should be covariant with PHPDoc @throws type');
     }
 }


### PR DESCRIPTION
Expands checked-exception analysis to Greenlight’s configuration, artifact, wire, coverage, discovery, and capture errors. Declares every direct and transitive `@throws` contract found by PHPStan, including bodyless attachment interfaces.

Also enables throws covariance and adds acceptance coverage for named runtime exceptions and incompatible implementation contracts.