### PR TITLE
build: enforce doubles integration exceptions

### DIFF
--- a/docs/api-doubles.md
+++ b/docs/api-doubles.md
@@ -35,7 +35,11 @@ It also accepts values when `get_debug_type()` returns `$type`.
 public static function type(string $type): ArgumentMatcher
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L24)
+PHPDoc:
+
+- `@throws DoublesError`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L25)
 
 ### `predicate()`
 
@@ -46,7 +50,7 @@ The description identifies the constraint in failure messages.
 public static function predicate(\Closure $predicate, string $description = 'predicate'): ArgumentMatcher
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L33)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L34)
 
 ### `equals()`
 
@@ -57,7 +61,7 @@ This form states the comparison explicitly.
 public static function equals(mixed $value): ArgumentMatcher
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L42)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L43)
 
 ### `captor()`
 
@@ -68,7 +72,7 @@ selects the related expectation for the call.
 public static function captor(): ArgumentCaptor
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L51)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L52)
 
 ## `ArgumentCaptor`
 
@@ -128,8 +132,9 @@ public function value(): mixed
 PHPDoc:
 
 - `@return TValue`
+- `@throws DoublesError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/ArgumentCaptor.php#L53)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/ArgumentCaptor.php#L56)
 
 ## `ArgumentMatcher`
 
@@ -197,8 +202,9 @@ public function __construct(?string $proxyDirectory = null)
 PHPDoc:
 
 - `@param string|null $proxyDirectory Directory for generated proxy classes. An empty string is invalid. The default is a project directory in the system temporary directory. A hash of the current working directory identifies it.`
+- `@throws DoublesError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L51)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L52)
 
 ### `mock()`
 
@@ -215,8 +221,9 @@ PHPDoc:
 - `@param class-string<T> $type`
 - `@param \Closure(MockPlan<T>): void|null $plan`
 - `@return T`
+- `@throws DoublesError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L87)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L89)
 
 ### `stub()`
 
@@ -233,8 +240,9 @@ PHPDoc:
 - `@template T of object`
 - `@param class-string<T> $type`
 - `@return T`
+- `@throws DoublesError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L103)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L106)
 
 ### `spy()`
 
@@ -251,8 +259,9 @@ PHPDoc:
 - `@template T of object`
 - `@param class-string<T> $type`
 - `@return T`
+- `@throws DoublesError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L119)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L123)
 
 ### `callsTo()`
 
@@ -267,8 +276,9 @@ public function callsTo(object $double, string $method): array
 PHPDoc:
 
 - `@return list<list<mixed>>`
+- `@throws DoublesError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L131)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L136)
 
 ### `dispose()`
 
@@ -284,7 +294,7 @@ PHPDoc:
 
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L155)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L160)
 
 ## `Fake`
 
@@ -345,5 +355,6 @@ PHPDoc:
 - `@template TMethod of non-empty-string`
 - `@param TMethod $method`
 - `@return MethodExpectation<TTarget, TMethod>`
+- `@throws DoublesError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/MockPlan.php#L43)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/MockPlan.php#L44)

--- a/docs/api-fixtures-harness.md
+++ b/docs/api-fixtures-harness.md
@@ -503,5 +503,6 @@ PHPDoc:
 
 - `@param class-string $type`
 - `@param list<object> $attributes`
+- `@throws \RuntimeException when the resolver cannot supply a valid service`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolver.php#L22)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolver.php#L24)

--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -44,8 +44,9 @@ PHPDoc:
 
 - `@param class-string $type`
 - `@param list<object> $attributes`
+- `@throws LaravelBridgeError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L81)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L82)
 
 ### `beforeTest()`
 
@@ -54,7 +55,7 @@ PHPDoc:
 public function beforeTest(TestContext $context): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L111)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L112)
 
 ### `afterTest()`
 
@@ -63,7 +64,7 @@ public function beforeTest(TestContext $context): void
 public function afterTest(TestContext $context, TestResult $result): TestResult
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L114)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L115)
 
 ## `Laravel\Service`
 
@@ -252,8 +253,9 @@ PHPDoc:
 
 - `@param class-string $type`
 - `@param list<object> $attributes`
+- `@throws SymfonyBridgeError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L84)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L85)
 
 ### `beforeTest()`
 
@@ -262,7 +264,7 @@ PHPDoc:
 public function beforeTest(TestContext $context): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L114)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L115)
 
 ### `afterTest()`
 
@@ -271,4 +273,4 @@ public function beforeTest(TestContext $context): void
 public function afterTest(TestContext $context, TestResult $result): TestResult
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L117)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L118)

--- a/docs/api-plugins.md
+++ b/docs/api-plugins.md
@@ -334,9 +334,10 @@ PHPDoc:
 - `@template T of object`
 - `@param class-string<T> $type`
 - `@return T`
+- `@throws \RuntimeException when a service resolver cannot supply a valid service`
 - `@throws UnresolvableService`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L43)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L44)
 
 ### `skip()`
 
@@ -352,7 +353,7 @@ PHPDoc:
 - `@param non-empty-string $reason`
 - `@throws SkipTest`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L62)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L63)
 
 ## `TestLifecycleSubscriber`
 

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -19,7 +19,11 @@ parameters:
             - Greenlight\Core\Wire\InvalidWirePayload
             - Greenlight\Coverage\CoverageError
             - Greenlight\Discovery\DiscoveryError
+            - Greenlight\Doubles\DoublesError
             - Greenlight\Expect\ExpectationFailed
+            - Greenlight\Laravel\LaravelBridgeError
+            - Greenlight\PhpStan\MatcherMapError
+            - Greenlight\Symfony\SymfonyBridgeError
         check:
             missingCheckedExceptionInThrows: true
             throwTypeCovariance: true

--- a/src/Doubles/Argument.php
+++ b/src/Doubles/Argument.php
@@ -20,6 +20,7 @@ final class Argument
     /**
      * This matcher accepts instances of the specified class or interface.
      * It also accepts values when `get_debug_type()` returns `$type`.
+     * @throws DoublesError
      */
     public static function type(string $type): ArgumentMatcher
     {

--- a/src/Doubles/ArgumentCaptor.php
+++ b/src/Doubles/ArgumentCaptor.php
@@ -49,7 +49,10 @@ final class ArgumentCaptor implements ArgumentMatcher
         return $this->captured;
     }
 
-    /** @return TValue */
+    /**
+     * @return TValue
+     * @throws DoublesError
+     */
     public function value(): mixed
     {
         if ($this->captured === []) {

--- a/src/Doubles/CallHandler.php
+++ b/src/Doubles/CallHandler.php
@@ -31,6 +31,7 @@ final readonly class CallHandler
      * @param list<mixed> $arguments
      *
      * @throws ExpectationFailed
+     * @throws DoublesError
      */
     public function invoke(object $double, string $method, array $arguments): mixed
     {
@@ -50,6 +51,7 @@ final readonly class CallHandler
      * @param list<mixed> $arguments
      *
      * @throws ExpectationFailed
+     * @throws DoublesError
      */
     private function invokeOnMock(object $double, string $method, array $arguments): mixed
     {
@@ -70,6 +72,9 @@ final readonly class CallHandler
         throw ExpectationFailed::fromDetail($detail);
     }
 
+    /**
+     * @throws DoublesError
+     */
     private function invokeOnSpy(object $double, string $method): mixed
     {
         if ($this->returnsNothing($double, $method)) {
@@ -81,6 +86,7 @@ final readonly class CallHandler
 
     /**
      * @param list<mixed> $arguments
+     * @throws DoublesError
      */
     private function answer(MethodExpectation $expectation, object $double, string $method, array $arguments): mixed
     {

--- a/src/Doubles/Doubles.php
+++ b/src/Doubles/Doubles.php
@@ -47,6 +47,7 @@ final class Doubles implements Disposable
      *   classes. An empty string is invalid. The default is a project
      *   directory in the system temporary directory. A hash of the current
      *   working directory identifies it.
+     * @throws DoublesError
      */
     public function __construct(?string $proxyDirectory = null)
     {
@@ -83,6 +84,7 @@ final class Doubles implements Disposable
      * @param \Closure(MockPlan<T>): void|null $plan
      *
      * @return T
+     * @throws DoublesError
      */
     public function mock(string $type, ?\Closure $plan = null): object
     {
@@ -99,6 +101,7 @@ final class Doubles implements Disposable
      * @param class-string<T> $type
      *
      * @return T
+     * @throws DoublesError
      */
     public function stub(string $type): object
     {
@@ -115,6 +118,7 @@ final class Doubles implements Disposable
      * @param class-string<T> $type
      *
      * @return T
+     * @throws DoublesError
      */
     public function spy(string $type): object
     {
@@ -127,6 +131,7 @@ final class Doubles implements Disposable
      * method must exist on the doubled type.
      *
      * @return list<list<mixed>>
+     * @throws DoublesError
      */
     public function callsTo(object $double, string $method): array
     {
@@ -190,6 +195,7 @@ final class Doubles implements Disposable
      * @param \Closure(MockPlan<T>): void|null $plan
      *
      * @return T
+     * @throws DoublesError
      */
     private function create(string $type, DoubleKind $kind, ?\Closure $plan): object
     {

--- a/src/Doubles/MethodCallContract.php
+++ b/src/Doubles/MethodCallContract.php
@@ -60,6 +60,9 @@ final readonly class MethodCallContract
         );
     }
 
+    /**
+     * @throws DoublesError
+     */
     public function assertPlannedArgumentCount(string $selector, int $count): void
     {
         if ($count < $this->requiredArguments) {
@@ -83,6 +86,9 @@ final readonly class MethodCallContract
         }
     }
 
+    /**
+     * @throws DoublesError
+     */
     public function assertCallArgumentCount(int $count): void
     {
         if ($count < $this->requiredArguments) {

--- a/src/Doubles/MethodExpectation.php
+++ b/src/Doubles/MethodExpectation.php
@@ -68,11 +68,17 @@ final class MethodExpectation
         $this->method = $contract->method;
     }
 
+    /**
+     * @throws DoublesError
+     */
     public function withNoArguments(): self
     {
         return $this->withArguments([], 'withNoArguments');
     }
 
+    /**
+     * @throws DoublesError
+     */
     public function with(mixed $first, mixed ...$rest): self
     {
         return $this->withArguments([$first, ...\array_values($rest)], 'with');
@@ -80,6 +86,7 @@ final class MethodExpectation
 
     /**
      * @param list<mixed> $arguments
+     * @throws DoublesError
      */
     private function withArguments(array $arguments, string $selector): self
     {
@@ -97,6 +104,9 @@ final class MethodExpectation
         return $this;
     }
 
+    /**
+     * @throws DoublesError
+     */
     public function times(int $count): self
     {
         if ($count < 0) {
@@ -109,6 +119,9 @@ final class MethodExpectation
         return $this;
     }
 
+    /**
+     * @throws DoublesError
+     */
     public function atLeast(int $count): self
     {
         if ($count < 1) {
@@ -129,6 +142,9 @@ final class MethodExpectation
         return $this;
     }
 
+    /**
+     * @throws DoublesError
+     */
     public function andReturns(mixed $value): self
     {
         $this->assertNoAnswerConfigured();
@@ -142,6 +158,7 @@ final class MethodExpectation
     /**
      * Each accepted call consumes the next value. A call after the last value
      * causes an error in the test code.
+     * @throws DoublesError
      */
     public function andReturnsSequence(mixed ...$values): self
     {
@@ -161,6 +178,7 @@ final class MethodExpectation
     /**
      * The closure receives the call arguments. The call returns the value
      * from the closure.
+     * @throws DoublesError
      */
     public function andReturnsUsing(\Closure $answer): self
     {
@@ -171,6 +189,9 @@ final class MethodExpectation
         return $this;
     }
 
+    /**
+     * @throws DoublesError
+     */
     public function andThrows(\Throwable $throwable): self
     {
         $this->assertNoAnswerConfigured();
@@ -187,6 +208,7 @@ final class MethodExpectation
      * the doubled method returns a value, configure its result first.
      *
      * @return ArgumentCaptor<mixed>
+     * @throws DoublesError
      */
     public function captureArgument(int $position = 0): ArgumentCaptor
     {
@@ -302,6 +324,7 @@ final class MethodExpectation
 
     /**
      * @internal Only the call handler calls this method.
+     * @throws DoublesError
      */
     public function consumeSequenceValue(): mixed
     {
@@ -394,6 +417,9 @@ final class MethodExpectation
         return $count === 1 ? '1 time' : $count . ' times';
     }
 
+    /**
+     * @throws DoublesError
+     */
     private function assertNoAnswerConfigured(): void
     {
         if ($this->hasReturnValue || $this->sequence !== null || $this->callback instanceof \Closure || $this->throwable instanceof \Throwable) {

--- a/src/Doubles/MockPlan.php
+++ b/src/Doubles/MockPlan.php
@@ -39,6 +39,7 @@ final readonly class MockPlan
      * @param TMethod $method
      *
      * @return MethodExpectation<TTarget, TMethod>
+     * @throws DoublesError
      */
     public function expects(string $method): MethodExpectation
     {
@@ -56,6 +57,7 @@ final readonly class MockPlan
      * @param TMethod $method
      *
      * @return MethodCallContract<TTarget, TMethod>
+     * @throws DoublesError
      */
     private function assertPlannable(string $method): MethodCallContract
     {

--- a/src/Doubles/ProxyGenerator.php
+++ b/src/Doubles/ProxyGenerator.php
@@ -35,6 +35,7 @@ final readonly class ProxyGenerator
      * @param class-string $type
      *
      * @return class-string
+     * @throws DoublesError
      */
     public function proxyClass(string $type): string
     {
@@ -64,6 +65,7 @@ final readonly class ProxyGenerator
      * @param class-string $type
      *
      * @return \ReflectionClass<object>
+     * @throws DoublesError
      */
     private function reflectDoubleable(string $type): \ReflectionClass
     {
@@ -114,6 +116,7 @@ final readonly class ProxyGenerator
 
     /**
      * @param \ReflectionClass<object> $reflection
+     * @throws DoublesError
      */
     private function renderBody(\ReflectionClass $reflection): string
     {
@@ -169,6 +172,9 @@ final readonly class ProxyGenerator
         ));
     }
 
+    /**
+     * @throws DoublesError
+     */
     private function renderProperty(\ReflectionProperty $property): string
     {
         $visibility = $property->isProtected() ? 'protected' : 'public';
@@ -178,6 +184,9 @@ final readonly class ProxyGenerator
         return \sprintf("    %s %s\$%s;\n", $visibility, $rendered, $property->name);
     }
 
+    /**
+     * @throws DoublesError
+     */
     private function renderMethod(\ReflectionMethod $method): ?string
     {
         $name = \strtolower($method->name);
@@ -207,6 +216,9 @@ final readonly class ProxyGenerator
         return $this->renderInstanceMethod($method);
     }
 
+    /**
+     * @throws DoublesError
+     */
     private function renderInstanceMethod(\ReflectionMethod $method): string
     {
         $returnType = $method->getReturnType() ?? $method->getTentativeReturnType();
@@ -266,6 +278,9 @@ final readonly class ProxyGenerator
         );
     }
 
+    /**
+     * @throws DoublesError
+     */
     private function renderStaticStub(\ReflectionMethod $method): string
     {
         $body = \sprintf(
@@ -281,6 +296,9 @@ final readonly class ProxyGenerator
         );
     }
 
+    /**
+     * @throws DoublesError
+     */
     private function renderSignature(\ReflectionMethod $method, ?\ReflectionType $returnType, bool $static = false): string
     {
         $context = $method->getDeclaringClass();
@@ -303,6 +321,7 @@ final readonly class ProxyGenerator
 
     /**
      * @param \ReflectionClass<object> $context
+     * @throws DoublesError
      */
     private function renderParameter(\ReflectionParameter $parameter, \ReflectionClass $context): string
     {
@@ -328,6 +347,7 @@ final readonly class ProxyGenerator
 
     /**
      * @param \ReflectionClass<object> $context
+     * @throws DoublesError
      */
     private function renderDefault(\ReflectionParameter $parameter, \ReflectionClass $context): string
     {
@@ -368,6 +388,9 @@ final readonly class ProxyGenerator
         return \var_export($value, true);
     }
 
+    /**
+     * @throws DoublesError
+     */
     private function write(string $file, string $source): void
     {
         $directory = $this->directory;

--- a/src/Doubles/TypeMatcher.php
+++ b/src/Doubles/TypeMatcher.php
@@ -7,6 +7,9 @@ namespace Greenlight\Doubles;
 /** @internal */
 final readonly class TypeMatcher implements ArgumentMatcher
 {
+    /**
+     * @throws DoublesError
+     */
     public function __construct(private string $type)
     {
         if (\trim($type) === '') {

--- a/src/Doubles/TypeRenderer.php
+++ b/src/Doubles/TypeRenderer.php
@@ -24,6 +24,7 @@ final class TypeRenderer
 
     /**
      * @param \ReflectionClass<object> $context Class that declares the member.
+     * @throws DoublesError
      */
     public static function render(\ReflectionType $type, \ReflectionClass $context): string
     {
@@ -62,6 +63,7 @@ final class TypeRenderer
 
     /**
      * @param \ReflectionClass<object> $context
+     * @throws DoublesError
      */
     private static function renderIntersection(\ReflectionIntersectionType $type, \ReflectionClass $context): string
     {
@@ -73,6 +75,7 @@ final class TypeRenderer
 
     /**
      * @param \ReflectionClass<object> $context
+     * @throws DoublesError
      */
     private static function renderNamed(\ReflectionNamedType $type, \ReflectionClass $context): string
     {
@@ -99,6 +102,9 @@ final class TypeRenderer
         return '\\' . $name;
     }
 
+    /**
+     * @throws DoublesError
+     */
     private static function expectNamed(\ReflectionType $type): \ReflectionNamedType
     {
         if (!$type instanceof \ReflectionNamedType) {

--- a/src/Harness/HarnessScopes.php
+++ b/src/Harness/HarnessScopes.php
@@ -39,6 +39,7 @@ final class HarnessScopes
      * @param non-empty-string $consumer
      * @param list<object> $attributes
      *
+     * @throws \RuntimeException when a service resolver cannot supply a valid service
      * @throws UnresolvableService
      */
     public function resolve(string $type, string $consumer, array $attributes = []): object

--- a/src/Harness/ServiceResolver.php
+++ b/src/Harness/ServiceResolver.php
@@ -18,6 +18,8 @@ interface ServiceResolver
     /**
      * @param class-string $type
      * @param list<object> $attributes
+     *
+     * @throws \RuntimeException when the resolver cannot supply a valid service
      */
     public function resolve(string $type, array $attributes): ?object;
 }

--- a/src/Laravel/LaravelFrameworkRequirement.php
+++ b/src/Laravel/LaravelFrameworkRequirement.php
@@ -14,11 +14,17 @@ use Illuminate\Foundation\Application;
  */
 final class LaravelFrameworkRequirement
 {
+    /**
+     * @throws LaravelBridgeError
+     */
     public static function check(): void
     {
         self::checkVersion(self::installedVersion());
     }
 
+    /**
+     * @throws LaravelBridgeError
+     */
     public static function checkVersion(?string $version): void
     {
         if ($version === null) {

--- a/src/Laravel/LaravelPlugin.php
+++ b/src/Laravel/LaravelPlugin.php
@@ -77,6 +77,7 @@ final class LaravelPlugin implements HarnessProvider, ServiceResolver, TestLifec
     /**
      * @param class-string $type
      * @param list<object> $attributes
+     * @throws LaravelBridgeError
      */
     #[\Override]
     public function resolve(string $type, array $attributes): ?object
@@ -123,7 +124,10 @@ final class LaravelPlugin implements HarnessProvider, ServiceResolver, TestLifec
         return $result;
     }
 
-    /** An invalid application fails before Greenlight supplies a container service. */
+    /**
+     * An invalid application fails before Greenlight supplies a container service.
+     * @throws LaravelBridgeError
+     */
     private function application(): Application
     {
         if ($this->app instanceof Application) {

--- a/src/PhpStan/ExpectationMethodsExtension.php
+++ b/src/PhpStan/ExpectationMethodsExtension.php
@@ -32,6 +32,7 @@ final readonly class ExpectationMethodsExtension implements MethodsClassReflecti
     /**
      * @throws ConfigFileError
      * @throws InvalidConfiguration
+     * @throws MatcherMapError
      */
     #[\Override]
     public function hasMethod(ClassReflection $classReflection, string $methodName): bool
@@ -48,6 +49,7 @@ final readonly class ExpectationMethodsExtension implements MethodsClassReflecti
     /**
      * @throws ConfigFileError
      * @throws InvalidConfiguration
+     * @throws MatcherMapError
      */
     #[\Override]
     public function getMethod(ClassReflection $classReflection, string $methodName): MethodReflection

--- a/src/PhpStan/ExtensionMatcherSubjectRule.php
+++ b/src/PhpStan/ExtensionMatcherSubjectRule.php
@@ -41,6 +41,7 @@ final readonly class ExtensionMatcherSubjectRule implements Rule
     /**
      * @throws ConfigFileError
      * @throws InvalidConfiguration
+     * @throws MatcherMapError
      */
     #[\Override]
     public function processNode(Node $node, Scope $scope): array

--- a/src/PhpStan/MatcherMapProvider.php
+++ b/src/PhpStan/MatcherMapProvider.php
@@ -25,6 +25,7 @@ final class MatcherMapProvider
     /**
      * @throws ConfigFileError
      * @throws InvalidConfiguration
+     * @throws MatcherMapError
      */
     public function get(): MatcherMap
     {

--- a/src/Plugin/TestContext.php
+++ b/src/Plugin/TestContext.php
@@ -38,6 +38,7 @@ final readonly class TestContext
      *
      * @return T
      *
+     * @throws \RuntimeException when a service resolver cannot supply a valid service
      * @throws UnresolvableService
      */
     public function service(string $type): object

--- a/src/Symfony/SymfonyPlugin.php
+++ b/src/Symfony/SymfonyPlugin.php
@@ -80,6 +80,7 @@ final class SymfonyPlugin implements HarnessProvider, ServiceResolver, TestLifec
     /**
      * @param class-string $type
      * @param list<object> $attributes
+     * @throws SymfonyBridgeError
      */
     #[\Override]
     public function resolve(string $type, array $attributes): ?object
@@ -127,6 +128,7 @@ final class SymfonyPlugin implements HarnessProvider, ServiceResolver, TestLifec
     /**
      * Greenlight does not cache an invalid kernel. Thus, each use fails before
      * a test runs without isolation.
+     * @throws SymfonyBridgeError
      */
     private function kernel(): KernelInterface
     {
@@ -162,6 +164,9 @@ final class SymfonyPlugin implements HarnessProvider, ServiceResolver, TestLifec
         return $kernel;
     }
 
+    /**
+     * @throws SymfonyBridgeError
+     */
     private function container(): ContainerInterface
     {
         $this->kernel();

--- a/tests/Acceptance/PhpStanCheckedExceptionTest.php
+++ b/tests/Acceptance/PhpStanCheckedExceptionTest.php
@@ -44,6 +44,7 @@ final readonly class PhpStanCheckedExceptionTest
 
             use Greenlight\Core\Result\FailureDetail;
             use Greenlight\Coverage\CoverageError;
+            use Greenlight\Doubles\DoublesError;
             use Greenlight\Expect\ExpectationFailed;
 
             function undocumentedProductionHelper(): void
@@ -55,6 +56,11 @@ final readonly class PhpStanCheckedExceptionTest
             {
                 throw CoverageError::driverUnavailable('probe', 'Expected operational failure.');
             }
+
+            function undocumentedAuthoringError(): void
+            {
+                throw DoublesError::invalidTimes(-1);
+            }
             PHP,
             \dirname(__DIR__, 2) . '/phpstan.dist.neon',
         );
@@ -65,12 +71,15 @@ final readonly class PhpStanCheckedExceptionTest
         Expect::that($probe->goodPassed)
             ->because('PHPStan MUST not require throws tags in test code')
             ->toBeTrue();
-        Expect::that($probe->errors)->toHaveCount(2);
+        Expect::that($probe->errors)->toHaveCount(3);
         Expect::that($probe->messages())->toContain(
             'throws checked exception Greenlight\\Expect\\ExpectationFailed but it\'s missing from the PHPDoc @throws tag.',
         );
         Expect::that($probe->messages())->toContain(
             'throws checked exception Greenlight\\Coverage\\CoverageError but it\'s missing from the PHPDoc @throws tag.',
+        );
+        Expect::that($probe->messages())->toContain(
+            'throws checked exception Greenlight\\Doubles\\DoublesError but it\'s missing from the PHPDoc @throws tag.',
         );
     }
 


### PR DESCRIPTION
Expands checked-exception analysis to doubles, PHPStan extension configuration, and the Laravel and Symfony bridges. Declares their direct and transitive `@throws` contracts, including the shared service-resolver boundary.

Adds acceptance coverage that proves named authoring errors remain checked.