### PR TITLE
feat(expect): match exact throwable instances

### DIFF
--- a/docs/api-expectations.md
+++ b/docs/api-expectations.md
@@ -674,6 +674,8 @@ PHPDoc:
 
 The subject must be callable. The matcher calls it with no arguments.
 It passes when the subject throws an instance of the specified class.
+A Throwable instance instead requires the subject to throw that exact
+object.
 
 The throwable can instead be a callback with one typed Throwable
 parameter. Its parameter type specifies the expected throwable class.
@@ -683,14 +685,15 @@ failure.
 
 The optional `matching:` argument checks the message with a regular
 expression. The `message:` argument checks the exact message. Do not use
-these arguments with a throwable callback.
+these arguments with a throwable callback or instance.
 
-With `not()`, a throwable that does not satisfy both conditions makes the
-matcher pass.
+With `not()`, a throwable that does not satisfy all applicable
+constraints makes the matcher pass. A different object does not satisfy
+an instance constraint.
 
 ```php
 public function toThrow(
-    string|\Closure $throwable,
+    string|\Closure|\Throwable $throwable,
     ?string $matching = null,
     ?string $message = null,
 ): self
@@ -699,12 +702,12 @@ public function toThrow(
 PHPDoc:
 
 - `@template TThrowable of \Throwable`
-- `@param class-string<TThrowable>|\Closure(TThrowable): void $throwable`
+- `@param class-string<TThrowable>|TThrowable|\Closure(TThrowable): void $throwable`
 - `@return self<T>`
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L784)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L787)
 
 ## `ExpectationExtension`
 

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -138,6 +138,15 @@ Expect::that(fn() => $service->load('missing'))
     ->toThrow(NotFound::class);
 ```
 
+Pass a Throwable instance to require the callable to throw that exact object:
+
+```php
+$failure = new DomainException('Order is closed.');
+
+Expect::that(fn() => throw $failure)
+    ->toThrow($failure);
+```
+
 Constrain the message by exact value or regular expression:
 
 ```php
@@ -153,7 +162,8 @@ Expect::that($callback)->toThrow(
 ```
 
 `message:` and `matching:` are mutually exclusive. Use them only with a
-throwable class-string.
+throwable class-string. A Throwable instance already specifies one exact
+object.
 
 A typed callback can specify the throwable type and check the caught
 throwable. Greenlight runs it only after the throwable type matches:
@@ -177,7 +187,11 @@ keeps its diagnostic. An `eventually()` expectation retries this failure.
 
 With `not()`, a failed callback expectation means that the throwable does not
 match. Thus, the negated `toThrow()` expectation passes. Other throwables from
-the callback stop the matcher.
+the callback stop the matcher. An instance constraint matches only the exact
+object. A different instance passes the negated expectation.
+
+An `eventually()` expectation retries when the callable throws a different
+instance. It passes when the callable throws the specified object.
 
 ## Asynchronous state
 

--- a/docs/migrating-from-phpunit.md
+++ b/docs/migrating-from-phpunit.md
@@ -152,6 +152,7 @@ These differences are important:
 * `toThrow()` accepts a callable subject and an optional message constraint.
   * Use `message:` for exact equality.
   * Use `matching:` for a regular expression.
+  * Pass a Throwable instance to require the exact object.
   * Use a typed throwable callback to check the caught throwable.
   * Do not use `message:` and `matching:` in one call.
 * `Fail::because()` replaces `$this->fail()` and supports explicit type guards.

--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -75,11 +75,13 @@ parameter.
 ## Native matcher constraints
 
 `toThrow()` can constrain the exception message with an exact string or a
-regular expression. A typed callback can specify and check the throwable:
+regular expression. A Throwable instance requires the exact object. A typed
+callback can specify and check the throwable:
 
 ```php
 Expect::that($callback)->toThrow(DomainException::class, message: 'Exact message');
 Expect::that($callback)->toThrow(DomainException::class, matching: '/message/i');
+Expect::that($callback)->toThrow($failure);
 Expect::that($callback)->toThrow(
     static function (DomainException $error): void {
         Expect::that($error->getPrevious())->toBeInstanceOf(LengthException::class);
@@ -96,6 +98,10 @@ A call that supplies a message constraint with a throwable callback causes the
 reports incompatible parameter and return types. The
 `greenlight.toThrow.callback` error reports constraints that the signature
 cannot express. Greenlight applies all callback checks at run time.
+
+A call that supplies a message constraint with a Throwable instance causes the
+`greenlight.toThrow.instanceConstraint` error. Greenlight also rejects the call
+at run time.
 
 The subject for `toThrow()` must be callable. The extension reports a known
 incompatible subject before the test runs:

--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -758,6 +758,8 @@ final class Expectation
     /**
      * The subject must be callable. The matcher calls it with no arguments.
      * It passes when the subject throws an instance of the specified class.
+     * A Throwable instance instead requires the subject to throw that exact
+     * object.
      *
      * The throwable can instead be a callback with one typed Throwable
      * parameter. Its parameter type specifies the expected throwable class.
@@ -767,14 +769,15 @@ final class Expectation
      *
      * The optional `matching:` argument checks the message with a regular
      * expression. The `message:` argument checks the exact message. Do not use
-     * these arguments with a throwable callback.
+     * these arguments with a throwable callback or instance.
      *
-     * With `not()`, a throwable that does not satisfy both conditions makes the
-     * matcher pass.
+     * With `not()`, a throwable that does not satisfy all applicable
+     * constraints makes the matcher pass. A different object does not satisfy
+     * an instance constraint.
      *
      * @template TThrowable of \Throwable
      *
-     * @param class-string<TThrowable>|\Closure(TThrowable): void $throwable
+     * @param class-string<TThrowable>|TThrowable|\Closure(TThrowable): void $throwable
      *
      * @return self<T>
      *
@@ -782,14 +785,21 @@ final class Expectation
      * @throws ExpectationFailed
      */
     public function toThrow(
-        string|\Closure $throwable,
+        string|\Closure|\Throwable $throwable,
         ?string $matching = null,
         ?string $message = null,
     ): self {
         $callback = $throwable instanceof \Closure ? $throwable : null;
+        $instance = $throwable instanceof \Throwable ? $throwable : null;
 
         if ($callback instanceof \Closure && ($matching !== null || $message !== null)) {
             $this->usageFailure('Do not specify matching: or message: when the throwable is a callback.');
+        }
+
+        if ($instance instanceof \Throwable && ($matching !== null || $message !== null)) {
+            $this->usageFailure(
+                'Do not specify matching: or message: when the throwable argument is a Throwable instance.',
+            );
         }
 
         if ($matching !== null && $message !== null) {
@@ -800,9 +810,11 @@ final class Expectation
             $this->requireValidPattern($matching, 'toThrow');
         }
 
-        $expectedThrowable = $callback instanceof \Closure
-            ? $this->requireThrowableCallback($callback)
-            : $throwable;
+        $expectedThrowable = match (true) {
+            $callback instanceof \Closure => $this->requireThrowableCallback($callback),
+            $instance instanceof \Throwable => $instance::class,
+            default => $throwable,
+        };
 
         if (!\is_callable($this->subject)) {
             $this->usageFailure(\sprintf(
@@ -819,7 +831,9 @@ final class Expectation
             $thrown = $caught;
         }
 
-        $matched = $thrown instanceof $expectedThrowable;
+        $matched = $instance instanceof \Throwable
+            ? $thrown === $instance
+            : $thrown instanceof $expectedThrowable;
 
         if ($matched && $matching !== null) {
             $matched = \preg_match($matching, $thrown->getMessage()) === 1;
@@ -850,7 +864,9 @@ final class Expectation
             $matched = $thrown instanceof \Throwable && $thrown->getMessage() === $message;
         }
 
-        $description = 'to throw ' . $expectedThrowable;
+        $description = $instance instanceof \Throwable
+            ? 'to throw the exact ' . $expectedThrowable . ' instance'
+            : 'to throw ' . $expectedThrowable;
 
         if ($matching !== null) {
             $description .= ' with message matching ' . $matching;
@@ -868,7 +884,11 @@ final class Expectation
             )
             : 'a callable that did not throw';
 
-        return $this->verify($matched, $description, $expectedThrowable, $actual);
+        $expected = $instance instanceof \Throwable
+            ? 'the exact ' . $expectedThrowable . ' instance'
+            : $expectedThrowable;
+
+        return $this->verify($matched, $description, $expected, $actual);
     }
 
     /**

--- a/src/Expect/TemporalExpectation.php
+++ b/src/Expect/TemporalExpectation.php
@@ -421,20 +421,27 @@ abstract class TemporalExpectation
     /**
      * @template TThrowable of \Throwable
      *
-     * @param class-string<TThrowable>|\Closure(TThrowable): void $throwable
+     * @param class-string<TThrowable>|TThrowable|\Closure(TThrowable): void $throwable
      *
      * @return Expectation<T>
      *
      * @throws ExpectationFailed
      */
     final public function toThrow(
-        string|\Closure $throwable,
+        string|\Closure|\Throwable $throwable,
         ?string $matching = null,
         ?string $message = null,
     ): Expectation {
         if ($throwable instanceof \Closure && ($matching !== null || $message !== null)) {
             throw ExpectationFailed::fromDetail(new FailureDetail(
                 'Do not specify matching: or message: when the throwable is a callback.',
+                location: CallSite::capture(),
+            ));
+        }
+
+        if ($throwable instanceof \Throwable && ($matching !== null || $message !== null)) {
+            throw ExpectationFailed::fromDetail(new FailureDetail(
+                'Do not specify matching: or message: when the throwable argument is a Throwable instance.',
                 location: CallSite::capture(),
             ));
         }

--- a/src/PhpStan/ToThrowConstraintRule.php
+++ b/src/PhpStan/ToThrowConstraintRule.php
@@ -59,6 +59,14 @@ final class ToThrowConstraintRule implements Rule
                 return [$this->callbackConstraintError($node->getStartLine())];
             }
 
+            if ($state['throwable'] instanceof Type
+                && new ObjectType(\Throwable::class)->isSuperTypeOf($state['throwable'])->yes()
+                && (($state['matching'] instanceof Type && !$state['matching']->isNull()->yes())
+                    || ($state['message'] instanceof Type && !$state['message']->isNull()->yes()))
+            ) {
+                return [$this->instanceConstraintError($node->getStartLine())];
+            }
+
             if ($state['matching'] instanceof Type
                 && $state['message'] instanceof Type
                 && !$state['matching']->isNull()->yes()
@@ -171,6 +179,16 @@ final class ToThrowConstraintRule implements Rule
             'Do not specify matching: or message: when the throwable is a callback.',
         )
             ->identifier('greenlight.toThrow.callbackConstraint')
+            ->line($line)
+            ->build();
+    }
+
+    private function instanceConstraintError(int $line): IdentifierRuleError
+    {
+        return RuleErrorBuilder::message(
+            'Do not specify matching: or message: when the throwable argument is a Throwable instance.',
+        )
+            ->identifier('greenlight.toThrow.instanceConstraint')
             ->line($line)
             ->build();
     }

--- a/tests/Acceptance/PhpStanToThrowRuleTest.php
+++ b/tests/Acceptance/PhpStanToThrowRuleTest.php
@@ -81,8 +81,12 @@ final readonly class PhpStanToThrowRuleTest
 
             function greenlightGoodToThrowProbe(): void
             {
+                $failure = new DomainException('boom');
+
                 Expect::that(static fn() => throw new DomainException('boom'))
                     ->toThrow(DomainException::class);
+                Expect::that(static fn() => throw $failure)
+                    ->toThrow($failure);
                 Expect::that(static fn() => throw new DomainException('boom'))
                     ->toThrow(DomainException::class, matching: '/boom/');
                 Expect::that(static fn() => throw new DomainException('boom'))
@@ -97,6 +101,9 @@ final readonly class PhpStanToThrowRuleTest
                 Expect::consistently(static fn(): Closure => static fn() => throw new DomainException('boom'))
                     ->for(0.1)
                     ->toThrow(DomainException::class, message: 'boom');
+                Expect::eventually(static fn(): Closure => static fn() => throw $failure)
+                    ->within(1.0)
+                    ->toThrow($failure);
             }
             PHP,
             <<<'PHP'
@@ -108,6 +115,8 @@ final readonly class PhpStanToThrowRuleTest
 
             function greenlightBadToThrowProbe(): void
             {
+                $failure = new DomainException('boom');
+
                 Expect::that(static fn() => throw new DomainException('boom'))
                     ->toThrow(DomainException::class, matching: '/boom/', message: 'boom');
                 Expect::that(static fn() => throw new DomainException('boom'))
@@ -137,16 +146,24 @@ final readonly class PhpStanToThrowRuleTest
                         static function (DomainException $error): void {},
                         message: 'boom',
                     );
+                Expect::that(static fn() => throw $failure)
+                    ->toThrow($failure, matching: '/boom/');
+                Expect::eventually(static fn(): Closure => static fn() => throw $failure)
+                    ->within(1.0)
+                    ->toThrow($failure, message: 'boom');
             }
             PHP,
         );
 
         Expect::that($probe->exitCode)->because('pattern and exact message constraints are mutually exclusive')->toBe(1);
         Expect::that($probe->goodPassed)->toBeTrue();
-        Expect::that(\count($probe->errors))->toBe(8);
+        Expect::that(\count($probe->errors))->toBe(10);
         Expect::that($probe->messages())->toContain('toThrow() accepts either matching: or message:, not both');
         Expect::that($probe->messages())->toContain(
             'Do not specify matching: or message: when the throwable is a callback.',
+        );
+        Expect::that($probe->messages())->toContain(
+            'Do not specify matching: or message: when the throwable argument is a Throwable instance.',
         );
     }
 

--- a/tests/Unit/Capture/OutputCaptureTest.php
+++ b/tests/Unit/Capture/OutputCaptureTest.php
@@ -274,11 +274,7 @@ final class OutputCaptureTest
             }
         })
             ->because('stop in a finally block restores everything when user code throws')
-            ->toThrow(
-                static function (\RuntimeException $caught) use ($failure): void {
-                    Expect::that($caught)->toBe($failure);
-                },
-            );
+            ->toThrow($failure);
 
         Expect::that($captured?->stdout)->toBe('before the throw');
         Expect::that(\ob_get_level())->toBe($baseline);

--- a/tests/Unit/Cli/ReporterSinkTest.php
+++ b/tests/Unit/Cli/ReporterSinkTest.php
@@ -61,10 +61,6 @@ final class ReporterSinkTest
             $sink->emit(new SuiteStarted('unit', 1.0));
         })
             ->because('a reporter failure MUST stop event delivery')
-            ->toThrow(
-                static function (ReportingError $caught) use ($failure): void {
-                    Expect::that($caught)->toBe($failure);
-                },
-            );
+            ->toThrow($failure);
     }
 }

--- a/tests/Unit/Core/ErrorTrapTest.php
+++ b/tests/Unit/Core/ErrorTrapTest.php
@@ -103,11 +103,7 @@ final class ErrorTrapTest
                 static fn(): never => throw $failure,
             ))
                 ->because('the trap MUST propagate an operation error')
-                ->toThrow(
-                    static function (\RuntimeException $caught) use ($failure): void {
-                        Expect::that($caught)->toBe($failure);
-                    },
-                );
+                ->toThrow($failure);
 
             \trigger_error('after trap', \E_USER_WARNING);
 

--- a/tests/Unit/Coverage/PcovDriverFailureTest.php
+++ b/tests/Unit/Coverage/PcovDriverFailureTest.php
@@ -24,11 +24,7 @@ final class PcovDriverFailureTest
             $driver->start();
         })
             ->because('a PCOV start failure MUST remain the reported failure')
-            ->toThrow(
-                static function (\RuntimeException $caught) use ($failure): void {
-                    Expect::that($caught)->toBe($failure);
-                },
-            );
+            ->toThrow($failure);
         Expect::that($runtime->calls)
             ->because('a PCOV start failure MUST stop before collection begins')
             ->toBe(['start']);
@@ -52,11 +48,7 @@ final class PcovDriverFailureTest
 
         Expect::that(static fn(): mixed => $driver->stop())
             ->because('a PCOV collection failure MUST remain the reported failure')
-            ->toThrow(
-                static function (\RuntimeException $caught) use ($failure): void {
-                    Expect::that($caught)->toBe($failure);
-                },
-            );
+            ->toThrow($failure);
         Expect::that($runtime->calls)
             ->because('a PCOV collection failure MUST still stop and clear extension state')
             ->toBe(['start', 'collect', 'stop', 'clear']);
@@ -130,11 +122,7 @@ final class PcovDriverFailureTest
 
         Expect::that(static fn(): mixed => $driver->stop())
             ->because('a PCOV cleanup failure MUST remain the reported failure')
-            ->toThrow(
-                static function (\RuntimeException $caught) use ($failure): void {
-                    Expect::that($caught)->toBe($failure);
-                },
-            );
+            ->toThrow($failure);
         Expect::that($runtime->calls)
             ->because('PCOV cleanup MUST attempt clear even if stop fails')
             ->toBe(['start', 'collect', 'stop', 'clear']);

--- a/tests/Unit/Coverage/XdebugDriverFailureTest.php
+++ b/tests/Unit/Coverage/XdebugDriverFailureTest.php
@@ -35,9 +35,7 @@ final readonly class XdebugDriverFailureTest
 
         Expect::that(static fn(): mixed => $driver->stop())
             ->because('an Xdebug runtime failure MUST remain the reported failure')
-            ->toThrow(static function (\RuntimeException $caught) use ($failure): void {
-                Expect::that($caught)->toBe($failure);
-            });
+            ->toThrow($failure);
 
         Expect::that($runtime->calls)
             ->because('Xdebug collection MUST stop the runtime after every collection attempt')

--- a/tests/Unit/Coverage/XdebugDriverStartFailureTest.php
+++ b/tests/Unit/Coverage/XdebugDriverStartFailureTest.php
@@ -22,9 +22,7 @@ final readonly class XdebugDriverStartFailureTest
             $driver->start();
         })
             ->because('an Xdebug start failure MUST remain the reported failure')
-            ->toThrow(static function (\RuntimeException $caught) use ($failure): void {
-                Expect::that($caught)->toBe($failure);
-            });
+            ->toThrow($failure);
 
         Expect::that($runtime->calls)
             ->because('a failed Xdebug start MUST NOT collect or stop the runtime')

--- a/tests/Unit/Doubles/MockTest.php
+++ b/tests/Unit/Doubles/MockTest.php
@@ -294,9 +294,7 @@ final class MockTest
         });
 
         Expect::that(static fn(): int => $calculator->add(1, 2))->because('andThrows() raises the configured throwable')
-            ->toThrow(static function (\RuntimeException $error) use ($throwable): void {
-                Expect::that($error)->toBe($throwable);
-            });
+            ->toThrow($throwable);
 
         $doubles->dispose();
     }

--- a/tests/Unit/Doubles/ProxyGenerationTest.php
+++ b/tests/Unit/Doubles/ProxyGenerationTest.php
@@ -227,9 +227,7 @@ final readonly class ProxyGenerationTest
         });
 
         Expect::that(static fn() => $wide->returnsNever())->because('a configured never returning method throws its plan')
-            ->toThrow(static function (\DomainException $error) use ($throwable): void {
-                Expect::that($error)->toBe($throwable);
-            });
+            ->toThrow($throwable);
     }
 
 }

--- a/tests/Unit/Expect/ExpectationRuntimeTest.php
+++ b/tests/Unit/Expect/ExpectationRuntimeTest.php
@@ -27,11 +27,7 @@ final class ExpectationRuntimeTest
                     static fn(): never => throw $expected,
                 ))
                     ->because('withClock propagates the operation exception')
-                    ->toThrow(
-                        static function (\RuntimeException $caught) use ($expected): void {
-                            Expect::that($caught)->toBe($expected);
-                        },
-                    );
+                    ->toThrow($expected);
 
                 Expect::that(ExpectationRuntime::clock())
                     ->toBe($outer);

--- a/tests/Unit/Expect/TemporalExpectationTest.php
+++ b/tests/Unit/Expect/TemporalExpectationTest.php
@@ -157,11 +157,7 @@ final class TemporalExpectationTest
             static fn() => Expect::eventually(
                 static fn(): never => throw $failure,
             )->within(0.100)->toBe('ready'),
-        ))->because('probe exceptions propagate unless explicitly retryable')->toThrow(
-            static function (TransientProbeFailure $caught) use ($failure): void {
-                Expect::that($caught)->toBe($failure);
-            },
-        );
+        ))->because('probe exceptions propagate unless explicitly retryable')->toThrow($failure);
 
         $calls = 0;
         ExpectationRuntime::withClock($clock, static function () use (&$calls): void {
@@ -246,11 +242,7 @@ final class TemporalExpectationTest
                     ->within(0.100)
                     ->toBe('unreachable');
             });
-        })->because('errors and matcher misuse are never retried')->toThrow(
-            static function (\Error $caught) use ($failure): void {
-                Expect::that($caught)->toBe($failure);
-            },
-        );
+        })->because('errors and matcher misuse are never retried')->toThrow($failure);
 
         Expect::that($calls)->because('errors and matcher misuse are never retried')->toBe(2);
     }

--- a/tests/Unit/Expect/TemporalToThrowTest.php
+++ b/tests/Unit/Expect/TemporalToThrowTest.php
@@ -58,6 +58,30 @@ final class TemporalToThrowTest
     }
 
     #[Test]
+    public function eventuallyRetriesUntilACallableThrowsTheExactThrowableInstance(): void
+    {
+        $clock = new FakePollingClock();
+        $calls = 0;
+        $failure = new \RuntimeException('ready');
+
+        ExpectationRuntime::withClock($clock, static function () use (&$calls, $failure): void {
+            Expect::eventually(static function () use (&$calls, $failure): \Closure {
+                ++$calls;
+
+                return $calls === 1
+                    ? static fn() => throw new \RuntimeException('ready')
+                    : static fn() => throw $failure;
+            })
+                ->pollEvery(0.010)
+                ->within(0.100)
+                ->toThrow($failure);
+        });
+
+        Expect::that($calls)->toBe(2);
+        Expect::that($clock->sleeps)->toBe([0.010]);
+    }
+
+    #[Test]
     public function temporalToThrowRejectsAConstraintWithAThrowableCallbackBeforePolling(): void
     {
         $calls = 0;
@@ -81,6 +105,35 @@ final class TemporalToThrowTest
 
         Expect::that($detail->message)->toBe(
             'Do not specify matching: or message: when the throwable is a callback.',
+        );
+        Expect::that($calls)->toBe(0);
+    }
+
+    #[Test]
+    public function temporalToThrowRejectsAConstraintWithAThrowableInstanceBeforePolling(): void
+    {
+        $calls = 0;
+        $failure = new \RuntimeException('boom');
+        $eventually = Expect::eventually(static function () use (&$calls, $failure): \Closure {
+            ++$calls;
+
+            return static fn() => throw $failure;
+        })->within(0.100);
+
+        $detail = FailureProbe::detailOf(
+            static function () use ($eventually, $failure): void {
+                new \ReflectionMethod($eventually, 'toThrow')->invokeArgs(
+                    $eventually,
+                    [
+                        'throwable' => $failure,
+                        'matching' => '/boom/',
+                    ],
+                );
+            },
+        );
+
+        Expect::that($detail->message)->toBe(
+            'Do not specify matching: or message: when the throwable argument is a Throwable instance.',
         );
         Expect::that($calls)->toBe(0);
     }

--- a/tests/Unit/Expect/ToThrowTest.php
+++ b/tests/Unit/Expect/ToThrowTest.php
@@ -32,6 +32,32 @@ final class ToThrowTest
     }
 
     #[Test]
+    public function toThrowPassesOnTheExactThrowableInstance(): void
+    {
+        $failure = new \DomainException('insufficient funds');
+
+        Expect::that(static fn() => throw $failure)
+            ->toThrow($failure);
+    }
+
+    #[Test]
+    public function toThrowFailsOnADifferentThrowableInstance(): void
+    {
+        $failure = new \DomainException('insufficient funds');
+
+        $detail = FailureProbe::detailOf(
+            static fn() => Expect::that(static fn() => throw new \DomainException('insufficient funds'))
+                ->toThrow($failure),
+        );
+
+        Expect::that($detail->message)->toBe(
+            "Expected a callable that threw DomainException with message 'insufficient funds' "
+            . 'to throw the exact DomainException instance.',
+        );
+        Expect::that($detail->expected)->toBe('the exact DomainException instance');
+    }
+
+    #[Test]
     public function toThrowPassesTheTypedThrowableToACallback(): void
     {
         $previous = new \LengthException('too short');
@@ -162,6 +188,27 @@ final class ToThrowTest
     }
 
     #[Test]
+    public function notToThrowUsesThrowableIdentity(): void
+    {
+        $failure = new \DomainException('boom');
+
+        Expect::that(static fn() => throw new \DomainException('boom'))
+            ->not()
+            ->toThrow($failure);
+
+        $detail = FailureProbe::detailOf(
+            static fn() => Expect::that(static fn() => throw $failure)
+                ->not()
+                ->toThrow($failure),
+        );
+
+        Expect::that($detail->message)->toBe(
+            "Expected a callable that threw DomainException with message 'boom' "
+            . 'not to throw the exact DomainException instance.',
+        );
+    }
+
+    #[Test]
     public function notToThrowPassesWhenTheThrowableCallbackExpectationFails(): void
     {
         Expect::that(static fn() => throw new \DomainException('boom'))
@@ -268,6 +315,34 @@ final class ToThrowTest
 
         Expect::that($detail->message)->toBe(
             'Do not specify matching: or message: when the throwable is a callback.',
+        );
+        Expect::that($invoked)->toBeFalse();
+    }
+
+    #[Test]
+    public function toThrowRejectsAConstraintWithAThrowableInstanceBeforeInvokingTheSubject(): void
+    {
+        $invoked = false;
+        $failure = new \DomainException('boom');
+
+        $detail = FailureProbe::detailOf(
+            static function () use (&$invoked, $failure): void {
+                $expectation = Expect::that(static function () use (&$invoked): void {
+                    $invoked = true;
+                });
+
+                new \ReflectionMethod($expectation, 'toThrow')->invokeArgs(
+                    $expectation,
+                    [
+                        'throwable' => $failure,
+                        'message' => 'boom',
+                    ],
+                );
+            },
+        );
+
+        Expect::that($detail->message)->toBe(
+            'Do not specify matching: or message: when the throwable argument is a Throwable instance.',
         );
         Expect::that($invoked)->toBeFalse();
     }

--- a/tests/Unit/Harness/ScopeContainerFailedLazyFactoryDisposalTest.php
+++ b/tests/Unit/Harness/ScopeContainerFailedLazyFactoryDisposalTest.php
@@ -40,11 +40,7 @@ final class ScopeContainerFailedLazyFactoryDisposalTest
 
         Expect::that(static fn(): string => $service->value())
             ->because('the lazy factory failure MUST propagate from service use')
-            ->toThrow(
-                static function (\RuntimeException $caught) use ($failure): void {
-                    Expect::that($caught)->toBe($failure);
-                },
-            );
+            ->toThrow($failure);
 
         $failures = $container->dispose();
 

--- a/tests/Unit/Harness/ScopeContainerLazyFactoryTest.php
+++ b/tests/Unit/Harness/ScopeContainerLazyFactoryTest.php
@@ -43,11 +43,7 @@ final class ScopeContainerLazyFactoryTest
 
         Expect::that(static fn() => $service->value())
             ->because('the lazy factory failure MUST propagate from the first service use')
-            ->toThrow(
-                static function (\RuntimeException $caught) use ($failure): void {
-                    Expect::that($caught)->toBe($failure);
-                },
-            );
+            ->toThrow($failure);
         Expect::that($factoryCalls)
             ->toBe(1);
     }

--- a/tests/Unit/Laravel/LaravelPluginTest.php
+++ b/tests/Unit/Laravel/LaravelPluginTest.php
@@ -236,11 +236,7 @@ final class LaravelPluginTest
 
         Expect::that(static function () use ($plugin): void {
             $plugin->resolve(Greeter::class, []);
-        })->toThrow(
-            static function (\RuntimeException $caught) use ($failure): void {
-                Expect::that($caught)->toBe($failure);
-            },
-        );
+        })->toThrow($failure);
         Expect::that(Container::getInstance())->toBe($container);
         Expect::that(\getenv('APP_ENV'))->toBe('before-laravel');
         Expect::that($_ENV['APP_ENV'] ?? null)->toBe('before-laravel');

--- a/tests/Unit/Runner/PluginEventSinkTest.php
+++ b/tests/Unit/Runner/PluginEventSinkTest.php
@@ -94,11 +94,7 @@ final class PluginEventSinkTest
             $sink->emit($event);
         })
             ->because('an orchestrator subscriber failure MUST fail event delivery')
-            ->toThrow(
-                static function (\RuntimeException $caught) use ($failure): void {
-                    Expect::that($caught)->toBe($failure);
-                },
-            );
+            ->toThrow($failure);
 
         Expect::that($inner->events)
             ->because('the inner sink MUST not observe an event rejected by a subscriber')


### PR DESCRIPTION
## Summary

- allow immediate and temporal `toThrow()` expectations to match one exact `Throwable` instance
- define instance constraints for negation, temporal retries, diagnostics, and invalid message combinations
- extend PHPDoc, PHPStan checks, public documentation, and focused coverage
- replace identity-only throwable callbacks throughout the test suite

Closes #1253
