### PR TITLE
build: enforce runner exception contracts

### DIFF
--- a/docs/api-fixtures-harness.md
+++ b/docs/api-fixtures-harness.md
@@ -475,6 +475,20 @@ PHPDoc:
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceDefinition.php#L26)
 
+## `ServiceResolutionError`
+
+Namespace: `Greenlight\Harness`
+
+A harness service resolver cannot supply a valid service.
+
+```php
+abstract class ServiceResolutionError extends \RuntimeException
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolutionError.php#L10)
+
+This type does not declare public members.
+
 ## `ServiceResolver`
 
 Namespace: `Greenlight\Harness`
@@ -503,6 +517,6 @@ PHPDoc:
 
 - `@param class-string $type`
 - `@param list<object> $attributes`
-- `@throws \RuntimeException when the resolver cannot supply a valid service`
+- `@throws ServiceResolutionError when the resolver cannot supply a valid service`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolver.php#L24)

--- a/docs/api-plugins.md
+++ b/docs/api-plugins.md
@@ -313,7 +313,7 @@ service scope closes before `afterTest()`, so `service()` throws during
 final readonly class TestContext
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L20)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L21)
 
 ### `$attachments`
 
@@ -321,7 +321,7 @@ final readonly class TestContext
 public Attachments $attachments;
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L22)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L23)
 
 ### `service()`
 
@@ -334,10 +334,10 @@ PHPDoc:
 - `@template T of object`
 - `@param class-string<T> $type`
 - `@return T`
-- `@throws \RuntimeException when a service resolver cannot supply a valid service`
+- `@throws ServiceResolutionError when a service resolver cannot supply a valid service`
 - `@throws UnresolvableService`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L44)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L45)
 
 ### `skip()`
 
@@ -353,7 +353,7 @@ PHPDoc:
 - `@param non-empty-string $reason`
 - `@throws SkipTest`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L63)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L64)
 
 ## `TestLifecycleSubscriber`
 

--- a/docs/api-test-contracts.md
+++ b/docs/api-test-contracts.md
@@ -133,7 +133,7 @@ Identifies a test across processes for assignment, rerun selection, and the timi
 final readonly class TestId implements WireSerializable, \Stringable
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L13)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L14)
 
 ### `$class`
 
@@ -145,7 +145,7 @@ PHPDoc:
 
 - `@var non-empty-string`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L18)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L19)
 
 ### `$method`
 
@@ -157,7 +157,7 @@ PHPDoc:
 
 - `@var non-empty-string`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L23)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L24)
 
 ### `__construct()`
 
@@ -173,7 +173,7 @@ PHPDoc:
 
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L28)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L29)
 
 ### `equals()`
 
@@ -181,7 +181,7 @@ PHPDoc:
 public function equals(self $other): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L45)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L46)
 
 ### `__toString()`
 
@@ -190,7 +190,7 @@ public function equals(self $other): bool
 public function __toString(): string
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L52)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L53)
 
 ### `toWire()`
 
@@ -199,7 +199,7 @@ public function __toString(): string
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L62)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L63)
 
 ### `fromWire()`
 
@@ -208,7 +208,12 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L72)
+PHPDoc:
+
+- `@throws \InvalidArgumentException when the decoded identity is empty`
+- `@throws InvalidWirePayload when a required field is missing or has the wrong type`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L77)
 
 ## `TestMetadata`
 
@@ -336,7 +341,12 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L146)
+PHPDoc:
+
+- `@throws \InvalidArgumentException when the decoded metadata violates a domain invariant`
+- `@throws InvalidWirePayload when a required field is missing or has the wrong type`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L150)
 
 ## `InvalidWirePayload`
 
@@ -349,7 +359,7 @@ The error always names the applicable key. Thus, its message identifies the
 protocol error.
 
 ```php
-final class InvalidWirePayload extends \RuntimeException
+final class InvalidWirePayload extends WireError
 ```
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Wire/InvalidWirePayload.php#L14)
@@ -369,6 +379,20 @@ public static function wrongType(string $key, string $expected, mixed $actual): 
 ```
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Wire/InvalidWirePayload.php#L26)
+
+## `WireError`
+
+Namespace: `Greenlight\Core\Wire`
+
+A value or frame cannot cross the orchestrator-worker wire boundary.
+
+```php
+abstract class WireError extends \RuntimeException
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Wire/WireError.php#L10)
+
+This type does not declare public members.
 
 ## `WireSerializable`
 
@@ -408,6 +432,6 @@ PHPDoc:
 
 - `@param array<string, mixed> $payload`
 - `@throws \InvalidArgumentException when a decoded value violates a domain invariant`
-- `@throws InvalidWirePayload`
+- `@throws WireError when the payload cannot be decoded`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Wire/WireSerializable.php#L27)

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -16,17 +16,19 @@ parameters:
             - Greenlight\Core\Artifact\AttachmentError
             - Greenlight\Core\AtomicFileError
             - Greenlight\Core\Test\SkipTest
-            - Greenlight\Core\Wire\InvalidWirePayload
+            - Greenlight\Core\Wire\WireError
             - Greenlight\Coverage\CoverageError
             - Greenlight\Discovery\DiscoveryError
             - Greenlight\Doubles\DoublesError
             - Greenlight\Expect\ExpectationFailed
-            - Greenlight\Laravel\LaravelBridgeError
+            - Greenlight\Harness\ServiceResolutionError
             - Greenlight\PhpStan\MatcherMapError
-            - Greenlight\Symfony\SymfonyBridgeError
+            - Greenlight\Reporting\ReportingError
+            - Greenlight\Runner\Integration\IntegrationFixtureError
         check:
             missingCheckedExceptionInThrows: true
             throwTypeCovariance: true
+            tooWideThrowType: true
     paths:
         - src
         - tests

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -23,6 +23,7 @@ use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Event\EventTags;
 use Greenlight\Core\GracefulShutdown;
 use Greenlight\Core\Wire\InvalidWirePayload;
+use Greenlight\Core\Wire\WireError;
 use Greenlight\Coverage\CoverageError;
 use Greenlight\Coverage\CoverageMap;
 use Greenlight\Coverage\Diff\BaselineDiff;
@@ -49,6 +50,7 @@ use Greenlight\Reporting\PlainReporter;
 use Greenlight\Reporting\ProfileAggregator;
 use Greenlight\Reporting\ProfileReporter;
 use Greenlight\Reporting\Reporter;
+use Greenlight\Reporting\ReportingError;
 use Greenlight\Reporting\RunHeader;
 use Greenlight\Reporting\Style;
 use Greenlight\Reporting\SummaryFormat;
@@ -174,6 +176,9 @@ final readonly class Application
     /**
      * @param list<string> $argv the arguments after the script name
      * @throws CoverageError
+     * @throws ProtocolError
+     * @throws ReportingError
+     * @throws WireError
      */
     public function run(array $argv, string $workingDirectory, ?string $binPath = null): int
     {
@@ -209,6 +214,8 @@ final readonly class Application
     /**
      * @param list<string> $argv the arguments after the script name
      * @throws CoverageError
+     * @throws ReportingError
+     * @throws WireError
      */
     private function dispatch(array $argv, string $workingDirectory, ?string $binPath): int
     {
@@ -268,6 +275,7 @@ final readonly class Application
 
     /**
      * @throws CoverageError
+     * @throws ReportingError
      */
     private function runCommand(ParsedArguments $arguments, string $workingDirectory, ?string $binPath = null): int
     {
@@ -444,6 +452,7 @@ final readonly class Application
      * @param list<non-empty-string> $priorityClasses
      * @param array<string, float> $classSeconds
      * @throws CoverageError
+     * @throws ReportingError
      */
     private function executeRun(
         ParsedArguments $arguments,
@@ -975,7 +984,10 @@ final readonly class Application
         return self::EXIT_OK;
     }
 
-    /** Creates a run profile from a saved JSONL event stream. */
+    /**
+     * Creates a run profile from a saved JSONL event stream.
+     * @throws WireError
+     */
     private function profileReportCommand(ParsedArguments $arguments, string $workingDirectory): int
     {
         $input = $arguments->value('input');

--- a/src/Cli/ReporterSink.php
+++ b/src/Cli/ReporterSink.php
@@ -6,6 +6,7 @@ namespace Greenlight\Cli;
 
 use Greenlight\Core\Event\Event;
 use Greenlight\Reporting\Reporter;
+use Greenlight\Reporting\ReportingError;
 use Greenlight\Runner\Worker\EventSink;
 
 /** @internal */
@@ -13,6 +14,9 @@ final readonly class ReporterSink implements EventSink
 {
     public function __construct(private Reporter $reporter) {}
 
+    /**
+     * @throws ReportingError
+     */
     #[\Override]
     public function emit(Event $event): void
     {

--- a/src/Core/Test/TestId.php
+++ b/src/Core/Test/TestId.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Core\Test;
 
+use Greenlight\Core\Wire\InvalidWirePayload;
 use Greenlight\Core\Wire\Wire;
 use Greenlight\Core\Wire\WireSerializable;
 
@@ -69,6 +70,10 @@ final readonly class TestId implements WireSerializable, \Stringable
         ];
     }
 
+    /**
+     * @throws \InvalidArgumentException when the decoded identity is empty
+     * @throws InvalidWirePayload when a required field is missing or has the wrong type
+     */
     #[\Override]
     public static function fromWire(array $payload): static
     {

--- a/src/Core/Test/TestMetadata.php
+++ b/src/Core/Test/TestMetadata.php
@@ -143,6 +143,10 @@ final readonly class TestMetadata implements WireSerializable
         ];
     }
 
+    /**
+     * @throws \InvalidArgumentException when the decoded metadata violates a domain invariant
+     * @throws InvalidWirePayload when a required field is missing or has the wrong type
+     */
     #[\Override]
     public static function fromWire(array $payload): static
     {

--- a/src/Core/Wire/InvalidWirePayload.php
+++ b/src/Core/Wire/InvalidWirePayload.php
@@ -11,7 +11,7 @@ namespace Greenlight\Core\Wire;
  * The error always names the applicable key. Thus, its message identifies the
  * protocol error.
  */
-final class InvalidWirePayload extends \RuntimeException
+final class InvalidWirePayload extends WireError
 {
     private function __construct(string $message)
     {

--- a/src/Core/Wire/WireError.php
+++ b/src/Core/Wire/WireError.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Core\Wire;
+
+/**
+ * A value or frame cannot cross the orchestrator-worker wire boundary.
+ */
+abstract class WireError extends \RuntimeException {}

--- a/src/Core/Wire/WireSerializable.php
+++ b/src/Core/Wire/WireSerializable.php
@@ -22,7 +22,7 @@ interface WireSerializable
      * @param array<string, mixed> $payload
      *
      * @throws \InvalidArgumentException when a decoded value violates a domain invariant
-     * @throws InvalidWirePayload
+     * @throws WireError when the payload cannot be decoded
      */
     public static function fromWire(array $payload): static;
 }

--- a/src/Harness/HarnessScopes.php
+++ b/src/Harness/HarnessScopes.php
@@ -39,7 +39,7 @@ final class HarnessScopes
      * @param non-empty-string $consumer
      * @param list<object> $attributes
      *
-     * @throws \RuntimeException when a service resolver cannot supply a valid service
+     * @throws ServiceResolutionError when a service resolver cannot supply a valid service
      * @throws UnresolvableService
      */
     public function resolve(string $type, string $consumer, array $attributes = []): object

--- a/src/Harness/ScopeContainer.php
+++ b/src/Harness/ScopeContainer.php
@@ -22,6 +22,9 @@ final class ScopeContainer
      */
     private array $services = [];
 
+    /**
+     * @throws UnresolvableService
+     */
     public function get(ServiceDefinition $definition): object
     {
         $existing = $this->services[$definition->type] ?? null;
@@ -69,6 +72,9 @@ final class ScopeContainer
         return $failures;
     }
 
+    /**
+     * @throws UnresolvableService
+     */
     private function instantiate(ServiceDefinition $definition): object
     {
         $reflection = new \ReflectionClass($definition->type);

--- a/src/Harness/ServiceResolutionError.php
+++ b/src/Harness/ServiceResolutionError.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Harness;
+
+/**
+ * A harness service resolver cannot supply a valid service.
+ */
+abstract class ServiceResolutionError extends \RuntimeException {}

--- a/src/Harness/ServiceResolver.php
+++ b/src/Harness/ServiceResolver.php
@@ -19,7 +19,7 @@ interface ServiceResolver
      * @param class-string $type
      * @param list<object> $attributes
      *
-     * @throws \RuntimeException when the resolver cannot supply a valid service
+     * @throws ServiceResolutionError when the resolver cannot supply a valid service
      */
     public function resolve(string $type, array $attributes): ?object;
 }

--- a/src/Harness/UnresolvableService.php
+++ b/src/Harness/UnresolvableService.php
@@ -12,7 +12,7 @@ namespace Greenlight\Harness;
  *
  * @internal
  */
-final class UnresolvableService extends \RuntimeException
+final class UnresolvableService extends ServiceResolutionError
 {
     private function __construct(string $message)
     {

--- a/src/Laravel/LaravelBridgeError.php
+++ b/src/Laravel/LaravelBridgeError.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Greenlight\Laravel;
 
+use Greenlight\Harness\ServiceResolutionError;
+
 /**
  * Reports a Laravel bridge configuration or run-time failure.
  *
  * @internal
  */
-final class LaravelBridgeError extends \RuntimeException
+final class LaravelBridgeError extends ServiceResolutionError
 {
     private function __construct(string $message)
     {

--- a/src/Plugin/TestContext.php
+++ b/src/Plugin/TestContext.php
@@ -10,6 +10,7 @@ use Greenlight\Core\Test\SkipTest;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Harness\HarnessScopes;
+use Greenlight\Harness\ServiceResolutionError;
 use Greenlight\Harness\UnresolvableService;
 
 /**
@@ -38,7 +39,7 @@ final readonly class TestContext
      *
      * @return T
      *
-     * @throws \RuntimeException when a service resolver cannot supply a valid service
+     * @throws ServiceResolutionError when a service resolver cannot supply a valid service
      * @throws UnresolvableService
      */
     public function service(string $type): object

--- a/src/Reporting/GithubReporter.php
+++ b/src/Reporting/GithubReporter.php
@@ -64,6 +64,9 @@ final class GithubReporter implements Reporter
         }
     }
 
+    /**
+     * @throws ReportingError
+     */
     private function writeFailures(TestResult $result): void
     {
         foreach ($result->failures as $failure) {
@@ -101,6 +104,9 @@ final class GithubReporter implements Reporter
         }
     }
 
+    /**
+     * @throws ReportingError
+     */
     private function writeError(TestResult $result): void
     {
         $error = $result->error;
@@ -126,6 +132,9 @@ final class GithubReporter implements Reporter
         $this->write($error->file, $error->line, $message);
     }
 
+    /**
+     * @throws ReportingError
+     */
     private function write(?string $file, ?int $line, string $message): void
     {
         $properties = '';

--- a/src/Reporting/JUnitReporter.php
+++ b/src/Reporting/JUnitReporter.php
@@ -135,6 +135,9 @@ final class JUnitReporter implements Reporter
         return \htmlspecialchars($this->xml($value), \ENT_XML1 | \ENT_COMPAT, 'UTF-8');
     }
 
+    /**
+     * @throws ReportingError
+     */
     private function renderCase(TestResult $result): string
     {
         if (!$this->xmlWriter->isAvailable()) {

--- a/src/Reporting/JsonLinesReporter.php
+++ b/src/Reporting/JsonLinesReporter.php
@@ -33,6 +33,9 @@ final readonly class JsonLinesReporter implements Reporter
         return EventTags::all();
     }
 
+    /**
+     * @throws ReportingError
+     */
     #[\Override]
     public function onEvent(Event $event): void
     {

--- a/src/Reporting/TeamCityReporter.php
+++ b/src/Reporting/TeamCityReporter.php
@@ -104,6 +104,9 @@ final class TeamCityReporter implements Reporter
         }
     }
 
+    /**
+     * @throws ReportingError
+     */
     private function onTestFinished(TestResult $result): void
     {
         $name = (string) $result->id;
@@ -143,6 +146,9 @@ final class TeamCityReporter implements Reporter
         ]);
     }
 
+    /**
+     * @throws ReportingError
+     */
     private function writeFailed(TestResult $result, string $name, string $flowId): void
     {
         $failure = $result->failures[0] ?? null;
@@ -192,6 +198,9 @@ final class TeamCityReporter implements Reporter
         $this->message('testFailed', $attributes);
     }
 
+    /**
+     * @throws ReportingError
+     */
     private function writeErrored(TestResult $result, string $name, string $flowId): void
     {
         $error = $result->error;
@@ -262,6 +271,7 @@ final class TeamCityReporter implements Reporter
 
     /**
      * @param array<non-empty-string, string> $attributes
+     * @throws ReportingError
      */
     private function message(string $name, array $attributes): void
     {

--- a/src/Reporting/Ticking.php
+++ b/src/Reporting/Ticking.php
@@ -13,6 +13,8 @@ interface Ticking
 {
     /**
      * @param float $now epoch seconds from microtime(true), the same clock as Event::occurredAt
+     *
+     * @throws ReportingError when the update cannot be rendered or delivered
      */
     public function tick(float $now): void;
 }

--- a/src/Reporting/TtyReporter.php
+++ b/src/Reporting/TtyReporter.php
@@ -214,6 +214,9 @@ final class TtyReporter implements Reporter, Ticking
         }
     }
 
+    /**
+     * @throws ReportingError
+     */
     #[\Override]
     public function tick(float $now): void
     {
@@ -282,6 +285,9 @@ final class TtyReporter implements Reporter, Ticking
         }
     }
 
+    /**
+     * @throws ReportingError
+     */
     private function finalizeClass(string $class): void
     {
         $state = $this->live[$class] ?? ['done' => 0, 'failed' => 0, 'skipped' => 0, 'duration' => 0.0, 'startedAt' => 0.0];
@@ -342,6 +348,7 @@ final class TtyReporter implements Reporter, Ticking
 
     /**
      * @param list<string> $scrollback permanent lines the frame leaves above the window
+     * @throws ReportingError
      */
     private function redraw(array $scrollback = [], bool $force = false): void
     {
@@ -422,6 +429,9 @@ final class TtyReporter implements Reporter, Ticking
         return $line;
     }
 
+    /**
+     * @throws ReportingError
+     */
     private function eraseLiveRegion(): void
     {
         if (!$this->cursor || $this->drawnLines === 0) {

--- a/src/Runner/InProcessRunner.php
+++ b/src/Runner/InProcessRunner.php
@@ -45,6 +45,7 @@ final readonly class InProcessRunner
      *
      * @throws DiscoveryError
      * @throws AttachmentError
+     * @throws IntegrationFixtureError
      */
     public function run(
         Configuration $configuration,

--- a/src/Runner/Integration/IntegrationFixtureManager.php
+++ b/src/Runner/Integration/IntegrationFixtureManager.php
@@ -23,6 +23,7 @@ final class IntegrationFixtureManager
      * @param positive-int $configuredWorkers
      * @param positive-int $channelCount
      * @param array{int, int}|null $shard
+     * @throws IntegrationFixtureError
      */
     public static function provision(
         PluginRegistry $plugins,
@@ -90,6 +91,7 @@ final class IntegrationFixtureManager
      * @param array<mixed> $provided
      *
      * @return list<IntegrationFixtureDefinition>
+     * @throws IntegrationFixtureError
      */
     private static function validatedDefinitions(IntegrationFixtureProvider $provider, array $provided): array
     {
@@ -115,6 +117,7 @@ final class IntegrationFixtureManager
      * @param array<string, IntegrationFixtureDefinition> $definitions
      *
      * @return list<IntegrationFixtureDefinition>
+     * @throws IntegrationFixtureError
      */
     private static function ordered(array $definitions): array
     {
@@ -134,6 +137,7 @@ final class IntegrationFixtureManager
      * @param array<string, int> $state
      * @param list<string> $path
      * @param list<IntegrationFixtureDefinition> $ordered
+     * @throws IntegrationFixtureError
      */
     private static function visit(
         IntegrationFixtureDefinition $definition,

--- a/src/Runner/Orchestrator/Orchestrator.php
+++ b/src/Runner/Orchestrator/Orchestrator.php
@@ -23,9 +23,11 @@ use Greenlight\Core\Result\ThrowableDetail;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Core\Wire\InvalidWirePayload;
 use Greenlight\Core\Wire\Utf8;
+use Greenlight\Core\Wire\WireError;
 use Greenlight\Coverage\CoverageMap;
 use Greenlight\Discovery\ExecutionPlan;
 use Greenlight\Discovery\PlanEntry;
+use Greenlight\Reporting\ReportingError;
 use Greenlight\Reporting\Ticking;
 use Greenlight\Runner\Artifact\ArtifactStore;
 use Greenlight\Runner\CoverageSettings;
@@ -173,6 +175,8 @@ final class Orchestrator
      * @throws ProtocolError
      * @throws AttachmentError
      * @throws InvalidWirePayload
+     * @throws ReportingError
+     * @throws WireError
      */
     public function run(ExecutionPlan $plan, EventSink $sink, int $workerCount): ResultSummary
     {
@@ -224,6 +228,7 @@ final class Orchestrator
      * @param positive-int $workerCount
      * @param non-empty-string $address
      * @param non-empty-string $token
+     * @throws ProtocolError
      */
     private function spawnUpTo(
         int $workerCount,
@@ -325,6 +330,8 @@ final class Orchestrator
      * @param non-empty-string $token
      * @throws AttachmentError
      * @throws InvalidWirePayload
+     * @throws ProtocolError
+     * @throws WireError
      */
     private function tick(mixed $server, string $token, EventSink $sink): void
     {
@@ -363,6 +370,8 @@ final class Orchestrator
      * @param non-empty-string $token
      * @throws InvalidWirePayload
      * @throws AttachmentError
+     * @throws ProtocolError
+     * @throws WireError
      */
     private function processHellos(string $token, EventSink $sink): void
     {
@@ -472,6 +481,8 @@ final class Orchestrator
     /**
      * @throws AttachmentError
      * @throws InvalidWirePayload
+     * @throws ProtocolError
+     * @throws WireError
      */
     private function pumpChannels(EventSink $sink): void
     {
@@ -634,6 +645,9 @@ final class Orchestrator
         }
     }
 
+    /**
+     * @throws ProtocolError
+     */
     private function onAttemptStarted(WorkerHandle $handle, AttemptStarted $message): void
     {
         $inFlight = $handle->inFlight;
@@ -677,6 +691,7 @@ final class Orchestrator
 
     /**
      * @throws AttachmentError
+     * @throws ProtocolError
      */
     private function detectCrashes(EventSink $sink): void
     {
@@ -728,6 +743,7 @@ final class Orchestrator
 
     /**
      * @throws AttachmentError
+     * @throws ProtocolError
      */
     private function enforceTimeouts(EventSink $sink): void
     {
@@ -901,6 +917,7 @@ final class Orchestrator
 
     /**
      * @param list<TestId> $reported
+     * @throws ProtocolError
      */
     private function assertRemainder(WorkerHandle $handle, array $reported): void
     {
@@ -968,6 +985,9 @@ final class Orchestrator
         return $this->scheduler;
     }
 
+    /**
+     * @throws ProtocolError
+     */
     private function crossCheck(WorkerHandle $handle, ResultSummary $reported): void
     {
         if ($handle->tally->toWire() !== $reported->toWire()) {

--- a/src/Runner/Orchestrator/ServerSocket.php
+++ b/src/Runner/Orchestrator/ServerSocket.php
@@ -24,6 +24,9 @@ final class ServerSocket
         private readonly ?string $unixPath,
     ) {}
 
+    /**
+     * @throws ProtocolError
+     */
     public static function listen(
         ?string $temporaryDirectory = null,
         ?ServerSocketRuntime $runtime = null,

--- a/src/Runner/Orchestrator/WorkerSpawnBudget.php
+++ b/src/Runner/Orchestrator/WorkerSpawnBudget.php
@@ -30,6 +30,7 @@ final class WorkerSpawnBudget
 
     /**
      * @return non-empty-string
+     * @throws ProtocolError
      */
     public function nextWorkerId(): string
     {

--- a/src/Runner/ParallelRunner.php
+++ b/src/Runner/ParallelRunner.php
@@ -46,6 +46,7 @@ final readonly class ParallelRunner
      *
      * @throws DiscoveryError
      * @throws AttachmentError
+     * @throws IntegrationFixtureError
      */
     public function run(
         Configuration $configuration,

--- a/src/Runner/Protocol/EventRegistry.php
+++ b/src/Runner/Protocol/EventRegistry.php
@@ -9,6 +9,7 @@ use Greenlight\Core\Event\Event;
 use Greenlight\Core\Event\EventTags;
 use Greenlight\Core\Wire\InvalidWirePayload;
 use Greenlight\Core\Wire\Wire;
+use Greenlight\Core\Wire\WireError;
 
 /** @internal */
 final class EventRegistry
@@ -18,6 +19,7 @@ final class EventRegistry
 
     /**
      * @return array<string, mixed>
+     * @throws ProtocolError
      */
     public static function toTagged(Event $event): array
     {
@@ -35,6 +37,7 @@ final class EventRegistry
      *
      * @throws ProtocolError
      * @throws InvalidWirePayload
+     * @throws WireError
      */
     public static function fromTagged(array $tagged): Event
     {

--- a/src/Runner/Protocol/MessageRegistry.php
+++ b/src/Runner/Protocol/MessageRegistry.php
@@ -7,6 +7,7 @@ namespace Greenlight\Runner\Protocol;
 use Greenlight\Attribute\CoverageIgnore;
 use Greenlight\Core\Wire\InvalidWirePayload;
 use Greenlight\Core\Wire\Wire;
+use Greenlight\Core\Wire\WireError;
 use Greenlight\Runner\Protocol\Messages\Assign;
 use Greenlight\Runner\Protocol\Messages\AttemptStarted;
 use Greenlight\Runner\Protocol\Messages\Bootstrap;
@@ -66,6 +67,7 @@ final class MessageRegistry
      *
      * @throws ProtocolError
      * @throws InvalidWirePayload
+     * @throws WireError
      */
     public static function open(array $envelope): Message
     {

--- a/src/Runner/Protocol/Messages/EventEnvelope.php
+++ b/src/Runner/Protocol/Messages/EventEnvelope.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Greenlight\Runner\Protocol\Messages;
 
 use Greenlight\Core\Event\Event;
+use Greenlight\Core\Wire\InvalidWirePayload;
+use Greenlight\Core\Wire\WireError;
 use Greenlight\Runner\Protocol\EventRegistry;
 use Greenlight\Runner\Protocol\Message;
+use Greenlight\Runner\Protocol\ProtocolError;
 
 /**
  * Sends one execution event from a worker to the orchestrator.
@@ -23,12 +26,20 @@ final readonly class EventEnvelope implements Message
         return 'event';
     }
 
+    /**
+     * @throws ProtocolError
+     */
     #[\Override]
     public function toWire(): array
     {
         return EventRegistry::toTagged($this->event);
     }
 
+    /**
+     * @throws ProtocolError
+     * @throws InvalidWirePayload
+     * @throws WireError
+     */
     #[\Override]
     public static function fromWire(array $payload): static
     {

--- a/src/Runner/Protocol/ProtocolError.php
+++ b/src/Runner/Protocol/ProtocolError.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Greenlight\Runner\Protocol;
 
+use Greenlight\Core\Wire\WireError;
+
 /**
  * Greenlight raises this error when a frame, envelope, or message violates
  * the worker protocol. Causes include an oversized or truncated frame and
@@ -12,7 +14,7 @@ namespace Greenlight\Runner\Protocol;
  *
  * @internal
  */
-final class ProtocolError extends \RuntimeException
+final class ProtocolError extends WireError
 {
     private function __construct(string $message, ?\Throwable $previous = null)
     {

--- a/src/Runner/Protocol/SocketChannel.php
+++ b/src/Runner/Protocol/SocketChannel.php
@@ -6,6 +6,7 @@ namespace Greenlight\Runner\Protocol;
 
 use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Wire\InvalidWirePayload;
+use Greenlight\Core\Wire\WireError;
 
 /**
  * Sends framed messages through one stream socket.
@@ -79,6 +80,7 @@ final class SocketChannel
      *
      * @throws ProtocolError
      * @throws InvalidWirePayload
+     * @throws WireError
      */
     public function receive(float $timeoutSeconds): ?Message
     {
@@ -123,6 +125,7 @@ final class SocketChannel
      *
      * @throws ProtocolError
      * @throws InvalidWirePayload
+     * @throws WireError
      */
     public function poll(): ?Message
     {

--- a/src/Runner/Worker/SocketEventSink.php
+++ b/src/Runner/Worker/SocketEventSink.php
@@ -6,6 +6,7 @@ namespace Greenlight\Runner\Worker;
 
 use Greenlight\Core\Event\Event;
 use Greenlight\Runner\Protocol\Messages\EventEnvelope;
+use Greenlight\Runner\Protocol\ProtocolError;
 use Greenlight\Runner\Protocol\SocketChannel;
 
 /** @internal */
@@ -13,6 +14,9 @@ final readonly class SocketEventSink implements EventSink
 {
     public function __construct(private SocketChannel $channel) {}
 
+    /**
+     * @throws ProtocolError
+     */
     #[\Override]
     public function emit(Event $event): void
     {

--- a/src/Runner/Worker/TestExecutor.php
+++ b/src/Runner/Worker/TestExecutor.php
@@ -22,6 +22,7 @@ use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\ExpectationFailed;
 use Greenlight\Expect\ExpectationRuntime;
 use Greenlight\Harness\HarnessScopes;
+use Greenlight\Harness\ServiceResolutionError;
 use Greenlight\Harness\UnresolvableService;
 use Greenlight\Plugin\PluginRegistry;
 use Greenlight\Plugin\TestContext;
@@ -390,6 +391,8 @@ final readonly class TestExecutor
 
     /**
      * @param non-empty-string $class
+     * @throws UnresolvableService
+     * @throws ServiceResolutionError
      */
     private function instantiate(string $class, Attachments $attachments): object
     {

--- a/src/Runner/Worker/WorkerProcess.php
+++ b/src/Runner/Worker/WorkerProcess.php
@@ -30,6 +30,7 @@ use Greenlight\Runner\Protocol\Messages\Fatal;
 use Greenlight\Runner\Protocol\Messages\Hello;
 use Greenlight\Runner\Protocol\Messages\Ready;
 use Greenlight\Runner\Protocol\Messages\Recycling;
+use Greenlight\Runner\Protocol\ProtocolError;
 use Greenlight\Runner\Protocol\SocketChannel;
 
 /**
@@ -49,6 +50,7 @@ final readonly class WorkerProcess
      * @param non-empty-string $address
      * @param non-empty-string $workerId
      * @param non-empty-string $token
+     * @throws ProtocolError
      */
     public function run(string $address, string $workerId, string $token): int
     {

--- a/src/Symfony/SymfonyBridgeError.php
+++ b/src/Symfony/SymfonyBridgeError.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Greenlight\Symfony;
 
+use Greenlight\Harness\ServiceResolutionError;
+
 /** @internal */
-final class SymfonyBridgeError extends \RuntimeException
+final class SymfonyBridgeError extends ServiceResolutionError
 {
     private function __construct(string $message)
     {

--- a/tests/Acceptance/PhpStanCheckedExceptionTest.php
+++ b/tests/Acceptance/PhpStanCheckedExceptionTest.php
@@ -43,9 +43,18 @@ final readonly class PhpStanCheckedExceptionTest
             namespace Greenlight\Probe;
 
             use Greenlight\Core\Result\FailureDetail;
+            use Greenlight\Core\Wire\WireError;
             use Greenlight\Coverage\CoverageError;
             use Greenlight\Doubles\DoublesError;
             use Greenlight\Expect\ExpectationFailed;
+            use Greenlight\Harness\ServiceResolutionError;
+            use Greenlight\Harness\UnresolvableService;
+            use Greenlight\Reporting\ReportingError;
+            use Greenlight\Runner\Integration\IntegrationFixtureError;
+            use Greenlight\Runner\Protocol\ProtocolError;
+
+            final class ProbeWireError extends WireError {}
+            final class ProbeServiceResolutionError extends ServiceResolutionError {}
 
             function undocumentedProductionHelper(): void
             {
@@ -61,6 +70,36 @@ final readonly class PhpStanCheckedExceptionTest
             {
                 throw DoublesError::invalidTimes(-1);
             }
+
+            function undocumentedResolutionError(): void
+            {
+                throw UnresolvableService::unknownType(\stdClass::class, \stdClass::class);
+            }
+
+            function undocumentedReportingError(): void
+            {
+                throw ReportingError::writeFailed();
+            }
+
+            function undocumentedIntegrationError(): void
+            {
+                throw IntegrationFixtureError::cleanup([]);
+            }
+
+            function undocumentedProtocolError(): void
+            {
+                throw ProtocolError::malformedFrame('probe');
+            }
+
+            function undocumentedWireErrorSubtype(): void
+            {
+                throw new ProbeWireError('Expected wire failure.');
+            }
+
+            function undocumentedServiceResolutionErrorSubtype(): void
+            {
+                throw new ProbeServiceResolutionError('Expected service resolution failure.');
+            }
             PHP,
             \dirname(__DIR__, 2) . '/phpstan.dist.neon',
         );
@@ -71,7 +110,7 @@ final readonly class PhpStanCheckedExceptionTest
         Expect::that($probe->goodPassed)
             ->because('PHPStan MUST not require throws tags in test code')
             ->toBeTrue();
-        Expect::that($probe->errors)->toHaveCount(3);
+        Expect::that($probe->errors)->toHaveCount(9);
         Expect::that($probe->messages())->toContain(
             'throws checked exception Greenlight\\Expect\\ExpectationFailed but it\'s missing from the PHPDoc @throws tag.',
         );
@@ -80,6 +119,24 @@ final readonly class PhpStanCheckedExceptionTest
         );
         Expect::that($probe->messages())->toContain(
             'throws checked exception Greenlight\\Doubles\\DoublesError but it\'s missing from the PHPDoc @throws tag.',
+        );
+        Expect::that($probe->messages())->toContain(
+            'throws checked exception Greenlight\\Harness\\UnresolvableService but it\'s missing from the PHPDoc @throws tag.',
+        );
+        Expect::that($probe->messages())->toContain(
+            'throws checked exception Greenlight\\Reporting\\ReportingError but it\'s missing from the PHPDoc @throws tag.',
+        );
+        Expect::that($probe->messages())->toContain(
+            'throws checked exception Greenlight\\Runner\\Integration\\IntegrationFixtureError but it\'s missing from the PHPDoc @throws tag.',
+        );
+        Expect::that($probe->messages())->toContain(
+            'throws checked exception Greenlight\\Runner\\Protocol\\ProtocolError but it\'s missing from the PHPDoc @throws tag.',
+        );
+        Expect::that($probe->messages())->toContain(
+            'throws checked exception Greenlight\\Probe\\ProbeWireError but it\'s missing from the PHPDoc @throws tag.',
+        );
+        Expect::that($probe->messages())->toContain(
+            'throws checked exception Greenlight\\Probe\\ProbeServiceResolutionError but it\'s missing from the PHPDoc @throws tag.',
         );
     }
 
@@ -149,5 +206,52 @@ final readonly class PhpStanCheckedExceptionTest
             ->toBeTrue();
         Expect::that($probe->errors)->toHaveCount(1);
         Expect::that($probe->messages())->toContain('should be covariant with PHPDoc @throws type');
+    }
+
+    #[Test]
+    public function throwsTagsMustNotBeWiderThanTheImplementation(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace Greenlight\Probe\ExactThrows;
+
+            use Greenlight\Coverage\CoverageError;
+
+            /** @throws CoverageError */
+            function documentedFailure(): void
+            {
+                throw CoverageError::driverUnavailable('probe', 'Expected operational failure.');
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace Greenlight\Probe\WideThrows;
+
+            use Greenlight\Coverage\CoverageError;
+
+            /** @throws CoverageError */
+            function documentedFailure(): void {}
+            PHP,
+            \dirname(__DIR__, 2) . '/phpstan.dist.neon',
+        );
+
+        Expect::that($probe->exitCode)
+            ->because('PHPStan MUST reject a throws type that the implementation does not throw')
+            ->toBe(1);
+        Expect::that($probe->goodPassed)
+            ->because('PHPStan MUST accept an exact throws contract')
+            ->toBeTrue();
+        Expect::that($probe->errors)->toHaveCount(1);
+        Expect::that($probe->messages())->toContain(
+            'has Greenlight\\Coverage\\CoverageError in PHPDoc @throws tag but it\'s not thrown.',
+        );
     }
 }


### PR DESCRIPTION
Completes checked-exception enforcement for harness resolution, reporting, integration fixtures, and runner protocol errors. Declares every direct and transitive @throws contract, including shared event and tick boundaries.

Replaces general wire and service-resolver contracts with checked WireError and ServiceResolutionError hierarchies. Concrete decoders keep precise InvalidWirePayload and InvalidArgumentException contracts, while runtime-selected decoders expose WireError.

Enables the PHPStan over-broad throws check so stale exception contracts also fail. Extends acceptance coverage across all remaining named exception types and verifies missing, non-covariant, and unused @throws declarations.