### PR TITLE
docs: clarify public guide contracts

### DIFF
--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -37,6 +37,9 @@ final readonly class CheckoutTest
 media type. `file()` copies a regular file and detects its media type when
 possible.
 
+Greenlight accepts media types in `type/subtype` form. A media type can include
+parameters. Greenlight rejects malformed values and control characters.
+
 Greenlight copies the content before the method returns. You can remove a
 temporary source file after `file()` returns. Later changes to a value or file
 do not change the attachment.

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -161,6 +161,8 @@ Adds one inline data set.
 the data-set key in test IDs and reports. Without a label, Greenlight uses
 `#<position>` as the key for the inline row.
 
+An explicit label must not be empty.
+
 Inline rows can contain only values that PHP attributes can express. Examples
 include scalars, arrays, and constants. Use a `#[DataSet]` provider for
 calculated rows, ranges, or objects.
@@ -204,6 +206,8 @@ string $name
 ```
 
 Tags a test method, or every test in a class, with a group name.
+
+A group name must not be empty.
 
 Select groups at run time with `--group=<name>`. The flag is
 repeatable. `list-tests` applies the same filter.
@@ -339,7 +343,7 @@ Parameters:
 float $seconds
 ```
 
-`$seconds` must be greater than zero.
+`$seconds` must be finite and greater than zero.
 
 Fails the test if it runs longer than the configured budget.
 

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -70,6 +70,9 @@ scalars strictly. It compares arrays by key and recursively equal values.
 Objects must have the same class and recursively equal properties. This rule
 includes private properties.
 
+Object comparisons preserve shared references and cycles. Object graphs with
+different relationships are not equal.
+
 Enum cases compare by identity.
 `DateTimeInterface` values compare by instant at microsecond precision.
 
@@ -215,6 +218,12 @@ Expect::eventually(fn() => $client->fetch($id))
     ->toBeInstanceOf(Response::class);
 ```
 
+`pollEvery()` accepts a finite duration of at least 0.001 seconds. `within()`
+accepts a finite duration greater than zero.
+
+`retryOnException()` accepts only subclasses of `Exception`. It does not accept
+`Error` types.
+
 `Expect::consistently()` requires the first probe result to match, then checks
 for the full duration:
 
@@ -224,6 +233,9 @@ Expect::consistently(fn() => $outbox->messagesFor($id))
     ->for(0.5)
     ->toHaveCount(1);
 ```
+
+For consistent checks, `pollEvery()` has the same minimum. `for()` accepts a
+finite duration greater than zero.
 
 Each temporal matcher counts as one expectation. The test timeout limits its
 duration. The worker timeout remains the hard limit for a blocked probe.

--- a/docs/migrating-from-phpunit.md
+++ b/docs/migrating-from-phpunit.md
@@ -72,11 +72,30 @@ The rule preserves each repeated `#[TestWith]` row. It converts
 It rejects class-process and global-state options that have different
 Greenlight behavior.
 
+The rule converts supported PHPUnit attributes as follows:
+
+| PHPUnit | Greenlight |
+| --- | --- |
+| `#[DataProvider]` | `#[DataSet]` |
+| `#[TestWith]` | `#[DataRow]` |
+| `#[Group]` or `#[Ticket]` | `#[Group]` |
+| `#[Small]` | `#[Group('small')]` |
+| `#[Medium]` | `#[Group('medium')]` |
+| `#[Large]` | `#[Group('large')]` |
+| `#[RunInSeparateProcess]` or `#[RunTestsInSeparateProcesses]` | `#[Isolated]` |
+| `#[DoesNotPerformAssertions]` | `#[NoExpectations]` |
+| `#[RequiresPhpExtension]` | `#[SkipUnless]` with `ExtensionLoaded` |
+| `#[RequiresOperatingSystemFamily]` | `#[SkipUnless]` with `OperatingSystemFamily` |
+
 The rule removes coverage metadata attributes, for example `#[CoversClass]`,
-because coverage configuration belongs in `greenlight.php`. Rector's printer
-also reflows each converted class. Run your code-style fixer after the
-conversion. Then run the suite one time with `--workers=1` before you enable
-parallel workers.
+because coverage configuration belongs in `greenlight.php`. It also removes
+the `#[UsesClass]`, `#[UsesFunction]`, `#[UsesMethod]`, and `#[UsesTrait]`
+attributes. It removes `#[TestDox]` and
+`#[DisableReturnValueGenerationForTestDoubles]` too.
+
+Rector's printer also reflows each converted class. Run your code-style fixer
+after the conversion. Then run the suite one time with `--workers=1` before you
+enable parallel workers.
 
 ## Map the concepts
 

--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -6,6 +6,13 @@ supplies native matcher constraints that the PHP type system cannot express.
 
 ## Setup
 
+Greenlight supports PHPStan 2.2 and later 2.x releases. Install PHPStan as a
+development dependency:
+
+```console
+composer require --dev phpstan/phpstan:^2.2
+```
+
 Include the extension in your PHPStan configuration. Set the Greenlight
 configuration files:
 
@@ -261,6 +268,9 @@ Errors have identifiers under `greenlight.lifecycleMethod.*` (`visibility`,
 For `#[SkipUnless]`, PHPStan checks the transferred arguments against the
 constructor of the referenced condition. It reports invalid argument counts
 and types before a worker evaluates the condition.
+
+Errors use `greenlight.skipUnlessCondition.arity` and
+`greenlight.skipUnlessCondition.argument`.
 
 ## Data provider checks
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -29,6 +29,9 @@ resources. Use integration resources in both runner modes.
 
 ## Capability interfaces
 
+`Greenlight\Reporting\Reporter` is not a plugin capability. You cannot pass a
+reporter to `plugins()`. Use `--reporter` to select a built-in reporter.
+
 ### IntegrationFixtureProvider
 
 Orchestrator-side.
@@ -279,7 +282,7 @@ public function onRunEvent(Event $event): void;
 ```
 
 Run subscribers receive the event stream in the orchestrator process. The
-stream contains run, worker, class, and test events.
+stream contains run, worker, suite, class, and test events.
 
 This side is observation-only. Results cannot be changed across the process
 boundary. Integration fixture provisioning completes before `RunStarted`.
@@ -421,15 +424,6 @@ only one signature for a matcher name.
 When PHPStan first loads the matcher map, it runs plugin constructors in its
 process. Each worker also runs the plugin constructors.
 
-### Reporter
-
-In `Greenlight\Reporting`.
-
-Implement `onEvent(Event $event): void` and `finish(): void`. These methods
-render the event stream in another format.
-
-The built-in Greenlight reporters use the same interface.
-
 ## Plugin order and error policy
 
 Subscribers run in registration order.
@@ -442,6 +436,19 @@ public function priority(): int;
 
 Lower numbers run earlier. The default priority is `0`. The stable sort keeps
 the registration order of plugins that have the same priority.
+
+Priority applies to these capabilities:
+
+* `IntegrationFixtureProvider`
+* `WorkerBootstrapSubscriber`
+* `TestLifecycleSubscriber`
+* `RetryDecider`
+* `RunLifecycleSubscriber`
+* `HarnessProvider`
+* `ServiceResolver`
+
+Priority does not apply to `ExpectationExtension`. Greenlight calls expectation
+extensions in registration order.
 
 Greenlight reports all plugin failures. A worker-side failure causes an error
 for the affected test and names the plugin. An orchestrator-side failure causes

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -41,7 +41,7 @@ Greenlight verifies mocks when the test ends.
 * If the test expects specific calls and responses, use
   `mock(Type::class, $plan)`. An unplanned interaction fails immediately.
 * If the test needs an unused dependency, use `stub(Type::class)`. Each
-  interaction fails immediately.
+  intercepted interaction fails immediately.
 * If the test must examine calls that return void, use `spy(Type::class)`. The
   spy records an unplanned call.
 
@@ -69,6 +69,10 @@ of these methods to change its cardinality:
 A call that does not match an expectation fails immediately. At teardown, an
 unmet expectation fails the test. Greenlight reports all unmet expectations
 together.
+
+Greenlight examines expectations in declaration order. It uses the first
+unsaturated expectation that accepts the call. When that expectation reaches
+its maximum cardinality, Greenlight continues to the next expectation.
 
 Without an argument constraint, an expectation accepts each argument list that
 the method declaration permits. Greenlight rejects arguments that the method
@@ -173,9 +177,16 @@ Expect::that(
 
 ## Supported types and limits
 
-Greenlight can create doubles for interfaces and non-final classes. It does not
-run the class constructor when it creates a double.
+Greenlight can create doubles for interfaces and non-final, non-readonly
+classes. It rejects final classes, readonly classes, enums, and traits.
 
-Greenlight rejects final classes, readonly classes, and enums. It does not
-support partial mocks or static method interception. Prefer a double for an
-interface at the application boundary.
+A class double intercepts overridable public instance methods. A mock plan
+accepts only these methods.
+
+Concrete final and static methods keep their original implementations.
+Concrete protected methods also keep their original implementations. Calls
+through these methods can run application code.
+
+Greenlight does not run the class constructor when it creates a double. It does
+not support static method interception. Prefer an interface at the application
+boundary.


### PR DESCRIPTION
Clarify the public contracts for plugins, test doubles, expectations, PHPStan, PHPUnit migration, attributes, and attachments.

- distinguish plugin capabilities from the reporter interface and document capability ordering
- describe double interception, equality, temporal, and attachment validation behavior
- add setup, conversion, and argument constraints that the guides previously omitted