### PR TITLE
docs: tighten guide prose

### DIFF
--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -37,8 +37,8 @@ final readonly class CheckoutTest
 media type. `file()` copies a regular file and detects its media type when
 possible.
 
-Greenlight accepts media types in `type/subtype` form. A media type can include
-parameters. Greenlight rejects malformed values and control characters.
+Media types use `type/subtype` form with optional parameters. Greenlight rejects
+malformed values and control characters.
 
 Greenlight copies the content before the method returns. You can remove a
 temporary source file after `file()` returns. Later changes to a value or file
@@ -105,8 +105,8 @@ source does not change during the copy operation. Published paths stay in the
 configured run directory. Greenlight creates artifact files with private
 permissions on supported platforms.
 
-Greenlight does not inspect attachment content. It does not redact attachment
-content. Before you attach a value or file, remove secrets and personal data.
+Greenlight does not inspect or redact attachment content. Before you attach a
+value or file, remove secrets and personal data.
 Apply the policy for sensitive CI artifacts to the output directory.
 
 ## Limits

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -188,9 +188,6 @@ Declares that the test intentionally verifies no expectations.
 Use this for tests that pass and do not throw. Risky-test detection and
 `--fail-on-risky` ignore tests marked with this attribute.
 
-The attribute makes the intent explicit. Thus, Greenlight does not confuse this
-test with a test that has a missing assertion.
-
 An `eventually()` or `consistently()` matcher counts as one expectation.
 
 ## Group
@@ -206,8 +203,6 @@ string $name
 ```
 
 Tags a test method, or every test in a class, with a group name.
-
-A group name must not be empty.
 
 Select groups at run time with `--group=<name>`. The flag is
 repeatable. `list-tests` applies the same filter.

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,7 +1,5 @@
 # Benchmarks
 
-The benchmark script generates reproducible results.
-
 Run the full benchmark with:
 
 ```sh

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -70,8 +70,8 @@ scalars strictly. It compares arrays by key and recursively equal values.
 Objects must have the same class and recursively equal properties. This rule
 includes private properties.
 
-Object comparisons preserve shared references and cycles. Object graphs with
-different relationships are not equal.
+Object comparisons distinguish shared objects from equal copies. They also
+require equal cycle shapes.
 
 Enum cases compare by identity.
 `DateTimeInterface` values compare by instant at microsecond precision.
@@ -218,11 +218,7 @@ Expect::eventually(fn() => $client->fetch($id))
     ->toBeInstanceOf(Response::class);
 ```
 
-`pollEvery()` accepts a finite duration of at least 0.001 seconds. `within()`
-accepts a finite duration greater than zero.
-
-`retryOnException()` accepts only subclasses of `Exception`. It does not accept
-`Error` types.
+`retryOnException()` accepts `Exception` subclasses, but not `Error` types.
 
 `Expect::consistently()` requires the first probe result to match, then checks
 for the full duration:
@@ -234,8 +230,8 @@ Expect::consistently(fn() => $outbox->messagesFor($id))
     ->toHaveCount(1);
 ```
 
-For consistent checks, `pollEvery()` has the same minimum. `for()` accepts a
-finite duration greater than zero.
+For both temporal chains, `pollEvery()` accepts a finite duration of at least
+0.001 seconds. `within()` and `for()` accept finite durations greater than zero.
 
 Each temporal matcher counts as one expectation. The test timeout limits its
 duration. The worker timeout remains the hard limit for a blocked probe.

--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -1,7 +1,7 @@
 # Laravel applications
 
-The Laravel bridge supplies Laravel container services to test constructors. It
-supplies these services together with the built-in Greenlight harness services.
+The Laravel bridge supplies Laravel container services and built-in Greenlight
+harness services to test constructors.
 
 The bridge boots a fresh application for each test that uses it. Register the
 plugin to activate the bridge. The bridge uses the Laravel package that the
@@ -43,9 +43,8 @@ worker lifetime.
 The application boots when a test first requests a container service. A worker
 does not boot Laravel when its tests do not use the container.
 
-Greenlight tests the bridge with `laravel/framework` 13. The bridge does not
-support applications that install individual `illuminate/*` components. A
-standard Laravel 13 application has the required package.
+The bridge requires the complete `laravel/framework` 13 package instead of
+individual `illuminate/*` components.
 
 ## Container services
 
@@ -127,8 +126,7 @@ false` to the plugin. The application then boots once for each worker and no
 reset occurs. Do not use this value with services that keep state. Tests on the
 same worker will share those service instances.
 
-The bridge boots and discards the Laravel application. Isolation for databases
-and other external services remains the test suite's responsibility.
+The bridge does not isolate databases or other external services.
 
 ## Parallel resources
 
@@ -172,15 +170,10 @@ resource rules.
 
 ## Doubles and the container
 
-The bridge injects only real Laravel container services.
-
-There is no API that replaces a container service with a double. If a test needs
-a doubled collaborator, get the double through `Doubles`. Then construct the
-test subject directly. Greenlight then controls the double lifecycle and
+The bridge does not replace container services with doubles. If a test needs a
+doubled collaborator, get the double through `Doubles`. Then construct the test
+subject directly. Greenlight then controls the double lifecycle and
 verification.
-
-Container-level replacement remains a possible future addition. Its design must
-prevent uncertain service replacement.
 
 ## Non-goals
 
@@ -192,6 +185,3 @@ The current bridge does not cover:
 * database creation or migration tools
 * bootstrap file auto-discovery
 * Dusk browser tests
-
-The bridge has a deliberately small scope. It provides the application,
-container services, per-test refreshes, and worker channels.

--- a/docs/migrating-from-phpunit.md
+++ b/docs/migrating-from-phpunit.md
@@ -67,21 +67,15 @@ Two conversions change the code shape. An `expectException()` block becomes a
 not move. `expectExceptionMessage()` finds a substring, so the rule writes a
 quoted `matching:` pattern and not an exact `message:` constraint.
 
-The rule preserves each repeated `#[TestWith]` row. It converts
-`#[RunInSeparateProcess]` and `#[RunTestsInSeparateProcesses]` to `#[Isolated]`.
-It rejects class-process and global-state options that have different
-Greenlight behavior.
+The rule preserves each repeated `#[TestWith]` row. It rejects class-process
+and global-state options that have different Greenlight behavior.
 
-The rule converts supported PHPUnit attributes as follows:
+Some attribute conversions are less direct:
 
 | PHPUnit | Greenlight |
 | --- | --- |
-| `#[DataProvider]` | `#[DataSet]` |
-| `#[TestWith]` | `#[DataRow]` |
-| `#[Group]` or `#[Ticket]` | `#[Group]` |
-| `#[Small]` | `#[Group('small')]` |
-| `#[Medium]` | `#[Group('medium')]` |
-| `#[Large]` | `#[Group('large')]` |
+| `#[Ticket]` | `#[Group]` |
+| `#[Small]`, `#[Medium]`, and `#[Large]` | `#[Group('small')]`, `#[Group('medium')]`, and `#[Group('large')]` |
 | `#[RunInSeparateProcess]` or `#[RunTestsInSeparateProcesses]` | `#[Isolated]` |
 | `#[DoesNotPerformAssertions]` | `#[NoExpectations]` |
 | `#[RequiresPhpExtension]` | `#[SkipUnless]` with `ExtensionLoaded` |
@@ -89,9 +83,7 @@ The rule converts supported PHPUnit attributes as follows:
 
 The rule removes coverage metadata attributes, for example `#[CoversClass]`,
 because coverage configuration belongs in `greenlight.php`. It also removes
-the `#[UsesClass]`, `#[UsesFunction]`, `#[UsesMethod]`, and `#[UsesTrait]`
-attributes. It removes `#[TestDox]` and
-`#[DisableReturnValueGenerationForTestDoubles]` too.
+use metadata, `#[TestDox]`, and `#[DisableReturnValueGenerationForTestDoubles]`.
 
 Rector's printer also reflows each converted class. Run your code-style fixer
 after the conversion. Then run the suite one time with `--workers=1` before you
@@ -225,10 +217,8 @@ stops the poll unless `retryOnException()` lists its type.
 
 Constructor injection supplies the `Doubles` service.
 
-Greenlight does not create tolerant doubles. PHPUnit `createMock()` can create
-a double whose methods return `null` or automatic stubs.
-
-Greenlight has no equivalent object.
+PHPUnit `createMock()` can create a tolerant double whose methods return `null`
+or automatic stubs. Greenlight has no tolerant double equivalent.
 
 `mock(Type::class, fn (MockPlan $plan) => ...)` creates a strict mock.
 Greenlight verifies each planned expectation at the end of the test.
@@ -282,11 +272,9 @@ $gateway = $this->doubles->mock(PaymentGateway::class, function (MockPlan $plan)
 Greenlight verifies mocks when the per-test scope closes. You do not need a
 `Mockery::close()` equivalent.
 
-Greenlight can double interfaces and non-final classes. It rejects final
-classes, readonly classes, and enums.
-
-The error recommends an interface. Greenlight does not support partial mocks
-or static method mocks.
+Double targets are interfaces or non-final, non-readonly classes. Prefer an
+interface because class doubles preserve final, static, and protected
+implementations.
 
 After migration, strict doubles can expose interactions that old tests
 accepted.

--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -6,8 +6,7 @@ supplies native matcher constraints that the PHP type system cannot express.
 
 ## Setup
 
-Greenlight supports PHPStan 2.2 and later 2.x releases. Install PHPStan as a
-development dependency:
+Install PHPStan 2.2 or a later 2.x release as a development dependency:
 
 ```console
 composer require --dev phpstan/phpstan:^2.2

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -29,8 +29,8 @@ resources. Use integration resources in both runner modes.
 
 ## Capability interfaces
 
-`Greenlight\Reporting\Reporter` is not a plugin capability. You cannot pass a
-reporter to `plugins()`. Use `--reporter` to select a built-in reporter.
+The `plugins()` method does not accept `Greenlight\Reporting\Reporter`. Use
+`--reporter` to select a built-in reporter.
 
 ### IntegrationFixtureProvider
 
@@ -284,8 +284,8 @@ public function onRunEvent(Event $event): void;
 Run subscribers receive the event stream in the orchestrator process. The
 stream contains run, worker, suite, class, and test events.
 
-This side is observation-only. Results cannot be changed across the process
-boundary. Integration fixture provisioning completes before `RunStarted`.
+Run subscribers cannot change results across the process boundary. Integration
+fixture provisioning completes before `RunStarted`.
 `RunFinished` is delivered before fixture teardown begins. If a run subscriber
 throws, the run fails and fixtures are still torn down.
 
@@ -328,8 +328,7 @@ In `Greenlight\Harness`.
 public function resolve(string $type, array $attributes): ?object;
 ```
 
-A service resolver is a fallback source for a constructor parameter type. Use
-it when no harness service provides that type.
+A service resolver is a fallback source for a constructor parameter type.
 
 Registered harness services always take precedence. If no service matches,
 Greenlight calls resolvers in registration order. Each call receives the
@@ -426,8 +425,6 @@ process. Each worker also runs the plugin constructors.
 
 ## Plugin order and error policy
 
-Subscribers run in registration order.
-
 A plugin can also implement `Greenlight\Plugin\Prioritized`:
 
 ```php
@@ -447,8 +444,7 @@ Priority applies to these capabilities:
 * `HarnessProvider`
 * `ServiceResolver`
 
-Priority does not apply to `ExpectationExtension`. Greenlight calls expectation
-extensions in registration order.
+`ExpectationExtension` uses registration order.
 
 Greenlight reports all plugin failures. A worker-side failure causes an error
 for the affected test and names the plugin. An orchestrator-side failure causes

--- a/docs/symfony.md
+++ b/docs/symfony.md
@@ -1,7 +1,7 @@
 # Symfony applications
 
-The Symfony bridge supplies Symfony services to test constructors. It supplies
-these services together with the built-in Greenlight harness services.
+The Symfony bridge supplies Symfony services and built-in Greenlight harness
+services to test constructors.
 
 The bridge boots the application kernel once for each worker. Register the
 plugin to activate the bridge. The bridge uses the Symfony packages that the
@@ -37,11 +37,8 @@ At boot, the bridge requires the kernel container to expose
 `services_resetter`. A standard FrameworkBundle test environment provides the
 test container when `framework.test` is active.
 
-At boot, the bridge checks that the container supports the features it needs.
-The bridge reports a configuration error if the Symfony test container is not
-present. It also reports a configuration error if an active service reset has
-no `services_resetter`. The error message contains a correction. The bridge
-reports an error and does not use weaker isolation.
+If a required container service is absent, the bridge reports a configuration
+error with a correction. It does not use weaker isolation.
 
 ## Container services
 
@@ -106,16 +103,14 @@ mechanism Symfony uses between requests. The resetter resets services with the
 each stateful service that must keep tests isolated.
 
 The bridge captures and checks the resetter when the kernel boots. If service
-resets are active without a container resetter, every test fails. No test runs
-with shared state that has not had a reset.
+resets are active without a container resetter, every test fails.
 
 For a container that has no stateful services, pass `resetBetweenTests: false`
 to the plugin. This value disables the resetter requirement. Do not use this
 value with services that keep state. Tests on the same worker will share those
 service instances.
 
-The bridge boots and resets the Symfony kernel. Isolation for databases and
-other external services remains the test suite's responsibility.
+The bridge does not isolate databases or other external services.
 
 ## Parallel resources
 
@@ -164,15 +159,10 @@ complete resource rules.
 
 ## Doubles and the container
 
-The bridge injects only real Symfony container services.
-
-There is no API that replaces a container service with a double. If a test needs
-a doubled collaborator, get the double through `Doubles`. Then construct the
-test subject directly. Greenlight then controls the double lifecycle and
+The bridge does not replace container services with doubles. If a test needs a
+doubled collaborator, get the double through `Doubles`. Then construct the test
+subject directly. Greenlight then controls the double lifecycle and
 verification.
-
-Container-level replacement remains a possible future addition. Its design must
-prevent uncertain service replacement.
 
 ## Non-goals
 
@@ -184,6 +174,3 @@ The current bridge does not cover:
 * kernel auto-discovery
 * database creation or migration tools
 * Messenger assertions
-
-The bridge has a deliberately small scope. It provides the kernel, container
-services, service resets, and worker channels.

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -71,8 +71,7 @@ unmet expectation fails the test. Greenlight reports all unmet expectations
 together.
 
 Greenlight examines expectations in declaration order. It uses the first
-unsaturated expectation that accepts the call. When that expectation reaches
-its maximum cardinality, Greenlight continues to the next expectation.
+unsaturated expectation that accepts the call.
 
 Without an argument constraint, an expectation accepts each argument list that
 the method declaration permits. Greenlight rejects arguments that the method
@@ -177,16 +176,12 @@ Expect::that(
 
 ## Supported types and limits
 
-Greenlight can create doubles for interfaces and non-final, non-readonly
-classes. It rejects final classes, readonly classes, enums, and traits.
+Double targets are interfaces or non-final, non-readonly classes.
 
-A class double intercepts overridable public instance methods. A mock plan
-accepts only these methods.
+A class double intercepts only overridable public instance methods.
 
-Concrete final and static methods keep their original implementations.
-Concrete protected methods also keep their original implementations. Calls
-through these methods can run application code.
+Concrete final, static, and protected methods keep their original
+implementations. Calls through these methods can run application code.
 
-Greenlight does not run the class constructor when it creates a double. It does
-not support static method interception. Prefer an interface at the application
-boundary.
+Greenlight does not run the class constructor when it creates a double. Prefer
+an interface at the application boundary.


### PR DESCRIPTION
## Summary

- remove local repetition and mirrored positive/negative statements from narrative guides
- preserve public constraints, defaults, failure modes, and lifecycle semantics
- consolidate bridge guidance and non-obvious migration, expectation, and double rules