### PR TITLE
docs: tighten architecture and site prose

### DIFF
--- a/docs/architecture/artifacts.md
+++ b/docs/architecture/artifacts.md
@@ -59,9 +59,8 @@ A locked `.quota` file in private staging coordinates attachment and byte
 totals across workers. Greenlight tracks per-test count and byte limits across
 every attempt for the test.
 
-The worker protocol carries metadata instead of base64 content. Thus,
-attachments stay outside its 8 MiB frame limit. Reporters do not load large
-attachment files.
+Attachment content therefore stays outside the protocol's 8 MiB frame limit.
+Reporters do not load large attachment files.
 
 ## Path safety
 

--- a/docs/architecture/coverage-json.md
+++ b/docs/architecture/coverage-json.md
@@ -37,11 +37,8 @@ The schema has a version. The fields and meanings in version 1 are stable. See
 
 ### v
 
-The schema version.
-
-For this revision, this value is always the integer `1`.
-
-Readers **MUST** reject all other values.
+The current schema version is the integer `1`. Readers **MUST** reject all
+other values.
 
 ### files
 
@@ -61,8 +58,6 @@ you compare them. Project-relative keys require a new schema version.
 ```json id="g6nqcx"
 {}
 ```
-
-It is never an array.
 
 ### files.*.covered
 
@@ -117,13 +112,12 @@ miss.
 
 ## Semantics
 
-The format stores line coverage only.
+The format stores covered and uncovered line sets, not hit counts.
 
 The format excludes lines that the coverage driver identifies as dead or
 unreachable code. These lines do not appear in `covered` or `uncovered`.
 
-A line has coverage if one or more tests in the run executed it. The format
-does not store hit counts.
+A line has coverage if one or more tests in the run executed it.
 
 The line lists supply the `percentage` values and the `totals` object.
 `import()` calculates these values again and ignores the stored values.
@@ -139,6 +133,3 @@ Readers **MUST** ignore unknown keys.
 
 If version 1 defines a field, a change to its definition or shape **MUST** use a
 new `v` value.
-
-Greenlight **MAY** add per-test coverage maps later as an optional extension.
-This extension **MUST** use an additive key and separate documentation.

--- a/docs/architecture/jsonl.md
+++ b/docs/architecture/jsonl.md
@@ -20,8 +20,6 @@ Each line is one JSON object with three keys:
 
 ### v
 
-Schema version.
-
 The current version is `2`.
 
 ### event
@@ -76,13 +74,9 @@ guarantees, and incomplete-output behavior.
 evidence from this run. Its value is `null` when an artifact directory is not
 available. The directory can be absent if the run retains no attachments.
 
-The schema reserves the `suite-started` and `suite-finished` event types.
-Greenlight does not emit them now. Suites only group configuration paths into
-one discovery set. Therefore, execution has no suite boundary.
-
-The event list and schema define these types to preserve their meaning. This
-meaning will apply if Greenlight adds suite-scope execution. Consumers
-**MUST NOT** wait for these events.
+The schema reserves `suite-started` and `suite-finished`, but Greenlight does
+not emit them because execution has no suite boundary. Consumers **MUST NOT**
+wait for these events.
 
 `test-started.id` is the test ID. It contains the class, method, and optional
 data-set key.

--- a/docs/architecture/mutation-testing.md
+++ b/docs/architecture/mutation-testing.md
@@ -69,8 +69,6 @@ The adapter has these responsibilities:
 * call Greenlight with `--test-id` for those test IDs
 * use the result to classify each mutant as killed or survived
 
-The proposed design requires no other runner changes.
-
 ## Decision
 
 Defer the adapter until a per-test coverage map exists.

--- a/docs/architecture/temporal-expectations.md
+++ b/docs/architecture/temporal-expectations.md
@@ -55,9 +55,8 @@ Each test retry has a new instance, scope, deadline, and observation log. The
 first interrupt signal still lets active tests finish. This rule includes tests
 that use a temporal expectation.
 
-`retryOnException()` accepts `Exception` subclasses only. PHP `Error` values are
-never valid for a retry. The method rejects a broad type that is not an
-`Exception` subtype.
+`retryOnException()` accepts only `Exception` subclasses, which excludes
+`Error`, `Throwable`, and other broader types.
 
 ## Failures
 

--- a/docs/architecture/worker-lifecycle.md
+++ b/docs/architecture/worker-lifecycle.md
@@ -140,11 +140,10 @@ assignment. Thus, the normal progress deadline does not classify the worker as
 stalled. After capacity becomes available, the orchestrator checks the workers
 that wait for resources.
 
-Resource assignment occurs only in the orchestrator. The `assign` message
-already contains the test metadata, so resource assignment requires no
-additional protocol message. Each Greenlight process, worktree, or shard has
-separate resource counters. Different runs require an external lock or service
-for coordination.
+The orchestrator claims resource capacity from the test metadata in `assign`,
+without another protocol message. Each Greenlight process, worktree, or shard
+has separate resource counters. Different runs require an external lock or
+service for coordination.
 
 The orchestrator controls capacity, not resource identity. A limit of two
 permits two assignments that require the resource at the same time. It does not
@@ -260,6 +259,5 @@ user-facing contract.
 
 Integration fixtures use the same channel pool. Greenlight merges shared values
 with the allocated channel overlay before bootstrap, so a worker never receives
-another channel's resource catalog. Replacement workers reuse released
-channels. Fresh workers running isolated tests draw from the same pool and
-receive the resources for their assigned channel.
+another channel's resource catalog. Fresh workers running isolated tests draw
+from the same pool and receive the resources for their assigned channel.

--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -8,8 +8,8 @@ import { sitePath } from '../lib/paths';
   description="The requested Greenlight documentation page does not exist."
 >
   <main id="main-content" class="not-found">
-    <p class="eyebrow">404 · Page not found</p>
-    <h1>The requested documentation page does not exist.</h1>
+    <p class="eyebrow">404</p>
+    <h1>Page not found.</h1>
     <p>Return to the documentation index to select an available page.</p>
     <a class="button primary" href={sitePath('docs/getting-started/')}>Browse documentation</a>
   </main>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -65,8 +65,7 @@ final class PriceTest
         <p class="eyebrow">Write a test</p>
         <h2>Tests stay plain PHP.</h2>
         <p>
-          Use ordinary classes, native attributes, and typed expectations. Greenlight
-          finds each <code>#[Test]</code> method without a base class or method-name convention.
+          Use ordinary classes, native attributes, and typed expectations.
         </p>
         <a class="text-link" href={sitePath('docs/getting-started/')}>Write your first test</a>
       </div>
@@ -168,9 +167,6 @@ final class PriceTest
       <div class="closing-cta-intro">
         <p class="eyebrow">Try one test class</p>
         <h2>Go from installation to your first run.</h2>
-        <p>
-          Before you change the rest of your suite, run one test class successfully.
-        </p>
       </div>
       <ol class="setup-steps">
         <li>


### PR DESCRIPTION
## Summary

- remove repeated schema and lifecycle explanations
- keep architecture constraints while reducing positive and negative restatements
- simplify repeated website headings and supporting copy