### PR TITLE
fix(test): escape generated acceptance paths

### DIFF
--- a/tests/Support/AcceptanceProject.php
+++ b/tests/Support/AcceptanceProject.php
@@ -70,7 +70,10 @@ final readonly class AcceptanceProject
         $requires = [];
 
         foreach ($testFiles as $relative) {
-            $requires[] = \sprintf("require_once __DIR__ . '/%s';", $relative);
+            $requires[] = \sprintf(
+                'require_once __DIR__ . %s;',
+                \var_export('/' . $relative, true),
+            );
         }
 
         $this->writeFile('greenlight.php', \sprintf(

--- a/tests/Unit/Support/AcceptanceProjectTest.php
+++ b/tests/Unit/Support/AcceptanceProjectTest.php
@@ -69,6 +69,23 @@ final readonly class AcceptanceProjectTest
     }
 
     #[Test]
+    public function escapesTestFilePathsInGeneratedConfiguration(): void
+    {
+        $project = AcceptanceProject::create($this->workspace, 'quoted-path');
+        $project->writeFile("tests/O'Brien.php", <<<'PHP'
+            <?php
+
+            file_put_contents(__DIR__ . '/../loaded.txt', 'loaded');
+            PHP);
+        $project->configureWithTestFiles(["tests/O'Brien.php"]);
+
+        $configuration = require $project->path('greenlight.php');
+
+        Expect::that($configuration)->because('escapes test file paths in generated configuration')->toBeInstanceOf(GreenlightConfig::class);
+        Expect::that(\file_get_contents($project->path('loaded.txt')))->toBe('loaded');
+    }
+
+    #[Test]
     public function projectWithDiscoveryBasicTestsTargetsTheSharedFixture(): void
     {
         $project = AcceptanceProject::createWithDiscoveryBasicTests($this->workspace, 'listing');


### PR DESCRIPTION
## Summary

- emit required test paths as escaped PHP string literals
- cover acceptance-project configuration for a filename that contains an apostrophe
- keep path-generation knowledge behind the existing AcceptanceProject interface