### PR TITLE
docs: clarify CLI and configuration contracts

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 **A parallel-first test framework for PHP 8.4 and later.**
 
 Greenlight runs test classes in parallel by default and has zero runtime
-dependencies. Greenlight discovers one suite and sends assignments to a pool of
-worker processes.
+dependencies. Greenlight discovers tests in the configured paths and sends
+class assignments to a pool of worker processes.
 
 [Read the documentation](https://ben-challis.github.io/greenlight/)
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,9 +44,11 @@ Every builder method returns `$this`. Thus, you can chain method calls.
 
 Default: `['tests']`.
 
-Sets the directories that Greenlight scans when you do not select a suite.
+Sets the top-level directories that Greenlight scans.
 
 Paths must be non-empty strings. The list itself must not be empty.
+
+Each run also scans every path from `suite()`.
 
 ### `suite(string $name, callable $configurator): self`
 
@@ -55,6 +57,9 @@ Default: no suites.
 Declares a named suite. Greenlight gives a `SuiteBuilder` to the configurator.
 The configurator must add at least one path. Greenlight ignores its return
 value. Thus, you can use an arrow function.
+
+Each run includes every named suite. Suite names and tags are descriptive. The
+`--dry-run` and `--list-suites` options print them.
 
 A second declaration with the same suite name causes an error.
 
@@ -145,8 +150,9 @@ accumulate.
 
 * `include(string ...$paths): self` adds source directories to measure. Default:
   none.
-* `driver(string $driver): self` prefers a specific driver, such as `'pcov'`.
-  Default: auto-detected.
+* `driver(string $driver): self` restricts coverage to `pcov` or `xdebug` when
+  you use that value. Other non-empty values have the default behavior:
+  Greenlight tries pcov, then Xdebug.
 * `export(string $format, string $target): self` adds a coverage export.
   Supported formats are `json`, `lcov`, `clover`, `cobertura`, and `html`.
   `$target` is a file path, or a directory for multi-file formats such as
@@ -389,7 +395,11 @@ Requires:
 --current=<path>
 ```
 
-Exits with code 1 when coverage regressed against the baseline.
+Exits with code 1 if total coverage decreases or the current export has a new
+uncovered line. A total coverage gain does not hide a new uncovered line.
+
+See the [coverage JSON schema](architecture/coverage-json.md) for the required
+format and path rules.
 
 ### profile:report
 
@@ -506,8 +516,9 @@ Repeatable. Exclusions take precedence over `--group` and `--filter`.
 
 Excludes classes with names that match the pattern.
 
-By default, Greenlight matches substrings without regard to case. A pattern
-that contains `*` or `?` must match the complete class name.
+Greenlight matches class names with case sensitivity. A pattern without a
+wildcard matches a substring. A pattern that contains `*` or `?` must match the
+complete class name.
 
 Repeatable.
 
@@ -515,8 +526,9 @@ Repeatable.
 
 Excludes methods with names that match the pattern.
 
-By default, Greenlight matches substrings without regard to case. A pattern
-that contains `*` or `?` must match the complete method name.
+Greenlight matches method names with case sensitivity. A pattern without a
+wildcard matches a substring. A pattern that contains `*` or `?` must match the
+complete method name.
 
 Repeatable.
 
@@ -569,7 +581,7 @@ Each shard enforces its own resource limits. If four shards each use
 
 ### `--failed`
 
-Reruns only tests that did not pass in the previous run.
+Reruns only tests that failed or had an error in the previous run.
 
 Greenlight records failure state for each run in the system temporary
 directory.
@@ -631,18 +643,28 @@ Sets the current coverage JSON file for `coverage:diff`.
 
 ### `--watch`
 
-Reruns on file changes.
+Starts with a complete run, then reruns all selected tests after a file change.
+
+Greenlight watches all configured test paths and coverage include paths. After
+a change, classes that failed in the previous watch iteration run first.
+
+Watch mode does not publish coverage totals or coverage exports.
 
 In watch mode:
 
-* Enter reruns everything.
-* `q` quits.
+* Enter reruns all selected tests.
+* `q` quits with exit code 0, regardless of the last iteration result.
+
+Signals use the exit codes in the [interruption](#interruption) section.
 
 ### `--detect-leaks`
 
 Verifies that garbage collection removes each test instance after its test.
 
 A detected leak fails the run.
+
+Xdebug develop mode can retain caught exceptions and report false leaks. Use
+`XDEBUG_MODE=off` to get correct leak results.
 
 ### `--fail-on-deprecation`
 
@@ -689,7 +711,8 @@ Default: `_greenlight_ide_helper.php`.
 
 ### `--dry-run`
 
-Prints the resolved configuration and does not run tests.
+Prints a summary of the resolved run settings without test discovery or
+execution.
 
 ### `--verbose`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -150,7 +150,7 @@ vendor/bin/greenlight
 Use these commands for common tasks:
 
 * `vendor/bin/greenlight list-tests` prints each discovered test ID.
-* `vendor/bin/greenlight run --dry-run` prints the execution plan.
+* `vendor/bin/greenlight run --dry-run` prints the resolved run-settings summary.
 * `vendor/bin/greenlight run --workers=1` uses one in-process worker.
 * `vendor/bin/greenlight run --group=slow` selects tests with `#[Group('slow')]`.
 * `vendor/bin/greenlight run --exclude-group=slow` excludes that group.
@@ -217,10 +217,15 @@ Start watch mode:
 vendor/bin/greenlight run --watch
 ```
 
-Watch mode runs affected tests after a file changes in a configured path.
-Classes from the previous failed run have priority.
+Watch mode runs all selected tests at startup and after each file change. It
+watches configured test paths and coverage include paths.
 
-Press Enter to run all tests. Press `q` to stop watch mode.
+Classes that failed in the previous watch iteration run first.
+
+Press Enter to rerun all selected tests. Press `q` to stop watch mode with exit
+code 0, regardless of the last iteration result.
+
+Watch mode does not print coverage totals or write coverage exports.
 
 Watch mode combines rapid save events. The default delay is 200 ms.
 

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -92,7 +92,8 @@ final readonly class Application
         Commands:
           run            Find and run tests (default)
           list-tests     List each found test ID, one per line
-          coverage:diff  Compare two coverage JSON exports (--baseline, --current)
+          coverage:diff  Compare two coverage JSON exports. Fail if total coverage
+                         decreases or a line becomes newly uncovered.
           profile:report Create a run profile from a saved JSONL stream (--input)
           ide-helper     Write the IDE autocomplete helper for extension matchers
                          (--output, default _greenlight_ide_helper.php)
@@ -113,13 +114,15 @@ final readonly class Application
           --test-id=<id>     Run only this exact test ID. You can repeat this option.
           --exclude-group=<name>     Skip tests in this group. You can repeat this option.
           --exclude-class=<pattern>  Skip classes that match this pattern.
-                             Use a substring or * wildcards. You can repeat this option.
+                             Matching is case-sensitive. Use a substring or * wildcards.
+                             You can repeat this option.
           --exclude-method=<pattern> Skip methods that match this pattern.
-                             Use a substring or * wildcards. You can repeat this option.
+                             Matching is case-sensitive. Use a substring or * wildcards.
+                             You can repeat this option.
           --exclude-path=<prefix>    Skip test files under this path prefix.
                              Greenlight resolves relative prefixes against the
                              working directory. You can repeat this option.
-          --failed           Run only tests that failed in the previous run
+          --failed           Run only tests that failed or had an error in the previous run
           --list-tests       Print the selected test IDs. Do not run the tests.
           --list-groups      Print each selected group and its test count
           --list-suites      Print the configured suites
@@ -134,8 +137,8 @@ final readonly class Application
           --reporter=<name>  Select tty, plain, junit, jsonl, github, or teamcity.
                              You can repeat this option.
           --artifacts-dir=<path> Persistent directory for retained test attachments
-          --watch            Run tests again after file changes. Enter runs all tests.
-                             q quits.
+          --watch            Run selected tests at startup and after file changes.
+                             Enter reruns them. q quits with exit code 0.
           --detect-leaks     Verify collection of each test instance. Leaks fail the run.
           --verbose          Print a permanent line per completed class in
                              interactive output
@@ -147,7 +150,8 @@ final readonly class Application
           --profile          Add a run profile after the summary. It contains worker
                              utilization, boot latency, makespan spread, and slow classes.
                              It also extends the slow-test list.
-          --dry-run          Print the resolved configuration. Do not run tests.
+          --dry-run          Print a run-settings summary without test discovery
+                             or execution.
           -h, --help         Show this help
           -V, --version      Show the version
 


### PR DESCRIPTION
Aligns the CLI and configuration guides with current runtime behavior.

- Clarifies suite path union, descriptive suite metadata, case-sensitive exclusions, failed-test selection, and dry-run output.
- Documents watch reruns, priority, watched roots, coverage suppression, and exit behavior.
- Defines coverage diff regressions, coverage driver selection, and the Xdebug leak-detection caveat.