### PR TITLE
fix(docs): document promoted API members

### DIFF
--- a/docs/api-artifacts.md
+++ b/docs/api-artifacts.md
@@ -18,6 +18,70 @@ readonly class Attachment implements WireSerializable
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachment.php#L15)
 
+### `$name`
+
+```php
+public string $name
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachment.php#L18)
+
+### `$kind`
+
+```php
+public AttachmentKind $kind
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachment.php#L19)
+
+### `$mediaType`
+
+```php
+public string $mediaType
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachment.php#L20)
+
+### `$sizeBytes`
+
+```php
+public int $sizeBytes
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachment.php#L21)
+
+### `$sha256`
+
+```php
+public string $sha256
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachment.php#L22)
+
+### `$attempt`
+
+```php
+public int $attempt
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachment.php#L23)
+
+### `$path`
+
+```php
+public string $path
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachment.php#L24)
+
+### `$retention`
+
+```php
+public AttachmentRetention $retention
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachment.php#L25)
+
 ### `__construct()`
 
 ```php

--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -80,6 +80,14 @@ PHPDoc:
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataRow.php#L20)
 
+### `$arguments`
+
+```php
+public array $arguments
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataRow.php#L28)
+
 ### `__construct()`
 
 ```php
@@ -408,6 +416,14 @@ final readonly class Test
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Test.php#L9)
 
+### `$capture`
+
+```php
+public bool $capture
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Test.php#L11)
+
 ### `__construct()`
 
 ```php
@@ -429,6 +445,14 @@ final readonly class Timeout
 ```
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Timeout.php#L12)
+
+### `$seconds`
+
+```php
+public float $seconds
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Timeout.php#L18)
 
 ### `__construct()`
 
@@ -484,6 +508,18 @@ final readonly class EnvironmentVariableEquals implements Condition
 ```
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableEquals.php#L9)
+
+### `__construct()`
+
+```php
+public function __construct(string $name, private string $value)
+```
+
+PHPDoc:
+
+- `@throws \InvalidArgumentException`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableEquals.php#L19)
 
 ### `isSatisfied()`
 

--- a/docs/api-configuration.md
+++ b/docs/api-configuration.md
@@ -160,7 +160,8 @@ public static function create(): self
 
 ### `paths()`
 
-Sets the test-discovery directories for runs without a selected suite.
+Sets the top-level test-discovery directories. Greenlight combines these
+paths with the paths from all named suites.
 
 ```php
 public function paths(array $tests): self
@@ -171,13 +172,15 @@ PHPDoc:
 - `@param list<string> $tests`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L90)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L91)
 
 ### `suite()`
 
-Declares a named suite. The configurator receives a `SuiteBuilder`. The
-configurator must add at least one path with `in()`. Greenlight ignores the
-return value, which permits short arrow functions.
+Declares a named suite. Greenlight adds its paths to test discovery.
+
+The configurator receives a `SuiteBuilder`. It must add at least one path
+with `in()`. Greenlight ignores its return value, which permits short
+arrow functions.
 
 ```php
 public function suite(string $name, callable $configurator): self
@@ -188,7 +191,7 @@ PHPDoc:
 - `@param callable(SuiteBuilder): mixed $configurator`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L120)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L123)
 
 ### `workers()`
 
@@ -210,7 +213,7 @@ PHPDoc:
 - `@param int|null $recycleAfterTests A null value disables test-count worker replacement.`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L148)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L151)
 
 ### `resourceLimit()`
 
@@ -227,7 +230,7 @@ PHPDoc:
 
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L176)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L179)
 
 ### `coverage()`
 
@@ -239,7 +242,7 @@ PHPDoc:
 
 - `@param callable(CoverageBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L204)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L207)
 
 ### `watch()`
 
@@ -251,7 +254,7 @@ PHPDoc:
 
 - `@param callable(WatchBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L216)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L219)
 
 ### `artifacts()`
 
@@ -263,7 +266,7 @@ PHPDoc:
 
 - `@param callable(ArtifactBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L228)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L231)
 
 ### `failOnDeprecation()`
 
@@ -279,7 +282,7 @@ PHPDoc:
 
 - `@see self::ignoreDeprecationsMatching()`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L244)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L247)
 
 ### `failOnNotice()`
 
@@ -287,7 +290,7 @@ PHPDoc:
 public function failOnNotice(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L251)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L254)
 
 ### `failOnRisky()`
 
@@ -299,7 +302,7 @@ expectations.
 public function failOnRisky(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L263)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L266)
 
 ### `ignoreDeprecationsMatching()`
 
@@ -315,7 +318,7 @@ PHPDoc:
 
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L276)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L279)
 
 ### `plugins()`
 
@@ -323,7 +326,7 @@ PHPDoc:
 public function plugins(Plugin ...$plugins): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L293)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L296)
 
 ### `failFast()`
 
@@ -331,7 +334,7 @@ public function plugins(Plugin ...$plugins): self
 public function failFast(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L302)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L305)
 
 ### `randomizeOrder()`
 
@@ -341,7 +344,7 @@ If the seed is null, Greenlight generates and prints a seed at run time.
 public function randomizeOrder(?int $seed = null): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L310)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L313)
 
 ### `build()`
 
@@ -353,7 +356,7 @@ PHPDoc:
 
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L342)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L345)
 
 ## `SuiteBuilder`
 
@@ -366,6 +369,18 @@ final class SuiteBuilder
 ```
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/SuiteBuilder.php#L8)
+
+### `__construct()`
+
+```php
+public function __construct(private readonly string $name)
+```
+
+PHPDoc:
+
+- `@param non-empty-string $name`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/SuiteBuilder.php#L23)
 
 ### `in()`
 

--- a/docs/api-events.md
+++ b/docs/api-events.md
@@ -84,6 +84,30 @@ PHPDoc:
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L15)
 
+### `$summary`
+
+```php
+public ResultSummary $summary
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L22)
+
+### `$durationSeconds`
+
+```php
+public float $durationSeconds
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L23)
+
+### `$occurredAt`
+
+```php
+public float $occurredAt
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L24)
+
 ### `__construct()`
 
 ```php
@@ -165,6 +189,22 @@ PHPDoc:
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunStarted.php#L24)
 
+### `$occurredAt`
+
+```php
+public float $occurredAt
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunStarted.php#L33)
+
+### `$artifactsDirectory`
+
+```php
+public ?string $artifactsDirectory
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunStarted.php#L34)
+
 ### `__construct()`
 
 ```php
@@ -223,6 +263,14 @@ PHPDoc:
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteFinished.php#L14)
 
+### `$occurredAt`
+
+```php
+public float $occurredAt
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteFinished.php#L19)
+
 ### `__construct()`
 
 ```php
@@ -275,6 +323,14 @@ PHPDoc:
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteStarted.php#L14)
 
+### `$occurredAt`
+
+```php
+public float $occurredAt
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteStarted.php#L19)
+
 ### `__construct()`
 
 ```php
@@ -326,6 +382,22 @@ PHPDoc:
 - `@var non-empty-string`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassFinished.php#L14)
+
+### `$occurredAt`
+
+```php
+public float $occurredAt
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassFinished.php#L24)
+
+### `$workerId`
+
+```php
+public string $workerId
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassFinished.php#L25)
 
 ### `__construct()`
 
@@ -384,6 +456,22 @@ PHPDoc:
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassStarted.php#L14)
 
+### `$occurredAt`
+
+```php
+public float $occurredAt
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassStarted.php#L24)
+
+### `$workerId`
+
+```php
+public string $workerId
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassStarted.php#L25)
+
 ### `__construct()`
 
 ```php
@@ -429,6 +517,22 @@ final readonly class TestFinished implements Event
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestFinished.php#L10)
 
+### `$result`
+
+```php
+public TestResult $result
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestFinished.php#L12)
+
+### `$occurredAt`
+
+```php
+public float $occurredAt
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestFinished.php#L12)
+
 ### `__construct()`
 
 ```php
@@ -464,6 +568,22 @@ final readonly class TestStarted implements Event
 ```
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestStarted.php#L10)
+
+### `$id`
+
+```php
+public TestId $id
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestStarted.php#L12)
+
+### `$occurredAt`
+
+```php
+public float $occurredAt
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestStarted.php#L12)
 
 ### `__construct()`
 
@@ -512,6 +632,22 @@ PHPDoc:
 - `@var non-empty-string`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerRecycled.php#L14)
+
+### `$reason`
+
+```php
+public RecycleReason $reason
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerRecycled.php#L21)
+
+### `$occurredAt`
+
+```php
+public float $occurredAt
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerRecycled.php#L22)
 
 ### `__construct()`
 
@@ -580,6 +716,14 @@ PHPDoc:
 - `@var positive-int`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerSpawned.php#L19)
+
+### `$occurredAt`
+
+```php
+public float $occurredAt
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerSpawned.php#L27)
 
 ### `__construct()`
 

--- a/docs/api-expectations.md
+++ b/docs/api-expectations.md
@@ -23,7 +23,26 @@ PHPDoc:
 - `@template T`
 - `@extends TemporalExpectation<T>`
 
-This type does not declare public members.
+### `__construct()`
+
+```php
+public function __construct(
+    \Closure $probe,
+    PollingClock $clock,
+    ?float $attemptDeadline,
+    float $intervalSeconds,
+    private readonly float $forSeconds,
+    ValueRenderer $renderer,
+    array $extensions,
+)
+```
+
+PHPDoc:
+
+- `@param \Closure(): T $probe`
+- `@param list<ExpectationExtension> $extensions`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/ConsistentlyExpectation.php#L23)
 
 ## `EventuallyExpectation`
 
@@ -42,7 +61,28 @@ PHPDoc:
 - `@template T`
 - `@extends TemporalExpectation<T>`
 
-This type does not declare public members.
+### `__construct()`
+
+```php
+public function __construct(
+    \Closure $probe,
+    PollingClock $clock,
+    ?float $attemptDeadline,
+    float $intervalSeconds,
+    private readonly float $withinSeconds,
+    private readonly array $retryOnExceptions,
+    ValueRenderer $renderer,
+    array $extensions,
+)
+```
+
+PHPDoc:
+
+- `@param \Closure(): T $probe`
+- `@param list<class-string<\Exception>> $retryOnExceptions`
+- `@param list<ExpectationExtension> $extensions`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/EventuallyExpectation.php#L25)
 
 ## `Expect`
 
@@ -757,6 +797,14 @@ final class ExpectationFailed extends \Exception
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/ExpectationFailed.php#L17)
 
+### `$details`
+
+```php
+public readonly array $details
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/ExpectationFailed.php#L24)
+
 ### `fromDetail()`
 
 ```php
@@ -826,6 +874,25 @@ PHPDoc:
 
 - `@template T`
 
+### `__construct()`
+
+```php
+public function __construct(
+    private readonly \Closure $probe,
+    private readonly PollingClock $clock,
+    private readonly ?float $attemptDeadline,
+    private readonly ValueRenderer $renderer,
+    private readonly array $extensions,
+)
+```
+
+PHPDoc:
+
+- `@param \Closure(): T $probe`
+- `@param list<ExpectationExtension> $extensions`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingConsistently.php#L22)
+
 ### `pollEvery()`
 
 ```php
@@ -865,6 +932,25 @@ final class PendingEventually
 PHPDoc:
 
 - `@template T`
+
+### `__construct()`
+
+```php
+public function __construct(
+    private readonly \Closure $probe,
+    private readonly PollingClock $clock,
+    private readonly ?float $attemptDeadline,
+    private readonly ValueRenderer $renderer,
+    private readonly array $extensions,
+)
+```
+
+PHPDoc:
+
+- `@param \Closure(): T $probe`
+- `@param list<ExpectationExtension> $extensions`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingEventually.php#L27)
 
 ### `pollEvery()`
 

--- a/docs/api-fixtures-harness.md
+++ b/docs/api-fixtures-harness.md
@@ -66,6 +66,14 @@ final class TempDirectory implements Disposable
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L15)
 
+### `__construct()`
+
+```php
+public function __construct(private readonly ?string $temporaryRoot = null)
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L19)
+
 ### `path()`
 
 ```php
@@ -289,6 +297,18 @@ final readonly class IntegrationResources implements WireSerializable
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/IntegrationResources.php#L18)
 
+### `__construct()`
+
+```php
+public function __construct(private array $fixtures = [])
+```
+
+PHPDoc:
+
+- `@param array<non-empty-string, FixtureResource> $fixtures`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/IntegrationResources.php#L23)
+
 ### `empty()`
 
 ```php
@@ -455,6 +475,22 @@ PHPDoc:
 - `@var class-string`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceDefinition.php#L16)
+
+### `$scope`
+
+```php
+public Scope $scope
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceDefinition.php#L28)
+
+### `$factory`
+
+```php
+public \Closure $factory
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceDefinition.php#L29)
 
 ### `__construct()`
 

--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -20,6 +20,24 @@ final class LaravelPlugin implements HarnessProvider, ServiceResolver, TestLifec
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L24)
 
+### `__construct()`
+
+```php
+public function __construct(
+    string|\Closure $application,
+    private readonly string $env = 'testing',
+    private readonly bool $refreshBetweenTests = true,
+)
+```
+
+PHPDoc:
+
+- `@param string|\Closure(): Application $application A path to the file that returns the application, usually bootstrap/app.php, or a closure returning the application when exotic construction is needed.`
+- `@param non-empty-string $env`
+- `@param bool $refreshBetweenTests Set to false only when no service carries state; tests on one worker then share one unreset application for the worker lifetime.`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L46)
+
 ### `services()`
 
 ```php
@@ -228,6 +246,25 @@ final class SymfonyPlugin implements HarnessProvider, ServiceResolver, TestLifec
 ```
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L29)
+
+### `__construct()`
+
+```php
+public function __construct(
+    string|\Closure $kernel,
+    string $env = 'test',
+    bool $debug = false,
+    private readonly bool $resetBetweenTests = true,
+)
+```
+
+PHPDoc:
+
+- `@param string|\Closure(): KernelInterface $kernel A kernel class name that Greenlight constructs as new $kernel($env, $debug), or a closure that constructs the kernel. Use a closure for other constructor requirements.`
+- `@param non-empty-string $env`
+- `@param bool $resetBetweenTests For a container without stateful services, use false to disable resets. Tests on one worker then share all service instances.`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L52)
 
 ### `services()`
 

--- a/docs/api-plugins.md
+++ b/docs/api-plugins.md
@@ -170,6 +170,14 @@ PHPDoc:
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/IntegrationFixtureDefinition.php#L21)
 
+### `$provision`
+
+```php
+public \Closure $provision
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/IntegrationFixtureDefinition.php#L29)
+
 ### `__construct()`
 
 ```php
@@ -323,6 +331,44 @@ public Attachments $attachments;
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L23)
 
+### `$instance`
+
+```php
+public object $instance
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L26)
+
+### `$id`
+
+```php
+public TestId $id
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L27)
+
+### `$metadata`
+
+```php
+public TestMetadata $metadata
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L28)
+
+### `__construct()`
+
+```php
+public function __construct(
+    public object $instance,
+    public TestId $id,
+    public TestMetadata $metadata,
+    private HarnessScopes $scopes,
+    ?Attachments $attachments = null,
+)
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L25)
+
 ### `service()`
 
 ```php
@@ -407,6 +453,30 @@ final readonly class WorkerBootstrapContext
 ```
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/WorkerBootstrapContext.php#L13)
+
+### `$workerId`
+
+```php
+public string $workerId
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/WorkerBootstrapContext.php#L19)
+
+### `$channel`
+
+```php
+public TestChannel $channel
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/WorkerBootstrapContext.php#L20)
+
+### `$resources`
+
+```php
+public IntegrationResources $resources
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/WorkerBootstrapContext.php#L21)
 
 ### `__construct()`
 

--- a/docs/api-results.md
+++ b/docs/api-results.md
@@ -33,6 +33,30 @@ PHPDoc:
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/CapturedOutput.php#L22)
 
+### `$stdout`
+
+```php
+public string $stdout
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/CapturedOutput.php#L30)
+
+### `$stdoutTruncated`
+
+```php
+public bool $stdoutTruncated
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/CapturedOutput.php#L32)
+
+### `$diagnosticsTruncated`
+
+```php
+public bool $diagnosticsTruncated
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/CapturedOutput.php#L33)
+
 ### `__construct()`
 
 ```php
@@ -94,6 +118,30 @@ PHPDoc:
 - `@var positive-int`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/Diagnostic.php#L21)
+
+### `$severity`
+
+```php
+public DiagnosticSeverity $severity
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/Diagnostic.php#L27)
+
+### `$message`
+
+```php
+public string $message
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/Diagnostic.php#L28)
+
+### `$file`
+
+```php
+public string $file
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/Diagnostic.php#L29)
 
 ### `__construct()`
 
@@ -203,6 +251,30 @@ PHPDoc:
 - `@var non-empty-string`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/FailureDetail.php#L19)
+
+### `$expected`
+
+```php
+public ?string $expected
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/FailureDetail.php#L26)
+
+### `$actual`
+
+```php
+public ?string $actual
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/FailureDetail.php#L27)
+
+### `$location`
+
+```php
+public ?SourceLocation $location
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/FailureDetail.php#L28)
 
 ### `__construct()`
 
@@ -315,6 +387,22 @@ PHPDoc:
 - `@var non-empty-string`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/OutcomeTransformation.php#L16)
+
+### `$from`
+
+```php
+public Outcome $from
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/OutcomeTransformation.php#L23)
+
+### `$to`
+
+```php
+public Outcome $to
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/OutcomeTransformation.php#L24)
 
 ### `__construct()`
 
@@ -588,6 +676,94 @@ PHPDoc:
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/TestResult.php#L32)
 
+### `$id`
+
+```php
+public TestId $id
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/TestResult.php#L42)
+
+### `$outcome`
+
+```php
+public Outcome $outcome
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/TestResult.php#L43)
+
+### `$durationSeconds`
+
+```php
+public float $durationSeconds
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/TestResult.php#L44)
+
+### `$memoryDeltaBytes`
+
+```php
+public int $memoryDeltaBytes
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/TestResult.php#L45)
+
+### `$failures`
+
+```php
+public array $failures
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/TestResult.php#L47)
+
+### `$error`
+
+```php
+public ?ThrowableDetail $error
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/TestResult.php#L48)
+
+### `$skipReason`
+
+```php
+public ?string $skipReason
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/TestResult.php#L49)
+
+### `$transformations`
+
+```php
+public array $transformations
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/TestResult.php#L50)
+
+### `$output`
+
+```php
+public ?CapturedOutput $output
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/TestResult.php#L51)
+
+### `$risky`
+
+```php
+public bool $risky
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/TestResult.php#L52)
+
+### `$attachments`
+
+```php
+public array $attachments
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/TestResult.php#L54)
+
 ### `__construct()`
 
 ```php
@@ -694,6 +870,22 @@ PHPDoc:
 - `@var positive-int`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ThrowableDetail.php#L29)
+
+### `$message`
+
+```php
+public string $message
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ThrowableDetail.php#L38)
+
+### `$stackFrames`
+
+```php
+public array $stackFrames
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ThrowableDetail.php#L41)
 
 ### `__construct()`
 

--- a/docs/api-test-contracts.md
+++ b/docs/api-test-contracts.md
@@ -159,6 +159,14 @@ PHPDoc:
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L24)
 
+### `$dataSetKey`
+
+```php
+public ?string $dataSetKey
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestId.php#L32)
+
 ### `__construct()`
 
 ```php
@@ -287,6 +295,86 @@ PHPDoc:
 - `@var list<non-empty-string>`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L40)
+
+### `$skipReason`
+
+```php
+public ?string $skipReason
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L59)
+
+### `$skipUnlessCondition`
+
+```php
+public ?string $skipUnlessCondition
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L60)
+
+### `$retryTimes`
+
+```php
+public ?int $retryTimes
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L61)
+
+### `$retryOnlyOn`
+
+```php
+public ?string $retryOnlyOn
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L62)
+
+### `$timeoutSeconds`
+
+```php
+public ?float $timeoutSeconds
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L63)
+
+### `$isolated`
+
+```php
+public bool $isolated
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L64)
+
+### `$dataSetProvider`
+
+```php
+public ?string $dataSetProvider
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L65)
+
+### `$capture`
+
+```php
+public bool $capture
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L66)
+
+### `$noExpectations`
+
+```php
+public bool $noExpectations
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L67)
+
+### `$dataSetProviderClass`
+
+```php
+public ?string $dataSetProviderClass
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L70)
 
 ### `__construct()`
 

--- a/src/Config/GreenlightConfig.php
+++ b/src/Config/GreenlightConfig.php
@@ -81,7 +81,8 @@ final class GreenlightConfig
     }
 
     /**
-     * Sets the test-discovery directories for runs without a selected suite.
+     * Sets the top-level test-discovery directories. Greenlight combines these
+     * paths with the paths from all named suites.
      *
      * @param list<string> $tests
      *
@@ -109,9 +110,11 @@ final class GreenlightConfig
     }
 
     /**
-     * Declares a named suite. The configurator receives a `SuiteBuilder`. The
-     * configurator must add at least one path with `in()`. Greenlight ignores the
-     * return value, which permits short arrow functions.
+     * Declares a named suite. Greenlight adds its paths to test discovery.
+     *
+     * The configurator receives a `SuiteBuilder`. It must add at least one path
+     * with `in()`. Greenlight ignores its return value, which permits short
+     * arrow functions.
      *
      * @param callable(SuiteBuilder): mixed $configurator
      *

--- a/tests/Unit/Tools/ApiReferenceGenerationTest.php
+++ b/tests/Unit/Tools/ApiReferenceGenerationTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Tools;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+
+final readonly class ApiReferenceGenerationTest
+{
+    #[Test]
+    public function privatePromotedParametersDoNotHidePublicConstructors(): void
+    {
+        Expect::that($this->reference('api-integrations.md'))
+            ->because('private promoted parameters MUST NOT hide a public constructor')
+            ->toContain(<<<'MARKDOWN'
+                ### `__construct()`
+
+                ```php
+                public function __construct(
+                    string|\Closure $application,
+                    private readonly string $env = 'testing',
+                    private readonly bool $refreshBetweenTests = true,
+                )
+                MARKDOWN);
+    }
+
+    #[Test]
+    public function mixedVisibilityPromotionIncludesPublicProperties(): void
+    {
+        Expect::that($this->reference('api-plugins.md'))
+            ->because('the API reference MUST include each public promoted property')
+            ->toContain('### `$instance`')
+            ->toContain('### `$id`')
+            ->toContain('### `$metadata`')
+            ->not()->toContain('### `$scopes`');
+    }
+
+    private function reference(string $file): string
+    {
+        return (string) \file_get_contents(\dirname(__DIR__, 3) . '/docs/' . $file);
+    }
+}

--- a/website/scripts/generate-api-reference.mjs
+++ b/website/scripts/generate-api-reference.mjs
@@ -43,7 +43,7 @@ const sections = [
     title: 'Test contracts API',
     description: 'This reference lists test metadata, skip signals, conditions, and wire contracts.',
     prefixes: ['Greenlight\\Core\\Test\\', 'Greenlight\\Core\\Wire\\'],
-    names: ['Greenlight\\Core\\AtomicFileError', 'Greenlight\\Core\\Condition'],
+    names: ['Greenlight\\Core\\Condition'],
   },
   {
     id: 'api-expectations',
@@ -353,6 +353,7 @@ function parseMembers(source, tokens, openIndex, closeIndex, typeKind) {
       const endIndex = matchingBrace(tokens, index);
 
       if (isMethod(significant)) {
+        addPromotedProperties(members, source, significant);
         addMember(members, source, significant, token.start, 'method', typeKind);
       } else if (isPublicProperty(significant)) {
         const propertyTokens = [...significant, ...tokens.slice(index, endIndex + 1)];
@@ -458,10 +459,13 @@ function classifySemicolonMember(tokens) {
 function addMember(members, source, tokens, end, kind, typeKind) {
   const docToken = tokens.find((token) => token.kind === 'doc');
   const significant = tokens.filter((token) => token.kind !== 'doc');
+  const visibilityTokens = kind === 'method'
+    ? significant.slice(0, significant.findIndex((token) => token.value === 'function') + 1)
+    : significant;
 
   if (
     significant.length === 0
-    || !isPublic(significant, typeKind)
+    || !isPublic(visibilityTokens, typeKind)
     || (docToken?.value.includes('@internal') ?? false)
   ) {
     return;
@@ -482,6 +486,68 @@ function addMember(members, source, tokens, end, kind, typeKind) {
     line: lineAt(source, first.start),
     doc: parseDoc(docToken?.value),
     signature,
+  });
+}
+
+function addPromotedProperties(members, source, tokens) {
+  const functionIndex = tokens.findIndex((token) => token.value === 'function');
+  const name = tokens.slice(functionIndex + 1).find((token) => token.kind === 'word');
+
+  if (name?.value !== '__construct') {
+    return;
+  }
+
+  const openIndex = tokens.findIndex((token, index) => index > functionIndex && token.value === '(');
+
+  if (openIndex === -1) {
+    return;
+  }
+
+  let depth = 0;
+  let parameterStart = openIndex + 1;
+
+  for (let index = parameterStart; index < tokens.length; index += 1) {
+    const token = tokens[index];
+
+    if (['(', '[', '{'].includes(token.value)) {
+      depth += 1;
+      continue;
+    }
+
+    if (token.value === ')' && depth === 0) {
+      addPromotedProperty(members, source, tokens.slice(parameterStart, index));
+      return;
+    }
+
+    if ([')', ']', '}'].includes(token.value)) {
+      depth -= 1;
+      continue;
+    }
+
+    if (token.value === ',' && depth === 0) {
+      addPromotedProperty(members, source, tokens.slice(parameterStart, index));
+      parameterStart = index + 1;
+    }
+  }
+}
+
+function addPromotedProperty(members, source, tokens) {
+  const docToken = tokens.find((token) => token.kind === 'doc');
+  const significant = tokens.filter((token) => token.kind !== 'doc');
+  const variable = significant.find((token) => token.kind === 'variable');
+
+  if (variable === undefined || !significant.some((token) => token.value === 'public')) {
+    return;
+  }
+
+  const first = significant[0];
+
+  members.push({
+    name: variable.value,
+    kind: 'property',
+    line: lineAt(source, first.start),
+    doc: parseDoc(docToken?.value),
+    signature: normalizeSignature(source.slice(first.start, variable.end), columnAt(source, first.start)),
   });
 }
 


### PR DESCRIPTION
## Summary

- preserve public constructor detection when parameters use non-public promotion
- document public promoted properties and remove the stale AtomicFileError allowlist entry
- clarify suite path discovery and regenerate the API reference