### PR TITLE
refactor(test): centralize scheduler fixtures

### DIFF
--- a/tests/Support/SchedulingFixture.php
+++ b/tests/Support/SchedulingFixture.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Support;
+
+use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Discovery\ExecutionPlan;
+use Greenlight\Discovery\PlanEntry;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Runner\Orchestrator\DispatchKind;
+use Greenlight\Runner\Orchestrator\ResourceLease;
+use Greenlight\Runner\Orchestrator\ResourceScheduler;
+use Greenlight\Runner\Orchestrator\SchedulingUnit;
+
+/**
+ * Creates one-test scheduling units and verifies scheduler assignments.
+ *
+ * @internal
+ */
+final class SchedulingFixture
+{
+    private function __construct() {}
+
+    /**
+     * @param non-empty-string $class
+     * @param list<non-empty-string> $resources
+     */
+    public static function unit(string $class, array $resources = [], bool $isolated = false): SchedulingUnit
+    {
+        $id = new TestId($class, 'runs');
+
+        return new SchedulingUnit(new ExecutionPlan([
+            new PlanEntry($id, new TestMetadata($class, 'runs', resources: $resources)),
+        ]), $isolated);
+    }
+
+    public static function assignedLease(ResourceScheduler $scheduler, bool $freshWorker = true): ResourceLease
+    {
+        $decision = $scheduler->dispatch($freshWorker);
+
+        Expect::that($decision->kind)
+            ->because('the scheduling fixture requires an assignment')
+            ->toBe(DispatchKind::Assign);
+
+        if (!$decision->lease instanceof ResourceLease) {
+            Fail::because(\sprintf('Expected an assignment, got %s.', $decision->kind->name));
+        }
+
+        return $decision->lease;
+    }
+}

--- a/tests/Unit/Runner/Orchestrator/DispatchDecisionTest.php
+++ b/tests/Unit/Runner/Orchestrator/DispatchDecisionTest.php
@@ -6,22 +6,18 @@ namespace Greenlight\Tests\Unit\Runner\Orchestrator;
 
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
-use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\Orchestrator\DispatchDecision;
 use Greenlight\Runner\Orchestrator\DispatchKind;
 use Greenlight\Runner\Orchestrator\ResourceLease;
-use Greenlight\Runner\Orchestrator\SchedulingUnit;
+use Greenlight\Tests\Support\SchedulingFixture;
 
 final readonly class DispatchDecisionTest
 {
     #[Test]
     public function assignmentCarriesItsExactLease(): void
     {
-        $lease = new ResourceLease(41, $this->unit());
+        $lease = new ResourceLease(41, SchedulingFixture::unit('Acme\\ExampleTest'));
         $decision = DispatchDecision::assign($lease);
 
         Expect::that($decision->kind)
@@ -59,12 +55,4 @@ final readonly class DispatchDecisionTest
         yield 'drain' => ['drain', DispatchKind::Drain];
     }
 
-    private function unit(): SchedulingUnit
-    {
-        $id = new TestId('Acme\\ExampleTest', 'runs');
-
-        return new SchedulingUnit(new ExecutionPlan([
-            new PlanEntry($id, new TestMetadata($id->class, $id->method)),
-        ]), isolated: false);
-    }
 }

--- a/tests/Unit/Runner/Orchestrator/ResourceLeaseIdentityTest.php
+++ b/tests/Unit/Runner/Orchestrator/ResourceLeaseIdentityTest.php
@@ -5,33 +5,27 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner\Orchestrator;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
-use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
 use Greenlight\Runner\Orchestrator\DispatchKind;
-use Greenlight\Runner\Orchestrator\ResourceLease;
 use Greenlight\Runner\Orchestrator\ResourceScheduler;
-use Greenlight\Runner\Orchestrator\SchedulingUnit;
+use Greenlight\Tests\Support\SchedulingFixture;
 
 final readonly class ResourceLeaseIdentityTest
 {
     #[Test]
     public function concurrentLeasesHaveDistinctIdentityAndReleaseIndependently(): void
     {
-        $thirdUnit = $this->unit('Acme\\ThirdTest');
-        $fourthUnit = $this->unit('Acme\\FourthTest');
+        $thirdUnit = SchedulingFixture::unit('Acme\\ThirdTest', ['database']);
+        $fourthUnit = SchedulingFixture::unit('Acme\\FourthTest', ['database']);
         $scheduler = new ResourceScheduler([
-            $this->unit('Acme\\FirstTest'),
-            $this->unit('Acme\\SecondTest'),
+            SchedulingFixture::unit('Acme\\FirstTest', ['database']),
+            SchedulingFixture::unit('Acme\\SecondTest', ['database']),
             $thirdUnit,
             $fourthUnit,
         ], [], ['database' => 2]);
 
-        $first = $this->assigned($scheduler);
-        $second = $this->assigned($scheduler);
+        $first = SchedulingFixture::assignedLease($scheduler);
+        $second = SchedulingFixture::assignedLease($scheduler);
 
         Expect::that($first->id)
             ->because('the first resource lease MUST use the first lease ID')
@@ -46,7 +40,7 @@ final readonly class ResourceLeaseIdentityTest
 
         $scheduler->release($first);
 
-        Expect::that($this->assigned($scheduler)->unit)
+        Expect::that(SchedulingFixture::assignedLease($scheduler)->unit)
             ->because('the first release MUST restore one resource slot')
             ->toBe($thirdUnit);
         Expect::that($scheduler->dispatch(true)->kind)
@@ -55,31 +49,9 @@ final readonly class ResourceLeaseIdentityTest
 
         $scheduler->release($second);
 
-        Expect::that($this->assigned($scheduler)->unit)
+        Expect::that(SchedulingFixture::assignedLease($scheduler)->unit)
             ->because('the second release MUST independently restore one resource slot')
             ->toBe($fourthUnit);
     }
 
-    /**
-     * @param non-empty-string $class
-     */
-    private function unit(string $class): SchedulingUnit
-    {
-        $id = new TestId($class, 'runs');
-
-        return new SchedulingUnit(new ExecutionPlan([
-            new PlanEntry($id, new TestMetadata($class, 'runs', resources: ['database'])),
-        ]), false);
-    }
-
-    private function assigned(ResourceScheduler $scheduler): ResourceLease
-    {
-        $decision = $scheduler->dispatch(true);
-
-        if (!$decision->lease instanceof ResourceLease) {
-            Fail::because(\sprintf('Expected an assignment, got %s.', $decision->kind->name));
-        }
-
-        return $decision->lease;
-    }
 }

--- a/tests/Unit/Runner/Orchestrator/ResourceSchedulerLeaseIdentityTest.php
+++ b/tests/Unit/Runner/Orchestrator/ResourceSchedulerLeaseIdentityTest.php
@@ -5,25 +5,20 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner\Orchestrator;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
-use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
 use Greenlight\Runner\Orchestrator\ResourceLease;
 use Greenlight\Runner\Orchestrator\ResourceScheduler;
-use Greenlight\Runner\Orchestrator\SchedulingUnit;
+use Greenlight\Tests\Support\SchedulingFixture;
 
 final readonly class ResourceSchedulerLeaseIdentityTest
 {
     #[Test]
     public function aLeaseIdDoesNotAuthorizeADifferentLeaseObject(): void
     {
-        $first = $this->unit('Acme\\FirstTest');
-        $second = $this->unit('Acme\\SecondTest');
+        $first = SchedulingFixture::unit('Acme\\FirstTest', ['database']);
+        $second = SchedulingFixture::unit('Acme\\SecondTest', ['database']);
         $scheduler = new ResourceScheduler([$first, $second], [], []);
-        $lease = $this->assigned($scheduler);
+        $lease = SchedulingFixture::assignedLease($scheduler);
         $forged = new ResourceLease($lease->id, $lease->unit);
 
         Expect::that(static fn() => $scheduler->release($forged))
@@ -38,31 +33,9 @@ final readonly class ResourceSchedulerLeaseIdentityTest
             ->not()
             ->toThrow(\Throwable::class);
 
-        Expect::that($this->assigned($scheduler)->unit)
+        Expect::that(SchedulingFixture::assignedLease($scheduler)->unit)
             ->because('the real lease MUST release its resource slot')
             ->toBe($second);
     }
 
-    /**
-     * @param non-empty-string $class
-     */
-    private function unit(string $class): SchedulingUnit
-    {
-        $id = new TestId($class, 'runs');
-
-        return new SchedulingUnit(new ExecutionPlan([
-            new PlanEntry($id, new TestMetadata($class, 'runs', resources: ['database'])),
-        ]), isolated: false);
-    }
-
-    private function assigned(ResourceScheduler $scheduler): ResourceLease
-    {
-        $decision = $scheduler->dispatch(freshWorker: true);
-
-        if (!$decision->lease instanceof ResourceLease) {
-            Fail::because(\sprintf('Expected an assignment, got %s.', $decision->kind->name));
-        }
-
-        return $decision->lease;
-    }
 }

--- a/tests/Unit/Runner/Orchestrator/ResourceSchedulerPendingTest.php
+++ b/tests/Unit/Runner/Orchestrator/ResourceSchedulerPendingTest.php
@@ -5,32 +5,26 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner\Orchestrator;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
-use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
 use Greenlight\Runner\Orchestrator\DispatchKind;
-use Greenlight\Runner\Orchestrator\ResourceLease;
 use Greenlight\Runner\Orchestrator\ResourceScheduler;
-use Greenlight\Runner\Orchestrator\SchedulingUnit;
+use Greenlight\Tests\Support\SchedulingFixture;
 
 final class ResourceSchedulerPendingTest
 {
     #[Test]
     public function clearingPendingWorkPreservesActiveLeasesAndAllowsRequeue(): void
     {
-        $active = $this->unit('ActiveTest', ['database']);
-        $queued = $this->unit('QueuedTest', ['database']);
-        $isolated = $this->unit('IsolatedTest', ['browser'], isolated: true);
+        $active = SchedulingFixture::unit('ActiveTest', ['database']);
+        $queued = SchedulingFixture::unit('QueuedTest', ['database']);
+        $isolated = SchedulingFixture::unit('IsolatedTest', ['browser'], isolated: true);
         $scheduler = new ResourceScheduler([$active, $queued], [$isolated], []);
 
         Expect::that($scheduler->pendingCount())
             ->because('pending count MUST include pooled and isolated work')
             ->toBe(3);
 
-        $lease = $this->assigned($scheduler);
+        $lease = SchedulingFixture::assignedLease($scheduler);
 
         Expect::that($scheduler->pendingCount())
             ->because('assignment MUST remove one pending unit')
@@ -49,31 +43,7 @@ final class ResourceSchedulerPendingTest
         Expect::that($scheduler->pendingCount())
             ->because('pooled work can be requeued after pending work is cleared')
             ->toBe(1);
-        Expect::that($this->assigned($scheduler, fresh: false)->unit)->toBe($queued);
+        Expect::that(SchedulingFixture::assignedLease($scheduler, freshWorker: false)->unit)->toBe($queued);
         Expect::that($scheduler->pendingCount())->toBe(0);
-    }
-
-    /**
-     * @param non-empty-string $class
-     * @param list<non-empty-string> $resources
-     */
-    private function unit(string $class, array $resources, bool $isolated = false): SchedulingUnit
-    {
-        $id = new TestId($class, 'runs');
-
-        return new SchedulingUnit(new ExecutionPlan([
-            new PlanEntry($id, new TestMetadata($class, 'runs', resources: $resources)),
-        ]), $isolated);
-    }
-
-    private function assigned(ResourceScheduler $scheduler, bool $fresh = true): ResourceLease
-    {
-        $decision = $scheduler->dispatch($fresh);
-
-        if (!$decision->lease instanceof ResourceLease) {
-            Fail::because(\sprintf('Expected an assignment, got %s.', $decision->kind->name));
-        }
-
-        return $decision->lease;
     }
 }

--- a/tests/Unit/Runner/Orchestrator/ResourceSchedulerQueuePriorityTest.php
+++ b/tests/Unit/Runner/Orchestrator/ResourceSchedulerQueuePriorityTest.php
@@ -5,30 +5,24 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner\Orchestrator;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
-use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
 use Greenlight\Runner\Orchestrator\DispatchKind;
-use Greenlight\Runner\Orchestrator\ResourceLease;
 use Greenlight\Runner\Orchestrator\ResourceScheduler;
-use Greenlight\Runner\Orchestrator\SchedulingUnit;
+use Greenlight\Tests\Support\SchedulingFixture;
 
 final readonly class ResourceSchedulerQueuePriorityTest
 {
     #[Test]
     public function pooledWorkPrecedesIsolatedWork(): void
     {
-        $pooled = $this->unit('Acme\\PooledTest', isolated: false);
-        $isolated = $this->unit('Acme\\IsolatedTest', isolated: true);
+        $pooled = SchedulingFixture::unit('Acme\\PooledTest', isolated: false);
+        $isolated = SchedulingFixture::unit('Acme\\IsolatedTest', isolated: true);
         $scheduler = new ResourceScheduler([$pooled], [$isolated], []);
 
-        $pooledLease = $this->assigned($scheduler, freshWorker: true);
+        $pooledLease = SchedulingFixture::assignedLease($scheduler, freshWorker: true);
         $scheduler->release($pooledLease);
         $staleWorkerDecision = $scheduler->dispatch(false);
-        $isolatedLease = $this->assigned($scheduler, freshWorker: true);
+        $isolatedLease = SchedulingFixture::assignedLease($scheduler, freshWorker: true);
 
         Expect::that($pooledLease->unit->plan->classes())
             ->because('pooled work MUST run before isolated work')
@@ -41,26 +35,4 @@ final readonly class ResourceSchedulerQueuePriorityTest
             ->toBe(['Acme\\IsolatedTest']);
     }
 
-    /**
-     * @param non-empty-string $class
-     */
-    private function unit(string $class, bool $isolated): SchedulingUnit
-    {
-        $id = new TestId($class, 'runs');
-
-        return new SchedulingUnit(new ExecutionPlan([
-            new PlanEntry($id, new TestMetadata($class, 'runs')),
-        ]), $isolated);
-    }
-
-    private function assigned(ResourceScheduler $scheduler, bool $freshWorker): ResourceLease
-    {
-        $decision = $scheduler->dispatch($freshWorker);
-
-        if (!$decision->lease instanceof ResourceLease) {
-            Fail::because(\sprintf('Expected an assignment, got %s.', $decision->kind->name));
-        }
-
-        return $decision->lease;
-    }
 }

--- a/tests/Unit/Runner/Orchestrator/ResourceSchedulerRequeueOrderTest.php
+++ b/tests/Unit/Runner/Orchestrator/ResourceSchedulerRequeueOrderTest.php
@@ -6,15 +6,9 @@ namespace Greenlight\Tests\Unit\Runner\Orchestrator;
 
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
-use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
-use Greenlight\Runner\Orchestrator\ResourceLease;
 use Greenlight\Runner\Orchestrator\ResourceScheduler;
-use Greenlight\Runner\Orchestrator\SchedulingUnit;
+use Greenlight\Tests\Support\SchedulingFixture;
 
 final readonly class ResourceSchedulerRequeueOrderTest
 {
@@ -22,8 +16,8 @@ final readonly class ResourceSchedulerRequeueOrderTest
     #[DataSet('queueKinds')]
     public function requeuedWorkAppendsBehindPendingWork(bool $isolated, bool $freshWorker): void
     {
-        $pending = $this->unit('Acme\\PendingTest', $isolated);
-        $requeued = $this->unit('Acme\\RetriedTest', $isolated);
+        $pending = SchedulingFixture::unit('Acme\\PendingTest', ['database'], $isolated);
+        $requeued = SchedulingFixture::unit('Acme\\RetriedTest', ['database'], $isolated);
         $scheduler = new ResourceScheduler(
             $isolated ? [] : [$pending],
             $isolated ? [$pending] : [],
@@ -31,9 +25,9 @@ final readonly class ResourceSchedulerRequeueOrderTest
         );
         $scheduler->requeue($requeued);
 
-        $first = $this->assigned($scheduler, $freshWorker);
+        $first = SchedulingFixture::assignedLease($scheduler, $freshWorker);
         $scheduler->release($first);
-        $second = $this->assigned($scheduler, $freshWorker);
+        $second = SchedulingFixture::assignedLease($scheduler, $freshWorker);
 
         Expect::that($first->unit->plan->classes())
             ->because('pending work MUST remain first in its queue')
@@ -52,26 +46,4 @@ final readonly class ResourceSchedulerRequeueOrderTest
         yield 'isolated queue' => [true, true];
     }
 
-    /**
-     * @param non-empty-string $class
-     */
-    private function unit(string $class, bool $isolated): SchedulingUnit
-    {
-        $id = new TestId($class, 'runs');
-
-        return new SchedulingUnit(new ExecutionPlan([
-            new PlanEntry($id, new TestMetadata($class, 'runs', resources: ['database'])),
-        ]), $isolated);
-    }
-
-    private function assigned(ResourceScheduler $scheduler, bool $freshWorker): ResourceLease
-    {
-        $decision = $scheduler->dispatch($freshWorker);
-
-        if (!$decision->lease instanceof ResourceLease) {
-            Fail::because(\sprintf('Expected an assignment, got %s.', $decision->kind->name));
-        }
-
-        return $decision->lease;
-    }
 }

--- a/tests/Unit/Runner/Orchestrator/ResourceSchedulerTest.php
+++ b/tests/Unit/Runner/Orchestrator/ResourceSchedulerTest.php
@@ -5,15 +5,10 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner\Orchestrator;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
-use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\Orchestrator\DispatchKind;
-use Greenlight\Runner\Orchestrator\ResourceLease;
 use Greenlight\Runner\Orchestrator\ResourceScheduler;
-use Greenlight\Runner\Orchestrator\SchedulingUnit;
+use Greenlight\Tests\Support\SchedulingFixture;
 
 final class ResourceSchedulerTest
 {
@@ -21,30 +16,30 @@ final class ResourceSchedulerTest
     public function unconfiguredResourcesAreExclusive(): void
     {
         $scheduler = new ResourceScheduler([
-            $this->unit('FirstTest', ['postgres']),
-            $this->unit('SecondTest', ['postgres']),
+            SchedulingFixture::unit('FirstTest', ['postgres']),
+            SchedulingFixture::unit('SecondTest', ['postgres']),
         ], [], []);
 
-        $first = $this->assigned($scheduler);
+        $first = SchedulingFixture::assignedLease($scheduler);
 
         Expect::that($scheduler->dispatch(true)->kind)->because('unconfigured resources are exclusive')->toBe(DispatchKind::Wait);
 
         $scheduler->release($first);
 
-        Expect::that($this->assigned($scheduler)->unit->plan->classes())->because('unconfigured resources are exclusive')->toBe(['SecondTest']);
+        Expect::that(SchedulingFixture::assignedLease($scheduler)->unit->plan->classes())->because('unconfigured resources are exclusive')->toBe(['SecondTest']);
     }
 
     #[Test]
     public function configuredLimitsPermitThatManyConcurrentLeases(): void
     {
         $scheduler = new ResourceScheduler([
-            $this->unit('FirstTest', ['postgres']),
-            $this->unit('SecondTest', ['postgres']),
-            $this->unit('ThirdTest', ['postgres']),
+            SchedulingFixture::unit('FirstTest', ['postgres']),
+            SchedulingFixture::unit('SecondTest', ['postgres']),
+            SchedulingFixture::unit('ThirdTest', ['postgres']),
         ], [], ['postgres' => 2]);
 
-        $this->assigned($scheduler);
-        $this->assigned($scheduler);
+        SchedulingFixture::assignedLease($scheduler);
+        SchedulingFixture::assignedLease($scheduler);
 
         Expect::that($scheduler->dispatch(true)->kind)->because('configured limits permit that many concurrent leases')->toBe(DispatchKind::Wait);
     }
@@ -53,92 +48,70 @@ final class ResourceSchedulerTest
     public function oldestBlockedUnitReservesItsResourcesButDisjointWorkCanBypassIt(): void
     {
         $scheduler = new ResourceScheduler([
-            $this->unit('BHoldingTest', ['b']),
-            $this->unit('NeedsBothTest', ['a', 'b']),
-            $this->unit('NeedsATest', ['a']),
-            $this->unit('DisjointTest', ['c']),
+            SchedulingFixture::unit('BHoldingTest', ['b']),
+            SchedulingFixture::unit('NeedsBothTest', ['a', 'b']),
+            SchedulingFixture::unit('NeedsATest', ['a']),
+            SchedulingFixture::unit('DisjointTest', ['c']),
         ], [], []);
 
-        $holdingB = $this->assigned($scheduler);
-        $disjoint = $this->assigned($scheduler);
+        $holdingB = SchedulingFixture::assignedLease($scheduler);
+        $disjoint = SchedulingFixture::assignedLease($scheduler);
 
         Expect::that($disjoint->unit->plan->classes())->because('oldest blocked unit reserves its resources but disjoint work can bypass it')->toBe(['DisjointTest']);
         Expect::that($scheduler->dispatch(true)->kind)->because('oldest blocked unit reserves its resources but disjoint work can bypass it')->toBe(DispatchKind::Wait);
 
         $scheduler->release($holdingB);
 
-        Expect::that($this->assigned($scheduler)->unit->plan->classes())->because('oldest blocked unit reserves its resources but disjoint work can bypass it')->toBe(['NeedsBothTest']);
+        Expect::that(SchedulingFixture::assignedLease($scheduler)->unit->plan->classes())->because('oldest blocked unit reserves its resources but disjoint work can bypass it')->toBe(['NeedsBothTest']);
     }
 
     #[Test]
     public function workCanUseCapacityBeyondTheOldestBlockedUnitReservation(): void
     {
         $scheduler = new ResourceScheduler([
-            $this->unit('BHoldingTest', ['b']),
-            $this->unit('NeedsBothTest', ['a', 'b']),
-            $this->unit('FirstNeedsATest', ['a']),
-            $this->unit('SecondNeedsATest', ['a']),
+            SchedulingFixture::unit('BHoldingTest', ['b']),
+            SchedulingFixture::unit('NeedsBothTest', ['a', 'b']),
+            SchedulingFixture::unit('FirstNeedsATest', ['a']),
+            SchedulingFixture::unit('SecondNeedsATest', ['a']),
         ], [], ['a' => 2]);
 
-        $this->assigned($scheduler);
+        SchedulingFixture::assignedLease($scheduler);
 
-        Expect::that($this->assigned($scheduler)->unit->plan->classes())->because('work can use capacity beyond the oldest blocked unit reservation')->toBe(['FirstNeedsATest']);
+        Expect::that(SchedulingFixture::assignedLease($scheduler)->unit->plan->classes())->because('work can use capacity beyond the oldest blocked unit reservation')->toBe(['FirstNeedsATest']);
         Expect::that($scheduler->dispatch(true)->kind)->because('work can use capacity beyond the oldest blocked unit reservation')->toBe(DispatchKind::Wait);
     }
 
     #[Test]
     public function isolatedUnitsNeedAFreshWorkerAndRunAfterThePooledQueue(): void
     {
-        $isolated = $this->unit('IsolatedTest', ['database'], isolated: true);
+        $isolated = SchedulingFixture::unit('IsolatedTest', ['database'], isolated: true);
         $scheduler = new ResourceScheduler([], [$isolated], []);
 
         Expect::that($scheduler->dispatch(false)->kind)->because('isolated units need a fresh worker and run after the pooled queue')->toBe(DispatchKind::Drain);
-        Expect::that($this->assigned($scheduler, fresh: true)->unit)->because('isolated units need a fresh worker and run after the pooled queue')->toBe($isolated);
+        Expect::that(SchedulingFixture::assignedLease($scheduler, freshWorker: true)->unit)->because('isolated units need a fresh worker and run after the pooled queue')->toBe($isolated);
     }
 
     #[Test]
     public function requeuedIsolatedUnitsStillNeedAFreshWorker(): void
     {
-        $isolated = $this->unit('IsolatedTest', ['database'], isolated: true);
+        $isolated = SchedulingFixture::unit('IsolatedTest', ['database'], isolated: true);
         $scheduler = new ResourceScheduler([], [], []);
 
         $scheduler->requeue($isolated);
 
         Expect::that($scheduler->dispatch(false)->kind)->because('requeued isolated units still need a fresh worker')->toBe(DispatchKind::Drain);
-        Expect::that($this->assigned($scheduler, fresh: true)->unit)->because('requeued isolated units still need a fresh worker')->toBe($isolated);
+        Expect::that(SchedulingFixture::assignedLease($scheduler, freshWorker: true)->unit)->because('requeued isolated units still need a fresh worker')->toBe($isolated);
     }
 
     #[Test]
     public function releasedLeasesCannotBeReleasedTwice(): void
     {
-        $scheduler = new ResourceScheduler([$this->unit('OnlyTest', ['database'])], [], []);
-        $lease = $this->assigned($scheduler);
+        $scheduler = new ResourceScheduler([SchedulingFixture::unit('OnlyTest', ['database'])], [], []);
+        $lease = SchedulingFixture::assignedLease($scheduler);
         $scheduler->release($lease);
 
         Expect::that(static fn() => $scheduler->release($lease))->because('released leases cannot be released twice')
             ->toThrow(\LogicException::class, matching: '/already been released/');
     }
 
-    /**
-     * @param non-empty-string $class
-     * @param list<non-empty-string> $resources
-     */
-    private function unit(string $class, array $resources, bool $isolated = false): SchedulingUnit
-    {
-        $id = new TestId($class, 'runs');
-
-        return new SchedulingUnit(new ExecutionPlan([
-            new PlanEntry($id, new TestMetadata($class, 'runs', resources: $resources)),
-        ]), $isolated);
-    }
-
-    private function assigned(ResourceScheduler $scheduler, bool $fresh = true): ResourceLease
-    {
-        $decision = $scheduler->dispatch($fresh);
-
-        Expect::that($decision->kind)->toBe(DispatchKind::Assign);
-        \assert($decision->lease instanceof ResourceLease);
-
-        return $decision->lease;
-    }
 }


### PR DESCRIPTION
## Summary

- add a shared scheduling fixture for one-test units and verified assignments
- remove duplicated scheduler setup and dispatch guards from seven test modules
- preserve direct construction in SchedulingUnitTest, where construction is the behavior under test
- reduce the affected test code by 126 net lines