### PR TITLE
refactor: replace generic runtime exceptions

### DIFF
--- a/docs/api-fixtures-harness.md
+++ b/docs/api-fixtures-harness.md
@@ -72,7 +72,11 @@ final class TempDirectory implements Disposable
 public function path(): string
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L21)
+PHPDoc:
+
+- `@throws TempDirectoryError`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L22)
 
 ### `subdirectory()`
 
@@ -84,6 +88,8 @@ PHPDoc:
 
 - `@param string $name A relative path of plain segments. The path can contain separators but cannot contain traversal segments.`
 - `@return non-empty-string`
+- `@throws \InvalidArgumentException`
+- `@throws TempDirectoryError`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L49)
 
@@ -94,7 +100,71 @@ PHPDoc:
 public function dispose(): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L97)
+PHPDoc:
+
+- `@throws TempDirectoryError`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L92)
+
+## `TempDirectoryError`
+
+Namespace: `Greenlight\Fixture`
+
+A temporary-directory operation cannot create, validate, or remove a path.
+
+```php
+final class TempDirectoryError extends \RuntimeException
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectoryError.php#L10)
+
+### `rootCreationFailed()`
+
+```php
+public static function rootCreationFailed(string $path, ?string $warning): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectoryError.php#L17)
+
+### `subdirectoryCreationFailed()`
+
+```php
+public static function subdirectoryCreationFailed(string $path, ?string $warning): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectoryError.php#L26)
+
+### `symbolicLink()`
+
+```php
+public static function symbolicLink(string $path): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectoryError.php#L35)
+
+### `rootLinkRemovalFailed()`
+
+```php
+public static function rootLinkRemovalFailed(string $path, ?string $warning): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectoryError.php#L40)
+
+### `entryRemovalFailed()`
+
+```php
+public static function entryRemovalFailed(string $entry, string $root): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectoryError.php#L49)
+
+### `rootRemovalFailed()`
+
+```php
+public static function rootRemovalFailed(string $path, ?string $warning): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectoryError.php#L54)
 
 ## `Disposable`
 

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -21,10 +21,12 @@ parameters:
             - Greenlight\Discovery\DiscoveryError
             - Greenlight\Doubles\DoublesError
             - Greenlight\Expect\ExpectationFailed
+            - Greenlight\Fixture\TempDirectoryError
             - Greenlight\Harness\ServiceResolutionError
             - Greenlight\PhpStan\MatcherMapError
             - Greenlight\Reporting\ReportingError
             - Greenlight\Runner\Integration\IntegrationFixtureError
+            - Greenlight\Runner\Worker\WorkerError
         check:
             missingCheckedExceptionInThrows: true
             throwTypeCovariance: true

--- a/src/Fixture/TempDirectory.php
+++ b/src/Fixture/TempDirectory.php
@@ -18,6 +18,7 @@ final class TempDirectory implements Disposable
 
     public function __construct(private readonly ?string $temporaryRoot = null) {}
 
+    /** @throws TempDirectoryError */
     public function path(): string
     {
         if ($this->path === null) {
@@ -27,11 +28,7 @@ final class TempDirectory implements Disposable
             $path = $temporaryRoot . '/greenlight-' . \bin2hex(\random_bytes(8));
 
             if (!ErrorTrap::run(static fn(): bool => \mkdir($path, 0700), $warning)) {
-                throw new \RuntimeException(\sprintf(
-                    'Failed to create temp directory "%s"%s.',
-                    $path,
-                    $warning === null ? '' : ': ' . $warning,
-                ));
+                throw TempDirectoryError::rootCreationFailed($path, $warning);
             }
 
             $this->path = $path;
@@ -45,6 +42,9 @@ final class TempDirectory implements Disposable
      *   contain separators but cannot contain traversal segments.
      *
      * @return non-empty-string
+     *
+     * @throws \InvalidArgumentException
+     * @throws TempDirectoryError
      */
     public function subdirectory(string $name): string
     {
@@ -74,26 +74,21 @@ final class TempDirectory implements Disposable
         $path = $root . '/' . $name;
 
         if (!\is_dir($path) && !ErrorTrap::run(static fn(): bool => \mkdir($path, 0700, true), $warning)) {
-            throw new \RuntimeException(\sprintf(
-                'Failed to create subdirectory "%s"%s.',
-                $path,
-                $warning === null ? '' : ': ' . $warning,
-            ));
+            throw TempDirectoryError::subdirectoryCreationFailed($path, $warning);
         }
 
         return $path;
     }
 
+    /** @throws TempDirectoryError */
     private function assertNotSymbolicLink(string $path): void
     {
         if (\is_link($path)) {
-            throw new \RuntimeException(\sprintf(
-                'Subdirectory path "%s" contains a symbolic link.',
-                $path,
-            ));
+            throw TempDirectoryError::symbolicLink($path);
         }
     }
 
+    /** @throws TempDirectoryError */
     #[\Override]
     public function dispose(): void
     {
@@ -105,11 +100,7 @@ final class TempDirectory implements Disposable
 
         if (\is_link($path)) {
             if (!ErrorTrap::run(static fn(): bool => \unlink($path), $warning)) {
-                throw new \RuntimeException(\sprintf(
-                    'Failed to remove temp directory symbolic link "%s"%s.',
-                    $path,
-                    $warning === null ? '' : ': ' . $warning,
-                ));
+                throw TempDirectoryError::rootLinkRemovalFailed($path, $warning);
             }
 
             $this->path = null;
@@ -135,17 +126,13 @@ final class TempDirectory implements Disposable
                 $removed = !$entry->isLink() && $entry->isDir() ? \rmdir($pathname) : \unlink($pathname);
 
                 if (!$removed) {
-                    throw new \RuntimeException(\sprintf('Failed to remove "%s" while disposing temp directory "%s".', $pathname, $path));
+                    throw TempDirectoryError::entryRemovalFailed($pathname, $path);
                 }
             }
         });
 
         if (!ErrorTrap::run(static fn(): bool => \rmdir($path), $warning)) {
-            throw new \RuntimeException(\sprintf(
-                'Failed to remove temp directory "%s"%s.',
-                $path,
-                $warning === null ? '' : ': ' . $warning,
-            ));
+            throw TempDirectoryError::rootRemovalFailed($path, $warning);
         }
 
         $this->path = null;

--- a/src/Fixture/TempDirectoryError.php
+++ b/src/Fixture/TempDirectoryError.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Fixture;
+
+/**
+ * A temporary-directory operation cannot create, validate, or remove a path.
+ */
+final class TempDirectoryError extends \RuntimeException
+{
+    private function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+
+    public static function rootCreationFailed(string $path, ?string $warning): self
+    {
+        return new self(\sprintf(
+            'Failed to create temp directory "%s"%s.',
+            $path,
+            $warning === null ? '' : ': ' . $warning,
+        ));
+    }
+
+    public static function subdirectoryCreationFailed(string $path, ?string $warning): self
+    {
+        return new self(\sprintf(
+            'Failed to create subdirectory "%s"%s.',
+            $path,
+            $warning === null ? '' : ': ' . $warning,
+        ));
+    }
+
+    public static function symbolicLink(string $path): self
+    {
+        return new self(\sprintf('Subdirectory path "%s" contains a symbolic link.', $path));
+    }
+
+    public static function rootLinkRemovalFailed(string $path, ?string $warning): self
+    {
+        return new self(\sprintf(
+            'Failed to remove temp directory symbolic link "%s"%s.',
+            $path,
+            $warning === null ? '' : ': ' . $warning,
+        ));
+    }
+
+    public static function entryRemovalFailed(string $entry, string $root): self
+    {
+        return new self(\sprintf('Failed to remove "%s" while disposing temp directory "%s".', $entry, $root));
+    }
+
+    public static function rootRemovalFailed(string $path, ?string $warning): self
+    {
+        return new self(\sprintf(
+            'Failed to remove temp directory "%s"%s.',
+            $path,
+            $warning === null ? '' : ': ' . $warning,
+        ));
+    }
+}

--- a/src/Runner/Orchestrator/Orchestrator.php
+++ b/src/Runner/Orchestrator/Orchestrator.php
@@ -46,6 +46,7 @@ use Greenlight\Runner\Protocol\Messages\Recycling;
 use Greenlight\Runner\Protocol\ProtocolError;
 use Greenlight\Runner\Protocol\SocketChannel;
 use Greenlight\Runner\Worker\EventSink;
+use Greenlight\Runner\Worker\WorkerError;
 
 /**
  * Workers request test classes when required. Isolated entries use new
@@ -838,18 +839,17 @@ final class Orchestrator
 
         if ($inFlight instanceof TestId) {
             $diagnostics = \trim($handle->diagnostics);
-            $message = \sprintf('Worker "%s" crashed during this test: %s.', $handle->workerId, $reason);
-
-            if ($diagnostics !== '') {
-                $message .= "\nWorker output:\n" . Utf8::tailBytes($diagnostics, 2_048);
-            }
 
             $this->recordSyntheticResult($handle, $sink, new TestResult(
                 $inFlight,
                 Outcome::Errored,
                 0.0,
                 0,
-                error: ThrowableDetail::fromThrowable(new \RuntimeException($message)),
+                error: ThrowableDetail::fromThrowable(WorkerError::crashedDuringTest(
+                    $handle->workerId,
+                    $reason,
+                    Utf8::tailBytes($diagnostics, 2_048),
+                )),
             ));
         }
 

--- a/src/Runner/Protocol/ProtocolError.php
+++ b/src/Runner/Protocol/ProtocolError.php
@@ -50,6 +50,21 @@ final class ProtocolError extends WireError
         return new self(\sprintf('Unknown event type "%s".', $tag));
     }
 
+    public static function duplicateBootstrap(): self
+    {
+        return new self('Worker received bootstrap more than once.');
+    }
+
+    public static function bootstrapChannelMismatch(): self
+    {
+        return new self('Worker bootstrap channel does not match GREENLIGHT_CHANNEL.');
+    }
+
+    public static function assignmentBeforeBootstrap(): self
+    {
+        return new self('Worker received an assignment before bootstrap completed.');
+    }
+
     public static function summaryMismatch(string $workerId, string $expected, string $reported): self
     {
         return new self(\sprintf(

--- a/src/Runner/Worker/ClassContext.php
+++ b/src/Runner/Worker/ClassContext.php
@@ -41,14 +41,13 @@ final class ClassContext
 
     /**
      * @param non-empty-string $class
+     *
+     * @throws WorkerError
      */
     public static function for(string $class, float $providerBudgetSeconds = 5.0): self
     {
         if (!\class_exists($class)) {
-            throw new \RuntimeException(\sprintf(
-                'This process cannot load test class "%s" from the execution plan.',
-                $class,
-            ));
+            throw WorkerError::classUnavailable($class);
         }
 
         $reflection = new \ReflectionClass($class);
@@ -89,6 +88,7 @@ final class ClassContext
      * @return list<mixed>
      *
      * @throws DiscoveryError
+     * @throws WorkerError
      */
     public function argumentsFor(?string $provider, ?string $providerClass, string $testMethod, string $key): array
     {
@@ -105,25 +105,22 @@ final class ClassContext
         $sets = $this->dataSets[$testMethod];
 
         if (!\array_key_exists($key, $sets)) {
-            throw new \RuntimeException(\sprintf(
-                'The execution plan contains data set "%s" for "%s::%s()", but its data provider no longer returns it. '
-                . 'Run discovery again.',
+            throw WorkerError::dataSetMissing(
                 $key,
                 $this->reflection->getName(),
                 $testMethod,
-            ));
+            );
         }
 
         $value = $sets[$key];
 
         if (!\is_array($value)) {
-            throw new \RuntimeException(\sprintf(
-                'Data set "%s" of "%s::%s()" requires an argument array. Actual type: %s.',
+            throw WorkerError::invalidDataSet(
                 $key,
                 $this->reflection->getName(),
                 $testMethod,
                 \get_debug_type($value),
-            ));
+            );
         }
 
         return \array_values($value);

--- a/src/Runner/Worker/TestExecutor.php
+++ b/src/Runner/Worker/TestExecutor.php
@@ -192,11 +192,7 @@ final readonly class TestExecutor
 
                     break;
                 } catch (\Throwable $threw) {
-                    $cause = new \RuntimeException(\sprintf(
-                        'Plugin "%s" caused an error during beforeTest(): %s',
-                        $subscriber::class,
-                        $threw->getMessage(),
-                    ), 0, $threw);
+                    $cause = WorkerError::pluginHookFailed($subscriber::class, 'beforeTest', $threw);
                     $error = ThrowableDetail::fromThrowable($cause);
 
                     break;
@@ -335,11 +331,7 @@ final readonly class TestExecutor
             } catch (\Throwable $threw) {
                 if ($result->outcome->isSuccessful()) {
                     $result = $result->erroredBy(
-                        ThrowableDetail::fromThrowable(new \RuntimeException(\sprintf(
-                            'Plugin "%s" caused an error during afterTest(): %s',
-                            $subscriber::class,
-                            $threw->getMessage(),
-                        ), 0, $threw)),
+                        ThrowableDetail::fromThrowable(WorkerError::pluginHookFailed($subscriber::class, 'afterTest', $threw)),
                     );
                 } else {
                     $result = $result->withFailures([
@@ -357,12 +349,11 @@ final readonly class TestExecutor
 
             if (!$replacement->id->equals($result->id)) {
                 $result = $result->erroredBy(
-                    ThrowableDetail::fromThrowable(new \RuntimeException(\sprintf(
-                        'Plugin "%s" changed the test identity during afterTest() from "%s" to "%s".',
+                    ThrowableDetail::fromThrowable(WorkerError::pluginChangedTestIdentity(
                         $subscriber::class,
                         $result->id,
                         $replacement->id,
-                    ))),
+                    )),
                 );
 
                 continue;
@@ -372,12 +363,11 @@ final readonly class TestExecutor
                 && \count($replacement->transformations) <= \count($result->transformations)
             ) {
                 $result = $result->erroredBy(
-                    ThrowableDetail::fromThrowable(new \RuntimeException(\sprintf(
-                        'Plugin "%s" changed the outcome from %s to %s without a new transformation-log entry from withOutcome().',
+                    ThrowableDetail::fromThrowable(WorkerError::pluginChangedOutcome(
                         $subscriber::class,
-                        $result->outcome->value,
-                        $replacement->outcome->value,
-                    ))),
+                        $result->outcome,
+                        $replacement->outcome,
+                    )),
                 );
 
                 continue;
@@ -439,17 +429,13 @@ final readonly class TestExecutor
     {
         try {
             if (!\class_exists($conditionClass)) {
-                return new \RuntimeException(\sprintf('Condition class "%s" does not exist.', $conditionClass));
+                return WorkerError::conditionClassMissing($conditionClass);
             }
 
             $condition = new $conditionClass(...$arguments);
 
             if (!$condition instanceof Condition) {
-                return new \RuntimeException(\sprintf(
-                    'Condition class "%s" does not implement %s.',
-                    $conditionClass,
-                    Condition::class,
-                ));
+                return WorkerError::invalidConditionClass($conditionClass);
             }
 
             return $condition->isSatisfied();

--- a/src/Runner/Worker/WorkerError.php
+++ b/src/Runner/Worker/WorkerError.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Runner\Worker;
+
+use Greenlight\Core\Condition;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Test\TestId;
+
+/**
+ * A worker cannot complete an assigned test or plugin lifecycle operation.
+ *
+ * @internal
+ */
+final class WorkerError extends \RuntimeException
+{
+    private function __construct(string $message, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, previous: $previous);
+    }
+
+    /** @param non-empty-string $class */
+    public static function classUnavailable(string $class): self
+    {
+        return new self(\sprintf(
+            'This process cannot load test class "%s" from the execution plan.',
+            $class,
+        ));
+    }
+
+    /**
+     * @param class-string $class
+     * @param non-empty-string $method
+     */
+    public static function dataSetMissing(string $key, string $class, string $method): self
+    {
+        return new self(\sprintf(
+            'The execution plan contains data set "%s" for "%s::%s()", but its data provider no longer returns it. '
+            . 'Run discovery again.',
+            $key,
+            $class,
+            $method,
+        ));
+    }
+
+    /**
+     * @param class-string $class
+     * @param non-empty-string $method
+     */
+    public static function invalidDataSet(string $key, string $class, string $method, string $actualType): self
+    {
+        return new self(\sprintf(
+            'Data set "%s" of "%s::%s()" requires an argument array. Actual type: %s.',
+            $key,
+            $class,
+            $method,
+            $actualType,
+        ));
+    }
+
+    /** @param class-string $plugin */
+    public static function pluginHookFailed(string $plugin, string $hook, \Throwable $cause): self
+    {
+        return new self(\sprintf(
+            'Plugin "%s" caused an error during %s(): %s',
+            $plugin,
+            $hook,
+            $cause->getMessage(),
+        ), $cause);
+    }
+
+    /** @param class-string $plugin */
+    public static function pluginChangedTestIdentity(string $plugin, TestId $before, TestId $after): self
+    {
+        return new self(\sprintf(
+            'Plugin "%s" changed the test identity during afterTest() from "%s" to "%s".',
+            $plugin,
+            $before,
+            $after,
+        ));
+    }
+
+    /** @param class-string $plugin */
+    public static function pluginChangedOutcome(string $plugin, Outcome $before, Outcome $after): self
+    {
+        return new self(\sprintf(
+            'Plugin "%s" changed the outcome from %s to %s without a new transformation-log entry from withOutcome().',
+            $plugin,
+            $before->value,
+            $after->value,
+        ));
+    }
+
+    /** @param non-empty-string $class */
+    public static function conditionClassMissing(string $class): self
+    {
+        return new self(\sprintf('Condition class "%s" does not exist.', $class));
+    }
+
+    /** @param class-string $class */
+    public static function invalidConditionClass(string $class): self
+    {
+        return new self(\sprintf(
+            'Condition class "%s" does not implement %s.',
+            $class,
+            Condition::class,
+        ));
+    }
+
+    public static function crashedDuringTest(string $workerId, string $reason, string $diagnostics): self
+    {
+        $message = \sprintf('Worker "%s" crashed during this test: %s.', $workerId, $reason);
+
+        if ($diagnostics !== '') {
+            $message .= "\nWorker output:\n" . $diagnostics;
+        }
+
+        return new self($message);
+    }
+}

--- a/src/Runner/Worker/WorkerProcess.php
+++ b/src/Runner/Worker/WorkerProcess.php
@@ -108,13 +108,13 @@ final readonly class WorkerProcess
 
                 if ($message instanceof Bootstrap) {
                     if ($plugins instanceof PluginRegistry) {
-                        throw new \RuntimeException('Worker received bootstrap more than once.');
+                        throw ProtocolError::duplicateBootstrap();
                     }
 
                     $rawChannel = \getenv('GREENLIGHT_CHANNEL');
 
                     if (!\is_string($rawChannel) || (int) $rawChannel !== $message->channel) {
-                        throw new \RuntimeException('Worker bootstrap channel does not match GREENLIGHT_CHANNEL.');
+                        throw ProtocolError::bootstrapChannelMismatch();
                     }
 
                     $userPlugins = $message->configFile === null
@@ -138,7 +138,7 @@ final readonly class WorkerProcess
                 }
 
                 if (!$plugins instanceof PluginRegistry || !$registry instanceof HarnessRegistry || !$scopes instanceof HarnessScopes) {
-                    throw new \RuntimeException('Worker received an assignment before bootstrap completed.');
+                    throw ProtocolError::assignmentBeforeBootstrap();
                 }
 
                 $collector = null;

--- a/tests/Acceptance/PhpStanCheckedExceptionTest.php
+++ b/tests/Acceptance/PhpStanCheckedExceptionTest.php
@@ -47,11 +47,13 @@ final readonly class PhpStanCheckedExceptionTest
             use Greenlight\Coverage\CoverageError;
             use Greenlight\Doubles\DoublesError;
             use Greenlight\Expect\ExpectationFailed;
+            use Greenlight\Fixture\TempDirectoryError;
             use Greenlight\Harness\ServiceResolutionError;
             use Greenlight\Harness\UnresolvableService;
             use Greenlight\Reporting\ReportingError;
             use Greenlight\Runner\Integration\IntegrationFixtureError;
             use Greenlight\Runner\Protocol\ProtocolError;
+            use Greenlight\Runner\Worker\WorkerError;
 
             final class ProbeWireError extends WireError {}
             final class ProbeServiceResolutionError extends ServiceResolutionError {}
@@ -86,6 +88,11 @@ final readonly class PhpStanCheckedExceptionTest
                 throw IntegrationFixtureError::cleanup([]);
             }
 
+            function undocumentedTempDirectoryError(): void
+            {
+                throw TempDirectoryError::symbolicLink('/probe');
+            }
+
             function undocumentedProtocolError(): void
             {
                 throw ProtocolError::malformedFrame('probe');
@@ -100,6 +107,11 @@ final readonly class PhpStanCheckedExceptionTest
             {
                 throw new ProbeServiceResolutionError('Expected service resolution failure.');
             }
+
+            function undocumentedWorkerError(): void
+            {
+                throw WorkerError::conditionClassMissing(\stdClass::class);
+            }
             PHP,
             \dirname(__DIR__, 2) . '/phpstan.dist.neon',
         );
@@ -110,7 +122,7 @@ final readonly class PhpStanCheckedExceptionTest
         Expect::that($probe->goodPassed)
             ->because('PHPStan MUST not require throws tags in test code')
             ->toBeTrue();
-        Expect::that($probe->errors)->toHaveCount(9);
+        Expect::that($probe->errors)->toHaveCount(11);
         Expect::that($probe->messages())->toContain(
             'throws checked exception Greenlight\\Expect\\ExpectationFailed but it\'s missing from the PHPDoc @throws tag.',
         );
@@ -130,6 +142,9 @@ final readonly class PhpStanCheckedExceptionTest
             'throws checked exception Greenlight\\Runner\\Integration\\IntegrationFixtureError but it\'s missing from the PHPDoc @throws tag.',
         );
         Expect::that($probe->messages())->toContain(
+            'throws checked exception Greenlight\\Fixture\\TempDirectoryError but it\'s missing from the PHPDoc @throws tag.',
+        );
+        Expect::that($probe->messages())->toContain(
             'throws checked exception Greenlight\\Runner\\Protocol\\ProtocolError but it\'s missing from the PHPDoc @throws tag.',
         );
         Expect::that($probe->messages())->toContain(
@@ -137,6 +152,9 @@ final readonly class PhpStanCheckedExceptionTest
         );
         Expect::that($probe->messages())->toContain(
             'throws checked exception Greenlight\\Probe\\ProbeServiceResolutionError but it\'s missing from the PHPDoc @throws tag.',
+        );
+        Expect::that($probe->messages())->toContain(
+            'throws checked exception Greenlight\\Runner\\Worker\\WorkerError but it\'s missing from the PHPDoc @throws tag.',
         );
     }
 

--- a/tests/Unit/Fixture/TempDirectoryRootSymbolicLinkTest.php
+++ b/tests/Unit/Fixture/TempDirectoryRootSymbolicLinkTest.php
@@ -9,6 +9,7 @@ use Greenlight\Core\Test\SkipTest;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\TempDirectory;
+use Greenlight\Fixture\TempDirectoryError;
 
 final class TempDirectoryRootSymbolicLinkTest
 {
@@ -74,7 +75,7 @@ final class TempDirectoryRootSymbolicLinkTest
             Expect::that(static fn() => $directory->dispose())
                 ->because('fixture cleanup MUST report a root symbolic link that it cannot remove')
                 ->toThrow(
-                    \RuntimeException::class,
+                    TempDirectoryError::class,
                     // PHP 8.5 includes the path argument.
                     // Remove the PHP 8.5 form when PHP 8.6 is the minimum version.
                     matching: \sprintf(

--- a/tests/Unit/Fixture/TempDirectorySubdirectoryLinkTest.php
+++ b/tests/Unit/Fixture/TempDirectorySubdirectoryLinkTest.php
@@ -9,6 +9,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\TempDirectory;
+use Greenlight\Fixture\TempDirectoryError;
 
 final class TempDirectorySubdirectoryLinkTest
 {
@@ -39,7 +40,7 @@ final class TempDirectorySubdirectoryLinkTest
             Expect::that(static fn(): string => $directory->subdirectory($name))
                 ->because('a subdirectory MUST remain inside its temp directory')
                 ->toThrow(
-                    \RuntimeException::class,
+                    TempDirectoryError::class,
                     message: \sprintf(
                         'Subdirectory path "%s" contains a symbolic link.',
                         $link,

--- a/tests/Unit/Fixture/TempDirectoryTest.php
+++ b/tests/Unit/Fixture/TempDirectoryTest.php
@@ -10,6 +10,7 @@ use Greenlight\Core\Test\SkipTest;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\TempDirectory;
+use Greenlight\Fixture\TempDirectoryError;
 use Greenlight\Tests\Support\Subprocess;
 
 final class TempDirectoryTest
@@ -63,7 +64,7 @@ final class TempDirectoryTest
 
                         try {
                             new Greenlight\Fixture\TempDirectory()->path();
-                        } catch (RuntimeException $error) {
+                        } catch (Greenlight\Fixture\TempDirectoryError $error) {
                             fwrite(STDOUT, $error->getMessage());
                             exit(23);
                         }
@@ -129,7 +130,7 @@ final class TempDirectoryTest
         Expect::that(static fn(): string => $directory->subdirectory('blocked/nested'))
             ->because('an existing file blocks a nested subdirectory with the full target')
             ->toThrow(
-                \RuntimeException::class,
+                TempDirectoryError::class,
                 message: \sprintf(
                     'Failed to create subdirectory "%s": mkdir(): Not a directory.',
                     $target,
@@ -221,7 +222,7 @@ final class TempDirectoryTest
             })
                 ->because('fixture cleanup MUST report the entry that it cannot remove')
                 ->toThrow(
-                    \RuntimeException::class,
+                    TempDirectoryError::class,
                     message: \sprintf(
                         'Failed to remove "%s" while disposing temp directory "%s".',
                         $file,
@@ -254,7 +255,7 @@ final class TempDirectoryTest
             })
                 ->because('fixture cleanup MUST report a root that it cannot remove')
                 ->toThrow(
-                    \RuntimeException::class,
+                    TempDirectoryError::class,
                     // PHP 8.5 includes the path argument.
                     // Remove the PHP 8.5 form when PHP 8.6 is the minimum version.
                     matching: \sprintf(

--- a/tests/Unit/Plugin/PluginTest.php
+++ b/tests/Unit/Plugin/PluginTest.php
@@ -28,6 +28,7 @@ use Greenlight\Plugin\TestContext;
 use Greenlight\Plugin\TestLifecycleSubscriber;
 use Greenlight\Runner\DefaultServices;
 use Greenlight\Runner\Worker\Worker;
+use Greenlight\Runner\Worker\WorkerError;
 use Greenlight\Tests\Fixture\Lifecycle\Services\ServiceProbe;
 use Greenlight\Tests\Fixture\Lifecycle\TraceLog;
 use Greenlight\Tests\Fixture\Plugins\EvenNumbersExtension;
@@ -112,6 +113,7 @@ final class PluginTest
             ->toBe(Outcome::Errored);
         Expect::that($results[0]->error?->message)
             ->toBe($message);
+        Expect::that($results[0]->error?->class)->toBe(WorkerError::class);
     }
 
     #[Test]
@@ -148,6 +150,7 @@ final class PluginTest
                 $rogue::class,
                 $expectedId,
             ));
+        Expect::that($result->error?->class)->toBe(WorkerError::class);
     }
 
     #[Test]
@@ -178,6 +181,7 @@ final class PluginTest
             ->toBe(Outcome::Errored);
         Expect::that($results[0]->error?->message)
             ->toBe($message);
+        Expect::that($results[0]->error?->class)->toBe(WorkerError::class);
     }
 
     #[Test]
@@ -212,6 +216,7 @@ final class PluginTest
             ->toBe(Outcome::Errored);
         Expect::that($byMethod['passes']->error?->message)
             ->toBe($pluginFailure);
+        Expect::that($byMethod['passes']->error?->class)->toBe(WorkerError::class);
 
         // The test keeps its original error. Greenlight records the plugin
         // failure as a failure detail.

--- a/tests/Unit/Runner/ConditionEvaluationTest.php
+++ b/tests/Unit/Runner/ConditionEvaluationTest.php
@@ -20,6 +20,7 @@ use Greenlight\Fixture\EnvironmentSandbox;
 use Greenlight\Harness\HarnessRegistry;
 use Greenlight\Plugin\PluginRegistry;
 use Greenlight\Runner\Worker\Worker;
+use Greenlight\Runner\Worker\WorkerError;
 use Greenlight\Tests\Fixture\Condition\ThrowingCondition;
 use Greenlight\Tests\Fixture\Lifecycle\ConditionArguments\ConditionArgumentsTest;
 use Greenlight\Tests\Support\CollectingEventSink;
@@ -53,11 +54,15 @@ final readonly class ConditionEvaluationTest
     /**
      * @param non-empty-string $conditionClass
      * @param non-empty-string $message
+     * @param class-string<\Throwable> $errorClass
      */
     #[Test]
     #[DataSet('invalidConditions')]
-    public function invalidRuntimeConditionMetadataErrorsTheTest(string $conditionClass, string $message): void
-    {
+    public function invalidRuntimeConditionMetadataErrorsTheTest(
+        string $conditionClass,
+        string $message,
+        string $errorClass,
+    ): void {
         $id = new TestId(ConditionArgumentsTest::class, 'runsWhenTheVersionIsSatisfied');
         $plan = new ExecutionPlan([
             new PlanEntry(
@@ -80,16 +85,18 @@ final readonly class ConditionEvaluationTest
             ->because('invalid runtime condition metadata errors the test')
             ->toBe(Outcome::Errored);
         Expect::that($result->error?->message)->toBe($message);
+        Expect::that($result->error?->class)->toBe($errorClass);
     }
 
     /**
-     * @return iterable<string, array{non-empty-string, non-empty-string}>
+     * @return iterable<string, array{non-empty-string, non-empty-string, class-string<\Throwable>}>
      */
     public static function invalidConditions(): iterable
     {
         yield 'missing class' => [
             'Example\MissingCondition',
             'Condition class "Example\MissingCondition" does not exist.',
+            WorkerError::class,
         ];
 
         yield 'wrong interface' => [
@@ -99,11 +106,13 @@ final readonly class ConditionEvaluationTest
                 \stdClass::class,
                 Condition::class,
             ),
+            WorkerError::class,
         ];
 
         yield 'throws while evaluating' => [
             ThrowingCondition::class,
             'condition evaluation failed',
+            \RuntimeException::class,
         ];
     }
 

--- a/tests/Unit/Runner/Orchestrator/OrchestratorTest.php
+++ b/tests/Unit/Runner/Orchestrator/OrchestratorTest.php
@@ -18,6 +18,7 @@ use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\Orchestrator\Orchestrator;
 use Greenlight\Runner\Protocol\ProtocolError;
+use Greenlight\Runner\Worker\WorkerError;
 use Greenlight\Tests\Fixture\CrashDiagnostics\CrashDiagnosticsTest;
 use Greenlight\Tests\Fixture\CrashUnicodeDiagnostics\CrashUnicodeDiagnosticsTest;
 use Greenlight\Tests\Fixture\LeakSuite\CleanTest;
@@ -534,6 +535,7 @@ final class OrchestratorTest
                 "Worker \"w-1\" crashed during this test: the worker process exited unexpectedly.\n"
                 . "Worker output:\nThe worker emitted crash diagnostics.",
             );
+        Expect::that($results[0]->error?->class)->toBe(WorkerError::class);
     }
 
     #[Test]

--- a/tests/Unit/Runner/Protocol/ProtocolErrorTest.php
+++ b/tests/Unit/Runner/Protocol/ProtocolErrorTest.php
@@ -31,6 +31,40 @@ final readonly class ProtocolErrorTest
     }
 
     /**
+     * @param \Closure(): ProtocolError $factory
+     */
+    #[Test]
+    #[DataSet('workerStateErrors')]
+    public function workerStateErrorsHaveNamedProtocolErrors(\Closure $factory, string $message): void
+    {
+        $error = $factory();
+
+        Expect::that($error)
+            ->because('invalid worker message order MUST produce a protocol error')
+            ->toBeInstanceOf(ProtocolError::class);
+        Expect::that($error->getMessage())->toBe($message);
+    }
+
+    /**
+     * @return iterable<string, array{\Closure(): ProtocolError, string}>
+     */
+    public static function workerStateErrors(): iterable
+    {
+        yield 'duplicate bootstrap' => [
+            ProtocolError::duplicateBootstrap(...),
+            'Worker received bootstrap more than once.',
+        ];
+        yield 'bootstrap channel mismatch' => [
+            ProtocolError::bootstrapChannelMismatch(...),
+            'Worker bootstrap channel does not match GREENLIGHT_CHANNEL.',
+        ];
+        yield 'assignment before bootstrap' => [
+            ProtocolError::assignmentBeforeBootstrap(...),
+            'Worker received an assignment before bootstrap completed.',
+        ];
+    }
+
+    /**
      * @param \Closure(string, float, string): ProtocolError $factory
      */
     #[Test]

--- a/tests/Unit/Runner/Worker/ClassContextTest.php
+++ b/tests/Unit/Runner/Worker/ClassContextTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Unit\Runner\Worker;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\Worker\ClassContext;
+use Greenlight\Runner\Worker\WorkerError;
 use Greenlight\Tests\Fixture\Runner\Worker\CachedDataSetProbe;
 use Greenlight\Tests\Fixture\Runner\Worker\ClassContextDataProbe;
 
@@ -18,7 +19,7 @@ final class ClassContextTest
         Expect::that(static fn(): ClassContext => ClassContext::for('Missing\ExampleTest'))
             ->because('the worker cannot execute a class that is absent from its process')
             ->toThrow(
-                \RuntimeException::class,
+                WorkerError::class,
                 message: 'This process cannot load test class "Missing\ExampleTest" from the execution plan.',
             );
     }
@@ -31,7 +32,7 @@ final class ClassContextTest
         Expect::that(static fn(): array => $context->argumentsFor('scalarRows', null, 'accepts', 'removed'))
             ->because('the worker rejects an execution-plan data set that no longer exists')
             ->toThrow(
-                \RuntimeException::class,
+                WorkerError::class,
                 message: \sprintf(
                     'The execution plan contains data set "removed" for "%s::accepts()", '
                     . 'but its data provider no longer returns it. Run discovery again.',
@@ -48,7 +49,7 @@ final class ClassContextTest
         Expect::that(static fn(): array => $context->argumentsFor('scalarRows', null, 'accepts', 'bad'))
             ->because('the worker requires each data set to contain positional arguments')
             ->toThrow(
-                \RuntimeException::class,
+                WorkerError::class,
                 message: \sprintf(
                     'Data set "bad" of "%s::accepts()" requires an argument array. Actual type: string.',
                     ClassContextDataProbe::class,


### PR DESCRIPTION
Replaces repository-owned generic RuntimeException values with the caller-facing TempDirectoryError and WorkerError types. Reuses ProtocolError for invalid worker bootstrap and assignment order.

Adds both new exception roots to PHPStan checked-exception configuration and documents every propagating TempDirectory contract. Extends unit and acceptance coverage to verify the named types and prevent missing, non-covariant, or over-broad throws declarations.

Updates the generated fixture API reference.