### PR TITLE
refactor(test): centralize connected stream pairs

### DIFF
--- a/tests/Support/ConnectedStreamPair.php
+++ b/tests/Support/ConnectedStreamPair.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Support;
+
+use Greenlight\Expect\Fail;
+
+final readonly class ConnectedStreamPair
+{
+    /**
+     * @return array{resource, resource}
+     */
+    public static function open(): array
+    {
+        $pair = \stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
+
+        if ($pair === false || \count($pair) !== 2 || !isset($pair[0], $pair[1])) {
+            Fail::because('Expected stream_socket_pair() to create a connected stream pair.');
+        }
+
+        return [$pair[0], $pair[1]];
+    }
+}

--- a/tests/Unit/Runner/Orchestrator/WorkerHandleTerminationTest.php
+++ b/tests/Unit/Runner/Orchestrator/WorkerHandleTerminationTest.php
@@ -11,6 +11,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Runner\Orchestrator\WorkerHandle;
 use Greenlight\Runner\Protocol\SocketChannel;
+use Greenlight\Tests\Support\ConnectedStreamPair;
 
 final readonly class WorkerHandleTerminationTest
 {
@@ -42,11 +43,7 @@ final readonly class WorkerHandleTerminationTest
                 Fail::because('Expected the worker process fixture to start.');
             }
 
-            $sockets = \stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, 0);
-
-            if ($sockets === false) {
-                Fail::because('Expected the worker channel fixture to open.');
-            }
+            $sockets = ConnectedStreamPair::open();
 
             \stream_set_timeout($pipes[1], 2);
 
@@ -74,9 +71,7 @@ final readonly class WorkerHandleTerminationTest
         } finally {
             $resources = $pipes;
 
-            if (\is_array($sockets)) {
-                $resources = [...$resources, ...$sockets];
-            }
+            $resources = [...$resources, ...$sockets];
 
             foreach ($resources as $resource) {
                 if (\is_resource($resource)) {

--- a/tests/Unit/Runner/Orchestrator/WorkerHandleTest.php
+++ b/tests/Unit/Runner/Orchestrator/WorkerHandleTest.php
@@ -13,6 +13,7 @@ use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Runner\Orchestrator\WorkerHandle;
+use Greenlight\Tests\Support\ConnectedStreamPair;
 
 final class WorkerHandleTest
 {
@@ -88,7 +89,7 @@ final class WorkerHandleTest
         string $remainder,
         string $expected,
     ): void {
-        [$reader, $writer] = $this->streamPair();
+        [$reader, $writer] = ConnectedStreamPair::open();
         $handle = new WorkerHandle(
             'worker-1',
             1,
@@ -111,7 +112,7 @@ final class WorkerHandleTest
     #[DataSet('malformedUtf8Prefixes')]
     public function malformedTrailingBytesAreScrubbedWithoutWaitingForAnotherPipeRead(string $malformed): void
     {
-        [$reader, $writer] = $this->streamPair();
+        [$reader, $writer] = ConnectedStreamPair::open();
         $handle = new WorkerHandle(
             'worker-1',
             1,
@@ -186,17 +187,4 @@ final class WorkerHandleTest
         return $stream;
     }
 
-    /**
-     * @return array{resource, resource}
-     */
-    private function streamPair(): array
-    {
-        $streams = \stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
-
-        if (!\is_array($streams) || \count($streams) !== 2) {
-            Fail::because('Expected the connected streams to open.');
-        }
-
-        return [$streams[0], $streams[1]];
-    }
 }

--- a/tests/Unit/Runner/Protocol/SocketChannelInterruptedReceiveTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelInterruptedReceiveTest.php
@@ -11,6 +11,7 @@ use Greenlight\Core\Test\SkipTest;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Runner\Protocol\SocketChannel;
+use Greenlight\Tests\Support\ConnectedStreamPair;
 
 final readonly class SocketChannelInterruptedReceiveTest
 {
@@ -23,11 +24,7 @@ final readonly class SocketChannelInterruptedReceiveTest
             throw new SkipTest('Process control is not available.');
         }
 
-        $pair = \stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
-
-        if ($pair === false || \count($pair) !== 2 || !isset($pair[0], $pair[1])) {
-            Fail::because('Expected stream_socket_pair() to create a connected socket pair.');
-        }
+        $pair = ConnectedStreamPair::open();
 
         $channel = new SocketChannel($pair[0]);
         $previousAsyncSignals = \pcntl_async_signals(true);

--- a/tests/Unit/Runner/Protocol/SocketChannelTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelTest.php
@@ -11,6 +11,7 @@ use Greenlight\Runner\Protocol\Messages\Drain;
 use Greenlight\Runner\Protocol\ProtocolError;
 use Greenlight\Runner\Protocol\SocketChannel;
 use Greenlight\Tests\Fixture\Runner\Protocol\UnselectableStream;
+use Greenlight\Tests\Support\ConnectedStreamPair;
 
 final class SocketChannelTest
 {
@@ -19,7 +20,7 @@ final class SocketChannelTest
     #[Test]
     public function receiveTimeoutLeavesTheChannelOpenForLaterMessages(): void
     {
-        [$stream, $peer] = $this->socketPair();
+        [$stream, $peer] = ConnectedStreamPair::open();
         $receiver = new SocketChannel($stream);
         $sender = new SocketChannel($peer);
 
@@ -45,7 +46,7 @@ final class SocketChannelTest
     #[Test]
     public function aCompleteFinalFrameIsDeliveredBeforeCleanEof(): void
     {
-        [$stream, $peer] = $this->socketPair();
+        [$stream, $peer] = ConnectedStreamPair::open();
         $receiver = new SocketChannel($stream);
         $sender = new SocketChannel($peer);
 
@@ -70,7 +71,7 @@ final class SocketChannelTest
     #[Test]
     public function peerEofRejectsAnIncompleteFrame(): void
     {
-        [$stream, $peer] = $this->socketPair();
+        [$stream, $peer] = ConnectedStreamPair::open();
         $channel = new SocketChannel($stream);
 
         try {
@@ -106,7 +107,7 @@ final class SocketChannelTest
     #[Test]
     public function anExternallyClosedStreamEndsPollingAndRejectsWrites(): void
     {
-        [$stream, $peer] = $this->socketPair();
+        [$stream, $peer] = ConnectedStreamPair::open();
         $channel = new SocketChannel($stream);
 
         try {
@@ -160,17 +161,4 @@ final class SocketChannelTest
         }
     }
 
-    /**
-     * @return array{resource, resource}
-     */
-    private function socketPair(): array
-    {
-        $pair = \stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
-
-        if ($pair === false || \count($pair) !== 2 || !isset($pair[0], $pair[1])) {
-            Fail::because('Expected stream_socket_pair() to create a connected socket pair.');
-        }
-
-        return [$pair[0], $pair[1]];
-    }
 }

--- a/tests/Unit/Runner/Worker/SocketEventSinkTest.php
+++ b/tests/Unit/Runner/Worker/SocketEventSinkTest.php
@@ -11,13 +11,14 @@ use Greenlight\Expect\Fail;
 use Greenlight\Runner\Protocol\Messages\EventEnvelope;
 use Greenlight\Runner\Protocol\SocketChannel;
 use Greenlight\Runner\Worker\SocketEventSink;
+use Greenlight\Tests\Support\ConnectedStreamPair;
 
 final class SocketEventSinkTest
 {
     #[Test]
     public function emittedEventsCrossTheWorkerChannelInAnEventEnvelope(): void
     {
-        [$senderStream, $receiverStream] = $this->socketPair();
+        [$senderStream, $receiverStream] = ConnectedStreamPair::open();
         $sender = new SocketChannel($senderStream);
         $receiver = new SocketChannel($receiverStream);
         $sink = new SocketEventSink($sender);
@@ -43,17 +44,4 @@ final class SocketEventSinkTest
         }
     }
 
-    /**
-     * @return array{resource, resource}
-     */
-    private function socketPair(): array
-    {
-        $pair = \stream_socket_pair(\STREAM_PF_UNIX, \STREAM_SOCK_STREAM, \STREAM_IPPROTO_IP);
-
-        if ($pair === false || \count($pair) !== 2 || !isset($pair[0], $pair[1])) {
-            Fail::because('Expected stream_socket_pair() to create a connected socket pair.');
-        }
-
-        return [$pair[0], $pair[1]];
-    }
 }


### PR DESCRIPTION
Add one connected-stream fixture for the low-level runner and protocol tests.

The fixture owns socket creation and validation, replacing five direct calls and two duplicate private helpers. Individual tests continue to own channel lifecycle and behavioral assertions, while the suite now has one consistent failure contract for this platform boundary.