### PR TITLE
fix(test): harden acceptance project writes

### DIFF
--- a/tests/Support/AcceptanceProject.php
+++ b/tests/Support/AcceptanceProject.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Support;
 
+use Greenlight\Core\ErrorTrap;
 use Greenlight\Fixture\TempDirectory;
 
 final readonly class AcceptanceProject
@@ -52,11 +53,23 @@ final readonly class AcceptanceProject
         $path = $this->path($relativePath);
         $parent = \dirname($path);
 
-        if (!\is_dir($parent)) {
-            \mkdir($parent, 0o777, true);
+        if (!\is_dir($parent)
+            && !ErrorTrap::run(static fn(): bool => \mkdir($parent, 0o777, true), $warning)
+        ) {
+            throw new \RuntimeException(\sprintf(
+                'Failed to create acceptance project directory "%s"%s.',
+                $parent,
+                $warning === null ? '' : ': ' . $warning,
+            ));
         }
 
-        \file_put_contents($path, $contents);
+        if (ErrorTrap::run(static fn(): int|false => \file_put_contents($path, $contents), $warning) === false) {
+            throw new \RuntimeException(\sprintf(
+                'Failed to write acceptance project file "%s"%s.',
+                $path,
+                $warning === null ? '' : ': ' . $warning,
+            ));
+        }
     }
 
     /**

--- a/tests/Support/AcceptanceProject.php
+++ b/tests/Support/AcceptanceProject.php
@@ -45,6 +45,22 @@ final readonly class AcceptanceProject
 
     public function path(string $relative): string
     {
+        if ($relative === '' || \str_starts_with($relative, '/') || \str_contains($relative, '\\')) {
+            throw new \InvalidArgumentException(\sprintf(
+                'Acceptance project path "%s" must be a relative path of plain segments.',
+                $relative,
+            ));
+        }
+
+        foreach (\explode('/', $relative) as $segment) {
+            if (\in_array($segment, ['', '.', '..'], true)) {
+                throw new \InvalidArgumentException(\sprintf(
+                    'Acceptance project path "%s" must be a relative path of plain segments.',
+                    $relative,
+                ));
+            }
+        }
+
         return $this->directory . '/' . $relative;
     }
 

--- a/tests/Unit/Support/AcceptanceProjectTest.php
+++ b/tests/Unit/Support/AcceptanceProjectTest.php
@@ -27,6 +27,42 @@ final readonly class AcceptanceProjectTest
     }
 
     #[Test]
+    public function aBlockedParentDirectoryFailsWithTheTargetPath(): void
+    {
+        $project = AcceptanceProject::create($this->workspace, 'blocked-parent');
+        $project->writeFile('blocked', 'keep');
+        $parent = $project->path('blocked');
+
+        Expect::that(static fn() => $project->writeFile('blocked/example.txt', 'contents'))
+            ->because('a blocked parent directory MUST fail before the fixture continues')
+            ->toThrow(
+                \RuntimeException::class,
+                matching: \sprintf('/^Failed to create acceptance project directory "%s"/', \preg_quote($parent, '/')),
+            );
+        Expect::that(\file_get_contents($parent))
+            ->because('a failed directory creation MUST preserve the blocking file')
+            ->toBe('keep');
+    }
+
+    #[Test]
+    public function anUnwritableTargetFailsWithTheTargetPath(): void
+    {
+        $project = AcceptanceProject::create($this->workspace, 'blocked-target');
+        $project->writeFile('blocked/seed.txt', 'keep');
+        $target = $project->path('blocked');
+
+        Expect::that(static fn() => $project->writeFile('blocked', 'contents'))
+            ->because('an unwritable target MUST fail before the fixture continues')
+            ->toThrow(
+                \RuntimeException::class,
+                matching: \sprintf('/^Failed to write acceptance project file "%s"/', \preg_quote($target, '/')),
+            );
+        Expect::that(\file_get_contents($project->path('blocked/seed.txt')))
+            ->because('a failed file write MUST preserve the target directory contents')
+            ->toBe('keep');
+    }
+
+    #[Test]
     public function configuresTheProjectWithTestFilesAndTheRequestedWorkerCount(): void
     {
         $project = AcceptanceProject::create($this->workspace, 'configured');

--- a/tests/Unit/Support/AcceptanceProjectTest.php
+++ b/tests/Unit/Support/AcceptanceProjectTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Support;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\GreenlightConfig;
 use Greenlight\Expect\Expect;
@@ -60,6 +61,37 @@ final readonly class AcceptanceProjectTest
         Expect::that(\file_get_contents($project->path('blocked/seed.txt')))
             ->because('a failed file write MUST preserve the target directory contents')
             ->toBe('keep');
+    }
+
+    #[Test]
+    #[DataSet('invalidProjectPaths')]
+    public function projectFilesRejectNonPlainRelativePaths(string $relativePath): void
+    {
+        $project = AcceptanceProject::create($this->workspace, 'invalid-path');
+
+        Expect::that(static fn() => $project->writeFile($relativePath, 'contents'))
+            ->because('acceptance project writes MUST stay in the project directory')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: \sprintf(
+                    'Acceptance project path "%s" must be a relative path of plain segments.',
+                    $relativePath,
+                ),
+            );
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function invalidProjectPaths(): iterable
+    {
+        yield 'empty path' => [''];
+        yield 'absolute path' => ['/tmp/fixture.php'];
+        yield 'current-directory segment' => ['./fixture.php'];
+        yield 'parent-directory segment' => ['../fixture.php'];
+        yield 'nested parent-directory segment' => ['tests/../fixture.php'];
+        yield 'empty segment' => ['tests//fixture.php'];
+        yield 'backslash separator' => ['tests\\fixture.php'];
     }
 
     #[Test]


### PR DESCRIPTION
Harden AcceptanceProject at its filesystem boundary.

The helper now rejects paths that can escape the project or behave differently across platforms. It also captures directory-creation and file-write warnings, names the failed target, and throws immediately instead of allowing an incomplete project to produce a later unrelated failure. Regression tests cover seven unsafe path shapes and both write failure modes, including preservation of existing entries.