### PR TITLE
feat: add PSR-11 application bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Greenlight runs its own test suite with `bin/greenlight run`.
 * Test attachments for values, text, bytes, and files
 * Coverage through pcov or Xdebug
 * Plain PHP test classes and PHP configuration
-* First-party Symfony, Laravel, and PHPStan extensions
+* First-party Symfony, Laravel, PSR-11, and PHPStan extensions
 * Automated PHPUnit test conversion with a bundled Rector rule
 
 ## Example test
@@ -134,6 +134,7 @@ for the complete model.
 * [Static analysis with PHPStan](docs/phpstan.md)
 * [Test Symfony applications](docs/symfony.md)
 * [Test Laravel applications](docs/laravel.md)
+* [Test PSR applications](docs/psr.md)
 * [Move from PHPUnit](docs/migrating-from-phpunit.md)
 * [Benchmarks](docs/benchmarks.md)
 * [Architecture](docs/architecture/README.md)

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "phpstan/phpstan": "^2.2",
         "phpstan/phpstan-deprecation-rules": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
+        "psr/container": "^2.0",
         "rector/rector": "^2.5",
         "symfony/config": "^6.4 || ^7.0 || ^8.0",
         "symfony/dependency-injection": "^6.4 || ^7.0 || ^8.0",
@@ -37,6 +38,7 @@
         "laravel/framework": "Provides the complete Laravel 13 framework that LaravelPlugin requires",
         "phpstan/extension-installer": "Registers the bundled PHPStan extension automatically",
         "phpstan/phpstan": "Type-checks extension matcher calls and data providers with the bundled 'extension.neon' file",
+        "psr/container": "Connects a PSR-11 application container to Greenlight through 'Psr11Plugin'",
         "rector/rector": "Converts PHPUnit test classes to Greenlight with the bundled 'PhpUnitToGreenlightRector' rule",
         "symfony/framework-bundle": "Enables container service injection into kernel-aware Symfony tests through the 'SymfonyPlugin' bridge"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0d410811fb6da5ac5d54d73d283a28b2",
+    "content-hash": "493fc232a7668344556a757b2aad6309",
     "packages": [],
     "packages-dev": [
         {
@@ -8309,5 +8309,5 @@
         "php": ">=8.4"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -89,6 +89,10 @@ deptrac:
       collectors:
         - type: directory
           value: src/Laravel/.*
+    - name: Psr
+      collectors:
+        - type: directory
+          value: src/Psr/.*
     - name: PhpStanFramework
       collectors:
         - type: classNameRegex
@@ -101,6 +105,10 @@ deptrac:
       collectors:
         - type: classNameRegex
           value: /^Illuminate\\/
+    - name: PsrFramework
+      collectors:
+        - type: classNameRegex
+          value: /^Psr\\Container\\/
     - name: CpuCoreCounter
       collectors:
         - type: classNameRegex
@@ -136,9 +144,11 @@ deptrac:
     Rector: [Core, Attribute, Condition, Expect, PhpParserFramework, RectorFramework]
     Symfony: [Core, Harness, Plugin, SymfonyFramework]
     Laravel: [Core, Harness, Plugin, LaravelFramework]
+    Psr: [Core, Harness, Plugin, PsrFramework]
     PhpStanFramework: []
     SymfonyFramework: []
     LaravelFramework: []
+    PsrFramework: []
     CpuCoreCounter: []
     PhpParserFramework: []
     RectorFramework: []

--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -2,7 +2,7 @@
 
 # Integration API
 
-This reference lists public integration types for Laravel, Rector, and Symfony.
+This reference lists public integration types for Laravel, PSR standards, Rector, and Symfony.
 
 These signatures are the public API.
 
@@ -121,6 +121,128 @@ PHPDoc:
 - `@throws \InvalidArgumentException`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/Service.php#L22)
+
+## `Psr11Plugin`
+
+Namespace: `Greenlight\Psr`
+
+Creates a PSR-11 container lazily and resolves its services. By default, the
+plugin discards the container after each test that uses it.
+
+`#[Service]` selects an explicit ID. Tests MUST isolate external resources
+by `GREENLIGHT_CHANNEL`.
+
+```php
+final class Psr11Plugin implements HarnessProvider, ServiceResolver, TestLifecycleSubscriber
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr/Psr11Plugin.php#L23)
+
+### `__construct()`
+
+```php
+public function __construct(
+    private readonly \Closure $factory,
+    private readonly bool $refreshBetweenTests = true,
+    private readonly ?\Closure $reset = null,
+)
+```
+
+PHPDoc:
+
+- `@param \Closure():ContainerInterface $factory A factory that returns the application container.`
+- `@param bool $refreshBetweenTests Set to false only when the reset callback removes all container state, or when services do not keep state.`
+- `@param (\Closure(ContainerInterface): void)|null $reset An optional callback that resets the active container after each test.`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr/Psr11Plugin.php#L36)
+
+### `services()`
+
+```php
+[\Override]
+public function services(): array
+```
+
+PHPDoc:
+
+- `@return list<ServiceDefinition>`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr/Psr11Plugin.php#L45)
+
+### `resolve()`
+
+```php
+[\Override]
+public function resolve(string $type, array $attributes): ?object
+```
+
+PHPDoc:
+
+- `@param class-string $type`
+- `@param list<object> $attributes`
+- `@throws Psr11BridgeError`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr/Psr11Plugin.php#L92)
+
+### `beforeTest()`
+
+```php
+[\Override]
+public function beforeTest(TestContext $context): void
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr/Psr11Plugin.php#L134)
+
+### `afterTest()`
+
+```php
+[\Override]
+public function afterTest(TestContext $context, TestResult $result): TestResult
+```
+
+PHPDoc:
+
+- `@throws Psr11BridgeError`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr/Psr11Plugin.php#L140)
+
+## `Psr\Service`
+
+Namespace: `Greenlight\Psr`
+
+Selects a PSR-11 service ID that differs from the parameter type. The
+resolved service must still have the declared type.
+
+```php
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+final readonly class Service
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr/Service.php#L12)
+
+### `$id`
+
+```php
+public string $id;
+```
+
+PHPDoc:
+
+- `@var non-empty-string`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr/Service.php#L17)
+
+### `__construct()`
+
+```php
+public function __construct(string $id)
+```
+
+PHPDoc:
+
+- `@throws \InvalidArgumentException`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr/Service.php#L22)
 
 ## `PhpUnitToGreenlightRector`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -19,4 +19,4 @@ Use the task guides for workflows and examples. Use these pages for exact signat
 - [Fixtures and harness API](api-fixtures-harness.md) — This reference lists fixtures and harness service contracts.
 - [Plugin API](api-plugins.md) — This reference lists plugin capabilities and lifecycle callback contracts.
 - [Reporter API](api-reporting.md) — This reference lists reporter and output contracts.
-- [Integration API](api-integrations.md) — This reference lists public integration types for Laravel, Rector, and Symfony.
+- [Integration API](api-integrations.md) — This reference lists public integration types for Laravel, PSR standards, Rector, and Symfony.

--- a/docs/architecture/technical-writing.md
+++ b/docs/architecture/technical-writing.md
@@ -155,6 +155,9 @@ and meaning. Use the singular form unless the context requires a plural.
 | poll | Technical verb | To observe a probe until a condition or deadline stops the operation |
 | probe | Technical noun | A callable that supplies values to a temporal expectation |
 | plugin | Technical noun | An extension that adds a Greenlight capability |
+| PSR-11 bridge | Technical noun | The component that connects the Greenlight harness to a PSR-11 container |
+| PSR-11 container | Technical noun | A service container that implements the PSR-11 container interface |
+| PSR-15 request handler | Technical noun | An object that accepts a PSR-7 server request and returns a PSR-7 response |
 | proxy class | Technical noun | A generated class that implements or extends a doubled type |
 | proxy object | Technical noun | An instance of a proxy class that acts as a double |
 | reporter | Technical noun | A component that converts run events to output |

--- a/docs/psr.md
+++ b/docs/psr.md
@@ -1,0 +1,139 @@
+# PSR applications
+
+The PSR-11 bridge supplies container services to test constructors. It works
+with each container that implements `Psr\Container\ContainerInterface`.
+
+The bridge uses the packages that the application provides. Greenlight does
+not declare a runtime dependency on a container implementation.
+
+## Setup
+
+Register `Psr11Plugin` with a factory that returns the application container:
+
+```php
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Psr\Psr11Plugin;
+use Psr\Container\ContainerInterface;
+
+return GreenlightConfig::create()
+    ->paths(['tests'])
+    ->plugins(new Psr11Plugin(
+        static fn(): ContainerInterface => require __DIR__ . '/config/container.php',
+    ));
+```
+
+The factory runs when a test first requests a container service. A worker does
+not create the container when its tests do not use it.
+
+The standard Mezzio configuration file, `config/container.php`, returns a
+PSR-11 container. The same setup works with Laminas ServiceManager, PHP-DI,
+and other PSR-11 implementations.
+
+## Container services
+
+Declare the dependency by type:
+
+```php
+final class RegistrationTest
+{
+    public function __construct(
+        private readonly UserRepository $users,
+        private readonly RegistrationHandler $handler,
+    ) {}
+}
+```
+
+Greenlight first resolves constructor parameters from its harness. It then
+uses the PSR-11 container. Thus, built-in and plugin harness services have
+precedence over container services.
+
+The container must report the requested type from `has()`. The value from
+`get()` must have that type. Greenlight reports a type mismatch before the test
+runs.
+
+### Services with another ID
+
+Use `#[Service]` when the container ID differs from the parameter type:
+
+```php
+use Greenlight\Psr\Service;
+
+public function __construct(
+    #[Service('application.repository.users')]
+    private readonly UserRepository $users,
+) {}
+```
+
+Greenlight reports an error if an explicit ID does not exist. A missing
+type-based ID lets the next service resolver try to supply the parameter.
+
+### The container
+
+Greenlight supplies `Psr\Container\ContainerInterface` as a harness service:
+
+```php
+public function __construct(private readonly ContainerInterface $container) {}
+```
+
+Use typed constructor dependencies for normal tests. Direct container access
+is useful when a test verifies container configuration.
+
+## State between tests
+
+By default, the bridge discards the active container after each test attempt.
+The next test creates a new container from the factory.
+
+The bridge can run a reset callback before it discards the container:
+
+```php
+new Psr11Plugin(
+    static fn(): ContainerInterface => require __DIR__ . '/config/container.php',
+    reset: static function (ContainerInterface $container): void {
+        $container->get(ApplicationResetter::class)->reset();
+    },
+);
+```
+
+The callback runs only after a test creates the container. The bridge discards
+the container even when the callback fails.
+
+For a container that can reset all service state, keep one container for each
+worker:
+
+```php
+new Psr11Plugin(
+    static fn(): ContainerInterface => require __DIR__ . '/config/container.php',
+    refreshBetweenTests: false,
+    reset: static function (ContainerInterface $container): void {
+        $container->get(ApplicationResetter::class)->reset();
+    },
+);
+```
+
+Do not disable refreshes when shared services can keep state. Tests on the same
+worker will receive the same service instances.
+
+The bridge controls only container state. Isolation for databases, caches,
+queues, files, and other external resources remains the test suite's
+responsibility.
+
+## Parallel resources
+
+Greenlight sets `GREENLIGHT_CHANNEL` in every worker process. Use the channel
+in application configuration to select worker-specific databases and similar
+resources.
+
+If a resource cannot use channels, protect its test classes with
+`#[RequiresResource]`. See [configuration](configuration.md) for the complete
+resource rules.
+
+## Non-goals
+
+The bridge does not provide these features:
+
+* Container auto-discovery
+* Container service replacement
+* HTTP request construction
+* Browser or network requests
+* Database creation, migration, or transaction control
+* Framework-specific helpers or fakes

--- a/src/Psr/Psr11BridgeError.php
+++ b/src/Psr/Psr11BridgeError.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Psr;
+
+use Greenlight\Harness\ServiceResolutionError;
+
+/**
+ * Reports a PSR-11 bridge configuration or run-time failure.
+ *
+ * @internal
+ */
+final class Psr11BridgeError extends ServiceResolutionError
+{
+    private function __construct(string $message, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, previous: $previous);
+    }
+
+    public static function factoryFailed(\Throwable $previous): self
+    {
+        return new self(
+            'The PSR-11 container factory failed. Check the container configuration.',
+            $previous,
+        );
+    }
+
+    public static function notAContainer(string $actual): self
+    {
+        return new self(\sprintf(
+            'The PSR-11 container factory returned "%s". Return an instance of Psr\\Container\\ContainerInterface.',
+            $actual,
+        ));
+    }
+
+    public static function serviceCheckFailed(string $id, \Throwable $previous): self
+    {
+        return new self(
+            \sprintf('The PSR-11 container failed when it checked service "%s". Check the container configuration.', $id),
+            $previous,
+        );
+    }
+
+    public static function serviceReadFailed(string $id, \Throwable $previous): self
+    {
+        return new self(
+            \sprintf('The PSR-11 container failed when it read service "%s". Check the container configuration.', $id),
+            $previous,
+        );
+    }
+
+    public static function unknownServiceId(string $id, string $type): self
+    {
+        return new self(\sprintf(
+            'The PSR-11 container has no service "%s" for the parameter of type "%s". Check the service ID.',
+            $id,
+            $type,
+        ));
+    }
+
+    public static function serviceTypeMismatch(string $id, string $type, string $actual): self
+    {
+        return new self(\sprintf(
+            'PSR-11 service "%s" has type "%s". The parameter requires type "%s".',
+            $id,
+            $actual,
+            $type,
+        ));
+    }
+
+    public static function resetFailed(\Throwable $previous): self
+    {
+        return new self(
+            'The PSR-11 container reset failed. Check the reset callback.',
+            $previous,
+        );
+    }
+}

--- a/src/Psr/Psr11Plugin.php
+++ b/src/Psr/Psr11Plugin.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Psr;
+
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Harness\Scope;
+use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Harness\ServiceResolver;
+use Greenlight\Plugin\HarnessProvider;
+use Greenlight\Plugin\TestContext;
+use Greenlight\Plugin\TestLifecycleSubscriber;
+use Psr\Container\ContainerInterface;
+
+/**
+ * Creates a PSR-11 container lazily and resolves its services. By default, the
+ * plugin discards the container after each test that uses it.
+ *
+ * `#[Service]` selects an explicit ID. Tests MUST isolate external resources
+ * by `GREENLIGHT_CHANNEL`.
+ */
+final class Psr11Plugin implements HarnessProvider, ServiceResolver, TestLifecycleSubscriber
+{
+    private ?ContainerInterface $activeContainer = null;
+
+    /**
+     * @param \Closure():ContainerInterface $factory
+     *   A factory that returns the application container.
+     * @param bool $refreshBetweenTests
+     *   Set to false only when the reset callback removes all container state,
+     *   or when services do not keep state.
+     * @param (\Closure(ContainerInterface): void)|null $reset
+     *   An optional callback that resets the active container after each test.
+     */
+    public function __construct(
+        private readonly \Closure $factory,
+        private readonly bool $refreshBetweenTests = true,
+        private readonly ?\Closure $reset = null,
+    ) {}
+
+    /**
+     * @return list<ServiceDefinition>
+     */
+    #[\Override]
+    public function services(): array
+    {
+        return [
+            new ServiceDefinition(
+                ContainerInterface::class,
+                $this->refreshBetweenTests ? Scope::PerTest : Scope::PerRun,
+                $this->container(...),
+            ),
+        ];
+    }
+
+    /**
+     * @throws Psr11BridgeError
+     */
+    private function container(): ContainerInterface
+    {
+        if ($this->activeContainer instanceof ContainerInterface) {
+            return $this->activeContainer;
+        }
+
+        try {
+            $container = $this->createContainer();
+        } catch (\Throwable $threw) {
+            throw Psr11BridgeError::factoryFailed($threw);
+        }
+
+        if (!$container instanceof ContainerInterface) {
+            throw Psr11BridgeError::notAContainer(\get_debug_type($container));
+        }
+
+        $this->activeContainer = $container;
+
+        return $container;
+    }
+
+    private function createContainer(): mixed
+    {
+        return ($this->factory)();
+    }
+
+    /**
+     * @param class-string $type
+     * @param list<object> $attributes
+     *
+     * @throws Psr11BridgeError
+     */
+    #[\Override]
+    public function resolve(string $type, array $attributes): ?object
+    {
+        $id = $type;
+        $explicit = false;
+
+        foreach ($attributes as $attribute) {
+            if ($attribute instanceof Service) {
+                $id = $attribute->id;
+                $explicit = true;
+            }
+        }
+
+        $container = $this->container();
+
+        try {
+            $hasService = $container->has($id);
+        } catch (\Throwable $threw) {
+            throw Psr11BridgeError::serviceCheckFailed($id, $threw);
+        }
+
+        if (!$hasService) {
+            if ($explicit) {
+                throw Psr11BridgeError::unknownServiceId($id, $type);
+            }
+
+            return null;
+        }
+
+        try {
+            $service = $container->get($id);
+        } catch (\Throwable $threw) {
+            throw Psr11BridgeError::serviceReadFailed($id, $threw);
+        }
+
+        if (!$service instanceof $type) {
+            throw Psr11BridgeError::serviceTypeMismatch($id, $type, \get_debug_type($service));
+        }
+
+        return $service;
+    }
+
+    #[\Override]
+    public function beforeTest(TestContext $context): void {}
+
+    /**
+     * @throws Psr11BridgeError
+     */
+    #[\Override]
+    public function afterTest(TestContext $context, TestResult $result): TestResult
+    {
+        $container = $this->activeContainer;
+
+        if (!$container instanceof ContainerInterface) {
+            return $result;
+        }
+
+        if ($this->refreshBetweenTests) {
+            $this->activeContainer = null;
+        }
+
+        if (!$this->reset instanceof \Closure) {
+            return $result;
+        }
+
+        try {
+            ($this->reset)($container);
+        } catch (\Throwable $threw) {
+            $this->activeContainer = null;
+
+            throw Psr11BridgeError::resetFailed($threw);
+        }
+
+        return $result;
+    }
+}

--- a/src/Psr/Service.php
+++ b/src/Psr/Service.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Psr;
+
+/**
+ * Selects a PSR-11 service ID that differs from the parameter type. The
+ * resolved service must still have the declared type.
+ */
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+final readonly class Service
+{
+    /**
+     * @var non-empty-string
+     */
+    public string $id;
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(string $id)
+    {
+        if ($id === '') {
+            throw new \InvalidArgumentException('Service identifier must not be empty.');
+        }
+
+        $this->id = $id;
+    }
+}

--- a/tests/Support/Psr/ArrayContainer.php
+++ b/tests/Support/Psr/ArrayContainer.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Support\Psr;
+
+use Psr\Container\ContainerInterface;
+
+/**
+ * Stores fixed PSR-11 service values for integration tests.
+ *
+ * @internal
+ */
+final readonly class ArrayContainer implements ContainerInterface
+{
+    /**
+     * @param array<string, mixed> $services
+     */
+    public function __construct(private array $services) {}
+
+    #[\Override]
+    public function get(string $id): mixed
+    {
+        if (!\array_key_exists($id, $this->services)) {
+            throw new \RuntimeException(\sprintf('Service "%s" does not exist.', $id));
+        }
+
+        return $this->services[$id];
+    }
+
+    #[\Override]
+    public function has(string $id): bool
+    {
+        return \array_key_exists($id, $this->services);
+    }
+}

--- a/tests/Support/Psr/Greeter.php
+++ b/tests/Support/Psr/Greeter.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Support\Psr;
+
+/** @internal */
+final readonly class Greeter
+{
+    public function greet(string $name): string
+    {
+        return 'Hello, ' . $name . '!';
+    }
+}

--- a/tests/Unit/Psr/Psr11PluginTest.php
+++ b/tests/Unit/Psr/Psr11PluginTest.php
@@ -1,0 +1,397 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Psr;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Harness\HarnessRegistry;
+use Greenlight\Harness\HarnessScopes;
+use Greenlight\Harness\Scope;
+use Greenlight\Plugin\TestContext;
+use Greenlight\Psr\Psr11BridgeError;
+use Greenlight\Psr\Psr11Plugin;
+use Greenlight\Psr\Service;
+use Greenlight\Tests\Support\Psr\ArrayContainer;
+use Greenlight\Tests\Support\Psr\Greeter;
+use Psr\Container\ContainerInterface;
+
+final readonly class Psr11PluginTest
+{
+    #[Test]
+    public function resolvesContainerServicesByType(): void
+    {
+        $greeter = new Greeter();
+        $plugin = $this->plugin([Greeter::class => $greeter]);
+
+        Expect::that($plugin->resolve(Greeter::class, []))->toBe($greeter);
+    }
+
+    #[Test]
+    public function resolvesAServiceByExplicitId(): void
+    {
+        $greeter = new Greeter();
+        $plugin = $this->plugin(['application.greeter' => $greeter]);
+        $resolved = $plugin->resolve(Greeter::class, [new Service('application.greeter')]);
+
+        Expect::that($resolved)->toBe($greeter);
+    }
+
+    #[Test]
+    public function anUnknownTypeReturnsNull(): void
+    {
+        Expect::that($this->plugin([])->resolve(Greeter::class, []))->toBeNull();
+    }
+
+    #[Test]
+    public function anUnknownExplicitIdFailsLoudly(): void
+    {
+        $plugin = $this->plugin([]);
+
+        Expect::that(static function () use ($plugin): void {
+            $plugin->resolve(Greeter::class, [new Service('missing')]);
+        })->toThrow(
+            Psr11BridgeError::class,
+            matching: '/no service "missing".*Check the service ID/s',
+        );
+    }
+
+    #[Test]
+    public function aServiceOfTheWrongTypeFailsLoudly(): void
+    {
+        $plugin = $this->plugin(['application' => new \stdClass()]);
+
+        Expect::that(static function () use ($plugin): void {
+            $plugin->resolve(Greeter::class, [new Service('application')]);
+        })->toThrow(
+            Psr11BridgeError::class,
+            matching: '/service "application" has type "stdClass".*requires type/s',
+        );
+    }
+
+    #[Test]
+    public function containerCreationIsLazy(): void
+    {
+        $created = false;
+        $plugin = new Psr11Plugin(static function () use (&$created): ContainerInterface {
+            $created = true;
+
+            return new ArrayContainer([]);
+        });
+
+        $plugin->beforeTest($this->context());
+
+        Expect::that($created)->toBeFalse();
+    }
+
+    #[Test]
+    public function theHarnessFactoryReturnsTheActiveContainer(): void
+    {
+        $container = new ArrayContainer([]);
+        $plugin = new Psr11Plugin(static fn(): ContainerInterface => $container);
+
+        Expect::that($this->containerFrom($plugin))->toBe($container);
+        Expect::that($this->containerFrom($plugin))->toBe($container);
+    }
+
+    #[Test]
+    public function theDefaultLifecycleCreatesAContainerForEachTest(): void
+    {
+        $created = 0;
+        $plugin = new Psr11Plugin(static function () use (&$created): ContainerInterface {
+            ++$created;
+
+            return new ArrayContainer([Greeter::class => new Greeter()]);
+        });
+        $first = $plugin->resolve(Greeter::class, []);
+
+        $plugin->afterTest($this->context(), $this->result());
+
+        Expect::that($plugin->resolve(Greeter::class, []))->not()->toBe($first);
+        Expect::that($created)->toBe(2);
+    }
+
+    #[Test]
+    public function aSharedLifecycleKeepsTheWorkerContainer(): void
+    {
+        $created = 0;
+        $plugin = new Psr11Plugin(
+            static function () use (&$created): ContainerInterface {
+                ++$created;
+
+                return new ArrayContainer([Greeter::class => new Greeter()]);
+            },
+            refreshBetweenTests: false,
+        );
+        $first = $plugin->resolve(Greeter::class, []);
+
+        $plugin->afterTest($this->context(), $this->result());
+
+        Expect::that($plugin->resolve(Greeter::class, []))->toBe($first);
+        Expect::that($created)->toBe(1);
+    }
+
+    #[Test]
+    public function theResetCallbackReceivesTheActiveContainer(): void
+    {
+        $container = new ArrayContainer([]);
+        $resetContainer = null;
+        $plugin = new Psr11Plugin(
+            static fn(): ContainerInterface => $container,
+            reset: static function (ContainerInterface $active) use (&$resetContainer): void {
+                $resetContainer = $active;
+            },
+        );
+        $this->containerFrom($plugin);
+
+        $plugin->afterTest($this->context(), $this->result());
+
+        Expect::that($resetContainer)->toBe($container);
+    }
+
+    #[Test]
+    public function aFailedResetStillDiscardsAPerTestContainer(): void
+    {
+        $failure = new \RuntimeException('Reset failed.');
+        $created = 0;
+        $plugin = new Psr11Plugin(
+            static function () use (&$created): ContainerInterface {
+                ++$created;
+
+                return new ArrayContainer([]);
+            },
+            reset: static function (ContainerInterface $container) use ($failure): never {
+                throw $failure;
+            },
+        );
+        $this->containerFrom($plugin);
+
+        $error = null;
+
+        try {
+            $plugin->afterTest($this->context(), $this->result());
+        } catch (Psr11BridgeError $caught) {
+            $error = $caught;
+        }
+
+        if (!$error instanceof Psr11BridgeError) {
+            Fail::because('The reset callback did not fail.');
+        }
+
+        Expect::that($error->getPrevious())->toBe($failure);
+        $this->containerFrom($plugin);
+        Expect::that($created)->toBe(2);
+    }
+
+    #[Test]
+    public function aFailedResetDiscardsASharedContainer(): void
+    {
+        $failure = new \RuntimeException('Reset failed.');
+        $created = 0;
+        $plugin = new Psr11Plugin(
+            static function () use (&$created): ContainerInterface {
+                ++$created;
+
+                return new ArrayContainer([Greeter::class => new Greeter()]);
+            },
+            refreshBetweenTests: false,
+            reset: static function (ContainerInterface $container) use ($failure): never {
+                throw $failure;
+            },
+        );
+        $plugin->resolve(Greeter::class, []);
+
+        try {
+            $plugin->afterTest($this->context(), $this->result());
+        } catch (Psr11BridgeError $error) {
+            Expect::that($error->getPrevious())->toBe($failure);
+        }
+
+        $plugin->resolve(Greeter::class, []);
+        Expect::that($created)->toBe(2);
+    }
+
+    #[Test]
+    public function aContainerFactoryFailureKeepsTheCause(): void
+    {
+        $failure = new \RuntimeException('Container construction failed.');
+        $plugin = new Psr11Plugin(static function () use ($failure): never {
+            throw $failure;
+        });
+
+        $error = null;
+
+        try {
+            $plugin->resolve(Greeter::class, []);
+        } catch (Psr11BridgeError $caught) {
+            $error = $caught;
+        }
+
+        if (!$error instanceof Psr11BridgeError) {
+            Fail::because('The container factory did not fail.');
+        }
+
+        Expect::that($error->getPrevious())->toBe($failure);
+    }
+
+    #[Test]
+    public function aFactoryMustReturnAPsr11Container(): void
+    {
+        $plugin = new Psr11Plugin($this->invalidContainerFactory());
+
+        Expect::that(static fn(): ?object => $plugin->resolve(Greeter::class, []))->toThrow(
+            Psr11BridgeError::class,
+            matching: '/returned "stdClass".*ContainerInterface/',
+        );
+    }
+
+    #[Test]
+    public function aContainerCheckFailureKeepsTheCause(): void
+    {
+        $failure = new \RuntimeException('The container cannot check services.');
+        $container = new readonly class ($failure) implements ContainerInterface {
+            public function __construct(private \Throwable $failure) {}
+
+            #[\Override]
+            public function get(string $id): mixed
+            {
+                return new \stdClass();
+            }
+
+            #[\Override]
+            public function has(string $id): bool
+            {
+                throw $this->failure;
+            }
+        };
+        $plugin = new Psr11Plugin(static fn(): ContainerInterface => $container);
+
+        $this->expectCause(
+            static fn(): ?object => $plugin->resolve(Greeter::class, []),
+            $failure,
+            '/failed when it checked service/',
+        );
+    }
+
+    #[Test]
+    public function aContainerReadFailureKeepsTheCause(): void
+    {
+        $failure = new \RuntimeException('The container cannot read services.');
+        $container = new readonly class ($failure) implements ContainerInterface {
+            public function __construct(private \Throwable $failure) {}
+
+            #[\Override]
+            public function get(string $id): mixed
+            {
+                throw $this->failure;
+            }
+
+            #[\Override]
+            public function has(string $id): bool
+            {
+                return true;
+            }
+        };
+        $plugin = new Psr11Plugin(static fn(): ContainerInterface => $container);
+
+        $this->expectCause(
+            static fn(): ?object => $plugin->resolve(Greeter::class, []),
+            $failure,
+            '/failed when it read service/',
+        );
+    }
+
+    #[Test]
+    public function theContainerHarnessServiceUsesTheConfiguredLifecycle(): void
+    {
+        $perTest = $this->plugin([])->services()[0];
+        $perRun = new Psr11Plugin(
+            static fn(): ContainerInterface => new ArrayContainer([]),
+            refreshBetweenTests: false,
+        );
+
+        Expect::that($perTest->type)->toBe(ContainerInterface::class);
+        Expect::that($perTest->scope)->toBe(Scope::PerTest);
+        Expect::that($perRun->services()[0]->scope)->toBe(Scope::PerRun);
+    }
+
+    #[Test]
+    public function afterTestWithoutAnActiveContainerIsANoOp(): void
+    {
+        $created = false;
+        $plugin = new Psr11Plugin(static function () use (&$created): ContainerInterface {
+            $created = true;
+
+            return new ArrayContainer([]);
+        });
+        $result = $this->result();
+
+        Expect::that($plugin->afterTest($this->context(), $result))->toBe($result);
+        Expect::that($created)->toBeFalse();
+    }
+
+    /**
+     * @param array<string, mixed> $services
+     */
+    private function plugin(array $services): Psr11Plugin
+    {
+        return new Psr11Plugin(static fn(): ContainerInterface => new ArrayContainer($services));
+    }
+
+    private function containerFrom(Psr11Plugin $plugin): ContainerInterface
+    {
+        $container = ($plugin->services()[0]->factory)();
+
+        if (!$container instanceof ContainerInterface) {
+            Fail::because(\sprintf(
+                'Expected the PSR-11 harness factory to return ContainerInterface, got %s.',
+                \get_debug_type($container),
+            ));
+        }
+
+        return $container;
+    }
+
+    private function invalidContainerFactory(): \Closure
+    {
+        return static fn(): object => new \stdClass();
+    }
+
+    /**
+     * @param \Closure(): ?object $operation
+     */
+    private function expectCause(\Closure $operation, \Throwable $cause, string $pattern): void
+    {
+        try {
+            $operation();
+        } catch (Psr11BridgeError $error) {
+            Expect::that($error->getMessage())->toMatch($pattern);
+            Expect::that($error->getPrevious())->toBe($cause);
+
+            return;
+        }
+
+        throw new \LogicException('The PSR-11 operation did not fail.');
+    }
+
+    private function context(): TestContext
+    {
+        return new TestContext(
+            new \stdClass(),
+            new TestId('Fixture', 'probe'),
+            new TestMetadata('Fixture', 'probe'),
+            new HarnessScopes(new HarnessRegistry()),
+        );
+    }
+
+    private function result(): TestResult
+    {
+        return new TestResult(new TestId('Fixture', 'probe'), Outcome::Passed, 0.0, 0);
+    }
+}

--- a/tests/Unit/ServiceAttributeTest.php
+++ b/tests/Unit/ServiceAttributeTest.php
@@ -8,12 +8,13 @@ use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Laravel\Service as LaravelService;
+use Greenlight\Psr\Service as PsrService;
 use Greenlight\Symfony\Service as SymfonyService;
 
 final readonly class ServiceAttributeTest
 {
     /**
-     * @param class-string<LaravelService|SymfonyService> $attribute
+     * @param class-string<LaravelService|PsrService|SymfonyService> $attribute
      */
     #[Test]
     #[DataSet('serviceAttributes')]
@@ -28,7 +29,7 @@ final readonly class ServiceAttributeTest
     }
 
     /**
-     * @param class-string<LaravelService|SymfonyService> $attribute
+     * @param class-string<LaravelService|PsrService|SymfonyService> $attribute
      */
     #[Test]
     #[DataSet('serviceAttributes')]
@@ -40,11 +41,12 @@ final readonly class ServiceAttributeTest
     }
 
     /**
-     * @return iterable<string, array{class-string<LaravelService|SymfonyService>}>
+     * @return iterable<string, array{class-string<LaravelService|PsrService|SymfonyService>}>
      */
     public static function serviceAttributes(): iterable
     {
         yield 'Laravel' => [LaravelService::class];
+        yield 'PSR-11' => [PsrService::class];
         yield 'Symfony' => [SymfonyService::class];
     }
 }

--- a/website/scripts/generate-api-reference.mjs
+++ b/website/scripts/generate-api-reference.mjs
@@ -78,8 +78,8 @@ const sections = [
   {
     id: 'api-integrations',
     title: 'Integration API',
-    description: 'This reference lists public integration types for Laravel, Rector, and Symfony.',
-    prefixes: ['Greenlight\\Laravel\\', 'Greenlight\\PhpStan\\', 'Greenlight\\Rector\\', 'Greenlight\\Symfony\\'],
+    description: 'This reference lists public integration types for Laravel, PSR standards, Rector, and Symfony.',
+    prefixes: ['Greenlight\\Laravel\\', 'Greenlight\\PhpStan\\', 'Greenlight\\Psr\\', 'Greenlight\\Rector\\', 'Greenlight\\Symfony\\'],
   },
 ];
 

--- a/website/src/lib/docs.ts
+++ b/website/src/lib/docs.ts
@@ -62,6 +62,11 @@ export const docSections = [
         description: 'This guide explains how tests receive container services from a fresh Laravel application.',
       },
       {
+        id: 'psr',
+        title: 'PSR applications',
+        description: 'This guide explains PSR-11 container services and PSR-15 request handlers.',
+      },
+      {
         id: 'phpstan',
         title: 'PHPStan',
         description: 'This guide explains how PHPStan checks matchers, data providers, and extension matchers.',
@@ -139,7 +144,7 @@ export const docSections = [
       {
         id: 'api-integrations',
         title: 'Integration API',
-        description: 'This reference lists public integration types for Laravel, Rector, and Symfony.',
+        description: 'This reference lists public integration types for Laravel, PSR standards, Rector, and Symfony.',
       },
     ],
   },


### PR DESCRIPTION
## Summary

- add a PSR-11 plugin with typed and named service injection
- manage per-test and per-run container lifecycles with optional reset callbacks
- provide lazy container construction, type validation, and cause-preserving diagnostics
- document standards-first container integration for Laminas ServiceManager, Mezzio, and other PSR-11 applications
- add architecture boundaries, generated API references, and focused coverage