### PR TITLE
fix(cli): use monotonic watch clock

### DIFF
--- a/src/Cli/Watch/SystemWatchClock.php
+++ b/src/Cli/Watch/SystemWatchClock.php
@@ -12,7 +12,7 @@ final readonly class SystemWatchClock implements WatchClock
     #[\Override]
     public function now(): float
     {
-        return \microtime(true);
+        return \hrtime(true) / 1_000_000_000;
     }
 
     #[\Override]

--- a/tests/Unit/Cli/Watch/SystemWatchClockTest.php
+++ b/tests/Unit/Cli/Watch/SystemWatchClockTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli\Watch;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\Watch\SystemWatchClock;
+use Greenlight\Expect\Expect;
+
+final readonly class SystemWatchClockTest
+{
+    #[Test]
+    public function nowUsesTheMonotonicSystemClock(): void
+    {
+        $before = \hrtime(true) / 1_000_000_000;
+        $now = new SystemWatchClock()->now();
+        $after = \hrtime(true) / 1_000_000_000;
+
+        Expect::that($now)
+            ->because('watch debounce timing MUST use the monotonic system clock')
+            ->toBeGreaterThanOrEqual($before)
+            ->toBeLessThanOrEqual($after);
+    }
+}


### PR DESCRIPTION
Use the monotonic system clock for watch-mode debounce timing. This prevents wall-clock corrections from firing a pending run early or delaying it, and adds a focused production-clock oracle.