### PR TITLE
refactor(test): centralize project file writes

### DIFF
--- a/tests/Acceptance/ProseCheckBehaviorTest.php
+++ b/tests/Acceptance/ProseCheckBehaviorTest.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Tests\Support\ProcessResult;
+use Greenlight\Tests\Support\ProjectFiles;
 use Greenlight\Tests\Support\Subprocess;
 
 final readonly class ProseCheckBehaviorTest
@@ -787,24 +788,12 @@ final readonly class ProseCheckBehaviorTest
 
     private function workspace(string $name): string
     {
-        $directory = $this->tempDirectory->subdirectory($name);
-        $root = $directory . '/project';
-
-        \mkdir($root);
-
-        return $root;
+        return ProjectFiles::create($this->tempDirectory, $name . '/project')->directory;
     }
 
     private function write(string $root, string $relativePath, string $contents): void
     {
-        $path = $root . '/' . $relativePath;
-        $directory = \dirname($path);
-
-        if (!\is_dir($directory)) {
-            \mkdir($directory, 0o777, true);
-        }
-
-        \file_put_contents($path, $contents);
+        new ProjectFiles($root)->write($relativePath, $contents);
     }
 
     private function run(string $command, string $root): ProcessResult

--- a/tests/Support/AcceptanceProject.php
+++ b/tests/Support/AcceptanceProject.php
@@ -4,16 +4,20 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Support;
 
-use Greenlight\Core\ErrorTrap;
 use Greenlight\Fixture\TempDirectory;
 
 final readonly class AcceptanceProject
 {
-    private function __construct(public string $directory) {}
+    private function __construct(
+        private ProjectFiles $files,
+        public string $directory,
+    ) {}
 
     public static function create(TempDirectory $workspace, string $name): self
     {
-        return new self($workspace->subdirectory($name));
+        $files = ProjectFiles::create($workspace, $name, 'acceptance project');
+
+        return new self($files, $files->directory);
     }
 
     /**
@@ -45,47 +49,12 @@ final readonly class AcceptanceProject
 
     public function path(string $relative): string
     {
-        if ($relative === '' || \str_starts_with($relative, '/') || \str_contains($relative, '\\')) {
-            throw new \InvalidArgumentException(\sprintf(
-                'Acceptance project path "%s" must be a relative path of plain segments.',
-                $relative,
-            ));
-        }
-
-        foreach (\explode('/', $relative) as $segment) {
-            if (\in_array($segment, ['', '.', '..'], true)) {
-                throw new \InvalidArgumentException(\sprintf(
-                    'Acceptance project path "%s" must be a relative path of plain segments.',
-                    $relative,
-                ));
-            }
-        }
-
-        return $this->directory . '/' . $relative;
+        return $this->files->path($relative);
     }
 
     public function writeFile(string $relativePath, string $contents): void
     {
-        $path = $this->path($relativePath);
-        $parent = \dirname($path);
-
-        if (!\is_dir($parent)
-            && !ErrorTrap::run(static fn(): bool => \mkdir($parent, 0o777, true), $warning)
-        ) {
-            throw new \RuntimeException(\sprintf(
-                'Failed to create acceptance project directory "%s"%s.',
-                $parent,
-                $warning === null ? '' : ': ' . $warning,
-            ));
-        }
-
-        if (ErrorTrap::run(static fn(): int|false => \file_put_contents($path, $contents), $warning) === false) {
-            throw new \RuntimeException(\sprintf(
-                'Failed to write acceptance project file "%s"%s.',
-                $path,
-                $warning === null ? '' : ': ' . $warning,
-            ));
-        }
+        $this->files->write($relativePath, $contents);
     }
 
     /**

--- a/tests/Support/PhpStanProbe.php
+++ b/tests/Support/PhpStanProbe.php
@@ -28,12 +28,13 @@ final readonly class PhpStanProbe
     ): self {
         $root = \dirname(__DIR__, 2);
         $configFile ??= $root . '/tests/Fixture/PhpStanExtension/probe.neon';
-        $probeDirectory = $workspace->subdirectory('phpstan-probe');
+        $files = ProjectFiles::create($workspace, 'phpstan-probe');
+        $probeDirectory = $files->directory;
         $goodFile = $probeDirectory . '/GoodProbe.php';
         $badFile = $probeDirectory . '/BadProbe.php';
 
-        \file_put_contents($goodFile, $goodSource);
-        \file_put_contents($badFile, $badSource);
+        $files->write('GoodProbe.php', $goodSource);
+        $files->write('BadProbe.php', $badSource);
 
         $result = Subprocess::run(
             $root,

--- a/tests/Support/ProjectFiles.php
+++ b/tests/Support/ProjectFiles.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Support;
+
+use Greenlight\Core\ErrorTrap;
+use Greenlight\Fixture\TempDirectory;
+
+/** Owns validated, fail-fast file writes inside one test project. */
+final readonly class ProjectFiles
+{
+    public function __construct(
+        public string $directory,
+        private string $description = 'test project',
+    ) {}
+
+    public static function create(
+        TempDirectory $workspace,
+        string $name,
+        string $description = 'test project',
+    ): self {
+        return new self($workspace->subdirectory($name), $description);
+    }
+
+    public function path(string $relative): string
+    {
+        if ($relative === '' || \str_starts_with($relative, '/') || \str_contains($relative, '\\')) {
+            throw $this->invalidPath($relative);
+        }
+
+        foreach (\explode('/', $relative) as $segment) {
+            if (\in_array($segment, ['', '.', '..'], true)) {
+                throw $this->invalidPath($relative);
+            }
+        }
+
+        return $this->directory . '/' . $relative;
+    }
+
+    public function write(string $relativePath, string $contents): void
+    {
+        $path = $this->path($relativePath);
+        $parent = \dirname($path);
+
+        if (!\is_dir($parent)
+            && !ErrorTrap::run(static fn(): bool => \mkdir($parent, 0o777, true), $warning)
+            && !\is_dir($parent)
+        ) {
+            throw new \RuntimeException(\sprintf(
+                'Failed to create %s directory "%s"%s.',
+                $this->description,
+                $parent,
+                $warning === null ? '' : ': ' . $warning,
+            ));
+        }
+
+        $written = ErrorTrap::run(
+            static fn(): int|false => \file_put_contents($path, $contents),
+            $warning,
+        );
+
+        if ($written !== \strlen($contents)) {
+            throw new \RuntimeException(\sprintf(
+                'Failed to write %s file "%s"%s.',
+                $this->description,
+                $path,
+                $warning === null ? '' : ': ' . $warning,
+            ));
+        }
+    }
+
+    private function invalidPath(string $relative): \InvalidArgumentException
+    {
+        return new \InvalidArgumentException(\sprintf(
+            '%s path "%s" must be a relative path of plain segments.',
+            \ucfirst($this->description),
+            $relative,
+        ));
+    }
+}

--- a/tests/Support/ProseCheckRuleProbe.php
+++ b/tests/Support/ProseCheckRuleProbe.php
@@ -20,17 +20,16 @@ final readonly class ProseCheckRuleProbe
         string $invalid,
         string $valid,
     ): void {
-        $root = $tempDirectory->subdirectory('blocking-' . $rule) . '/project';
-        \mkdir($root);
-        $sample = $root . '/sample.md';
+        $files = ProjectFiles::create($tempDirectory, 'blocking-' . $rule . '/project');
+        $root = $files->directory;
 
-        \file_put_contents($sample, "# Sample\n\n" . $invalid . "\n");
+        $files->write('sample.md', "# Sample\n\n" . $invalid . "\n");
 
         $invalidResult = self::run($root);
         Expect::that($invalidResult->exitCode)->because('blocking rules reject invalid prose and accept the valid counterpart')->toBe(1);
         Expect::that($invalidResult->output())->toContain($rule);
 
-        \file_put_contents($sample, "# Sample\n\n" . $valid . "\n");
+        $files->write('sample.md', "# Sample\n\n" . $valid . "\n");
 
         $validResult = self::run($root);
         Expect::that($validResult->exitCode)->because('blocking rules reject invalid prose and accept the valid counterpart')->toBe(0);

--- a/tests/Support/RectorProbe.php
+++ b/tests/Support/RectorProbe.php
@@ -33,12 +33,13 @@ final readonly class RectorProbe
         string $name = 'rector-probe',
     ): self {
         $root = \dirname(__DIR__, 2);
-        $directory = $workspace->subdirectory($name);
-        $testsDirectory = $workspace->subdirectory($name . '/tests');
+        $files = ProjectFiles::create($workspace, $name);
+        $directory = $files->directory;
+        $testsDirectory = $directory . '/tests';
         $testFile = $testsDirectory . '/ProbeTest.php';
 
-        \file_put_contents($testFile, $testClassSource);
-        \file_put_contents($directory . '/rector.php', self::rectorConfig($root, $directory, $configuration));
+        $files->write('tests/ProbeTest.php', $testClassSource);
+        $files->write('rector.php', self::rectorConfig($root, $directory, $configuration));
 
         $result = Subprocess::run(
             $root,


### PR DESCRIPTION
Extract one validated, fail-fast project-file module from AcceptanceProject and reuse it across prose, PHPStan, and Rector probes. Project setup now rejects unsafe relative paths, tolerates directory-creation races, preserves native diagnostics, and rejects partial writes consistently.