### PR TITLE
fix(test): harden subprocess input and waits

### DIFF
--- a/tests/Support/Subprocess.php
+++ b/tests/Support/Subprocess.php
@@ -93,7 +93,24 @@ final class Subprocess
     {
         $stdin = $this->pipes[0] ?? null;
 
-        if (!\is_resource($stdin) || \fwrite($stdin, $input) === false || !\fflush($stdin)) {
+        if (!\is_resource($stdin)) {
+            throw new \RuntimeException('Could not write to process stdin.');
+        }
+
+        $offset = 0;
+        $length = \strlen($input);
+
+        while ($offset < $length) {
+            $written = ErrorTrap::run(static fn(): int|false => \fwrite($stdin, \substr($input, $offset)));
+
+            if ($written === false || $written === 0) {
+                throw new \RuntimeException('Could not write to process stdin.');
+            }
+
+            $offset += $written;
+        }
+
+        if (!ErrorTrap::run(static fn(): bool => \fflush($stdin))) {
             throw new \RuntimeException('Could not write to process stdin.');
         }
     }
@@ -141,9 +158,9 @@ final class Subprocess
             ));
         }
 
-        $deadline = \microtime(true) + $timeoutSeconds;
+        $deadline = $this->monotonicTime() + $timeoutSeconds;
 
-        while (\microtime(true) < $deadline) {
+        while ($this->monotonicTime() < $deadline) {
             $this->pump();
             $output = \substr($this->stdout, $offset);
 
@@ -202,10 +219,10 @@ final class Subprocess
      */
     public function wait(float $timeoutSeconds): ProcessResult
     {
-        $deadline = \microtime(true) + $timeoutSeconds;
+        $deadline = $this->monotonicTime() + $timeoutSeconds;
 
         try {
-            while (\microtime(true) < $deadline) {
+            while ($this->monotonicTime() < $deadline) {
                 $this->pump();
                 $status = \proc_get_status($this->process);
 
@@ -323,5 +340,10 @@ final class Subprocess
     private function normalize(string $output): string
     {
         return \rtrim(\str_replace("\r\n", "\n", $output), "\n");
+    }
+
+    private function monotonicTime(): float
+    {
+        return \hrtime(true) / 1_000_000_000;
     }
 }

--- a/tests/Unit/Support/SubprocessTest.php
+++ b/tests/Unit/Support/SubprocessTest.php
@@ -98,6 +98,36 @@ final readonly class SubprocessTest
     }
 
     #[Test]
+    public function interactiveProcessReceivesTheCompleteInput(): void
+    {
+        $input = \str_repeat('payload', 131_072);
+        $process = Subprocess::start(
+            $this->workspace->path(),
+            [
+                \PHP_BINARY,
+                '-r',
+                <<<'PHP'
+                $input = stream_get_contents(STDIN);
+                fwrite(STDOUT, hash('sha256', $input));
+                PHP,
+            ],
+        );
+
+        try {
+            $process->write($input);
+            $result = $process->complete();
+
+            Expect::that($result->exitCode)
+                ->because('a subprocess MUST receive the complete input before stdin closes')
+                ->toBe(0);
+            Expect::that($result->stdout)
+                ->toBe(\hash('sha256', $input));
+        } finally {
+            $process->terminate();
+        }
+    }
+
+    #[Test]
     public function readStdoutUntilReportsAProcessThatAlreadyExited(): void
     {
         $process = Subprocess::start(


### PR DESCRIPTION
Make the shared subprocess harness write stdin to completion, suppress native pipe diagnostics behind its own exception contract, and measure output and exit deadlines with the monotonic system clock. Add a large-input oracle that verifies the child receives every byte.