### PR TITLE
feat(tempest): add framework bridge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,7 @@ jobs:
     timeout-minutes: 20
     permissions:
       contents: "read"
+      id-token: "write"
     env:
       XDEBUG_MODE: "off"
 
@@ -396,7 +397,7 @@ jobs:
         with:
           php-version: "8.5"
           extensions: "pcntl, sockets"
-          coverage: "none"
+          coverage: "xdebug"
           ini-values: "memory_limit=-1"
 
       - name: "Install Tempest and test dependencies"
@@ -405,16 +406,24 @@ jobs:
           composer config platform.php 8.5.0
           composer require --dev --no-interaction --no-progress --with-all-dependencies "tempest/framework:^3.18"
 
-      - name: "Run Tempest bridge tests"
+      - name: "Run Tempest bridge tests with coverage"
         shell: "bash"
         run: |
-          php bin/greenlight run \
-            --filter=TempestRunTest \
-            --filter=TempestFrameworkRequirementTest \
-            --filter=TempestFrameworkVersionBoundaryTest \
-            --filter=TempestFrameworkUnavailableTest \
-            --filter=TempestPluginConfigurationTest \
-            --filter=TempestProcessEnvironmentValidationTest
+          XDEBUG_MODE=coverage php bin/greenlight run --config=greenlight.tempest-coverage.php \
+            --filter='*Tempest*Test::*'
+
+      - name: "Upload Tempest coverage to Codecov"
+        continue-on-error: true
+        uses: "codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f" # v7.0.0
+        with:
+          disable_search: true
+          fail_ci_if_error: false
+          files: "build/coverage/cobertura.xml"
+          use_oidc: true
+
+      - name: "Run the Tempest coverage gate"
+        if: "always()"
+        run: "composer coverage-gate"
 
   php-next:
     name: "PHP 8.6 pre-release compatibility"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,6 +376,46 @@ jobs:
             --filter=TerminalTest \
             --filter=WorkerProcessRunTest
 
+  tempest:
+    name: "Tempest 3.18 bridge (PHP 8.5)"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 20
+    permissions:
+      contents: "read"
+    env:
+      XDEBUG_MODE: "off"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7
+        with:
+          persist-credentials: false
+
+      - name: "Set up PHP"
+        uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # v2
+        with:
+          php-version: "8.5"
+          extensions: "pcntl, sockets"
+          coverage: "none"
+          ini-values: "memory_limit=-1"
+
+      - name: "Install Tempest and test dependencies"
+        shell: "bash"
+        run: |
+          composer config platform.php 8.5.0
+          composer require --dev --no-interaction --no-progress --with-all-dependencies "tempest/framework:^3.18"
+
+      - name: "Run Tempest bridge tests"
+        shell: "bash"
+        run: |
+          php bin/greenlight run \
+            --filter=TempestRunTest \
+            --filter=TempestFrameworkRequirementTest \
+            --filter=TempestFrameworkVersionBoundaryTest \
+            --filter=TempestFrameworkUnavailableTest \
+            --filter=TempestPluginConfigurationTest \
+            --filter=TempestProcessEnvironmentValidationTest
+
   php-next:
     name: "PHP 8.6 pre-release compatibility"
     runs-on: "ubuntu-latest"
@@ -581,6 +621,7 @@ jobs:
       - "installed-package"
       - "ci"
       - "macos-portability"
+      - "tempest"
       - "memory"
       - "coverage"
       - "pcov"
@@ -601,6 +642,7 @@ jobs:
           MEMORY_RESULT: "${{ needs.memory.result }}"
           PCOV_RESULT: "${{ needs.pcov.result }}"
           RENOVATE_CONFIG_RESULT: "${{ needs.renovate-config.result }}"
+          TEMPEST_RESULT: "${{ needs.tempest.result }}"
           ZIZMOR_RESULT: "${{ needs.zizmor.result }}"
         shell: "bash"
         run: |
@@ -611,6 +653,7 @@ jobs:
           test "${INSTALLED_PACKAGE_RESULT}" = "success"
           test "${CI_RESULT}" = "success"
           test "${MACOS_PORTABILITY_RESULT}" = "success"
+          test "${TEMPEST_RESULT}" = "success"
           test "${MEMORY_RESULT}" = "success"
           test "${COVERAGE_RESULT}" = "success"
           test "${PCOV_RESULT}" = "success"

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ for the complete model.
 * [Test Hyperf applications](docs/hyperf.md)
 * [Test PSR applications](docs/psr.md)
 * [Test PSR-15 applications](docs/psr15.md)
+* [Test Tempest applications](docs/tempest.md)
 * [Move from PHPUnit](docs/migrating-from-phpunit.md)
 * [Benchmarks](docs/benchmarks.md)
 * [Architecture](docs/architecture/README.md)

--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,8 @@
         "psr/http-message": "Provides the PSR-7 request and response interfaces that HttpHarness requires",
         "psr/http-server-handler": "Provides the PSR-15 request handler interface that Psr15Plugin requires",
         "rector/rector": "Converts PHPUnit test classes to Greenlight with the bundled 'PhpUnitToGreenlightRector' rule",
-        "symfony/framework-bundle": "Enables container service injection into kernel-aware Symfony tests through the 'SymfonyPlugin' bridge"
+        "symfony/framework-bundle": "Enables container service injection into kernel-aware Symfony tests through the 'SymfonyPlugin' bridge",
+        "tempest/framework": "Enables discovery, configuration, container injection, and reset-safe tests through the 'TempestPlugin' bridge"
     },
     "autoload": {
         "psr-4": {

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -101,6 +101,10 @@ deptrac:
       collectors:
         - type: directory
           value: src/Psr15/.*
+    - name: Tempest
+      collectors:
+        - type: directory
+          value: src/Tempest/.*
     - name: PhpStanFramework
       collectors:
         - type: classNameRegex
@@ -133,6 +137,10 @@ deptrac:
       collectors:
         - type: classNameRegex
           value: /^Psr\\Http\\(Message|Server)\\/
+    - name: TempestFramework
+      collectors:
+        - type: classNameRegex
+          value: /^Tempest\\/
     - name: CpuCoreCounter
       collectors:
         - type: classNameRegex
@@ -171,6 +179,7 @@ deptrac:
     Hyperf: [Core, Harness, Plugin, HyperfFramework, PsrFramework, SwooleFramework, ComposerRuntime]
     Psr: [Core, Harness, Plugin, PsrFramework]
     Psr15: [Harness, Plugin, PsrHttpFramework]
+    Tempest: [Core, Harness, Plugin, TempestFramework]
     PhpStanFramework: []
     SymfonyFramework: []
     LaravelFramework: []
@@ -179,6 +188,7 @@ deptrac:
     ComposerRuntime: []
     PsrFramework: []
     PsrHttpFramework: []
+    TempestFramework: []
     CpuCoreCounter: []
     PhpParserFramework: []
     RectorFramework: []

--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -2,7 +2,7 @@
 
 # Integration API
 
-This reference lists public integration types for Hyperf, Laravel, PSR standards, Rector, and Symfony.
+This reference lists public integration types for Hyperf, Laravel, PSR standards, Rector, Symfony, and Tempest.
 
 These signatures are the public API.
 
@@ -766,3 +766,98 @@ public function afterTest(TestContext $context, TestResult $result): TestResult
 ```
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L118)
+
+## `TempestPlugin`
+
+Namespace: `Greenlight\Tempest`
+
+Boots one Tempest long-running kernel for each worker. Tempest discovery,
+configuration, container reset, deferred tasks, and shutdown events stay
+under kernel control.
+
+The bridge uses the `testing` environment by default. Native `#[Tag]`
+attributes select tagged Tempest bindings. Tests MUST isolate external
+resources by `GREENLIGHT_CHANNEL`.
+
+```php
+final class TempestPlugin implements HarnessProvider, ServiceResolver, TestLifecycleSubscriber, WorkerBootstrapSubscriber
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L35)
+
+### `__construct()`
+
+```php
+public function __construct(
+    private readonly string $root,
+    private readonly string $environment = 'testing',
+    private readonly array $discoveryLocations = [],
+)
+```
+
+PHPDoc:
+
+- `@param string $root The directory that contains the Tempest composer.json file.`
+- `@param list<DiscoveryLocation> $discoveryLocations Additional locations for Tempest discovery.`
+- `@throws \InvalidArgumentException`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L48)
+
+### `onWorkerBootstrap()`
+
+```php
+[\Override]
+public function onWorkerBootstrap(WorkerBootstrapContext $context): void
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L62)
+
+### `services()`
+
+```php
+[\Override]
+public function services(): array
+```
+
+PHPDoc:
+
+- `@return list<ServiceDefinition>`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L71)
+
+### `resolve()`
+
+```php
+[\Override]
+public function resolve(string $type, array $attributes): object
+```
+
+PHPDoc:
+
+- `@param class-string $type`
+- `@param list<object> $attributes`
+- `@throws TempestBridgeError`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L85)
+
+### `beforeTest()`
+
+```php
+[\Override]
+public function beforeTest(TestContext $context): void
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L111)
+
+### `afterTest()`
+
+```php
+[\Override]
+public function afterTest(TestContext $context, TestResult $result): TestResult
+```
+
+PHPDoc:
+
+- `@throws TempestBridgeError`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L124)

--- a/docs/api.md
+++ b/docs/api.md
@@ -19,4 +19,4 @@ Use the task guides for workflows and examples. Use these pages for exact signat
 - [Fixtures and harness API](api-fixtures-harness.md) — This reference lists fixtures and harness service contracts.
 - [Plugin API](api-plugins.md) — This reference lists plugin capabilities and lifecycle callback contracts.
 - [Reporter API](api-reporting.md) — This reference lists reporter and output contracts.
-- [Integration API](api-integrations.md) — This reference lists public integration types for Hyperf, Laravel, PSR standards, Rector, and Symfony.
+- [Integration API](api-integrations.md) — This reference lists public integration types for Hyperf, Laravel, PSR standards, Rector, Symfony, and Tempest.

--- a/docs/architecture/technical-writing.md
+++ b/docs/architecture/technical-writing.md
@@ -201,6 +201,7 @@ and meaning. Use the singular form unless the context requires a plural.
 | temporal expectation | Technical noun | An expectation that observes probe values over time |
 | terminal emulator | Technical noun | Test support that models the terminal state after control sequences |
 | terminal result | Technical noun | The final result after all test and plugin changes |
+| Tempest bridge | Technical noun | The component that connects the Greenlight harness to a Tempest kernel and container |
 | test | Technical noun | One invocation of a test method with one optional data set |
 | test class | Technical noun | A class that contains one or more test methods |
 | test container | Technical noun | A Symfony container that makes test services available |

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -385,9 +385,9 @@ an object of a different type, the test has an error and names the resolver.
 The resolver owns each object that it returns. Harness scopes do not track or
 call disposal methods on these objects.
 
-The Symfony bridge uses this interface to inject container services. You can
-bridge other dependency containers in the same way. See
-[Symfony applications](symfony.md).
+The framework bridges use this interface to inject container services. See
+[Symfony applications](symfony.md), [Laravel applications](laravel.md), and
+[Tempest applications](tempest.md).
 
 ### ExpectationExtension
 

--- a/docs/tempest.md
+++ b/docs/tempest.md
@@ -1,0 +1,166 @@
+# Tempest applications
+
+The Tempest bridge supplies Tempest container services and built-in Greenlight
+harness services to test constructors.
+
+The bridge boots one long-running Tempest kernel for each worker. The kernel
+owns application discovery, configuration, deferred tasks, reset, and shutdown
+events.
+
+## Compatibility
+
+Greenlight requires PHP 8.4 or later. Greenlight has no Tempest runtime
+dependency.
+
+Tempest 3.18 requires PHP 8.5. Install Tempest only in an application that uses
+PHP 8.5 or later:
+
+```console
+composer require tempest/framework:^3.18
+```
+
+Greenlight tests its normal package and dependency matrix on PHP 8.4 and later.
+A separate PHP 8.5 CI job installs Tempest 3.18 and runs the bridge acceptance
+test. This arrangement preserves the Greenlight PHP 8.4 package contract.
+
+The bridge requires Tempest 3.18 or later in major version 3. This version has
+the verified long-running kernel lifecycle that the bridge uses.
+
+## Setup
+
+Register the plugin in `greenlight.php` with the application root:
+
+```php
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Tempest\TempestPlugin;
+
+return GreenlightConfig::create()
+    ->paths(['tests'])
+    ->plugins(new TempestPlugin(__DIR__));
+```
+
+The root directory must contain the application `composer.json` file and
+`vendor` directory. Tempest uses this Composer metadata for discovery.
+
+The bridge sets `ENVIRONMENT` to `testing` while a test uses Tempest. Tempest
+then loads `.test.config.php` and `.testing.config.php` files. Pass
+`environment:` to select a different environment.
+
+The bridge restores the prior environment and global Tempest container after
+each test.
+
+The bridge also registers a new `GET /` Tempest request for each test. Tempest
+uses this baseline request in its integration tests. The request lets framework
+reset hooks resolve session services after a non-HTTP test. Application code can
+replace the request binding during the test.
+
+### Additional discovery locations
+
+Tempest discovers application and package namespaces from Composer metadata.
+Pass additional locations when test fixtures are outside these namespaces:
+
+```php
+use Tempest\Discovery\DiscoveryLocation;
+
+new TempestPlugin(
+    root: __DIR__,
+    discoveryLocations: [
+        new DiscoveryLocation('Tests\\Fixtures', __DIR__ . '/tests/Fixtures'),
+    ],
+);
+```
+
+The kernel adds these locations to normal Tempest discovery. Greenlight does
+not replace or reproduce discovery.
+
+## Container services
+
+Declare application dependencies by type:
+
+```php
+final class RegistrationTest
+{
+    public function __construct(
+        private readonly UserRepository $users,
+        private readonly RegistrationHandler $handler,
+    ) {}
+}
+```
+
+Greenlight first resolves constructor parameters from its harness. It then asks
+the Tempest container to resolve the type. Thus, `Doubles`, `TestChannel`, and
+provider services take precedence over Tempest services.
+
+Tempest can use discovered initializers and automatic constructor injection.
+If resolution fails, the test reports a `TempestBridgeError` with the Tempest
+container error as its cause.
+
+### Tagged services
+
+Use the native Tempest `#[Tag]` attribute for a tagged binding:
+
+```php
+use Tempest\Container\Tag;
+
+public function __construct(
+    #[Tag('archive')] private readonly Storage $storage,
+) {}
+```
+
+The bridge gives the tag to the Tempest container. The resolved service must
+have the declared parameter type.
+
+### Kernel and container services
+
+Greenlight supplies `Tempest\Core\Kernel` and
+`Tempest\Container\Container` as per-run harness services:
+
+```php
+public function __construct(
+    private readonly Kernel $kernel,
+    private readonly Container $container,
+) {}
+```
+
+These services expose the same kernel and container that resolve application
+dependencies.
+
+## State between tests
+
+After each test, the bridge calls the Tempest long-running kernel shutdown
+operation. Tempest performs these operations:
+
+1. Dispatch `KernelEvent::SHUTTING_DOWN`.
+2. Complete deferred tasks.
+3. Dispatch `KernelEvent::RESETTING`.
+4. Reset the container and each discovered `Resettable` implementation.
+5. Dispatch `KernelEvent::RESET` and `KernelEvent::SHUTDOWN`.
+
+The long-running mode prevents the shutdown operation from ending the worker.
+The next test uses the reset container from the same kernel.
+
+Use Tempest's `Resettable` interface for state that must not reach the next
+test. State outside the container remains the test suite's responsibility.
+
+The bridge does not isolate databases or other external services.
+
+## Parallel resources
+
+Each worker uses `.tempest/greenlight/<channel>` for Tempest internal storage.
+This path prevents workers from writing to the same discovery and configuration
+cache directory.
+
+Greenlight also sets `GREENLIGHT_CHANNEL` in each worker process. Use this value
+to separate databases, cache paths, queues, and other external resources.
+
+If a service cannot use separate resources, mark the test class with
+`#[RequiresResource]`. Configure the safe concurrency limit in `greenlight.php`.
+
+## Non-goals
+
+The current bridge does not supply these Tempest testing utilities:
+
+* `IntegrationTest` or PHPUnit integration
+* HTTP, console, mail, event, storage, or database tester objects
+* database creation, migration, or transaction rollback
+* replacement container bindings for Greenlight doubles

--- a/greenlight.tempest-coverage.php
+++ b/greenlight.tempest-coverage.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Greenlight\Config\CoverageBuilder;
+use Greenlight\Config\GreenlightConfig;
+
+$config = require __DIR__ . '/greenlight.php';
+\assert($config instanceof GreenlightConfig);
+
+return $config
+    ->coverage(fn(CoverageBuilder $coverage) => $coverage
+        ->include('src/Tempest')
+        ->driver('xdebug')
+        ->export('json', 'build/coverage/coverage.json')
+        ->export('cobertura', 'build/coverage/cobertura.xml'));

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -36,6 +36,7 @@ parameters:
         - tests
         - tools
     scanFiles:
+        - stubs/tempest.stub.php
         - tools/phpstan-stubs/hyperf.php
     excludePaths:
         analyse:

--- a/src/Tempest/TempestBridgeError.php
+++ b/src/Tempest/TempestBridgeError.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tempest;
+
+use Greenlight\Harness\ServiceResolutionError;
+
+/**
+ * Reports a Tempest bridge configuration or run-time failure.
+ *
+ * @internal
+ */
+final class TempestBridgeError extends ServiceResolutionError
+{
+    private function __construct(string $message, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, previous: $previous);
+    }
+
+    public static function frameworkUnavailable(): self
+    {
+        return new self(
+            'The Tempest framework is not available. TempestPlugin requires '
+            . 'tempest/framework 3.18 or later in major version 3. Install the framework '
+            . 'before you activate the plugin.',
+        );
+    }
+
+    public static function frameworkVersionUnsupported(string $version): self
+    {
+        return new self(\sprintf(
+            'TempestPlugin found tempest/framework "%s", but it requires version 3.18 or later '
+            . 'in major version 3. Install tempest/framework ^3.18.',
+            $version,
+        ));
+    }
+
+    public static function bootFailed(string $root, \Throwable $cause): self
+    {
+        return new self(\sprintf(
+            'TempestPlugin could not boot the application at "%s": %s',
+            $root,
+            $cause->getMessage(),
+        ), $cause);
+    }
+
+    public static function shutdownFailed(string $root, \Throwable $cause): self
+    {
+        return new self(\sprintf(
+            'TempestPlugin could not shut down the application at "%s": %s',
+            $root,
+            $cause->getMessage(),
+        ), $cause);
+    }
+
+    public static function serviceResolutionFailed(string $type, \Throwable $cause): self
+    {
+        return new self(\sprintf(
+            'The Tempest container could not resolve the parameter type "%s": %s',
+            $type,
+            $cause->getMessage(),
+        ), $cause);
+    }
+
+    public static function serviceTypeMismatch(string $type, string $actual): self
+    {
+        return new self(\sprintf(
+            'The Tempest container returned "%s" for the parameter type "%s".',
+            $actual,
+            $type,
+        ));
+    }
+}

--- a/src/Tempest/TempestFrameworkRequirement.php
+++ b/src/Tempest/TempestFrameworkRequirement.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tempest;
+
+use Tempest\Container\Container;
+use Tempest\Container\GenericContainer;
+use Tempest\Core\FrameworkKernel;
+use Tempest\Core\Kernel;
+
+/**
+ * Checks whether TempestPlugin can use the Tempest long-running kernel.
+ * The bridge supports Tempest 3.18 and later releases in major version 3.
+ *
+ * @internal
+ */
+final class TempestFrameworkRequirement
+{
+    /**
+     * @throws TempestBridgeError
+     */
+    public static function check(): void
+    {
+        if (!\class_exists(FrameworkKernel::class)
+            || !\interface_exists(Kernel::class)
+            || !\interface_exists(Container::class)
+            || !\class_exists(GenericContainer::class)
+        ) {
+            throw TempestBridgeError::frameworkUnavailable();
+        }
+
+        self::checkVersion(Kernel::VERSION);
+    }
+
+    /**
+     * @throws TempestBridgeError
+     */
+    public static function checkVersion(?string $version): void
+    {
+        if ($version === null) {
+            throw TempestBridgeError::frameworkUnavailable();
+        }
+
+        if (\version_compare($version, '3.18.0', '<') || \version_compare($version, '4.0.0', '>=')) {
+            throw TempestBridgeError::frameworkVersionUnsupported($version);
+        }
+    }
+}

--- a/src/Tempest/TempestFrameworkRequirement.php
+++ b/src/Tempest/TempestFrameworkRequirement.php
@@ -27,7 +27,7 @@ final class TempestFrameworkRequirement
             || !\interface_exists(Container::class)
             || !\class_exists(GenericContainer::class)
         ) {
-            throw TempestBridgeError::frameworkUnavailable();
+            throw TempestBridgeError::frameworkUnavailable(); // @codeCoverageIgnore
         }
 
         self::checkVersion(Kernel::VERSION);

--- a/src/Tempest/TempestPlugin.php
+++ b/src/Tempest/TempestPlugin.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tempest;
+
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Harness\Scope;
+use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Harness\ServiceResolver;
+use Greenlight\Plugin\HarnessProvider;
+use Greenlight\Plugin\TestContext;
+use Greenlight\Plugin\TestLifecycleSubscriber;
+use Greenlight\Plugin\WorkerBootstrapContext;
+use Greenlight\Plugin\WorkerBootstrapSubscriber;
+use Tempest\Container\Container;
+use Tempest\Container\GenericContainer;
+use Tempest\Container\Tag;
+use Tempest\Core\FrameworkKernel;
+use Tempest\Core\Kernel;
+use Tempest\Discovery\DiscoveryLocation;
+use Tempest\Http\GenericRequest;
+use Tempest\Http\Method;
+use Tempest\Http\Request;
+
+/**
+ * Boots one Tempest long-running kernel for each worker. Tempest discovery,
+ * configuration, container reset, deferred tasks, and shutdown events stay
+ * under kernel control.
+ *
+ * The bridge uses the `testing` environment by default. Native `#[Tag]`
+ * attributes select tagged Tempest bindings. Tests MUST isolate external
+ * resources by `GREENLIGHT_CHANNEL`.
+ */
+final class TempestPlugin implements HarnessProvider, ServiceResolver, TestLifecycleSubscriber, WorkerBootstrapSubscriber
+{
+    private ?FrameworkKernel $kernel = null;
+
+    private ?TempestProcessState $processState = null;
+
+    private ?int $channel = null;
+
+    /**
+     * @param string $root The directory that contains the Tempest composer.json file.
+     * @param list<DiscoveryLocation> $discoveryLocations Additional locations for Tempest discovery.
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(
+        private readonly string $root,
+        private readonly string $environment = 'testing',
+        private readonly array $discoveryLocations = [],
+    ) {
+        if ($root === '') {
+            throw new \InvalidArgumentException('Tempest application root MUST NOT be empty.');
+        }
+
+        if ($environment === '') {
+            throw new \InvalidArgumentException('Tempest environment MUST NOT be empty.');
+        }
+    }
+
+    #[\Override]
+    public function onWorkerBootstrap(WorkerBootstrapContext $context): void
+    {
+        $this->channel = $context->channel->number;
+    }
+
+    /**
+     * @return list<ServiceDefinition>
+     */
+    #[\Override]
+    public function services(): array
+    {
+        return [
+            new ServiceDefinition(Kernel::class, Scope::PerRun, $this->kernel(...)),
+            new ServiceDefinition(Container::class, Scope::PerRun, $this->container(...)),
+        ];
+    }
+
+    /**
+     * @param class-string $type
+     * @param list<object> $attributes
+     * @throws TempestBridgeError
+     */
+    #[\Override]
+    public function resolve(string $type, array $attributes): object
+    {
+        $tag = null;
+
+        foreach ($attributes as $attribute) {
+            if ($attribute instanceof Tag) {
+                $tag = $attribute->name;
+            }
+        }
+
+        try {
+            $service = $this->container()->get($type, $tag);
+        } catch (TempestBridgeError $error) {
+            throw $error;
+        } catch (\Throwable $cause) {
+            throw TempestBridgeError::serviceResolutionFailed($type, $cause);
+        }
+
+        if (!$service instanceof $type) {
+            throw TempestBridgeError::serviceTypeMismatch($type, \get_debug_type($service));
+        }
+
+        return $service;
+    }
+
+    #[\Override]
+    public function beforeTest(TestContext $context): void
+    {
+        $kernel = $this->kernel;
+
+        if ($kernel instanceof FrameworkKernel && $this->activate($kernel->container)) {
+            $this->prepareBaseRequest($kernel->container);
+        }
+    }
+
+    /**
+     * @throws TempestBridgeError
+     */
+    #[\Override]
+    public function afterTest(TestContext $context, TestResult $result): TestResult
+    {
+        if (!$this->kernel instanceof FrameworkKernel) {
+            return $result;
+        }
+
+        try {
+            $this->kernel->shutdown();
+        } catch (\Throwable $cause) {
+            $this->kernel = null;
+
+            throw TempestBridgeError::shutdownFailed($this->root, $cause);
+        } finally {
+            $this->restoreProcessState();
+        }
+
+        return $result;
+    }
+
+    /**
+     * @throws TempestBridgeError
+     */
+    private function kernel(): Kernel
+    {
+        $kernel = $this->kernel;
+
+        if ($kernel instanceof FrameworkKernel) {
+            if ($this->activate($kernel->container)) {
+                $this->prepareBaseRequest($kernel->container);
+            }
+
+            return $kernel;
+        }
+
+        TempestFrameworkRequirement::check();
+        $this->activate();
+
+        try {
+            $kernel = FrameworkKernel::boot(
+                root: $this->root,
+                discoveryLocations: $this->discoveryLocations,
+                internalStorage: $this->internalStorage(),
+                longRunning: true,
+            );
+            $this->prepareBaseRequest($kernel->container);
+        } catch (\Throwable $cause) {
+            $this->restoreProcessState();
+
+            throw TempestBridgeError::bootFailed($this->root, $cause);
+        }
+
+        $this->kernel = $kernel;
+
+        return $kernel;
+    }
+
+    /**
+     * @throws TempestBridgeError
+     */
+    private function container(): Container
+    {
+        $kernel = $this->kernel();
+
+        return $kernel->container;
+    }
+
+    private function activate(?Container $container = null): bool
+    {
+        if ($this->processState instanceof TempestProcessState) {
+            return false;
+        }
+
+        $generic = $container instanceof GenericContainer ? $container : null;
+        $this->processState = TempestProcessState::activate($this->environment, $generic);
+
+        return true;
+    }
+
+    private function prepareBaseRequest(Container $container): void
+    {
+        $request = new GenericRequest(Method::GET, '/');
+        $container->singleton(Request::class, $request);
+        $container->singleton(GenericRequest::class, $request);
+    }
+
+    private function restoreProcessState(): void
+    {
+        $state = $this->processState;
+        $this->processState = null;
+        $state?->restore();
+    }
+
+    private function internalStorage(): string
+    {
+        $channel = $this->channel;
+
+        if ($channel === null) {
+            $rawChannel = \getenv('GREENLIGHT_CHANNEL');
+            $channel = \is_string($rawChannel) && $rawChannel !== '' ? (int) $rawChannel : 0;
+        }
+
+        return \rtrim($this->root, '/\\') . '/.tempest/greenlight/' . \max(0, $channel);
+    }
+}

--- a/src/Tempest/TempestProcessState.php
+++ b/src/Tempest/TempestProcessState.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tempest;
+
+use Tempest\Container\GenericContainer;
+
+/**
+ * Records process state that the Tempest kernel uses. restore() returns each
+ * recorded value after one test attempt ends.
+ *
+ * @internal
+ */
+final readonly class TempestProcessState
+{
+    private function __construct(
+        private ?GenericContainer $container,
+        private string|false $processEnvironment,
+        private bool $environmentWasSet,
+        private mixed $environment,
+        private bool $serverEnvironmentWasSet,
+        private mixed $serverEnvironment,
+    ) {}
+
+    /**
+     * @throws \InvalidArgumentException If $environment contains a null byte.
+     */
+    public static function activate(string $environment, ?GenericContainer $container = null): self
+    {
+        if (\str_contains($environment, "\0")) {
+            throw new \InvalidArgumentException('Tempest environment MUST NOT contain a null byte.');
+        }
+
+        $state = new self(
+            GenericContainer::instance(),
+            \getenv('ENVIRONMENT'),
+            \array_key_exists('ENVIRONMENT', $_ENV),
+            $_ENV['ENVIRONMENT'] ?? null,
+            \array_key_exists('ENVIRONMENT', $_SERVER),
+            $_SERVER['ENVIRONMENT'] ?? null,
+        );
+
+        \putenv('ENVIRONMENT=' . $environment);
+        $_ENV['ENVIRONMENT'] = $environment;
+        $_SERVER['ENVIRONMENT'] = $environment;
+
+        if ($container instanceof GenericContainer) {
+            GenericContainer::setInstance($container);
+        }
+
+        return $state;
+    }
+
+    public function restore(): void
+    {
+        GenericContainer::setInstance($this->container);
+
+        if ($this->processEnvironment === false) {
+            \putenv('ENVIRONMENT');
+        } else {
+            \putenv('ENVIRONMENT=' . $this->processEnvironment);
+        }
+
+        if ($this->environmentWasSet) {
+            $_ENV['ENVIRONMENT'] = $this->environment;
+        } else {
+            unset($_ENV['ENVIRONMENT']);
+        }
+
+        if ($this->serverEnvironmentWasSet) {
+            $_SERVER['ENVIRONMENT'] = $this->serverEnvironment;
+        } else {
+            unset($_SERVER['ENVIRONMENT']);
+        }
+    }
+}

--- a/src/Tempest/TempestProcessState.php
+++ b/src/Tempest/TempestProcessState.php
@@ -14,7 +14,7 @@ use Tempest\Container\GenericContainer;
  */
 final readonly class TempestProcessState
 {
-    private function __construct(
+    private function __construct(// @codeCoverageIgnore
         private ?GenericContainer $container,
         private string|false $processEnvironment,
         private bool $environmentWasSet,

--- a/stubs/tempest.stub.php
+++ b/stubs/tempest.stub.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tempest\Container;
+
+interface Container
+{
+    public function get(string $className, string|\UnitEnum|null $tag = null, mixed ...$params): object;
+
+    public function singleton(string $className, mixed $definition, string|\UnitEnum|null $tag = null): self;
+
+    public function reset(): self;
+}
+
+final class GenericContainer implements Container
+{
+    public static function instance(): ?self {}
+
+    public static function setInstance(?self $instance): void {}
+
+    public function get(string $className, string|\UnitEnum|null $tag = null, mixed ...$params): object {}
+
+    public function singleton(string $className, mixed $definition, string|\UnitEnum|null $tag = null): self {}
+
+    public function reset(): self {}
+}
+
+#[\Attribute]
+final readonly class Tag
+{
+    public function __construct(public string|\UnitEnum $name) {}
+}
+
+namespace Tempest\Core;
+
+use Tempest\Container\Container;
+
+interface Kernel
+{
+    public const string VERSION = '3.18.0';
+
+    public string $root { get; }
+
+    public string $internalStorage { get; }
+
+    public Container $container { get; }
+
+    public function shutdown(int|string $status = ''): void;
+}
+
+final class FrameworkKernel implements Kernel
+{
+    public string $root;
+
+    public string $internalStorage;
+
+    public Container $container;
+
+    /**
+     * @param list<\Tempest\Discovery\DiscoveryLocation> $discoveryLocations
+     */
+    public static function boot(
+        string $root,
+        array $discoveryLocations = [],
+        ?Container $container = null,
+        ?string $internalStorage = null,
+        bool $longRunning = false,
+    ): self {}
+
+    public function shutdown(int|string $status = ''): void {}
+}
+
+namespace Tempest\Discovery;
+
+final readonly class DiscoveryLocation
+{
+    public function __construct(public string $namespace, public string $path) {}
+}
+
+namespace Tempest\Http;
+
+interface Request {}
+
+enum Method: string
+{
+    case GET = 'GET';
+}
+
+final class GenericRequest implements Request
+{
+    /**
+     * @param array<array-key, mixed> $body
+     * @param array<array-key, mixed> $headers
+     * @param array<array-key, mixed> $files
+     */
+    public function __construct(
+        public Method $method,
+        public string $uri,
+        public array $body = [],
+        public array $headers = [],
+        public array $files = [],
+        public ?string $raw = null,
+    ) {}
+}

--- a/tests/Acceptance/TempestRunTest.php
+++ b/tests/Acceptance/TempestRunTest.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\SkipUnless;
+use Greenlight\Attribute\Test;
+use Greenlight\Condition\ClassAvailable;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\GreenlightCli;
+use Tempest\Core\FrameworkKernel;
+
+#[SkipUnless(ClassAvailable::class, FrameworkKernel::class)]
+final readonly class TempestRunTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function bootsDiscoveryAndResetsTheApplicationBetweenTests(): void
+    {
+        $project = $this->writeProject();
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=plain']);
+
+        Expect::that($result->exitCode)
+            ->because(\sprintf(
+                "the Tempest acceptance project MUST complete. Output:\n%s",
+                $result->output(),
+            ))
+            ->toBe(0);
+        Expect::that($result->output())->toContain('2 tests, 2 passed');
+    }
+
+    private function writeProject(): AcceptanceProject
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'tempest');
+        $root = \dirname(__DIR__, 2);
+
+        $project->writeFile('composer.json', <<<'JSON'
+            {
+                "name": "greenlight/tempest-acceptance",
+                "require": {
+                    "tempest/framework": "^3.18"
+                },
+                "autoload": {
+                    "psr-4": {
+                        "TempestProbe\\": "app/"
+                    }
+                }
+            }
+            JSON);
+
+        if (!\symlink($root . '/vendor', $project->path('vendor'))) {
+            throw new \RuntimeException('The Tempest acceptance project could not link the vendor directory.');
+        }
+
+        $project->writeFile('app/GreetingConfig.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace TempestProbe;
+
+            final readonly class GreetingConfig
+            {
+                public function __construct(public string $prefix) {}
+            }
+            PHP);
+
+        $project->writeFile('app/Greeter.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace TempestProbe;
+
+            use Tempest\Container\Singleton;
+
+            #[Singleton]
+            final readonly class Greeter
+            {
+                public function __construct(private GreetingConfig $config) {}
+
+                public function greet(string $name): string
+                {
+                    return $this->config->prefix . ', ' . $name . '!';
+                }
+            }
+            PHP);
+
+        $project->writeFile('app/VisitCounter.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace TempestProbe;
+
+            use Tempest\Container\Resettable;
+
+            final class VisitCounter implements Resettable
+            {
+                public static int $resets = 0;
+
+                private static int $visits = 0;
+
+                public function record(): void
+                {
+                    ++self::$visits;
+                }
+
+                public function count(): int
+                {
+                    return self::$visits;
+                }
+
+                public function reset(): void
+                {
+                    ++self::$resets;
+                    self::$visits = 0;
+                }
+            }
+            PHP);
+
+        $project->writeFile('app/LifecycleObserver.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace TempestProbe;
+
+            use Tempest\Core\KernelEvent;
+            use Tempest\EventBus\EventHandler;
+
+            final class LifecycleObserver
+            {
+                public static int $shutdowns = 0;
+
+                #[EventHandler(KernelEvent::SHUTDOWN)]
+                public function onShutdown(): void
+                {
+                    ++self::$shutdowns;
+                }
+            }
+            PHP);
+
+        $project->writeFile('app/greeting.testing.config.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            return new \TempestProbe\GreetingConfig('Hello from testing');
+            PHP);
+
+        $project->writeFile('tests/TempestApplicationTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace TempestProbe;
+
+            use Greenlight\Attribute\Test;
+            use Greenlight\Expect\Expect;
+            use Tempest\Container\Container;
+            use Tempest\Core\Environment;
+            use Tempest\Core\Kernel;
+            use Tempest\Http\Method;
+            use Tempest\Http\Request;
+
+            final class TempestApplicationTest
+            {
+                public function __construct(
+                    private readonly Greeter $greeter,
+                    private readonly VisitCounter $counter,
+                    private readonly Environment $environment,
+                    private readonly Kernel $kernel,
+                    private readonly Container $container,
+                    private readonly Request $request,
+                ) {}
+
+                #[Test]
+                public function discoveryLoadsTestingConfigurationAndContainerServices(): void
+                {
+                    $this->counter->record();
+
+                    Expect::that($this->greeter->greet('Ada'))->toBe('Hello from testing, Ada!');
+                    Expect::that($this->environment)->toBe(Environment::TESTING);
+                    Expect::that($this->container->get(Greeter::class))->toBe($this->greeter);
+                    Expect::that($this->kernel->internalStorage)->toContain('/.tempest/greenlight/1');
+                    Expect::that($this->request->method)->toBe(Method::GET);
+                    Expect::that($this->request->uri)->toBe('/');
+                    Expect::that($this->counter->count())->toBe(1);
+                }
+
+                #[Test]
+                public function shutdownAndContainerResetIsolateTheNextTest(): void
+                {
+                    Expect::that($this->counter->count())->toBe(0);
+                    Expect::that(VisitCounter::$resets)->toBe(1);
+                    Expect::that(LifecycleObserver::$shutdowns)->toBe(1);
+                }
+            }
+            PHP);
+
+        $project->writeFile('greenlight.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Config\GreenlightConfig;
+            use Greenlight\Tempest\TempestPlugin;
+
+            require_once __DIR__ . '/app/GreetingConfig.php';
+            require_once __DIR__ . '/app/Greeter.php';
+            require_once __DIR__ . '/app/VisitCounter.php';
+            require_once __DIR__ . '/app/LifecycleObserver.php';
+            require_once __DIR__ . '/tests/TempestApplicationTest.php';
+
+            return GreenlightConfig::create()
+                ->paths([__DIR__ . '/tests'])
+                ->workers(1)
+                ->plugins(new TempestPlugin(__DIR__));
+            PHP);
+
+        return $project;
+    }
+}

--- a/tests/Unit/Tempest/TempestBridgeErrorTest.php
+++ b/tests/Unit/Tempest/TempestBridgeErrorTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Tempest;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Tempest\TempestBridgeError;
+
+final readonly class TempestBridgeErrorTest
+{
+    #[Test]
+    public function reportsAnUnavailableFramework(): void
+    {
+        $error = TempestBridgeError::frameworkUnavailable();
+
+        Expect::that($error->getMessage())->toBe(
+            'The Tempest framework is not available. TempestPlugin requires '
+                . 'tempest/framework 3.18 or later in major version 3. Install the framework '
+                . 'before you activate the plugin.',
+        );
+        Expect::that($error->getPrevious())->toBeNull();
+    }
+
+    #[Test]
+    public function reportsABootFailureWithItsCause(): void
+    {
+        $cause = new \RuntimeException('boot probe');
+        $error = TempestBridgeError::bootFailed('/project', $cause);
+
+        Expect::that($error->getMessage())
+            ->toBe('TempestPlugin could not boot the application at "/project": boot probe');
+        Expect::that($error->getPrevious())->toBe($cause);
+    }
+
+    #[Test]
+    public function reportsAShutdownFailureWithItsCause(): void
+    {
+        $cause = new \RuntimeException('shutdown probe');
+        $error = TempestBridgeError::shutdownFailed('/project', $cause);
+
+        Expect::that($error->getMessage())
+            ->toBe('TempestPlugin could not shut down the application at "/project": shutdown probe');
+        Expect::that($error->getPrevious())->toBe($cause);
+    }
+
+    #[Test]
+    public function reportsAServiceResolutionFailureWithItsCause(): void
+    {
+        $cause = new \RuntimeException('resolution probe');
+        $error = TempestBridgeError::serviceResolutionFailed(ProbeService::class, $cause);
+
+        Expect::that($error->getMessage())->toBe(
+            'The Tempest container could not resolve the parameter type "'
+            . ProbeService::class
+            . '": resolution probe',
+        );
+        Expect::that($error->getPrevious())->toBe($cause);
+    }
+
+    #[Test]
+    public function reportsAServiceTypeMismatch(): void
+    {
+        $error = TempestBridgeError::serviceTypeMismatch(ProbeService::class, \stdClass::class);
+
+        Expect::that($error->getMessage())->toBe(
+            'The Tempest container returned "stdClass" for the parameter type "'
+            . ProbeService::class
+            . '".',
+        );
+        Expect::that($error->getPrevious())->toBeNull();
+    }
+}
+
+interface ProbeService {}

--- a/tests/Unit/Tempest/TempestFrameworkRequirementTest.php
+++ b/tests/Unit/Tempest/TempestFrameworkRequirementTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Tempest;
+
+use Greenlight\Attribute\SkipUnless;
+use Greenlight\Attribute\Test;
+use Greenlight\Condition\ClassAvailable;
+use Greenlight\Expect\Expect;
+use Greenlight\Tempest\TempestFrameworkRequirement;
+use Tempest\Core\FrameworkKernel;
+use Tempest\Core\Kernel;
+
+#[SkipUnless(ClassAvailable::class, FrameworkKernel::class)]
+final readonly class TempestFrameworkRequirementTest
+{
+    #[Test]
+    public function installedFrameworkSatisfiesTheBridgeRequirement(): void
+    {
+        TempestFrameworkRequirement::check();
+
+        Expect::that(Kernel::VERSION)
+            ->because('the installed Tempest framework MUST satisfy the bridge requirement')
+            ->toMatch('/^3\.(?:1[89]|[2-9][0-9]|[1-9][0-9]{2,})(?:\.|$)/D');
+    }
+}

--- a/tests/Unit/Tempest/TempestFrameworkUnavailableTest.php
+++ b/tests/Unit/Tempest/TempestFrameworkUnavailableTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Tempest;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\Subprocess;
+
+final readonly class TempestFrameworkUnavailableTest
+{
+    #[Test]
+    public function publicRequirementProbeRejectsAMissingFramework(): void
+    {
+        $root = \dirname(__DIR__, 3);
+
+        $result = Subprocess::run($root, [
+            \PHP_BINARY,
+            '-n',
+            '-r',
+            <<<'PHP'
+            $source = $argv[1];
+
+            spl_autoload_register(static function (string $class) use ($source): void {
+                $prefix = 'Greenlight\\';
+
+                if (!str_starts_with($class, $prefix)) {
+                    return;
+                }
+
+                $path = $source . '/' . str_replace('\\', '/', substr($class, strlen($prefix))) . '.php';
+
+                if (is_file($path)) {
+                    require $path;
+                }
+            });
+
+            if (class_exists(\Tempest\Core\FrameworkKernel::class)) {
+                exit(2);
+            }
+
+            try {
+                \Greenlight\Tempest\TempestFrameworkRequirement::check();
+            } catch (\Greenlight\Tempest\TempestBridgeError $error) {
+                fwrite(STDOUT, $error->getMessage());
+                exit(0);
+            }
+
+            exit(3);
+            PHP,
+            $root . '/src',
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('the public framework probe MUST reject an installation without Tempest')
+            ->toBe(0);
+        Expect::that($result->stdout)
+            ->because('the error MUST explain how to install the required Tempest framework')
+            ->toBe(
+                'The Tempest framework is not available. TempestPlugin requires '
+                . 'tempest/framework 3.18 or later in major version 3. Install the framework '
+                . 'before you activate the plugin.',
+            );
+    }
+}

--- a/tests/Unit/Tempest/TempestFrameworkVersionBoundaryTest.php
+++ b/tests/Unit/Tempest/TempestFrameworkVersionBoundaryTest.php
@@ -13,6 +13,19 @@ use Greenlight\Tempest\TempestFrameworkRequirement;
 final readonly class TempestFrameworkVersionBoundaryTest
 {
     #[Test]
+    public function rejectsAnUnavailableFrameworkVersion(): void
+    {
+        Expect::that(static function (): void {
+            TempestFrameworkRequirement::checkVersion(null);
+        })->toThrow(
+            TempestBridgeError::class,
+            message: 'The Tempest framework is not available. TempestPlugin requires '
+                . 'tempest/framework 3.18 or later in major version 3. Install the framework '
+                . 'before you activate the plugin.',
+        );
+    }
+
+    #[Test]
     #[DataSet('supportedVersions')]
     public function acceptsSupportedTempestThreeVersions(string $version): void
     {

--- a/tests/Unit/Tempest/TempestFrameworkVersionBoundaryTest.php
+++ b/tests/Unit/Tempest/TempestFrameworkVersionBoundaryTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Tempest;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Tempest\TempestBridgeError;
+use Greenlight\Tempest\TempestFrameworkRequirement;
+
+final readonly class TempestFrameworkVersionBoundaryTest
+{
+    #[Test]
+    #[DataSet('supportedVersions')]
+    public function acceptsSupportedTempestThreeVersions(string $version): void
+    {
+        TempestFrameworkRequirement::checkVersion($version);
+
+        Expect::that($version)
+            ->because('the supported Tempest version MUST be 3.18 or later in major version 3')
+            ->toMatch('/^3\.(?:1[89]|[2-9][0-9]|[1-9][0-9]{2,})(?:\.|$)/D');
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function supportedVersions(): iterable
+    {
+        yield 'minimum release' => ['3.18.0'];
+        yield 'later minor' => ['3.20.1'];
+        yield 'later patch' => ['3.18.9'];
+    }
+
+    #[Test]
+    #[DataSet('unsupportedVersions')]
+    public function rejectsVersionsWithoutTheRequiredLifecycle(string $version): void
+    {
+        Expect::that(static function () use ($version): void {
+            TempestFrameworkRequirement::checkVersion($version);
+        })
+            ->because('the Tempest bridge MUST require the verified long-running lifecycle')
+            ->toThrow(
+                TempestBridgeError::class,
+                message: \sprintf(
+                    'TempestPlugin found tempest/framework "%s", but it requires version 3.18 or later '
+                    . 'in major version 3. Install tempest/framework ^3.18.',
+                    $version,
+                ),
+            );
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function unsupportedVersions(): iterable
+    {
+        yield 'previous minor' => ['3.17.9'];
+        yield 'minimum prerelease' => ['3.18.0-beta.1'];
+        yield 'next major' => ['4.0.0'];
+    }
+}

--- a/tests/Unit/Tempest/TempestPluginConfigurationTest.php
+++ b/tests/Unit/Tempest/TempestPluginConfigurationTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Tempest;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Expect\Expect;
+use Greenlight\Harness\HarnessRegistry;
+use Greenlight\Harness\HarnessScopes;
+use Greenlight\Harness\Scope;
+use Greenlight\Plugin\TestContext;
+use Greenlight\Tempest\TempestPlugin;
+use Tempest\Container\Container;
+use Tempest\Core\Kernel;
+
+final readonly class TempestPluginConfigurationTest
+{
+    #[Test]
+    public function exposesTheKernelAndContainerAsPerRunServices(): void
+    {
+        $definitions = new TempestPlugin('/project')->services();
+
+        Expect::that($definitions)->toHaveCount(2);
+        Expect::that($definitions[0]->type)->toBe(Kernel::class);
+        Expect::that($definitions[0]->scope)->toBe(Scope::PerRun);
+        Expect::that($definitions[1]->type)->toBe(Container::class);
+        Expect::that($definitions[1]->scope)->toBe(Scope::PerRun);
+    }
+
+    #[Test]
+    public function lifecycleHooksDoNotBootAnUnusedKernel(): void
+    {
+        $plugin = new TempestPlugin('/project');
+        $context = $this->context();
+        $result = $this->result();
+
+        $plugin->beforeTest($context);
+
+        Expect::that($plugin->afterTest($context, $result))
+            ->because('an unused Tempest bridge MUST preserve the test result')
+            ->toBe($result);
+    }
+
+    #[Test]
+    public function rejectsAnEmptyApplicationRoot(): void
+    {
+        Expect::that(static fn(): TempestPlugin => new TempestPlugin(''))
+            ->toThrow(\InvalidArgumentException::class, message: 'Tempest application root MUST NOT be empty.');
+    }
+
+    #[Test]
+    public function rejectsAnEmptyEnvironment(): void
+    {
+        Expect::that(static fn(): TempestPlugin => new TempestPlugin('/project', environment: ''))
+            ->toThrow(\InvalidArgumentException::class, message: 'Tempest environment MUST NOT be empty.');
+    }
+
+    private function context(): TestContext
+    {
+        return new TestContext(
+            new \stdClass(),
+            new TestId('Fixture', 'probe'),
+            new TestMetadata('Fixture', 'probe'),
+            new HarnessScopes(new HarnessRegistry()),
+        );
+    }
+
+    private function result(): TestResult
+    {
+        return new TestResult(new TestId('Fixture', 'probe'), Outcome::Passed, 0.0, 0);
+    }
+}

--- a/tests/Unit/Tempest/TempestPluginConfigurationTest.php
+++ b/tests/Unit/Tempest/TempestPluginConfigurationTest.php
@@ -5,16 +5,12 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Tempest;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Expect\Expect;
-use Greenlight\Harness\HarnessRegistry;
-use Greenlight\Harness\HarnessScopes;
 use Greenlight\Harness\Scope;
 use Greenlight\Plugin\TestContext;
 use Greenlight\Tempest\TempestPlugin;
+use Greenlight\Tests\Support\PluginLifecycle;
 use Tempest\Container\Container;
 use Tempest\Core\Kernel;
 
@@ -62,16 +58,11 @@ final readonly class TempestPluginConfigurationTest
 
     private function context(): TestContext
     {
-        return new TestContext(
-            new \stdClass(),
-            new TestId('Fixture', 'probe'),
-            new TestMetadata('Fixture', 'probe'),
-            new HarnessScopes(new HarnessRegistry()),
-        );
+        return PluginLifecycle::context();
     }
 
     private function result(): TestResult
     {
-        return new TestResult(new TestId('Fixture', 'probe'), Outcome::Passed, 0.0, 0);
+        return PluginLifecycle::passedResult();
     }
 }

--- a/tests/Unit/Tempest/TempestPluginLifecycleTest.php
+++ b/tests/Unit/Tempest/TempestPluginLifecycleTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Tempest;
+
+use Greenlight\Attribute\After;
+use Greenlight\Attribute\SkipUnless;
+use Greenlight\Attribute\Test;
+use Greenlight\Condition\ClassAvailable;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Fixture\EnvironmentBackup;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Plugin\TestContext;
+use Greenlight\Tempest\TempestBridgeError;
+use Greenlight\Tempest\TempestPlugin;
+use Greenlight\Tests\Support\PluginLifecycle;
+use Tempest\Container\GenericContainer;
+use Tempest\Container\Tag;
+use Tempest\Core\FrameworkKernel;
+use Tempest\Http\GenericRequest;
+use Tempest\Http\Request;
+
+#[SkipUnless(ClassAvailable::class, FrameworkKernel::class)]
+final class TempestPluginLifecycleTest
+{
+    /** @var list<TempestPlugin> */
+    private array $plugins = [];
+
+    private int $projectNumber = 0;
+
+    public function __construct(private readonly TempDirectory $tempDirectory) {}
+
+    /** A failed expectation MUST NOT leave an active Tempest kernel in the worker. */
+    #[After]
+    public function releaseKernels(): void
+    {
+        foreach ($this->plugins as $plugin) {
+            $plugin->afterTest($this->context(), $this->result());
+        }
+
+        $this->plugins = [];
+    }
+
+    #[Test]
+    public function resolvesATaggedContainerService(): void
+    {
+        $plugin = $this->plugin();
+        $kernel = $this->kernel($plugin);
+        $expected = new TaggedProbeImplementation();
+        $kernel->container->singleton(TaggedProbe::class, $expected, 'preferred');
+
+        Expect::that($plugin->resolve(TaggedProbe::class, [new Tag('preferred')]))
+            ->because('the Tempest Tag attribute MUST select the tagged container binding')
+            ->toBe($expected);
+    }
+
+    #[Test]
+    public function wrapsContainerResolutionFailures(): void
+    {
+        $plugin = $this->plugin();
+        $this->kernel($plugin);
+
+        Expect::that(static fn(): object => $plugin->resolve(MissingProbe::class, []))
+            ->toThrow(
+                TempestBridgeError::class,
+                matching: '/^The Tempest container could not resolve the parameter type "'
+                    . \preg_quote(MissingProbe::class, '/')
+                    . '":/',
+            );
+    }
+
+    #[Test]
+    public function preservesBridgeFailuresDuringResolution(): void
+    {
+        $missingRoot = $this->tempDirectory->path() . '/missing-resolution-root';
+        $plugin = new TempestPlugin($missingRoot);
+
+        Expect::that(static fn(): object => $plugin->resolve(MissingProbe::class, []))
+            ->toThrow(
+                TempestBridgeError::class,
+                matching: '/^TempestPlugin could not boot the application at "'
+                    . \preg_quote($missingRoot, '/')
+                    . '": /',
+            );
+    }
+
+    #[Test]
+    public function preparesANewBaseRequestForTheNextTest(): void
+    {
+        $plugin = $this->plugin();
+        $kernel = $this->kernel($plugin);
+        $plugin->afterTest($this->context(), $this->result());
+
+        $plugin->beforeTest($this->context());
+
+        Expect::that($kernel->container->get(Request::class))
+            ->because('each Tempest test MUST receive a new base request after the container reset')
+            ->toBeInstanceOf(GenericRequest::class);
+    }
+
+    #[Test]
+    public function rejectsAContainerServiceOfTheWrongType(): void
+    {
+        $plugin = $this->plugin();
+        $kernel = $this->kernel($plugin);
+        $kernel->container->singleton(MissingProbe::class, new \stdClass());
+
+        Expect::that(static fn(): object => $plugin->resolve(MissingProbe::class, []))
+            ->toThrow(
+                TempestBridgeError::class,
+                message: 'The Tempest container returned "stdClass" for the parameter type "'
+                    . MissingProbe::class
+                    . '".',
+            );
+    }
+
+    #[Test]
+    public function bootFailuresRestoreTheProcessEnvironment(): void
+    {
+        $backup = EnvironmentBackup::capture('ENVIRONMENT');
+
+        try {
+            \putenv('ENVIRONMENT=before-tempest');
+            $_ENV['ENVIRONMENT'] = 'before-tempest';
+            $_SERVER['ENVIRONMENT'] = 'before-tempest';
+            $missingRoot = $this->tempDirectory->path() . '/missing';
+            $plugin = new TempestPlugin($missingRoot);
+            $factory = $plugin->services()[0]->factory;
+
+            Expect::that(static fn(): object => $factory())
+                ->toThrow(
+                    TempestBridgeError::class,
+                    matching: '/^TempestPlugin could not boot the application at "'
+                        . \preg_quote($missingRoot, '/')
+                        . '": /',
+                );
+            Expect::that(\getenv('ENVIRONMENT'))->toBe('before-tempest');
+            Expect::that($_ENV['ENVIRONMENT'])->toBe('before-tempest');
+            Expect::that($_SERVER['ENVIRONMENT'])->toBe('before-tempest');
+        } finally {
+            $backup->restore();
+        }
+    }
+
+    #[Test]
+    public function shutdownFailuresRestoreTheProcessEnvironment(): void
+    {
+        $backup = EnvironmentBackup::capture('ENVIRONMENT');
+
+        try {
+            \putenv('ENVIRONMENT=before-tempest');
+            $_ENV['ENVIRONMENT'] = 'before-tempest';
+            $_SERVER['ENVIRONMENT'] = 'before-tempest';
+            $plugin = $this->plugin();
+            $kernel = $this->kernel($plugin);
+            $kernel->container->singleton('Tempest\EventBus\EventBus', new \stdClass());
+
+            Expect::that(fn(): TestResult => $plugin->afterTest($this->context(), $this->result()))
+                ->toThrow(
+                    TempestBridgeError::class,
+                    matching: '/^TempestPlugin could not shut down the application/',
+                );
+            Expect::that(\getenv('ENVIRONMENT'))->toBe('before-tempest');
+            Expect::that($_ENV['ENVIRONMENT'])->toBe('before-tempest');
+            Expect::that($_SERVER['ENVIRONMENT'])->toBe('before-tempest');
+            Expect::that(GenericContainer::instance())->not()->toBe($kernel->container);
+        } finally {
+            $backup->restore();
+        }
+    }
+
+    private function plugin(): TempestPlugin
+    {
+        $root = $this->tempDirectory->subdirectory('tempest-plugin-' . ++$this->projectNumber);
+        $repository = \dirname(__DIR__, 3);
+        $composer = <<<'JSON'
+            {
+                "name": "greenlight/tempest-unit-probe",
+                "require": {
+                    "tempest/framework": "^3.18"
+                }
+            }
+            JSON;
+
+        if (\file_put_contents($root . '/composer.json', $composer) === false) {
+            Fail::because('Expected to write the Tempest test project composer.json file.');
+        }
+
+        if (!\symlink($repository . '/vendor', $root . '/vendor')) {
+            Fail::because('Expected to link the Tempest test project vendor directory.');
+        }
+
+        $plugin = new TempestPlugin($root);
+        $this->plugins[] = $plugin;
+
+        return $plugin;
+    }
+
+    private function kernel(TempestPlugin $plugin): FrameworkKernel
+    {
+        $factory = $plugin->services()[0]->factory;
+        $kernel = $factory();
+
+        if (!$kernel instanceof FrameworkKernel) {
+            Fail::because(\sprintf(
+                'Expected the Tempest kernel factory to return FrameworkKernel, got %s.',
+                \get_debug_type($kernel),
+            ));
+        }
+
+        return $kernel;
+    }
+
+    private function context(): TestContext
+    {
+        return PluginLifecycle::context();
+    }
+
+    private function result(): TestResult
+    {
+        return PluginLifecycle::passedResult();
+    }
+}
+
+interface MissingProbe {}
+
+interface TaggedProbe {}
+
+final readonly class TaggedProbeImplementation implements TaggedProbe {}

--- a/tests/Unit/Tempest/TempestProcessEnvironmentValidationTest.php
+++ b/tests/Unit/Tempest/TempestProcessEnvironmentValidationTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Tempest;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Tempest\TempestProcessState;
+
+final readonly class TempestProcessEnvironmentValidationTest
+{
+    #[Test]
+    public function rejectsAnEnvironmentWithANullByteBeforeFrameworkAccess(): void
+    {
+        Expect::that(static fn(): TempestProcessState => TempestProcessState::activate("test\0ing"))
+            ->because('environment validation MUST run before Tempest framework access')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Tempest environment MUST NOT contain a null byte.',
+            );
+    }
+}

--- a/tests/Unit/Tempest/TempestProcessStateTest.php
+++ b/tests/Unit/Tempest/TempestProcessStateTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Tempest;
+
+use Greenlight\Attribute\SkipUnless;
+use Greenlight\Attribute\Test;
+use Greenlight\Condition\ClassAvailable;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\EnvironmentBackup;
+use Greenlight\Tempest\TempestProcessState;
+use Tempest\Container\GenericContainer;
+
+#[SkipUnless(ClassAvailable::class, GenericContainer::class)]
+final readonly class TempestProcessStateTest
+{
+    #[Test]
+    public function activationReplacesAndRestoresExistingProcessState(): void
+    {
+        $backup = EnvironmentBackup::capture('ENVIRONMENT');
+        $originalContainer = GenericContainer::instance();
+        $replacementContainer = new GenericContainer();
+        $state = null;
+
+        try {
+            \putenv('ENVIRONMENT=process-original');
+            $_ENV['ENVIRONMENT'] = null;
+            $_SERVER['ENVIRONMENT'] = 'server-original';
+
+            $state = TempestProcessState::activate('testing', $replacementContainer);
+
+            Expect::that(\getenv('ENVIRONMENT'))->toBe('testing');
+            Expect::that($_ENV['ENVIRONMENT'])->toBe('testing');
+            Expect::that($_SERVER['ENVIRONMENT'])->toBe('testing');
+            Expect::that(GenericContainer::instance())->toBe($replacementContainer);
+
+            $state->restore();
+
+            Expect::that(\getenv('ENVIRONMENT'))->toBe('process-original');
+            Expect::that(\array_key_exists('ENVIRONMENT', $_ENV))->toBeTrue();
+            Expect::that($_ENV['ENVIRONMENT'])->toBeNull();
+            Expect::that($_SERVER['ENVIRONMENT'])->toBe('server-original');
+            Expect::that(GenericContainer::instance())->toBe($originalContainer);
+        } finally {
+            $state?->restore();
+            $backup->restore();
+            GenericContainer::setInstance($originalContainer);
+        }
+    }
+
+    #[Test]
+    public function restorationRemovesProcessStateThatWasInitiallyAbsent(): void
+    {
+        $backup = EnvironmentBackup::capture('ENVIRONMENT');
+        $originalContainer = GenericContainer::instance();
+        $state = null;
+
+        try {
+            \putenv('ENVIRONMENT');
+            unset($_ENV['ENVIRONMENT'], $_SERVER['ENVIRONMENT']);
+
+            $state = TempestProcessState::activate('testing');
+            $state->restore();
+
+            Expect::that(\getenv('ENVIRONMENT'))->toBeFalse();
+            Expect::that(\array_key_exists('ENVIRONMENT', $_ENV))->toBeFalse();
+            Expect::that(\array_key_exists('ENVIRONMENT', $_SERVER))->toBeFalse();
+            Expect::that(GenericContainer::instance())->toBe($originalContainer);
+        } finally {
+            $state?->restore();
+            $backup->restore();
+            GenericContainer::setInstance($originalContainer);
+        }
+    }
+}

--- a/website/scripts/generate-api-reference.mjs
+++ b/website/scripts/generate-api-reference.mjs
@@ -78,7 +78,7 @@ const sections = [
   {
     id: 'api-integrations',
     title: 'Integration API',
-    description: 'This reference lists public integration types for Hyperf, Laravel, PSR standards, Rector, and Symfony.',
+    description: 'This reference lists public integration types for Hyperf, Laravel, PSR standards, Rector, Symfony, and Tempest.',
     prefixes: [
       'Greenlight\\Hyperf\\',
       'Greenlight\\Laravel\\',
@@ -87,6 +87,7 @@ const sections = [
       'Greenlight\\Psr15\\',
       'Greenlight\\Rector\\',
       'Greenlight\\Symfony\\',
+      'Greenlight\\Tempest\\',
     ],
   },
 ];

--- a/website/src/lib/docs.ts
+++ b/website/src/lib/docs.ts
@@ -77,6 +77,11 @@ export const docSections = [
         description: 'This guide explains how tests send PSR-7 requests directly to PSR-15 applications.',
       },
       {
+        id: 'tempest',
+        title: 'Tempest',
+        description: 'This guide explains how tests use Tempest discovery, configuration, container services, and reset.',
+      },
+      {
         id: 'phpstan',
         title: 'PHPStan',
         description: 'This guide explains how PHPStan checks matchers, data providers, and extension matchers.',
@@ -154,7 +159,7 @@ export const docSections = [
       {
         id: 'api-integrations',
         title: 'Integration API',
-        description: 'This reference lists public integration types for Hyperf, Laravel, PSR standards, Rector, and Symfony.',
+        description: 'This reference lists public integration types for Hyperf, Laravel, PSR standards, Rector, Symfony, and Tempest.',
       },
     ],
   },


### PR DESCRIPTION
## Summary

- add a first-party Tempest bridge that boots one long-running framework kernel per worker and delegates discovery, configuration, deferred tasks, reset, and shutdown to Tempest
- resolve constructor services and native tagged bindings through the Tempest container while restoring process environment and global container state after each test
- preserve the Greenlight PHP 8.4 and zero-runtime-dependency contracts with an optional Composer suggestion, static-analysis declarations, and a dedicated PHP 8.5 Tempest 3.18 acceptance job
- document setup, compatibility, isolation, parallel resources, and explicit non-goals
