### PR TITLE
fix(cli): complete stream writes

### DIFF
--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -165,14 +165,21 @@ final readonly class Application
      */
     private function __construct(private \Closure $out, private \Closure $err) {}
 
-    public static function forStreams(): self
+    /**
+     * @param resource|null $stdout
+     * @param resource|null $stderr
+     */
+    public static function forStreams($stdout = null, $stderr = null): self
     {
+        $out = new StreamOutput($stdout ?? \STDOUT);
+        $err = new StreamOutput($stderr ?? \STDERR);
+
         return new self(
-            static function (string $text): void {
-                \fwrite(\STDOUT, $text);
+            static function (string $text) use ($out): void {
+                $out->write($text);
             },
-            static function (string $text): void {
-                \fwrite(\STDERR, $text);
+            static function (string $text) use ($err): void {
+                $err->write($text);
             },
         );
     }

--- a/tests/Unit/Cli/ApplicationStreamOutputTest.php
+++ b/tests/Unit/Cli/ApplicationStreamOutputTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\Application;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Tests\Fixture\Reporting\PartialWriteStream;
+
+final class ApplicationStreamOutputTest
+{
+    private const string SCHEME = 'greenlight-application-partial-write';
+
+    /**
+     * @param list<string> $arguments
+     */
+    #[Test]
+    #[DataSet('writes')]
+    public function partialWritesDoNotTruncateCliOutput(
+        array $arguments,
+        int $expectedExit,
+        string $expectedOutput,
+        bool $useStderr,
+    ): void {
+        if (!\stream_wrapper_register(self::SCHEME, PartialWriteStream::class)) {
+            Fail::because('Greenlight did not register the partial-write stream.');
+        }
+
+        $partial = \fopen(self::SCHEME . '://partial', 'wb');
+        $other = \fopen('php://memory', 'wb');
+
+        if ($partial === false || $other === false) {
+            if (\is_resource($partial)) {
+                \fclose($partial);
+            }
+
+            \stream_wrapper_unregister(self::SCHEME);
+            Fail::because('Greenlight did not open the CLI test streams.');
+        }
+
+        try {
+            $application = $useStderr
+                ? Application::forStreams($other, $partial)
+                : Application::forStreams($partial, $other);
+
+            Expect::that($application->run($arguments, __DIR__))
+                ->because('a CLI write through a partial stream MUST preserve the exit code')
+                ->toBe($expectedExit);
+            Expect::that(PartialWriteStream::contents())
+                ->because('a short CLI stream write MUST NOT truncate output')
+                ->toBe($expectedOutput);
+        } finally {
+            \fclose($partial);
+            \fclose($other);
+            \stream_wrapper_unregister(self::SCHEME);
+        }
+    }
+
+    /**
+     * @return iterable<string, array{list<string>, int, string, bool}>
+     */
+    public static function writes(): iterable
+    {
+        yield 'standard output' => [
+            ['--version'],
+            0,
+            "Greenlight dev-main\n",
+            false,
+        ];
+
+        yield 'standard error' => [
+            ['__worker'],
+            64,
+            "__worker requires <address> <workerId> <token>.\n",
+            true,
+        ];
+    }
+}


### PR DESCRIPTION
Route the CLI stdout and stderr adapters through StreamOutput so short writes retry until all bytes are delivered.

Add an application-level regression oracle for partial writes on both output streams.