### PR TITLE
refactor(test): centralize converted rector runs

### DIFF
--- a/tests/Acceptance/RectorMigrationRunTest.php
+++ b/tests/Acceptance/RectorMigrationRunTest.php
@@ -9,7 +9,6 @@ use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Rector\PhpUnitToGreenlightRector;
-use Greenlight\Tests\Support\GreenlightCli;
 use Greenlight\Tests\Support\RectorProbe;
 
 #[RequiresResource('analysis-process')]
@@ -184,8 +183,7 @@ final readonly class RectorMigrationRunTest
             ->not()->toContain('#[CoversClass')
             ->not()->toContain('expectNotToPerformAssertions');
 
-        $this->writeGreenlightConfig($probe->directory);
-        $run = GreenlightCli::run($probe->directory, ['run', '--no-ansi']);
+        $run = $probe->runConvertedTests();
 
         Expect::that($run->exitCode)->toBe(0);
         Expect::that($run->stdout)->toContain('7 tests, 6 passed, 1 skipped')
@@ -206,8 +204,7 @@ final readonly class RectorMigrationRunTest
                 "->toThrow(\\RuntimeException::class, matching: '/code=\\d+/');",
             );
 
-        $this->writeGreenlightConfig($probe->directory);
-        $run = GreenlightCli::run($probe->directory, ['run', '--no-ansi']);
+        $run = $probe->runConvertedTests();
 
         Expect::that($run->exitCode)
             ->because('the converted exception matcher MUST preserve runtime behavior')
@@ -594,8 +591,7 @@ final readonly class RectorMigrationRunTest
         Expect::that($probe->code)->toContain('#[\Greenlight\Attribute\DataRow([1])]')
             ->toContain('#[\Greenlight\Attribute\DataRow([2])]');
 
-        $this->writeGreenlightConfig($probe->directory);
-        $run = GreenlightCli::run($probe->directory, ['run', '--no-ansi']);
+        $run = $probe->runConvertedTests();
 
         Expect::that($run->exitCode)->toBe(0);
         Expect::that($run->stdout)->toContain('2 tests, 2 passed');
@@ -679,28 +675,10 @@ final readonly class RectorMigrationRunTest
         Expect::that($probe->code)->not()->toContain('->assert')
             ->not()->toContain('::assert');
 
-        $this->writeGreenlightConfig($probe->directory);
-        $run = GreenlightCli::run($probe->directory, ['run', '--no-ansi']);
+        $run = $probe->runConvertedTests();
 
         Expect::that($run->exitCode)->toBe(0);
         Expect::that($run->stdout)->toContain('1 test, 1 passed');
     }
 
-    private function writeGreenlightConfig(string $directory): void
-    {
-        \file_put_contents($directory . '/greenlight.php', <<<'PHP'
-            <?php
-
-            declare(strict_types=1);
-
-            use Greenlight\Config\GreenlightConfig;
-
-            require_once __DIR__ . '/tests/ProbeTest.php';
-
-            return GreenlightConfig::create()
-                ->paths([__DIR__ . '/tests'])
-                ->workers(1);
-
-            PHP);
-    }
 }

--- a/tests/Acceptance/RectorOperatingSystemRequirementTest.php
+++ b/tests/Acceptance/RectorOperatingSystemRequirementTest.php
@@ -8,7 +8,6 @@ use Greenlight\Attribute\RequiresResource;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
-use Greenlight\Tests\Support\GreenlightCli;
 use Greenlight\Tests\Support\RectorProbe;
 
 #[RequiresResource('analysis-process')]
@@ -54,22 +53,7 @@ final readonly class RectorOperatingSystemRequirementTest
                     . '\Greenlight\Condition\OperatingSystemFamily::class, \PHP_OS_FAMILY)]',
             );
 
-        \file_put_contents($probe->directory . '/greenlight.php', <<<'PHP'
-            <?php
-
-            declare(strict_types=1);
-
-            use Greenlight\Config\GreenlightConfig;
-
-            require_once __DIR__ . '/tests/ProbeTest.php';
-
-            return GreenlightConfig::create()
-                ->paths([__DIR__ . '/tests'])
-                ->workers(1);
-
-            PHP);
-
-        $run = GreenlightCli::run($probe->directory, ['run', '--no-ansi']);
+        $run = $probe->runConvertedTests();
 
         Expect::that($run->exitCode)
             ->because('the converted operating-system condition MUST permit the matching family')

--- a/tests/Acceptance/RectorTicketGroupTest.php
+++ b/tests/Acceptance/RectorTicketGroupTest.php
@@ -8,7 +8,6 @@ use Greenlight\Attribute\RequiresResource;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
-use Greenlight\Tests\Support\GreenlightCli;
 use Greenlight\Tests\Support\RectorProbe;
 
 #[RequiresResource('analysis-process')]
@@ -56,25 +55,7 @@ final readonly class RectorTicketGroupTest
             ->because('the converted group MUST keep the ticket identifier')
             ->toContain("#[\Greenlight\Attribute\Group('GH-123')]");
 
-        \file_put_contents($probe->directory . '/greenlight.php', <<<'PHP'
-            <?php
-
-            declare(strict_types=1);
-
-            use Greenlight\Config\GreenlightConfig;
-
-            require_once __DIR__ . '/tests/ProbeTest.php';
-
-            return GreenlightConfig::create()
-                ->paths([__DIR__ . '/tests'])
-                ->workers(1);
-
-            PHP);
-
-        $run = GreenlightCli::run(
-            $probe->directory,
-            ['run', '--group=GH-123', '--no-ansi'],
-        );
+        $run = $probe->runConvertedTests(['--group=GH-123']);
 
         Expect::that($run->exitCode)
             ->because('the converted ticket group MUST select its test')

--- a/tests/Support/RectorProbe.php
+++ b/tests/Support/RectorProbe.php
@@ -15,10 +15,10 @@ use Greenlight\Fixture\TempDirectory;
 final readonly class RectorProbe
 {
     private function __construct(
+        private ProjectFiles $files,
         public int $exitCode,
         public string $code,
         public bool $changed,
-        public string $directory,
     ) {}
 
     /**
@@ -69,7 +69,33 @@ final readonly class RectorProbe
             throw new \RuntimeException(\sprintf('Could not read the probe file "%s" back.', $testFile));
         }
 
-        return new self($result->exitCode, $code, $code !== $testClassSource, $directory);
+        return new self($files, $result->exitCode, $code, $code !== $testClassSource);
+    }
+
+    /**
+     * @param list<string> $arguments additional Greenlight run arguments
+     */
+    public function runConvertedTests(array $arguments = []): ProcessResult
+    {
+        $this->files->write('greenlight.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Config\GreenlightConfig;
+
+            require_once __DIR__ . '/tests/ProbeTest.php';
+
+            return GreenlightConfig::create()
+                ->paths([__DIR__ . '/tests'])
+                ->workers(1);
+
+            PHP);
+
+        return GreenlightCli::run(
+            $this->files->directory,
+            ['run', '--no-ansi', ...$arguments],
+        );
     }
 
     /**


### PR DESCRIPTION
Let RectorProbe own the runnable converted-test project after conversion. Callers now supply only Greenlight run overrides while the probe owns configuration writes and CLI execution.

Remove the exposed project directory and six duplicated setup paths across the Rector acceptance suites.