### PR TITLE
perf(discovery): index exact test filters

### DIFF
--- a/src/Discovery/Filter.php
+++ b/src/Discovery/Filter.php
@@ -56,6 +56,9 @@ final readonly class Filter
     /** @var list<non-empty-string> */
     public array $includeExactIds;
 
+    /** @var array<array-key, true> */
+    private array $includeExactIdSet;
+
     /**
      * @param list<string> $includeGroups
      * @param list<string> $excludeGroups
@@ -90,6 +93,7 @@ final readonly class Filter
         $this->excludePaths = $this->validateValues('excludePaths', $excludePaths);
         $this->includeIds = $this->validateValues('includeIds', $includeIds);
         $this->includeExactIds = $this->validateValues('includeExactIds', $includeExactIds);
+        $this->includeExactIdSet = \array_fill_keys($this->includeExactIds, true);
     }
 
     public static function all(): self
@@ -139,7 +143,7 @@ final readonly class Filter
             return true;
         }
 
-        if (\in_array($renderedId, $this->includeExactIds, true)) {
+        if (isset($this->includeExactIdSet[$renderedId])) {
             return true;
         }
 

--- a/tests/Unit/Discovery/FilterTest.php
+++ b/tests/Unit/Discovery/FilterTest.php
@@ -176,6 +176,28 @@ final class FilterTest
     }
 
     #[Test]
+    public function largeExactIdSelectionsRetainExactMembership(): void
+    {
+        $ids = [];
+
+        for ($index = 0; $index < 10_000; ++$index) {
+            $ids[] = \sprintf('Acme\\GeneratedTest%d::runs', $index);
+        }
+
+        $filter = new Filter(includeExactIds: $ids);
+
+        Expect::that($filter->acceptsId('Acme\\GeneratedTest0::runs'))
+            ->because('a large exact-ID selection MUST retain its first member')
+            ->toBeTrue();
+        Expect::that($filter->acceptsId('Acme\\GeneratedTest9999::runs'))
+            ->because('a large exact-ID selection MUST retain its last member')
+            ->toBeTrue();
+        Expect::that($filter->acceptsId('Acme\\GeneratedTest10000::runs'))
+            ->because('a large exact-ID selection MUST reject a nonmember')
+            ->toBeFalse();
+    }
+
+    #[Test]
     public function discovererAppliesIdFilters(): void
     {
         $plan = new TestDiscoverer()->discover([$this->basicDir()], new Filter(includeIds: ['bravotest::alpha']));


### PR DESCRIPTION
Build a private membership index for exact test-ID filters when Greenlight constructs the discovery filter. Exact lookups are now constant-time while the existing public ordered list remains unchanged.

Cover first, last, and absent membership across a 10,000-ID selection, plus the existing exact and wildcard-union behavior.