### PR TITLE
perf(cli): index repeat failure aggregation

### DIFF
--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -371,12 +371,14 @@ final readonly class Application
         }
 
         $priorityClasses = [];
+        $priorityClassSet = [];
 
         if (!$resolved->randomizeOrder && \is_array($previousFailures)) {
             foreach ($previousFailures as $id) {
                 $class = \strstr($id, '::', true);
 
-                if (\is_string($class) && $class !== '' && !\in_array($class, $priorityClasses, true)) {
+                if (\is_string($class) && $class !== '' && !isset($priorityClassSet[$class])) {
+                    $priorityClassSet[$class] = true;
                     $priorityClasses[] = $class;
                 }
             }
@@ -399,6 +401,7 @@ final readonly class Application
         $bounded = $overrides->repeat !== null;
         $failedIterations = [];
         $failedTests = [];
+        $failedTestSet = [];
         $lastClassSeconds = [];
 
         for ($iteration = 1; $iteration <= $limit; $iteration++) {
@@ -420,7 +423,8 @@ final readonly class Application
             $exit = $this->executeRun($arguments, $resolved, $configFile, $workingDirectory, $binPath, $shutdown, $priorityClasses, $classSeconds, $reporter, $failedTap, $state);
 
             foreach ($failedTap->failedTests() as $id) {
-                if (!\in_array($id, $failedTests, true)) {
+                if (!isset($failedTestSet[$id])) {
+                    $failedTestSet[$id] = true;
                     $failedTests[] = $id;
                 }
             }

--- a/tests/Acceptance/RepeatTest.php
+++ b/tests/Acceptance/RepeatTest.php
@@ -74,6 +74,26 @@ final readonly class RepeatTest
     }
 
     #[Test]
+    public function failedRerunsFailuresFromDifferentRepeatIterations(): void
+    {
+        $project = $this->writeFailuresAcrossIterationsProject();
+        $state = $project->path('repeat-state');
+        $environment = ['GREENLIGHT_REPEAT_STATE' => $state];
+
+        $result = $this->run($project, $environment, '--repeat=3');
+        Expect::that($result->exitCode)->because('repeat collects failures from different iterations')->toBe(1);
+        Expect::that($result->output())
+            ->because('repeat collects failures from different iterations')
+            ->toContain('Repeat: failed iterations: 1, 2');
+
+        $result = $this->run($project, $environment, '--failed');
+        Expect::that($result->exitCode)->because('failed reruns failures from different repeat iterations')->toBe(0);
+        Expect::that($result->output())
+            ->because('failed reruns failures from different repeat iterations')
+            ->toContain('2 tests, 2 passed');
+    }
+
+    #[Test]
     public function repeatComposesWithFilter(): void
     {
         $project = $this->writeProject(passing: true);
@@ -175,6 +195,58 @@ final readonly class RepeatTest
                     if ($count >= 3) {
                         throw new \RuntimeException('flaked on run ' . $count);
                     }
+                }
+            }
+            PHP);
+    }
+
+    private function writeFailuresAcrossIterationsProject(): AcceptanceProject
+    {
+        return $this->writeProjectWithTestClass(<<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace RepeatProbe;
+
+            use Greenlight\Attribute\Test;
+
+            final class RepeatProbeTest
+            {
+                #[Test]
+                public function failsOnTheFirstRun(): void
+                {
+                    if ($this->runNumber(__FUNCTION__) === 1) {
+                        throw new \RuntimeException('failed on the first run');
+                    }
+                }
+
+                #[Test]
+                public function failsOnTheSecondRun(): void
+                {
+                    if ($this->runNumber(__FUNCTION__) === 2) {
+                        throw new \RuntimeException('failed on the second run');
+                    }
+                }
+
+                private function runNumber(string $test): int
+                {
+                    $directory = \getenv('GREENLIGHT_REPEAT_STATE');
+
+                    if (!\is_string($directory) || $directory === '') {
+                        throw new \RuntimeException('GREENLIGHT_REPEAT_STATE is not set');
+                    }
+
+                    if (!\is_dir($directory)) {
+                        \mkdir($directory);
+                    }
+
+                    $path = $directory . '/' . $test;
+                    $count = \is_file($path) ? (int) \file_get_contents($path) : 0;
+                    $count++;
+                    \file_put_contents($path, (string) $count);
+
+                    return $count;
                 }
             }
             PHP);


### PR DESCRIPTION
## Summary

- index failed-first class membership while preserving first-seen order
- aggregate failures across repeat iterations with constant-time membership checks
- cover failures that first appear in different repeat iterations through the CLI boundary