### PR TITLE
feat(hyperf): add runtime bridge

### DIFF
--- a/.github/fixtures/hyperf-bridge/.gitignore
+++ b/.github/fixtures/hyperf-bridge/.gitignore
@@ -1,0 +1,3 @@
+/composer.lock
+/runtime/
+/vendor/

--- a/.github/fixtures/hyperf-bridge/app/DisposalProbe.php
+++ b/.github/fixtures/hyperf-bridge/app/DisposalProbe.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use Hyperf\Coroutine\Coroutine;
+
+final class DisposalProbe
+{
+    public static int $containers = 0;
+
+    public static int $resets = 0;
+
+    public static int $disposals = 0;
+
+    public static bool $resetInCoroutine = false;
+
+    public static bool $disposeInCoroutine = false;
+
+    public static function containerCreated(): void
+    {
+        ++self::$containers;
+    }
+
+    public function reset(): void
+    {
+        ++self::$resets;
+        self::$resetInCoroutine = Coroutine::inCoroutine();
+    }
+
+    public function dispose(): void
+    {
+        ++self::$disposals;
+        self::$disposeInCoroutine = Coroutine::inCoroutine();
+    }
+
+    /** @return array{containers: int, resets: int, disposals: int, resetInCoroutine: bool, disposeInCoroutine: bool} */
+    public function snapshot(): array
+    {
+        return [
+            'containers' => self::$containers,
+            'resets' => self::$resets,
+            'disposals' => self::$disposals,
+            'resetInCoroutine' => self::$resetInCoroutine,
+            'disposeInCoroutine' => self::$disposeInCoroutine,
+        ];
+    }
+}

--- a/.github/fixtures/hyperf-bridge/app/Greeter.php
+++ b/.github/fixtures/hyperf-bridge/app/Greeter.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+final class Greeter
+{
+    public function greet(string $name): string
+    {
+        return 'Hello, ' . $name;
+    }
+}

--- a/.github/fixtures/hyperf-bridge/app/GreetingAspect.php
+++ b/.github/fixtures/hyperf-bridge/app/GreetingAspect.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+use Hyperf\Di\Aop\AbstractAspect;
+use Hyperf\Di\Aop\ProceedingJoinPoint;
+
+final class GreetingAspect extends AbstractAspect
+{
+    public array $classes = [Greeter::class . '::greet'];
+
+    public array $annotations = [];
+
+    public function process(ProceedingJoinPoint $proceedingJoinPoint): string
+    {
+        return $proceedingJoinPoint->process() . ' through AOP';
+    }
+}

--- a/.github/fixtures/hyperf-bridge/app/NamedGreeter.php
+++ b/.github/fixtures/hyperf-bridge/app/NamedGreeter.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+final class NamedGreeter
+{
+    public function greet(): string
+    {
+        return 'Named service';
+    }
+}

--- a/.github/fixtures/hyperf-bridge/app/VisitCounter.php
+++ b/.github/fixtures/hyperf-bridge/app/VisitCounter.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App;
+
+final class VisitCounter
+{
+    private int $visits = 0;
+
+    public function record(): void
+    {
+        ++$this->visits;
+    }
+
+    public function count(): int
+    {
+        return $this->visits;
+    }
+}

--- a/.github/fixtures/hyperf-bridge/composer.json
+++ b/.github/fixtures/hyperf-bridge/composer.json
@@ -1,0 +1,40 @@
+{
+    "name": "greenlight/hyperf-bridge-acceptance",
+    "description": "Exercises the Greenlight bridge against a real Hyperf runtime.",
+    "type": "project",
+    "license": "MIT",
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../..",
+            "options": {
+                "symlink": false
+            }
+        }
+    ],
+    "require": {
+        "php": ">=8.4",
+        "ext-swoole": "*",
+        "greenlight/greenlight": "@dev",
+        "hyperf/command": "~3.2.0",
+        "hyperf/config": "~3.2.0",
+        "hyperf/di": "~3.2.0",
+        "hyperf/framework": "~3.2.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "HyperfBridgeAcceptance\\": "tests/"
+        }
+    },
+    "config": {
+        "allow-plugins": false,
+        "sort-packages": true
+    },
+    "minimum-stability": "dev",
+    "prefer-stable": true
+}

--- a/.github/fixtures/hyperf-bridge/config/autoload/annotations.php
+++ b/.github/fixtures/hyperf-bridge/config/autoload/annotations.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'scan' => [
+        'paths' => [BASE_PATH . '/app'],
+    ],
+];

--- a/.github/fixtures/hyperf-bridge/config/autoload/aspects.php
+++ b/.github/fixtures/hyperf-bridge/config/autoload/aspects.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+use App\GreetingAspect;
+
+return [GreetingAspect::class];

--- a/.github/fixtures/hyperf-bridge/config/autoload/dependencies.php
+++ b/.github/fixtures/hyperf-bridge/config/autoload/dependencies.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use App\NamedGreeter;
+
+return [
+    'probe.named_greeter' => static fn(): NamedGreeter => new NamedGreeter(),
+];

--- a/.github/fixtures/hyperf-bridge/config/config.php
+++ b/.github/fixtures/hyperf-bridge/config/config.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'app_env' => 'testing',
+    'scan_cacheable' => false,
+];

--- a/.github/fixtures/hyperf-bridge/config/container.php
+++ b/.github/fixtures/hyperf-bridge/config/container.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Hyperf\Context\ApplicationContext;
+use Hyperf\Di\Container;
+use Hyperf\Di\Definition\DefinitionSourceFactory;
+use App\DisposalProbe;
+
+$container = new Container((new DefinitionSourceFactory())());
+DisposalProbe::containerCreated();
+
+return ApplicationContext::setContainer($container);

--- a/.github/fixtures/hyperf-bridge/greenlight.php
+++ b/.github/fixtures/hyperf-bridge/greenlight.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use App\DisposalProbe;
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Hyperf\ContainerLifetime;
+use Greenlight\Hyperf\HyperfPlugin;
+use Psr\Container\ContainerInterface;
+
+$mode = \getenv('GREENLIGHT_HYPERF_CONTAINER_LIFETIME') ?: 'worker';
+$lifetime = match ($mode) {
+    'worker' => ContainerLifetime::Worker,
+    'attempt' => ContainerLifetime::TestAttempt,
+    default => throw new \RuntimeException('The Hyperf acceptance container lifetime is invalid.'),
+};
+$marker = __DIR__ . '/runtime/lifecycle-' . $mode . '.json';
+@\unlink($marker);
+$record = static function (ContainerInterface $container) use ($marker): void {
+    $probe = $container->get(DisposalProbe::class);
+    $json = \json_encode($probe->snapshot(), \JSON_THROW_ON_ERROR);
+
+    if (\file_put_contents($marker, $json) === false) {
+        throw new \RuntimeException('The Hyperf acceptance fixture did not write its lifecycle marker.');
+    }
+};
+
+return GreenlightConfig::create()
+    ->paths([__DIR__ . '/tests/' . \ucfirst($mode)])
+    ->workers(1)
+    ->plugins(new HyperfPlugin(
+        __DIR__,
+        containerLifetime: $lifetime,
+        reset: static function (ContainerInterface $container) use ($record): void {
+            $container->get(DisposalProbe::class)->reset();
+            $record($container);
+        },
+        dispose: static function (ContainerInterface $container) use ($record): void {
+            $container->get(DisposalProbe::class)->dispose();
+            $record($container);
+        },
+    ));

--- a/.github/fixtures/hyperf-bridge/tests/Attempt/HyperfAttemptLifetimeTest.php
+++ b/.github/fixtures/hyperf-bridge/tests/Attempt/HyperfAttemptLifetimeTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfBridgeAcceptance\Attempt;
+
+use App\DisposalProbe;
+use App\Greeter;
+use App\VisitCounter;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Hyperf\Context\Context;
+use Hyperf\Coroutine\Coroutine;
+
+final readonly class HyperfAttemptLifetimeTest
+{
+    public function __construct(
+        private Greeter $greeter,
+        private VisitCounter $counter,
+        private DisposalProbe $probe,
+    ) {}
+
+    #[Test]
+    public function firstAttemptUsesAnIsolatedContainer(): void
+    {
+        Expect::that(Coroutine::inCoroutine())->toBeTrue();
+        Expect::that($this->greeter->greet('Ada'))->toBe('Hello, Ada through AOP');
+        Expect::that($this->counter->count())->toBe(0);
+        Expect::that($this->probe->snapshot())->toBe([
+            'containers' => 1,
+            'resets' => 0,
+            'disposals' => 0,
+            'resetInCoroutine' => false,
+            'disposeInCoroutine' => false,
+        ]);
+
+        $this->counter->record();
+        Context::set('greenlight.hyperf.probe', 'first attempt');
+    }
+
+    #[Test]
+    public function nextAttemptGetsANewContainerAndCoroutineContext(): void
+    {
+        Expect::that($this->counter->count())->toBe(0);
+        Expect::that(Context::has('greenlight.hyperf.probe'))->toBeFalse();
+        Expect::that($this->probe->snapshot())->toBe([
+            'containers' => 2,
+            'resets' => 1,
+            'disposals' => 1,
+            'resetInCoroutine' => true,
+            'disposeInCoroutine' => true,
+        ]);
+    }
+}

--- a/.github/fixtures/hyperf-bridge/tests/Worker/HyperfWorkerLifetimeTest.php
+++ b/.github/fixtures/hyperf-bridge/tests/Worker/HyperfWorkerLifetimeTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfBridgeAcceptance\Worker;
+
+use App\DisposalProbe;
+use App\Greeter;
+use App\NamedGreeter;
+use App\VisitCounter;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Hyperf\Service;
+use Hyperf\Context\Context;
+use Hyperf\Contract\ApplicationInterface;
+use Hyperf\Coroutine\Coroutine;
+use Symfony\Component\Console\Application;
+
+final readonly class HyperfWorkerLifetimeTest
+{
+    public function __construct(
+        #[Service(ApplicationInterface::class)] private Application $application,
+        private Greeter $greeter,
+        private VisitCounter $counter,
+        private DisposalProbe $probe,
+        #[Service('probe.named_greeter')] private NamedGreeter $namedGreeter,
+    ) {}
+
+    #[Test]
+    public function firstAttemptUsesTheBootedWorkerContainer(): void
+    {
+        Expect::that($this->application)->toBeInstanceOf(Application::class);
+        Expect::that(Coroutine::inCoroutine())->toBeTrue();
+        Expect::that($this->greeter->greet('Ada'))->toBe('Hello, Ada through AOP');
+        Expect::that($this->namedGreeter->greet())->toBe('Named service');
+        Expect::that($this->counter->count())->toBe(0);
+        Expect::that($this->probe->snapshot())->toBe([
+            'containers' => 1,
+            'resets' => 0,
+            'disposals' => 0,
+            'resetInCoroutine' => false,
+            'disposeInCoroutine' => false,
+        ]);
+
+        $this->counter->record();
+        Context::set('greenlight.hyperf.probe', 'first attempt');
+    }
+
+    #[Test]
+    public function nextAttemptKeepsWorkerStateButReplacesCoroutineContext(): void
+    {
+        Expect::that($this->counter->count())->toBe(1);
+        Expect::that(Context::has('greenlight.hyperf.probe'))->toBeFalse();
+        Expect::that($this->probe->snapshot())->toBe([
+            'containers' => 1,
+            'resets' => 1,
+            'disposals' => 0,
+            'resetInCoroutine' => true,
+            'disposeInCoroutine' => false,
+        ]);
+    }
+}

--- a/.github/fixtures/hyperf-bridge/verify-lifecycle.php
+++ b/.github/fixtures/hyperf-bridge/verify-lifecycle.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+$mode = $argv[1] ?? '';
+$expected = match ($mode) {
+    'worker' => [
+        'containers' => 1,
+        'resets' => 2,
+        'disposals' => 1,
+        'resetInCoroutine' => true,
+        'disposeInCoroutine' => true,
+    ],
+    'attempt' => [
+        'containers' => 2,
+        'resets' => 2,
+        'disposals' => 2,
+        'resetInCoroutine' => true,
+        'disposeInCoroutine' => true,
+    ],
+    default => throw new RuntimeException('The lifecycle verification mode is invalid.'),
+};
+$path = __DIR__ . '/runtime/lifecycle-' . $mode . '.json';
+$contents = @file_get_contents($path);
+
+if (!is_string($contents)) {
+    throw new RuntimeException('The Hyperf lifecycle marker does not exist.');
+}
+
+$actual = json_decode($contents, true, flags: JSON_THROW_ON_ERROR);
+
+if ($actual !== $expected) {
+    throw new RuntimeException(sprintf(
+        'The Hyperf %s lifecycle marker does not match. Expected %s, got %s.',
+        $mode,
+        json_encode($expected, JSON_THROW_ON_ERROR),
+        json_encode($actual, JSON_THROW_ON_ERROR),
+    ));
+}
+
+fwrite(STDOUT, sprintf("Verified the Hyperf %s container lifecycle.\n", $mode));

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,51 @@ jobs:
           vendor/bin/greenlight --version | grep -Eq '^Greenlight [^[:space:]]+$'
           vendor/bin/greenlight run --no-ansi
 
+  hyperf-bridge:
+    name: "Hyperf bridge"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 15
+    permissions:
+      contents: "read"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7
+        with:
+          persist-credentials: false
+
+      - name: "Set up PHP with Swoole"
+        uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # v2
+        with:
+          php-version: "8.4"
+          extensions: "pcntl, swoole"
+          coverage: "none"
+          ini-values: "memory_limit=-1"
+
+      - name: "Install bridge acceptance dependencies"
+        working-directory: ".github/fixtures/hyperf-bridge"
+        run: "composer update --no-interaction --no-progress --prefer-dist"
+
+      - name: "Run Hyperf worker-container acceptance tests"
+        working-directory: ".github/fixtures/hyperf-bridge"
+        env:
+          GREENLIGHT_HYPERF_CONTAINER_LIFETIME: "worker"
+        run: "vendor/bin/greenlight run --no-ansi --reporter=plain"
+
+      - name: "Verify Hyperf worker-container disposal"
+        working-directory: ".github/fixtures/hyperf-bridge"
+        run: "php verify-lifecycle.php worker"
+
+      - name: "Run Hyperf attempt-container acceptance tests"
+        working-directory: ".github/fixtures/hyperf-bridge"
+        env:
+          GREENLIGHT_HYPERF_CONTAINER_LIFETIME: "attempt"
+        run: "vendor/bin/greenlight run --no-ansi --reporter=plain"
+
+      - name: "Verify Hyperf attempt-container disposal"
+        working-directory: ".github/fixtures/hyperf-bridge"
+        run: "php verify-lifecycle.php attempt"
+
   ci:
     name: "CI (PHP ${{ matrix.php-version }}, ${{ matrix.dependencies }} deps${{ matrix.symfony-version && format(', Symfony {0}', matrix.symfony-version) || '' }})"
     runs-on: "ubuntu-latest"

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ for the complete model.
 * [Static analysis with PHPStan](docs/phpstan.md)
 * [Test Symfony applications](docs/symfony.md)
 * [Test Laravel applications](docs/laravel.md)
+* [Test Hyperf applications](docs/hyperf.md)
 * [Test PSR applications](docs/psr.md)
 * [Test PSR-15 applications](docs/psr15.md)
 * [Move from PHPUnit](docs/migrating-from-phpunit.md)

--- a/composer.json
+++ b/composer.json
@@ -38,8 +38,12 @@
         "symfony/http-kernel": "^6.4 || ^7.0 || ^8.0"
     },
     "suggest": {
+        "ext-pcntl": "Scans Hyperf classes before 'HyperfPlugin' starts a worker",
         "ext-pcov": "Collects line coverage quickly",
+        "ext-swoole": "Runs 'HyperfPlugin' workers and test attempts in Hyperf coroutines",
         "fidry/cpu-core-counter": "Improves the 'auto' worker count across platforms and on systems with cgroup limits",
+        "hyperf/di": "Scans Hyperf classes and generates AOP proxies for the 'HyperfPlugin' bridge",
+        "hyperf/framework": "Provides the Hyperf 3.2 application runtime that 'HyperfPlugin' requires",
         "laravel/framework": "Provides the complete Laravel 13 framework that LaravelPlugin requires",
         "phpstan/extension-installer": "Registers the bundled PHPStan extension automatically",
         "phpstan/phpstan": "Type-checks extension matcher calls and data providers with the bundled 'extension.neon' file",

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -89,6 +89,10 @@ deptrac:
       collectors:
         - type: directory
           value: src/Laravel/.*
+    - name: Hyperf
+      collectors:
+        - type: directory
+          value: src/Hyperf/.*
     - name: Psr
       collectors:
         - type: directory
@@ -109,6 +113,18 @@ deptrac:
       collectors:
         - type: classNameRegex
           value: /^Illuminate\\/
+    - name: HyperfFramework
+      collectors:
+        - type: classNameRegex
+          value: /^Hyperf\\/
+    - name: SwooleFramework
+      collectors:
+        - type: classNameRegex
+          value: /^Swoole\\/
+    - name: ComposerRuntime
+      collectors:
+        - type: classNameRegex
+          value: /^Composer\\InstalledVersions$/
     - name: PsrFramework
       collectors:
         - type: classNameRegex
@@ -152,11 +168,15 @@ deptrac:
     Rector: [Core, Attribute, Condition, Expect, PhpParserFramework, RectorFramework]
     Symfony: [Core, Harness, Plugin, SymfonyFramework]
     Laravel: [Core, Harness, Plugin, LaravelFramework]
+    Hyperf: [Core, Harness, Plugin, HyperfFramework, PsrFramework, SwooleFramework, ComposerRuntime]
     Psr: [Core, Harness, Plugin, PsrFramework]
     Psr15: [Harness, Plugin, PsrHttpFramework]
     PhpStanFramework: []
     SymfonyFramework: []
     LaravelFramework: []
+    HyperfFramework: []
+    SwooleFramework: []
+    ComposerRuntime: []
     PsrFramework: []
     PsrHttpFramework: []
     CpuCoreCounter: []

--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -2,9 +2,188 @@
 
 # Integration API
 
-This reference lists public integration types for Laravel, PSR standards, Rector, and Symfony.
+This reference lists public integration types for Hyperf, Laravel, PSR standards, Rector, and Symfony.
 
 These signatures are the public API.
+
+## `ContainerLifetime`
+
+Namespace: `Greenlight\Hyperf`
+
+Selects the lifetime of the Hyperf application container.
+
+```php
+enum ContainerLifetime
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/ContainerLifetime.php#L8)
+
+### `Worker`
+
+One container belongs to one physical Greenlight worker.
+
+```php
+case Worker;
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/ContainerLifetime.php#L11)
+
+### `TestAttempt`
+
+One container belongs to one test attempt.
+
+```php
+case TestAttempt;
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/ContainerLifetime.php#L14)
+
+## `HyperfPlugin`
+
+Namespace: `Greenlight\Hyperf`
+
+Initializes the Hyperf class loader once in each worker. It creates a
+coroutine context for each test attempt.
+
+The default worker container lifetime matches a long-running Hyperf worker.
+`#[Service]` selects an explicit container ID. Tests MUST isolate external
+resources by `GREENLIGHT_CHANNEL`.
+
+```php
+final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemptRunner, WorkerBootstrapSubscriber, WorkerRuntimeRunner
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L38)
+
+### `__construct()`
+
+```php
+public function __construct(
+    string $basePath,
+    private readonly ContainerLifetime $containerLifetime = ContainerLifetime::Worker,
+    private readonly ?\Closure $reset = null,
+    private readonly ?\Closure $dispose = null,
+    private readonly ?int $hookFlags = null,
+)
+```
+
+PHPDoc:
+
+- `@param null|\Closure(ContainerInterface): void $reset Resets project-owned request state after each test attempt. The callback runs inside the test coroutine.`
+- `@param null|\Closure(ContainerInterface): void $dispose Releases project-owned resources when the selected container lifetime ends. The callback runs inside a coroutine.`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L61)
+
+### `services()`
+
+```php
+[\Override]
+public function services(): array
+```
+
+PHPDoc:
+
+- `@return list<ServiceDefinition>`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L73)
+
+### `resolve()`
+
+```php
+[\Override]
+public function resolve(string $type, array $attributes): ?object
+```
+
+PHPDoc:
+
+- `@param class-string $type`
+- `@param list<object> $attributes`
+- `@throws HyperfBridgeError`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L86)
+
+### `onWorkerBootstrap()`
+
+```php
+[\Override]
+public function onWorkerBootstrap(WorkerBootstrapContext $context): void
+```
+
+PHPDoc:
+
+- `@throws HyperfBridgeError`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L117)
+
+### `runWorker()`
+
+```php
+[\Override]
+public function runWorker(\Closure $worker): mixed
+```
+
+PHPDoc:
+
+- `@template T`
+- `@param \Closure(): T $worker`
+- `@return T`
+- `@throws HyperfBridgeError`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L166)
+
+### `runTestAttempt()`
+
+```php
+[\Override]
+public function runTestAttempt(\Closure $attempt): mixed
+```
+
+PHPDoc:
+
+- `@template T`
+- `@param \Closure(): T $attempt`
+- `@return T`
+- `@throws HyperfBridgeError`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L210)
+
+## `Hyperf\Service`
+
+Namespace: `Greenlight\Hyperf`
+
+Use this attribute when a parameter type does not select one container ID.
+The service must have the declared type.
+
+```php
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+final readonly class Service
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/Service.php#L12)
+
+### `$id`
+
+```php
+public string $id;
+```
+
+PHPDoc:
+
+- `@var non-empty-string`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/Service.php#L15)
+
+### `__construct()`
+
+```php
+public function __construct(string $id)
+```
+
+PHPDoc:
+
+- `@throws \InvalidArgumentException`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/Service.php#L18)
 
 ## `LaravelPlugin`
 

--- a/docs/api-plugins.md
+++ b/docs/api-plugins.md
@@ -226,14 +226,15 @@ Namespace: `Greenlight\Plugin`
 Identifies an object as a Greenlight plugin.
 
 Plugins implement one or more capability interfaces such as
-`TestLifecycleSubscriber`, `RunLifecycleSubscriber`, `RetryDecider`,
-`HarnessProvider`, or `ExpectationExtension`.
+`WorkerRuntimeRunner`, `TestAttemptRunner`, `TestLifecycleSubscriber`,
+`RunLifecycleSubscriber`, `RetryDecider`, `HarnessProvider`, or
+`ExpectationExtension`.
 
 ```php
 interface Plugin
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/Plugin.php#L14)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/Plugin.php#L15)
 
 This type does not declare public members.
 
@@ -308,6 +309,32 @@ public function onRunEvent(Event $event): void;
 ```
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/RunLifecycleSubscriber.php#L19)
+
+## `TestAttemptRunner`
+
+Namespace: `Greenlight\Plugin`
+
+Runs each complete test attempt in a plugin-defined runtime boundary.
+
+```php
+interface TestAttemptRunner extends Plugin
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestAttemptRunner.php#L8)
+
+### `runTestAttempt()`
+
+```php
+public function runTestAttempt(\Closure $attempt): mixed;
+```
+
+PHPDoc:
+
+- `@template T`
+- `@param \Closure(): T $attempt`
+- `@return T`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestAttemptRunner.php#L17)
 
 ## `TestContext`
 
@@ -514,3 +541,29 @@ public function onWorkerBootstrap(WorkerBootstrapContext $context): void;
 ```
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/WorkerBootstrapSubscriber.php#L13)
+
+## `WorkerRuntimeRunner`
+
+Namespace: `Greenlight\Plugin`
+
+Runs one physical worker in a plugin-defined runtime boundary.
+
+```php
+interface WorkerRuntimeRunner extends Plugin
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/WorkerRuntimeRunner.php#L8)
+
+### `runWorker()`
+
+```php
+public function runWorker(\Closure $worker): mixed;
+```
+
+PHPDoc:
+
+- `@template T`
+- `@param \Closure(): T $worker`
+- `@return T`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/WorkerRuntimeRunner.php#L17)

--- a/docs/api.md
+++ b/docs/api.md
@@ -19,4 +19,4 @@ Use the task guides for workflows and examples. Use these pages for exact signat
 - [Fixtures and harness API](api-fixtures-harness.md) — This reference lists fixtures and harness service contracts.
 - [Plugin API](api-plugins.md) — This reference lists plugin capabilities and lifecycle callback contracts.
 - [Reporter API](api-reporting.md) — This reference lists reporter and output contracts.
-- [Integration API](api-integrations.md) — This reference lists public integration types for Laravel, PSR standards, Rector, and Symfony.
+- [Integration API](api-integrations.md) — This reference lists public integration types for Hyperf, Laravel, PSR standards, Rector, and Symfony.

--- a/docs/architecture/technical-writing.md
+++ b/docs/architecture/technical-writing.md
@@ -110,6 +110,7 @@ and meaning. Use the singular form unless the context requires a plural.
 | condition | Technical noun | A rule that determines if Greenlight skips a test |
 | configuration | Technical noun | The settings that control a Greenlight run |
 | configurator | Technical noun | A callable that changes a builder |
+| container lifetime | Technical noun | The period that one application container belongs to a worker or test attempt |
 | consumer | Technical noun | A program or tool that reads Greenlight output |
 | coverage driver | Technical noun | A component that collects raw line coverage |
 | coverage export | Technical noun | A file or directory that contains coverage results |
@@ -138,6 +139,7 @@ and meaning. Use the singular form unless the context requires a plural.
 | harness | Technical noun | The test environment that supplies application services to a worker |
 | harness provider | Technical noun | A plugin that supplies services to the Greenlight harness |
 | harness service | Technical noun | An object that the harness supplies to a test constructor |
+| Hyperf bridge | Technical noun | The component that connects the Greenlight harness to a Hyperf application, container, and coroutine runtime |
 | hook | Technical noun | A method or subscriber callback that runs before or after a test |
 | interaction | Technical noun | One call from code under test to a double |
 | Laravel bridge | Technical noun | The component that connects the Greenlight harness to a Laravel application and container |
@@ -178,6 +180,7 @@ and meaning. Use the singular form unless the context requires a plural.
 | run subscriber | Technical noun | An orchestrator plugin that observes run events |
 | run time | Technical noun | The time when a program executes |
 | runtime | Noun modifier | Related to program execution |
+| runtime boundary | Technical noun | A plugin-defined execution context that contains one complete test attempt |
 | service provider | Technical noun | A Laravel class that registers services in the Laravel container |
 | service resolver | Technical noun | A fallback component that supplies constructor arguments by type |
 | service scope | Technical noun | The lifetime and ownership boundary of a harness service |

--- a/docs/hyperf.md
+++ b/docs/hyperf.md
@@ -1,0 +1,229 @@
+# Hyperf applications
+
+The Hyperf bridge runs Greenlight tests in the Hyperf coroutine runtime. It
+does more than pass calls to a PSR-11 container.
+
+The bridge supports Hyperf 3.2 with Swoole 5 or later. It does not support the
+Swow engine.
+
+## Setup
+
+Install the Hyperf framework and dependency injector in the application:
+
+```console
+composer require hyperf/framework:^3.2 hyperf/di:^3.2
+```
+
+Install the Swoole and pcntl extensions for the PHP command that runs
+Greenlight.
+
+Register the plugin in `greenlight.php`:
+
+```php
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Hyperf\HyperfPlugin;
+
+return GreenlightConfig::create()
+    ->paths(['tests'])
+    ->plugins(new HyperfPlugin(dirname(__DIR__)));
+```
+
+Give the plugin the application root directory. The directory must contain the
+standard `config/container.php` file.
+
+The container file must return a `Psr\Container\ContainerInterface` instance.
+It must create a new instance for the test-attempt container lifetime. The
+standard Hyperf container file has this behavior.
+
+## Container lifetime
+
+The default `ContainerLifetime::Worker` mode models a long-running Hyperf
+worker. Greenlight boots one application container for each physical worker and
+reuses that container for all test attempts in the worker.
+
+```php
+use Greenlight\Hyperf\ContainerLifetime;
+use Greenlight\Hyperf\HyperfPlugin;
+
+new HyperfPlugin(
+    dirname(__DIR__),
+    containerLifetime: ContainerLifetime::Worker,
+);
+```
+
+Container singleton state can reach later tests in this mode. This behavior is
+intentional. It exposes request data that an application incorrectly stores in
+a worker service, global variable, or static property.
+
+Use `ContainerLifetime::TestAttempt` for a new application container in each
+test attempt:
+
+```php
+new HyperfPlugin(
+    dirname(__DIR__),
+    containerLifetime: ContainerLifetime::TestAttempt,
+);
+```
+
+This mode gives deterministic container isolation. It matches the fresh
+container strategy in Hyperf's testing helpers. It does not validate that
+container services are safe across requests in a long-running worker. Static
+properties and global variables still belong to the Greenlight worker process.
+
+## Worker bootstrap
+
+Each Greenlight worker calls `Hyperf\Di\ClassLoader::init()` once. This call
+loads scan configuration and generates the necessary AOP proxy classes.
+
+The bridge locks `runtime/container/greenlight.scan.lock` during this call.
+The lock prevents parallel workers from writing the Hyperf scan cache at the
+same time.
+
+Normal Hyperf scan configuration applies. Keep `scan_cacheable` disabled during
+development. If you enable `scan_cacheable`, generate current scan caches before
+the test run.
+
+The class-loader step occurs before Greenlight loads test classes in the
+worker. Composer can then select generated classes for application services.
+
+In worker-container mode, bootstrap also loads `config/container.php` and
+resolves `Hyperf\Contract\ApplicationInterface`. This operation boots the
+application once for the physical worker.
+
+## Worker-container lifecycle
+
+The default mode uses this lifecycle:
+
+1. Boot one application container during Greenlight worker bootstrap.
+2. Start one root Swoole coroutine runtime for the physical worker.
+3. Start one child coroutine for each test attempt.
+4. Construct the test and run all hooks, plugins, and the test method.
+5. Close the Greenlight test service scope.
+6. Call the configured reset callback.
+7. End the child coroutine and release its `Hyperf\Context\Context` data.
+8. Reuse the application container for the next test attempt.
+9. When the worker exits, call the disposal callback inside the root coroutine.
+10. Clear Swoole timers and resume Hyperf's worker-exit coordinator.
+11. End the root coroutine runtime.
+
+The root runtime contains all assignments that Greenlight sends to one
+physical worker. Worker recycling closes this runtime and gives the replacement
+worker a new application container.
+
+## Test-attempt container lifecycle
+
+The isolated mode uses this lifecycle for each attempt:
+
+1. Start one root Swoole coroutine runtime.
+2. Load `config/container.php` and activate its new container.
+3. Resolve `Hyperf\Contract\ApplicationInterface` to boot the application.
+4. Construct the test and run all hooks, plugins, and the test method.
+5. Close the Greenlight test service scope.
+6. Call the reset callback and disposal callback.
+7. Remove access to the discarded application container.
+8. Clear Swoole timers and resume Hyperf's worker-exit coordinator.
+9. End the coroutine runtime.
+
+In both modes, the complete Greenlight attempt runs inside its own coroutine.
+This boundary includes constructor injection, hooks, test-scope disposal, and
+`afterTest()` plugins. Swoole destroys the coroutine context when the attempt
+ends.
+
+## Container services
+
+Declare a service dependency by type:
+
+```php
+final readonly class RegistrationTest
+{
+    public function __construct(private RegistrationHandler $handler) {}
+}
+```
+
+Greenlight first checks its harness services. It then asks the active Hyperf
+container. Normal Hyperf container rules apply.
+
+Use `#[Service]` when the parameter type does not select the necessary ID:
+
+```php
+use Greenlight\Hyperf\Service;
+
+public function __construct(
+    #[Service('payments.client')] private PaymentClient $client,
+) {}
+```
+
+The bridge checks the returned service type. A different type causes a test
+error.
+
+Tests can also receive `Psr\Container\ContainerInterface`. This service is
+available only during the current test attempt.
+
+## Reset and disposal
+
+Hyperf does not define one reset operation for an arbitrary application object
+graph. The application MUST keep request state in coroutine context or reset
+that state explicitly. See Hyperf's
+[coroutine guidance](https://hyperf.wiki/3.1/#/en/coroutine).
+
+Use `reset` for project state that must change after every attempt. Use
+`dispose` for resources that belong to the selected container lifetime:
+
+```php
+use Psr\Container\ContainerInterface;
+
+new HyperfPlugin(
+    dirname(__DIR__),
+    reset: static function (ContainerInterface $container): void {
+        $container->get(RequestStateProbe::class)->reset();
+    },
+    dispose: static function (ContainerInterface $container): void {
+        $container->get(TestResourceRegistry::class)->close();
+    },
+);
+```
+
+The reset callback runs after Greenlight closes its per-test service scope. It
+runs inside the test coroutine in both modes.
+
+The disposal callback runs before Greenlight discards its container. In worker
+mode, it runs once when the worker exits. In test-attempt mode, it runs after
+each attempt. It always runs inside a coroutine.
+
+The bridge does not reset arbitrary application static properties or global
+variables. Reset these values in an `#[After]` hook or the reset callback.
+
+The bridge does not isolate databases, queues, caches, or remote services.
+
+## Parallel resources
+
+Workers run tests at the same time. Use `GREENLIGHT_CHANNEL` in Hyperf
+configuration to give each worker separate external resources.
+
+For example, add the channel to database names, cache prefixes, queue names,
+and temporary directories. The channel remains stable for the worker slot.
+
+Use `#[RequiresResource]` when an external resource cannot use channels. See
+[configuration](configuration.md) for concurrency limits.
+
+## Supported surface
+
+The bridge covers these runtime behaviors:
+
+* Hyperf class scan and AOP proxy generation
+* One long-running Swoole runtime for each worker-container worker
+* Application boot for the selected container lifetime
+* One coroutine context for each complete test attempt
+* Persistent or isolated container singleton state
+* Project reset and disposal callbacks
+* Hyperf timer and coordinator cleanup at the container lifetime boundary
+* Type-based and explicit-ID service injection
+
+The bridge does not cover these behaviors:
+
+* A live Swoole HTTP server or server worker events
+* Concurrent test attempts inside one Greenlight worker
+* Hyperf `co-phpunit` or PHPUnit helper traits
+* Swow coroutine execution
+* Database transactions or schema creation
+* Automatic cleanup for arbitrary static state or external resources

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -203,6 +203,29 @@ final class BrokerPlugin implements WorkerBootstrapSubscriber, HarnessProvider
 `IntegrationResources`. Subscribers may implement `Prioritized`. Lower values
 run first. An exception fails the run before tests begin.
 
+### WorkerRuntimeRunner
+
+Worker-side.
+
+```php
+public function runWorker(\Closure $worker): mixed;
+```
+
+This capability puts all assignments for one physical worker in a runtime
+boundary. Greenlight calls it after worker bootstrap and before it reports that
+the worker is ready.
+
+Call the callback once and return its value. Use `finally` to close the runtime
+when the worker drains, recycles, disconnects, or throws. Run-scope harness
+services close before the callback returns.
+
+Greenlight nests multiple runtime boundaries in priority order. A boundary
+failure stops the worker. Greenlight sends a final worker message only after
+all runtime boundaries close successfully.
+
+The Hyperf bridge uses this capability for its long-running root Swoole
+runtime. See [Hyperf applications](hyperf.md).
+
 ### TestLifecycleSubscriber
 
 Worker-side.
@@ -254,6 +277,27 @@ retention and size limits apply. See [attachments](attachments.md).
 
 The `service()` method is available during `beforeTest()` and the test. The
 per-test scope closes before `afterTest()`, so `service()` throws in that hook.
+
+### TestAttemptRunner
+
+Worker-side.
+
+```php
+public function runTestAttempt(\Closure $attempt): mixed;
+```
+
+This capability puts one complete attempt in a runtime boundary. The callback
+contains constructor injection, hooks, the test, scope disposal, and
+`afterTest()` subscribers.
+
+Call the callback one time and return its value. Use `finally` to leave the
+runtime boundary when the callback throws.
+
+Greenlight converts a boundary failure to an error result. It can then apply
+the normal retry policy.
+
+The Hyperf bridge uses this capability to run each attempt in one Swoole
+coroutine. See [Hyperf applications](hyperf.md).
 
 ### RetryDecider
 
@@ -438,6 +482,8 @@ Priority applies to these capabilities:
 
 * `IntegrationFixtureProvider`
 * `WorkerBootstrapSubscriber`
+* `WorkerRuntimeRunner`
+* `TestAttemptRunner`
 * `TestLifecycleSubscriber`
 * `RetryDecider`
 * `RunLifecycleSubscriber`
@@ -445,6 +491,9 @@ Priority applies to these capabilities:
 * `ServiceResolver`
 
 `ExpectationExtension` uses registration order.
+
+For attempt runners, the lower-priority runner is the outer boundary. Each
+runner must call the next callback one time.
 
 Greenlight reports all plugin failures. A worker-side failure causes an error
 for the affected test and names the plugin. An orchestrator-side failure causes

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -35,6 +35,8 @@ parameters:
         - src
         - tests
         - tools
+    scanFiles:
+        - tools/phpstan-stubs/hyperf.php
     excludePaths:
         analyse:
             - tests/Fixture/DataRowsDuplicateInline

--- a/src/Hyperf/ContainerLifetime.php
+++ b/src/Hyperf/ContainerLifetime.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Hyperf;
+
+/** Selects the lifetime of the Hyperf application container. */
+enum ContainerLifetime
+{
+    /** One container belongs to one physical Greenlight worker. */
+    case Worker;
+
+    /** One container belongs to one test attempt. */
+    case TestAttempt;
+}

--- a/src/Hyperf/HyperfBridgeError.php
+++ b/src/Hyperf/HyperfBridgeError.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Hyperf;
+
+use Greenlight\Harness\ServiceResolutionError;
+
+/**
+ * Reports a Hyperf bridge configuration or runtime failure.
+ *
+ * @internal
+ */
+final class HyperfBridgeError extends ServiceResolutionError
+{
+    private function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+
+    public static function basePathMissing(string $path): self
+    {
+        return new self(\sprintf(
+            'The Hyperf base path "%s" does not exist. Give HyperfPlugin the application root directory.',
+            $path,
+        ));
+    }
+
+    public static function basePathConflict(string $configured, string $defined): self
+    {
+        return new self(\sprintf(
+            'HyperfPlugin uses base path "%s", but BASE_PATH is already "%s". Use one Hyperf application in each worker.',
+            $configured,
+            $defined,
+        ));
+    }
+
+    public static function containerFileMissing(string $path): self
+    {
+        return new self(\sprintf(
+            'The Hyperf container file "%s" does not exist. Add the standard config/container.php file.',
+            $path,
+        ));
+    }
+
+    public static function frameworkUnavailable(): self
+    {
+        return new self(
+            'HyperfPlugin requires hyperf/framework and hyperf/di 3.2. Install both packages before you activate the plugin.',
+        );
+    }
+
+    public static function frameworkVersionUnsupported(string $version): self
+    {
+        return new self(\sprintf(
+            'HyperfPlugin found hyperf/framework "%s", but it requires version 3.2. Install hyperf/framework 3.2.',
+            $version,
+        ));
+    }
+
+    public static function swooleUnavailable(): self
+    {
+        return new self(
+            'HyperfPlugin requires the Swoole extension. Install Swoole 5 or later to run tests in Hyperf coroutines.',
+        );
+    }
+
+    public static function pcntlUnavailable(): self
+    {
+        return new self(
+            'HyperfPlugin requires the pcntl extension for the Hyperf class scan. Enable pcntl for the Greenlight PHP command.',
+        );
+    }
+
+    public static function swooleVersionUnsupported(string $version): self
+    {
+        return new self(\sprintf(
+            'HyperfPlugin found Swoole "%s", but it requires major version 5 or later.',
+            $version,
+        ));
+    }
+
+    public static function scanLockUnavailable(string $path): self
+    {
+        return new self(\sprintf(
+            'HyperfPlugin cannot open scan lock "%s". Make the runtime/container directory writable.',
+            $path,
+        ));
+    }
+
+    public static function scanLockFailed(string $path): self
+    {
+        return new self(\sprintf(
+            'HyperfPlugin cannot lock "%s" for the class scan.',
+            $path,
+        ));
+    }
+
+    public static function notAContainer(string $path, string $actual): self
+    {
+        return new self(\sprintf(
+            'The Hyperf container file "%s" returned "%s". It must return a Psr\\Container\\ContainerInterface instance.',
+            $path,
+            $actual,
+        ));
+    }
+
+    public static function reusedContainer(): self
+    {
+        return new self(
+            'The Hyperf container file returned the previous test container. It must create a new container for each test.',
+        );
+    }
+
+    public static function applicationUnavailable(string $actual): self
+    {
+        return new self(\sprintf(
+            'The Hyperf application binding returned "%s". The binding must return an application object.',
+            $actual,
+        ));
+    }
+
+    public static function coroutineDidNotStart(): self
+    {
+        return new self('Swoole did not start the test coroutine. Check the Swoole runtime configuration.');
+    }
+
+    public static function workerContainerUnavailable(): self
+    {
+        return new self(
+            'The Hyperf worker container is not available. Greenlight cannot start the worker runtime.',
+        );
+    }
+
+    public static function workerRuntimeUnavailable(): self
+    {
+        return new self(
+            'The Hyperf worker runtime is not active. Run the test attempt inside WorkerRuntimeRunner.',
+        );
+    }
+
+    public static function containerOutsideAttempt(): self
+    {
+        return new self(
+            'The Hyperf container is not active. Resolve Hyperf services only during a Greenlight test attempt.',
+        );
+    }
+
+    public static function unknownServiceId(string $id, string $type): self
+    {
+        return new self(\sprintf(
+            'The Hyperf container has no service "%s" for type "%s". Check the service ID.',
+            $id,
+            $type,
+        ));
+    }
+
+    public static function serviceTypeMismatch(string $id, string $type, string $actual): self
+    {
+        return new self(\sprintf(
+            'The Hyperf service "%s" has type "%s". The parameter requires type "%s".',
+            $id,
+            $actual,
+            $type,
+        ));
+    }
+}

--- a/src/Hyperf/HyperfFrameworkRequirement.php
+++ b/src/Hyperf/HyperfFrameworkRequirement.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Hyperf;
+
+use Composer\InstalledVersions;
+use Hyperf\Context\ApplicationContext;
+use Hyperf\Di\ClassLoader;
+
+/**
+ * Checks the framework and coroutine prerequisites for the Hyperf bridge.
+ *
+ * @internal
+ */
+final class HyperfFrameworkRequirement
+{
+    /**
+     * The isolated Hyperf acceptance job exercises this environment adapter.
+     *
+     * @codeCoverageIgnore
+     * @throws HyperfBridgeError
+     */
+    public static function check(): void
+    {
+        self::checkEnvironment(
+            \class_exists(ClassLoader::class) && \class_exists(ApplicationContext::class),
+            InstalledVersions::isInstalled('hyperf/framework')
+                ? InstalledVersions::getPrettyVersion('hyperf/framework')
+                : null,
+            \phpversion('swoole'),
+            \function_exists('pcntl_fork'),
+        );
+    }
+
+    /** @throws HyperfBridgeError */
+    public static function checkEnvironment(
+        bool $frameworkAvailable,
+        ?string $frameworkVersion,
+        string|false $swooleVersion,
+        bool $pcntlAvailable,
+    ): void {
+        if (!$frameworkAvailable) {
+            throw HyperfBridgeError::frameworkUnavailable();
+        }
+
+        self::checkFrameworkVersion($frameworkVersion);
+        self::checkSwooleVersion($swooleVersion);
+
+        if (!$pcntlAvailable) {
+            throw HyperfBridgeError::pcntlUnavailable();
+        }
+    }
+
+    /** @throws HyperfBridgeError */
+    public static function checkFrameworkVersion(?string $version): void
+    {
+        if ($version === null) {
+            throw HyperfBridgeError::frameworkUnavailable();
+        }
+
+        if (\preg_match('/^v?3\.2(?:\.|$)/D', $version) !== 1) {
+            throw HyperfBridgeError::frameworkVersionUnsupported($version);
+        }
+    }
+
+    /** @throws HyperfBridgeError */
+    public static function checkSwooleVersion(string|false $version): void
+    {
+        if ($version === false) {
+            throw HyperfBridgeError::swooleUnavailable();
+        }
+
+        if (\preg_match('/^(?:[5-9]|[1-9][0-9]+)(?:\.|$)/D', $version) !== 1) {
+            throw HyperfBridgeError::swooleVersionUnsupported($version);
+        }
+    }
+}

--- a/src/Hyperf/HyperfPlugin.php
+++ b/src/Hyperf/HyperfPlugin.php
@@ -1,0 +1,476 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Hyperf;
+
+use Greenlight\Core\ErrorTrap;
+use Greenlight\Harness\Scope;
+use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Harness\ServiceResolver;
+use Greenlight\Plugin\HarnessProvider;
+use Greenlight\Plugin\TestAttemptRunner;
+use Greenlight\Plugin\WorkerBootstrapContext;
+use Greenlight\Plugin\WorkerBootstrapSubscriber;
+use Greenlight\Plugin\WorkerRuntimeRunner;
+use Hyperf\Context\ApplicationContext;
+use Hyperf\Contract\ApplicationInterface;
+use Hyperf\Coordinator\Constants;
+use Hyperf\Coordinator\CoordinatorManager;
+use Hyperf\Coroutine\Coroutine as HyperfCoroutine;
+use Hyperf\Di\ClassLoader;
+use Psr\Container\ContainerInterface;
+use Swoole\Coroutine as SwooleCoroutine;
+use Swoole\Coroutine\Channel;
+use Swoole\Runtime;
+use Swoole\Timer;
+
+use function Hyperf\Coroutine\run;
+
+/**
+ * Initializes the Hyperf class loader once in each worker. It creates a
+ * coroutine context for each test attempt.
+ *
+ * The default worker container lifetime matches a long-running Hyperf worker.
+ * `#[Service]` selects an explicit container ID. Tests MUST isolate external
+ * resources by `GREENLIGHT_CHANNEL`.
+ */
+final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemptRunner, WorkerBootstrapSubscriber, WorkerRuntimeRunner
+{
+    private readonly string $basePath;
+
+    private readonly string $containerFile;
+
+    private bool $bootstrapped = false;
+
+    private ?ContainerInterface $workerContainer = null;
+
+    private ?ContainerInterface $activeContainer = null;
+
+    /** @var null|\WeakReference<ContainerInterface> */
+    private ?\WeakReference $previousContainer = null;
+
+    /**
+     * @param null|\Closure(ContainerInterface): void $reset
+     *   Resets project-owned request state after each test attempt. The
+     *   callback runs inside the test coroutine.
+     * @param null|\Closure(ContainerInterface): void $dispose
+     *   Releases project-owned resources when the selected container lifetime
+     *   ends. The callback runs inside a coroutine.
+     */
+    public function __construct(
+        string $basePath,
+        private readonly ContainerLifetime $containerLifetime = ContainerLifetime::Worker,
+        private readonly ?\Closure $reset = null,
+        private readonly ?\Closure $dispose = null,
+        private readonly ?int $hookFlags = null,
+    ) {
+        $this->basePath = \rtrim($basePath, '/');
+        $this->containerFile = $this->basePath . '/config/container.php';
+    }
+
+    /** @return list<ServiceDefinition> */
+    #[\Override]
+    public function services(): array
+    {
+        return [
+            new ServiceDefinition(ContainerInterface::class, Scope::PerTest, $this->container(...)),
+        ];
+    }
+
+    /**
+     * @param class-string $type
+     * @param list<object> $attributes
+     * @throws HyperfBridgeError
+     */
+    #[\Override]
+    public function resolve(string $type, array $attributes): ?object
+    {
+        $id = $type;
+
+        foreach ($attributes as $attribute) {
+            if ($attribute instanceof Service) {
+                $id = $attribute->id;
+            }
+        }
+
+        $container = $this->container();
+
+        if (!$container->has($id)) {
+            if ($id !== $type) {
+                throw HyperfBridgeError::unknownServiceId($id, $type);
+            }
+
+            return null;
+        }
+
+        $service = $container->get($id);
+
+        if (!$service instanceof $type) {
+            throw HyperfBridgeError::serviceTypeMismatch($id, $type, \get_debug_type($service));
+        }
+
+        return $service;
+    }
+
+    /** @throws HyperfBridgeError */
+    #[\Override]
+    public function onWorkerBootstrap(WorkerBootstrapContext $context): void
+    {
+        HyperfFrameworkRequirement::check();
+        $basePath = \realpath($this->basePath);
+
+        if ($basePath === false || !\is_dir($basePath)) {
+            throw HyperfBridgeError::basePathMissing($this->basePath);
+        }
+
+        if (!\is_file($this->containerFile)) {
+            throw HyperfBridgeError::containerFileMissing($this->containerFile);
+        }
+
+        if (\defined('BASE_PATH')) {
+            $defined = \constant('BASE_PATH');
+
+            if (!\is_string($defined)) {
+                throw HyperfBridgeError::basePathConflict($basePath, \get_debug_type($defined));
+            }
+
+            $definedPath = \realpath($defined);
+
+            if ($definedPath === false || $definedPath !== $basePath) {
+                throw HyperfBridgeError::basePathConflict($basePath, $defined);
+            }
+        } else {
+            \define('BASE_PATH', $basePath);
+        }
+
+        $this->initializeClassLoader($basePath);
+        $this->bootstrapped = true;
+
+        if ($this->containerLifetime === ContainerLifetime::Worker) {
+            $container = $this->createContainer();
+            $this->workerContainer = $container;
+            ApplicationContext::setContainer($container);
+            $this->bootApplication($container);
+        }
+    }
+
+    /**
+     * @template T
+     *
+     * @param \Closure(): T $worker
+     *
+     * @return T
+     * @throws HyperfBridgeError
+     */
+    #[\Override]
+    public function runWorker(\Closure $worker): mixed
+    {
+        if ($this->containerLifetime === ContainerLifetime::TestAttempt) {
+            return $worker();
+        }
+
+        if (!$this->bootstrapped || !$this->workerContainer instanceof ContainerInterface) {
+            throw HyperfBridgeError::workerContainerUnavailable();
+        }
+
+        /** @var array{value: T}|array{} $result */
+        $result = [];
+        $failure = null;
+        $completed = false;
+        $flags = $this->hookFlags ?? SWOOLE_HOOK_ALL;
+
+        try {
+            $started = run(function () use ($worker, &$result, &$failure, &$completed): void {
+                try {
+                    $result = ['value' => $worker()];
+                    $completed = true;
+                } catch (\Throwable $threw) {
+                    $failure = $threw;
+                } finally {
+                    $this->captureCleanup($failure, $this->disposeWorkerContainer(...));
+                    $this->captureRuntimeCleanup($failure);
+                }
+            }, $flags);
+        } finally {
+            Runtime::enableCoroutine(0);
+        }
+
+        return $this->coroutineResult($started, $completed, $result, $failure);
+    }
+
+    /**
+     * @template T
+     *
+     * @param \Closure(): T $attempt
+     *
+     * @return T
+     * @throws HyperfBridgeError
+     */
+    #[\Override]
+    public function runTestAttempt(\Closure $attempt): mixed
+    {
+        if (!$this->bootstrapped) {
+            throw HyperfBridgeError::containerOutsideAttempt();
+        }
+
+        if ($this->containerLifetime === ContainerLifetime::Worker) {
+            return $this->runWorkerAttempt($attempt);
+        }
+
+        return $this->runIsolatedAttempt($attempt);
+    }
+
+    /** @throws HyperfBridgeError */
+    private function initializeClassLoader(string $basePath): void
+    {
+        $runtimeDirectory = $basePath . '/runtime/container';
+
+        if (!\is_dir($runtimeDirectory)
+            && !ErrorTrap::run(static fn(): bool => \mkdir($runtimeDirectory, 0o755, true), $warning)
+        ) {
+            throw HyperfBridgeError::scanLockUnavailable($runtimeDirectory . '/greenlight.scan.lock');
+        }
+
+        $lockPath = $runtimeDirectory . '/greenlight.scan.lock';
+        $lock = ErrorTrap::run(static fn() => \fopen($lockPath, 'c'), $warning);
+
+        if (!\is_resource($lock)) {
+            throw HyperfBridgeError::scanLockUnavailable($lockPath);
+        }
+
+        try {
+            if (!ErrorTrap::run(static fn(): bool => \flock($lock, \LOCK_EX), $warning)) {
+                throw HyperfBridgeError::scanLockFailed($lockPath);
+            }
+
+            ClassLoader::init();
+        } finally {
+            ErrorTrap::run(static fn(): bool => \flock($lock, \LOCK_UN), $warning);
+            \fclose($lock);
+        }
+    }
+
+    /**
+     * @template T
+     *
+     * @param \Closure(): T $attempt
+     *
+     * @return T
+     * @throws HyperfBridgeError
+     */
+    private function runWorkerAttempt(\Closure $attempt): mixed
+    {
+        if (!HyperfCoroutine::inCoroutine()) {
+            throw HyperfBridgeError::workerRuntimeUnavailable();
+        }
+
+        $container = $this->workerContainer
+            ?? throw HyperfBridgeError::workerContainerUnavailable();
+        /** @var array{value: T}|array{} $result */
+        $result = [];
+        $failure = null;
+        $completed = false;
+        $finished = new Channel(1);
+        $coroutineId = SwooleCoroutine::create(function () use (
+            $attempt,
+            $container,
+            $finished,
+            &$result,
+            &$failure,
+            &$completed,
+        ): void {
+            try {
+                $this->activeContainer = $container;
+                $result = ['value' => $attempt()];
+                $completed = true;
+            } catch (\Throwable $threw) {
+                $failure = $threw;
+            } finally {
+                $this->captureCleanup($failure, function () use ($container): void {
+                    $this->resetContainer($container);
+                });
+                $this->activeContainer = null;
+                $finished->push(true);
+            }
+        });
+
+        if ($coroutineId === false) {
+            $finished->close();
+
+            throw HyperfBridgeError::coroutineDidNotStart();
+        }
+
+        $didFinish = $finished->pop();
+        $finished->close();
+
+        return $this->coroutineResult($didFinish === true, $completed, $result, $failure);
+    }
+
+    /**
+     * @template T
+     *
+     * @param \Closure(): T $attempt
+     *
+     * @return T
+     * @throws HyperfBridgeError
+     */
+    private function runIsolatedAttempt(\Closure $attempt): mixed
+    {
+        /** @var array{value: T}|array{} $result */
+        $result = [];
+        $failure = null;
+        $completed = false;
+        $flags = $this->hookFlags ?? SWOOLE_HOOK_ALL;
+
+        try {
+            $started = run(function () use ($attempt, &$result, &$failure, &$completed): void {
+                try {
+                    $container = $this->createContainer();
+                    $this->rejectReusedContainer($container);
+                    $this->activeContainer = $container;
+                    ApplicationContext::setContainer($container);
+                    $this->bootApplication($container);
+                    $result = ['value' => $attempt()];
+                    $completed = true;
+                } catch (\Throwable $threw) {
+                    $failure = $threw;
+                } finally {
+                    $this->captureCleanup($failure, $this->disposeAttemptContainer(...));
+                    $this->captureRuntimeCleanup($failure);
+                }
+            }, $flags);
+        } finally {
+            Runtime::enableCoroutine(0);
+        }
+
+        return $this->coroutineResult($started, $completed, $result, $failure);
+    }
+
+    /** @throws HyperfBridgeError */
+    private function createContainer(): ContainerInterface
+    {
+        $loader = static fn(string $file): mixed => require $file;
+        $container = $loader($this->containerFile);
+
+        if (!$container instanceof ContainerInterface) {
+            throw HyperfBridgeError::notAContainer($this->containerFile, \get_debug_type($container));
+        }
+
+        return $container;
+    }
+
+    /** @throws HyperfBridgeError */
+    private function rejectReusedContainer(ContainerInterface $container): void
+    {
+        if ($this->previousContainer?->get() === $container) {
+            throw HyperfBridgeError::reusedContainer();
+        }
+
+        $this->previousContainer = \WeakReference::create($container);
+    }
+
+    /** @throws HyperfBridgeError */
+    private function bootApplication(ContainerInterface $container): void
+    {
+        $application = $container->get(ApplicationInterface::class);
+
+        if (!\is_object($application)) {
+            throw HyperfBridgeError::applicationUnavailable(\get_debug_type($application));
+        }
+    }
+
+    private function resetContainer(ContainerInterface $container): void
+    {
+        if ($this->reset instanceof \Closure) {
+            ($this->reset)($container);
+        }
+    }
+
+    private function disposeAttemptContainer(): void
+    {
+        $container = $this->activeContainer;
+        $this->activeContainer = null;
+
+        try {
+            if ($container instanceof ContainerInterface) {
+                $this->resetContainer($container);
+
+                if ($this->dispose instanceof \Closure) {
+                    ($this->dispose)($container);
+                }
+            }
+        } finally {
+            ApplicationContext::setContainer(new UnavailableContainer());
+        }
+    }
+
+    private function disposeWorkerContainer(): void
+    {
+        $container = $this->workerContainer;
+        $this->activeContainer = null;
+        $this->workerContainer = null;
+
+        try {
+            if ($container instanceof ContainerInterface && $this->dispose instanceof \Closure) {
+                ($this->dispose)($container);
+            }
+        } finally {
+            ApplicationContext::setContainer(new UnavailableContainer());
+        }
+    }
+
+    private function captureRuntimeCleanup(?\Throwable &$failure): void
+    {
+        $this->captureCleanup($failure, static function (): void {
+            Timer::clearAll();
+        });
+        $this->captureCleanup(
+            $failure,
+            static function (): void {
+                CoordinatorManager::until(Constants::WORKER_EXIT)->resume();
+            },
+        );
+    }
+
+    /** @param \Closure(): void $cleanup */
+    private function captureCleanup(?\Throwable &$failure, \Closure $cleanup): void
+    {
+        try {
+            $cleanup();
+        } catch (\Throwable $threw) {
+            $failure ??= $threw;
+        }
+    }
+
+    /**
+     * @template T
+     *
+     * @param array{value: T}|array{} $result
+     *
+     * @return T
+     * @throws HyperfBridgeError
+     */
+    private function coroutineResult(bool $started, bool $completed, array $result, ?\Throwable $failure): mixed
+    {
+        if (!$started) {
+            throw HyperfBridgeError::coroutineDidNotStart();
+        }
+
+        if ($failure instanceof \Throwable) {
+            throw $failure;
+        }
+
+        if (!$completed || !\array_key_exists('value', $result)) {
+            throw HyperfBridgeError::coroutineDidNotStart();
+        }
+
+        return $result['value'];
+    }
+
+    /** @throws HyperfBridgeError */
+    private function container(): ContainerInterface
+    {
+        return $this->activeContainer ?? throw HyperfBridgeError::containerOutsideAttempt();
+    }
+}

--- a/src/Hyperf/Service.php
+++ b/src/Hyperf/Service.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Hyperf;
+
+/**
+ * Use this attribute when a parameter type does not select one container ID.
+ * The service must have the declared type.
+ */
+#[\Attribute(\Attribute::TARGET_PARAMETER)]
+final readonly class Service
+{
+    /** @var non-empty-string */
+    public string $id;
+
+    /** @throws \InvalidArgumentException */
+    public function __construct(string $id)
+    {
+        if ($id === '') {
+            throw new \InvalidArgumentException('Service ID MUST NOT be empty.');
+        }
+
+        $this->id = $id;
+    }
+}

--- a/src/Hyperf/UnavailableContainer.php
+++ b/src/Hyperf/UnavailableContainer.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Hyperf;
+
+use Psr\Container\ContainerInterface;
+
+/** Rejects access to the Hyperf container outside a test attempt. @internal */
+final class UnavailableContainer implements ContainerInterface
+{
+    /** @throws UnavailableContainerError */
+    public function get(string $id): never
+    {
+        throw new UnavailableContainerError();
+    }
+
+    public function has(string $id): bool
+    {
+        return false;
+    }
+}

--- a/src/Hyperf/UnavailableContainerError.php
+++ b/src/Hyperf/UnavailableContainerError.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Hyperf;
+
+use Psr\Container\ContainerExceptionInterface;
+
+/**
+ * Reports Hyperf container access outside a test attempt.
+ *
+ * @internal
+ */
+final class UnavailableContainerError extends \RuntimeException implements ContainerExceptionInterface
+{
+    public function __construct()
+    {
+        parent::__construct(
+            'The Hyperf container is not active. Resolve Hyperf services only during a Greenlight test attempt.',
+        );
+    }
+}

--- a/src/Plugin/Plugin.php
+++ b/src/Plugin/Plugin.php
@@ -8,7 +8,8 @@ namespace Greenlight\Plugin;
  * Identifies an object as a Greenlight plugin.
  *
  * Plugins implement one or more capability interfaces such as
- * `TestLifecycleSubscriber`, `RunLifecycleSubscriber`, `RetryDecider`,
- * `HarnessProvider`, or `ExpectationExtension`.
+ * `WorkerRuntimeRunner`, `TestAttemptRunner`, `TestLifecycleSubscriber`,
+ * `RunLifecycleSubscriber`, `RetryDecider`, `HarnessProvider`, or
+ * `ExpectationExtension`.
  */
 interface Plugin {}

--- a/src/Plugin/PluginRegistry.php
+++ b/src/Plugin/PluginRegistry.php
@@ -52,6 +52,33 @@ final readonly class PluginRegistry
     }
 
     /**
+     * @return list<TestAttemptRunner>
+     */
+    public function testAttemptRunners(): array
+    {
+        return $this->sorted($this->ofType(TestAttemptRunner::class));
+    }
+
+    /**
+     * @template T
+     *
+     * @param \Closure(): T $worker
+     *
+     * @return T
+     */
+    public function runWorker(\Closure $worker): mixed
+    {
+        $runners = $this->sorted($this->ofType(WorkerRuntimeRunner::class));
+
+        foreach (\array_reverse($runners) as $runner) {
+            $next = $worker;
+            $worker = static fn(): mixed => $runner->runWorker($next);
+        }
+
+        return $worker();
+    }
+
+    /**
      * @return list<RetryDecider>
      */
     public function retryDeciders(): array

--- a/src/Plugin/TestAttemptRunner.php
+++ b/src/Plugin/TestAttemptRunner.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Plugin;
+
+/** Runs each complete test attempt in a plugin-defined runtime boundary. */
+interface TestAttemptRunner extends Plugin
+{
+    /**
+     * @template T
+     *
+     * @param \Closure(): T $attempt
+     *
+     * @return T
+     */
+    public function runTestAttempt(\Closure $attempt): mixed;
+}

--- a/src/Plugin/WorkerRuntimeRunner.php
+++ b/src/Plugin/WorkerRuntimeRunner.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Plugin;
+
+/** Runs one physical worker in a plugin-defined runtime boundary. */
+interface WorkerRuntimeRunner extends Plugin
+{
+    /**
+     * @template T
+     *
+     * @param \Closure(): T $worker
+     *
+     * @return T
+     */
+    public function runWorker(\Closure $worker): mixed;
+}

--- a/src/Runner/InProcessRunner.php
+++ b/src/Runner/InProcessRunner.php
@@ -142,7 +142,7 @@ final readonly class InProcessRunner
                 $collectingCoverage = $collector instanceof CoverageCollector;
                 $collector?->start();
 
-                $outcome = new Worker(
+                $outcome = $plugins->runWorker(static fn() => new Worker(
                     DefaultServices::registry($plugins, $resources),
                     $plugins,
                     $detectLeaks ? new LeakDetector() : null,
@@ -155,7 +155,7 @@ final readonly class InProcessRunner
                     $configuration->stopAfterFailures,
                     null,
                     $shutdown instanceof GracefulShutdown ? $shutdown->requested(...) : null,
-                );
+                ));
                 $summary = $outcome->summary;
 
                 $collectingCoverage = false;

--- a/src/Runner/Worker/TestExecutor.php
+++ b/src/Runner/Worker/TestExecutor.php
@@ -112,7 +112,22 @@ final readonly class TestExecutor
                 ($this->attemptStarted)($entry->id, $attempt);
             }
 
-            [$result, $cause, $attachments] = $this->attempt($entry, $attempt, $artifactBudget);
+            try {
+                [$result, $cause, $attachments] = $this->runTestAttempt(
+                    fn(): array => $this->attempt($entry, $attempt, $artifactBudget),
+                );
+            } catch (\Throwable $threw) {
+                $cause = $threw;
+                $attachments = null;
+                $result = new TestResult(
+                    $entry->id,
+                    Outcome::Errored,
+                    0.0,
+                    0,
+                    $attempt,
+                    error: ThrowableDetail::fromThrowable($threw),
+                );
+            }
 
             if ($attachments instanceof StagedAttachments) {
                 $result = $result->withAttachments($attachments->collected());
@@ -147,6 +162,25 @@ final readonly class TestExecutor
 
             $retainedAttachments = [...$retainedAttachments, ...$sealed];
         } while (true);
+    }
+
+    /**
+     * @template T
+     *
+     * @param \Closure(): T $attempt
+     *
+     * @return T
+     */
+    private function runTestAttempt(\Closure $attempt): mixed
+    {
+        $runners = $this->plugins->testAttemptRunners();
+
+        foreach (\array_reverse($runners) as $runner) {
+            $next = $attempt;
+            $attempt = static fn(): mixed => $runner->runTestAttempt($next);
+        }
+
+        return $attempt();
     }
 
     /**

--- a/src/Runner/Worker/WorkerProcess.php
+++ b/src/Runner/Worker/WorkerProcess.php
@@ -11,6 +11,7 @@ use Greenlight\Core\Event\RecycleReason;
 use Greenlight\Core\Result\ThrowableDetail;
 use Greenlight\Core\Test\TestChannel;
 use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Wire\WireError;
 use Greenlight\Harness\HarnessRegistry;
 use Greenlight\Harness\HarnessScopes;
 use Greenlight\Plugin\PluginRegistry;
@@ -77,13 +78,8 @@ final readonly class WorkerProcess
         $channel->send(new Hello($workerId, $token, $pid === false ? 1 : \max(1, $pid)));
 
         // Build plugins during bootstrap and reuse them for later assignments.
-        // Thus, plugin construction occurs one time for each worker. Run-scope
-        // harness services remain available across assignments.
-        $plugins = null;
-        $registry = null;
+        // Thus, plugin construction occurs one time for each worker.
         $scopes = null;
-        $executedTotal = 0;
-        $artifactStore = null;
 
         try {
             while (true) {
@@ -96,121 +92,56 @@ final readonly class WorkerProcess
                         continue;
                     }
 
-                    $scopes?->closeRun();
-
                     return 0;
                 }
 
                 if ($message instanceof Drain) {
-                    $scopes?->closeRun();
-
                     return 0;
                 }
 
-                if ($message instanceof Bootstrap) {
-                    if ($plugins instanceof PluginRegistry) {
-                        throw ProtocolError::duplicateBootstrap();
+                if (!$message instanceof Bootstrap) {
+                    if ($message instanceof Assign) {
+                        throw ProtocolError::assignmentBeforeBootstrap();
                     }
-
-                    if (ChannelEnvironment::parse(\getenv('GREENLIGHT_CHANNEL')) !== $message->channel) {
-                        throw ProtocolError::bootstrapChannelMismatch();
-                    }
-
-                    $userPlugins = $message->configFile === null
-                        ? []
-                        : new ConfigLoader()->loadFile($message->configFile)->build()->plugins;
-                    $plugins = PluginRegistry::forWorker($userPlugins);
-                    $plugins->bootstrapWorker(new WorkerBootstrapContext(
-                        $workerId,
-                        new TestChannel($message->channel),
-                        $message->resources,
-                    ));
-                    $registry = DefaultServices::registry($plugins, $message->resources);
-                    $scopes = new HarnessScopes($registry, $plugins->serviceResolvers());
-                    $channel->send(new Ready());
 
                     continue;
                 }
 
-                if (!$message instanceof Assign) {
-                    continue;
+                if (ChannelEnvironment::parse(\getenv('GREENLIGHT_CHANNEL')) !== $message->channel) {
+                    throw ProtocolError::bootstrapChannelMismatch();
                 }
 
-                if (!$plugins instanceof PluginRegistry || !$registry instanceof HarnessRegistry || !$scopes instanceof HarnessScopes) {
-                    throw ProtocolError::assignmentBeforeBootstrap();
-                }
-
-                $collector = null;
-
-                if ($message->coverageInclude !== null) {
-                    $collector = CoverageCollector::create(
-                        new CoverageSettings($message->coverageInclude, $message->coverageDriver),
-                    );
-                }
-
-                if (!$artifactStore instanceof ArtifactStore
-                    && $message->artifactSession instanceof ArtifactSession
-                    && $message->artifactConfiguration instanceof ArtifactConfiguration
-                ) {
-                    $artifactStore = ArtifactStore::fromSession(
-                        $message->artifactSession,
-                        $message->artifactConfiguration,
-                    );
-                }
-
-                $collector?->start();
-
-                $leakDetector = $message->detectLeaks ? new LeakDetector() : null;
-
-                $outcome = new Worker(
-                    $registry,
-                    $plugins,
-                    $leakDetector,
+                $userPlugins = $message->configFile === null
+                    ? []
+                    : new ConfigLoader()->loadFile($message->configFile)->build()->plugins;
+                $plugins = PluginRegistry::forWorker($userPlugins);
+                $plugins->bootstrapWorker(new WorkerBootstrapContext(
                     $workerId,
-                    $message->policy,
-                    $artifactStore,
-                )->run(
-                    $message->slice,
-                    new SocketEventSink($channel),
-                    null,
-                    new WorkerBudget($message->recycleAfterTests, $message->recycleAboveMemoryBytes),
-                    static fn(): bool => $channel->poll() instanceof Drain,
+                    new TestChannel($message->channel),
+                    $message->resources,
+                ));
+                $registry = DefaultServices::registry($plugins, $message->resources);
+                $scopes = new HarnessScopes($registry, $plugins->serviceResolvers());
+
+                $finalMessage = $plugins->runWorker(function () use (
+                    $channel,
+                    $plugins,
+                    $registry,
                     $scopes,
-                    static function (TestId $id, int $attempt) use ($channel): void {
-                        $channel->send(new AttemptStarted($id, $attempt));
-                    },
-                );
+                    $workerId,
+                ): ?Message {
+                    try {
+                        return $this->runAssignments($channel, $plugins, $registry, $scopes, $workerId);
+                    } finally {
+                        $scopes->closeRun();
+                    }
+                });
 
-                $coverage = $collector?->stop();
-
-                if ($outcome->recycleReason instanceof RecycleReason) {
-                    $scopes->closeRun();
-                    $channel->send(new Recycling(
-                        $outcome->recycleReason,
-                        $outcome->remaining,
-                        $outcome->summary,
-                        $coverage,
-                    ));
-
-                    return 0;
+                if ($finalMessage instanceof Message) {
+                    $channel->send($finalMessage);
                 }
 
-                $executedTotal += $outcome->summary->total();
-                $wantsRecycle = null;
-
-                if ($message->recycleAfterTests !== null && $executedTotal >= $message->recycleAfterTests) {
-                    $wantsRecycle = RecycleReason::TestCount;
-                } elseif ($message->recycleAboveMemoryBytes !== null && \memory_get_usage(true) >= $message->recycleAboveMemoryBytes) {
-                    $wantsRecycle = RecycleReason::Memory;
-                }
-
-                $channel->send(new Done($outcome->summary, \memory_get_peak_usage(true), $coverage, $outcome->leaks, $wantsRecycle));
-
-                if ($outcome->drained || $wantsRecycle instanceof RecycleReason) {
-                    $scopes->closeRun();
-
-                    return 0;
-                }
+                return 0;
             }
         } catch (\Throwable $threw) {
             try {
@@ -226,4 +157,127 @@ final readonly class WorkerProcess
             $channel->close();
         }
     }
+
+    /**
+     * Runs assignments after bootstrap. The returned message is sent only
+     * after every worker runtime boundary closes successfully.
+     *
+     * @throws WireError
+     * @throws ProtocolError
+     */
+    private function runAssignments(
+        SocketChannel $channel,
+        PluginRegistry $plugins,
+        HarnessRegistry $registry,
+        HarnessScopes $scopes,
+        string $workerId,
+    ): ?Message {
+        $executedTotal = 0;
+        $artifactStore = null;
+
+        $channel->send(new Ready());
+
+        while (true) {
+            $message = $channel->receive($this->receivePollSeconds);
+
+            if (!$message instanceof Message) {
+                if (!$channel->isEof()) {
+                    continue;
+                }
+
+                return null;
+            }
+
+            if ($message instanceof Drain) {
+                return null;
+            }
+
+            if ($message instanceof Bootstrap) {
+                throw ProtocolError::duplicateBootstrap();
+            }
+
+            if (!$message instanceof Assign) {
+                continue;
+            }
+
+            $collector = null;
+
+            if ($message->coverageInclude !== null) {
+                // A collector cannot observe the code that creates it. The
+                // coverage acceptance tests exercise this bootstrap path.
+                // @codeCoverageIgnoreStart
+                $collector = CoverageCollector::create(
+                    new CoverageSettings($message->coverageInclude, $message->coverageDriver),
+                );
+                // @codeCoverageIgnoreEnd
+            }
+
+            if (!$artifactStore instanceof ArtifactStore
+                && $message->artifactSession instanceof ArtifactSession
+                && $message->artifactConfiguration instanceof ArtifactConfiguration
+            ) {
+                $artifactStore = ArtifactStore::fromSession(
+                    $message->artifactSession,
+                    $message->artifactConfiguration,
+                );
+            }
+
+            $collector?->start();
+
+            $leakDetector = $message->detectLeaks ? new LeakDetector() : null;
+
+            $outcome = new Worker(
+                $registry,
+                $plugins,
+                $leakDetector,
+                $workerId,
+                $message->policy,
+                $artifactStore,
+            )->run(
+                $message->slice,
+                new SocketEventSink($channel),
+                null,
+                new WorkerBudget($message->recycleAfterTests, $message->recycleAboveMemoryBytes),
+                static fn(): bool => $channel->poll() instanceof Drain,
+                $scopes,
+                static function (TestId $id, int $attempt) use ($channel): void {
+                    $channel->send(new AttemptStarted($id, $attempt));
+                },
+            );
+
+            $coverage = $collector?->stop();
+
+            if ($outcome->recycleReason instanceof RecycleReason) {
+                return new Recycling(
+                    $outcome->recycleReason,
+                    $outcome->remaining,
+                    $outcome->summary,
+                    $coverage,
+                );
+            }
+
+            $executedTotal += $outcome->summary->total();
+            $wantsRecycle = null;
+
+            if ($message->recycleAfterTests !== null && $executedTotal >= $message->recycleAfterTests) {
+                $wantsRecycle = RecycleReason::TestCount;
+            } elseif ($message->recycleAboveMemoryBytes !== null && \memory_get_usage(true) >= $message->recycleAboveMemoryBytes) {
+                $wantsRecycle = RecycleReason::Memory;
+            }
+
+            $done = new Done(
+                $outcome->summary,
+                \memory_get_peak_usage(true),
+                $coverage,
+                $outcome->leaks,
+                $wantsRecycle,
+            );
+
+            if ($outcome->drained || $wantsRecycle instanceof RecycleReason) {
+                return $done;
+            }
+
+            $channel->send($done);
+        }
+    } // @codeCoverageIgnore
 }

--- a/tests/Acceptance/TestAttemptRunnerRunTest.php
+++ b/tests/Acceptance/TestAttemptRunnerRunTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\GreenlightCli;
+
+final readonly class TestAttemptRunnerRunTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function runtimeBoundaryContainsTheCompleteTestAttempt(): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'test-attempt-runner');
+        $project->writeFile('tests/RuntimeBoundaryTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace RuntimeBoundaryProbe;
+
+            use Greenlight\Attribute\After;
+            use Greenlight\Attribute\Before;
+            use Greenlight\Attribute\Test;
+            use Greenlight\Core\Result\TestResult;
+            use Greenlight\Expect\Expect;
+            use Greenlight\Harness\Disposable;
+            use Greenlight\Harness\Scope;
+            use Greenlight\Harness\ServiceDefinition;
+            use Greenlight\Plugin\HarnessProvider;
+            use Greenlight\Plugin\TestAttemptRunner;
+            use Greenlight\Plugin\TestContext;
+            use Greenlight\Plugin\TestLifecycleSubscriber;
+
+            final class Boundary
+            {
+                public static bool $active = false;
+
+                /** @var list<string> */
+                public static array $events = [];
+
+                public static function record(string $event): void
+                {
+                    if (!self::$active) {
+                        throw new \RuntimeException('The test attempt ran outside the runtime boundary.');
+                    }
+
+                    self::$events[] = $event;
+                }
+            }
+
+            final class RecordingDisposable implements Disposable
+            {
+                public function dispose(): void
+                {
+                    Boundary::record('dispose');
+                }
+            }
+
+            final class RuntimePlugin implements HarnessProvider, TestAttemptRunner, TestLifecycleSubscriber
+            {
+                public function services(): array
+                {
+                    return [new ServiceDefinition(
+                        RecordingDisposable::class,
+                        Scope::PerTest,
+                        static fn(): RecordingDisposable => new RecordingDisposable(),
+                    )];
+                }
+
+                public function runTestAttempt(\Closure $attempt): mixed
+                {
+                    Boundary::$active = true;
+
+                    try {
+                        return $attempt();
+                    } finally {
+                        Boundary::$events[] = 'exit';
+                        Boundary::$active = false;
+                    }
+                }
+
+                public function beforeTest(TestContext $context): void
+                {
+                    Boundary::record('beforeTest');
+                }
+
+                public function afterTest(TestContext $context, TestResult $result): TestResult
+                {
+                    Boundary::record('afterTest');
+
+                    return $result;
+                }
+            }
+
+            final readonly class RuntimeBoundaryTest
+            {
+                public function __construct(private RecordingDisposable $disposable)
+                {
+                    Boundary::record('constructor');
+                }
+
+                #[Before]
+                public function before(): void
+                {
+                    Boundary::record('before');
+                }
+
+                #[After]
+                public function after(): void
+                {
+                    Boundary::record('after');
+                }
+
+                #[Test]
+                public function firstAttemptStaysInsideTheBoundary(): void
+                {
+                    Boundary::record('test');
+                    Expect::that(Boundary::$active)->toBeTrue();
+                }
+
+                #[Test]
+                public function nextAttemptSeesTheCompletedFirstBoundary(): void
+                {
+                    Expect::that(Boundary::$events)->toBe([
+                        'constructor',
+                        'beforeTest',
+                        'before',
+                        'test',
+                        'after',
+                        'dispose',
+                        'afterTest',
+                        'exit',
+                        'constructor',
+                        'beforeTest',
+                        'before',
+                    ]);
+                }
+            }
+            PHP);
+        $project->writeFile('greenlight.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Config\GreenlightConfig;
+            use RuntimeBoundaryProbe\RuntimePlugin;
+
+            require_once __DIR__ . '/tests/RuntimeBoundaryTest.php';
+
+            return GreenlightConfig::create()
+                ->paths([__DIR__ . '/tests'])
+                ->workers(1)
+                ->plugins(new RuntimePlugin());
+            PHP);
+
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=plain']);
+
+        $output = $result->output();
+        Expect::that($result->exitCode)
+            ->because($output === '' ? 'The subprocess returned no output.' : $output)
+            ->toBe(0);
+        Expect::that($result->output())->toContain('2 tests, 2 passed');
+    }
+
+    #[Test]
+    public function runtimeBoundaryFailureErrorsTheAttempt(): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'test-attempt-runner-failure');
+        $project->writeFile('tests/BoundaryFailureTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace RuntimeBoundaryFailureProbe;
+
+            use Greenlight\Attribute\Test;
+            use Greenlight\Plugin\TestAttemptRunner;
+
+            final class FailingRuntimePlugin implements TestAttemptRunner
+            {
+                public function runTestAttempt(\Closure $attempt): mixed
+                {
+                    throw new \RuntimeException('The attempt runtime failed before the test started.');
+                }
+            }
+
+            final readonly class BoundaryFailureTest
+            {
+                #[Test]
+                public function doesNotRunOutsideTheFailedBoundary(): void
+                {
+                    throw new \RuntimeException('The test method must not run.');
+                }
+            }
+            PHP);
+        $project->writeFile('greenlight.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Config\GreenlightConfig;
+            use RuntimeBoundaryFailureProbe\FailingRuntimePlugin;
+
+            require_once __DIR__ . '/tests/BoundaryFailureTest.php';
+
+            return GreenlightConfig::create()
+                ->paths([__DIR__ . '/tests'])
+                ->workers(1)
+                ->plugins(new FailingRuntimePlugin());
+            PHP);
+
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=plain']);
+
+        Expect::that($result->exitCode)->toBe(1);
+        Expect::that($result->output())
+            ->toContain('The attempt runtime failed before the test started.')
+            ->toContain('1 test, 0 passed, 1 errored');
+    }
+}

--- a/tests/Acceptance/WorkerRuntimeRunnerRunTest.php
+++ b/tests/Acceptance/WorkerRuntimeRunnerRunTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\GreenlightCli;
+
+final readonly class WorkerRuntimeRunnerRunTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function runtimeBoundaryContainsAllPhysicalWorkerAssignments(): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'worker-runtime-runner');
+        $project->writeFile('tests/WorkerBoundaryTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace WorkerBoundaryProbe;
+
+            use Greenlight\Attribute\Test;
+            use Greenlight\Expect\Expect;
+            use Greenlight\Plugin\WorkerRuntimeRunner;
+
+            final class Boundary
+            {
+                public static bool $active = false;
+            }
+
+            final readonly class RuntimePlugin implements WorkerRuntimeRunner
+            {
+                public function __construct(private string $marker) {}
+
+                public function runWorker(\Closure $worker): mixed
+                {
+                    Boundary::$active = true;
+
+                    try {
+                        return $worker();
+                    } finally {
+                        Boundary::$active = false;
+                        file_put_contents($this->marker, 'closed');
+                    }
+                }
+            }
+
+            final readonly class WorkerBoundaryTest
+            {
+                #[Test]
+                public function firstAssignmentRunsInsideTheBoundary(): void
+                {
+                    Expect::that(Boundary::$active)->toBeTrue();
+                }
+
+                #[Test]
+                public function nextAssignmentUsesTheSameBoundary(): void
+                {
+                    Expect::that(Boundary::$active)->toBeTrue();
+                }
+            }
+            PHP);
+        $project->writeFile('greenlight.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Config\GreenlightConfig;
+            use WorkerBoundaryProbe\RuntimePlugin;
+
+            require_once __DIR__ . '/tests/WorkerBoundaryTest.php';
+
+            return GreenlightConfig::create()
+                ->paths([__DIR__ . '/tests'])
+                ->workers(1)
+                ->plugins(new RuntimePlugin(__DIR__ . '/worker-runtime.marker'));
+            PHP);
+
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=plain']);
+
+        Expect::that($result->exitCode)
+            ->because('worker runtime boundary run failed: ' . $result->output())
+            ->toBe(0);
+        Expect::that($result->output())->toContain('2 tests, 2 passed');
+        Expect::that(\file_get_contents($project->directory . '/worker-runtime.marker'))->toBe('closed');
+    }
+}

--- a/tests/Unit/Hyperf/HyperfBridgeErrorTest.php
+++ b/tests/Unit/Hyperf/HyperfBridgeErrorTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Hyperf;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Hyperf\HyperfBridgeError;
+
+final readonly class HyperfBridgeErrorTest
+{
+    /** @param \Closure(): HyperfBridgeError $factory */
+    #[Test]
+    #[DataSet('diagnostics')]
+    public function factoriesPreserveActionableDiagnostics(\Closure $factory, string $message): void
+    {
+        Expect::that($factory()->getMessage())->toBe($message);
+    }
+
+    /** @return iterable<string, array{\Closure(): HyperfBridgeError, string}> */
+    public static function diagnostics(): iterable
+    {
+        yield 'missing base path' => [
+            static fn(): HyperfBridgeError => HyperfBridgeError::basePathMissing('/app'),
+            'The Hyperf base path "/app" does not exist. Give HyperfPlugin the application root directory.',
+        ];
+        yield 'conflicting base path' => [
+            static fn(): HyperfBridgeError => HyperfBridgeError::basePathConflict('/app', '/other'),
+            'HyperfPlugin uses base path "/app", but BASE_PATH is already "/other". Use one Hyperf application in each worker.',
+        ];
+        yield 'missing container file' => [
+            static fn(): HyperfBridgeError => HyperfBridgeError::containerFileMissing('/app/config/container.php'),
+            'The Hyperf container file "/app/config/container.php" does not exist. Add the standard config/container.php file.',
+        ];
+        yield 'unavailable framework' => [
+            HyperfBridgeError::frameworkUnavailable(...),
+            'HyperfPlugin requires hyperf/framework and hyperf/di 3.2. Install both packages before you activate the plugin.',
+        ];
+        yield 'unsupported framework' => [
+            static fn(): HyperfBridgeError => HyperfBridgeError::frameworkVersionUnsupported('3.1.0'),
+            'HyperfPlugin found hyperf/framework "3.1.0", but it requires version 3.2. Install hyperf/framework 3.2.',
+        ];
+        yield 'unavailable Swoole' => [
+            HyperfBridgeError::swooleUnavailable(...),
+            'HyperfPlugin requires the Swoole extension. Install Swoole 5 or later to run tests in Hyperf coroutines.',
+        ];
+        yield 'unavailable pcntl' => [
+            HyperfBridgeError::pcntlUnavailable(...),
+            'HyperfPlugin requires the pcntl extension for the Hyperf class scan. Enable pcntl for the Greenlight PHP command.',
+        ];
+        yield 'unsupported Swoole' => [
+            static fn(): HyperfBridgeError => HyperfBridgeError::swooleVersionUnsupported('4.8.0'),
+            'HyperfPlugin found Swoole "4.8.0", but it requires major version 5 or later.',
+        ];
+        yield 'unavailable scan lock' => [
+            static fn(): HyperfBridgeError => HyperfBridgeError::scanLockUnavailable('/app/runtime/container/greenlight.scan.lock'),
+            'HyperfPlugin cannot open scan lock "/app/runtime/container/greenlight.scan.lock". Make the runtime/container directory writable.',
+        ];
+        yield 'failed scan lock' => [
+            static fn(): HyperfBridgeError => HyperfBridgeError::scanLockFailed('/app/runtime/container/greenlight.scan.lock'),
+            'HyperfPlugin cannot lock "/app/runtime/container/greenlight.scan.lock" for the class scan.',
+        ];
+        yield 'invalid container' => [
+            static fn(): HyperfBridgeError => HyperfBridgeError::notAContainer('/app/config/container.php', 'string'),
+            'The Hyperf container file "/app/config/container.php" returned "string". It must return a Psr\\Container\\ContainerInterface instance.',
+        ];
+        yield 'reused container' => [
+            HyperfBridgeError::reusedContainer(...),
+            'The Hyperf container file returned the previous test container. It must create a new container for each test.',
+        ];
+        yield 'invalid application' => [
+            static fn(): HyperfBridgeError => HyperfBridgeError::applicationUnavailable('null'),
+            'The Hyperf application binding returned "null". The binding must return an application object.',
+        ];
+        yield 'coroutine start failure' => [
+            HyperfBridgeError::coroutineDidNotStart(...),
+            'Swoole did not start the test coroutine. Check the Swoole runtime configuration.',
+        ];
+        yield 'missing worker container' => [
+            HyperfBridgeError::workerContainerUnavailable(...),
+            'The Hyperf worker container is not available. Greenlight cannot start the worker runtime.',
+        ];
+        yield 'missing worker runtime' => [
+            HyperfBridgeError::workerRuntimeUnavailable(...),
+            'The Hyperf worker runtime is not active. Run the test attempt inside WorkerRuntimeRunner.',
+        ];
+        yield 'inactive attempt container' => [
+            HyperfBridgeError::containerOutsideAttempt(...),
+            'The Hyperf container is not active. Resolve Hyperf services only during a Greenlight test attempt.',
+        ];
+        yield 'unknown service' => [
+            static fn(): HyperfBridgeError => HyperfBridgeError::unknownServiceId('clock', \DateTimeInterface::class),
+            'The Hyperf container has no service "clock" for type "DateTimeInterface". Check the service ID.',
+        ];
+        yield 'service type mismatch' => [
+            static fn(): HyperfBridgeError => HyperfBridgeError::serviceTypeMismatch('clock', \DateTimeInterface::class, 'stdClass'),
+            'The Hyperf service "clock" has type "stdClass". The parameter requires type "DateTimeInterface".',
+        ];
+    }
+}

--- a/tests/Unit/Hyperf/HyperfFrameworkRequirementTest.php
+++ b/tests/Unit/Hyperf/HyperfFrameworkRequirementTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Hyperf;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Hyperf\HyperfBridgeError;
+use Greenlight\Hyperf\HyperfFrameworkRequirement;
+
+final readonly class HyperfFrameworkRequirementTest
+{
+    #[Test]
+    public function acceptsACompleteRuntimeEnvironment(): void
+    {
+        HyperfFrameworkRequirement::checkEnvironment(true, '3.2.0', '5.1.0', true);
+
+        Expect::that(true)->toBeTrue();
+    }
+
+    #[Test]
+    public function rejectsAnUnavailableFrameworkEnvironment(): void
+    {
+        Expect::that(static function (): void {
+            HyperfFrameworkRequirement::checkEnvironment(false, '3.2.0', '5.1.0', true);
+        })->toThrow(HyperfBridgeError::class, matching: '/requires hyperf\/framework and hyperf\/di 3\.2/');
+    }
+
+    #[Test]
+    public function rejectsAnUnavailablePcntlExtension(): void
+    {
+        Expect::that(static function (): void {
+            HyperfFrameworkRequirement::checkEnvironment(true, '3.2.0', '5.1.0', false);
+        })->toThrow(HyperfBridgeError::class, matching: '/requires the pcntl extension/');
+    }
+
+    #[Test]
+    public function acceptsHyperfThreePointTwoVersions(): void
+    {
+        HyperfFrameworkRequirement::checkFrameworkVersion('v3.2.0');
+
+        Expect::that(true)->toBeTrue();
+    }
+
+    #[Test]
+    public function rejectsOtherHyperfVersions(): void
+    {
+        Expect::that(static function (): void {
+            HyperfFrameworkRequirement::checkFrameworkVersion('3.1.70');
+        })->toThrow(HyperfBridgeError::class, matching: '/requires version 3\.2/');
+    }
+
+    #[Test]
+    public function rejectsAnUnavailableHyperfFramework(): void
+    {
+        Expect::that(static function (): void {
+            HyperfFrameworkRequirement::checkFrameworkVersion(null);
+        })->toThrow(HyperfBridgeError::class, matching: '/requires hyperf\/framework and hyperf\/di 3\.2/');
+    }
+
+    #[Test]
+    public function acceptsSupportedSwooleVersions(): void
+    {
+        HyperfFrameworkRequirement::checkSwooleVersion('5.1.0');
+        HyperfFrameworkRequirement::checkSwooleVersion('6.0.2');
+
+        Expect::that(true)->toBeTrue();
+    }
+
+    #[Test]
+    public function rejectsOldSwooleVersions(): void
+    {
+        Expect::that(static function (): void {
+            HyperfFrameworkRequirement::checkSwooleVersion('4.8.13');
+        })->toThrow(HyperfBridgeError::class, matching: '/requires major version 5 or later/');
+    }
+
+    #[Test]
+    public function rejectsAnUnavailableSwooleExtension(): void
+    {
+        Expect::that(static function (): void {
+            HyperfFrameworkRequirement::checkSwooleVersion(false);
+        })->toThrow(HyperfBridgeError::class, matching: '/requires the Swoole extension/');
+    }
+}

--- a/tests/Unit/Hyperf/ServiceTest.php
+++ b/tests/Unit/Hyperf/ServiceTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Hyperf;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Hyperf\Service;
+
+final readonly class ServiceTest
+{
+    #[Test]
+    public function storesANonEmptyServiceId(): void
+    {
+        Expect::that(new Service('probe.greeter')->id)->toBe('probe.greeter');
+    }
+
+    #[Test]
+    public function rejectsAnEmptyServiceId(): void
+    {
+        Expect::that(static fn(): Service => new Service(''))
+            ->toThrow(\InvalidArgumentException::class, message: 'Service ID MUST NOT be empty.');
+    }
+}

--- a/tests/Unit/Plugin/PluginRegistryTest.php
+++ b/tests/Unit/Plugin/PluginRegistryTest.php
@@ -5,8 +5,11 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Plugin;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Fake;
 use Greenlight\Expect\Expect;
 use Greenlight\Plugin\PluginRegistry;
+use Greenlight\Plugin\Prioritized;
+use Greenlight\Plugin\WorkerRuntimeRunner;
 use Greenlight\Tests\Fixture\Plugins\FakeCapabilityPlugin;
 use Greenlight\Tests\Fixture\Plugins\NamedFakePlugin;
 use Greenlight\Tests\Fixture\Plugins\PrioritizedFakeCapabilityPlugin;
@@ -29,6 +32,8 @@ final class PluginRegistryTest
             ->toBe([]);
         Expect::that($registry->serviceResolvers())
             ->toBe([]);
+        Expect::that($registry->runWorker(static fn(): string => 'worker result'))
+            ->toBe('worker result');
     }
 
     #[Test]
@@ -49,5 +54,56 @@ final class PluginRegistryTest
         Expect::that($registry->runSubscribers())->toBe($expected);
         Expect::that($registry->serviceResolvers())->toBe($expected);
         Expect::that($registry->ofType(NamedFakePlugin::class))->toBe([$unrelated]);
+    }
+
+    #[Test]
+    public function workerRuntimeBoundariesNestInPriorityOrder(): void
+    {
+        /** @var \ArrayObject<int, string> $events */
+        $events = new \ArrayObject();
+        $runner = (static fn(string $name, int $priority): WorkerRuntimeRunner => new readonly class ($events, $name, $priority) implements Fake, Prioritized, WorkerRuntimeRunner {
+            /** @param \ArrayObject<int, string> $events */
+            public function __construct(
+                private \ArrayObject $events,
+                private string $name,
+                private int $priority,
+            ) {}
+
+            #[\Override]
+            public function priority(): int
+            {
+                return $this->priority;
+            }
+
+            #[\Override]
+            public function runWorker(\Closure $worker): mixed
+            {
+                $this->events->append($this->name . ':enter');
+
+                try {
+                    return $worker();
+                } finally {
+                    $this->events->append($this->name . ':exit');
+                }
+            }
+        });
+        $late = $runner('late', 10);
+        $early = $runner('early', -10);
+        $registry = new PluginRegistry([$late, $early]);
+
+        $result = $registry->runWorker(function () use ($events): string {
+            $events->append('worker');
+
+            return 'result';
+        });
+
+        Expect::that($result)->toBe('result');
+        Expect::that($events->getArrayCopy())->toBe([
+            'early:enter',
+            'late:enter',
+            'worker',
+            'late:exit',
+            'early:exit',
+        ]);
     }
 }

--- a/tests/Unit/Runner/Worker/WorkerProcessTest.php
+++ b/tests/Unit/Runner/Worker/WorkerProcessTest.php
@@ -225,8 +225,35 @@ final readonly class WorkerProcessTest
      */
     public static function cleanControlChannelEndings(): iterable
     {
-        yield 'orchestrator disconnect' => ['eof'];
-        yield 'unexpected message followed by drain' => ['unexpected-then-drain'];
+        yield 'orchestrator disconnect before bootstrap' => ['eof'];
+        yield 'drain before bootstrap' => ['drain-before-bootstrap'];
+        yield 'orchestrator disconnect after bootstrap' => ['bootstrap-then-eof'];
+        yield 'unexpected message before bootstrap' => ['unexpected-before-bootstrap'];
+        yield 'unexpected message after bootstrap' => ['unexpected-then-drain'];
+    }
+
+    #[Test]
+    #[Timeout(5.0)]
+    #[DataSet('workerProtocolViolations')]
+    public function protocolViolationsStopTheWorkerAbnormally(string $scenario): void
+    {
+        [$workerExit, $serverExit] = $this->runScenario($scenario);
+
+        Expect::that($workerExit)
+            ->because('a worker protocol violation MUST stop the worker abnormally')
+            ->toBe(1);
+        Expect::that($serverExit)
+            ->because('the protocol fixture MUST receive the worker fatal message')
+            ->toBe(0);
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function workerProtocolViolations(): iterable
+    {
+        yield 'assignment before bootstrap' => ['assignment-before-bootstrap'];
+        yield 'duplicate bootstrap' => ['duplicate-bootstrap'];
     }
 
     /**
@@ -271,6 +298,30 @@ final readonly class WorkerProcessTest
                 exit(0);
             }
 
+            if ($scenario === 'drain-before-bootstrap') {
+                $channel->send(new Greenlight\Runner\Protocol\Messages\Drain());
+                exit(0);
+            }
+
+            if ($scenario === 'assignment-before-bootstrap') {
+                $channel->send(new Greenlight\Runner\Protocol\Messages\Assign(
+                    new Greenlight\Discovery\ExecutionPlan([]),
+                ));
+                $fatal = $channel->receive(2.0);
+
+                if (!$fatal instanceof Greenlight\Runner\Protocol\Messages\Fatal
+                    || $fatal->detail->message !== 'Worker received an assignment before bootstrap completed.'
+                ) {
+                    exit(5);
+                }
+
+                exit(0);
+            }
+
+            if ($scenario === 'unexpected-before-bootstrap') {
+                $channel->send(new Greenlight\Runner\Protocol\Messages\Hello('unexpected', 'token', 1));
+            }
+
             $channel->send(new Greenlight\Runner\Protocol\Messages\Bootstrap(
                 1,
                 null,
@@ -291,6 +342,28 @@ final readonly class WorkerProcessTest
 
             if (!$bootstrapResponse instanceof Greenlight\Runner\Protocol\Messages\Ready) {
                 exit(5);
+            }
+
+            if ($scenario === 'bootstrap-then-eof') {
+                $channel->close();
+                exit(0);
+            }
+
+            if ($scenario === 'duplicate-bootstrap') {
+                $channel->send(new Greenlight\Runner\Protocol\Messages\Bootstrap(
+                    1,
+                    null,
+                    Greenlight\Harness\IntegrationResources::empty(),
+                ));
+                $fatal = $channel->receive(2.0);
+
+                if (!$fatal instanceof Greenlight\Runner\Protocol\Messages\Fatal
+                    || $fatal->detail->message !== 'Worker received bootstrap more than once.'
+                ) {
+                    exit(6);
+                }
+
+                exit(0);
             }
 
             if ($scenario === 'passing-assignment-recycles') {
@@ -390,7 +463,7 @@ final readonly class WorkerProcessTest
                 $channel->send(new Greenlight\Runner\Protocol\Messages\Hello('unexpected', 'token', 1));
             } elseif ($scenario === 'idle-then-drain') {
                 usleep(100_000);
-            } else {
+            } elseif ($scenario !== 'unexpected-before-bootstrap') {
                 exit(9);
             }
 

--- a/tools/phpstan-stubs/hyperf.php
+++ b/tools/phpstan-stubs/hyperf.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Hyperf\Context;
+
+use Psr\Container\ContainerInterface;
+
+class ApplicationContext
+{
+    /** @phpstan-impure */
+    public static function setContainer(ContainerInterface $container): ContainerInterface
+    {
+        return $container;
+    }
+}
+
+namespace Hyperf\Contract;
+
+interface ApplicationInterface {}
+
+namespace Hyperf\Coordinator;
+
+class Constants
+{
+    public const string WORKER_EXIT = 'WORKER_EXIT';
+}
+
+class Coordinator
+{
+    /** @phpstan-impure */
+    public function resume(mixed $value = null): void {}
+}
+
+class CoordinatorManager
+{
+    public static function until(string $identifier): Coordinator
+    {
+        return new Coordinator();
+    }
+}
+
+namespace Hyperf\Di;
+
+class ClassLoader
+{
+    /** @phpstan-impure */
+    public static function init(): void {}
+}
+
+namespace Hyperf\Coroutine;
+
+class Coroutine
+{
+    public static function inCoroutine(): bool
+    {
+        return true;
+    }
+}
+
+/**
+ * @param callable(): void $callbacks
+ * @phpstan-impure
+ */
+function run(callable $callbacks, int $flags): bool
+{
+    $callbacks();
+
+    return true;
+}
+
+namespace Swoole;
+
+class Coroutine
+{
+    /**
+     * @param callable(): void $callback
+     * @phpstan-impure
+     */
+    public static function create(callable $callback): int|false
+    {
+        $callback();
+
+        return 1;
+    }
+}
+
+class Timer
+{
+    /** @phpstan-impure */
+    public static function clearAll(): bool
+    {
+        return true;
+    }
+}
+
+class Runtime
+{
+    /** @phpstan-impure */
+    public static function enableCoroutine(int $flags = 0): bool
+    {
+        return true;
+    }
+}
+
+namespace Swoole\Coroutine;
+
+class Channel
+{
+    private mixed $value = null;
+
+    public function __construct(private readonly int $capacity = 1) {}
+
+    /** @phpstan-impure */
+    public function push(mixed $value): bool
+    {
+        if ($this->capacity < 1) {
+            return false;
+        }
+
+        $this->value = $value;
+
+        return true;
+    }
+
+    /** @phpstan-impure */
+    public function pop(float $timeout = -1): mixed
+    {
+        return $this->value;
+    }
+
+    /** @phpstan-impure */
+    public function close(): bool
+    {
+        return true;
+    }
+}

--- a/website/scripts/generate-api-reference.mjs
+++ b/website/scripts/generate-api-reference.mjs
@@ -78,8 +78,9 @@ const sections = [
   {
     id: 'api-integrations',
     title: 'Integration API',
-    description: 'This reference lists public integration types for Laravel, PSR standards, Rector, and Symfony.',
+    description: 'This reference lists public integration types for Hyperf, Laravel, PSR standards, Rector, and Symfony.',
     prefixes: [
+      'Greenlight\\Hyperf\\',
       'Greenlight\\Laravel\\',
       'Greenlight\\PhpStan\\',
       'Greenlight\\Psr\\',

--- a/website/src/lib/docs.ts
+++ b/website/src/lib/docs.ts
@@ -62,6 +62,11 @@ export const docSections = [
         description: 'This guide explains how tests receive container services from a fresh Laravel application.',
       },
       {
+        id: 'hyperf',
+        title: 'Hyperf',
+        description: 'This guide explains coroutine test attempts, AOP classes, and persistent or isolated containers.',
+      },
+      {
         id: 'psr',
         title: 'PSR applications',
         description: 'This guide explains how tests receive services from a PSR-11 container.',
@@ -149,7 +154,7 @@ export const docSections = [
       {
         id: 'api-integrations',
         title: 'Integration API',
-        description: 'This reference lists public integration types for Laravel, PSR standards, Rector, and Symfony.',
+        description: 'This reference lists public integration types for Hyperf, Laravel, PSR standards, Rector, and Symfony.',
       },
     ],
   },


### PR DESCRIPTION
## Summary

- add a first-party Hyperf 3.2 and Swoole bridge that models a persistent worker container by default and offers opt-in per-attempt container isolation
- add worker and test-attempt runtime boundaries so application boot, AOP classes, coroutine context, reset, disposal, timers, and coordinator cleanup occur at their truthful lifetimes
- add real Hyperf acceptance coverage for both persistence and isolation, plus Composer suggestions, dependency metadata, API reference, and website documentation