### PR TITLE
perf(runner): avoid shifting scheduler queues

### DIFF
--- a/src/Runner/Orchestrator/ResourceScheduler.php
+++ b/src/Runner/Orchestrator/ResourceScheduler.php
@@ -34,8 +34,11 @@ final class ResourceScheduler
      * @param array<non-empty-string, positive-int> $limits
      */
     public function __construct(
+        /** @var array<int, SchedulingUnit> */
         private array $pooled,
+        /** @var array<int, SchedulingUnit> */
         private array $isolated,
+        /** @var array<non-empty-string, positive-int> */
         private array $limits,
     ) {}
 
@@ -96,18 +99,26 @@ final class ResourceScheduler
     }
 
     /**
-     * @param list<SchedulingUnit> $queue
+     * @param array<int, SchedulingUnit> $queue
      */
     private function dispatchFrom(array &$queue): DispatchDecision
     {
-        if ($this->fits($queue[0])) {
-            return DispatchDecision::assign($this->acquire($queue, 0));
+        $firstIndex = \array_key_first($queue);
+
+        if ($firstIndex === null) {
+            return DispatchDecision::drain();
         }
 
-        $reserved = \array_fill_keys($queue[0]->resources, 1);
+        $first = $queue[$firstIndex];
+
+        if ($this->fits($first)) {
+            return DispatchDecision::assign($this->acquire($queue, $firstIndex));
+        }
+
+        $reserved = \array_fill_keys($first->resources, 1);
 
         foreach ($queue as $index => $unit) {
-            if ($index === 0) {
+            if ($index === $firstIndex) {
                 continue;
             }
 
@@ -136,12 +147,12 @@ final class ResourceScheduler
     }
 
     /**
-     * @param list<SchedulingUnit> $queue
+     * @param array<int, SchedulingUnit> $queue
      */
     private function acquire(array &$queue, int $index): ResourceLease
     {
         $unit = $queue[$index];
-        \array_splice($queue, $index, 1);
+        unset($queue[$index]);
 
         foreach ($unit->resources as $resource) {
             $used = ($this->inUse[$resource] ?? 0) + 1;

--- a/tests/Unit/Runner/Orchestrator/ResourceSchedulerRequeueOrderTest.php
+++ b/tests/Unit/Runner/Orchestrator/ResourceSchedulerRequeueOrderTest.php
@@ -14,15 +14,18 @@ final readonly class ResourceSchedulerRequeueOrderTest
 {
     #[Test]
     #[DataSet('queueKinds')]
-    public function requeuedWorkAppendsBehindPendingWork(bool $isolated, bool $freshWorker): void
+    public function requeuedWorkAppendsBehindSparsePendingWork(bool $isolated, bool $freshWorker): void
     {
+        $active = SchedulingFixture::unit('Acme\\ActiveTest', ['database'], $isolated);
         $pending = SchedulingFixture::unit('Acme\\PendingTest', ['database'], $isolated);
         $requeued = SchedulingFixture::unit('Acme\\RetriedTest', ['database'], $isolated);
         $scheduler = new ResourceScheduler(
-            $isolated ? [] : [$pending],
-            $isolated ? [$pending] : [],
+            $isolated ? [] : [$active, $pending],
+            $isolated ? [$active, $pending] : [],
             [],
         );
+        $activeLease = SchedulingFixture::assignedLease($scheduler, $freshWorker);
+        $scheduler->release($activeLease);
         $scheduler->requeue($requeued);
 
         $first = SchedulingFixture::assignedLease($scheduler, $freshWorker);


### PR DESCRIPTION
## Summary

- remove dispatched scheduling units without shifting the remaining queue
- preserve FIFO traversal and resource-reservation behavior with sparse integer keys
- exercise requeue ordering after a prior dispatch makes each queue sparse