### PR TITLE
fix(runner): restore in-process channel environment

### DIFF
--- a/src/Runner/InProcessRunner.php
+++ b/src/Runner/InProcessRunner.php
@@ -16,6 +16,7 @@ use Greenlight\Discovery\DiscoveryCache;
 use Greenlight\Discovery\DiscoveryError;
 use Greenlight\Discovery\ExecutionPlan;
 use Greenlight\Discovery\TestDiscoverer;
+use Greenlight\Fixture\EnvironmentBackup;
 use Greenlight\Plugin\PluginRegistry;
 use Greenlight\Plugin\WorkerBootstrapContext;
 use Greenlight\Runner\Artifact\ArtifactStore;
@@ -77,6 +78,7 @@ final readonly class InProcessRunner
             $this->workingDirectory,
             $runId,
         );
+        $channelEnvironment = null;
 
         try {
             $plugins = PluginRegistry::forWorker($configuration->plugins);
@@ -113,6 +115,7 @@ final readonly class InProcessRunner
                 // A single in-process worker always uses channel 1. Set the
                 // variable to replace a value inherited from an outer Greenlight
                 // run.
+                $channelEnvironment = EnvironmentBackup::capture('GREENLIGHT_CHANNEL');
                 \putenv('GREENLIGHT_CHANNEL=1');
 
                 $resources = $fixtures->forChannel(1);
@@ -188,6 +191,7 @@ final readonly class InProcessRunner
 
             return $result;
         } finally {
+            $channelEnvironment?->restore();
             $artifactStore->cleanup();
         }
     }

--- a/tests/Unit/Runner/InProcessRunnerTest.php
+++ b/tests/Unit/Runner/InProcessRunnerTest.php
@@ -11,6 +11,7 @@ use Greenlight\Config\GreenlightConfig;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Doubles\Fake;
 use Greenlight\Expect\Expect;
+use Greenlight\Fixture\EnvironmentSandbox;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Plugin\WorkerBootstrapContext;
 use Greenlight\Plugin\WorkerBootstrapSubscriber;
@@ -21,7 +22,10 @@ use Greenlight\Tests\Support\CollectingEventSink;
 
 final readonly class InProcessRunnerTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private EnvironmentSandbox $environment,
+    ) {}
 
     #[Test]
     public function runSubscribersObserveTheCompleteInProcessEventStream(): void
@@ -110,8 +114,31 @@ final readonly class InProcessRunnerTest
     }
 
     #[Test]
+    public function runRestoresTheCallerChannelEnvironment(): void
+    {
+        $this->environment->set('GREENLIGHT_CHANNEL', 'caller-channel');
+        $configuration = GreenlightConfig::create()->build();
+        $fixtureDirectory = \dirname(__DIR__, 2) . '/Fixture/DiscoveryBasic';
+
+        new InProcessRunner($this->tempDirectory->path())->run(
+            $configuration,
+            [$fixtureDirectory],
+            new CollectingEventSink(),
+        );
+
+        Expect::that(\getenv('GREENLIGHT_CHANNEL'))
+            ->because('an in-process run MUST restore the caller process environment')
+            ->toBe('caller-channel');
+        Expect::that($_ENV['GREENLIGHT_CHANNEL'] ?? null)
+            ->toBe('caller-channel');
+        Expect::that($_SERVER['GREENLIGHT_CHANNEL'] ?? null)
+            ->toBe('caller-channel');
+    }
+
+    #[Test]
     public function workerBootstrapFailuresUseTheWorkerFatalProtocolError(): void
     {
+        $this->environment->unset('GREENLIGHT_CHANNEL');
         $failure = new \RuntimeException('worker bootstrap exploded');
         $plugin = new readonly class ($failure) implements WorkerBootstrapSubscriber, Fake {
             public function __construct(private \RuntimeException $failure) {}
@@ -141,6 +168,14 @@ final readonly class InProcessRunnerTest
                     Expect::that($error->getPrevious())->toBe($failure);
                 },
             );
+
+        Expect::that(\getenv('GREENLIGHT_CHANNEL'))
+            ->because('a failed in-process run MUST restore an absent caller environment value')
+            ->toBeFalse();
+        Expect::that(\array_key_exists('GREENLIGHT_CHANNEL', $_ENV))
+            ->toBeFalse();
+        Expect::that(\array_key_exists('GREENLIGHT_CHANNEL', $_SERVER))
+            ->toBeFalse();
     }
 
     /**


### PR DESCRIPTION
Restore the caller GREENLIGHT_CHANNEL state after every non-empty in-process run. Reuse EnvironmentBackup so getenv(), $_ENV, and $_SERVER are preserved independently across successful runs and bootstrap failures.