### PR TITLE
fix(cli): restore coverage relay after failures

### DIFF
--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -57,8 +57,6 @@ use Greenlight\Reporting\SummaryFormat;
 use Greenlight\Reporting\TeamCityReporter;
 use Greenlight\Reporting\Ticking;
 use Greenlight\Reporting\TtyReporter;
-use Greenlight\Runner\CoverageCollector;
-use Greenlight\Runner\CoverageSettings;
 use Greenlight\Runner\CpuCores;
 use Greenlight\Runner\InProcessRunner;
 use Greenlight\Runner\Integration\IntegrationFixtureError;
@@ -66,7 +64,6 @@ use Greenlight\Runner\ParallelRunner;
 use Greenlight\Runner\PlanShard;
 use Greenlight\Runner\Protocol\ProtocolError;
 use Greenlight\Runner\SelectionFilter;
-use Greenlight\Runner\SharedCoverageDirectory;
 use Greenlight\Runner\SubprocessCoverage;
 use Greenlight\Runner\Worker\LeakDetector;
 use Greenlight\Runner\Worker\WorkerProcess;
@@ -487,63 +484,42 @@ final readonly class Application
         $coverageSettings = CoverageSettingsResolver::resolve($resolved->coverage, $workingDirectory);
         $detectLeaks = $arguments->has('detect-leaks');
 
-        $orchestratorCollector = null;
-        $shared = null;
-
-        if ($coverageSettings instanceof CoverageSettings) {
-            // The worker-pool path collects orchestrator coverage unless this
-            // process inherits relay variables. A second driver period closes
-            // the inherited process period too early.
-            if ($workers !== 1 && $realBin !== false && !SubprocessCoverage::requested()) {
-                $orchestratorCollector = CoverageCollector::create($coverageSettings);
-                $orchestratorCollector?->start();
-            }
-
-            $shared = SharedCoverageDirectory::open($coverageSettings);
-        }
+        // The worker-pool path collects orchestrator coverage unless this
+        // process inherits relay variables. A second driver period closes
+        // the inherited process period too early.
+        $coverageSession = CoverageSession::open(
+            $coverageSettings,
+            $workers !== 1 && $realBin !== false && !SubprocessCoverage::requested(),
+        );
 
         try {
-            if ($workers === 1 || $realBin === false) {
-                $run = new InProcessRunner($workingDirectory)
-                    ->run($resolved, $this->directories($resolved, $workingDirectory), $failedTap, $coverageSettings, $detectLeaks, $priorityClasses, $classSeconds, $shutdown);
-            } else {
-                $run = new ParallelRunner([\PHP_BINARY, $realBin], $workingDirectory)
-                    ->run($resolved, $this->directories($resolved, $workingDirectory), $failedTap, $workers, $coverageSettings, $configFile, $detectLeaks, $priorityClasses, $classSeconds, $shutdown, $reporter instanceof Ticking ? $reporter : null);
+            try {
+                if ($workers === 1 || $realBin === false) {
+                    $run = new InProcessRunner($workingDirectory)
+                        ->run($resolved, $this->directories($resolved, $workingDirectory), $failedTap, $coverageSettings, $detectLeaks, $priorityClasses, $classSeconds, $shutdown);
+                } else {
+                    $run = new ParallelRunner([\PHP_BINARY, $realBin], $workingDirectory)
+                        ->run($resolved, $this->directories($resolved, $workingDirectory), $failedTap, $workers, $coverageSettings, $configFile, $detectLeaks, $priorityClasses, $classSeconds, $shutdown, $reporter instanceof Ticking ? $reporter : null);
+                }
+            } catch (AttachmentError|DiscoveryError|IntegrationFixtureError|ProtocolError $error) {
+                $reporter->finish();
+                $this->printError($error->getMessage(), $arguments->has('no-ansi'));
+
+                $interruptExit = $shutdown->exitCode();
+
+                if ($interruptExit !== null) {
+                    ($this->err)("Interrupted. Integration fixture teardown was attempted before exit.\n");
+                }
+
+                return $interruptExit ?? self::EXIT_FAILURE;
             }
-        } catch (AttachmentError|DiscoveryError|IntegrationFixtureError|ProtocolError $error) {
-            $orchestratorCollector?->stop();
-            $shared?->drain();
-            $reporter->finish();
-            $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-            $interruptExit = $shutdown->exitCode();
-
-            if ($interruptExit !== null) {
-                ($this->err)("Interrupted. Integration fixture teardown was attempted before exit.\n");
-            }
-
-            return $interruptExit ?? self::EXIT_FAILURE;
-        }
-
-        // Merge before an early return. Thus, this operation restores relay
-        // variables and removes the shared directory for interrupted or empty
-        // runs.
-        $coverage = $run->coverage;
-
-        if ($orchestratorCollector instanceof CoverageCollector) {
-            $collected = $orchestratorCollector->stop();
-
-            if (!$collected->isEmpty()) {
-                $coverage = $coverage instanceof CoverageMap ? $coverage->merge($collected) : $collected;
-            }
-        }
-
-        if ($shared instanceof SharedCoverageDirectory) {
-            $dumped = $shared->drain();
-
-            if ($dumped instanceof CoverageMap) {
-                $coverage = $coverage instanceof CoverageMap ? $coverage->merge($dumped) : $dumped;
-            }
+            // Merge before an early return. Thus, this operation restores relay
+            // variables and removes the shared directory for interrupted or empty
+            // runs.
+            $coverage = $coverageSession->finish($run->coverage);
+        } finally {
+            $coverageSession->close();
         }
 
         // Apply the filter after all source maps merge. Thus, exclusion markers

--- a/src/Cli/CoverageSession.php
+++ b/src/Cli/CoverageSession.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli;
+
+use Greenlight\Coverage\CoverageError;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Runner\CoverageCollector;
+use Greenlight\Runner\CoverageSettings;
+use Greenlight\Runner\SharedCoverageDirectory;
+
+/**
+ * Owns and merges the coverage resources for one CLI run.
+ *
+ * @internal
+ */
+final class CoverageSession
+{
+    private ?CoverageCollector $collector = null;
+
+    private bool $collecting = false;
+
+    private ?SharedCoverageDirectory $shared = null;
+
+    private function __construct() {}
+
+    /**
+     * @throws CoverageError
+     */
+    public static function open(?CoverageSettings $settings, bool $collectProcess): self
+    {
+        $session = new self();
+
+        if (!$settings instanceof CoverageSettings) {
+            return $session;
+        }
+
+        try {
+            if ($collectProcess) {
+                $session->collector = CoverageCollector::create($settings);
+
+                if ($session->collector instanceof CoverageCollector) {
+                    $session->collector->start();
+                    $session->collecting = true;
+                }
+            }
+
+            $session->shared = SharedCoverageDirectory::open($settings);
+        } catch (\Throwable $failure) {
+            $session->close();
+
+            throw $failure;
+        }
+
+        return $session;
+    }
+
+    public function finish(?CoverageMap $coverage): ?CoverageMap
+    {
+        if ($this->collecting) {
+            $this->collecting = false;
+            $collected = $this->collector?->stop();
+
+            if ($collected instanceof CoverageMap && !$collected->isEmpty()) {
+                $coverage = $coverage instanceof CoverageMap ? $coverage->merge($collected) : $collected;
+            }
+        }
+
+        if ($this->shared instanceof SharedCoverageDirectory) {
+            $shared = $this->shared;
+            $this->shared = null;
+            $dumped = $shared->drain();
+
+            if ($dumped instanceof CoverageMap) {
+                $coverage = $coverage instanceof CoverageMap ? $coverage->merge($dumped) : $dumped;
+            }
+        }
+
+        return $coverage;
+    }
+
+    public function close(): void
+    {
+        if ($this->collecting) {
+            $this->collecting = false;
+
+            try {
+                $this->collector?->stop();
+            } catch (\Throwable) {
+                // A cleanup failure MUST not replace the run failure.
+            }
+        }
+
+        if ($this->shared instanceof SharedCoverageDirectory) {
+            $shared = $this->shared;
+            $this->shared = null;
+
+            try {
+                $shared->drain();
+            } catch (\Throwable) {
+                // A cleanup failure MUST not replace the run failure.
+            }
+        }
+    }
+}

--- a/tests/Unit/Cli/ApplicationCoverageCleanupTest.php
+++ b/tests/Unit/Cli/ApplicationCoverageCleanupTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\Application;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Fixture\EnvironmentSandbox;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Reporting\ReportingError;
+use Greenlight\Runner\SubprocessCoverage;
+use Greenlight\Tests\Support\AcceptanceProject;
+
+final readonly class ApplicationCoverageCleanupTest
+{
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private EnvironmentSandbox $environment,
+    ) {}
+
+    #[Test]
+    public function runEventFailuresRestoreTheCoverageRelayEnvironment(): void
+    {
+        $this->environment->unset(SubprocessCoverage::DIRECTORY_ENV);
+        $this->environment->unset(SubprocessCoverage::INCLUDE_ENV);
+        $fixtureDirectory = \dirname(__DIR__, 2) . '/Fixture/DiscoveryBasic';
+        $project = AcceptanceProject::create($this->tempDirectory, 'application-coverage-cleanup');
+        $project->writeFile('greenlight.php', \sprintf(
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Config\GreenlightConfig;
+            use Greenlight\Core\Event\Event;
+            use Greenlight\Plugin\RunLifecycleSubscriber;
+            use Greenlight\Reporting\ReportingError;
+
+            $failure = new class implements RunLifecycleSubscriber {
+                #[\Override]
+                public function onRunEvent(Event $event): never
+                {
+                    throw ReportingError::writeFailed();
+                }
+            };
+
+            return GreenlightConfig::create()
+                ->paths([%s])
+                ->workers(1)
+                ->coverage(fn($coverage) => $coverage->include(%s))
+                ->plugins($failure);
+
+            PHP,
+            \var_export($fixtureDirectory, true),
+            \var_export($fixtureDirectory, true),
+        ));
+        $stdout = \fopen('php://memory', 'w');
+        $stderr = \fopen('php://memory', 'w');
+
+        if ($stdout === false || $stderr === false) {
+            Fail::because('Greenlight did not open the CLI test streams.');
+        }
+
+        try {
+            Expect::that(fn() => Application::forStreams($stdout, $stderr)->run(
+                ['run', '--reporter=plain', '--no-ansi'],
+                $project->directory,
+            ))
+                ->because('a run event failure MUST propagate after coverage cleanup')
+                ->toThrow(ReportingError::class);
+        } finally {
+            \fclose($stdout);
+            \fclose($stderr);
+        }
+
+        Expect::that(\getenv(SubprocessCoverage::DIRECTORY_ENV))
+            ->because('a failed run MUST restore an absent coverage relay directory')
+            ->toBeFalse();
+        Expect::that(\getenv(SubprocessCoverage::INCLUDE_ENV))
+            ->because('a failed run MUST restore absent coverage include paths')
+            ->toBeFalse();
+    }
+}


### PR DESCRIPTION
Restore coverage relay variables and remove the temporary relay directory when run-event delivery fails unexpectedly. Move collector and relay ownership into an exception-safe CoverageSession so setup, merge, and cleanup use one lifecycle contract.