### PR TITLE
fix(expect): align canonical sort keys with equality

### DIFF
--- a/src/Expect/Equality.php
+++ b/src/Expect/Equality.php
@@ -44,7 +44,18 @@ final class Equality
             // Compute each key one time for each element. A comparator
             // serializes both operands again for each comparison.
             $keys = \array_map(static fn(mixed $item): string => self::sortKey($item, []), $canonical);
-            \array_multisort($keys, \SORT_ASC, \SORT_STRING, $canonical);
+            // Original positions give each item a unique scalar tie-breaker.
+            // PHP would otherwise compare cyclic values when sort keys match.
+            $positions = \array_keys($canonical);
+            \array_multisort(
+                $keys,
+                \SORT_ASC,
+                \SORT_STRING,
+                $positions,
+                \SORT_ASC,
+                \SORT_NUMERIC,
+                $canonical,
+            );
         }
 
         return $canonical;

--- a/src/Expect/Equality.php
+++ b/src/Expect/Equality.php
@@ -62,9 +62,10 @@ final class Equality
     }
 
     /**
-     * Converts a canonical value to a stable sort key. Numbers use one
-     * representation, so 1 and 1.0 have the same sort position. Closures and
-     * resources use their identity because they have no comparable state.
+     * Converts a canonical value to a stable sort key. Equal dates use their
+     * timestamp. Equal integers and floats use one numeric representation.
+     * Closures and resources use their identity because they have no
+     * comparable state.
      *
      * @param list<int> $seen Object IDs already in the conversion stack. This
      *   list stops cycles.
@@ -92,7 +93,15 @@ final class Equality
         }
 
         if (\is_float($value)) {
+            if ($value === 0.0) {
+                return 'number:0';
+            }
+
             return 'number:' . $value;
+        }
+
+        if ($value instanceof \DateTimeInterface) {
+            return 'date-time:' . $value->format('U.u');
         }
 
         if ($value instanceof \Closure) {

--- a/tests/Unit/Expect/CanonicalizingTest.php
+++ b/tests/Unit/Expect/CanonicalizingTest.php
@@ -84,6 +84,19 @@ final class CanonicalizingTest
     }
 
     #[Test]
+    public function toEqualCanonicalizingDoesNotCompareCyclicSortKeyTies(): void
+    {
+        $first = new CanonicalNode('same');
+        $first->next = $first;
+        $second = new CanonicalNode('same');
+        $second->next = $second;
+
+        Expect::that([$second, $first])
+            ->because('canonical sort-key ties MUST not recursively compare cyclic values')
+            ->toEqualCanonicalizing([$first, $second]);
+    }
+
+    #[Test]
     public function toEqualCanonicalizingOrdersIdentityOnlyValues(): void
     {
         $firstClosure = static fn(): string => 'first';

--- a/tests/Unit/Expect/CanonicalizingTest.php
+++ b/tests/Unit/Expect/CanonicalizingTest.php
@@ -97,6 +97,25 @@ final class CanonicalizingTest
     }
 
     #[Test]
+    public function toEqualCanonicalizingUsesDateTimeEqualityForOrdering(): void
+    {
+        $first = '2024-01-01T00:00:00Z';
+        $second = '2024-01-02T00:00:00Z';
+
+        Expect::that([new \DateTime($first), new \DateTimeImmutable($second)])
+            ->because('canonical sort keys MUST follow DateTimeInterface equality')
+            ->toEqualCanonicalizing([new \DateTime($second), new \DateTimeImmutable($first)]);
+    }
+
+    #[Test]
+    public function toEqualCanonicalizingUsesOneSortKeyForSignedZero(): void
+    {
+        Expect::that([-0.0, -1.0])
+            ->because('canonical sort keys MUST treat equal signed zero values alike')
+            ->toEqualCanonicalizing([-1.0, 0.0]);
+    }
+
+    #[Test]
     public function toEqualCanonicalizingOrdersIdentityOnlyValues(): void
     {
         $firstClosure = static fn(): string => 'first';


### PR DESCRIPTION
Make canonical list ordering obey the same equality rules as the final deep comparison. Use scalar positions for cyclic sort-key ties, timestamp keys across DateTimeInterface implementations, and one numeric key for positive and negative zero.