### PR TITLE
fix(cli): honor configured reporter streams

### DIFF
--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -160,10 +160,17 @@ final readonly class Application
         HELP;
 
     /**
+     * @param resource $stdout
+     * @param resource $stderr
      * @param \Closure(string): void $out
      * @param \Closure(string): void $err
      */
-    private function __construct(private \Closure $out, private \Closure $err) {}
+    private function __construct(
+        private mixed $stdout,
+        private mixed $stderr,
+        private \Closure $out,
+        private \Closure $err,
+    ) {}
 
     /**
      * @param resource|null $stdout
@@ -171,10 +178,14 @@ final readonly class Application
      */
     public static function forStreams($stdout = null, $stderr = null): self
     {
-        $out = new StreamOutput($stdout ?? \STDOUT);
-        $err = new StreamOutput($stderr ?? \STDERR);
+        $stdout ??= \STDOUT;
+        $stderr ??= \STDERR;
+        $out = new StreamOutput($stdout);
+        $err = new StreamOutput($stderr);
 
         return new self(
+            $stdout,
+            $stderr,
             static function (string $text) use ($out): void {
                 $out->write($text);
             },
@@ -647,7 +658,7 @@ final readonly class Application
     private function stdoutStyle(bool $noAnsiFlag): Style
     {
         $capabilities = TerminalCapabilities::detect(
-            Terminal::isTty(\STDOUT),
+            Terminal::isTty($this->stdout),
             ['CI' => \getenv('CI'), 'NO_COLOR' => \getenv('NO_COLOR')],
             $noAnsiFlag,
         );
@@ -658,7 +669,7 @@ final readonly class Application
     private function stderrStyle(bool $noAnsiFlag): Style
     {
         $capabilities = TerminalCapabilities::detect(
-            Terminal::isTty(\STDERR),
+            Terminal::isTty($this->stderr),
             ['CI' => \getenv('CI'), 'NO_COLOR' => \getenv('NO_COLOR')],
             $noAnsiFlag,
         );
@@ -887,9 +898,9 @@ final readonly class Application
      */
     private function buildReporter(ParsedArguments $arguments, ?int $seed, string $configFile, string $workingDirectory, bool $workerFallback = false): Reporter
     {
-        $output = new StreamOutput(\STDOUT);
+        $output = new StreamOutput($this->stdout);
         $capabilities = TerminalCapabilities::detect(
-            Terminal::isTty(\STDOUT),
+            Terminal::isTty($this->stdout),
             ['CI' => \getenv('CI'), 'NO_COLOR' => \getenv('NO_COLOR')],
             $arguments->has('no-ansi'),
         );
@@ -1067,7 +1078,7 @@ final readonly class Application
         }
 
         $report = $aggregator->render(new Style(TerminalCapabilities::detect(
-            Terminal::isTty(\STDOUT),
+            Terminal::isTty($this->stdout),
             ['CI' => \getenv('CI'), 'NO_COLOR' => \getenv('NO_COLOR')],
             $arguments->has('no-ansi'),
         )->color));

--- a/tests/Unit/Cli/ApplicationReporterStreamTest.php
+++ b/tests/Unit/Cli/ApplicationReporterStreamTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\Application;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Fixture\EnvironmentSandbox;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\AcceptanceProject;
+
+final readonly class ApplicationReporterStreamTest
+{
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private EnvironmentSandbox $environment,
+    ) {}
+
+    #[Test]
+    public function runReportersUseTheConfiguredOutputStream(): void
+    {
+        $this->environment->unset('GREENLIGHT_CHANNEL');
+        $project = AcceptanceProject::createWithDiscoveryBasicTests(
+            $this->tempDirectory,
+            'application-reporter-stream',
+        );
+        $stdout = \fopen('php://memory', 'w+');
+        $stderr = \fopen('php://memory', 'w+');
+
+        if ($stdout === false || $stderr === false) {
+            Fail::because('Greenlight did not open the CLI test streams.');
+        }
+
+        try {
+            $exit = Application::forStreams($stdout, $stderr)->run(
+                ['run', '--workers=1', '--reporter=plain', '--no-ansi'],
+                $project->directory,
+            );
+            \rewind($stdout);
+            \rewind($stderr);
+            $output = \stream_get_contents($stdout);
+            $errors = \stream_get_contents($stderr);
+        } finally {
+            \fclose($stdout);
+            \fclose($stderr);
+        }
+
+        Expect::that($exit)
+            ->because('a run through configured streams MUST preserve the reporter exit code')
+            ->toBe(0);
+        Expect::that($output)
+            ->because('the configured output stream MUST receive the complete run report')
+            ->toContain('Greenlight dev-main')
+            ->toContain('7 tests, 7 passed');
+        Expect::that($errors)
+            ->toBe('');
+    }
+}


### PR DESCRIPTION
Route run reporters, terminal capability detection, styles, and offline profile rendering through the streams supplied to Application::forStreams(). Add an end-to-end run contract that proves reporter output reaches the configured stream.