### PR TITLE
fix(harness): accept empty fixture maps

### DIFF
--- a/src/Harness/FixtureResource.php
+++ b/src/Harness/FixtureResource.php
@@ -142,7 +142,7 @@ final readonly class FixtureResource implements WireSerializable
     {
         $value = $this->value($key);
 
-        if (!\is_array($value) || \array_is_list($value)) {
+        if (!\is_array($value) || ($value !== [] && \array_is_list($value))) {
             throw $this->wrongType($key, 'a map', $value);
         }
 

--- a/tests/Unit/Harness/FixtureResourceAccessTest.php
+++ b/tests/Unit/Harness/FixtureResourceAccessTest.php
@@ -50,6 +50,22 @@ final readonly class FixtureResourceAccessTest
     }
 
     #[Test]
+    public function emptyCollectionsCanBeReadAsListsOrMaps(): void
+    {
+        $resource = FixtureResource::fromWire(FixtureResource::from([
+            'list' => [],
+            'map' => [],
+        ])->toWire());
+
+        Expect::that($resource->list('list'))
+            ->because('an empty transported collection MUST remain usable as a list')
+            ->toBe([]);
+        Expect::that($resource->map('map'))
+            ->because('an empty transported collection MUST remain usable as a map')
+            ->toBe([]);
+    }
+
+    #[Test]
     #[DataSet('wrongTypedValues')]
     public function typedAccessorsReportWrongValuesExactly(
         string $accessor,


### PR DESCRIPTION
Treat an empty transported collection as a valid fixture-resource map, consistent with the wire map reader and PHP’s ambiguous empty-array representation. Add an accessor contract that covers both empty lists and empty maps after a wire round trip.