### PR TITLE
fix(expect): avoid invoking property hooks in diagnostics

### DIFF
--- a/src/Expect/ValueRenderer.php
+++ b/src/Expect/ValueRenderer.php
@@ -191,9 +191,12 @@ final class ValueRenderer
                 break;
             }
 
-            $parts[] = $property->getName() . ': ' . ($property->isInitialized($value)
-                ? $this->renderValue($property->getValue($value), $depth + 1)
-                : '(uninitialized)');
+            $renderedValue = match (true) {
+                $property->isVirtual() => '(virtual)',
+                !$property->isInitialized($value) => '(uninitialized)',
+                default => $this->renderValue($property->getRawValue($value), $depth + 1),
+            };
+            $parts[] = $property->getName() . ': ' . $renderedValue;
             ++$rendered;
         }
 

--- a/tests/Fixture/Expect/HookedProperties.php
+++ b/tests/Fixture/Expect/HookedProperties.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Expect;
+
+final class HookedProperties
+{
+    public string $backed = 'stored' {
+        get {
+            throw new \RuntimeException('The backed getter MUST NOT render ' . $this->backed . '.');
+        }
+        set {
+            $this->backed = $value;
+        }
+    }
+
+    public string $virtual {
+        get => throw new \RuntimeException('The virtual getter MUST NOT run during rendering.');
+    }
+}

--- a/tests/Unit/Expect/ValueRendererTest.php
+++ b/tests/Unit/Expect/ValueRendererTest.php
@@ -9,6 +9,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Expect\ValueRenderer;
 use Greenlight\Tests\Fixture\Expect\Credentials;
 use Greenlight\Tests\Fixture\Expect\Holder;
+use Greenlight\Tests\Fixture\Expect\HookedProperties;
 use Greenlight\Tests\Fixture\Expect\LateInit;
 use Greenlight\Tests\Fixture\Expect\Signal;
 
@@ -123,6 +124,14 @@ final class ValueRendererTest
         $rendered = new ValueRenderer()->render(new LateInit());
 
         Expect::that($rendered)->because('marks uninitialized properties')->toBe(LateInit::class . ' {value: (uninitialized)}');
+    }
+
+    #[Test]
+    public function rendersHookedPropertiesWithoutInvokingUserCode(): void
+    {
+        Expect::that(new ValueRenderer()->render(new HookedProperties()))
+            ->because('failure rendering MUST NOT invoke property hooks')
+            ->toBe(HookedProperties::class . " {backed: 'stored', virtual: (virtual)}");
     }
 
     #[Test]


### PR DESCRIPTION
Render PHP 8.4 backed properties from raw storage and represent virtual properties without calling their hooks. This keeps assertion diagnostics from executing user getters or replacing the original failure with a hook error.