### PR TITLE
fix(discovery): normalize inline data row labels

### DIFF
--- a/src/Discovery/DataSetExpander.php
+++ b/src/Discovery/DataSetExpander.php
@@ -75,7 +75,9 @@ final readonly class DataSetExpander
                 throw DiscoveryError::invalidAttribute($className . '::' . $testMethod . '()', $e);
             }
 
-            $key = $row->label ?? \sprintf('#%d', $position);
+            $key = $row->label === null
+                ? \sprintf('#%d', $position)
+                : $this->deriveKey($className, $testMethod, $row->label);
 
             if (\array_key_exists($key, $rows)) {
                 throw DiscoveryError::duplicateDataSetKey($className, $testMethod, $key);

--- a/tests/Fixture/DataRowsControlLabel/ControlLabelRowTest.php
+++ b/tests/Fixture/DataRowsControlLabel/ControlLabelRowTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\DataRowsControlLabel;
+
+use Greenlight\Attribute\DataRow;
+use Greenlight\Attribute\Test;
+
+final readonly class ControlLabelRowTest
+{
+    #[Test]
+    #[DataRow([], label: "line\n")]
+    public function accepts(): void {}
+}

--- a/tests/Unit/Discovery/DataRowTest.php
+++ b/tests/Unit/Discovery/DataRowTest.php
@@ -12,6 +12,7 @@ use Greenlight\Discovery\TestDiscoverer;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\DataRows\InlineRowsTest;
 use Greenlight\Tests\Fixture\DataRowsConflict\DuplicateRowKeyTest;
+use Greenlight\Tests\Fixture\DataRowsControlLabel\ControlLabelRowTest;
 use Greenlight\Tests\Fixture\DataRowsDuplicateInline\DuplicateInlineRowKeyTest;
 use Greenlight\Tests\Fixture\DataRowsInvalid\EmptyDataRowLabelTest;
 use Greenlight\Tests\Fixture\DataRowsZeroLabel\ZeroLabelRowTest;
@@ -40,6 +41,21 @@ final class DataRowTest
         Expect::that($ids)
             ->because('a zero-string inline label MUST remain the plan data-set key')
             ->toBe([ZeroLabelRowTest::class . '::accepts[0]']);
+    }
+
+    #[Test]
+    public function aControlCharacterInlineLabelBecomesAStableHashPrefix(): void
+    {
+        $rows = new DataSetExpander()->rowsFor(
+            new \ReflectionClass(ControlLabelRowTest::class),
+            'accepts',
+            null,
+            5.0,
+        );
+
+        Expect::that(\array_keys($rows))
+            ->because('an inline data-set key MUST NOT preserve control characters')
+            ->toBe([\substr(\hash('sha256', "line\n"), 0, 8)]);
     }
 
     #[Test]


### PR DESCRIPTION
Route inline DataRow labels through the same stable key normalization as provider rows. Control characters and invalid printable forms can no longer enter test IDs or corrupt human-readable reporter output.