### PR TITLE
fix(config): validate top-level test path shape

### DIFF
--- a/docs/api-configuration.md
+++ b/docs/api-configuration.md
@@ -191,7 +191,7 @@ PHPDoc:
 - `@param callable(SuiteBuilder): mixed $configurator`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L123)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L143)
 
 ### `workers()`
 
@@ -213,7 +213,7 @@ PHPDoc:
 - `@param int|null $recycleAfterTests A null value disables test-count worker replacement.`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L151)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L171)
 
 ### `resourceLimit()`
 
@@ -230,7 +230,7 @@ PHPDoc:
 
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L179)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L199)
 
 ### `coverage()`
 
@@ -242,7 +242,7 @@ PHPDoc:
 
 - `@param callable(CoverageBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L207)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L227)
 
 ### `watch()`
 
@@ -254,7 +254,7 @@ PHPDoc:
 
 - `@param callable(WatchBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L219)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L239)
 
 ### `artifacts()`
 
@@ -266,7 +266,7 @@ PHPDoc:
 
 - `@param callable(ArtifactBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L231)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L251)
 
 ### `failOnDeprecation()`
 
@@ -282,7 +282,7 @@ PHPDoc:
 
 - `@see self::ignoreDeprecationsMatching()`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L247)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L267)
 
 ### `failOnNotice()`
 
@@ -290,7 +290,7 @@ PHPDoc:
 public function failOnNotice(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L254)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L274)
 
 ### `failOnRisky()`
 
@@ -302,7 +302,7 @@ expectations.
 public function failOnRisky(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L266)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L286)
 
 ### `ignoreDeprecationsMatching()`
 
@@ -318,7 +318,7 @@ PHPDoc:
 
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L279)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L299)
 
 ### `plugins()`
 
@@ -326,7 +326,7 @@ PHPDoc:
 public function plugins(Plugin ...$plugins): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L296)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L316)
 
 ### `failFast()`
 
@@ -334,7 +334,7 @@ public function plugins(Plugin ...$plugins): self
 public function failFast(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L305)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L325)
 
 ### `randomizeOrder()`
 
@@ -344,7 +344,7 @@ If the seed is null, Greenlight generates and prints a seed at run time.
 public function randomizeOrder(?int $seed = null): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L313)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L333)
 
 ### `build()`
 
@@ -356,7 +356,7 @@ PHPDoc:
 
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L345)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L365)
 
 ## `SuiteBuilder`
 

--- a/src/Config/GreenlightConfig.php
+++ b/src/Config/GreenlightConfig.php
@@ -90,9 +90,31 @@ final class GreenlightConfig
      */
     public function paths(array $tests): self
     {
+        $this->paths = $this->validatePaths($tests);
+
+        return $this;
+    }
+
+    /**
+     * @param array<mixed> $tests
+     *
+     * @return non-empty-list<non-empty-string>
+     *
+     * @throws InvalidConfiguration
+     */
+    private function validatePaths(array $tests): array
+    {
+        if (!\array_is_list($tests)) {
+            throw new InvalidConfiguration('Test paths must be a list.');
+        }
+
         $validated = [];
 
         foreach ($tests as $path) {
+            if (!\is_string($path)) {
+                throw new InvalidConfiguration('Test paths must contain only strings.');
+            }
+
             if ($path === '') {
                 throw new InvalidConfiguration('Test paths cannot be empty strings.');
             }
@@ -104,9 +126,7 @@ final class GreenlightConfig
             throw new InvalidConfiguration('paths() needs at least one directory.');
         }
 
-        $this->paths = $validated;
-
-        return $this;
+        return $validated;
     }
 
     /**

--- a/tests/Unit/Config/GreenlightConfigTest.php
+++ b/tests/Unit/Config/GreenlightConfigTest.php
@@ -257,28 +257,37 @@ final class GreenlightConfigTest
         Expect::that($callable)->toThrow(InvalidConfiguration::class);
     }
 
-    /**
-     * @param list<string> $paths
-     */
+    /** @param array<mixed> $paths */
     #[Test]
     #[DataSet('invalidPaths')]
     public function invalidPathsGiveExactGuidance(array $paths, string $message): void
     {
         Expect::that(static function () use ($paths): void {
-            GreenlightConfig::create()->paths($paths);
+            new \ReflectionMethod(GreenlightConfig::class, 'paths')
+                ->invoke(GreenlightConfig::create(), $paths);
         })
             ->because('each invalid path shape MUST identify the required fix')
             ->toThrow(InvalidConfiguration::class, message: $message);
     }
 
     /**
-     * @return iterable<string, array{list<string>, non-empty-string}>
+     * @return iterable<string, array{array<mixed>, non-empty-string}>
      */
     public static function invalidPaths(): iterable
     {
         yield 'no directories' => [
             [],
             'paths() needs at least one directory.',
+        ];
+
+        yield 'directories are not a list' => [
+            ['unit' => 'tests/Unit'],
+            'Test paths must be a list.',
+        ];
+
+        yield 'directory is not a string' => [
+            [42],
+            'Test paths must contain only strings.',
         ];
 
         yield 'empty directory' => [


### PR DESCRIPTION
Validate the runtime shape of GreenlightConfig::paths() while preserving its strong list<string> caller contract. Associative arrays and non-string entries now fail at the configuration boundary with exact guidance.