### PR TITLE
fix(discovery): reject object-shaped cache entries

### DIFF
--- a/src/Discovery/DiscoveryCacheEntry.php
+++ b/src/Discovery/DiscoveryCacheEntry.php
@@ -32,7 +32,14 @@ final readonly class DiscoveryCacheEntry implements \JsonSerializable
      */
     public static function fromDecoded(array $decoded): ?self
     {
-        if (!\is_int($decoded['mtime'] ?? null) || !\is_int($decoded['size'] ?? null) || !\is_array($decoded['entries'] ?? null)) {
+        $decodedEntries = $decoded['entries'] ?? null;
+
+        if (
+            !\is_int($decoded['mtime'] ?? null)
+            || !\is_int($decoded['size'] ?? null)
+            || !\is_array($decodedEntries)
+            || !\array_is_list($decodedEntries)
+        ) {
             return null;
         }
 
@@ -44,7 +51,7 @@ final readonly class DiscoveryCacheEntry implements \JsonSerializable
 
         $payloads = [];
 
-        foreach ($decoded['entries'] as $payload) {
+        foreach ($decodedEntries as $payload) {
             if (!\is_array($payload)) {
                 return null;
             }

--- a/tests/Unit/Discovery/DiscoveryCacheEntryTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheEntryTest.php
@@ -105,6 +105,10 @@ final class DiscoveryCacheEntryTest
 
         yield 'entry is not a map' => [[...$valid, 'entries' => ['not a map']]];
 
+        yield 'entries are not a list' => [[...$valid, 'entries' => [
+            'first' => ['class' => 'Example\\Test'],
+        ]]];
+
         yield 'entry key is not a string' => [[...$valid, 'entries' => [[0 => 'value']]]];
 
         yield 'dependencies are not a map' => [[...$valid, 'dependencies' => 'not a map']];


### PR DESCRIPTION
## Summary

- enforce the documented list shape for cached discovery entries
- treat object-shaped cache data as a cache miss instead of silently reindexing it
- cover the malformed boundary shape in the cache-entry contract tests