### PR TITLE
fix(cli): reject object-shaped failed state

### DIFF
--- a/src/Cli/RunState.php
+++ b/src/Cli/RunState.php
@@ -44,14 +44,15 @@ final readonly class RunState
     public function failedTests(): ?array
     {
         $decoded = $this->decoded();
+        $failed = $decoded['failed'] ?? null;
 
-        if ($decoded === null || !\is_array($decoded['failed'] ?? null)) {
+        if (!\is_array($failed) || !\array_is_list($failed)) {
             return null;
         }
 
         $ids = [];
 
-        foreach ($decoded['failed'] as $id) {
+        foreach ($failed as $id) {
             if (\is_string($id) && $id !== '') {
                 $ids[] = $id;
             }

--- a/tests/Unit/Cli/RunStateTest.php
+++ b/tests/Unit/Cli/RunStateTest.php
@@ -75,6 +75,9 @@ final readonly class RunStateTest
 
         \file_put_contents($file, '{"failed": "not a list"}');
         Expect::that(RunState::forFile($file)->failedTests())->because('corrupt state reads as absent')->toBeNull();
+
+        \file_put_contents($file, '{"failed": {"first": "Acme\\\\AlphaTest::one"}}');
+        Expect::that(RunState::forFile($file)->failedTests())->because('object-shaped state reads as absent')->toBeNull();
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- enforce the persisted list shape for previous-run failure IDs
- treat object-shaped `failed` state as unusable instead of silently reindexing it
- prevent corrupted state from changing the test selection used by `--failed`