### PR TITLE
fix(config): reject null bytes in wire directories

### DIFF
--- a/src/Config/ArtifactConfiguration.php
+++ b/src/Config/ArtifactConfiguration.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Config;
 
+use Greenlight\Core\Wire\InvalidWirePayload;
 use Greenlight\Core\Wire\Wire;
 use Greenlight\Core\Wire\WireSerializable;
 
@@ -58,8 +59,18 @@ final readonly class ArtifactConfiguration implements WireSerializable
     #[\Override]
     public static function fromWire(array $payload): static
     {
+        $directory = Wire::nonEmptyString($payload, 'directory');
+
+        if (\str_contains($directory, "\0")) {
+            throw InvalidWirePayload::wrongType(
+                'directory',
+                'an artifact directory without null bytes',
+                $directory,
+            );
+        }
+
         return new self(
-            Wire::nonEmptyString($payload, 'directory'),
+            $directory,
             \max(1, Wire::int($payload, 'maxAttachmentsPerTest')),
             \max(1, Wire::int($payload, 'maxAttachmentBytes')),
             \max(1, Wire::int($payload, 'maxTestBytes')),

--- a/tests/Unit/Config/ArtifactConfigurationWireTest.php
+++ b/tests/Unit/Config/ArtifactConfigurationWireTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Unit\Config;
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\Wire\InvalidWirePayload;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Support\JsonWire;
 
@@ -31,6 +32,20 @@ final class ArtifactConfigurationWireTest
         Expect::that($restored)
             ->because('workers MUST receive every configured artifact safety limit')
             ->toEqual($configuration);
+    }
+
+    #[Test]
+    public function nullByteDirectoriesAreRejectedAtTheWireBoundary(): void
+    {
+        $payload = new ArtifactConfiguration()->toWire();
+        $payload['directory'] = "artifacts\0hidden";
+
+        Expect::that(static fn(): ArtifactConfiguration => ArtifactConfiguration::fromWire($payload))
+            ->because('artifact directories MUST remain valid file-system paths across the worker wire')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "directory" must be an artifact directory without null bytes, got string.',
+            );
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- reject null bytes while decoding artifact directories from worker payloads
- report malformed directories as protocol errors before filesystem use
- cover the wire boundary with an exact diagnostic contract