### PR TITLE
fix(artifacts): reject null bytes in session paths

### DIFF
--- a/src/Runner/Artifact/ArtifactSession.php
+++ b/src/Runner/Artifact/ArtifactSession.php
@@ -31,16 +31,8 @@ final readonly class ArtifactSession implements WireSerializable
         string $stagingDirectory,
         string $publicDirectory,
     ) {
-        if ($stagingDirectory === '') {
-            throw new \InvalidArgumentException('Artifact staging directory must not be empty.');
-        }
-
-        if ($publicDirectory === '') {
-            throw new \InvalidArgumentException('Artifact public directory must not be empty.');
-        }
-
-        $this->stagingDirectory = $stagingDirectory;
-        $this->publicDirectory = $publicDirectory;
+        $this->stagingDirectory = $this->validatedDirectory($stagingDirectory, 'staging');
+        $this->publicDirectory = $this->validatedDirectory($publicDirectory, 'public');
     }
 
     #[\Override]
@@ -59,5 +51,23 @@ final readonly class ArtifactSession implements WireSerializable
             Wire::nonEmptyString($payload, 'stagingDirectory'),
             Wire::nonEmptyString($payload, 'publicDirectory'),
         );
+    }
+
+    /**
+     * @param 'public'|'staging' $role
+     *
+     * @return non-empty-string
+     */
+    private function validatedDirectory(string $directory, string $role): string
+    {
+        if ($directory === '') {
+            throw new \InvalidArgumentException(\sprintf('Artifact %s directory must not be empty.', $role));
+        }
+
+        if (\str_contains($directory, "\0")) {
+            throw new \InvalidArgumentException(\sprintf('Artifact %s directory must not contain a null byte.', $role));
+        }
+
+        return $directory;
     }
 }

--- a/tests/Unit/Artifact/ArtifactSessionTest.php
+++ b/tests/Unit/Artifact/ArtifactSessionTest.php
@@ -49,6 +49,37 @@ final readonly class ArtifactSessionTest
             ->toThrow(\InvalidArgumentException::class, message: $message);
     }
 
+    #[Test]
+    #[DataSet('nullByteDirectories')]
+    public function artifactSessionsRejectNullByteDirectories(
+        string $field,
+        string $value,
+        string $message,
+    ): void {
+        Expect::that(static fn(): ArtifactSession => new ArtifactSession(
+            $field === 'stagingDirectory' ? $value : '/project/.greenlight/staging/run-1',
+            $field === 'publicDirectory' ? $value : '/project/build/artifacts/run-1',
+        ))
+            ->because('artifact session directories MUST be valid file-system paths')
+            ->toThrow(\InvalidArgumentException::class, message: $message);
+    }
+
+    #[Test]
+    #[DataSet('nullByteDirectories')]
+    public function artifactSessionWireRejectsNullByteDirectories(
+        string $field,
+        string $value,
+        string $message,
+    ): void {
+        $payload = new ArtifactSession('/project/.greenlight/staging/run-1', '/project/build/artifacts/run-1')
+            ->toWire();
+        $payload[$field] = $value;
+
+        Expect::that(static fn(): ArtifactSession => ArtifactSession::fromWire($payload))
+            ->because('artifact session directories MUST remain valid file-system paths across the worker wire')
+            ->toThrow(\InvalidArgumentException::class, message: $message);
+    }
+
     /**
      * @return iterable<string, array{string, string, string}>
      */
@@ -63,6 +94,23 @@ final readonly class ArtifactSessionTest
             '/project/.greenlight/staging/run-1',
             '',
             'Artifact public directory must not be empty.',
+        ];
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string, non-empty-string, non-empty-string}>
+     */
+    public static function nullByteDirectories(): iterable
+    {
+        yield 'staging directory' => [
+            'stagingDirectory',
+            "/project/.greenlight/staging\0hidden",
+            'Artifact staging directory must not contain a null byte.',
+        ];
+        yield 'public directory' => [
+            'publicDirectory',
+            "/project/build/artifacts\0hidden",
+            'Artifact public directory must not contain a null byte.',
         ];
     }
 


### PR DESCRIPTION
## Summary

- centralize artifact-session directory validation in one constructor seam
- reject null bytes in staging and public paths before worker filesystem operations
- reuse one invalid-path matrix across direct-construction and wire-decoding contracts