### PR TITLE
test(coverage): remove duplicate line validation

### DIFF
--- a/tests/Unit/Coverage/FileCoverageTest.php
+++ b/tests/Unit/Coverage/FileCoverageTest.php
@@ -93,14 +93,4 @@ final class FileCoverageTest
         Expect::that(static fn(): FileCoverage => $a->merge($b))->because('merging different files is rejected')
             ->toThrow(\LogicException::class, '/Cannot merge coverage of "\/src\/B\.php"/');
     }
-
-    #[Test]
-    public function nonPositiveLineNumbersAreRejected(): void
-    {
-        Expect::that(static fn(): FileCoverage => new FileCoverage('/src/A.php', [0], []))->because('nonpositive line numbers are rejected')
-            ->toThrow(
-                \InvalidArgumentException::class,
-                message: 'Use positive coverage line numbers. Actual value: 0.',
-            );
-    }
 }


### PR DESCRIPTION
## Summary

- remove the duplicate zero-covered-line constructor oracle from the general FileCoverage tests
- retain the identical case in the dedicated four-row line-validation matrix
- preserve positive, negative, covered, and uncovered line-number coverage with less suite noise