### PR TITLE
fix(runner): parse channel environment strictly

### DIFF
--- a/src/Runner/ChannelEnvironment.php
+++ b/src/Runner/ChannelEnvironment.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Runner;
+
+use Greenlight\Core\DecimalInteger;
+
+/**
+ * Parses the worker channel from its environment value.
+ *
+ * @internal
+ */
+final class ChannelEnvironment
+{
+    /** @codeCoverageIgnore */
+    private function __construct() {}
+
+    /**
+     * @return positive-int|null
+     */
+    public static function parse(string|false $raw): ?int
+    {
+        if (!\is_string($raw)) {
+            return null;
+        }
+
+        $channel = DecimalInteger::parse($raw);
+
+        return $channel !== null && $channel > 0 ? $channel : null;
+    }
+}

--- a/src/Runner/DefaultServices.php
+++ b/src/Runner/DefaultServices.php
@@ -39,11 +39,11 @@ final class DefaultServices
             new ServiceDefinition(TempDirectory::class, Scope::PerTest, static fn(): TempDirectory => new TempDirectory()),
             new ServiceDefinition(EnvironmentSandbox::class, Scope::PerTest, static fn(): EnvironmentSandbox => new EnvironmentSandbox()),
             new ServiceDefinition(IntegrationResources::class, Scope::PerRun, static fn(): IntegrationResources => $integrationResources),
-            new ServiceDefinition(TestChannel::class, Scope::PerRun, static function (): TestChannel {
-                $raw = \getenv('GREENLIGHT_CHANNEL');
-
-                return new TestChannel(\max(1, \is_string($raw) ? (int) $raw : 1));
-            }),
+            new ServiceDefinition(
+                TestChannel::class,
+                Scope::PerRun,
+                static fn(): TestChannel => new TestChannel(ChannelEnvironment::parse(\getenv('GREENLIGHT_CHANNEL')) ?? 1),
+            ),
         ]);
 
         foreach ($plugins->harnessServices() as $definition) {

--- a/src/Runner/Worker/WorkerProcess.php
+++ b/src/Runner/Worker/WorkerProcess.php
@@ -17,6 +17,7 @@ use Greenlight\Plugin\PluginRegistry;
 use Greenlight\Plugin\WorkerBootstrapContext;
 use Greenlight\Runner\Artifact\ArtifactSession;
 use Greenlight\Runner\Artifact\ArtifactStore;
+use Greenlight\Runner\ChannelEnvironment;
 use Greenlight\Runner\CoverageCollector;
 use Greenlight\Runner\CoverageSettings;
 use Greenlight\Runner\DefaultServices;
@@ -111,9 +112,7 @@ final readonly class WorkerProcess
                         throw ProtocolError::duplicateBootstrap();
                     }
 
-                    $rawChannel = \getenv('GREENLIGHT_CHANNEL');
-
-                    if (!\is_string($rawChannel) || (int) $rawChannel !== $message->channel) {
+                    if (ChannelEnvironment::parse(\getenv('GREENLIGHT_CHANNEL')) !== $message->channel) {
                         throw ProtocolError::bootstrapChannelMismatch();
                     }
 

--- a/tests/Unit/Runner/DefaultServicesTest.php
+++ b/tests/Unit/Runner/DefaultServicesTest.php
@@ -56,6 +56,8 @@ final readonly class DefaultServicesTest
         yield 'zero' => ['0', 1];
         yield 'negative' => ['-2', 1];
         yield 'not numeric' => ['worker', 1];
+        yield 'numeric prefix' => ['3workers', 1];
+        yield 'integer overflow' => [\str_repeat('9', 30), 1];
         yield 'positive' => ['3', 3];
     }
 }

--- a/tests/Unit/Runner/Worker/WorkerProcessTest.php
+++ b/tests/Unit/Runner/Worker/WorkerProcessTest.php
@@ -128,6 +128,20 @@ final readonly class WorkerProcessTest
 
     #[Test]
     #[Timeout(5.0)]
+    public function bootstrapRejectsATruncatedChannelEnvironmentValue(): void
+    {
+        [$workerExit, $serverExit] = $this->runScenario('bootstrap-channel-mismatch', '1worker');
+
+        Expect::that($workerExit)
+            ->because('a malformed channel environment value MUST fail worker bootstrap')
+            ->toBe(1);
+        Expect::that($serverExit)
+            ->because('the protocol fixture MUST receive the channel mismatch diagnostic')
+            ->toBe(0);
+    }
+
+    #[Test]
+    #[Timeout(5.0)]
     public function itKeepsPollingAfterAnIdleReceiveTimesOut(): void
     {
         [$workerExit, $serverExit] = $this->runScenario('idle-then-drain');
@@ -218,7 +232,7 @@ final readonly class WorkerProcessTest
     /**
      * @return array{int, int}
      */
-    private function runScenario(string $scenario): array
+    private function runScenario(string $scenario, string $environmentChannel = '1'): array
     {
         $root = \dirname(__DIR__, 4);
         $server = Subprocess::start($root, [
@@ -263,7 +277,19 @@ final readonly class WorkerProcessTest
                 Greenlight\Harness\IntegrationResources::empty(),
             ));
 
-            if (!$channel->receive(2.0) instanceof Greenlight\Runner\Protocol\Messages\Ready) {
+            $bootstrapResponse = $channel->receive(2.0);
+
+            if ($scenario === 'bootstrap-channel-mismatch') {
+                if (!$bootstrapResponse instanceof Greenlight\Runner\Protocol\Messages\Fatal
+                    || $bootstrapResponse->detail->message !== 'Worker bootstrap channel does not match GREENLIGHT_CHANNEL.'
+                ) {
+                    exit(5);
+                }
+
+                exit(0);
+            }
+
+            if (!$bootstrapResponse instanceof Greenlight\Runner\Protocol\Messages\Ready) {
                 exit(5);
             }
 
@@ -381,7 +407,7 @@ final readonly class WorkerProcessTest
                 Fail::because('Worker protocol server did not publish its address.');
             }
 
-            $this->environment->set('GREENLIGHT_CHANNEL', '1');
+            $this->environment->set('GREENLIGHT_CHANNEL', $environmentChannel);
             $workerExit = new WorkerProcess(0.01)->run($address, 'worker-under-test', 'token');
             $serverResult = $server->wait(2.0);
 


### PR DESCRIPTION
## Summary

- parse `GREENLIGHT_CHANNEL` through one overflow-safe decimal boundary
- reject truncated and overflow values during worker bootstrap
- keep the default channel fallback at one for malformed environment values