### PR TITLE
fix(artifact): reject overflowing quota metadata

### DIFF
--- a/src/Runner/Artifact/ArtifactStore.php
+++ b/src/Runner/Artifact/ArtifactStore.php
@@ -9,6 +9,7 @@ use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Core\Artifact\AttachmentKind;
 use Greenlight\Core\Artifact\AttachmentRetention;
 use Greenlight\Core\Artifact\StagedAttachment;
+use Greenlight\Core\DecimalInteger;
 use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Core\Test\TestId;
@@ -603,7 +604,14 @@ final class ArtifactStore
             }
 
             $parts = \preg_split('/\s+/', $raw === '' ? '0 0' : $raw);
-            [$count, $bytes] = $update((int) ($parts[0] ?? 0), (int) ($parts[1] ?? 0));
+            $count = DecimalInteger::parse($parts[0] ?? '');
+            $bytes = DecimalInteger::parse($parts[1] ?? '');
+
+            if ($count === null || $bytes === null) {
+                throw AttachmentError::storage('Attachment quota metadata is corrupt');
+            }
+
+            [$count, $bytes] = $update($count, $bytes);
             \rewind($stream);
             $encoded = \sprintf('%020d %020d' . "\n", $count, $bytes);
 

--- a/tests/Unit/Artifact/ArtifactQuotaTest.php
+++ b/tests/Unit/Artifact/ArtifactQuotaTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Artifact;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Artifact\AttachmentError;
@@ -51,12 +52,13 @@ final readonly class ArtifactQuotaTest
     }
 
     #[Test]
-    public function corruptRunQuotaMetadataFailsBeforeStaging(): void
+    #[DataSet('invalidQuotaMetadata')]
+    public function corruptRunQuotaMetadataFailsBeforeStaging(string $metadata): void
     {
         $root = $this->tempDirectory->subdirectory('corrupt-run-quota');
         $staging = $root . '/staging';
         \mkdir($staging);
-        \file_put_contents($staging . '/.quota', 'not quota metadata');
+        \file_put_contents($staging . '/.quota', $metadata);
         $store = ArtifactStore::fromSession(
             new ArtifactSession($staging, $root . '/published/run-1'),
             new ArtifactConfiguration($root . '/published'),
@@ -78,5 +80,15 @@ final readonly class ArtifactQuotaTest
         Expect::that(\glob($staging . '/*/attempt-*'))
             ->because('a rejected quota reservation MUST NOT leave staging data')
             ->toBe([]);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function invalidQuotaMetadata(): iterable
+    {
+        yield 'invalid syntax' => ['not quota metadata'];
+        yield 'attachment count overflows an integer' => [\str_repeat('9', 30) . ' 0'];
+        yield 'byte count overflows an integer' => ['0 ' . \str_repeat('9', 30)];
     }
 }


### PR DESCRIPTION
## Summary

- parse persisted artifact quota counters without integer overflow
- classify overflowing counters as corrupt metadata before quota arithmetic
- reuse one data-driven corruption contract for syntax, attachment-count, and byte-count failures