### PR TITLE
fix(cli): parse terminal rows strictly

### DIFF
--- a/src/Cli/TerminalRowsResolver.php
+++ b/src/Cli/TerminalRowsResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Cli;
 
+use Greenlight\Core\DecimalInteger;
 use Greenlight\Core\ErrorTrap;
 
 /**
@@ -18,15 +19,28 @@ final class TerminalRowsResolver
 
     public static function resolve(): int
     {
-        $linesEnv = \getenv('LINES');
-        $lines = $linesEnv === false || $linesEnv === '' ? 0 : (int) $linesEnv;
+        $lines = self::positiveRows(\getenv('LINES'));
 
-        if ($lines > 0) {
+        if ($lines !== null) {
             return $lines;
         }
 
-        $probed = (int) ErrorTrap::run(static fn(): string|false => \exec('tput lines 2>/dev/null'));
+        $probed = ErrorTrap::run(static fn(): string|false => \exec('tput lines 2>/dev/null'));
 
-        return $probed > 0 ? $probed : 24;
+        return self::positiveRows($probed) ?? 24;
+    }
+
+    /**
+     * @return positive-int|null
+     */
+    private static function positiveRows(string|false $raw): ?int
+    {
+        if (!\is_string($raw)) {
+            return null;
+        }
+
+        $rows = DecimalInteger::parse($raw);
+
+        return $rows !== null && $rows > 0 ? $rows : null;
     }
 }

--- a/tests/Unit/Cli/ApplicationTerminalRowsFallbackTest.php
+++ b/tests/Unit/Cli/ApplicationTerminalRowsFallbackTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Cli;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Cli\TerminalRowsResolver;
 use Greenlight\Expect\Expect;
@@ -43,6 +44,38 @@ final readonly class ApplicationTerminalRowsFallbackTest
         Expect::that($rows)
             ->because('the reporter MUST use 24 rows when terminal height detection fails')
             ->toBe(24);
+    }
+
+    #[Test]
+    #[DataSet('malformedRowSources')]
+    public function malformedRowSourcesUseTheDefault(string|false $lines, ?string $probeOutput): void
+    {
+        if ($lines === false) {
+            $this->environment->unset('LINES');
+        } else {
+            $this->environment->set('LINES', $lines);
+        }
+
+        $this->environment->set('PATH', $this->temporaryDirectory->path());
+
+        if ($probeOutput !== null) {
+            $this->installTput($probeOutput);
+        }
+
+        Expect::that(TerminalRowsResolver::resolve())
+            ->because('malformed terminal row text MUST NOT set the reporter height')
+            ->toBe(24);
+    }
+
+    /**
+     * @return iterable<string, array{string|false, string|null}>
+     */
+    public static function malformedRowSources(): iterable
+    {
+        yield 'LINES numeric prefix' => ['31rows', null];
+        yield 'LINES integer overflow' => [\str_repeat('9', 30), null];
+        yield 'terminal probe numeric prefix' => [false, "31rows\n"];
+        yield 'terminal probe integer overflow' => [false, \str_repeat('9', 30) . "\n"];
     }
 
     private function installTput(string $output): void


### PR DESCRIPTION
## Summary

- parse `LINES` and terminal probe output as overflow-safe positive decimals
- ignore numeric prefixes and overflowing values instead of truncating them
- reuse one data-driven fallback contract across both terminal-row sources