### PR TITLE
fix(runner): parse Darwin CPU count strictly

### DIFF
--- a/src/Runner/CpuCores.php
+++ b/src/Runner/CpuCores.php
@@ -7,6 +7,7 @@ namespace Greenlight\Runner;
 use Fidry\CpuCoreCounter\CpuCoreCounter;
 use Fidry\CpuCoreCounter\NumberOfCpuCoreNotFound;
 use Greenlight\Attribute\CoverageIgnore;
+use Greenlight\Core\DecimalInteger;
 use Greenlight\Core\ErrorTrap;
 
 /**
@@ -62,8 +63,12 @@ final class CpuCores
         if (\PHP_OS_FAMILY === 'Darwin' && \function_exists('shell_exec')) {
             $output = ErrorTrap::run(static fn(): string|false|null => \shell_exec('sysctl -n hw.logicalcpu 2>/dev/null'));
 
-            if (\is_string($output) && (int) \trim($output) > 0) {
-                return \max(1, (int) \trim($output));
+            if (\is_string($output)) {
+                $count = DecimalInteger::parse(\trim($output));
+
+                if ($count !== null && $count > 0) {
+                    return $count;
+                }
             }
         }
 

--- a/tests/Unit/Runner/CpuCoresTest.php
+++ b/tests/Unit/Runner/CpuCoresTest.php
@@ -6,17 +6,24 @@ namespace Greenlight\Tests\Unit\Runner;
 
 use Fidry\CpuCoreCounter\CpuCoreCounter;
 use Fidry\CpuCoreCounter\NumberOfCpuCoreNotFound;
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Isolated;
+use Greenlight\Attribute\SkipUnless;
 use Greenlight\Attribute\Test;
+use Greenlight\Condition\OperatingSystemFamily;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
+use Greenlight\Fixture\TempDirectory;
 use Greenlight\Runner\CpuCores;
 use Greenlight\Tests\Fixture\Runner\FakeCpuCoreCounter;
 use Greenlight\Tests\Fixture\Runner\FakeNumberOfCpuCoreNotFound;
+use Greenlight\Tests\Support\ProcessResult;
 use Greenlight\Tests\Support\Subprocess;
 
-final class CpuCoresTest
+final readonly class CpuCoresTest
 {
+    public function __construct(private TempDirectory $tempDirectory) {}
+
     #[Test]
     #[Isolated]
     public function countUsesTheOptionalCpuCounterWhenItIsAvailable(): void
@@ -48,8 +55,71 @@ final class CpuCoresTest
     #[Test]
     public function countUsesTheBuiltInProbeWithoutTheOptionalPackage(): void
     {
+        $result = $this->runBuiltInProbe();
+
+        Expect::that($result->exitCode)
+            ->because('the built-in CPU probe runs without the optional package')
+            ->toBe(0);
+        Expect::that($result->stdout)
+            ->because('the built-in CPU probe returns a positive integer')
+            ->toMatch('/^[1-9]\d*$/D');
+    }
+
+    #[Test]
+    #[SkipUnless(OperatingSystemFamily::class, 'Darwin')]
+    #[DataSet('malformedDarwinProbeOutputs')]
+    public function malformedDarwinProbeOutputUsesTheConservativeDefault(string $output): void
+    {
+        $bin = $this->tempDirectory->subdirectory('darwin-cpu-probe');
+        $sysctl = $bin . '/sysctl';
+        $written = \file_put_contents(
+            $sysctl,
+            "#!/bin/sh\nprintf '%s\\n' " . \escapeshellarg($output) . "\n",
+        );
+
+        if ($written === false || !\chmod($sysctl, 0o700)) {
+            Fail::because('The test could not install its CPU probe.');
+        }
+
+        $result = $this->runBuiltInProbe(['PATH' => $bin]);
+
+        Expect::that($result->exitCode)
+            ->because('the built-in CPU probe MUST complete for malformed system output')
+            ->toBe(0);
+        Expect::that($result->stdout)
+            ->because('malformed system output MUST use the conservative CPU count')
+            ->toBe('4');
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function malformedDarwinProbeOutputs(): iterable
+    {
+        yield 'numeric prefix' => ['8cores'];
+        yield 'integer overflow' => [\str_repeat('9', 30)];
+    }
+
+    private function installFakeOptionalCounter(bool $notFound): void
+    {
+        if (\class_exists(CpuCoreCounter::class, false) || \class_exists(NumberOfCpuCoreNotFound::class, false)) {
+            Fail::because('Expected an isolated worker without loaded optional CPU counter classes.');
+        }
+
+        \class_alias(FakeNumberOfCpuCoreNotFound::class, NumberOfCpuCoreNotFound::class);
+        \class_alias(FakeCpuCoreCounter::class, CpuCoreCounter::class);
+        FakeCpuCoreCounter::$notFound = $notFound;
+        FakeCpuCoreCounter::$calls = 0;
+    }
+
+    /**
+     * @param array<string, string> $environment
+     */
+    private function runBuiltInProbe(array $environment = []): ProcessResult
+    {
         $root = \dirname(__DIR__, 3);
-        $result = Subprocess::run($root, [
+
+        return Subprocess::run($root, [
             \PHP_BINARY,
             '-n',
             '-r',
@@ -77,25 +147,6 @@ final class CpuCoresTest
             echo \Greenlight\Runner\CpuCores::count();
             PHP,
             $root . '/src',
-        ]);
-
-        Expect::that($result->exitCode)
-            ->because('the built-in CPU probe runs without the optional package')
-            ->toBe(0);
-        Expect::that($result->stdout)
-            ->because('the built-in CPU probe returns a positive integer')
-            ->toMatch('/^[1-9]\d*$/D');
-    }
-
-    private function installFakeOptionalCounter(bool $notFound): void
-    {
-        if (\class_exists(CpuCoreCounter::class, false) || \class_exists(NumberOfCpuCoreNotFound::class, false)) {
-            Fail::because('Expected an isolated worker without loaded optional CPU counter classes.');
-        }
-
-        \class_alias(FakeNumberOfCpuCoreNotFound::class, NumberOfCpuCoreNotFound::class);
-        \class_alias(FakeCpuCoreCounter::class, CpuCoreCounter::class);
-        FakeCpuCoreCounter::$notFound = $notFound;
-        FakeCpuCoreCounter::$calls = 0;
+        ], $environment);
     }
 }


### PR DESCRIPTION
## Summary

- parse Darwin logical CPU probe output as an overflow-safe positive decimal
- fall back conservatively for numeric prefixes and overflowing values
- reuse the no-dependency subprocess fixture across normal and malformed probe cases