### PR TITLE
test(support): normalize subprocess output lines

### DIFF
--- a/tests/Support/JsonlEvents.php
+++ b/tests/Support/JsonlEvents.php
@@ -24,14 +24,10 @@ final class JsonlEvents
      */
     public static function from(ProcessResult $result): array
     {
-        if ($result->stdout === '') {
+        $lines = $result->stdoutLines();
+
+        if ($lines === []) {
             return [];
-        }
-
-        $lines = \explode("\n", $result->stdout);
-
-        if ($lines[\array_key_last($lines)] === '') {
-            \array_pop($lines);
         }
 
         $events = [];

--- a/tests/Support/ProcessResult.php
+++ b/tests/Support/ProcessResult.php
@@ -50,6 +50,16 @@ final readonly class ProcessResult
      */
     private function lines(string $output): array
     {
-        return $output === '' ? [] : \explode("\n", $output);
+        if ($output === '') {
+            return [];
+        }
+
+        $lines = \explode("\n", $output);
+
+        if ($lines[\array_key_last($lines)] === '') {
+            \array_pop($lines);
+        }
+
+        return $lines;
     }
 }

--- a/tests/Unit/Support/ProcessResultTest.php
+++ b/tests/Unit/Support/ProcessResultTest.php
@@ -37,4 +37,20 @@ final class ProcessResultTest
         Expect::that($empty->output())->toBe('');
         Expect::that($empty->outputLines())->toBe([]);
     }
+
+    #[Test]
+    public function lineListsRemoveOneFinalTerminatorAndPreserveBlankContent(): void
+    {
+        $terminated = new ProcessResult(0, "first\nsecond\n", "warning\n");
+        $blankFinalLine = new ProcessResult(0, "first\n\n", '');
+
+        Expect::that($terminated->stdoutLines())
+            ->because('a final line terminator MUST NOT create a phantom output line')
+            ->toBe(['first', 'second']);
+        Expect::that($terminated->outputLines())
+            ->toBe(['first', 'second', 'warning']);
+        Expect::that($blankFinalLine->stdoutLines())
+            ->because('line normalization MUST preserve intentional blank content')
+            ->toBe(['first', '']);
+    }
 }


### PR DESCRIPTION
## Summary

- remove one final line terminator from reusable subprocess line lists
- preserve intentional blank output lines
- route JSONL event parsing through the shared line-normalization seam