### PR TITLE
refactor(artifact): centralize media type validation

### DIFF
--- a/docs/api-artifacts.md
+++ b/docs/api-artifacts.md
@@ -106,7 +106,7 @@ public function __construct(
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachment.php#L43)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachment.php#L39)
 
 ### `fromWire()`
 
@@ -115,7 +115,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachment.php#L58)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Artifact/Attachment.php#L54)
 
 ## `AttachmentError`
 

--- a/src/Core/Artifact/Attachment.php
+++ b/src/Core/Artifact/Attachment.php
@@ -25,11 +25,7 @@ readonly class Attachment implements WireSerializable
         public AttachmentRetention $retention = AttachmentRetention::OnFailure,
     ) {
         if ($name === ''
-            || \preg_match('/[\x00-\x1F\x7F]/', $mediaType) === 1
-            || \preg_match(
-                '~^[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*/[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*(?:\s*;\s*[^=\s]+=(?:"[^"]*"|[^;\s]+))*$~',
-                $mediaType,
-            ) !== 1
+            || !AttachmentMediaType::isValid($mediaType)
             || $sizeBytes < 0
             || \preg_match('/^[0-9a-f]{64}$/', $sha256) !== 1
             || $attempt < 1

--- a/src/Core/Artifact/AttachmentMediaType.php
+++ b/src/Core/Artifact/AttachmentMediaType.php
@@ -9,7 +9,7 @@ namespace Greenlight\Core\Artifact;
  *
  * @internal
  */
-final class AttachmentMediaType
+final readonly class AttachmentMediaType
 {
     private const string PATTERN = '~^[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*/[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*(?:\s*;\s*[^=\s]+=(?:"[^"]*"|[^;\s]+))*$~';
 

--- a/src/Core/Artifact/AttachmentMediaType.php
+++ b/src/Core/Artifact/AttachmentMediaType.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Core\Artifact;
+
+/**
+ * Validates media types for test attachments.
+ *
+ * @internal
+ */
+final class AttachmentMediaType
+{
+    private const string PATTERN = '~^[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*/[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*(?:\s*;\s*[^=\s]+=(?:"[^"]*"|[^;\s]+))*$~';
+
+    /** @codeCoverageIgnore */
+    private function __construct() {}
+
+    public static function isValid(string $mediaType): bool
+    {
+        return \preg_match('/[\x00-\x1F\x7F]/', $mediaType) !== 1
+            && \preg_match(self::PATTERN, $mediaType) === 1;
+    }
+}

--- a/src/Runner/Artifact/StagedAttachments.php
+++ b/src/Runner/Artifact/StagedAttachments.php
@@ -7,6 +7,7 @@ namespace Greenlight\Runner\Artifact;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Core\Artifact\AttachmentKind;
+use Greenlight\Core\Artifact\AttachmentMediaType;
 use Greenlight\Core\Artifact\AttachmentRetention;
 use Greenlight\Core\Artifact\Attachments;
 use Greenlight\Core\Artifact\StagedAttachment;
@@ -231,12 +232,7 @@ final class StagedAttachments implements Attachments
             throw AttachmentError::invalidName($name);
         }
 
-        if (\preg_match('/[\x00-\x1F\x7F]/', $mediaType) === 1
-            || \preg_match(
-                '~^[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*/[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*(?:\s*;\s*[^=\s]+=(?:"[^"]*"|[^;\s]+))*$~',
-                $mediaType,
-            ) !== 1
-        ) {
+        if (!AttachmentMediaType::isValid($mediaType)) {
             throw AttachmentError::invalidMediaType($mediaType);
         }
     }


### PR DESCRIPTION
## Summary

- define the attachment media-type language in one domain validator
- reuse it for retained attachment construction and staged writes
- preserve each boundary’s existing diagnostics and validation behavior