### PR TITLE
fix(runner): saturate worker spawn budget

### DIFF
--- a/src/Runner/Orchestrator/WorkerSpawnBudget.php
+++ b/src/Runner/Orchestrator/WorkerSpawnBudget.php
@@ -25,7 +25,10 @@ final class WorkerSpawnBudget
     {
         // Worker replacement and crash containment can start replacement
         // processes. Permit only a small number for each planned test.
-        $this->limit = $plannedTests + $workerCount * 8 + 16;
+        $remaining = \PHP_INT_MAX - $plannedTests;
+        $this->limit = $remaining < 16 || $workerCount > \intdiv($remaining - 16, 8)
+            ? \PHP_INT_MAX
+            : $plannedTests + $workerCount * 8 + 16;
     }
 
     /**

--- a/tests/Unit/Runner/Orchestrator/WorkerSpawnBudgetTest.php
+++ b/tests/Unit/Runner/Orchestrator/WorkerSpawnBudgetTest.php
@@ -37,4 +37,14 @@ final readonly class WorkerSpawnBudgetTest
                     . 'This count indicates a worker replacement loop.',
             );
     }
+
+    #[Test]
+    public function extremeWorkerCountsKeepTheReplacementBudgetBounded(): void
+    {
+        $budget = new WorkerSpawnBudget(plannedTests: 1, workerCount: \PHP_INT_MAX);
+
+        Expect::that($budget->nextWorkerId())
+            ->because('the replacement budget MUST remain usable for every accepted worker count')
+            ->toBe('w-1');
+    }
 }


### PR DESCRIPTION
Prevent accepted extreme worker counts from overflowing the replacement-budget formula into a float. Saturate unrepresentable totals at the platform integer maximum while preserving the existing budget for ordinary execution plans. Add a regression that proves worker IDs remain available at the accepted integer boundary.