### PR TITLE
fix(cli): resolve Windows absolute paths

### DIFF
--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -21,6 +21,7 @@ use Greenlight\Core\AtomicFile;
 use Greenlight\Core\AtomicFileError;
 use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Event\EventTags;
+use Greenlight\Core\FilePath;
 use Greenlight\Core\GracefulShutdown;
 use Greenlight\Core\Wire\InvalidWirePayload;
 use Greenlight\Core\Wire\Wire;
@@ -1369,10 +1370,6 @@ final readonly class Application
 
     private function absolutePath(string $path, string $workingDirectory): string
     {
-        if (\str_starts_with($path, '/')) {
-            return $path;
-        }
-
-        return \rtrim($workingDirectory, '/') . '/' . $path;
+        return FilePath::resolve($path, $workingDirectory);
     }
 }

--- a/src/Cli/CoverageSettingsResolver.php
+++ b/src/Cli/CoverageSettingsResolver.php
@@ -6,6 +6,7 @@ namespace Greenlight\Cli;
 
 use Greenlight\Config\CoverageConfiguration;
 use Greenlight\Core\ErrorTrap;
+use Greenlight\Core\FilePath;
 use Greenlight\Runner\CoverageSettings;
 
 /** Resolves CLI coverage configuration into runner settings.
@@ -17,8 +18,11 @@ final class CoverageSettingsResolver
     /** @codeCoverageIgnore */
     private function __construct() {}
 
-    public static function resolve(?CoverageConfiguration $configuration, string $workingDirectory): ?CoverageSettings
-    {
+    public static function resolve(
+        ?CoverageConfiguration $configuration,
+        string $workingDirectory,
+        string $directorySeparator = \DIRECTORY_SEPARATOR,
+    ): ?CoverageSettings {
         if (!$configuration instanceof CoverageConfiguration) {
             return null;
         }
@@ -26,9 +30,7 @@ final class CoverageSettingsResolver
         $include = [];
 
         foreach ($configuration->includePaths as $path) {
-            $absolute = \str_starts_with($path, '/')
-                ? $path
-                : \rtrim($workingDirectory, '/') . '/' . $path;
+            $absolute = FilePath::resolve($path, $workingDirectory, $directorySeparator);
             $real = ErrorTrap::run(static fn() => \realpath($absolute));
 
             if ($real !== false) {

--- a/src/Core/FilePath.php
+++ b/src/Core/FilePath.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Core;
+
+/**
+ * Identifies absolute POSIX and Windows file-system paths.
+ *
+ * @internal
+ */
+final class FilePath
+{
+    /** @codeCoverageIgnore */
+    private function __construct() {}
+
+    public static function resolve(
+        string $path,
+        string $workingDirectory,
+        string $directorySeparator = \DIRECTORY_SEPARATOR,
+    ): string {
+        if (self::isAbsolute($path, $directorySeparator)) {
+            return $path;
+        }
+
+        return \rtrim($workingDirectory, '/\\') . $directorySeparator . $path;
+    }
+
+    public static function isAbsolute(
+        string $path,
+        string $directorySeparator = \DIRECTORY_SEPARATOR,
+    ): bool {
+        if ($directorySeparator !== '\\') {
+            return \str_starts_with($path, '/');
+        }
+
+        if (\str_starts_with($path, '/') || \str_starts_with($path, '\\')) {
+            return true;
+        }
+
+        if (\strlen($path) < 3 || $path[1] !== ':' || $path[2] !== '/' && $path[2] !== '\\') {
+            return false;
+        }
+
+        return $path[0] >= 'A' && $path[0] <= 'Z'
+            || $path[0] >= 'a' && $path[0] <= 'z';
+    }
+}

--- a/tests/Unit/Cli/CoverageMissingIncludePathTest.php
+++ b/tests/Unit/Cli/CoverageMissingIncludePathTest.php
@@ -19,6 +19,22 @@ use Greenlight\Tests\Support\FilesystemRestriction;
 final class CoverageMissingIncludePathTest
 {
     #[Test]
+    public function unresolvedWindowsIncludePathsRemainAbsolute(): void
+    {
+        $paths = ['C:\\project\\src', '\\\\server\\share\\src'];
+        $configuration = new CoverageConfiguration($paths, null, []);
+        $settings = CoverageSettingsResolver::resolve($configuration, 'C:\\project', '\\');
+
+        Expect::that($settings)
+            ->because('The coverage configuration MUST create coverage settings.')
+            ->toBeInstanceOf(CoverageSettings::class);
+
+        Expect::that($settings->includePaths)
+            ->because('Windows absolute include paths MUST NOT use the current working directory')
+            ->toBe($paths);
+    }
+
+    #[Test]
     public function anUnresolvedIncludePathRemainsRestrictive(): void
     {
         $configuration = new CoverageConfiguration(['future/src'], null, []);

--- a/tests/Unit/Core/FilePathTest.php
+++ b/tests/Unit/Core/FilePathTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\FilePath;
+use Greenlight\Expect\Expect;
+
+final readonly class FilePathTest
+{
+    #[Test]
+    #[DataSet('paths')]
+    public function recognizesAbsolutePathsAcrossPlatforms(
+        string $path,
+        string $directorySeparator,
+        bool $absolute,
+    ): void {
+        Expect::that(FilePath::isAbsolute($path, $directorySeparator))
+            ->because('absolute path detection MUST distinguish rooted paths from relative paths')
+            ->toBe($absolute);
+    }
+
+    /**
+     * @return iterable<string, array{string, string, bool}>
+     */
+    public static function paths(): iterable
+    {
+        yield 'POSIX root' => ['/', '/', true];
+        yield 'POSIX path' => ['/project/src', '/', true];
+        yield 'Windows drive with backslashes' => ['C:\\project\\src', '\\', true];
+        yield 'Windows drive with slashes' => ['d:/project/src', '\\', true];
+        yield 'Windows root-relative path' => ['\\project\\src', '\\', true];
+        yield 'Windows UNC path' => ['\\\\server\\share\\src', '\\', true];
+        yield 'empty POSIX path' => ['', '/', false];
+        yield 'empty Windows path' => ['', '\\', false];
+        yield 'relative path' => ['project/src', '/', false];
+        yield 'Windows drive-relative path' => ['C:project\\src', '\\', false];
+        yield 'nonletter drive prefix' => ['1:\\project\\src', '\\', false];
+        yield 'Windows path on POSIX' => ['C:\\project\\src', '/', false];
+        yield 'backslash path on POSIX' => ['\\project\\src', '/', false];
+    }
+
+    #[Test]
+    #[DataSet('resolvedPaths')]
+    public function resolvesRelativePathsAndPreservesAbsolutePaths(
+        string $path,
+        string $workingDirectory,
+        string $directorySeparator,
+        string $resolved,
+    ): void {
+        Expect::that(FilePath::resolve($path, $workingDirectory, $directorySeparator))
+            ->because('path resolution MUST join only relative paths to the working directory')
+            ->toBe($resolved);
+    }
+
+    /**
+     * @return iterable<string, array{string, string, string, string}>
+     */
+    public static function resolvedPaths(): iterable
+    {
+        yield 'relative POSIX path' => ['tests/Unit', '/project', '/', '/project/tests/Unit'];
+        yield 'relative POSIX path from root' => ['tests/Unit', '/', '/', '/tests/Unit'];
+        yield 'absolute POSIX path' => ['/tests/Unit', '/project', '/', '/tests/Unit'];
+        yield 'relative Windows path' => ['tests\\Unit', 'C:\\project', '\\', 'C:\\project\\tests\\Unit'];
+        yield 'drive-rooted Windows path' => ['D:\\tests', 'C:\\project', '\\', 'D:\\tests'];
+        yield 'root-relative Windows path' => ['\\tests', 'C:\\project', '\\', '\\tests'];
+        yield 'UNC Windows path' => ['\\\\server\\tests', 'C:\\project', '\\', '\\\\server\\tests'];
+    }
+}


### PR DESCRIPTION
Recognize drive-rooted, root-relative, and UNC paths with Windows path semantics. Reuse one Core resolver for configuration, test-discovery, exclusion, and coverage include paths while preserving POSIX-relative behavior. Add platform-specific contracts and a coverage-settings regression for unresolved Windows paths.