### PR TITLE
fix(config): reject null bytes in suite paths

### DIFF
--- a/docs/api-configuration.md
+++ b/docs/api-configuration.md
@@ -404,7 +404,7 @@ PHPDoc:
 
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/SuiteBuilder.php#L48)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/SuiteBuilder.php#L52)
 
 ## `WatchBuilder`
 

--- a/src/Config/SuiteBuilder.php
+++ b/src/Config/SuiteBuilder.php
@@ -34,6 +34,10 @@ final class SuiteBuilder
                 throw new InvalidConfiguration(\sprintf('Suite "%s" was given an empty path.', $this->name));
             }
 
+            if (\str_contains($path, "\0")) {
+                throw new InvalidConfiguration(\sprintf('Suite "%s" paths cannot contain a null byte.', $this->name));
+            }
+
             $validated[] = $path;
         }
 

--- a/src/Config/SuiteConfiguration.php
+++ b/src/Config/SuiteConfiguration.php
@@ -52,6 +52,10 @@ final readonly class SuiteConfiguration
                 throw new InvalidConfiguration(\sprintf('Suite "%s" was given an empty path.', $name));
             }
 
+            if (\str_contains($path, "\0")) {
+                throw new InvalidConfiguration(\sprintf('Suite "%s" paths cannot contain a null byte.', $name));
+            }
+
             $validatedPaths[] = $path;
         }
 

--- a/tests/Unit/Config/SuiteBuilderTest.php
+++ b/tests/Unit/Config/SuiteBuilderTest.php
@@ -55,6 +55,19 @@ final class SuiteBuilderTest
             ->toBe(['existing']);
     }
 
+    #[Test]
+    public function rejectsNullBytesAtTheBuilderBoundary(): void
+    {
+        $builder = new SuiteBuilder('integration');
+
+        Expect::that(static fn(): SuiteBuilder => $builder->in("tests/Integration\0nested"))
+            ->because('suite paths MUST be valid filesystem inputs')
+            ->toThrow(
+                InvalidConfiguration::class,
+                message: 'Suite "integration" paths cannot contain a null byte.',
+            );
+    }
+
     /**
      * @param list<string> $paths
      * @param list<string> $tags

--- a/tests/Unit/Config/SuiteConfigurationTest.php
+++ b/tests/Unit/Config/SuiteConfigurationTest.php
@@ -74,6 +74,12 @@ final class SuiteConfigurationTest
             [],
             'Suite "unit" was given an empty path.',
         ];
+        yield 'path contains a null byte' => [
+            'unit',
+            ["tests\0nested"],
+            [],
+            'Suite "unit" paths cannot contain a null byte.',
+        ];
         yield 'no paths' => [
             'unit',
             [],


### PR DESCRIPTION
Reject NUL bytes at both named-suite path boundaries before discovery reaches PHP filesystem APIs. Preserve atomic variadic builder updates and defend direct SuiteConfiguration construction with the same diagnostic.