### PR TITLE
fix(config): reject null coverage include paths

### DIFF
--- a/docs/api-configuration.md
+++ b/docs/api-configuration.md
@@ -124,7 +124,7 @@ PHPDoc:
 
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/CoverageBuilder.php#L48)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/CoverageBuilder.php#L52)
 
 ### `export()`
 
@@ -136,7 +136,7 @@ PHPDoc:
 
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/CoverageBuilder.php#L62)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/CoverageBuilder.php#L66)
 
 ## `GreenlightConfig`
 

--- a/src/Config/CoverageBuilder.php
+++ b/src/Config/CoverageBuilder.php
@@ -34,6 +34,10 @@ final class CoverageBuilder
                 throw new InvalidConfiguration('Coverage include paths cannot be empty.');
             }
 
+            if (\str_contains($path, "\0")) {
+                throw new InvalidConfiguration('Coverage include paths cannot contain a null byte.');
+            }
+
             $validated[] = $path;
         }
 

--- a/tests/Unit/Config/CoverageBuilderTest.php
+++ b/tests/Unit/Config/CoverageBuilderTest.php
@@ -40,6 +40,17 @@ final class CoverageBuilderTest
     }
 
     #[Test]
+    public function aNullByteIncludePathIsRejected(): void
+    {
+        Expect::that(static fn(): CoverageBuilder => new CoverageBuilder()->include("src\0hidden"))
+            ->because('coverage include paths MUST be valid filesystem inputs')
+            ->toThrow(
+                InvalidConfiguration::class,
+                message: 'Coverage include paths cannot contain a null byte.',
+            );
+    }
+
+    #[Test]
     public function anEmptyDriverNameIsRejected(): void
     {
         Expect::that(static function (): void {


### PR DESCRIPTION
Reject NUL bytes in coverage include paths before resolution reaches PHP filesystem APIs. Preserve atomic multi-path builder updates, add focused regression coverage, and refresh generated API source links.