### PR TITLE
fix(discovery): avoid provider budget overflow

### DIFF
--- a/src/Discovery/DataSetExpander.php
+++ b/src/Discovery/DataSetExpander.php
@@ -142,7 +142,8 @@ final readonly class DataSetExpander
             throw DiscoveryError::providerNotPublicStatic($testClassName, $testMethod, $providerClassName, $provider);
         }
 
-        $deadline = ($this->monotonicTime)() + (int) \round($budgetSeconds * 1_000_000_000);
+        $startedAt = ($this->monotonicTime)();
+        $budgetNanoseconds = $budgetSeconds * 1_000_000_000;
 
         try {
             $result = $method->invoke(null);
@@ -158,7 +159,7 @@ final readonly class DataSetExpander
 
         try {
             foreach ($result as $key => $value) {
-                if (($this->monotonicTime)() > $deadline) {
+                if (($this->monotonicTime)() - $startedAt > $budgetNanoseconds) {
                     throw DiscoveryError::providerTooSlow($providerClassName, $provider, $budgetSeconds);
                 }
 
@@ -176,7 +177,7 @@ final readonly class DataSetExpander
             throw DiscoveryError::providerThrew($providerClassName, $provider, $e);
         }
 
-        if (($this->monotonicTime)() > $deadline) {
+        if (($this->monotonicTime)() - $startedAt > $budgetNanoseconds) {
             throw DiscoveryError::providerTooSlow($providerClassName, $provider, $budgetSeconds);
         }
 

--- a/tests/Unit/Discovery/DataSetBudgetBoundaryTest.php
+++ b/tests/Unit/Discovery/DataSetBudgetBoundaryTest.php
@@ -31,4 +31,23 @@ final readonly class DataSetBudgetBoundaryTest
                 'second case' => ['b'],
             ]);
     }
+
+    #[Test]
+    public function aLargeFiniteBudgetDoesNotOverflowTheDeadline(): void
+    {
+        $clock = new FakeMonotonicClock(10, 11, 12, 13);
+        $rows = new DataSetExpander($clock)->rowsFor(
+            new \ReflectionClass(ProviderKeysTest::class),
+            'withStringKeys',
+            'stringKeys',
+            \PHP_FLOAT_MAX,
+        );
+
+        Expect::that($rows)
+            ->because('a finite provider budget MUST retain its duration after conversion to nanoseconds')
+            ->toBe([
+                'first case' => ['a'],
+                'second case' => ['b'],
+            ]);
+    }
 }


### PR DESCRIPTION
Compare provider execution against elapsed nanoseconds instead of an absolute integer deadline. This preserves exact-boundary behavior and prevents large finite budgets from overflowing to an immediate timeout. Add a deterministic regression with the maximum finite float budget.