### PR TITLE
fix(fixture): reject null bytes in temp paths

### DIFF
--- a/docs/api-fixtures-harness.md
+++ b/docs/api-fixtures-harness.md
@@ -69,10 +69,14 @@ final class TempDirectory implements Disposable
 ### `__construct()`
 
 ```php
-public function __construct(private readonly ?string $temporaryRoot = null)
+public function __construct(?string $temporaryRoot = null)
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L19)
+PHPDoc:
+
+- `@throws \InvalidArgumentException If $temporaryRoot contains a null byte.`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L22)
 
 ### `path()`
 
@@ -84,7 +88,7 @@ PHPDoc:
 
 - `@throws TempDirectoryError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L22)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L32)
 
 ### `subdirectory()`
 
@@ -99,7 +103,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException`
 - `@throws TempDirectoryError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L49)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L59)
 
 ### `dispose()`
 
@@ -112,7 +116,7 @@ PHPDoc:
 
 - `@throws TempDirectoryError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L92)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L106)
 
 ## `TempDirectoryError`
 

--- a/src/Fixture/TempDirectory.php
+++ b/src/Fixture/TempDirectory.php
@@ -16,7 +16,17 @@ final class TempDirectory implements Disposable
 {
     private ?string $path = null;
 
-    public function __construct(private readonly ?string $temporaryRoot = null) {}
+    private readonly ?string $temporaryRoot;
+
+    /** @throws \InvalidArgumentException If $temporaryRoot contains a null byte. */
+    public function __construct(?string $temporaryRoot = null)
+    {
+        if ($temporaryRoot !== null && \str_contains($temporaryRoot, "\0")) {
+            throw new \InvalidArgumentException('Temporary root MUST NOT contain a null byte.');
+        }
+
+        $this->temporaryRoot = $temporaryRoot;
+    }
 
     /** @throws TempDirectoryError */
     public function path(): string
@@ -48,6 +58,10 @@ final class TempDirectory implements Disposable
      */
     public function subdirectory(string $name): string
     {
+        if (\str_contains($name, "\0")) {
+            throw new \InvalidArgumentException('Subdirectory name MUST NOT contain a null byte.');
+        }
+
         if ($name === '' || \str_starts_with($name, '/') || \str_contains($name, '\\')) {
             throw new \InvalidArgumentException(\sprintf('Subdirectory name "%s" must be a relative path.', $name));
         }

--- a/tests/Unit/Fixture/TempDirectoryTest.php
+++ b/tests/Unit/Fixture/TempDirectoryTest.php
@@ -43,6 +43,17 @@ final class TempDirectoryTest
     }
 
     #[Test]
+    public function aTemporaryRootCannotContainANullByte(): void
+    {
+        Expect::that(static fn(): TempDirectory => new TempDirectory("root\0suffix"))
+            ->because('the fixture MUST reject an invalid temporary root before a file-system operation')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Temporary root MUST NOT contain a null byte.',
+            );
+    }
+
+    #[Test]
     public function aBlockedTempRootGivesExactGuidance(): void
     {
         $directory = new TempDirectory();
@@ -185,6 +196,10 @@ final class TempDirectoryTest
         yield 'current-directory segment' => [
             'a/./b',
             'Subdirectory name "a/./b" must not contain empty or traversal segments.',
+        ];
+        yield 'null byte' => [
+            "a\0b",
+            'Subdirectory name MUST NOT contain a null byte.',
         ];
     }
 


### PR DESCRIPTION
Reject null bytes in configured temporary roots and subdirectory names at the fixture boundary. This prevents native file-system calls from leaking ValueError and keeps invalid fixture input deterministic. Regenerate the public fixture API reference and cover both entry points.