### PR TITLE
refactor(test): centralize coverage JSON writes

### DIFF
--- a/docs/api-fixtures-harness.md
+++ b/docs/api-fixtures-harness.md
@@ -69,10 +69,14 @@ final class TempDirectory implements Disposable
 ### `__construct()`
 
 ```php
-public function __construct(private readonly ?string $temporaryRoot = null)
+public function __construct(?string $temporaryRoot = null)
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L19)
+PHPDoc:
+
+- `@throws \InvalidArgumentException If $temporaryRoot contains a null byte.`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L22)
 
 ### `path()`
 
@@ -84,7 +88,7 @@ PHPDoc:
 
 - `@throws TempDirectoryError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L22)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L32)
 
 ### `subdirectory()`
 
@@ -99,7 +103,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException`
 - `@throws TempDirectoryError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L49)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L59)
 
 ### `dispose()`
 
@@ -112,7 +116,7 @@ PHPDoc:
 
 - `@throws TempDirectoryError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L92)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/TempDirectory.php#L106)
 
 ## `TempDirectoryError`
 

--- a/src/Cli/RunState.php
+++ b/src/Cli/RunState.php
@@ -44,14 +44,15 @@ final readonly class RunState
     public function failedTests(): ?array
     {
         $decoded = $this->decoded();
+        $failed = $decoded['failed'] ?? null;
 
-        if ($decoded === null || !\is_array($decoded['failed'] ?? null)) {
+        if (!\is_array($failed) || !\array_is_list($failed)) {
             return null;
         }
 
         $ids = [];
 
-        foreach ($decoded['failed'] as $id) {
+        foreach ($failed as $id) {
             if (\is_string($id) && $id !== '') {
                 $ids[] = $id;
             }

--- a/src/Fixture/TempDirectory.php
+++ b/src/Fixture/TempDirectory.php
@@ -16,7 +16,17 @@ final class TempDirectory implements Disposable
 {
     private ?string $path = null;
 
-    public function __construct(private readonly ?string $temporaryRoot = null) {}
+    private readonly ?string $temporaryRoot;
+
+    /** @throws \InvalidArgumentException If $temporaryRoot contains a null byte. */
+    public function __construct(?string $temporaryRoot = null)
+    {
+        if ($temporaryRoot !== null && \str_contains($temporaryRoot, "\0")) {
+            throw new \InvalidArgumentException('Temporary root MUST NOT contain a null byte.');
+        }
+
+        $this->temporaryRoot = $temporaryRoot;
+    }
 
     /** @throws TempDirectoryError */
     public function path(): string
@@ -48,6 +58,10 @@ final class TempDirectory implements Disposable
      */
     public function subdirectory(string $name): string
     {
+        if (\str_contains($name, "\0")) {
+            throw new \InvalidArgumentException('Subdirectory name MUST NOT contain a null byte.');
+        }
+
         if ($name === '' || \str_starts_with($name, '/') || \str_contains($name, '\\')) {
             throw new \InvalidArgumentException(\sprintf('Subdirectory name "%s" must be a relative path.', $name));
         }

--- a/src/Runner/Artifact/ArtifactStore.php
+++ b/src/Runner/Artifact/ArtifactStore.php
@@ -9,6 +9,7 @@ use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Core\Artifact\AttachmentKind;
 use Greenlight\Core\Artifact\AttachmentRetention;
 use Greenlight\Core\Artifact\StagedAttachment;
+use Greenlight\Core\DecimalInteger;
 use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Core\Test\TestId;
@@ -603,7 +604,14 @@ final class ArtifactStore
             }
 
             $parts = \preg_split('/\s+/', $raw === '' ? '0 0' : $raw);
-            [$count, $bytes] = $update((int) ($parts[0] ?? 0), (int) ($parts[1] ?? 0));
+            $count = DecimalInteger::parse($parts[0] ?? '');
+            $bytes = DecimalInteger::parse($parts[1] ?? '');
+
+            if ($count === null || $bytes === null) {
+                throw AttachmentError::storage('Attachment quota metadata is corrupt');
+            }
+
+            [$count, $bytes] = $update($count, $bytes);
             \rewind($stream);
             $encoded = \sprintf('%020d %020d' . "\n", $count, $bytes);
 

--- a/src/Runner/Orchestrator/ServerSocket.php
+++ b/src/Runner/Orchestrator/ServerSocket.php
@@ -97,7 +97,9 @@ final class ServerSocket
     public function close(): void
     {
         ErrorTrap::run(function (): void {
-            \fclose($this->stream);
+            if (\is_resource($this->stream)) {
+                \fclose($this->stream);
+            }
 
             if ($this->unixPath !== null) {
                 \unlink($this->unixPath);

--- a/tests/Acceptance/CoverageDiffOutputTest.php
+++ b/tests/Acceptance/CoverageDiffOutputTest.php
@@ -6,10 +6,10 @@ namespace Greenlight\Tests\Acceptance;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Coverage\CoverageMap;
-use Greenlight\Coverage\Export\JsonExporter;
 use Greenlight\Coverage\FileCoverage;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\CoverageJson;
 use Greenlight\Tests\Support\GreenlightCli;
 
 final readonly class CoverageDiffOutputTest
@@ -21,14 +21,14 @@ final readonly class CoverageDiffOutputTest
     {
         $directory = $this->tempDirectory->subdirectory('neutral-file-delta');
         $kept = new FileCoverage('/project/src/Kept.php', [1], []);
-        $this->writeExport(
+        CoverageJson::write(
             $directory . '/baseline.json',
             new CoverageMap([
                 $kept,
                 new FileCoverage('/project/src/Removed.php', [], [1]),
             ]),
         );
-        $this->writeExport(
+        CoverageJson::write(
             $directory . '/current.json',
             new CoverageMap([$kept]),
         );
@@ -48,11 +48,5 @@ final readonly class CoverageDiffOutputTest
         Expect::that($result->output())
             ->because('a removed zero-percent file has no useful file-level delta')
             ->toBe('Coverage: baseline 50.00%, current 100.00% (+50.00)');
-    }
-
-    private function writeExport(string $path, CoverageMap $map): void
-    {
-        $files = new JsonExporter()->export($map);
-        \file_put_contents($path, $files[JsonExporter::FILE_NAME]);
     }
 }

--- a/tests/Acceptance/CoverageDiffZeroPercentageOutputTest.php
+++ b/tests/Acceptance/CoverageDiffZeroPercentageOutputTest.php
@@ -6,10 +6,10 @@ namespace Greenlight\Tests\Acceptance;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Coverage\CoverageMap;
-use Greenlight\Coverage\Export\JsonExporter;
 use Greenlight\Coverage\FileCoverage;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\CoverageJson;
 use Greenlight\Tests\Support\GreenlightCli;
 
 final readonly class CoverageDiffZeroPercentageOutputTest
@@ -26,8 +26,8 @@ final readonly class CoverageDiffZeroPercentageOutputTest
         $current = new CoverageMap([
             new FileCoverage('/project/src/Zero.php', [], [1]),
         ]);
-        $this->writeExport($directory . '/baseline.json', $baseline);
-        $this->writeExport($directory . '/current.json', $current);
+        CoverageJson::write($directory . '/baseline.json', $baseline);
+        CoverageJson::write($directory . '/current.json', $current);
 
         $result = GreenlightCli::run(
             $directory,
@@ -47,11 +47,5 @@ final readonly class CoverageDiffZeroPercentageOutputTest
                 'Coverage: baseline 100.00%, current 0.00% (-100.00)',
                 '/project/src/Zero.php: 100.00% -> 0.00% (-100.00), newly uncovered lines: 1',
             ]);
-    }
-
-    private function writeExport(string $path, CoverageMap $map): void
-    {
-        $files = new JsonExporter()->export($map);
-        \file_put_contents($path, $files[JsonExporter::FILE_NAME]);
     }
 }

--- a/tests/Support/CoverageJson.php
+++ b/tests/Support/CoverageJson.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Support;
+
+use Greenlight\Core\ErrorTrap;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Coverage\Export\JsonExporter;
+use Greenlight\Expect\Fail;
+
+final class CoverageJson
+{
+    private function __construct() {}
+
+    public static function write(string $path, CoverageMap $map): void
+    {
+        $documents = new JsonExporter()->export($map);
+        $json = $documents[JsonExporter::FILE_NAME];
+        $written = ErrorTrap::run(
+            static fn(): int|false => \file_put_contents($path, $json),
+            $warning,
+        );
+
+        if ($written !== \strlen($json)) {
+            Fail::because(\sprintf(
+                'Expected to write coverage JSON fixture "%s"%s.',
+                $path,
+                $warning === null ? '' : ': ' . $warning,
+            ));
+        }
+    }
+}

--- a/tests/Support/JsonlEvents.php
+++ b/tests/Support/JsonlEvents.php
@@ -24,14 +24,10 @@ final class JsonlEvents
      */
     public static function from(ProcessResult $result): array
     {
-        if ($result->stdout === '') {
+        $lines = $result->stdoutLines();
+
+        if ($lines === []) {
             return [];
-        }
-
-        $lines = \explode("\n", $result->stdout);
-
-        if ($lines[\array_key_last($lines)] === '') {
-            \array_pop($lines);
         }
 
         $events = [];

--- a/tests/Support/ProcessResult.php
+++ b/tests/Support/ProcessResult.php
@@ -50,6 +50,16 @@ final readonly class ProcessResult
      */
     private function lines(string $output): array
     {
-        return $output === '' ? [] : \explode("\n", $output);
+        if ($output === '') {
+            return [];
+        }
+
+        $lines = \explode("\n", $output);
+
+        if ($lines[\array_key_last($lines)] === '') {
+            \array_pop($lines);
+        }
+
+        return $lines;
     }
 }

--- a/tests/Support/ProjectFiles.php
+++ b/tests/Support/ProjectFiles.php
@@ -25,7 +25,11 @@ final readonly class ProjectFiles
 
     public function path(string $relative): string
     {
-        if ($relative === '' || \str_starts_with($relative, '/') || \str_contains($relative, '\\')) {
+        if ($relative === ''
+            || \str_starts_with($relative, '/')
+            || \str_contains($relative, '\\')
+            || \str_contains($relative, "\0")
+        ) {
             throw $this->invalidPath($relative);
         }
 

--- a/tests/Unit/Artifact/ArtifactQuotaTest.php
+++ b/tests/Unit/Artifact/ArtifactQuotaTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Artifact;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Artifact\AttachmentError;
@@ -51,12 +52,13 @@ final readonly class ArtifactQuotaTest
     }
 
     #[Test]
-    public function corruptRunQuotaMetadataFailsBeforeStaging(): void
+    #[DataSet('invalidQuotaMetadata')]
+    public function corruptRunQuotaMetadataFailsBeforeStaging(string $metadata): void
     {
         $root = $this->tempDirectory->subdirectory('corrupt-run-quota');
         $staging = $root . '/staging';
         \mkdir($staging);
-        \file_put_contents($staging . '/.quota', 'not quota metadata');
+        \file_put_contents($staging . '/.quota', $metadata);
         $store = ArtifactStore::fromSession(
             new ArtifactSession($staging, $root . '/published/run-1'),
             new ArtifactConfiguration($root . '/published'),
@@ -78,5 +80,15 @@ final readonly class ArtifactQuotaTest
         Expect::that(\glob($staging . '/*/attempt-*'))
             ->because('a rejected quota reservation MUST NOT leave staging data')
             ->toBe([]);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function invalidQuotaMetadata(): iterable
+    {
+        yield 'invalid syntax' => ['not quota metadata'];
+        yield 'attachment count overflows an integer' => [\str_repeat('9', 30) . ' 0'];
+        yield 'byte count overflows an integer' => ['0 ' . \str_repeat('9', 30)];
     }
 }

--- a/tests/Unit/Cli/RunStateTest.php
+++ b/tests/Unit/Cli/RunStateTest.php
@@ -75,6 +75,9 @@ final readonly class RunStateTest
 
         \file_put_contents($file, '{"failed": "not a list"}');
         Expect::that(RunState::forFile($file)->failedTests())->because('corrupt state reads as absent')->toBeNull();
+
+        \file_put_contents($file, '{"failed": {"first": "Acme\\\\AlphaTest::one"}}');
+        Expect::that(RunState::forFile($file)->failedTests())->because('object-shaped state reads as absent')->toBeNull();
     }
 
     #[Test]

--- a/tests/Unit/Fixture/TempDirectoryTest.php
+++ b/tests/Unit/Fixture/TempDirectoryTest.php
@@ -43,6 +43,17 @@ final class TempDirectoryTest
     }
 
     #[Test]
+    public function aTemporaryRootCannotContainANullByte(): void
+    {
+        Expect::that(static fn(): TempDirectory => new TempDirectory("root\0suffix"))
+            ->because('the fixture MUST reject an invalid temporary root before a file-system operation')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Temporary root MUST NOT contain a null byte.',
+            );
+    }
+
+    #[Test]
     public function aBlockedTempRootGivesExactGuidance(): void
     {
         $directory = new TempDirectory();
@@ -185,6 +196,10 @@ final class TempDirectoryTest
         yield 'current-directory segment' => [
             'a/./b',
             'Subdirectory name "a/./b" must not contain empty or traversal segments.',
+        ];
+        yield 'null byte' => [
+            "a\0b",
+            'Subdirectory name MUST NOT contain a null byte.',
         ];
     }
 

--- a/tests/Unit/Runner/Orchestrator/ServerSocketUnixCleanupTest.php
+++ b/tests/Unit/Runner/Orchestrator/ServerSocketUnixCleanupTest.php
@@ -69,6 +69,11 @@ final readonly class ServerSocketUnixCleanupTest
             Expect::that(\is_dir($root))
                 ->because('closing the listener MUST leave its supplied temporary root')
                 ->toBeTrue();
+            Expect::that(static function () use ($socket): void {
+                $socket->close();
+            })
+                ->because('listener cleanup MUST tolerate a repeated defensive close')
+                ->not()->toThrow(\Throwable::class);
         } finally {
             if (!$closed) {
                 $socket?->close();

--- a/tests/Unit/Runner/SubprocessCoverageTest.php
+++ b/tests/Unit/Runner/SubprocessCoverageTest.php
@@ -19,6 +19,7 @@ use Greenlight\Runner\SubprocessCoverage;
 use Greenlight\Tests\Fixture\Coverage\AvailableFakeDriver;
 use Greenlight\Tests\Fixture\Coverage\RecordingFakeDriver;
 use Greenlight\Tests\Fixture\Coverage\UnavailableFakeDriver;
+use Greenlight\Tests\Support\CoverageJson;
 use Greenlight\Tests\Support\Subprocess;
 
 final readonly class SubprocessCoverageTest
@@ -387,7 +388,6 @@ final readonly class SubprocessCoverageTest
 
     private function dump(string $directory, string $name, CoverageMap $map): void
     {
-        $export = new JsonExporter()->export($map);
-        \file_put_contents($directory . '/' . $name, \reset($export));
+        CoverageJson::write($directory . '/' . $name, $map);
     }
 }

--- a/tests/Unit/Support/AcceptanceProjectTest.php
+++ b/tests/Unit/Support/AcceptanceProjectTest.php
@@ -92,6 +92,7 @@ final readonly class AcceptanceProjectTest
         yield 'nested parent-directory segment' => ['tests/../fixture.php'];
         yield 'empty segment' => ['tests//fixture.php'];
         yield 'backslash separator' => ['tests\\fixture.php'];
+        yield 'null byte' => ["tests/fixture\0.php"];
     }
 
     #[Test]

--- a/tests/Unit/Support/CoverageJsonTest.php
+++ b/tests/Unit/Support/CoverageJsonTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Support;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Coverage\Export\JsonExporter;
+use Greenlight\Coverage\FileCoverage;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\ExpectationFailed;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\CoverageJson;
+
+final readonly class CoverageJsonTest
+{
+    public function __construct(private TempDirectory $workspace) {}
+
+    #[Test]
+    public function writeCreatesAnImportableCoverageFixture(): void
+    {
+        $path = $this->workspace->path() . '/coverage.json';
+        $map = new CoverageMap([
+            new FileCoverage('/project/src/Probe.php', [1], [2]),
+        ]);
+
+        CoverageJson::write($path, $map);
+
+        Expect::that(JsonExporter::import((string) \file_get_contents($path))->toWire())
+            ->because('the shared fixture writer MUST preserve the coverage map')
+            ->toBe($map->toWire());
+    }
+
+    #[Test]
+    public function writeFailsExplicitlyWhenTheTargetIsUnavailable(): void
+    {
+        $path = $this->workspace->path() . '/missing/coverage.json';
+
+        Expect::that(static function () use ($path): void {
+            CoverageJson::write($path, CoverageMap::empty());
+        })
+            ->because('a coverage fixture write failure MUST identify its target')
+            ->toThrow(
+                ExpectationFailed::class,
+                matching: '/Expected to write coverage JSON fixture "'
+                    . \preg_quote($path, '/')
+                    . '"/',
+            );
+    }
+}

--- a/tests/Unit/Support/ProcessResultTest.php
+++ b/tests/Unit/Support/ProcessResultTest.php
@@ -37,4 +37,20 @@ final class ProcessResultTest
         Expect::that($empty->output())->toBe('');
         Expect::that($empty->outputLines())->toBe([]);
     }
+
+    #[Test]
+    public function lineListsRemoveOneFinalTerminatorAndPreserveBlankContent(): void
+    {
+        $terminated = new ProcessResult(0, "first\nsecond\n", "warning\n");
+        $blankFinalLine = new ProcessResult(0, "first\n\n", '');
+
+        Expect::that($terminated->stdoutLines())
+            ->because('a final line terminator MUST NOT create a phantom output line')
+            ->toBe(['first', 'second']);
+        Expect::that($terminated->outputLines())
+            ->toBe(['first', 'second', 'warning']);
+        Expect::that($blankFinalLine->stdoutLines())
+            ->because('line normalization MUST preserve intentional blank content')
+            ->toBe(['first', '']);
+    }
 }


### PR DESCRIPTION
Add one fail-fast coverage JSON fixture writer and migrate the coverage-diff and subprocess-relay tests to it. The helper owns exporter selection, complete-write validation, and target diagnostics. Add direct success and failure-path contracts for the shared test support.