### PR TITLE
fix(test): reject null project paths

### DIFF
--- a/tests/Support/ProjectFiles.php
+++ b/tests/Support/ProjectFiles.php
@@ -25,7 +25,11 @@ final readonly class ProjectFiles
 
     public function path(string $relative): string
     {
-        if ($relative === '' || \str_starts_with($relative, '/') || \str_contains($relative, '\\')) {
+        if ($relative === ''
+            || \str_starts_with($relative, '/')
+            || \str_contains($relative, '\\')
+            || \str_contains($relative, "\0")
+        ) {
             throw $this->invalidPath($relative);
         }
 

--- a/tests/Unit/Support/AcceptanceProjectTest.php
+++ b/tests/Unit/Support/AcceptanceProjectTest.php
@@ -92,6 +92,7 @@ final readonly class AcceptanceProjectTest
         yield 'nested parent-directory segment' => ['tests/../fixture.php'];
         yield 'empty segment' => ['tests//fixture.php'];
         yield 'backslash separator' => ['tests\\fixture.php'];
+        yield 'null byte' => ["tests/fixture\0.php"];
     }
 
     #[Test]


### PR DESCRIPTION
Reject null bytes in shared generated-project paths before any filesystem operation. This keeps invalid acceptance-fixture input on the ProjectFiles validation path instead of leaking a native ValueError. Extend the existing unsafe-path contract with the regression case.