### PR TITLE
fix(test): bound subprocess output drains

### DIFF
--- a/tests/Support/Subprocess.php
+++ b/tests/Support/Subprocess.php
@@ -227,7 +227,7 @@ final class Subprocess
                 $status = \proc_get_status($this->process);
 
                 if (!$status['running']) {
-                    $this->drain();
+                    $this->drainAvailable();
                     $closedExitCode = \proc_close($this->process);
                     $this->finished = true;
 
@@ -280,6 +280,29 @@ final class Subprocess
 
             if ($ready === false) {
                 throw new \RuntimeException('Could not read process output.');
+            }
+
+            $this->capture($read);
+        }
+    }
+
+    /** @throws \RuntimeException when output cannot be read */
+    private function drainAvailable(): void
+    {
+        while (($read = $this->outputPipes()) !== []) {
+            $write = null;
+            $except = null;
+            $ready = \stream_select($read, $write, $except, 0, 0);
+
+            if ($ready === false) {
+                throw new \RuntimeException('Could not read process output.');
+            }
+
+            if ($ready === 0) {
+                $this->closePipe(1);
+                $this->closePipe(2);
+
+                return;
             }
 
             $this->capture($read);

--- a/tests/Unit/Support/SubprocessTest.php
+++ b/tests/Unit/Support/SubprocessTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Support;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\SkipTest;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\TempDirectory;
@@ -159,6 +160,51 @@ final readonly class SubprocessTest
         try {
             Expect::that(static fn(): ProcessResult => $process->wait(0.05))
                 ->toThrow(\RuntimeException::class, '/Timed out after 0.1s/');
+        } finally {
+            $process->terminate();
+        }
+    }
+
+    #[Test]
+    public function waitDoesNotDrainAnInheritedPipePastItsDeadline(): void
+    {
+        if (!\function_exists('pcntl_fork')) {
+            throw new SkipTest('The pcntl extension is not available.');
+        }
+
+        $process = Subprocess::start(
+            $this->workspace->path(),
+            [
+                \PHP_BINARY,
+                '-r',
+                <<<'PHP'
+                $pid = pcntl_fork();
+
+                if ($pid === -1) {
+                    exit(2);
+                }
+
+                if ($pid === 0) {
+                    usleep(2_000_000);
+                    exit(0);
+                }
+
+                fwrite(STDOUT, "parent exited\n");
+                exit(7);
+                PHP,
+            ],
+        );
+
+        try {
+            $started = \hrtime(true);
+            $result = $process->wait(0.5);
+            $elapsedSeconds = (\hrtime(true) - $started) / 1_000_000_000;
+
+            Expect::that($result->exitCode)->toBe(7);
+            Expect::that($result->stdout)->toBe('parent exited');
+            Expect::that($elapsedSeconds)
+                ->because('wait MUST NOT drain a pipe inherited by a descendant past its deadline')
+                ->toBeLessThan(1.0);
         } finally {
             $process->terminate();
         }


### PR DESCRIPTION
Keep bounded subprocess waits bounded when a descendant inherits the direct child output pipes. After the direct child exits, capture ready bytes and close inherited streams instead of waiting for descendant EOF. Add a process-tree regression contract that previously exceeded the requested deadline.