### PR TITLE
fix(capture): reject blocked output buffers

### DIFF
--- a/src/Capture/CaptureError.php
+++ b/src/Capture/CaptureError.php
@@ -21,4 +21,9 @@ final class CaptureError extends \LogicException
     {
         return new self('Output capture is not active. Call start() before stop().');
     }
+
+    public static function nestedBufferCannotBeRemoved(): self
+    {
+        return new self('Output capture cannot stop because a nested output buffer cannot be removed.');
+    }
 }

--- a/src/Capture/OutputCapture.php
+++ b/src/Capture/OutputCapture.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Capture;
 
+use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Result\CapturedOutput;
 use Greenlight\Core\Result\Diagnostic;
 use Greenlight\Core\Result\DiagnosticSeverity;
@@ -103,7 +104,7 @@ final class OutputCapture
      * changes. The method does not remove a handler that user code installs
      * during output capture.
      *
-     * @throws CaptureError when no capture window is active
+     * @throws CaptureError when no capture window is active or a nested buffer cannot be removed
      */
     public function stop(): CapturedOutput
     {
@@ -115,21 +116,21 @@ final class OutputCapture
         $this->bufferLevel = null;
 
         while (\ob_get_level() > $level) {
-            \ob_end_flush();
+            $previousLevel = \ob_get_level();
+            $removed = ErrorTrap::run(static fn(): bool => \ob_end_flush());
+
+            if (!$removed || \ob_get_level() >= $previousLevel) {
+                $this->restoreErrorHandler();
+
+                throw CaptureError::nestedBufferCannotBeRemoved();
+            }
         }
 
         if (!$this->bufferClosed && \ob_get_level() === $level) {
             \ob_end_clean();
         }
 
-        $active = \set_error_handler(null);
-        \restore_error_handler();
-
-        if ($active === $this->errorHandler) {
-            \restore_error_handler();
-        }
-
-        $this->errorHandler = null;
+        $this->restoreErrorHandler();
 
         $scrubbedStdout = Utf8::scrub($this->stdout);
         $boundedStdout = Utf8::headBytes($scrubbedStdout, $this->maxStdoutBytes);
@@ -183,5 +184,17 @@ final class OutputCapture
         }
 
         $this->diagnostics[] = $diagnostic;
+    }
+
+    private function restoreErrorHandler(): void
+    {
+        $active = \set_error_handler(null);
+        \restore_error_handler();
+
+        if ($active === $this->errorHandler) {
+            \restore_error_handler();
+        }
+
+        $this->errorHandler = null;
     }
 }

--- a/tests/Unit/Capture/OutputCaptureTest.php
+++ b/tests/Unit/Capture/OutputCaptureTest.php
@@ -10,6 +10,7 @@ use Greenlight\Capture\CaptureError;
 use Greenlight\Capture\OutputCapture;
 use Greenlight\Core\Result\DiagnosticSeverity;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\Subprocess;
 
 final class OutputCaptureTest
 {
@@ -339,6 +340,43 @@ final class OutputCaptureTest
                 ->toThrow(CaptureError::class, '/already active.*stop\(\)/');
         } finally {
             $capture->stop();
+        }
+    }
+
+    #[Test]
+    public function aNonRemovableNestedBufferDoesNotHangStop(): void
+    {
+        $root = \dirname(__DIR__, 3);
+        $process = Subprocess::start($root, [
+            \PHP_BINARY,
+            '-r',
+            <<<'PHP_WRAP'
+            require $argv[1];
+
+            $capture = new Greenlight\Capture\OutputCapture();
+            $capture->start();
+            ob_start(null, 0, PHP_OUTPUT_HANDLER_STDFLAGS & ~PHP_OUTPUT_HANDLER_REMOVABLE);
+
+            try {
+                $capture->stop();
+            } catch (Greenlight\Capture\CaptureError $error) {
+                fwrite(STDERR, $error->getMessage());
+                exit(23);
+            }
+            PHP_WRAP,
+            $root . '/vendor/autoload.php',
+        ]);
+
+        try {
+            $result = $process->wait(0.5);
+
+            Expect::that($result->exitCode)
+                ->because('a blocked nested output buffer MUST fail without hanging the worker')
+                ->toBe(23);
+            Expect::that($result->stderr)
+                ->toBe('Output capture cannot stop because a nested output buffer cannot be removed.');
+        } finally {
+            $process->terminate();
         }
     }
 


### PR DESCRIPTION
Prevent OutputCapture::stop() from looping forever when test code leaves a non-removable nested output buffer open. Detect a buffer stack that cannot make progress, restore the capture error handler, and raise a specific CaptureError. Cover the failure in a bounded subprocess so the contract cannot hang the suite.