### PR TITLE
fix(watch): reject blocking standard input

### DIFF
--- a/src/Cli/Watch/StdinKeyInput.php
+++ b/src/Cli/Watch/StdinKeyInput.php
@@ -38,6 +38,8 @@ final class StdinKeyInput implements KeyInput
      * @param (\Closure(): bool)|null $isTty
      * @param (\Closure(): (string|false))|null $read
      * @param (\Closure(string): (string|false|null))|null $runShellCommand
+     *
+     * @throws \RuntimeException when standard input cannot become non-blocking
      */
     public function __construct(
         ?\Closure $configureBlocking = null,
@@ -54,7 +56,10 @@ final class StdinKeyInput implements KeyInput
 
         $this->read = $read;
         $this->runShellCommand = $runShellCommand;
-        $configureBlocking(false);
+
+        if ($configureBlocking(false) === false) {
+            throw new \RuntimeException('Greenlight could not make standard input non-blocking.');
+        }
 
         if ($isTty() && $runShellCommand instanceof \Closure) {
             ErrorTrap::run(static fn(): string|false|null => $runShellCommand(self::ENABLE_RAW_MODE_COMMAND));

--- a/tests/Unit/Cli/StdinKeyInputTest.php
+++ b/tests/Unit/Cli/StdinKeyInputTest.php
@@ -99,4 +99,19 @@ final class StdinKeyInputTest
             ->because('non-terminal input does not change terminal mode')
             ->toBe([]);
     }
+
+    #[Test]
+    public function failureToDisableBlockingInputIsRejected(): void
+    {
+        Expect::that(static fn(): StdinKeyInput => new StdinKeyInput(
+            configureBlocking: static fn(bool $enabled): false => false,
+            isTty: static fn(): bool => false,
+            read: static fn(): false => false,
+        ))
+            ->because('watch input MUST NOT continue with a potentially blocking read')
+            ->toThrow(
+                \RuntimeException::class,
+                message: 'Greenlight could not make standard input non-blocking.',
+            );
+    }
 }


### PR DESCRIPTION
Reject a failed attempt to make standard input non-blocking before the watch loop starts. This prevents key polling from falling through to a potentially blocking read that can freeze an interactive session. Preserve void-returning adapters and add a direct failure contract.