### PR TITLE
fix(runner): make listener cleanup idempotent

### DIFF
--- a/src/Runner/Orchestrator/ServerSocket.php
+++ b/src/Runner/Orchestrator/ServerSocket.php
@@ -97,7 +97,9 @@ final class ServerSocket
     public function close(): void
     {
         ErrorTrap::run(function (): void {
-            \fclose($this->stream);
+            if (\is_resource($this->stream)) {
+                \fclose($this->stream);
+            }
 
             if ($this->unixPath !== null) {
                 \unlink($this->unixPath);

--- a/tests/Unit/Runner/Orchestrator/ServerSocketUnixCleanupTest.php
+++ b/tests/Unit/Runner/Orchestrator/ServerSocketUnixCleanupTest.php
@@ -69,6 +69,11 @@ final readonly class ServerSocketUnixCleanupTest
             Expect::that(\is_dir($root))
                 ->because('closing the listener MUST leave its supplied temporary root')
                 ->toBeTrue();
+            Expect::that(static function () use ($socket): void {
+                $socket->close();
+            })
+                ->because('listener cleanup MUST tolerate a repeated defensive close')
+                ->not()->toThrow(\Throwable::class);
         } finally {
             if (!$closed) {
                 $socket?->close();


### PR DESCRIPTION
Make orchestrator listener cleanup safe after a repeated or external stream close. Close the listener only while its stream remains open, but always attempt owned Unix socket cleanup. Extend the Unix listener contract with a repeated defensive close that previously raised TypeError.