### PR TITLE
refactor(test): centralize run summary parsing

### DIFF
--- a/tests/Acceptance/WorkerFailureContainmentTest.php
+++ b/tests/Acceptance/WorkerFailureContainmentTest.php
@@ -27,7 +27,7 @@ final readonly class WorkerFailureContainmentTest
         $result = $this->runIn('CrashConfig', ['run', '--workers=2']);
 
         Expect::that($result->exitCode)->because('crashed workers are contained and the run completes')->toBe(1);
-        Expect::that($this->summaryLine($result->output()))->toBe('3 tests, 2 passed, 1 errored, 0 expectations');
+        Expect::that(GreenlightCli::summaryLine($result))->toBe('3 tests, 2 passed, 1 errored, 0 expectations');
         Expect::that($result->output())->toContain('crashed during this test');
     }
 
@@ -160,12 +160,4 @@ final readonly class WorkerFailureContainmentTest
         return GreenlightCli::run(\dirname(__DIR__) . '/Fixture/' . $fixtureConfigDir, $arguments);
     }
 
-    private function summaryLine(string $output): string
-    {
-        if (\preg_match('/^\d+ tests?, \d+ passed(?:, \d+ failed)?(?:, \d+ errored)?(?:, \d+ skipped)?, \d+ expectations?$/m', $output, $matches) !== 1) {
-            Fail::because("No summary line found in output:\n" . $output);
-        }
-
-        return $matches[0];
-    }
 }

--- a/tests/Acceptance/WorkerProcessRunTest.php
+++ b/tests/Acceptance/WorkerProcessRunTest.php
@@ -6,7 +6,6 @@ namespace Greenlight\Tests\Acceptance;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
 use Greenlight\Tests\Support\GreenlightCli;
@@ -26,8 +25,8 @@ final readonly class WorkerProcessRunTest
         $parallel = GreenlightCli::run($project->directory, ['run', '--workers=3']);
         Expect::that($sequential->exitCode)->because('parallel results match sequential results')->toBe(0);
         Expect::that($parallel->exitCode)->toBe(0);
-        Expect::that($this->summaryLine($sequential->output()))->toBe('7 tests, 7 passed, 0 expectations');
-        Expect::that($this->summaryLine($parallel->output()))->toBe('7 tests, 7 passed, 0 expectations');
+        Expect::that(GreenlightCli::summaryLine($sequential))->toBe('7 tests, 7 passed, 0 expectations');
+        Expect::that(GreenlightCli::summaryLine($parallel))->toBe('7 tests, 7 passed, 0 expectations');
     }
 
     #[Test]
@@ -36,7 +35,7 @@ final readonly class WorkerProcessRunTest
         $result = $this->runIn('PluginRunConfig', ['run', '--workers=2']);
 
         Expect::that($result->exitCode)->because('configured plugins reach workers across the process boundary')->toBe(0);
-        Expect::that($this->summaryLine($result->output()))->toBe('2 tests, 1 passed, 1 skipped, 0 expectations');
+        Expect::that(GreenlightCli::summaryLine($result))->toBe('2 tests, 1 passed, 1 skipped, 0 expectations');
     }
 
     #[Test]
@@ -45,7 +44,7 @@ final readonly class WorkerProcessRunTest
         $result = $this->runIn('RecycleConfig', ['run']);
 
         Expect::that($result->exitCode)->because('worker recycling keeps results intact')->toBe(0);
-        Expect::that($this->summaryLine($result->output()))->toBe('7 tests, 7 passed, 0 expectations');
+        Expect::that(GreenlightCli::summaryLine($result))->toBe('7 tests, 7 passed, 0 expectations');
     }
 
     /**
@@ -56,12 +55,4 @@ final readonly class WorkerProcessRunTest
         return GreenlightCli::run(\dirname(__DIR__) . '/Fixture/' . $fixtureConfigDir, $arguments);
     }
 
-    private function summaryLine(string $output): string
-    {
-        if (\preg_match('/^\d+ tests?, \d+ passed(?:, \d+ failed)?(?:, \d+ errored)?(?:, \d+ skipped)?, \d+ expectations?$/m', $output, $matches) !== 1) {
-            Fail::because("No summary line found in output:\n" . $output);
-        }
-
-        return $matches[0];
-    }
 }

--- a/tests/Support/GreenlightCli.php
+++ b/tests/Support/GreenlightCli.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Support;
 
+use Greenlight\Expect\Fail;
+
 /** Passes arguments directly to PHP and does not ask a shell to parse them. */
 final class GreenlightCli
 {
@@ -50,5 +52,16 @@ final class GreenlightCli
             ],
             $environment,
         );
+    }
+
+    public static function summaryLine(ProcessResult $result): string
+    {
+        $output = $result->output();
+
+        if (\preg_match('/^\d+ tests?, \d+ passed(?:, \d+ failed)?(?:, \d+ errored)?(?:, \d+ skipped)?, \d+ expectations?$/m', $output, $matches) !== 1) {
+            Fail::because("No summary line found in output:\n" . $output);
+        }
+
+        return $matches[0];
     }
 }

--- a/tests/Unit/Support/GreenlightCliTest.php
+++ b/tests/Unit/Support/GreenlightCliTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Support;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\ExpectationFailed;
+use Greenlight\Tests\Support\GreenlightCli;
+use Greenlight\Tests\Support\ProcessResult;
+
+final class GreenlightCliTest
+{
+    #[Test]
+    public function summaryLineReturnsTheRunSummaryFromCombinedOutput(): void
+    {
+        $result = new ProcessResult(
+            1,
+            "Greenlight dev-main\n3 tests, 2 passed, 1 errored, 4 expectations",
+            'extension diagnostic',
+        );
+
+        Expect::that(GreenlightCli::summaryLine($result))
+            ->because('summary parsing MUST use the complete normalized process output')
+            ->toBe('3 tests, 2 passed, 1 errored, 4 expectations');
+    }
+
+    #[Test]
+    public function missingSummaryReportsTheCompleteOutput(): void
+    {
+        $result = new ProcessResult(1, 'run failed early', 'extension diagnostic');
+
+        Expect::that(static fn(): string => GreenlightCli::summaryLine($result))
+            ->because('a missing summary MUST preserve the process output for diagnosis')
+            ->toThrow(static function (ExpectationFailed $failure): void {
+                Expect::that($failure->detail()->message)
+                    ->toBe("No summary line found in output:\nrun failed early\nextension diagnostic");
+            });
+    }
+}


### PR DESCRIPTION
Move Greenlight run-summary extraction into the shared GreenlightCli support seam. Give the parser direct success and structured failure contracts, then migrate the process-parity and worker-containment acceptance suites. This removes two identical regex and diagnostic implementations while preserving their assertions.