### PR TITLE
refactor(test): centralize finished test IDs

### DIFF
--- a/tests/Acceptance/DataRowRunTest.php
+++ b/tests/Acceptance/DataRowRunTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Acceptance;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Event\TestFinished;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Support\GreenlightCli;
 use Greenlight\Tests\Support\JsonlEvents;
@@ -18,7 +17,7 @@ final class DataRowRunTest
     {
         $result = $this->run('--workers=2');
         Expect::that($result->exitCode)->because('all inline data rows MUST run')->toBe(0);
-        Expect::that($this->finishedTestIds($result))->because('all inline data rows MUST run')->toBe([
+        Expect::that($this->sortedFinishedTestIds($result))->because('all inline data rows MUST run')->toBe([
             'Greenlight\Tests\Fixture\DataRows\InlineRowsTest::acceptsWord[from attribute]',
             'Greenlight\Tests\Fixture\DataRows\InlineRowsTest::acceptsWord[from provider]',
             'Greenlight\Tests\Fixture\DataRows\InlineRowsTest::addsUp[#1]',
@@ -27,7 +26,7 @@ final class DataRowRunTest
 
         $result = $this->run('--filter=*[from attribute]');
         Expect::that($result->exitCode)->because('the label filter MUST select only its row')->toBe(0);
-        Expect::that($this->finishedTestIds($result))->because('the label filter MUST select only its row')->toBe([
+        Expect::that($this->sortedFinishedTestIds($result))->because('the label filter MUST select only its row')->toBe([
             'Greenlight\Tests\Fixture\DataRows\InlineRowsTest::acceptsWord[from attribute]',
         ]);
     }
@@ -35,15 +34,9 @@ final class DataRowRunTest
     /**
      * @return list<string>
      */
-    private function finishedTestIds(ProcessResult $result): array
+    private function sortedFinishedTestIds(ProcessResult $result): array
     {
-        $testIds = [];
-
-        foreach (JsonlEvents::from($result) as $event) {
-            if ($event instanceof TestFinished) {
-                $testIds[] = (string) $event->result->id;
-            }
-        }
+        $testIds = JsonlEvents::finishedTestIds($result);
 
         \sort($testIds);
 

--- a/tests/Acceptance/ParallelShardRunTest.php
+++ b/tests/Acceptance/ParallelShardRunTest.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Acceptance;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Event\TestFinished;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
 use Greenlight\Tests\Support\GreenlightCli;
 use Greenlight\Tests\Support\JsonlEvents;
-use Greenlight\Tests\Support\ProcessResult;
 
 final readonly class ParallelShardRunTest
 {
@@ -30,9 +28,9 @@ final readonly class ParallelShardRunTest
             $project->directory,
             ['run', '--workers=2', '--reporter=jsonl', '--shard=2/2'],
         );
-        $allIds = $this->finishedTestIds($all);
-        $firstIds = $this->finishedTestIds($first);
-        $secondIds = $this->finishedTestIds($second);
+        $allIds = JsonlEvents::finishedTestIds($all);
+        $firstIds = JsonlEvents::finishedTestIds($first);
+        $secondIds = JsonlEvents::finishedTestIds($second);
         $union = [...$firstIds, ...$secondIds];
 
         \sort($allIds);
@@ -63,19 +61,4 @@ final readonly class ParallelShardRunTest
             ->toBe($allIds);
     }
 
-    /**
-     * @return list<string>
-     */
-    private function finishedTestIds(ProcessResult $result): array
-    {
-        $ids = [];
-
-        foreach (JsonlEvents::from($result) as $event) {
-            if ($event instanceof TestFinished) {
-                $ids[] = (string) $event->result->id;
-            }
-        }
-
-        return $ids;
-    }
 }

--- a/tests/Acceptance/SelectionTest.php
+++ b/tests/Acceptance/SelectionTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Acceptance;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Event\TestFinished;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
@@ -24,7 +23,7 @@ final readonly class SelectionTest
         $result = $this->run($project, '--filter=alwaysPasses');
 
         Expect::that($result->exitCode)->because('filter selects by method')->toBe(0);
-        Expect::that($this->finishedTestIds($result))->because('filter selects by method')->toBe([
+        Expect::that($this->sortedFinishedTestIds($result))->because('filter selects by method')->toBe([
             'SelectionProbe\SelectionProbeTest::alwaysPasses',
         ]);
     }
@@ -36,7 +35,7 @@ final readonly class SelectionTest
         $result = $this->run($project, '--filter=SelectionProbeTest');
 
         Expect::that($result->exitCode)->because('filter selects by class')->toBe(1);
-        Expect::that($this->finishedTestIds($result))->because('filter selects by class')->toBe([
+        Expect::that($this->sortedFinishedTestIds($result))->because('filter selects by class')->toBe([
             'SelectionProbe\SelectionProbeTest::alsoPasses',
             'SelectionProbe\SelectionProbeTest::alwaysPasses',
             'SelectionProbe\SelectionProbeTest::breaksSometimes',
@@ -50,7 +49,7 @@ final readonly class SelectionTest
         $result = $this->run($project, '--filter=*::breaks?ometimes');
 
         Expect::that($result->exitCode)->because('filter selects with a wildcard')->toBe(1);
-        Expect::that($this->finishedTestIds($result))->because('filter selects with a wildcard')->toBe([
+        Expect::that($this->sortedFinishedTestIds($result))->because('filter selects with a wildcard')->toBe([
             'SelectionProbe\SelectionProbeTest::breaksSometimes',
         ]);
     }
@@ -75,7 +74,7 @@ final readonly class SelectionTest
         );
 
         Expect::that($result->exitCode)->because('test ID selects only an exact ID')->toBe(0);
-        Expect::that($this->finishedTestIds($result))->because('test ID selects only an exact ID')->toBe([
+        Expect::that($this->sortedFinishedTestIds($result))->because('test ID selects only an exact ID')->toBe([
             'SelectionProbe\SelectionProbeTest::alsoPasses',
         ]);
 
@@ -95,7 +94,7 @@ final readonly class SelectionTest
         $result = $this->run($project, '--group=fast');
 
         Expect::that($result->exitCode)->because('group selects matching tests')->toBe(0);
-        Expect::that($this->finishedTestIds($result))->because('group selects matching tests')->toBe([
+        Expect::that($this->sortedFinishedTestIds($result))->because('group selects matching tests')->toBe([
             'SelectionProbe\GroupedProbeTest::fastOne',
         ]);
     }
@@ -107,7 +106,7 @@ final readonly class SelectionTest
         $result = $this->run($project, '--exclude-group=slow');
 
         Expect::that($result->exitCode)->because('exclude group removes grouped tests from a run')->toBe(1);
-        Expect::that($this->finishedTestIds($result))->because('exclude group removes grouped tests from a run')->toBe([
+        Expect::that($this->sortedFinishedTestIds($result))->because('exclude group removes grouped tests from a run')->toBe([
             'SelectionProbe\GroupedProbeTest::fastOne',
             'SelectionProbe\SelectionProbeTest::alsoPasses',
             'SelectionProbe\SelectionProbeTest::alwaysPasses',
@@ -122,7 +121,7 @@ final readonly class SelectionTest
         $result = $this->run($project, '--exclude-method=*Passes');
 
         Expect::that($result->exitCode)->because('exclude method with a wildcard removes matching methods')->toBe(1);
-        Expect::that($this->finishedTestIds($result))->because('exclude method with a wildcard removes matching methods')->toBe([
+        Expect::that($this->sortedFinishedTestIds($result))->because('exclude method with a wildcard removes matching methods')->toBe([
             'SelectionProbe\GroupedProbeTest::fastOne',
             'SelectionProbe\GroupedProbeTest::slowOne',
             'SelectionProbe\SelectionProbeTest::breaksSometimes',
@@ -146,7 +145,7 @@ final readonly class SelectionTest
         $result = $this->run($project, '--group=fast', '--group=slow', '--exclude-group=slow');
 
         Expect::that($result->exitCode)->because('excluded group wins over included groups')->toBe(0);
-        Expect::that($this->finishedTestIds($result))->because('excluded group wins over included groups')->toBe([
+        Expect::that($this->sortedFinishedTestIds($result))->because('excluded group wins over included groups')->toBe([
             'SelectionProbe\GroupedProbeTest::fastOne',
         ]);
     }
@@ -161,7 +160,7 @@ final readonly class SelectionTest
 
         $result = $this->run($project);
         Expect::that($result->exitCode)->because('failed reruns exactly the previous failures')->toBe(1);
-        Expect::that($this->finishedTestIds($result))->because('failed reruns exactly the previous failures')->toBe([
+        Expect::that($this->sortedFinishedTestIds($result))->because('failed reruns exactly the previous failures')->toBe([
             'SelectionProbe\GroupedProbeTest::fastOne',
             'SelectionProbe\GroupedProbeTest::slowOne',
             'SelectionProbe\SelectionProbeTest::alsoPasses',
@@ -171,13 +170,13 @@ final readonly class SelectionTest
 
         $result = $this->run($project, '--failed');
         Expect::that($result->exitCode)->because('failed reruns exactly the previous failures')->toBe(1);
-        Expect::that($this->finishedTestIds($result))->because('failed reruns exactly the previous failures')->toBe([
+        Expect::that($this->sortedFinishedTestIds($result))->because('failed reruns exactly the previous failures')->toBe([
             'SelectionProbe\SelectionProbeTest::breaksSometimes',
         ]);
 
         $result = $this->run($project, '--filter=alwaysPasses');
         Expect::that($result->exitCode)->because('failed reruns exactly the previous failures')->toBe(0);
-        Expect::that($this->finishedTestIds($result))->because('failed reruns exactly the previous failures')->toBe([
+        Expect::that($this->sortedFinishedTestIds($result))->because('failed reruns exactly the previous failures')->toBe([
             'SelectionProbe\SelectionProbeTest::alwaysPasses',
         ]);
 
@@ -202,7 +201,7 @@ final readonly class SelectionTest
             ['TMPDIR' => $project->directory . '/not-a-directory'],
         );
         Expect::that($result->exitCode)->because('unpersistable run state warns without failing the run')->toBe(0);
-        Expect::that($this->finishedTestIds($result))->because('unpersistable run state warns without failing the run')->toBe([
+        Expect::that($this->sortedFinishedTestIds($result))->because('unpersistable run state warns without failing the run')->toBe([
             'SelectionProbe\SelectionProbeTest::alwaysPasses',
         ]);
         Expect::that($result->output())->because('unpersistable run state warns without failing the run')->toContain('Greenlight did not save run state');
@@ -216,15 +215,9 @@ final readonly class SelectionTest
     /**
      * @return list<string>
      */
-    private function finishedTestIds(ProcessResult $result): array
+    private function sortedFinishedTestIds(ProcessResult $result): array
     {
-        $testIds = [];
-
-        foreach (JsonlEvents::from($result) as $event) {
-            if ($event instanceof TestFinished) {
-                $testIds[] = (string) $event->result->id;
-            }
-        }
+        $testIds = JsonlEvents::finishedTestIds($result);
 
         \sort($testIds);
 

--- a/tests/Support/JsonlEvents.php
+++ b/tests/Support/JsonlEvents.php
@@ -6,6 +6,7 @@ namespace Greenlight\Tests\Support;
 
 use Greenlight\Core\Event\Event;
 use Greenlight\Core\Event\EventTags;
+use Greenlight\Core\Event\TestFinished;
 use Greenlight\Core\Wire\Wire;
 
 /**
@@ -74,5 +75,21 @@ final class JsonlEvents
         }
 
         return $events;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function finishedTestIds(ProcessResult $result): array
+    {
+        $ids = [];
+
+        foreach (self::from($result) as $event) {
+            if ($event instanceof TestFinished) {
+                $ids[] = (string) $event->result->id;
+            }
+        }
+
+        return $ids;
     }
 }

--- a/tests/Unit/Support/JsonlEventsTest.php
+++ b/tests/Unit/Support/JsonlEventsTest.php
@@ -6,7 +6,11 @@ namespace Greenlight\Tests\Unit\Support;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Event\TestClassStarted;
+use Greenlight\Core\Event\TestFinished;
 use Greenlight\Core\Event\WorkerSpawned;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Tests\Support\JsonlEvents;
@@ -55,6 +59,27 @@ final class JsonlEventsTest
     public function emptyStdoutProducesNoEvents(): void
     {
         Expect::that(JsonlEvents::from(new ProcessResult(0, '', 'diagnostic')))->because('empty stdout produces no events')->toBe([]);
+    }
+
+    #[Test]
+    public function finishedTestIdsPreserveEventOrderAndIgnoreOtherEvents(): void
+    {
+        $first = new TestFinished(new TestResult(new TestId('AlphaTest', 'one'), Outcome::Passed, 0.1, 0), 1.0);
+        $spawned = new WorkerSpawned('worker-1', 42, 1.1);
+        $second = new TestFinished(new TestResult(new TestId('BetaTest', 'two', 'row'), Outcome::Passed, 0.2, 0), 1.2);
+        $result = new ProcessResult(
+            0,
+            $this->line('test-finished', $first->toWire())
+                . "\n"
+                . $this->line('worker-spawned', $spawned->toWire())
+                . "\n"
+                . $this->line('test-finished', $second->toWire()),
+            '',
+        );
+
+        Expect::that(JsonlEvents::finishedTestIds($result))
+            ->because('finished test extraction MUST preserve JSONL event order')
+            ->toBe(['AlphaTest::one', 'BetaTest::two[row]']);
     }
 
     #[Test]


### PR DESCRIPTION
Move TestFinished ID extraction into the shared JsonlEvents support seam. Preserve JSONL event order in the helper, keep sorting as an explicit consumer policy, and migrate the data-row, parallel-shard, and selection acceptance suites. Add a mixed-event contract that proves non-test events are ignored without reordering results.