### PR TITLE
fix(cli): validate profile JSONL envelopes

### DIFF
--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -23,6 +23,7 @@ use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Event\EventTags;
 use Greenlight\Core\GracefulShutdown;
 use Greenlight\Core\Wire\InvalidWirePayload;
+use Greenlight\Core\Wire\Wire;
 use Greenlight\Core\Wire\WireError;
 use Greenlight\Coverage\CoverageError;
 use Greenlight\Coverage\CoverageMap;
@@ -1037,30 +1038,50 @@ final readonly class Application
                 return self::EXIT_FAILURE;
             }
 
-            if (!\is_array($decoded) || !\is_string($decoded['event'] ?? null) || !\is_array($decoded['data'] ?? null)) {
+            if (!\is_array($decoded) || ($decoded !== [] && \array_is_list($decoded))) {
                 ($this->err)("The input is not a JSONL event stream. A line does not contain an event envelope.\n");
 
                 return self::EXIT_FAILURE;
             }
 
-            $class = EventTags::classFor($decoded['event']);
+            $envelope = [];
+
+            foreach ($decoded as $key => $value) {
+                if (!\is_string($key)) {
+                    ($this->err)("The input is not a JSONL event stream. A line does not contain an event envelope.\n");
+
+                    return self::EXIT_FAILURE;
+                }
+
+                $envelope[$key] = $value;
+            }
+
+            try {
+                $version = Wire::int($envelope, 'v');
+                $tag = Wire::nonEmptyString($envelope, 'event');
+                $data = Wire::map($envelope, 'data');
+            } catch (InvalidWirePayload) {
+                ($this->err)("The input is not a JSONL event stream. A line does not contain an event envelope.\n");
+
+                return self::EXIT_FAILURE;
+            }
+
+            if ($version !== 2) {
+                ($this->err)(\sprintf("The input uses unsupported JSONL version %d.\n", $version));
+
+                return self::EXIT_FAILURE;
+            }
+
+            $class = EventTags::classFor($tag);
 
             if ($class === null) {
                 continue;
             }
 
-            $data = [];
-
-            foreach ($decoded['data'] as $key => $value) {
-                if (\is_string($key)) {
-                    $data[$key] = $value;
-                }
-            }
-
             try {
                 $aggregator->onEvent($class::fromWire($data));
             } catch (InvalidWirePayload $error) {
-                $this->printError(\sprintf('Greenlight could not decode a "%s" event: %s', $decoded['event'], $error->getMessage()), $arguments->has('no-ansi'));
+                $this->printError(\sprintf('Greenlight could not decode a "%s" event: %s', $tag, $error->getMessage()), $arguments->has('no-ansi'));
 
                 return self::EXIT_FAILURE;
             }

--- a/tests/Acceptance/CommandErrorsTest.php
+++ b/tests/Acceptance/CommandErrorsTest.php
@@ -113,15 +113,33 @@ final readonly class CommandErrorsTest
             'A line does not contain an event envelope.',
         ];
 
+        yield 'invalid envelope key' => [
+            'profile-invalid-envelope-key',
+            '{"0":true,"v":2,"event":"future-event","data":{}}',
+            'A line does not contain an event envelope.',
+        ];
+
+        yield 'unsupported envelope version' => [
+            'profile-unsupported-version',
+            '{"v":3,"event":"run-started","data":{}}',
+            'The input uses unsupported JSONL version 3.',
+        ];
+
         yield 'invalid known event payload' => [
             'profile-invalid-payload',
-            '{"event":"run-started","data":[]}',
+            '{"v":2,"event":"run-started","data":[]}',
             'Greenlight could not decode a "run-started" event:',
+        ];
+
+        yield 'invalid event data map' => [
+            'profile-invalid-data-map',
+            '{"v":2,"event":"future-event","data":{"0":true}}',
+            'A line does not contain an event envelope.',
         ];
 
         yield 'no finished run' => [
             'profile-no-finished-run',
-            '{"event":"future-event","data":[]}',
+            '{"v":2,"event":"future-event","data":[]}',
             'The stream has no finished run to profile.',
         ];
     }


### PR DESCRIPTION
The offline profile reader previously accepted versionless envelopes and silently discarded non-string payload keys. This change applies the shared wire readers at the JSONL boundary, rejects malformed map keys, and reports unsupported protocol versions before event dispatch. Acceptance coverage preserves forward compatibility for unknown event tags within the supported version.