### PR TITLE
fix(reporting): bound TeamCity durations

### DIFF
--- a/src/Reporting/TeamCityReporter.php
+++ b/src/Reporting/TeamCityReporter.php
@@ -141,9 +141,20 @@ final class TeamCityReporter implements Reporter
 
         $this->message('testFinished', [
             'name' => $name,
-            'duration' => (string) (int) \round($result->durationSeconds * 1000),
+            'duration' => (string) $this->durationMilliseconds($result->durationSeconds),
             'flowId' => $flowId,
         ]);
+    }
+
+    private function durationMilliseconds(float $seconds): int
+    {
+        $milliseconds = \round($seconds * 1000);
+
+        if (!\is_finite($milliseconds) || $milliseconds >= \PHP_INT_MAX) {
+            return \PHP_INT_MAX;
+        }
+
+        return (int) $milliseconds;
     }
 
     /**

--- a/tests/Unit/Reporting/TeamCityReporterTest.php
+++ b/tests/Unit/Reporting/TeamCityReporterTest.php
@@ -74,6 +74,28 @@ final class TeamCityReporterTest
     }
 
     #[Test]
+    public function anUnrepresentableDurationSaturatesAtTheIntegerMaximum(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new TeamCityReporter($output);
+        $id = new TestId('Acme\DurationTest', 'reports');
+
+        $reporter->onEvent(new TestFinished(new TestResult(
+            $id,
+            Outcome::Passed,
+            \PHP_FLOAT_MAX,
+            0,
+        ), 1.0));
+
+        Expect::that($output->buffer())
+            ->because('an unrepresentable TeamCity duration MUST NOT collapse to zero')
+            ->toBe(\sprintf(
+                "##teamcity[testFinished name='Acme\\DurationTest::reports' duration='%d' flowId='Acme\\DurationTest']\n",
+                \PHP_INT_MAX,
+            ));
+    }
+
+    #[Test]
     public function zeroStringFailureMessagesRemainDistinctFromMissingDetails(): void
     {
         $output = new BufferOutput();


### PR DESCRIPTION
TeamCity duration output multiplied every finite test duration by 1,000 and cast the rounded result directly to an integer. A valid duration whose millisecond representation exceeded the platform integer range collapsed to zero. This change saturates unrepresentable values at `PHP_INT_MAX` while preserving existing rounding for ordinary durations, with direct reporter regression coverage.