### PR TITLE
refactor(test): centralize memory streams

### DIFF
--- a/tests/Support/MemoryStream.php
+++ b/tests/Support/MemoryStream.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Support;
+
+use Greenlight\Expect\Fail;
+
+final class MemoryStream
+{
+    /**
+     * @return resource
+     */
+    public static function open(string $contents = ''): mixed
+    {
+        $stream = \fopen('php://memory', 'r+');
+
+        if (!\is_resource($stream)) {
+            Fail::because('The in-memory stream did not open.');
+        }
+
+        if (\fwrite($stream, $contents) !== \strlen($contents) || !\rewind($stream)) {
+            \fclose($stream);
+
+            Fail::because('The in-memory stream did not accept its initial content.');
+        }
+
+        return $stream;
+    }
+
+    public static function close(mixed ...$streams): void
+    {
+        foreach ($streams as $stream) {
+            if (\is_resource($stream)) {
+                \fclose($stream);
+            }
+        }
+    }
+
+    private function __construct() {}
+}

--- a/tests/Unit/Runner/Orchestrator/WorkerHandleAssignmentLifecycleTest.php
+++ b/tests/Unit/Runner/Orchestrator/WorkerHandleAssignmentLifecycleTest.php
@@ -11,19 +11,19 @@ use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\ExecutionPlan;
 use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
 use Greenlight\Runner\Orchestrator\ResourceLease;
 use Greenlight\Runner\Orchestrator\SchedulingUnit;
 use Greenlight\Runner\Orchestrator\WorkerHandle;
+use Greenlight\Tests\Support\MemoryStream;
 
 final readonly class WorkerHandleAssignmentLifecycleTest
 {
     #[Test]
     public function assignmentLifecycleTransfersResetsAndClearsWorkerState(): void
     {
-        $process = $this->stream();
-        $stdout = $this->stream();
-        $stderr = $this->stream();
+        $process = MemoryStream::open();
+        $stdout = MemoryStream::open();
+        $stderr = MemoryStream::open();
 
         try {
             $handle = new WorkerHandle('worker-1', 1, $process, $stdout, $stderr);
@@ -98,9 +98,7 @@ final readonly class WorkerHandleAssignmentLifecycleTest
                 ->because('assignment finish MUST mark the worker as used')
                 ->toBeFalse();
         } finally {
-            $this->close($process);
-            $this->close($stdout);
-            $this->close($stderr);
+            MemoryStream::close($process, $stdout, $stderr);
         }
     }
 
@@ -114,24 +112,4 @@ final readonly class WorkerHandleAssignmentLifecycleTest
         return new ResourceLease(41, new SchedulingUnit($plan, isolated: true));
     }
 
-    /**
-     * @return resource
-     */
-    private function stream(): mixed
-    {
-        $stream = \fopen('php://memory', 'r+');
-
-        if (!\is_resource($stream)) {
-            Fail::because('Expected the in-memory stream to open.');
-        }
-
-        return $stream;
-    }
-
-    private function close(mixed $stream): void
-    {
-        if (\is_resource($stream)) {
-            \fclose($stream);
-        }
-    }
 }

--- a/tests/Unit/Runner/Orchestrator/WorkerHandleDiagnosticStreamsTest.php
+++ b/tests/Unit/Runner/Orchestrator/WorkerHandleDiagnosticStreamsTest.php
@@ -6,8 +6,8 @@ namespace Greenlight\Tests\Unit\Runner\Orchestrator;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
 use Greenlight\Runner\Orchestrator\WorkerHandle;
+use Greenlight\Tests\Support\MemoryStream;
 
 final readonly class WorkerHandleDiagnosticStreamsTest
 {
@@ -17,9 +17,9 @@ final readonly class WorkerHandleDiagnosticStreamsTest
         $handle = new WorkerHandle(
             'worker-1',
             1,
-            $this->stream(),
-            $this->stream("standard output\n"),
-            $this->stream("standard error\n"),
+            MemoryStream::open(),
+            MemoryStream::open("standard output\n"),
+            MemoryStream::open("standard error\n"),
         );
 
         $handle->drainPipes();
@@ -29,20 +29,4 @@ final readonly class WorkerHandleDiagnosticStreamsTest
             ->toBe("standard output\nstandard error\n");
     }
 
-    /**
-     * @return resource
-     */
-    private function stream(string $contents = ''): mixed
-    {
-        $stream = \fopen('php://memory', 'r+');
-
-        if (!\is_resource($stream)) {
-            Fail::because('Expected the in-memory stream to open.');
-        }
-
-        \fwrite($stream, $contents);
-        \rewind($stream);
-
-        return $stream;
-    }
 }

--- a/tests/Unit/Runner/Orchestrator/WorkerHandlePipeLifecycleTest.php
+++ b/tests/Unit/Runner/Orchestrator/WorkerHandlePipeLifecycleTest.php
@@ -6,17 +6,17 @@ namespace Greenlight\Tests\Unit\Runner\Orchestrator;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
 use Greenlight\Runner\Orchestrator\WorkerHandle;
+use Greenlight\Tests\Support\MemoryStream;
 
 final readonly class WorkerHandlePipeLifecycleTest
 {
     #[Test]
     public function pipeDrainSkipsClosedPipesWithoutDuplicatingDiagnostics(): void
     {
-        $process = $this->stream();
-        $stdout = $this->stream();
-        $stderr = $this->stream("standard error\n");
+        $process = MemoryStream::open();
+        $stdout = MemoryStream::open();
+        $stderr = MemoryStream::open("standard error\n");
         \fclose($stdout);
 
         try {
@@ -36,33 +36,7 @@ final readonly class WorkerHandlePipeLifecycleTest
                 ->because('pipe draining MUST skip closed output pipes')
                 ->toBe("standard error\n");
         } finally {
-            $this->close($process);
-            $this->close($stdout);
-            $this->close($stderr);
-        }
-    }
-
-    /**
-     * @return resource
-     */
-    private function stream(string $contents = ''): mixed
-    {
-        $stream = \fopen('php://memory', 'r+');
-
-        if (!\is_resource($stream)) {
-            Fail::because('Expected the in-memory stream to open.');
-        }
-
-        \fwrite($stream, $contents);
-        \rewind($stream);
-
-        return $stream;
-    }
-
-    private function close(mixed $stream): void
-    {
-        if (\is_resource($stream)) {
-            \fclose($stream);
+            MemoryStream::close($process, $stdout, $stderr);
         }
     }
 }

--- a/tests/Unit/Runner/Orchestrator/WorkerHandleTest.php
+++ b/tests/Unit/Runner/Orchestrator/WorkerHandleTest.php
@@ -11,9 +11,9 @@ use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\ExecutionPlan;
 use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
 use Greenlight\Runner\Orchestrator\WorkerHandle;
 use Greenlight\Tests\Support\ConnectedStreamPair;
+use Greenlight\Tests\Support\MemoryStream;
 
 final class WorkerHandleTest
 {
@@ -36,14 +36,14 @@ final class WorkerHandleTest
     #[Test]
     public function aClosedProcessHandleIsNotRunning(): void
     {
-        $process = $this->stream();
+        $process = MemoryStream::open();
         \fclose($process);
         $handle = new WorkerHandle(
             'worker-1',
             1,
             $process,
-            $this->stream(),
-            $this->stream(),
+            MemoryStream::open(),
+            MemoryStream::open(),
         );
 
         Expect::that($handle->isRunning())
@@ -75,16 +75,16 @@ final class WorkerHandleTest
     #[Test]
     public function drainedDiagnosticsKeepACompleteUnicodeTailWithinTheByteLimit(): void
     {
-        $stdout = $this->stream();
+        $stdout = MemoryStream::open();
         \fwrite($stdout, 'z');
         \rewind($stdout);
 
         $handle = new WorkerHandle(
             'worker-1',
             1,
-            $this->stream(),
+            MemoryStream::open(),
             $stdout,
-            $this->stream(),
+            MemoryStream::open(),
         );
         $handle->diagnostics = 'xx€' . \str_repeat('y', 65_533);
 
@@ -109,9 +109,9 @@ final class WorkerHandleTest
         $handle = new WorkerHandle(
             'worker-1',
             1,
-            $this->stream(),
+            MemoryStream::open(),
             $reader,
-            $this->stream(),
+            MemoryStream::open(),
         );
 
         \fwrite($writer, $lead);
@@ -132,9 +132,9 @@ final class WorkerHandleTest
         $handle = new WorkerHandle(
             'worker-1',
             1,
-            $this->stream(),
+            MemoryStream::open(),
             $reader,
-            $this->stream(),
+            MemoryStream::open(),
         );
 
         \fwrite($writer, $malformed);
@@ -183,24 +183,9 @@ final class WorkerHandleTest
         return new WorkerHandle(
             'worker-1',
             1,
-            $this->stream(),
-            $this->stream(),
-            $this->stream(),
+            MemoryStream::open(),
+            MemoryStream::open(),
+            MemoryStream::open(),
         );
     }
-
-    /**
-     * @return resource
-     */
-    private function stream(): mixed
-    {
-        $stream = \fopen('php://memory', 'r+');
-
-        if (!\is_resource($stream)) {
-            Fail::because('Expected the in-memory stream to open.');
-        }
-
-        return $stream;
-    }
-
 }

--- a/tests/Unit/Runner/Orchestrator/WorkerHandleZeroDiagnosticsTest.php
+++ b/tests/Unit/Runner/Orchestrator/WorkerHandleZeroDiagnosticsTest.php
@@ -6,8 +6,8 @@ namespace Greenlight\Tests\Unit\Runner\Orchestrator;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
 use Greenlight\Runner\Orchestrator\WorkerHandle;
+use Greenlight\Tests\Support\MemoryStream;
 
 final class WorkerHandleZeroDiagnosticsTest
 {
@@ -17,9 +17,9 @@ final class WorkerHandleZeroDiagnosticsTest
         $handle = new WorkerHandle(
             'worker-1',
             1,
-            $this->stream(),
-            $this->stream('0'),
-            $this->stream(),
+            MemoryStream::open(),
+            MemoryStream::open('0'),
+            MemoryStream::open(),
         );
 
         $handle->drainPipes();
@@ -29,20 +29,4 @@ final class WorkerHandleZeroDiagnosticsTest
             ->toBe('0');
     }
 
-    /**
-     * @return resource
-     */
-    private function stream(string $contents = ''): mixed
-    {
-        $stream = \fopen('php://memory', 'r+');
-
-        if (!\is_resource($stream)) {
-            Fail::because('Expected the in-memory stream to open.');
-        }
-
-        \fwrite($stream, $contents);
-        \rewind($stream);
-
-        return $stream;
-    }
 }

--- a/tests/Unit/Support/MemoryStreamTest.php
+++ b/tests/Unit/Support/MemoryStreamTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Support;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\MemoryStream;
+
+final readonly class MemoryStreamTest
+{
+    #[Test]
+    public function opensAtTheStartOfExactContentAndClosesIdempotently(): void
+    {
+        $stream = MemoryStream::open('initial content');
+
+        Expect::that(\stream_get_contents($stream))
+            ->because('the shared stream MUST expose all initial content from its start')
+            ->toBe('initial content');
+
+        MemoryStream::close($stream, $stream);
+
+        Expect::that(\is_resource($stream))
+            ->because('the shared close operation MUST tolerate an already closed stream')
+            ->toBeFalse();
+    }
+}


### PR DESCRIPTION
Five WorkerHandle test classes independently opened and initialized `php://memory` streams, and two also duplicated idempotent cleanup. This change introduces one checked support utility for complete writes, rewinds, and multi-stream closure, gives that utility a direct contract test, and migrates all five consumers. The migration removes more duplicated setup code than it adds.