### PR TITLE
fix(coverage): contain HTML source read warnings

### DIFF
--- a/src/Coverage/Export/HtmlExporter.php
+++ b/src/Coverage/Export/HtmlExporter.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Coverage\Export;
 
+use Greenlight\Core\ErrorTrap;
 use Greenlight\Coverage\CoverageMap;
 use Greenlight\Coverage\FileCoverage;
 
@@ -203,7 +204,7 @@ final readonly class HtmlExporter implements CoverageExporter
             return null;
         }
 
-        $content = \file_get_contents($path);
+        $content = ErrorTrap::run(static fn(): string|false => \file_get_contents($path));
 
         if ($content === false) {
             return null;

--- a/tests/Unit/Coverage/HtmlExporterSourceFailureTest.php
+++ b/tests/Unit/Coverage/HtmlExporterSourceFailureTest.php
@@ -39,12 +39,9 @@ final readonly class HtmlExporterSourceFailureTest
             );
             $page = $pages[HtmlExporter::pageName($path)];
 
-            Expect::that($warning ?? '')
-                ->because('the source becomes unreadable when the exporter opens it')
-                // PHP 8.5 includes the path in this warning, but PHP 8.6 omits it.
-                // Require file_get_contents() when PHP 8.6 is the minimum version.
-                ->toContain('file_get_contents')
-                ->toContain('Failed to open stream');
+            Expect::that($warning)
+                ->because('a late source read failure MUST not leak an engine diagnostic')
+                ->toBeNull();
             Expect::that($page)
                 ->because('a late read failure shows only coverage line numbers')
                 ->toContain('<span class="cov"><span class="num">2</span></span>')


### PR DESCRIPTION
## Summary

- contain native source-read diagnostics in the HTML coverage exporter
- preserve the line-number fallback when a source becomes unreadable after validation
- convert the existing read-race coverage into an explicit no-warning oracle