### PR TITLE
fix(runner): contain CPU probe warnings

### DIFF
--- a/src/Runner/CpuCores.php
+++ b/src/Runner/CpuCores.php
@@ -35,7 +35,7 @@ final class CpuCores
     {
         if (\class_exists(CpuCoreCounter::class)) {
             try {
-                return new CpuCoreCounter()->getCount();
+                return ErrorTrap::run(static fn(): int => new CpuCoreCounter()->getCount());
             } catch (NumberOfCpuCoreNotFound) {
             }
         }
@@ -48,7 +48,7 @@ final class CpuCores
      */
     private static function probe(): int
     {
-        if (\is_file('/proc/cpuinfo')) {
+        if (ErrorTrap::run(static fn(): bool => \is_file('/proc/cpuinfo'))) {
             $cpuinfo = ErrorTrap::run(static fn(): string|false => \file_get_contents('/proc/cpuinfo'));
 
             if (\is_string($cpuinfo)) {

--- a/tests/Unit/Runner/CpuCoresFallbackTest.php
+++ b/tests/Unit/Runner/CpuCoresFallbackTest.php
@@ -38,10 +38,8 @@ final readonly class CpuCoresFallbackTest
             ->because('an unavailable platform CPU count MUST use the conservative default')
             ->toBe(4);
 
-        if (\PHP_OS_FAMILY === 'Linux') {
-            Expect::that($warning)
-                ->because('the restricted procfs path proves the primary platform probe was unavailable')
-                ->toContain('/proc/cpuinfo');
-        }
+        Expect::that($warning)
+            ->because('unavailable platform CPU probes MUST not leak engine diagnostics')
+            ->toBeNull();
     }
 }


### PR DESCRIPTION
## Summary

- contain diagnostics from the optional CPU counter before fallback
- contain native procfs availability diagnostics in the built-in probe
- require unavailable platform probes to use the conservative default silently