### PR TITLE
ci: queue documentation deployments

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+paths:
+  .github/workflows/ci.yml:
+    ignore:
+      - '^unexpected key "queue" for "concurrency" section\. expected one of "cancel-in-progress", "group"$'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -510,6 +510,7 @@ jobs:
     concurrency:
       group: "pages"
       cancel-in-progress: false
+      queue: "max"
     runs-on: "ubuntu-latest"
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
Keep pending GitHub Pages deployments instead of allowing newer main pushes to cancel them. This prevents successful main-branch CI runs from appearing failed because their documentation deployment was displaced.\n\nScope the Actionlint compatibility exception to the new `queue` key in this workflow until the pinned linter recognizes GitHub’s current concurrency syntax.