### PR TITLE
fix(cli): contain coverage path warnings

### DIFF
--- a/src/Cli/CoverageSettingsResolver.php
+++ b/src/Cli/CoverageSettingsResolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Cli;
 
 use Greenlight\Config\CoverageConfiguration;
+use Greenlight\Core\ErrorTrap;
 use Greenlight\Runner\CoverageSettings;
 
 /** Resolves CLI coverage configuration into runner settings.
@@ -28,7 +29,7 @@ final class CoverageSettingsResolver
             $absolute = \str_starts_with($path, '/')
                 ? $path
                 : \rtrim($workingDirectory, '/') . '/' . $path;
-            $real = \realpath($absolute);
+            $real = ErrorTrap::run(static fn(): string|false => \realpath($absolute));
 
             if ($real !== false) {
                 $include[] = $real;

--- a/tests/Unit/Cli/CoverageMissingIncludePathTest.php
+++ b/tests/Unit/Cli/CoverageMissingIncludePathTest.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Cli;
 
+use Greenlight\Attribute\Isolated;
 use Greenlight\Attribute\Test;
 use Greenlight\Cli\CoverageSettingsResolver;
 use Greenlight\Config\CoverageConfiguration;
+use Greenlight\Core\ErrorTrap;
 use Greenlight\Coverage\Driver\DriverSelector;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
@@ -44,5 +46,43 @@ final class CoverageMissingIncludePathTest
         Expect::that($collector->stop()->files())
             ->because('an unresolved include path MUST NOT broaden coverage to all files')
             ->toBe([]);
+    }
+
+    #[Test]
+    #[Isolated]
+    public function aRestrictedIncludePathFallsBackWithoutADiagnostic(): void
+    {
+        $root = \dirname(__DIR__, 3);
+        $outside = \realpath(\dirname($root));
+
+        if (!\is_string($outside)) {
+            Fail::because('The test could not resolve its restricted include path.');
+        }
+
+        $previousOpenBasedir = \ini_set(
+            'open_basedir',
+            $root . \PATH_SEPARATOR . \sys_get_temp_dir(),
+        );
+
+        if ($previousOpenBasedir === false) {
+            Fail::because('The test could not restrict file system access.');
+        }
+
+        $configuration = new CoverageConfiguration([$outside], null, []);
+        $settings = ErrorTrap::run(
+            static fn(): ?CoverageSettings => CoverageSettingsResolver::resolve($configuration, $root),
+            $warning,
+        );
+
+        if (!$settings instanceof CoverageSettings) {
+            Fail::because('Expected coverage configuration to create coverage settings.');
+        }
+
+        Expect::that($settings->includePaths)
+            ->because('a restricted include path MUST remain restrictive')
+            ->toBe([$outside]);
+        Expect::that($warning)
+            ->because('a restricted include path MUST not leak an engine diagnostic')
+            ->toBeNull();
     }
 }


### PR DESCRIPTION
## Summary

- contain native diagnostics while resolving coverage include paths
- preserve unresolved or restricted paths so coverage remains restrictive
- cover open_basedir fallback with an isolated no-warning regression