### PR TITLE
test(capture): stabilize blocked buffer subprocess

### DIFF
--- a/tests/Unit/Capture/OutputCaptureTest.php
+++ b/tests/Unit/Capture/OutputCaptureTest.php
@@ -368,7 +368,7 @@ final class OutputCaptureTest
         ]);
 
         try {
-            $result = $process->wait(0.5);
+            $result = $process->wait(2.0);
 
             Expect::that($result->exitCode)
                 ->because('a blocked nested output buffer MUST fail without hanging the worker')


### PR DESCRIPTION
## Summary

- align the blocked-buffer subprocess timeout with the established unit-test process budget
- retain the exact exit-code and diagnostic assertions that prove stop does not hang
- remove scheduler-load sensitivity observed during the full suite