### PR TITLE
refactor(test): centralize plugin lifecycle fixtures

### DIFF
--- a/tests/Support/PluginLifecycle.php
+++ b/tests/Support/PluginLifecycle.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Support;
+
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Harness\HarnessRegistry;
+use Greenlight\Harness\HarnessScopes;
+use Greenlight\Plugin\TestContext;
+
+final class PluginLifecycle
+{
+    public static function context(): TestContext
+    {
+        return new TestContext(
+            new \stdClass(),
+            new TestId('Fixture', 'probe'),
+            new TestMetadata('Fixture', 'probe'),
+            new HarnessScopes(new HarnessRegistry()),
+        );
+    }
+
+    public static function passedResult(): TestResult
+    {
+        return new TestResult(new TestId('Fixture', 'probe'), Outcome::Passed, 0.0, 0);
+    }
+
+    private function __construct() {}
+}

--- a/tests/Unit/Laravel/LaravelPluginTest.php
+++ b/tests/Unit/Laravel/LaravelPluginTest.php
@@ -10,17 +10,12 @@ use Greenlight\Attribute\SkipUnless;
 use Greenlight\Attribute\Test;
 use Greenlight\Condition\ClassAvailable;
 use Greenlight\Core\ErrorTrap;
-use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Doubles\Doubles;
 use Greenlight\Doubles\MockPlan;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\EnvironmentSandbox;
-use Greenlight\Harness\HarnessRegistry;
-use Greenlight\Harness\HarnessScopes;
 use Greenlight\Harness\Scope;
 use Greenlight\Laravel\LaravelBridgeError;
 use Greenlight\Laravel\LaravelFrameworkRequirement;
@@ -31,6 +26,7 @@ use Greenlight\Tests\Fixture\Laravel\FixtureApplication;
 use Greenlight\Tests\Fixture\Laravel\Greeter;
 use Greenlight\Tests\Fixture\Laravel\NamedGreeter;
 use Greenlight\Tests\Fixture\Laravel\VisitCounter;
+use Greenlight\Tests\Support\PluginLifecycle;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Contracts\Foundation\Application;
@@ -530,16 +526,11 @@ final class LaravelPluginTest
 
     private function context(): TestContext
     {
-        return new TestContext(
-            new \stdClass(),
-            new TestId('Fixture', 'probe'),
-            new TestMetadata('Fixture', 'probe'),
-            new HarnessScopes(new HarnessRegistry()),
-        );
+        return PluginLifecycle::context();
     }
 
     private function result(): TestResult
     {
-        return new TestResult(new TestId('Fixture', 'probe'), Outcome::Passed, 0.0, 0);
+        return PluginLifecycle::passedResult();
     }
 }

--- a/tests/Unit/Psr/Psr11PluginTest.php
+++ b/tests/Unit/Psr/Psr11PluginTest.php
@@ -5,19 +5,15 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Psr;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
-use Greenlight\Harness\HarnessRegistry;
-use Greenlight\Harness\HarnessScopes;
 use Greenlight\Harness\Scope;
 use Greenlight\Plugin\TestContext;
 use Greenlight\Psr\Psr11BridgeError;
 use Greenlight\Psr\Psr11Plugin;
 use Greenlight\Psr\Service;
+use Greenlight\Tests\Support\PluginLifecycle;
 use Greenlight\Tests\Support\Psr\ArrayContainer;
 use Greenlight\Tests\Support\Psr\Greeter;
 use Psr\Container\ContainerInterface;
@@ -382,16 +378,11 @@ final readonly class Psr11PluginTest
 
     private function context(): TestContext
     {
-        return new TestContext(
-            new \stdClass(),
-            new TestId('Fixture', 'probe'),
-            new TestMetadata('Fixture', 'probe'),
-            new HarnessScopes(new HarnessRegistry()),
-        );
+        return PluginLifecycle::context();
     }
 
     private function result(): TestResult
     {
-        return new TestResult(new TestId('Fixture', 'probe'), Outcome::Passed, 0.0, 0);
+        return PluginLifecycle::passedResult();
     }
 }

--- a/tests/Unit/Symfony/SymfonyPluginTest.php
+++ b/tests/Unit/Symfony/SymfonyPluginTest.php
@@ -5,14 +5,9 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Symfony;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
-use Greenlight\Harness\HarnessRegistry;
-use Greenlight\Harness\HarnessScopes;
 use Greenlight\Harness\Scope;
 use Greenlight\Plugin\TestContext;
 use Greenlight\Symfony\Service;
@@ -23,6 +18,7 @@ use Greenlight\Tests\Fixture\Symfony\FixtureKernel;
 use Greenlight\Tests\Fixture\Symfony\Greeter;
 use Greenlight\Tests\Fixture\Symfony\NamedGreeter;
 use Greenlight\Tests\Fixture\Symfony\VisitCounter;
+use Greenlight\Tests\Support\PluginLifecycle;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 final class SymfonyPluginTest
@@ -248,16 +244,11 @@ final class SymfonyPluginTest
 
     private function context(): TestContext
     {
-        return new TestContext(
-            new \stdClass(),
-            new TestId('Fixture', 'probe'),
-            new TestMetadata('Fixture', 'probe'),
-            new HarnessScopes(new HarnessRegistry()),
-        );
+        return PluginLifecycle::context();
     }
 
     private function result(): TestResult
     {
-        return new TestResult(new TestId('Fixture', 'probe'), Outcome::Passed, 0.0, 0);
+        return PluginLifecycle::passedResult();
     }
 }


### PR DESCRIPTION
## Summary

- add one canonical plugin lifecycle fixture for test contexts and passed results
- reuse it across Laravel, Symfony, and PSR-11 plugin suites
- remove duplicated domain wiring while keeping framework-specific helpers local