### PR TITLE
refactor(test): centralize XML fixture parsing

### DIFF
--- a/tests/Support/SimpleXml.php
+++ b/tests/Support/SimpleXml.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Support;
+
+final class SimpleXml
+{
+    /**
+     * @return array<string, string>
+     */
+    public static function attributes(\SimpleXMLElement $element): array
+    {
+        $attributes = [];
+
+        foreach ($element->attributes() as $name => $value) {
+            $attributes[$name] = (string) $value;
+        }
+
+        return $attributes;
+    }
+
+    /**
+     * @param list<\SimpleXMLElement> $elements
+     *
+     * @return list<array<string, string>>
+     */
+    public static function attributeSets(array $elements): array
+    {
+        return \array_map(self::attributes(...), $elements);
+    }
+
+    /**
+     * @return list<\SimpleXMLElement>
+     */
+    public static function xpath(\SimpleXMLElement $xml, string $expression): array
+    {
+        $nodes = $xml->xpath($expression);
+
+        if (!\is_array($nodes)) {
+            throw new \RuntimeException(\sprintf('XPath query "%s" failed.', $expression));
+        }
+
+        return \array_values($nodes);
+    }
+
+    private function __construct() {}
+}

--- a/tests/Unit/Coverage/CloverExporterTest.php
+++ b/tests/Unit/Coverage/CloverExporterTest.php
@@ -9,6 +9,7 @@ use Greenlight\Coverage\CoverageMap;
 use Greenlight\Coverage\Export\CloverExporter;
 use Greenlight\Coverage\FileCoverage;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\SimpleXml;
 
 final class CloverExporterTest
 {
@@ -139,14 +140,14 @@ final class CloverExporterTest
     {
         $projects = [];
 
-        foreach ($this->xpath($xml, '/coverage/project') as $project) {
+        foreach (SimpleXml::xpath($xml, '/coverage/project') as $project) {
             $files = [];
 
-            foreach ($this->xpath($project, 'file') as $file) {
+            foreach (SimpleXml::xpath($project, 'file') as $file) {
                 $files[] = [
                     'path' => (string) $file['name'],
-                    'lines' => $this->attributeSets($this->xpath($file, 'line')),
-                    'metrics' => $this->attributeSets($this->xpath($file, 'metrics')),
+                    'lines' => SimpleXml::attributeSets(SimpleXml::xpath($file, 'line')),
+                    'metrics' => SimpleXml::attributeSets(SimpleXml::xpath($file, 'metrics')),
                 ];
             }
 
@@ -154,7 +155,7 @@ final class CloverExporterTest
                 'timestamp' => (string) $project['timestamp'],
                 'name' => (string) $project['name'],
                 'files' => $files,
-                'metrics' => $this->attributeSets($this->xpath($project, 'metrics')),
+                'metrics' => SimpleXml::attributeSets(SimpleXml::xpath($project, 'metrics')),
             ];
         }
 
@@ -164,39 +165,4 @@ final class CloverExporterTest
         ];
     }
 
-    /**
-     * @param list<\SimpleXMLElement> $elements
-     *
-     * @return list<array<string, string>>
-     */
-    private function attributeSets(array $elements): array
-    {
-        $sets = [];
-
-        foreach ($elements as $element) {
-            $attributes = [];
-
-            foreach ($element->attributes() as $name => $value) {
-                $attributes[$name] = (string) $value;
-            }
-
-            $sets[] = $attributes;
-        }
-
-        return $sets;
-    }
-
-    /**
-     * @return list<\SimpleXMLElement>
-     */
-    private function xpath(\SimpleXMLElement $xml, string $expression): array
-    {
-        $nodes = $xml->xpath($expression);
-
-        if (!\is_array($nodes)) {
-            throw new \RuntimeException(\sprintf('XPath query "%s" failed.', $expression));
-        }
-
-        return \array_values($nodes);
-    }
 }

--- a/tests/Unit/Coverage/CoberturaExporterTest.php
+++ b/tests/Unit/Coverage/CoberturaExporterTest.php
@@ -9,6 +9,7 @@ use Greenlight\Coverage\CoverageMap;
 use Greenlight\Coverage\Export\CoberturaExporter;
 use Greenlight\Coverage\FileCoverage;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\SimpleXml;
 
 final class CoberturaExporterTest
 {
@@ -128,71 +129,34 @@ final class CoberturaExporterTest
     {
         $sources = [];
 
-        foreach ($this->xpath($xml, '/coverage/sources/source') as $source) {
+        foreach (SimpleXml::xpath($xml, '/coverage/sources/source') as $source) {
             $sources[] = (string) $source;
         }
 
         $packages = [];
 
-        foreach ($this->xpath($xml, '/coverage/packages/package') as $package) {
+        foreach (SimpleXml::xpath($xml, '/coverage/packages/package') as $package) {
             $classes = [];
 
-            foreach ($this->xpath($package, 'classes/class') as $class) {
+            foreach (SimpleXml::xpath($package, 'classes/class') as $class) {
                 $classes[] = [
-                    'attributes' => $this->attributes($class),
-                    'methods' => $this->attributeSets($this->xpath($class, 'methods')),
-                    'lines' => $this->attributeSets($this->xpath($class, 'lines/line')),
+                    'attributes' => SimpleXml::attributes($class),
+                    'methods' => SimpleXml::attributeSets(SimpleXml::xpath($class, 'methods')),
+                    'lines' => SimpleXml::attributeSets(SimpleXml::xpath($class, 'lines/line')),
                 ];
             }
 
             $packages[] = [
-                'attributes' => $this->attributes($package),
+                'attributes' => SimpleXml::attributes($package),
                 'classes' => $classes,
             ];
         }
 
         return [
-            'attributes' => $this->attributes($xml),
+            'attributes' => SimpleXml::attributes($xml),
             'sources' => $sources,
             'packages' => $packages,
         ];
     }
 
-    /**
-     * @return array<string, string>
-     */
-    private function attributes(\SimpleXMLElement $element): array
-    {
-        $attributes = [];
-
-        foreach ($element->attributes() as $name => $value) {
-            $attributes[$name] = (string) $value;
-        }
-
-        return $attributes;
-    }
-
-    /**
-     * @param list<\SimpleXMLElement> $elements
-     *
-     * @return list<array<string, string>>
-     */
-    private function attributeSets(array $elements): array
-    {
-        return \array_map($this->attributes(...), $elements);
-    }
-
-    /**
-     * @return list<\SimpleXMLElement>
-     */
-    private function xpath(\SimpleXMLElement $xml, string $expression): array
-    {
-        $nodes = $xml->xpath($expression);
-
-        if (!\is_array($nodes)) {
-            throw new \RuntimeException(\sprintf('XPath query "%s" failed.', $expression));
-        }
-
-        return \array_values($nodes);
-    }
 }


### PR DESCRIPTION
## Summary

- add one SimpleXML test helper for checked XPath queries and attribute normalization
- reuse it across Clover and Cobertura exporter suites
- keep format-specific document structure mapping in each consumer