### PR TITLE
fix(discovery): contain path probe warnings

### DIFF
--- a/src/Discovery/TestDiscoverer.php
+++ b/src/Discovery/TestDiscoverer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Discovery;
 
+use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Test\TestId;
 use Random\Engine\Mt19937;
 use Random\Randomizer;
@@ -240,7 +241,7 @@ final readonly class TestDiscoverer
         $files = [];
 
         foreach ($directories as $directory) {
-            $real = \realpath($directory);
+            $real = ErrorTrap::run(static fn(): string|false => \realpath($directory));
 
             if ($real === false || !\is_dir($real)) {
                 throw DiscoveryError::directoryNotFound($directory);

--- a/tests/Unit/Discovery/TestDiscovererTest.php
+++ b/tests/Unit/Discovery/TestDiscovererTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Discovery;
 
 use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Isolated;
 use Greenlight\Attribute\Test;
+use Greenlight\Core\ErrorTrap;
 use Greenlight\Discovery\DiscoveryError;
 use Greenlight\Discovery\ExecutionPlan;
 use Greenlight\Discovery\TestDiscoverer;
@@ -152,6 +154,36 @@ final class TestDiscovererTest
             DiscoveryError::class,
             message: \sprintf('Discovery directory "%s" is missing or is not a directory.', $directory),
         );
+    }
+
+    #[Test]
+    #[Isolated]
+    public function inaccessibleDirectoryFailsWithoutEngineDiagnostics(): void
+    {
+        $root = \dirname(__DIR__, 3);
+        $directory = \dirname($root);
+        $previousOpenBasedir = \ini_set('open_basedir', $root . \PATH_SEPARATOR . \sys_get_temp_dir());
+
+        Expect::that($previousOpenBasedir)
+            ->because('the isolated fixture MUST restrict access to the discovery directory')
+            ->not()
+            ->toBeFalse();
+
+        Expect::that(
+            static function () use ($directory, &$warning): void {
+                ErrorTrap::run(
+                    static fn(): array => new TestDiscoverer()->testFiles([$directory]),
+                    $warning,
+                );
+            },
+        )->because('an inaccessible discovery directory causes a domain error')->toThrow(
+            DiscoveryError::class,
+            message: \sprintf('Discovery directory "%s" is missing or is not a directory.', $directory),
+        );
+
+        Expect::that($warning)
+            ->because('inaccessible discovery paths MUST not leak engine diagnostics')
+            ->toBeNull();
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- contain warnings from discovery directory path probes
- preserve the existing domain error for inaccessible directories
- add an isolated open_basedir regression that rejects leaked engine diagnostics