### PR TITLE
fix(fixture): contain temp root warnings

### DIFF
--- a/src/Fixture/TempDirectory.php
+++ b/src/Fixture/TempDirectory.php
@@ -33,7 +33,7 @@ final class TempDirectory implements Disposable
     {
         if ($this->path === null) {
             $systemTemporaryRoot = $this->temporaryRoot ?? \sys_get_temp_dir();
-            $resolvedTemporaryRoot = \realpath($systemTemporaryRoot);
+            $resolvedTemporaryRoot = ErrorTrap::run(static fn(): string|false => \realpath($systemTemporaryRoot));
             $temporaryRoot = $resolvedTemporaryRoot === false ? $systemTemporaryRoot : $resolvedTemporaryRoot;
             $path = $temporaryRoot . '/greenlight-' . \bin2hex(\random_bytes(8));
 

--- a/tests/Unit/Fixture/TempDirectoryTest.php
+++ b/tests/Unit/Fixture/TempDirectoryTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Fixture;
 
 use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Isolated;
 use Greenlight\Attribute\Test;
+use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Test\SkipTest;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
@@ -103,6 +105,31 @@ final class TempDirectoryTest
         } finally {
             $directory->dispose();
         }
+    }
+
+    #[Test]
+    #[Isolated]
+    public function aRestrictedTempRootFailsWithoutEngineDiagnostics(): void
+    {
+        $root = \dirname(__DIR__, 3);
+        $restricted = \dirname($root);
+        $previousOpenBasedir = \ini_set('open_basedir', $root . \PATH_SEPARATOR . \sys_get_temp_dir());
+
+        Expect::that($previousOpenBasedir)
+            ->because('the isolated fixture MUST restrict access to the temporary root')
+            ->not()
+            ->toBeFalse();
+
+        $directory = new TempDirectory($restricted);
+
+        Expect::that(
+            static function () use ($directory, &$warning): void {
+                ErrorTrap::run(static fn(): string => $directory->path(), $warning);
+            },
+        )->because('a restricted temporary root causes a fixture error')->toThrow(TempDirectoryError::class);
+        Expect::that($warning)
+            ->because('a restricted temporary root MUST not leak engine diagnostics')
+            ->toBeNull();
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- contain warnings from temporary-root canonicalization
- preserve the typed creation error for inaccessible roots
- add an isolated regression for the reusable TempDirectory fixture