### PR TITLE
fix(laravel): contain bootstrap path warnings

### DIFF
--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -18,7 +18,7 @@ resources by `GREENLIGHT_CHANNEL`.
 final class LaravelPlugin implements HarnessProvider, ServiceResolver, TestLifecycleSubscriber
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L24)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L25)
 
 ### `__construct()`
 
@@ -36,7 +36,7 @@ PHPDoc:
 - `@param non-empty-string $env`
 - `@param bool $refreshBetweenTests Set to false only when no service carries state; tests on one worker then share one unreset application for the worker lifetime.`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L46)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L47)
 
 ### `services()`
 
@@ -49,7 +49,7 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L65)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L66)
 
 ### `resolve()`
 
@@ -64,7 +64,7 @@ PHPDoc:
 - `@param list<object> $attributes`
 - `@throws LaravelBridgeError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L82)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L83)
 
 ### `beforeTest()`
 
@@ -73,7 +73,7 @@ PHPDoc:
 public function beforeTest(TestContext $context): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L112)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L113)
 
 ### `afterTest()`
 
@@ -82,7 +82,7 @@ public function beforeTest(TestContext $context): void
 public function afterTest(TestContext $context, TestResult $result): TestResult
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L115)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L116)
 
 ## `Laravel\Service`
 

--- a/src/Laravel/LaravelPlugin.php
+++ b/src/Laravel/LaravelPlugin.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Laravel;
 
+use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Harness\Scope;
 use Greenlight\Harness\ServiceDefinition;
@@ -51,7 +52,7 @@ final class LaravelPlugin implements HarnessProvider, ServiceResolver, TestLifec
         $this->factory = $application instanceof \Closure
             ? $application
             : static function () use ($application): mixed {
-                if (!\is_file($application)) {
+                if (!ErrorTrap::run(static fn(): bool => \is_file($application))) {
                     throw LaravelBridgeError::bootstrapFileMissing($application);
                 }
 

--- a/tests/Unit/Laravel/LaravelPluginTest.php
+++ b/tests/Unit/Laravel/LaravelPluginTest.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Laravel;
 
 use Greenlight\Attribute\After;
+use Greenlight\Attribute\Isolated;
 use Greenlight\Attribute\SkipUnless;
 use Greenlight\Attribute\Test;
 use Greenlight\Condition\ClassAvailable;
+use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Core\Test\TestId;
@@ -157,6 +159,34 @@ final class LaravelPluginTest
         Expect::that(\getenv('APP_ENV'))->toBe('before-laravel');
         Expect::that($_ENV['APP_ENV'] ?? null)->toBe('before-laravel');
         Expect::that($_SERVER['APP_ENV'] ?? null)->toBe('before-laravel');
+    }
+
+    #[Test]
+    #[Isolated]
+    public function aRestrictedBootstrapFileFailsWithoutEngineDiagnostics(): void
+    {
+        $root = \dirname(__DIR__, 3);
+        $bootstrap = \dirname($root) . '/bootstrap/app.php';
+        $previousOpenBasedir = \ini_set('open_basedir', $root . \PATH_SEPARATOR . \sys_get_temp_dir());
+
+        Expect::that($previousOpenBasedir)
+            ->because('the isolated fixture MUST restrict access to the Laravel bootstrap file')
+            ->not()
+            ->toBeFalse();
+
+        $plugin = $this->track(new LaravelPlugin($bootstrap));
+        Expect::that(
+            static function () use ($plugin, &$warning): void {
+                ErrorTrap::run(
+                    static fn(): ?object => $plugin->resolve(Greeter::class, []),
+                    $warning,
+                );
+            },
+        )->because('a restricted Laravel bootstrap file causes a bridge error')
+            ->toThrow(LaravelBridgeError::class, matching: '/does not exist.*bootstrap\/app\.php/s');
+        Expect::that($warning)
+            ->because('a restricted Laravel bootstrap file MUST not leak engine diagnostics')
+            ->toBeNull();
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- contain warnings from Laravel bootstrap path probes
- preserve the existing bridge error for inaccessible bootstrap files
- add an isolated regression alongside the plugin lifecycle coverage