### PR TITLE
fix(doubles): contain proxy storage warnings

### DIFF
--- a/src/Doubles/ProxyGenerator.php
+++ b/src/Doubles/ProxyGenerator.php
@@ -49,7 +49,7 @@ final readonly class ProxyGenerator
         if (!\class_exists($proxyClass, false)) {
             $file = $this->directory . '/' . $shortName . '.php';
 
-            if (!\is_file($file)) {
+            if (!ErrorTrap::run(static fn(): bool => \is_file($file))) {
                 $this->write($file, $this->renderFile($reflection, $shortName, $body));
             }
 
@@ -395,8 +395,14 @@ final readonly class ProxyGenerator
     {
         $directory = $this->directory;
 
-        if (!\is_dir($directory) && !ErrorTrap::run(static fn(): bool => \mkdir($directory, 0o777, true), $warning) && !\is_dir($directory)) {
-            throw DoublesError::proxyDirectoryNotCreated($directory, $warning);
+        $directoryExists = ErrorTrap::run(static fn(): bool => \is_dir($directory));
+
+        if (!$directoryExists && !ErrorTrap::run(static fn(): bool => \mkdir($directory, 0o777, true), $warning)) {
+            $directoryExists = ErrorTrap::run(static fn(): bool => \is_dir($directory));
+
+            if (!$directoryExists) {
+                throw DoublesError::proxyDirectoryNotCreated($directory, $warning);
+            }
         }
 
         try {

--- a/tests/Unit/Doubles/ProxyStorageTest.php
+++ b/tests/Unit/Doubles/ProxyStorageTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Doubles;
 
+use Greenlight\Attribute\Isolated;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\AtomicFileError;
+use Greenlight\Core\ErrorTrap;
 use Greenlight\Doubles\Doubles;
 use Greenlight\Doubles\DoublesError;
 use Greenlight\Expect\Expect;
@@ -37,6 +39,34 @@ final readonly class ProxyStorageTest
                     . $directory
                     . ': mkdir(): File exists.',
             );
+    }
+
+    #[Test]
+    #[Isolated]
+    public function aRestrictedProxyDirectoryFailsWithoutEngineDiagnostics(): void
+    {
+        $root = \dirname(__DIR__, 3);
+        $directory = \dirname($root) . '/proxies';
+        $previousOpenBasedir = \ini_set('open_basedir', $root . \PATH_SEPARATOR . \sys_get_temp_dir());
+
+        Expect::that($previousOpenBasedir)
+            ->because('the isolated fixture MUST restrict access to the proxy directory')
+            ->not()
+            ->toBeFalse();
+
+        $doubles = new Doubles($directory);
+        Expect::that(
+            static function () use ($doubles, &$warning): void {
+                ErrorTrap::run(
+                    static fn(): object => $doubles->stub(ProxyStorageContract::class),
+                    $warning,
+                );
+            },
+        )->because('a restricted proxy directory causes a typed storage error')
+            ->toThrow(DoublesError::class);
+        Expect::that($warning)
+            ->because('a restricted proxy directory MUST not leak engine diagnostics')
+            ->toBeNull();
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- contain warnings from proxy cache file and directory probes
- preserve the existing typed storage error for inaccessible proxy directories
- extend proxy storage coverage with an isolated regression