### PR TITLE
fix(cli): contain run state path warnings

### DIFF
--- a/src/Cli/RunState.php
+++ b/src/Cli/RunState.php
@@ -66,11 +66,12 @@ final readonly class RunState
      */
     private function decoded(): ?array
     {
-        if (!\is_file($this->file)) {
+        $file = $this->file;
+
+        if (!ErrorTrap::run(static fn(): bool => \is_file($file))) {
             return null;
         }
 
-        $file = $this->file;
         $raw = ErrorTrap::run(static fn(): string|false => \file_get_contents($file));
 
         if (!\is_string($raw)) {

--- a/tests/Unit/Cli/RunStateTest.php
+++ b/tests/Unit/Cli/RunStateTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Cli;
 
 use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Isolated;
 use Greenlight\Attribute\Test;
 use Greenlight\Cli\RunState;
+use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Test\SkipTest;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -123,6 +125,32 @@ final readonly class RunStateTest
 
         Expect::that(RunState::forFile($file)->failedTests())
             ->because('unreadable advisory state MUST behave as absent state')
+            ->toBeNull();
+    }
+
+    #[Test]
+    #[Isolated]
+    public function aRestrictedStatePathReadsAsAbsentWithoutEngineDiagnostics(): void
+    {
+        $root = \dirname(__DIR__, 3);
+        $file = \dirname($root) . '/run-state.json';
+        $previousOpenBasedir = \ini_set('open_basedir', $root . \PATH_SEPARATOR . \sys_get_temp_dir());
+
+        Expect::that($previousOpenBasedir)
+            ->because('the isolated fixture MUST restrict access to the state path')
+            ->not()
+            ->toBeFalse();
+
+        $failedTests = ErrorTrap::run(
+            static fn(): ?array => RunState::forFile($file)->failedTests(),
+            $warning,
+        );
+
+        Expect::that($failedTests)
+            ->because('restricted advisory state MUST behave as absent state')
+            ->toBeNull();
+        Expect::that($warning)
+            ->because('a restricted advisory state path MUST not leak engine diagnostics')
             ->toBeNull();
     }
 


### PR DESCRIPTION
## Summary

- contain warnings from advisory run-state file probes
- preserve absent-state behavior for inaccessible paths
- add an isolated regression for restricted state paths