### PR TITLE
fix(cli): contain watch directory warnings

### DIFF
--- a/src/Cli/Watch/StatChangeDetector.php
+++ b/src/Cli/Watch/StatChangeDetector.php
@@ -68,7 +68,7 @@ final class StatChangeDetector implements ChangeDetector
         $snapshot = [];
 
         foreach ($this->directories as $directory) {
-            if (!\is_dir($directory)) {
+            if (!ErrorTrap::run(static fn(): bool => \is_dir($directory))) {
                 continue;
             }
 

--- a/tests/Unit/Cli/StatChangeDetectorTest.php
+++ b/tests/Unit/Cli/StatChangeDetectorTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Cli;
 
+use Greenlight\Attribute\Isolated;
 use Greenlight\Attribute\Test;
 use Greenlight\Cli\Watch\StatChangeDetector;
+use Greenlight\Core\ErrorTrap;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
 
@@ -35,5 +37,29 @@ final readonly class StatChangeDetectorTest
         Expect::that($detector->poll())
             ->because('missing directories and non-PHP changes MUST be ignored')
             ->toBe([]);
+    }
+
+    #[Test]
+    #[Isolated]
+    public function aRestrictedDirectoryIsIgnoredWithoutEngineDiagnostics(): void
+    {
+        $root = \dirname(__DIR__, 3);
+        $directory = \dirname($root);
+        $previousOpenBasedir = \ini_set('open_basedir', $root . \PATH_SEPARATOR . \sys_get_temp_dir());
+
+        Expect::that($previousOpenBasedir)
+            ->because('the isolated fixture MUST restrict access to the watch directory')
+            ->not()
+            ->toBeFalse();
+
+        $detector = new StatChangeDetector([$directory]);
+        $changed = ErrorTrap::run(static fn(): array => $detector->poll(), $warning);
+
+        Expect::that($changed)
+            ->because('a restricted watch directory MUST behave as a missing directory')
+            ->toBe([]);
+        Expect::that($warning)
+            ->because('a restricted watch directory MUST not leak engine diagnostics')
+            ->toBeNull();
     }
 }


### PR DESCRIPTION
## Summary

- contain warnings from watch-directory availability probes
- preserve missing-directory behavior for inaccessible paths
- add an isolated regression for restricted watch directories