### PR TITLE
fix(coverage): contain HTML source path warnings

### DIFF
--- a/src/Coverage/Export/HtmlExporter.php
+++ b/src/Coverage/Export/HtmlExporter.php
@@ -200,7 +200,7 @@ final readonly class HtmlExporter implements CoverageExporter
      */
     private function highlightedLines(string $path): ?array
     {
-        if (!\is_file($path) || !\is_readable($path)) {
+        if (!ErrorTrap::run(static fn(): bool => \is_file($path) && \is_readable($path))) {
             return null;
         }
 

--- a/tests/Unit/Coverage/HtmlExporterSourceFailureTest.php
+++ b/tests/Unit/Coverage/HtmlExporterSourceFailureTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Coverage;
 
+use Greenlight\Attribute\Isolated;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\ErrorTrap;
 use Greenlight\Coverage\CoverageMap;
@@ -11,10 +12,36 @@ use Greenlight\Coverage\Export\HtmlExporter;
 use Greenlight\Coverage\FileCoverage;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\Coverage\UnreadableAfterStatStream;
+use Greenlight\Tests\Support\FilesystemRestriction;
 
 final readonly class HtmlExporterSourceFailureTest
 {
     private const string SCHEME = 'greenlight-unreadable-after-stat';
+
+    #[Test]
+    #[Isolated]
+    public function restrictedSourceFallsBackWithoutEngineDiagnostics(): void
+    {
+        $root = \dirname(__DIR__, 3);
+        $path = \dirname($root) . '/Source.php';
+        FilesystemRestriction::toProject($root);
+
+        $map = new CoverageMap([
+            new FileCoverage($path, [2], [4]),
+        ]);
+        $pages = ErrorTrap::run(
+            static fn(): array => new HtmlExporter()->export($map),
+            $warning,
+        );
+
+        Expect::that($warning)
+            ->because('a restricted source path MUST not leak engine diagnostics')
+            ->toBeNull();
+        Expect::that($pages[HtmlExporter::pageName($path)])
+            ->because('a restricted source shows only coverage line numbers')
+            ->toContain('<span class="cov"><span class="num">2</span></span>')
+            ->toContain('<span class="unc"><span class="num">4</span></span>');
+    }
 
     #[Test]
     public function sourceReadFailureFallsBackToLineNumbersOnly(): void


### PR DESCRIPTION
## Summary

- contain warnings from HTML coverage source path probes
- preserve line-number-only fallback output for inaccessible sources
- extend source-failure coverage with an isolated regression