### PR TITLE
refactor(tests): reuse filesystem restriction setup

### DIFF
--- a/tests/Support/FilesystemRestriction.php
+++ b/tests/Support/FilesystemRestriction.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Support;
+
+use Greenlight\Expect\Fail;
+
+final class FilesystemRestriction
+{
+    private function __construct() {}
+
+    /** @param non-empty-string $projectRoot */
+    public static function toProject(string $projectRoot): void
+    {
+        $temporaryDirectory = \sys_get_temp_dir();
+
+        if ($temporaryDirectory === '') {
+            Fail::because('The test could not resolve the system temporary directory.');
+        }
+
+        if (\ini_set('open_basedir', $projectRoot . \PATH_SEPARATOR . $temporaryDirectory) === false) {
+            Fail::because('The test could not restrict file system access.');
+        }
+    }
+}

--- a/tests/Unit/Cli/CoverageMissingIncludePathTest.php
+++ b/tests/Unit/Cli/CoverageMissingIncludePathTest.php
@@ -15,6 +15,7 @@ use Greenlight\Expect\Fail;
 use Greenlight\Runner\CoverageCollector;
 use Greenlight\Runner\CoverageSettings;
 use Greenlight\Tests\Fixture\Coverage\RecordingFakeDriver;
+use Greenlight\Tests\Support\FilesystemRestriction;
 
 final class CoverageMissingIncludePathTest
 {
@@ -59,14 +60,7 @@ final class CoverageMissingIncludePathTest
             Fail::because('The test could not resolve its restricted include path.');
         }
 
-        $previousOpenBasedir = \ini_set(
-            'open_basedir',
-            $root . \PATH_SEPARATOR . \sys_get_temp_dir(),
-        );
-
-        if ($previousOpenBasedir === false) {
-            Fail::because('The test could not restrict file system access.');
-        }
+        FilesystemRestriction::toProject($root);
 
         $configuration = new CoverageConfiguration([$outside], null, []);
         $settings = ErrorTrap::run(

--- a/tests/Unit/Doubles/ProxyStorageTest.php
+++ b/tests/Unit/Doubles/ProxyStorageTest.php
@@ -14,6 +14,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Tests\Fixture\Doubles\ProxyStorageContract;
+use Greenlight\Tests\Support\FilesystemRestriction;
 use Greenlight\Tests\Support\Subprocess;
 
 final readonly class ProxyStorageTest
@@ -47,12 +48,7 @@ final readonly class ProxyStorageTest
     {
         $root = \dirname(__DIR__, 3);
         $directory = \dirname($root) . '/proxies';
-        $previousOpenBasedir = \ini_set('open_basedir', $root . \PATH_SEPARATOR . \sys_get_temp_dir());
-
-        Expect::that($previousOpenBasedir)
-            ->because('the isolated fixture MUST restrict access to the proxy directory')
-            ->not()
-            ->toBeFalse();
+        FilesystemRestriction::toProject($root);
 
         $doubles = new Doubles($directory);
         Expect::that(

--- a/tests/Unit/Fixture/TempDirectoryTest.php
+++ b/tests/Unit/Fixture/TempDirectoryTest.php
@@ -13,6 +13,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Fixture\TempDirectoryError;
+use Greenlight\Tests\Support\FilesystemRestriction;
 use Greenlight\Tests\Support\Subprocess;
 
 final class TempDirectoryTest
@@ -113,12 +114,7 @@ final class TempDirectoryTest
     {
         $root = \dirname(__DIR__, 3);
         $restricted = \dirname($root);
-        $previousOpenBasedir = \ini_set('open_basedir', $root . \PATH_SEPARATOR . \sys_get_temp_dir());
-
-        Expect::that($previousOpenBasedir)
-            ->because('the isolated fixture MUST restrict access to the temporary root')
-            ->not()
-            ->toBeFalse();
+        FilesystemRestriction::toProject($root);
 
         $directory = new TempDirectory($restricted);
 

--- a/tests/Unit/Runner/CpuCoresFallbackTest.php
+++ b/tests/Unit/Runner/CpuCoresFallbackTest.php
@@ -10,6 +10,7 @@ use Greenlight\Core\ErrorTrap;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\EnvironmentSandbox;
 use Greenlight\Runner\CpuCores;
+use Greenlight\Tests\Support\FilesystemRestriction;
 
 final readonly class CpuCoresFallbackTest
 {
@@ -21,13 +22,7 @@ final readonly class CpuCoresFallbackTest
     {
         $root = \dirname(__DIR__, 3);
         $this->environment->set('PATH', '');
-        $openBasedir = $root . \PATH_SEPARATOR . \sys_get_temp_dir();
-        $previousOpenBasedir = \ini_set('open_basedir', $openBasedir);
-
-        Expect::that($previousOpenBasedir)
-            ->because('the isolated fixture MUST restrict access to platform CPU metadata')
-            ->not()
-            ->toBeFalse();
+        FilesystemRestriction::toProject($root);
 
         $count = ErrorTrap::run(
             static fn(): int => CpuCores::count(),


### PR DESCRIPTION
## Summary

- centralize isolated open_basedir setup in a focused test-support helper
- validate the system temporary directory at the shared boundary
- migrate coverage, fixture, CPU, and doubles regressions to the reusable setup