### PR TITLE
fix(fixture): report inaccessible temp roots

### DIFF
--- a/src/Fixture/TempDirectory.php
+++ b/src/Fixture/TempDirectory.php
@@ -111,8 +111,13 @@ final class TempDirectory implements Disposable
         }
 
         $path = $this->path;
+        $isLink = ErrorTrap::run(static fn(): bool => \is_link($path), $warning);
 
-        if (\is_link($path)) {
+        if ($warning !== null) {
+            throw TempDirectoryError::rootRemovalFailed($path, $warning);
+        }
+
+        if ($isLink) {
             if (!ErrorTrap::run(static fn(): bool => \unlink($path), $warning)) {
                 throw TempDirectoryError::rootLinkRemovalFailed($path, $warning);
             }
@@ -122,7 +127,13 @@ final class TempDirectory implements Disposable
             return;
         }
 
-        if (!\is_dir($path)) {
+        $isDirectory = ErrorTrap::run(static fn(): bool => \is_dir($path), $warning);
+
+        if ($warning !== null) {
+            throw TempDirectoryError::rootRemovalFailed($path, $warning);
+        }
+
+        if (!$isDirectory) {
             $this->path = null;
 
             return;

--- a/tests/Unit/Fixture/TempDirectoryRestrictedDisposalTest.php
+++ b/tests/Unit/Fixture/TempDirectoryRestrictedDisposalTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Fixture;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\Subprocess;
+
+final readonly class TempDirectoryRestrictedDisposalTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function restrictedRootDisposalFailsWithoutEngineDiagnostics(): void
+    {
+        $root = \dirname(__DIR__, 3);
+        $result = Subprocess::run($root, [
+            \PHP_BINARY,
+            '-r',
+            <<<'PHP'
+                require $argv[1];
+
+                $directory = new Greenlight\Fixture\TempDirectory($argv[2]);
+                $directory->path();
+
+                if (ini_set('open_basedir', $argv[3]) === false) {
+                    exit(22);
+                }
+
+                try {
+                    Greenlight\Core\ErrorTrap::run(
+                        static function () use ($directory): void {
+                            $directory->dispose();
+                        },
+                        $warning,
+                    );
+                } catch (Greenlight\Fixture\TempDirectoryError $error) {
+                    echo $warning === null ? "clean\n" : "leaked: {$warning}\n";
+                    echo $error->getMessage();
+                    exit(23);
+                }
+
+                echo $warning === null ? 'no typed error' : "leaked: {$warning}";
+                exit(24);
+                PHP,
+            $root . '/vendor/autoload.php',
+            $this->tempDirectory->path(),
+            $root,
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('restricted root disposal MUST produce a typed fixture error')
+            ->toBe(23);
+        Expect::that($result->stdout)
+            ->because('restricted root disposal MUST contain diagnostics and identify the failed cleanup')
+            ->toStartWith("clean\nFailed to remove temp directory \"")
+            ->toContain('open_basedir restriction in effect');
+    }
+}


### PR DESCRIPTION
## Summary

- contain diagnostics from temporary-root disposal probes
- distinguish absent roots from inaccessible roots instead of silently forgetting cleanup
- add a subprocess regression for access revoked before disposal