### PR TITLE
fix(artifact): contain recovery marker warnings

### DIFF
--- a/src/Runner/Artifact/ArtifactStore.php
+++ b/src/Runner/Artifact/ArtifactStore.php
@@ -421,7 +421,10 @@ final class ArtifactStore
             return $result;
         }
 
-        $attempt = DecimalInteger::parse(\trim((string) @\file_get_contents($directory . '/.attempt')));
+        $attemptRecord = ErrorTrap::run(
+            static fn(): string|false => \file_get_contents($directory . '/.attempt'),
+        );
+        $attempt = DecimalInteger::parse(\trim((string) $attemptRecord));
 
         if ($attempt !== null && $attempt > 0) {
             $result = $result->withAttempts(\max($result->attempts, $attempt));

--- a/tests/Unit/Artifact/ArtifactRecoveryAttemptFloorTest.php
+++ b/tests/Unit/Artifact/ArtifactRecoveryAttemptFloorTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Unit\Artifact;
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Core\Test\TestId;
@@ -79,6 +80,38 @@ final readonly class ArtifactRecoveryAttemptFloorTest
         Expect::that($recovered->attempts)
             ->because('corrupt recovery metadata MUST NOT inflate a reported attempt count')
             ->toBe(3);
+    }
+
+    #[Test]
+    public function aMissingAttemptMarkerDoesNotLeakEngineDiagnostics(): void
+    {
+        $root = $this->tempDirectory->subdirectory('missing-recovery-attempt');
+        $staging = $root . '/staging';
+        $id = new TestId('Example\\EvidenceTest', 'crashesBeforeRetry');
+        $testDirectory = $staging . '/' . ArtifactStore::testDirectory($id);
+        \mkdir($testDirectory, 0o700, true);
+        $store = ArtifactStore::fromSession(
+            new ArtifactSession($staging, $root . '/published/run-missing-attempt'),
+            new ArtifactConfiguration($root . '/published'),
+        );
+
+        $recovered = ErrorTrap::run(
+            static fn(): TestResult => $store->recover(new TestResult(
+                $id,
+                Outcome::Errored,
+                0.0,
+                0,
+                attempts: 3,
+            )),
+            $warning,
+        );
+
+        Expect::that($recovered->attempts)
+            ->because('a missing recovery marker MUST preserve the reported attempt count')
+            ->toBe(3);
+        Expect::that($warning)
+            ->because('a missing recovery marker MUST not leak an engine diagnostic')
+            ->toBeNull();
     }
 
     /**


### PR DESCRIPTION
Crash recovery treats a missing attempt marker as valid absent metadata, but the suppression operator still invokes installed host error handlers. Read the optional marker through ErrorTrap so the expected miss cannot become a runner diagnostic. Add a regression that observes the host handler while preserving the reported attempt count.