### PR TITLE
fix(test): synchronize inherited pipe deadline

### DIFF
--- a/tests/Unit/Support/SubprocessTest.php
+++ b/tests/Unit/Support/SubprocessTest.php
@@ -196,6 +196,7 @@ final readonly class SubprocessTest
         );
 
         try {
+            $process->readStdoutUntil('parent exited', 5.0);
             $started = \hrtime(true);
             $result = $process->wait(0.5);
             $elapsedSeconds = (\hrtime(true) - $started) / 1_000_000_000;


### PR DESCRIPTION
Synchronize on the parent process output before the inherited-pipe deadline starts. The descendant still owns the pipe during wait(), but process startup and scheduler latency no longer consume the assertion window. This keeps the regression focused on bounded output draining and removes a full-suite load flake.