### PR TITLE
refactor(test): centralize filesystem restrictions

### DIFF
--- a/tests/Unit/Artifact/ArtifactOutputSafetyTest.php
+++ b/tests/Unit/Artifact/ArtifactOutputSafetyTest.php
@@ -18,6 +18,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Runner\Artifact\ArtifactStore;
 use Greenlight\Runner\Artifact\TestArtifactBudget;
+use Greenlight\Tests\Support\FilesystemRestriction;
 
 final readonly class ArtifactOutputSafetyTest
 {
@@ -46,12 +47,7 @@ final readonly class ArtifactOutputSafetyTest
     {
         $root = \dirname(__DIR__, 3);
         $restricted = \dirname($root);
-        $previousOpenBasedir = \ini_set('open_basedir', $root . \PATH_SEPARATOR . \sys_get_temp_dir());
-
-        Expect::that($previousOpenBasedir)
-            ->because('the isolated fixture MUST restrict access to artifact paths')
-            ->not()
-            ->toBeFalse();
+        FilesystemRestriction::toProject($root);
 
         $absoluteStore = ErrorTrap::run(
             static fn(): ArtifactStore => ArtifactStore::open(

--- a/tests/Unit/Cli/RunStateTest.php
+++ b/tests/Unit/Cli/RunStateTest.php
@@ -12,6 +12,7 @@ use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Test\SkipTest;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\FilesystemRestriction;
 
 final readonly class RunStateTest
 {
@@ -134,12 +135,7 @@ final readonly class RunStateTest
     {
         $root = \dirname(__DIR__, 3);
         $file = \dirname($root) . '/run-state.json';
-        $previousOpenBasedir = \ini_set('open_basedir', $root . \PATH_SEPARATOR . \sys_get_temp_dir());
-
-        Expect::that($previousOpenBasedir)
-            ->because('the isolated fixture MUST restrict access to the state path')
-            ->not()
-            ->toBeFalse();
+        FilesystemRestriction::toProject($root);
 
         $failedTests = ErrorTrap::run(
             static fn(): ?array => RunState::forFile($file)->failedTests(),

--- a/tests/Unit/Cli/StatChangeDetectorTest.php
+++ b/tests/Unit/Cli/StatChangeDetectorTest.php
@@ -10,6 +10,7 @@ use Greenlight\Cli\Watch\StatChangeDetector;
 use Greenlight\Core\ErrorTrap;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\FilesystemRestriction;
 
 final readonly class StatChangeDetectorTest
 {
@@ -45,12 +46,7 @@ final readonly class StatChangeDetectorTest
     {
         $root = \dirname(__DIR__, 3);
         $directory = \dirname($root);
-        $previousOpenBasedir = \ini_set('open_basedir', $root . \PATH_SEPARATOR . \sys_get_temp_dir());
-
-        Expect::that($previousOpenBasedir)
-            ->because('the isolated fixture MUST restrict access to the watch directory')
-            ->not()
-            ->toBeFalse();
+        FilesystemRestriction::toProject($root);
 
         $detector = new StatChangeDetector([$directory]);
         $changed = ErrorTrap::run(static fn(): array => $detector->poll(), $warning);

--- a/tests/Unit/Config/ConfigLoaderTest.php
+++ b/tests/Unit/Config/ConfigLoaderTest.php
@@ -11,6 +11,7 @@ use Greenlight\Config\ConfigLoader;
 use Greenlight\Config\GreenlightConfig;
 use Greenlight\Core\ErrorTrap;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\FilesystemRestriction;
 
 final class ConfigLoaderTest
 {
@@ -62,12 +63,7 @@ final class ConfigLoaderTest
         $root = \dirname(__DIR__, 3);
         $restrictedDirectory = \dirname($root);
         $restrictedFile = $restrictedDirectory . '/greenlight.php';
-        $previousOpenBasedir = \ini_set('open_basedir', $root . \PATH_SEPARATOR . \sys_get_temp_dir());
-
-        Expect::that($previousOpenBasedir)
-            ->because('the isolated fixture MUST restrict access to configuration paths')
-            ->not()
-            ->toBeFalse();
+        FilesystemRestriction::toProject($root);
 
         $loader = new ConfigLoader();
         Expect::that(

--- a/tests/Unit/Discovery/TestDiscovererTest.php
+++ b/tests/Unit/Discovery/TestDiscovererTest.php
@@ -12,6 +12,7 @@ use Greenlight\Discovery\DiscoveryError;
 use Greenlight\Discovery\ExecutionPlan;
 use Greenlight\Discovery\TestDiscoverer;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\FilesystemRestriction;
 use Greenlight\Tests\Support\JsonWire;
 
 final class TestDiscovererTest
@@ -162,12 +163,7 @@ final class TestDiscovererTest
     {
         $root = \dirname(__DIR__, 3);
         $directory = \dirname($root);
-        $previousOpenBasedir = \ini_set('open_basedir', $root . \PATH_SEPARATOR . \sys_get_temp_dir());
-
-        Expect::that($previousOpenBasedir)
-            ->because('the isolated fixture MUST restrict access to the discovery directory')
-            ->not()
-            ->toBeFalse();
+        FilesystemRestriction::toProject($root);
 
         Expect::that(
             static function () use ($directory, &$warning): void {

--- a/tests/Unit/Laravel/LaravelPluginTest.php
+++ b/tests/Unit/Laravel/LaravelPluginTest.php
@@ -26,6 +26,7 @@ use Greenlight\Tests\Fixture\Laravel\FixtureApplication;
 use Greenlight\Tests\Fixture\Laravel\Greeter;
 use Greenlight\Tests\Fixture\Laravel\NamedGreeter;
 use Greenlight\Tests\Fixture\Laravel\VisitCounter;
+use Greenlight\Tests\Support\FilesystemRestriction;
 use Greenlight\Tests\Support\PluginLifecycle;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Console\Kernel;
@@ -163,12 +164,7 @@ final class LaravelPluginTest
     {
         $root = \dirname(__DIR__, 3);
         $bootstrap = \dirname($root) . '/bootstrap/app.php';
-        $previousOpenBasedir = \ini_set('open_basedir', $root . \PATH_SEPARATOR . \sys_get_temp_dir());
-
-        Expect::that($previousOpenBasedir)
-            ->because('the isolated fixture MUST restrict access to the Laravel bootstrap file')
-            ->not()
-            ->toBeFalse();
+        FilesystemRestriction::toProject($root);
 
         $plugin = $this->track(new LaravelPlugin($bootstrap));
         Expect::that(


### PR DESCRIPTION
Route the remaining isolated open_basedir regressions through the shared FilesystemRestriction fixture. This keeps failure handling and temporary-directory access in one place while preserving each test’s behavior and diagnostic oracle.