### PR TITLE
refactor(test): manage doubles regression fixtures

### DIFF
--- a/tests/Unit/Doubles/PrivateHandlerMethodTest.php
+++ b/tests/Unit/Doubles/PrivateHandlerMethodTest.php
@@ -9,12 +9,14 @@ use Greenlight\Doubles\Doubles;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\Doubles\PrivateHandlerMethod;
 
-final class PrivateHandlerMethodTest
+final readonly class PrivateHandlerMethodTest
 {
+    public function __construct(private Doubles $doubles) {}
+
     #[Test]
     public function privateParentHandlerMethodsRemainValid(): void
     {
-        Expect::that(new Doubles()->stub(PrivateHandlerMethod::class))
+        Expect::that($this->doubles->stub(PrivateHandlerMethod::class))
             ->because('a private parent method does not conflict with the proxy handler method')
             ->toBeInstanceOf(PrivateHandlerMethod::class);
     }

--- a/tests/Unit/Doubles/ProxyByReferenceTest.php
+++ b/tests/Unit/Doubles/ProxyByReferenceTest.php
@@ -10,13 +10,14 @@ use Greenlight\Doubles\MockPlan;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\Doubles\Wide;
 
-final class ProxyByReferenceTest
+final readonly class ProxyByReferenceTest
 {
+    public function __construct(private Doubles $doubles) {}
+
     #[Test]
     public function configuredCallbacksCanChangeByReferenceArguments(): void
     {
-        $doubles = new Doubles();
-        $wide = $doubles->mock(Wide::class, static function (MockPlan $plan): void {
+        $wide = $this->doubles->mock(Wide::class, static function (MockPlan $plan): void {
             $plan->expects('byReference')
                 ->andReturnsUsing(static function (array &$items): void {
                     $items[] = 'changed';
@@ -24,14 +25,10 @@ final class ProxyByReferenceTest
         });
         $items = ['original'];
 
-        try {
-            $wide->byReference($items);
+        $wide->byReference($items);
 
-            Expect::that($items)
-                ->because('a doubled method MUST preserve by-reference argument changes')
-                ->toBe(['original', 'changed']);
-        } finally {
-            $doubles->dispose();
-        }
+        Expect::that($items)
+            ->because('a doubled method MUST preserve by-reference argument changes')
+            ->toBe(['original', 'changed']);
     }
 }

--- a/tests/Unit/Doubles/ProxyStaticReturnTest.php
+++ b/tests/Unit/Doubles/ProxyStaticReturnTest.php
@@ -10,26 +10,23 @@ use Greenlight\Doubles\MockPlan;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\Doubles\Wide;
 
-final class ProxyStaticReturnTest
+final readonly class ProxyStaticReturnTest
 {
+    public function __construct(private Doubles $doubles) {}
+
     #[Test]
     public function aConfiguredStaticReturnAcceptsTheGeneratedProxy(): void
     {
         $double = null;
-        $doubles = new Doubles();
 
-        try {
-            $double = $doubles->mock(Wide::class, static function (MockPlan $plan) use (&$double): void {
-                $plan->expects('returnsStatic')->andReturnsUsing(static function () use (&$double): ?Wide {
-                    return $double;
-                });
+        $double = $this->doubles->mock(Wide::class, static function (MockPlan $plan) use (&$double): void {
+            $plan->expects('returnsStatic')->andReturnsUsing(static function () use (&$double): ?Wide {
+                return $double;
             });
+        });
 
-            Expect::that($double->returnsStatic())
-                ->because('a static return type MUST accept the generated proxy instance')
-                ->toBe($double);
-        } finally {
-            $doubles->dispose();
-        }
+        Expect::that($double->returnsStatic())
+            ->because('a static return type MUST accept the generated proxy instance')
+            ->toBe($double);
     }
 }

--- a/tests/Unit/Doubles/SpyMethodCaseTest.php
+++ b/tests/Unit/Doubles/SpyMethodCaseTest.php
@@ -10,21 +10,20 @@ use Greenlight\Doubles\Doubles;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\Doubles\Notifier;
 
-final class SpyMethodCaseTest
+final readonly class SpyMethodCaseTest
 {
+    public function __construct(private Doubles $doubles) {}
+
     #[Test]
     #[DataSet('methodNames')]
     public function recordedMethodNamesFollowPhpCaseInsensitivity(string $method): void
     {
-        $doubles = new Doubles();
-        $notifier = $doubles->spy(Notifier::class);
+        $notifier = $this->doubles->spy(Notifier::class);
         $notifier->notify('ops', 'deployed');
 
-        Expect::that($doubles->callsTo($notifier, $method))
+        Expect::that($this->doubles->callsTo($notifier, $method))
             ->because('recorded method names MUST follow PHP case-insensitive dispatch')
             ->toBe([['ops', 'deployed']]);
-
-        $doubles->dispose();
     }
 
     /**

--- a/tests/Unit/Doubles/SpyMethodValidationTest.php
+++ b/tests/Unit/Doubles/SpyMethodValidationTest.php
@@ -10,22 +10,21 @@ use Greenlight\Doubles\DoublesError;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\Doubles\Notifier;
 
-final class SpyMethodValidationTest
+final readonly class SpyMethodValidationTest
 {
+    public function __construct(private Doubles $doubles) {}
+
     #[Test]
     public function rejectsAnUnknownMethodInsteadOfReportingThatItWasNotCalled(): void
     {
-        $doubles = new Doubles();
-        $spy = $doubles->spy(Notifier::class);
+        $spy = $this->doubles->spy(Notifier::class);
 
-        Expect::that(static fn(): array => $doubles->callsTo($spy, 'notifiy')) // @phpstan-ignore greenlight.doubles.callsToMethod (deliberately invalid: tests runtime validation)
+        Expect::that(fn(): array => $this->doubles->callsTo($spy, 'notifiy')) // @phpstan-ignore greenlight.doubles.callsToMethod (deliberately invalid: tests runtime validation)
             ->because('a misspelled method MUST NOT look like an uncalled method')
             ->toThrow(
                 DoublesError::class,
                 message: 'Greenlight\Tests\Fixture\Doubles\Notifier has no method notifiy(). '
                 . 'Doubles cannot inspect calls to it.',
             );
-
-        $doubles->dispose();
     }
 }


### PR DESCRIPTION
Inject the managed per-test Doubles fixture into five focused proxy and spy regressions that do not test disposal itself. This removes local lifecycle code, guarantees verification at scope close, and gives the previously undisposed private-handler stub normal harness cleanup.