### PR TITLE
refactor(test): centralize discovery cache paths

### DIFF
--- a/tests/Support/DiscoveryCachePath.php
+++ b/tests/Support/DiscoveryCachePath.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Support;
+
+final class DiscoveryCachePath
+{
+    private function __construct() {}
+
+    /**
+     * @param list<non-empty-string> $directories
+     *
+     * @return non-empty-string
+     */
+    public static function forDirectories(array $directories): string
+    {
+        \sort($directories);
+
+        return \sprintf(
+            '%s/greenlight-discovery-%s.json',
+            \rtrim(\sys_get_temp_dir(), '/'),
+            \substr(\sha1(\implode("\n", $directories)), 0, 12),
+        );
+    }
+}

--- a/tests/Unit/Discovery/DiscoveryCacheContentFingerprintTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheContentFingerprintTest.php
@@ -12,6 +12,7 @@ use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\DiscoveryCachePath;
 
 final readonly class DiscoveryCacheContentFingerprintTest
 {
@@ -22,7 +23,7 @@ final readonly class DiscoveryCacheContentFingerprintTest
     {
         $directory = $this->tempDirectory->subdirectory('discovery-content');
         $source = $directory . '/ContentProbeTest.php';
-        $cacheFile = $this->cacheFile($directory);
+        $cacheFile = DiscoveryCachePath::forDirectories([$directory]);
         $original = '<?php // alpha';
         $replacement = '<?php // bravo';
         $mtime = 1_700_000_000;
@@ -79,7 +80,7 @@ final readonly class DiscoveryCacheContentFingerprintTest
         $directory = $this->tempDirectory->subdirectory('discovery-provider-content');
         $source = $directory . '/ProviderProbeTest.php';
         $provider = $directory . '/ContentRows.php';
-        $cacheFile = $this->cacheFile($directory);
+        $cacheFile = DiscoveryCachePath::forDirectories([$directory]);
         $shortClass = 'ContentRows' . \bin2hex(\random_bytes(6));
         $providerClass = 'GreenlightDiscoveryFingerprint\\' . $shortClass;
         $providerSource = <<<PHP
@@ -152,12 +153,4 @@ final readonly class DiscoveryCacheContentFingerprintTest
         }
     }
 
-    private function cacheFile(string $directory): string
-    {
-        return \sprintf(
-            '%s/greenlight-discovery-%s.json',
-            \rtrim(\sys_get_temp_dir(), '/'),
-            \substr(\sha1($directory), 0, 12),
-        );
-    }
 }

--- a/tests/Unit/Discovery/DiscoveryCacheCorruptPlanTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheCorruptPlanTest.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Discovery\DiscoveryCache;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\DiscoveryCachePath;
 
 final readonly class DiscoveryCacheCorruptPlanTest
 {
@@ -18,7 +19,7 @@ final readonly class DiscoveryCacheCorruptPlanTest
     {
         $directory = $this->tempDirectory->subdirectory('corrupt-plan');
         $source = $directory . '/ExampleTest.php';
-        $cacheFile = $this->cacheFile($directory);
+        $cacheFile = DiscoveryCachePath::forDirectories([$directory]);
         \file_put_contents($source, '<?php');
         \file_put_contents($cacheFile, \json_encode([
             'version' => 3,
@@ -52,15 +53,4 @@ final readonly class DiscoveryCacheCorruptPlanTest
         }
     }
 
-    /**
-     * @param non-empty-string $directory
-     */
-    private function cacheFile(string $directory): string
-    {
-        return \sprintf(
-            '%s/greenlight-discovery-%s.json',
-            \rtrim(\sys_get_temp_dir(), '/'),
-            \substr(\sha1($directory), 0, 12),
-        );
-    }
 }

--- a/tests/Unit/Discovery/DiscoveryCacheDirectoryOrderTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheDirectoryOrderTest.php
@@ -11,6 +11,7 @@ use Greenlight\Discovery\DiscoveryCache;
 use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\DiscoveryCachePath;
 
 final readonly class DiscoveryCacheDirectoryOrderTest
 {
@@ -30,7 +31,7 @@ final readonly class DiscoveryCacheDirectoryOrderTest
             new TestMetadata($id->class, $id->method),
         );
         $directories = [$first, $second];
-        $cacheFile = $this->cacheFile($directories);
+        $cacheFile = DiscoveryCachePath::forDirectories($directories);
 
         try {
             $cache = DiscoveryCache::forDirectories($directories);
@@ -47,19 +48,4 @@ final readonly class DiscoveryCacheDirectoryOrderTest
         }
     }
 
-    /**
-     * @param list<non-empty-string> $directories
-     *
-     * @return non-empty-string
-     */
-    private function cacheFile(array $directories): string
-    {
-        \sort($directories);
-
-        return \sprintf(
-            '%s/greenlight-discovery-%s.json',
-            \rtrim(\sys_get_temp_dir(), '/'),
-            \substr(\sha1(\implode("\n", $directories)), 0, 12),
-        );
-    }
 }

--- a/tests/Unit/Discovery/DiscoveryCacheEmptyPlanTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheEmptyPlanTest.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Discovery\DiscoveryCache;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\DiscoveryCachePath;
 
 final readonly class DiscoveryCacheEmptyPlanTest
 {
@@ -19,11 +20,7 @@ final readonly class DiscoveryCacheEmptyPlanTest
         $directory = $this->tempDirectory->subdirectory('empty-plan');
         $source = $directory . '/NoTests.php';
         \file_put_contents($source, '<?php');
-        $cacheFile = \sprintf(
-            '%s/greenlight-discovery-%s.json',
-            \rtrim(\sys_get_temp_dir(), '/'),
-            \substr(\sha1($directory), 0, 12),
-        );
+        $cacheFile = DiscoveryCachePath::forDirectories([$directory]);
 
         try {
             $cache = DiscoveryCache::forDirectories([$directory]);

--- a/tests/Unit/Discovery/DiscoveryCacheInternalProviderTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheInternalProviderTest.php
@@ -11,6 +11,7 @@ use Greenlight\Discovery\DiscoveryCache;
 use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\DiscoveryCachePath;
 
 final readonly class DiscoveryCacheInternalProviderTest
 {
@@ -23,7 +24,7 @@ final readonly class DiscoveryCacheInternalProviderTest
         $source = $directory . '/ProbeTest.php';
         $providerSource = $directory . '/InternalProviderRows.php';
         $providerClass = 'GreenlightCacheInternalProvider\\InternalProviderRows';
-        $cacheFile = $this->cacheFile($directory);
+        $cacheFile = DiscoveryCachePath::forDirectories([$directory]);
         \file_put_contents($source, "<?php\n");
         \file_put_contents($providerSource, <<<'PHP'
             <?php
@@ -77,12 +78,4 @@ final readonly class DiscoveryCacheInternalProviderTest
         }
     }
 
-    private function cacheFile(string $directory): string
-    {
-        return \sprintf(
-            '%s/greenlight-discovery-%s.json',
-            \rtrim(\sys_get_temp_dir(), '/'),
-            \substr(\sha1($directory), 0, 12),
-        );
-    }
 }

--- a/tests/Unit/Discovery/DiscoveryCachePersistenceTest.php
+++ b/tests/Unit/Discovery/DiscoveryCachePersistenceTest.php
@@ -11,6 +11,7 @@ use Greenlight\Discovery\DiscoveryCache;
 use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\DiscoveryCachePath;
 
 final readonly class DiscoveryCachePersistenceTest
 {
@@ -21,7 +22,7 @@ final readonly class DiscoveryCachePersistenceTest
     {
         $directory = $this->tempDirectory->subdirectory('unencodable-cache');
         $source = $directory . '/InvalidUtf8Test.php';
-        $cacheFile = $this->cacheFile($directory);
+        $cacheFile = DiscoveryCachePath::forDirectories([$directory]);
         \file_put_contents($source, '<?php');
 
         $id = new TestId('Example\InvalidUtf8Test', 'runs');
@@ -44,15 +45,4 @@ final readonly class DiscoveryCachePersistenceTest
         }
     }
 
-    /**
-     * @param non-empty-string $directory
-     */
-    private function cacheFile(string $directory): string
-    {
-        return \sprintf(
-            '%s/greenlight-discovery-%s.json',
-            \rtrim(\sys_get_temp_dir(), '/'),
-            \substr(\sha1($directory), 0, 12),
-        );
-    }
 }

--- a/tests/Unit/Discovery/DiscoveryCacheRuntimeProviderTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheRuntimeProviderTest.php
@@ -10,6 +10,7 @@ use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\DiscoveryCache;
 use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\DiscoveryCachePath;
 
 final class DiscoveryCacheRuntimeProviderTest
 {
@@ -20,7 +21,7 @@ final class DiscoveryCacheRuntimeProviderTest
         $provider = 'GreenlightRuntimeProvider\\Rows' . $suffix;
         $directory = \sys_get_temp_dir() . '/greenlight-runtime-provider-' . $suffix;
         $source = $directory . '/RuntimeProviderTest.php';
-        $cacheFile = $this->cacheFile($directory);
+        $cacheFile = DiscoveryCachePath::forDirectories([$directory]);
 
         eval(\sprintf(
             <<<'PHP'
@@ -68,15 +69,4 @@ final class DiscoveryCacheRuntimeProviderTest
         }
     }
 
-    /**
-     * @param non-empty-string $directory
-     */
-    private function cacheFile(string $directory): string
-    {
-        return \sprintf(
-            '%s/greenlight-discovery-%s.json',
-            \rtrim(\sys_get_temp_dir(), '/'),
-            \substr(\sha1($directory), 0, 12),
-        );
-    }
 }

--- a/tests/Unit/Discovery/DiscoveryCacheWriteFailureTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheWriteFailureTest.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Discovery\DiscoveryCache;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\DiscoveryCachePath;
 
 final readonly class DiscoveryCacheWriteFailureTest
 {
@@ -18,7 +19,7 @@ final readonly class DiscoveryCacheWriteFailureTest
     {
         $directory = $this->tempDirectory->subdirectory('cache-write-failure');
         $source = $directory . '/ExampleTest.php';
-        $cacheFile = $this->cacheFile($directory);
+        $cacheFile = DiscoveryCachePath::forDirectories([$directory]);
         \file_put_contents($source, '<?php');
         \mkdir($cacheFile);
         \file_put_contents($cacheFile . '/occupant.txt', 'keep');
@@ -44,15 +45,4 @@ final readonly class DiscoveryCacheWriteFailureTest
         }
     }
 
-    /**
-     * @param non-empty-string $directory
-     */
-    private function cacheFile(string $directory): string
-    {
-        return \sprintf(
-            '%s/greenlight-discovery-%s.json',
-            \rtrim(\sys_get_temp_dir(), '/'),
-            \substr(\sha1($directory), 0, 12),
-        );
-    }
 }


### PR DESCRIPTION
Add a shared DiscoveryCachePath test helper and route eight cache persistence regressions through it. This keeps the private cache identity algorithm in one test-side location, removes repeated hash and path implementations, and preserves the directory-order oracle.