### PR TITLE
refactor(test): manage worker protocol paths

### DIFF
--- a/tests/Unit/Runner/Worker/WorkerProcessFatalSendFailureTest.php
+++ b/tests/Unit/Runner/Worker/WorkerProcessFatalSendFailureTest.php
@@ -9,24 +9,26 @@ use Greenlight\Attribute\Timeout;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\EnvironmentSandbox;
+use Greenlight\Fixture\TempDirectory;
 use Greenlight\Runner\Worker\WorkerProcess;
 use Greenlight\Tests\Support\Subprocess;
 
 final readonly class WorkerProcessFatalSendFailureTest
 {
-    public function __construct(private EnvironmentSandbox $environment) {}
+    public function __construct(
+        private EnvironmentSandbox $environment,
+        private TempDirectory $tempDirectory,
+    ) {}
 
     #[Test]
     #[Timeout(5.0)]
     public function aClosedChannelCannotHideTheAssignmentFailure(): void
     {
         $root = \dirname(__DIR__, 4);
-        $config = \sys_get_temp_dir()
-            . '/greenlight-failing-config-' . \bin2hex(\random_bytes(6)) . '.php';
-        $ready = \sys_get_temp_dir()
-            . '/greenlight-failing-config-ready-' . \bin2hex(\random_bytes(6));
-        $release = \sys_get_temp_dir()
-            . '/greenlight-failing-config-release-' . \bin2hex(\random_bytes(6));
+        $temporaryDirectory = $this->tempDirectory->path();
+        $config = $temporaryDirectory . '/failing-config.php';
+        $ready = $temporaryDirectory . '/failing-config-ready';
+        $release = $temporaryDirectory . '/failing-config-release';
         $server = Subprocess::start($root, [
             \PHP_BINARY,
             '-r',

--- a/tests/Unit/Runner/Worker/WorkerProcessTest.php
+++ b/tests/Unit/Runner/Worker/WorkerProcessTest.php
@@ -10,19 +10,22 @@ use Greenlight\Attribute\Timeout;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\EnvironmentSandbox;
+use Greenlight\Fixture\TempDirectory;
 use Greenlight\Runner\Worker\WorkerProcess;
 use Greenlight\Tests\Support\Subprocess;
 
 final readonly class WorkerProcessTest
 {
-    public function __construct(private EnvironmentSandbox $environment) {}
+    public function __construct(
+        private EnvironmentSandbox $environment,
+        private TempDirectory $tempDirectory,
+    ) {}
 
     #[Test]
     public function connectionFailureNamesTheExactAddress(): void
     {
         $root = \dirname(__DIR__, 4);
-        $address = 'unix://' . \sys_get_temp_dir()
-            . '/greenlight-missing-worker-' . \bin2hex(\random_bytes(6)) . '.sock';
+        $address = 'unix://' . $this->tempDirectory->path() . '/missing-worker.sock';
 
         $result = Subprocess::run($root, [
             \PHP_BINARY,
@@ -52,8 +55,7 @@ final readonly class WorkerProcessTest
     public function assignmentSetupFailuresAreReportedToTheOrchestrator(): void
     {
         $root = \dirname(__DIR__, 4);
-        $missingConfig = \sys_get_temp_dir()
-            . '/greenlight-missing-config-' . \bin2hex(\random_bytes(6)) . '.php';
+        $missingConfig = $this->tempDirectory->path() . '/missing-config.php';
         $server = Subprocess::start($root, [
             \PHP_BINARY,
             '-r',


### PR DESCRIPTION
Route worker protocol configuration and synchronization paths through the per-test TempDirectory fixture. This removes unmanaged system-temporary files and ad hoc random path construction while retaining short Unix socket paths for platform portability.