### PR TITLE
fix(discovery): reject unresolved class paths

### DIFF
--- a/src/Discovery/TestDiscoverer.php
+++ b/src/Discovery/TestDiscoverer.php
@@ -210,8 +210,17 @@ final readonly class TestDiscoverer
             }
 
             $actualFile = new \ReflectionClass($fqcn)->getFileName();
+            [$resolvedActualFile, $resolvedExpectedFile] = ErrorTrap::run(
+                static fn(): array => [
+                    $actualFile === false ? false : \realpath($actualFile),
+                    \realpath($file),
+                ],
+            );
 
-            if ($actualFile === false || \realpath($actualFile) !== \realpath($file)) {
+            if ($resolvedActualFile === false
+                || $resolvedExpectedFile === false
+                || $resolvedActualFile !== $resolvedExpectedFile
+            ) {
                 throw DiscoveryError::classLoadedFromOtherFile($file, $fqcn, $actualFile === false ? '(no file)' : $actualFile);
             }
 

--- a/tests/Unit/Discovery/TestDiscovererLoadedClassTest.php
+++ b/tests/Unit/Discovery/TestDiscovererLoadedClassTest.php
@@ -16,6 +16,59 @@ final readonly class TestDiscovererLoadedClassTest
     public function __construct(private TempDirectory $tempDirectory) {}
 
     #[Test]
+    public function unresolvedClassPathsCannotMasqueradeAsTheSameFile(): void
+    {
+        $root = $this->tempDirectory->path();
+        $expectedDirectory = $root . '/scanned';
+        $actualDirectory = $root . '/autoloaded';
+        \mkdir($expectedDirectory);
+        \mkdir($actualDirectory);
+        $expectedFile = $expectedDirectory . '/VanishedTest.php';
+        $actualFile = $actualDirectory . '/VanishedTest.php';
+        $namespace = 'GreenlightDiscoveryVanished' . \bin2hex(\random_bytes(6));
+        $class = $namespace . '\\VanishedTest';
+        $source = \sprintf(
+            <<<'PHP'
+                <?php
+
+                declare(strict_types=1);
+
+                namespace %s;
+
+                final class VanishedTest {}
+                PHP,
+            $namespace,
+        );
+        \file_put_contents($expectedFile, $source);
+        \file_put_contents($actualFile, $source);
+
+        $loader = static function (string $candidate) use ($class, $actualFile, $expectedFile): void {
+            if ($candidate === $class) {
+                require_once $actualFile;
+                \unlink($actualFile);
+                \unlink($expectedFile);
+            }
+        };
+        \spl_autoload_register($loader);
+
+        try {
+            Expect::that(
+                static fn(): ExecutionPlan => new TestDiscoverer()->discover([$expectedDirectory]),
+            )->because('discovery MUST reject class paths that it cannot resolve')->toThrow(
+                DiscoveryError::class,
+                message: \sprintf(
+                    'The autoloader loaded class "%s" from "%s". It expected the class in "%s". Only one file can declare a class.',
+                    $class,
+                    $actualFile,
+                    $expectedFile,
+                ),
+            );
+        } finally {
+            \spl_autoload_unregister($loader);
+        }
+    }
+
+    #[Test]
     public function aClassLoadedFromAnotherFileFailsWithBothPaths(): void
     {
         $root = $this->tempDirectory->path();


### PR DESCRIPTION
Reject discovery class-path validation when either canonical path cannot be resolved. Previously, a filesystem race could make both realpath calls return false, causing the paths to compare equal and an invalid autoload result to be accepted. Add a regression that removes both files during autoload and proves discovery fails with the existing wrong-file diagnostic.