### PR TITLE
refactor(test): manage argument matching doubles

### DIFF
--- a/tests/Unit/Doubles/ArgumentMatchingTest.php
+++ b/tests/Unit/Doubles/ArgumentMatchingTest.php
@@ -19,8 +19,10 @@ use Greenlight\Tests\Fixture\Doubles\Calculator;
 use Greenlight\Tests\Fixture\Doubles\Recorder;
 use Greenlight\Tests\Fixture\Doubles\Wide;
 
-final class ArgumentMatchingTest
+final readonly class ArgumentMatchingTest
 {
+    public function __construct(private Doubles $doubles) {}
+
     /**
      * @param list<int> $expectedRest
      * @param list<int> $actualRest
@@ -54,27 +56,21 @@ final class ArgumentMatchingTest
     #[Test]
     public function typeMatchesBuiltinValues(): void
     {
-        $doubles = new Doubles();
-        $calculator = $doubles->mock(Calculator::class, static function (MockPlan $plan): void {
+        $calculator = $this->doubles->mock(Calculator::class, static function (MockPlan $plan): void {
             $plan->expects('add')->with(Argument::type('int'), Argument::type('int'))->once()->andReturns(5);
         });
 
         Expect::that($calculator->add(2, 3))->because('type matches builtin values')->toBe(5);
-
-        $doubles->dispose();
     }
 
     #[Test]
     public function typeMatchesInterfaceInstances(): void
     {
-        $doubles = new Doubles();
-        $recorder = $doubles->mock(Recorder::class, static function (MockPlan $plan): void {
+        $recorder = $this->doubles->mock(Recorder::class, static function (MockPlan $plan): void {
             $plan->expects('record')->with(Argument::type(\DateTimeInterface::class))->once();
         });
 
         $recorder->record(new \DateTimeImmutable('2026-01-01'));
-
-        $doubles->dispose();
     }
 
     #[Test]
@@ -121,8 +117,7 @@ final class ArgumentMatchingTest
     #[Test]
     public function predicateMatchesWhenTheClosureReturnsTrue(): void
     {
-        $doubles = new Doubles();
-        $calculator = $doubles->mock(Calculator::class, static function (MockPlan $plan): void {
+        $calculator = $this->doubles->mock(Calculator::class, static function (MockPlan $plan): void {
             $plan->expects('add')
                 ->with(Argument::predicate(static fn(mixed $value): bool => \is_int($value) && $value > 0, 'positive'), 1)
                 ->once()
@@ -130,8 +125,6 @@ final class ArgumentMatchingTest
         });
 
         Expect::that($calculator->add(2, 1))->because('predicate matches when the closure returns true')->toBe(3);
-
-        $doubles->dispose();
     }
 
     #[Test]
@@ -157,14 +150,11 @@ final class ArgumentMatchingTest
     {
         $expected = ['a' => (object) ['values' => [1, 2]]];
         $actual = ['a' => (object) ['values' => [1, 2]]];
-        $doubles = new Doubles();
-        $recorder = $doubles->mock(Recorder::class, static function (MockPlan $plan) use ($expected): void {
+        $recorder = $this->doubles->mock(Recorder::class, static function (MockPlan $plan) use ($expected): void {
             $plan->expects('record')->with(Argument::equals($expected))->once();
         });
 
         $recorder->record($actual);
-
-        $doubles->dispose();
     }
 
     #[Test]
@@ -178,14 +168,11 @@ final class ArgumentMatchingTest
     #[Test]
     public function bareValuesAndMatchersMixInOneWith(): void
     {
-        $doubles = new Doubles();
-        $calculator = $doubles->mock(Calculator::class, static function (MockPlan $plan): void {
+        $calculator = $this->doubles->mock(Calculator::class, static function (MockPlan $plan): void {
             $plan->expects('add')->with(1, Argument::type('int'))->once()->andReturns(9);
         });
 
         Expect::that($calculator->add(1, 8))->because('bare values and matchers mix in one with')->toBe(9);
-
-        $doubles->dispose();
     }
 
     #[Test]
@@ -199,9 +186,8 @@ final class ArgumentMatchingTest
     #[Test]
     public function aCaptorInWithCollectsValuesInCallOrder(): void
     {
-        $doubles = new Doubles();
         $captor = Argument::captor();
-        $calculator = $doubles->mock(Calculator::class, static function (MockPlan $plan) use ($captor): void {
+        $calculator = $this->doubles->mock(Calculator::class, static function (MockPlan $plan) use ($captor): void {
             $plan->expects('add')->with($captor, 7)->times(2)->andReturns(0);
         });
 
@@ -210,8 +196,6 @@ final class ArgumentMatchingTest
 
         Expect::that($captor->values())->because('a captor in with collects values in call order')->toEqual([1, 999]);
         Expect::that($captor->value())->toBe(999);
-
-        $doubles->dispose();
     }
 
     #[Test]
@@ -233,9 +217,8 @@ final class ArgumentMatchingTest
     #[Test]
     public function captureArgumentRecordsEveryMatchedCall(): void
     {
-        $doubles = new Doubles();
         $captor = null;
-        $calculator = $doubles->mock(Calculator::class, static function (MockPlan $plan) use (&$captor): void {
+        $calculator = $this->doubles->mock(Calculator::class, static function (MockPlan $plan) use (&$captor): void {
             $captor = $plan->expects('add')->times(2)->andReturns(0)->captureArgument(1);
         });
 
@@ -250,16 +233,13 @@ final class ArgumentMatchingTest
         }
 
         Expect::that($captor->values())->because('capture argument records every matched call')->toEqual([9, 8]);
-
-        $doubles->dispose();
     }
 
     #[Test]
     public function captureArgumentWorksAlongsideWithConstraints(): void
     {
-        $doubles = new Doubles();
         $captor = null;
-        $calculator = $doubles->mock(Calculator::class, static function (MockPlan $plan) use (&$captor): void {
+        $calculator = $this->doubles->mock(Calculator::class, static function (MockPlan $plan) use (&$captor): void {
             $captor = $plan->expects('add')->with(Argument::any(), 7)->once()->andReturns(0)->captureArgument(0);
         });
 
@@ -273,8 +253,6 @@ final class ArgumentMatchingTest
         }
 
         Expect::that($captor->value())->because('capture argument works alongside with constraints')->toBe(42);
-
-        $doubles->dispose();
     }
 
     #[Test]
@@ -291,10 +269,9 @@ final class ArgumentMatchingTest
     #[Test]
     public function captorsOnlySeeCallsTheirOwnExpectationMatched(): void
     {
-        $doubles = new Doubles();
         $first = Argument::captor();
         $second = Argument::captor();
-        $calculator = $doubles->mock(Calculator::class, static function (MockPlan $plan) use ($first, $second): void {
+        $calculator = $this->doubles->mock(Calculator::class, static function (MockPlan $plan) use ($first, $second): void {
             $plan->expects('add')->with(1, $first)->once()->andReturns(0);
             $plan->expects('add')->with(2, $second)->once()->andReturns(0);
         });
@@ -304,7 +281,5 @@ final class ArgumentMatchingTest
 
         Expect::that($first->values())->because('captors only see calls their own expectation matched')->toEqual([10]);
         Expect::that($second->values())->toEqual([20]);
-
-        $doubles->dispose();
     }
 }

--- a/tests/Unit/Doubles/MethodArgumentContractTest.php
+++ b/tests/Unit/Doubles/MethodArgumentContractTest.php
@@ -37,8 +37,7 @@ final readonly class MethodArgumentContractTest
     #[Test]
     public function aDoubleRejectsArgumentsThatTheMethodDoesNotDeclare(): void
     {
-        $doubles = new Doubles();
-        $wide = $doubles->mock(Wide::class, static function (MockPlan $plan): void {
+        $wide = $this->doubles->mock(Wide::class, static function (MockPlan $plan): void {
             $plan->expects('returnsVoid')->never();
         });
 
@@ -47,8 +46,6 @@ final readonly class MethodArgumentContractTest
                 DoublesError::class,
                 '/accepts at most 0 arguments/',
             );
-
-        $doubles->dispose();
     }
 
     #[Test]


### PR DESCRIPTION
Use the per-test Doubles fixture for successful argument-matching and method-contract scenarios. This centralizes verification and disposal in the harness while retaining local unmanaged doubles for negative paths whose intentionally unmet expectations must not fail teardown.