### PR TITLE
fix(protocol): reject channel read failures

### DIFF
--- a/src/Runner/Protocol/SocketChannel.php
+++ b/src/Runner/Protocol/SocketChannel.php
@@ -151,17 +151,19 @@ final class SocketChannel
 
         \stream_set_blocking($this->stream, false);
 
-        $reachedEof = ErrorTrap::run(function (): bool {
+        [$bytes, $reachedEof] = ErrorTrap::run(function (): array {
             $bytes = \fread($this->stream, 65536);
 
-            if (\is_string($bytes) && $bytes !== '') {
-                $this->buffer->feed($bytes);
+            return [$bytes, $bytes === '' && \feof($this->stream)];
+        }, $warning);
 
-                return false;
-            }
+        if ($bytes === false) {
+            throw ProtocolError::malformedFrame('peer connection failed during a read', $warning);
+        }
 
-            return \feof($this->stream);
-        });
+        if ($bytes !== '') {
+            $this->buffer->feed($bytes);
+        }
 
         if ($reachedEof) {
             $this->eof = true;

--- a/src/Runner/Protocol/SocketChannel.php
+++ b/src/Runner/Protocol/SocketChannel.php
@@ -154,14 +154,14 @@ final class SocketChannel
         [$bytes, $reachedEof] = ErrorTrap::run(function (): array {
             $bytes = \fread($this->stream, 65536);
 
-            return [$bytes, $bytes === '' && \feof($this->stream)];
+            return [$bytes, ($bytes === false || $bytes === '') && \feof($this->stream)];
         }, $warning);
 
-        if ($bytes === false) {
+        if ($bytes === false && !$reachedEof) {
             throw ProtocolError::malformedFrame('peer connection failed during a read', $warning);
         }
 
-        if ($bytes !== '') {
+        if (\is_string($bytes) && $bytes !== '') {
             $this->buffer->feed($bytes);
         }
 

--- a/tests/Fixture/Runner/Protocol/EofReadFailureStream.php
+++ b/tests/Fixture/Runner/Protocol/EofReadFailureStream.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Runner\Protocol;
+
+use Greenlight\Doubles\Fake;
+
+final class EofReadFailureStream implements Fake
+{
+    public mixed $context;
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        return true;
+    }
+
+    public function stream_read(int $count): false
+    {
+        return false;
+    }
+
+    public function stream_eof(): bool
+    {
+        return true;
+    }
+
+    public function stream_set_option(
+        int $option,
+        int $argumentOne,
+        ?int $argumentTwo,
+    ): bool {
+        return true;
+    }
+}

--- a/tests/Fixture/Runner/Protocol/ReadFailureStream.php
+++ b/tests/Fixture/Runner/Protocol/ReadFailureStream.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Runner\Protocol;
+
+use Greenlight\Doubles\Fake;
+
+final class ReadFailureStream implements Fake
+{
+    public mixed $context;
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        return true;
+    }
+
+    public function stream_read(int $count): false
+    {
+        return false;
+    }
+
+    public function stream_eof(): bool
+    {
+        return false;
+    }
+
+    public function stream_set_option(
+        int $option,
+        int $argumentOne,
+        ?int $argumentTwo,
+    ): bool {
+        return true;
+    }
+}

--- a/tests/Unit/Runner/Protocol/SocketChannelEofReadFailureTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelEofReadFailureTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Protocol;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Runner\Protocol\SocketChannel;
+use Greenlight\Tests\Fixture\Runner\Protocol\EofReadFailureStream;
+
+final readonly class SocketChannelEofReadFailureTest
+{
+    private const string STREAM_SCHEME = 'greenlight-eof-read-failure';
+
+    #[Test]
+    public function aFailedReadAtPeerEofClosesTheChannelCleanly(): void
+    {
+        if (!\stream_wrapper_register(self::STREAM_SCHEME, EofReadFailureStream::class)) {
+            Fail::because('The test could not register the EOF read-failure stream.');
+        }
+
+        $stream = \fopen(self::STREAM_SCHEME . '://channel', 'r+');
+
+        if ($stream === false) {
+            \stream_wrapper_unregister(self::STREAM_SCHEME);
+            Fail::because('The test could not open the EOF read-failure stream.');
+        }
+
+        $channel = new SocketChannel($stream);
+
+        try {
+            Expect::that($channel->poll())
+                ->because('a failed read that reaches peer EOF MUST end polling cleanly')
+                ->toBeNull();
+            Expect::that($channel->isEof())->toBeTrue();
+        } finally {
+            $channel->close();
+            \stream_wrapper_unregister(self::STREAM_SCHEME);
+        }
+    }
+}

--- a/tests/Unit/Runner/Protocol/SocketChannelReadFailureTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelReadFailureTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Protocol;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Runner\Protocol\ProtocolError;
+use Greenlight\Runner\Protocol\SocketChannel;
+use Greenlight\Tests\Fixture\Runner\Protocol\ReadFailureStream;
+
+final readonly class SocketChannelReadFailureTest
+{
+    private const string STREAM_SCHEME = 'greenlight-read-failure';
+
+    #[Test]
+    public function aFailedReadRejectsTheChannel(): void
+    {
+        if (!\stream_wrapper_register(self::STREAM_SCHEME, ReadFailureStream::class)) {
+            Fail::because('The test could not register the read-failure stream.');
+        }
+
+        $stream = \fopen(self::STREAM_SCHEME . '://channel', 'r+');
+
+        if ($stream === false) {
+            \stream_wrapper_unregister(self::STREAM_SCHEME);
+            Fail::because('The test could not open the read-failure stream.');
+        }
+
+        $channel = new SocketChannel($stream);
+
+        try {
+            Expect::that(static fn() => $channel->poll())
+                ->because('a failed read MUST not masquerade as an idle channel')
+                ->toThrow(
+                    ProtocolError::class,
+                    message: 'Malformed frame: peer connection failed during a read.',
+                );
+        } finally {
+            $channel->close();
+            \stream_wrapper_unregister(self::STREAM_SCHEME);
+        }
+    }
+}


### PR DESCRIPTION
Treat a failed socket read as a protocol error instead of an idle channel. The existing poll path collapsed fread false and an empty non-EOF read into the same null result, which could hide a broken worker connection until a later timeout. Add a failing stream fixture and regression for the distinction.