### PR TITLE
feat(fixture): manage stream wrapper lifecycle

### DIFF
--- a/docs/api-fixtures-harness.md
+++ b/docs/api-fixtures-harness.md
@@ -52,6 +52,76 @@ public function dispose(): void
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/EnvironmentSandbox.php#L50)
 
+## `StreamWrapperError`
+
+Namespace: `Greenlight\Fixture`
+
+A stream-wrapper sandbox cannot register or unregister a wrapper.
+
+```php
+final class StreamWrapperError extends \RuntimeException
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/StreamWrapperError.php#L10)
+
+### `registrationFailed()`
+
+```php
+public static function registrationFailed(string $scheme, ?string $warning): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/StreamWrapperError.php#L17)
+
+### `unregistrationFailed()`
+
+```php
+public static function unregistrationFailed(array $failures): self
+```
+
+PHPDoc:
+
+- `@param non-empty-list<array{non-empty-string, string|null}> $failures`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/StreamWrapperError.php#L29)
+
+## `StreamWrapperSandbox`
+
+Namespace: `Greenlight\Fixture`
+
+Registers stream wrappers and unregisters them when the test scope closes.
+
+```php
+final class StreamWrapperSandbox implements Disposable
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/StreamWrapperSandbox.php#L13)
+
+### `register()`
+
+```php
+public function register(string $scheme, string $wrapper): void
+```
+
+PHPDoc:
+
+- `@param class-string $wrapper`
+- `@throws StreamWrapperError`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/StreamWrapperSandbox.php#L23)
+
+### `dispose()`
+
+```php
+[\Override]
+public function dispose(): void
+```
+
+PHPDoc:
+
+- `@throws StreamWrapperError`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/StreamWrapperSandbox.php#L40)
+
 ## `TempDirectory`
 
 Namespace: `Greenlight\Fixture`

--- a/src/Fixture/StreamWrapperError.php
+++ b/src/Fixture/StreamWrapperError.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Fixture;
+
+/**
+ * A stream-wrapper sandbox cannot register or unregister a wrapper.
+ */
+final class StreamWrapperError extends \RuntimeException
+{
+    private function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+
+    public static function registrationFailed(string $scheme, ?string $warning): self
+    {
+        return new self(\sprintf(
+            'Failed to register stream wrapper "%s"%s.',
+            $scheme,
+            $warning === null ? '' : ': ' . $warning,
+        ));
+    }
+
+    /**
+     * @param non-empty-list<array{non-empty-string, string|null}> $failures
+     */
+    public static function unregistrationFailed(array $failures): self
+    {
+        $details = \array_map(
+            static fn(array $failure): string => \sprintf(
+                '"%s"%s',
+                $failure[0],
+                $failure[1] === null ? '' : ': ' . $failure[1],
+            ),
+            $failures,
+        );
+
+        return new self(\sprintf(
+            'Failed to unregister stream wrapper%s %s.',
+            \count($failures) === 1 ? '' : 's',
+            \implode(', ', $details),
+        ));
+    }
+}

--- a/src/Fixture/StreamWrapperSandbox.php
+++ b/src/Fixture/StreamWrapperSandbox.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Fixture;
+
+use Greenlight\Core\ErrorTrap;
+use Greenlight\Harness\Disposable;
+
+/**
+ * Registers stream wrappers and unregisters them when the test scope closes.
+ */
+final class StreamWrapperSandbox implements Disposable
+{
+    /** @var list<non-empty-string> */
+    private array $schemes = [];
+
+    /**
+     * @param class-string $wrapper
+     *
+     * @throws StreamWrapperError
+     */
+    public function register(string $scheme, string $wrapper): void
+    {
+        if ($scheme === '') {
+            throw new \InvalidArgumentException('Stream wrapper scheme cannot be empty.');
+        }
+
+        if (!ErrorTrap::run(
+            static fn(): bool => \stream_wrapper_register($scheme, $wrapper),
+            $warning,
+        )) {
+            throw StreamWrapperError::registrationFailed($scheme, $warning);
+        }
+
+        $this->schemes[] = $scheme;
+    }
+
+    /** @throws StreamWrapperError */
+    #[\Override]
+    public function dispose(): void
+    {
+        $failures = [];
+
+        foreach (\array_reverse($this->schemes) as $scheme) {
+            if (!ErrorTrap::run(static fn(): bool => \stream_wrapper_unregister($scheme), $warning)) {
+                $failures[] = [$scheme, $warning];
+            }
+        }
+
+        $this->schemes = [];
+
+        if ($failures !== []) {
+            throw StreamWrapperError::unregistrationFailed($failures);
+        }
+    }
+}

--- a/src/Runner/DefaultServices.php
+++ b/src/Runner/DefaultServices.php
@@ -10,6 +10,7 @@ use Greenlight\Doubles\Doubles;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\ExpectationExtension;
 use Greenlight\Fixture\EnvironmentSandbox;
+use Greenlight\Fixture\StreamWrapperSandbox;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Harness\HarnessRegistry;
 use Greenlight\Harness\IntegrationResources;
@@ -38,6 +39,7 @@ final class DefaultServices
             new ServiceDefinition(Doubles::class, Scope::PerTest, static fn(): Doubles => new Doubles()),
             new ServiceDefinition(TempDirectory::class, Scope::PerTest, static fn(): TempDirectory => new TempDirectory()),
             new ServiceDefinition(EnvironmentSandbox::class, Scope::PerTest, static fn(): EnvironmentSandbox => new EnvironmentSandbox()),
+            new ServiceDefinition(StreamWrapperSandbox::class, Scope::PerTest, static fn(): StreamWrapperSandbox => new StreamWrapperSandbox()),
             new ServiceDefinition(IntegrationResources::class, Scope::PerRun, static fn(): IntegrationResources => $integrationResources),
             new ServiceDefinition(
                 TestChannel::class,

--- a/tests/Unit/Artifact/ArtifactCopyFlushFailureTest.php
+++ b/tests/Unit/Artifact/ArtifactCopyFlushFailureTest.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
+use Greenlight\Fixture\StreamWrapperSandbox;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Runner\Artifact\NativeFileCopier;
 use Greenlight\Tests\Fixture\Artifact\UnflushableStream;
@@ -16,38 +17,34 @@ final readonly class ArtifactCopyFlushFailureTest
 {
     private const string SCHEME = 'greenlight-unflushable';
 
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private StreamWrapperSandbox $streamWrappers,
+    ) {}
 
     #[Test]
     public function aFlushFailureRejectsTheCopyAndClosesTheDestination(): void
     {
-        if (!\stream_wrapper_register(self::SCHEME, UnflushableStream::class)) {
-            Fail::because('The test could not register the unflushable stream.');
+        $this->streamWrappers->register(self::SCHEME, UnflushableStream::class);
+        $source = $this->tempDirectory->path() . '/copy-flush-source.txt';
+
+        if (\file_put_contents($source, 'evidence') === false) {
+            Fail::because('The test could not write its attachment source.');
         }
 
-        try {
-            $source = $this->tempDirectory->path() . '/copy-flush-source.txt';
+        UnflushableStream::reset();
 
-            if (\file_put_contents($source, 'evidence') === false) {
-                Fail::because('The test could not write its attachment source.');
-            }
-
-            UnflushableStream::reset();
-
-            Expect::that(static fn() => new NativeFileCopier()->copy(
-                $source,
-                self::SCHEME . '://destination',
-            ))
-                ->because('an unflushed attachment copy MUST fail')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: 'Failed to flush the published attachment.',
-                );
-            Expect::that(UnflushableStream::closedStreams())
-                ->because('a flush failure MUST close the destination stream')
-                ->toBe(1);
-        } finally {
-            \stream_wrapper_unregister(self::SCHEME);
-        }
+        Expect::that(static fn() => new NativeFileCopier()->copy(
+            $source,
+            self::SCHEME . '://destination',
+        ))
+            ->because('an unflushed attachment copy MUST fail')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Failed to flush the published attachment.',
+            );
+        Expect::that(UnflushableStream::closedStreams())
+            ->because('a flush failure MUST close the destination stream')
+            ->toBe(1);
     }
 }

--- a/tests/Unit/Artifact/ArtifactCopyOpenFailureTest.php
+++ b/tests/Unit/Artifact/ArtifactCopyOpenFailureTest.php
@@ -8,7 +8,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Core\ErrorTrap;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
+use Greenlight\Fixture\StreamWrapperSandbox;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Runner\Artifact\NativeFileCopier;
 use Greenlight\Tests\Fixture\Artifact\TrackedOpenStream;
@@ -17,69 +17,65 @@ final readonly class ArtifactCopyOpenFailureTest
 {
     private const string SCHEME = 'greenlight-tracked-open';
 
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private StreamWrapperSandbox $streamWrappers,
+    ) {}
 
     #[Test]
     public function copyOpenFailuresCloseTheOtherStream(): void
     {
-        if (!\stream_wrapper_register(self::SCHEME, TrackedOpenStream::class)) {
-            Fail::because('The test could not register the tracked-open stream.');
-        }
-
+        $this->streamWrappers->register(self::SCHEME, TrackedOpenStream::class);
         $root = $this->tempDirectory->subdirectory('copy-open-failures');
 
-        try {
-            TrackedOpenStream::reset();
+        TrackedOpenStream::reset();
 
-            $sourceWarning = null;
-            Expect::that(static function () use ($root, &$sourceWarning): void {
-                ErrorTrap::run(
-                    static fn() => new NativeFileCopier()->copy(
-                        $root . '/missing-source.txt',
-                        self::SCHEME . '://destination',
-                    ),
-                    $sourceWarning,
-                );
-            })
-                ->because('a missing source MUST fail the attachment copy')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: 'Failed to copy attachment into its output directory.',
-                );
-            Expect::that($sourceWarning)
-                ->because('a source open failure MUST not leak an engine diagnostic')
-                ->toBeNull();
+        $sourceWarning = null;
+        Expect::that(static function () use ($root, &$sourceWarning): void {
+            ErrorTrap::run(
+                static fn() => new NativeFileCopier()->copy(
+                    $root . '/missing-source.txt',
+                    self::SCHEME . '://destination',
+                ),
+                $sourceWarning,
+            );
+        })
+            ->because('a missing source MUST fail the attachment copy')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Failed to copy attachment into its output directory.',
+            );
+        Expect::that($sourceWarning)
+            ->because('a source open failure MUST not leak an engine diagnostic')
+            ->toBeNull();
 
-            Expect::that(TrackedOpenStream::closedStreams())
-                ->because('a source open failure MUST close the destination stream')
-                ->toBe(1);
+        Expect::that(TrackedOpenStream::closedStreams())
+            ->because('a source open failure MUST close the destination stream')
+            ->toBe(1);
 
-            TrackedOpenStream::reset();
+        TrackedOpenStream::reset();
 
-            $destinationWarning = null;
-            Expect::that(static function () use ($root, &$destinationWarning): void {
-                ErrorTrap::run(
-                    static fn() => new NativeFileCopier()->copy(
-                        self::SCHEME . '://source',
-                        $root . '/missing/destination.txt',
-                    ),
-                    $destinationWarning,
-                );
-            })
-                ->because('an unavailable destination MUST fail the attachment copy')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: 'Failed to copy attachment into its output directory.',
-                );
-            Expect::that($destinationWarning)
-                ->because('a destination open failure MUST not leak an engine diagnostic')
-                ->toBeNull();
+        $destinationWarning = null;
+        Expect::that(static function () use ($root, &$destinationWarning): void {
+            ErrorTrap::run(
+                static fn() => new NativeFileCopier()->copy(
+                    self::SCHEME . '://source',
+                    $root . '/missing/destination.txt',
+                ),
+                $destinationWarning,
+            );
+        })
+            ->because('an unavailable destination MUST fail the attachment copy')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Failed to copy attachment into its output directory.',
+            );
+        Expect::that($destinationWarning)
+            ->because('a destination open failure MUST not leak an engine diagnostic')
+            ->toBeNull();
 
-            Expect::that(TrackedOpenStream::closedStreams())
-                ->because('a destination open failure MUST close the source stream')
-                ->toBe(1);
-        } finally {
-            \stream_wrapper_unregister(self::SCHEME);
-        }
+        Expect::that(TrackedOpenStream::closedStreams())
+            ->because('a destination open failure MUST close the source stream')
+            ->toBe(1);
     }
 }

--- a/tests/Unit/Artifact/ArtifactCopyReadFailureTest.php
+++ b/tests/Unit/Artifact/ArtifactCopyReadFailureTest.php
@@ -7,7 +7,7 @@ namespace Greenlight\Tests\Unit\Artifact;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
+use Greenlight\Fixture\StreamWrapperSandbox;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Runner\Artifact\NativeFileCopier;
 use Greenlight\Tests\Fixture\Artifact\UnreadableCopySourceStream;
@@ -16,33 +16,29 @@ final readonly class ArtifactCopyReadFailureTest
 {
     private const string SCHEME = 'greenlight-unreadable-copy-source';
 
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private StreamWrapperSandbox $streamWrappers,
+    ) {}
 
     #[Test]
     public function aReadFailureRejectsTheCopyAndClosesTheSource(): void
     {
-        if (!\stream_wrapper_register(self::SCHEME, UnreadableCopySourceStream::class)) {
-            Fail::because('The test could not register the unreadable copy-source stream.');
-        }
+        $this->streamWrappers->register(self::SCHEME, UnreadableCopySourceStream::class);
+        UnreadableCopySourceStream::reset();
+        $destination = $this->tempDirectory->path() . '/destination.txt';
 
-        try {
-            UnreadableCopySourceStream::reset();
-            $destination = $this->tempDirectory->path() . '/destination.txt';
-
-            Expect::that(static fn() => new NativeFileCopier()->copy(
-                self::SCHEME . '://source',
-                $destination,
-            ))
-                ->because('an unreadable attachment source MUST fail its copy')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: 'Failed to read attachment staging content.',
-                );
-            Expect::that(UnreadableCopySourceStream::closedStreams())
-                ->because('a read failure MUST close the source stream')
-                ->toBe(1);
-        } finally {
-            \stream_wrapper_unregister(self::SCHEME);
-        }
+        Expect::that(static fn() => new NativeFileCopier()->copy(
+            self::SCHEME . '://source',
+            $destination,
+        ))
+            ->because('an unreadable attachment source MUST fail its copy')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Failed to read attachment staging content.',
+            );
+        Expect::that(UnreadableCopySourceStream::closedStreams())
+            ->because('a read failure MUST close the source stream')
+            ->toBe(1);
     }
 }

--- a/tests/Unit/Artifact/ArtifactIntermittentReadTest.php
+++ b/tests/Unit/Artifact/ArtifactIntermittentReadTest.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
+use Greenlight\Fixture\StreamWrapperSandbox;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Runner\Artifact\ArtifactStore;
 use Greenlight\Runner\Artifact\TestArtifactBudget;
@@ -17,14 +18,15 @@ final readonly class ArtifactIntermittentReadTest
 {
     private const string SCHEME = 'greenlight-intermittent-file-read';
 
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private StreamWrapperSandbox $streamWrappers,
+    ) {}
 
     #[Test]
     public function anEmptyReadBeforeContentDoesNotTruncateTheAttachment(): void
     {
-        if (!\stream_wrapper_register(self::SCHEME, IntermittentFileReadStream::class)) {
-            throw new \RuntimeException('Greenlight did not register the intermittent-file-read stream.');
-        }
+        $this->streamWrappers->register(self::SCHEME, IntermittentFileReadStream::class);
 
         $store = null;
 
@@ -60,7 +62,6 @@ final readonly class ArtifactIntermittentReadTest
                 ->toBe(\hash('sha256', 'evidence'));
         } finally {
             $store?->cleanup();
-            \stream_wrapper_unregister(self::SCHEME);
         }
     }
 }

--- a/tests/Unit/Artifact/ArtifactSourceMutationTest.php
+++ b/tests/Unit/Artifact/ArtifactSourceMutationTest.php
@@ -9,6 +9,7 @@ use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
+use Greenlight\Fixture\StreamWrapperSandbox;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Runner\Artifact\ArtifactStore;
 use Greenlight\Runner\Artifact\TestArtifactBudget;
@@ -21,14 +22,15 @@ final readonly class ArtifactSourceMutationTest
 
     private const string FAILING_READ_SCHEME = 'greenlight-failing-file-read';
 
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private StreamWrapperSandbox $streamWrappers,
+    ) {}
 
     #[Test]
     public function aSourceThatChangesDuringCopyIsRejectedAndReleased(): void
     {
-        if (!\stream_wrapper_register(self::SCHEME, ChangingFileStream::class)) {
-            throw new \RuntimeException('Greenlight did not register the changing-file stream.');
-        }
+        $this->streamWrappers->register(self::SCHEME, ChangingFileStream::class);
 
         $store = null;
 
@@ -65,16 +67,13 @@ final readonly class ArtifactSourceMutationTest
                 ->toBe('replacement.txt');
         } finally {
             $store?->cleanup();
-            \stream_wrapper_unregister(self::SCHEME);
         }
     }
 
     #[Test]
     public function aSourceThatFailsDuringCopyIsRejectedAndReleased(): void
     {
-        if (!\stream_wrapper_register(self::FAILING_READ_SCHEME, FailingFileReadStream::class)) {
-            throw new \RuntimeException('Greenlight did not register the failing-file-read stream.');
-        }
+        $this->streamWrappers->register(self::FAILING_READ_SCHEME, FailingFileReadStream::class);
 
         $store = null;
 
@@ -123,7 +122,6 @@ final readonly class ArtifactSourceMutationTest
                 ->toBe('replacement.txt');
         } finally {
             $store?->cleanup();
-            \stream_wrapper_unregister(self::FAILING_READ_SCHEME);
         }
     }
 }

--- a/tests/Unit/Artifact/ArtifactStreamPartialWriteTest.php
+++ b/tests/Unit/Artifact/ArtifactStreamPartialWriteTest.php
@@ -7,24 +7,23 @@ namespace Greenlight\Tests\Unit\Artifact;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
+use Greenlight\Fixture\StreamWrapperSandbox;
 use Greenlight\Runner\Artifact\StreamWriter;
 use Greenlight\Tests\Fixture\Artifact\PartialWriteStream;
 
-final class ArtifactStreamPartialWriteTest
+final readonly class ArtifactStreamPartialWriteTest
 {
     private const string SCHEME = 'greenlight-partial-write';
+
+    public function __construct(private StreamWrapperSandbox $streamWrappers) {}
 
     #[Test]
     public function partialWritesContinueUntilEveryByteIsWritten(): void
     {
-        if (!\stream_wrapper_register(self::SCHEME, PartialWriteStream::class)) {
-            Fail::because('The test could not register the partial-write stream.');
-        }
-
+        $this->streamWrappers->register(self::SCHEME, PartialWriteStream::class);
         $stream = \fopen(self::SCHEME . '://attachment', 'wb');
 
         if ($stream === false) {
-            \stream_wrapper_unregister(self::SCHEME);
             Fail::because('The test could not open the partial-write stream.');
         }
 
@@ -39,7 +38,6 @@ final class ArtifactStreamPartialWriteTest
                 ->toBe(4);
         } finally {
             \fclose($stream);
-            \stream_wrapper_unregister(self::SCHEME);
         }
     }
 }

--- a/tests/Unit/Artifact/ArtifactStreamWriteFailureTest.php
+++ b/tests/Unit/Artifact/ArtifactStreamWriteFailureTest.php
@@ -8,24 +8,23 @@ use Greenlight\Attribute\Test;
 use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
+use Greenlight\Fixture\StreamWrapperSandbox;
 use Greenlight\Runner\Artifact\StreamWriter;
 use Greenlight\Tests\Fixture\Artifact\ZeroWriteStream;
 
-final class ArtifactStreamWriteFailureTest
+final readonly class ArtifactStreamWriteFailureTest
 {
     private const string SCHEME = 'greenlight-zero-write';
+
+    public function __construct(private StreamWrapperSandbox $streamWrappers) {}
 
     #[Test]
     public function aZeroByteWriteFailsInsteadOfLooping(): void
     {
-        if (!\stream_wrapper_register(self::SCHEME, ZeroWriteStream::class)) {
-            Fail::because('The test could not register the zero-write stream.');
-        }
-
+        $this->streamWrappers->register(self::SCHEME, ZeroWriteStream::class);
         $stream = \fopen(self::SCHEME . '://attachment', 'wb');
 
         if ($stream === false) {
-            \stream_wrapper_unregister(self::SCHEME);
             Fail::because('The test could not open the zero-write stream.');
         }
 
@@ -38,7 +37,6 @@ final class ArtifactStreamWriteFailureTest
                 );
         } finally {
             \fclose($stream);
-            \stream_wrapper_unregister(self::SCHEME);
         }
     }
 }

--- a/tests/Unit/Artifact/ArtifactUnknownSizeTest.php
+++ b/tests/Unit/Artifact/ArtifactUnknownSizeTest.php
@@ -9,6 +9,7 @@ use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
+use Greenlight\Fixture\StreamWrapperSandbox;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Runner\Artifact\ArtifactStore;
 use Greenlight\Runner\Artifact\TestArtifactBudget;
@@ -18,14 +19,15 @@ final readonly class ArtifactUnknownSizeTest
 {
     private const string SCHEME = 'greenlight-unknown-size';
 
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private StreamWrapperSandbox $streamWrappers,
+    ) {}
 
     #[Test]
     public function aSourceWithAnUnknownSizeIsRejected(): void
     {
-        if (!\stream_wrapper_register(self::SCHEME, UnknownSizeFileStream::class)) {
-            throw new \RuntimeException('Greenlight did not register the unknown-size stream.');
-        }
+        $this->streamWrappers->register(self::SCHEME, UnknownSizeFileStream::class);
 
         $store = null;
 
@@ -50,7 +52,6 @@ final readonly class ArtifactUnknownSizeTest
                 );
         } finally {
             $store?->cleanup();
-            \stream_wrapper_unregister(self::SCHEME);
         }
     }
 }

--- a/tests/Unit/Fixture/StreamWrapperSandboxTest.php
+++ b/tests/Unit/Fixture/StreamWrapperSandboxTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Fixture;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\StreamWrapperError;
+use Greenlight\Fixture\StreamWrapperSandbox;
+use Greenlight\Tests\Fixture\Runner\Protocol\UnselectableStream;
+
+final readonly class StreamWrapperSandboxTest
+{
+    #[Test]
+    public function registrationRejectsAnEmptyScheme(): void
+    {
+        Expect::that(static function (): void {
+            new StreamWrapperSandbox()->register('', UnselectableStream::class);
+        })->toThrow(
+            \InvalidArgumentException::class,
+            message: 'Stream wrapper scheme cannot be empty.',
+        );
+    }
+
+    #[Test]
+    public function disposalUnregistersEveryOwnedWrapper(): void
+    {
+        $sandbox = new StreamWrapperSandbox();
+        $sandbox->register('greenlight-sandbox-one', UnselectableStream::class);
+        $sandbox->register('greenlight-sandbox-two', UnselectableStream::class);
+
+        Expect::that(\stream_get_wrappers())
+            ->toContain('greenlight-sandbox-one')
+            ->toContain('greenlight-sandbox-two');
+
+        $sandbox->dispose();
+
+        Expect::that(\stream_get_wrappers())
+            ->not()->toContain('greenlight-sandbox-one')
+            ->not()->toContain('greenlight-sandbox-two');
+    }
+
+    #[Test]
+    public function aRegistrationFailureKeepsTheEngineDiagnostic(): void
+    {
+        $owner = new StreamWrapperSandbox();
+        $duplicate = new StreamWrapperSandbox();
+        $scheme = 'greenlight-sandbox-duplicate';
+        $owner->register($scheme, UnselectableStream::class);
+
+        try {
+            Expect::that(static function () use ($duplicate, $scheme): void {
+                $duplicate->register($scheme, UnselectableStream::class);
+            })->because('a duplicate wrapper registration MUST identify the scheme and cause')->toThrow(
+                StreamWrapperError::class,
+                '/Failed to register stream wrapper "greenlight-sandbox-duplicate": .+/',
+            );
+        } finally {
+            $owner->dispose();
+        }
+    }
+
+    #[Test]
+    public function disposalContinuesAfterAWrapperWasRemovedExternally(): void
+    {
+        $sandbox = new StreamWrapperSandbox();
+        $first = 'greenlight-sandbox-first';
+        $second = 'greenlight-sandbox-second';
+        $sandbox->register($first, UnselectableStream::class);
+        $sandbox->register($second, UnselectableStream::class);
+
+        Expect::that(\stream_wrapper_unregister($second))
+            ->because('the external cleanup MUST remove the second wrapper')
+            ->toBeTrue();
+
+        Expect::that(static function () use ($sandbox): void {
+            $sandbox->dispose();
+        })->because('one failed cleanup MUST not stop the remaining wrapper cleanup')->toThrow(
+            StreamWrapperError::class,
+            '/Failed to unregister stream wrapper "greenlight-sandbox-second": .+/',
+        );
+        Expect::that(\stream_get_wrappers())
+            ->because('the sandbox MUST unregister wrappers after an earlier cleanup failure')
+            ->not()->toContain($first);
+    }
+}


### PR DESCRIPTION
Add a per-test StreamWrapperSandbox fixture that contains registration warnings, unregisters owned wrappers in reverse order, continues after cleanup failures, and reports those failures through one fixture error. Register it with the default harness and migrate the artifact stream tests from manual global-state cleanup.