### PR TITLE
fix(artifact): contain cleanup diagnostics

### DIFF
--- a/src/Runner/Artifact/ArtifactStore.php
+++ b/src/Runner/Artifact/ArtifactStore.php
@@ -278,7 +278,7 @@ final class ArtifactStore
                     || $after['size'] !== $before['size']
                     || $after['mtime'] !== $before['mtime']
                 ) {
-                    @\unlink($part);
+                    ErrorTrap::run(static fn(): bool => \unlink($part));
 
                     throw AttachmentError::source($sourcePath, 'changed while it was being copied');
                 }
@@ -395,13 +395,13 @@ final class ArtifactStore
                     throw AttachmentError::storage('Failed to publish attachment');
                 }
             } catch (\Throwable $error) {
-                @\unlink($part);
+                ErrorTrap::run(static fn(): bool => \unlink($part));
 
                 throw $error;
             }
 
-            @\unlink($source);
-            @\unlink($this->metadataPath($storageKey));
+            ErrorTrap::run(static fn(): bool => \unlink($source));
+            ErrorTrap::run(fn(): bool => \unlink($this->metadataPath($storageKey)));
             $published[] = $attachment->published();
         }
 
@@ -498,10 +498,15 @@ final class ArtifactStore
             }
 
             $path = $entry->getPathname();
-            !$entry->isLink() && $entry->isDir() ? @\rmdir($path) : @\unlink($path);
+
+            if (!$entry->isLink() && $entry->isDir()) {
+                ErrorTrap::run(static fn(): bool => \rmdir($path));
+            } else {
+                ErrorTrap::run(static fn(): bool => \unlink($path));
+            }
         }
 
-        @\rmdir($directory);
+        ErrorTrap::run(static fn(): bool => \rmdir($directory));
     }
 
     /**
@@ -674,7 +679,7 @@ final class ArtifactStore
         );
 
         if (\file_put_contents($part, $encoded . "\n", \LOCK_EX) === false) {
-            @\unlink($part);
+            ErrorTrap::run(static fn(): bool => \unlink($part));
 
             throw AttachmentError::storage('Greenlight did not write attachment recovery metadata');
         }
@@ -682,7 +687,7 @@ final class ArtifactStore
         \chmod($part, 0o600);
 
         if (!\rename($part, $path)) {
-            @\unlink($part);
+            ErrorTrap::run(static fn(): bool => \unlink($part));
 
             throw AttachmentError::storage('Failed to finalize attachment recovery metadata');
         }
@@ -707,7 +712,7 @@ final class ArtifactStore
         $part = $path . '.part-' . \bin2hex(\random_bytes(4));
 
         if (\file_put_contents($part, $attempt . "\n", \LOCK_EX) === false) {
-            @\unlink($part);
+            ErrorTrap::run(static fn(): bool => \unlink($part));
 
             throw AttachmentError::storage('Failed to record the current test attempt');
         }
@@ -715,7 +720,7 @@ final class ArtifactStore
         \chmod($part, 0o600);
 
         if (!\rename($part, $path)) {
-            @\unlink($part);
+            ErrorTrap::run(static fn(): bool => \unlink($part));
 
             throw AttachmentError::storage('Greenlight did not finalize the current test attempt record');
         }

--- a/tests/Fixture/Artifact/DirectoryCreatingFileCopier.php
+++ b/tests/Fixture/Artifact/DirectoryCreatingFileCopier.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Artifact;
+
+use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Doubles\Fake;
+use Greenlight\Runner\Artifact\FileCopier;
+
+final class DirectoryCreatingFileCopier implements Fake, FileCopier
+{
+    public ?string $destination = null;
+
+    #[\Override]
+    public function copy(string $sourcePath, string $destinationPath): never
+    {
+        $this->destination = $destinationPath;
+
+        if (!\mkdir($destinationPath, 0o700, true)) {
+            throw new \RuntimeException('The fake copier did not create its destination directory.');
+        }
+
+        throw AttachmentError::storage('The fake copier stopped after it created a directory');
+    }
+}

--- a/tests/Unit/Artifact/ArtifactBestEffortCleanupDiagnosticTest.php
+++ b/tests/Unit/Artifact/ArtifactBestEffortCleanupDiagnosticTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Core\ErrorTrap;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Runner\Artifact\ArtifactStore;
+use Greenlight\Runner\Artifact\TestArtifactBudget;
+use Greenlight\Tests\Fixture\Artifact\DirectoryCreatingFileCopier;
+
+final readonly class ArtifactBestEffortCleanupDiagnosticTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function aFailedPublicationCleanupDoesNotLeakEngineDiagnostics(): void
+    {
+        $root = $this->tempDirectory->subdirectory('best-effort-cleanup-diagnostic');
+        $copier = new DirectoryCreatingFileCopier();
+        $store = ArtifactStore::open(
+            new ArtifactConfiguration($root),
+            $root,
+            'run-cleanup-diagnostic',
+            $copier,
+        );
+        $id = new TestId('Example\EvidenceTest', 'fails');
+        $attachments = $store->forAttempt($id, 1, new TestArtifactBudget());
+        $attachments->text('evidence.txt', 'evidence');
+        $staged = $attachments->seal()[0];
+
+        try {
+            Expect::that(static function () use ($store, $id, $staged, &$warning): TestResult {
+                return ErrorTrap::run(
+                    static fn(): TestResult => $store->publish(new TestResult(
+                        $id,
+                        Outcome::Failed,
+                        0.1,
+                        0,
+                        attachments: [$staged],
+                    )),
+                    $warning,
+                );
+            })
+                ->because('publication MUST preserve the copier failure')
+                ->toThrow(
+                    AttachmentError::class,
+                    message: 'The fake copier stopped after it created a directory.',
+                );
+
+            Expect::that($warning)
+                ->because('best-effort publication cleanup MUST not leak an engine diagnostic')
+                ->toBeNull();
+        } finally {
+            if ($copier->destination !== null) {
+                \rmdir($copier->destination);
+            }
+
+            $store->cleanup();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- route best-effort artifact cleanup through the managed error trap
- preserve primary publication failures without leaking native cleanup diagnostics
- cover a copier that leaves an unexpected directory at the temporary output path