### PR TITLE
fix(runner): retain buffered worker diagnostics

### DIFF
--- a/src/Runner/Orchestrator/WorkerHandle.php
+++ b/src/Runner/Orchestrator/WorkerHandle.php
@@ -128,7 +128,7 @@ final class WorkerHandle
                 }
 
                 \stream_set_blocking($pipe, false);
-                $bytes = \fread($pipe, 8192);
+                $bytes = \stream_get_contents($pipe);
 
                 if (!\is_string($bytes)) {
                     continue;

--- a/tests/Unit/Runner/Orchestrator/WorkerHandleDiagnosticStreamsTest.php
+++ b/tests/Unit/Runner/Orchestrator/WorkerHandleDiagnosticStreamsTest.php
@@ -29,4 +29,23 @@ final readonly class WorkerHandleDiagnosticStreamsTest
             ->toBe("standard output\nstandard error\n");
     }
 
+    #[Test]
+    public function pipeDrainKeepsTheBoundedTailOfAvailableOutput(): void
+    {
+        $tail = \str_repeat('t', 65_536);
+        $handle = new WorkerHandle(
+            'worker-1',
+            1,
+            MemoryStream::open(),
+            MemoryStream::open(\str_repeat('p', 8_192) . $tail),
+            MemoryStream::open(),
+        );
+
+        $handle->drainPipes();
+
+        Expect::that($handle->diagnostics)
+            ->because('one pipe drain MUST retain the bounded tail of all available output')
+            ->toBe($tail);
+    }
+
 }


### PR DESCRIPTION
## Summary

- drain all worker output that is currently available from each non-blocking pipe
- retain the most recent 64 KiB when a crash or timeout produces more than one read chunk
- cover buffered output that exceeds the former 8 KiB read size