### PR TITLE
fix(reporting): emit fallback JUnit failures

### DIFF
--- a/src/Reporting/JUnitReporter.php
+++ b/src/Reporting/JUnitReporter.php
@@ -167,6 +167,13 @@ final class JUnitReporter implements Reporter
         $writer->writeAttribute('time', $this->time($result->durationSeconds));
 
         if ($result->outcome === Outcome::Failed) {
+            if ($result->failures === []) {
+                $writer->startElement('failure');
+                $writer->writeAttribute('type', 'failure');
+                $writer->writeAttribute('message', 'failed');
+                $writer->endElement();
+            }
+
             foreach ($result->failures as $failure) {
                 $writer->startElement('failure');
                 $writer->writeAttribute('type', 'failure');

--- a/tests/Unit/Reporting/JUnitFailureFallbackTest.php
+++ b/tests/Unit/Reporting/JUnitFailureFallbackTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\TestFinished;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\JUnitReporter;
+
+final class JUnitFailureFallbackTest
+{
+    #[Test]
+    public function failedOutcomeWithoutDetailsWritesAFailureElement(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new JUnitReporter($output);
+        $reporter->onEvent(new TestFinished(new TestResult(
+            new TestId('Acme\PartialResultTest', 'missingFailureDetail'),
+            Outcome::Failed,
+            0.002,
+            0,
+        ), 1.0));
+
+        $reporter->finish();
+
+        Expect::that($output->buffer())
+            ->because('the failure count and testcase element MUST remain consistent without details')
+            ->toBe(
+                "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+                . "<testsuites name=\"greenlight\" tests=\"1\" failures=\"1\" errors=\"0\" skipped=\"0\" time=\"0.002000\">\n"
+                . "  <testsuite name=\"Acme\\PartialResultTest\" tests=\"1\" failures=\"1\" errors=\"0\" skipped=\"0\" assertions=\"0\" time=\"0.002000\">\n"
+                . "    <testcase name=\"missingFailureDetail\" classname=\"Acme\\PartialResultTest\" assertions=\"0\" time=\"0.002000\">\n"
+                . "      <failure type=\"failure\" message=\"failed\"/>\n"
+                . "    </testcase>\n"
+                . "  </testsuite>\n"
+                . "</testsuites>\n",
+            );
+    }
+}


### PR DESCRIPTION
## Summary

- emit a failure element when a failed result has no structured failure detail
- keep JUnit testcase status consistent with its suite failure counters
- cover the fallback XML alongside the existing error fallback behavior