### PR TITLE
fix(coverage): ignore removed files in regression gate

### DIFF
--- a/src/Coverage/Diff/BaselineDiff.php
+++ b/src/Coverage/Diff/BaselineDiff.php
@@ -53,6 +53,8 @@ final readonly class BaselineDiff
             $deltas,
             $baseline->totalPercentage(),
             $current->totalPercentage(),
+            new CoverageMap(\array_values(\array_intersect_key($baselineFiles, $currentFiles)))->totalPercentage(),
+            new CoverageMap(\array_values(\array_intersect_key($currentFiles, $baselineFiles)))->totalPercentage(),
         );
     }
 }

--- a/src/Coverage/Diff/BaselineDiffReport.php
+++ b/src/Coverage/Diff/BaselineDiffReport.php
@@ -6,6 +6,8 @@ namespace Greenlight\Coverage\Diff;
 
 /**
  * Omits files with no percentage change and no new uncovered lines.
+ * hasRegressions() compares the total coverage of files that are in both maps.
+ * Thus, a removed file cannot cause a regression.
  *
  * @internal
  */
@@ -18,6 +20,8 @@ final readonly class BaselineDiffReport
         public array $fileDeltas,
         public float $baselinePercentage,
         public float $currentPercentage,
+        private float $sharedBaselinePercentage,
+        private float $sharedCurrentPercentage,
     ) {}
 
     public function totalDelta(): float
@@ -27,7 +31,7 @@ final readonly class BaselineDiffReport
 
     public function hasRegressions(): bool
     {
-        if ($this->totalDelta() < 0.0) {
+        if ($this->sharedCurrentPercentage < $this->sharedBaselinePercentage) {
             return true;
         }
         return \array_any($this->fileDeltas, static fn(FileDelta $delta): bool => $delta->newlyUncoveredLines !== []);

--- a/tests/Unit/Coverage/BaselineDiffTest.php
+++ b/tests/Unit/Coverage/BaselineDiffTest.php
@@ -102,4 +102,24 @@ final class BaselineDiffTest
             ->because('an overall gain MUST NOT hide a newly uncovered line')
             ->toBeTrue();
     }
+
+    #[Test]
+    public function retainedFilePercentageDecreaseRemainsARegression(): void
+    {
+        $baseline = new CoverageMap([
+            new FileCoverage('/src/A.php', [1, 2], [3]),
+        ]);
+        $current = new CoverageMap([
+            new FileCoverage('/src/A.php', [1], [3]),
+        ]);
+
+        $report = BaselineDiff::between($baseline, $current);
+
+        Expect::that($report->fileDeltas['/src/A.php']->newlyUncoveredLines)
+            ->because('the retained file has no newly uncovered line')
+            ->toBe([]);
+        Expect::that($report->hasRegressions())
+            ->because('a total coverage decrease in retained files MUST remain a regression')
+            ->toBeTrue();
+    }
 }

--- a/tests/Unit/Coverage/BaselineRemovedFileTest.php
+++ b/tests/Unit/Coverage/BaselineRemovedFileTest.php
@@ -24,4 +24,25 @@ final readonly class BaselineRemovedFileTest
             ->because('removing a source file MUST NOT fail the coverage regression gate')
             ->toBeFalse();
     }
+
+    #[Test]
+    public function removedCoveredFileDoesNotTurnUnchangedCoverageIntoARegression(): void
+    {
+        $baseline = new CoverageMap([
+            new FileCoverage('/src/Removed.php', [1], []),
+            new FileCoverage('/src/Unchanged.php', [1], [2]),
+        ]);
+        $current = new CoverageMap([
+            new FileCoverage('/src/Unchanged.php', [1], [2]),
+        ]);
+
+        $report = BaselineDiff::between($baseline, $current);
+
+        Expect::that($report->totalDelta())
+            ->because('displayed totals still describe the complete coverage maps')
+            ->toBeLessThan(0.0);
+        Expect::that($report->hasRegressions())
+            ->because('a removed file MUST NOT make unchanged source coverage fail the regression gate')
+            ->toBeFalse();
+    }
 }


### PR DESCRIPTION
## Summary

- compare aggregate coverage across files present in both maps
- keep raw baseline and current percentages in command output
- preserve regression detection for retained files and newly uncovered lines