### PR TITLE
fix(coverage): reject lossy JSON file paths

### DIFF
--- a/docs/architecture/coverage-json.md
+++ b/docs/architecture/coverage-json.md
@@ -46,6 +46,9 @@ An object that uses absolute file paths as keys.
 
 Greenlight sorts entries by path.
 
+Each path **MUST** contain valid UTF-8. `JsonExporter::export()` throws
+`InvalidArgumentException` if JSON cannot keep the exact path.
+
 Absolute keys make a baseline specific to its checkout root. Coverage from two
 sources represents the same file only when the keys match exactly. Sources
 include worktrees, containers, and machines.

--- a/src/Coverage/Export/JsonExporter.php
+++ b/src/Coverage/Export/JsonExporter.php
@@ -24,12 +24,19 @@ final readonly class JsonExporter implements CoverageExporter
     #[\Override]
     public function export(CoverageMap $map): array
     {
+        $files = [];
 
-        $files = \array_map(fn($file) => [
-            'covered' => $file->coveredLines,
-            'uncovered' => $file->uncoveredLines,
-            'percentage' => \round($file->percentage(), 2),
-        ], $map->files());
+        foreach ($map->files() as $path => $file) {
+            if (\preg_match('//u', $path) !== 1) {
+                throw new \InvalidArgumentException('Coverage JSON file paths MUST contain valid UTF-8.');
+            }
+
+            $files[$path] = [
+                'covered' => $file->coveredLines,
+                'uncovered' => $file->uncoveredLines,
+                'percentage' => \round($file->percentage(), 2),
+            ];
+        }
 
         $document = [
             'v' => self::VERSION,
@@ -44,7 +51,7 @@ final readonly class JsonExporter implements CoverageExporter
 
         return [self::FILE_NAME => \json_encode(
             $document,
-            \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES | \JSON_INVALID_UTF8_SUBSTITUTE,
+            \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES,
         ) . "\n"];
     }
 

--- a/tests/Unit/Coverage/JsonExporterTest.php
+++ b/tests/Unit/Coverage/JsonExporterTest.php
@@ -50,19 +50,19 @@ final class JsonExporterTest
     }
 
     #[Test]
-    public function exportScrubsInvalidUtf8FilePaths(): void
+    public function exportRejectsFilePathsThatCannotRetainTheirIdentityInJson(): void
     {
         $map = new CoverageMap([
             new FileCoverage("/src/\xB1.php", [1], []),
+            new FileCoverage("/src/\xB2.php", [2], []),
         ]);
 
-        $json = new JsonExporter()->export($map)[JsonExporter::FILE_NAME];
-        $decoded = \json_decode($json, true, 512, \JSON_THROW_ON_ERROR);
-        \assert(\is_array($decoded) && \is_array($decoded['files']));
-
-        Expect::that(\array_keys($decoded['files']))
-            ->because('coverage JSON MUST remain valid for file-system paths with invalid UTF-8')
-            ->toBe(["/src/\u{FFFD}.php"]);
+        Expect::that(static fn(): array => new JsonExporter()->export($map))
+            ->because('distinct coverage paths MUST NOT collapse to the same JSON object key')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Coverage JSON file paths MUST contain valid UTF-8.',
+            );
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- reject non-UTF-8 coverage paths before JSON key substitution can collapse distinct files
- remove lossy invalid-byte substitution from coverage JSON exports
- document and test the exact-path UTF-8 constraint