### PR TITLE
fix(artifact): validate media type parameter tokens

### DIFF
--- a/src/Core/Artifact/AttachmentMediaType.php
+++ b/src/Core/Artifact/AttachmentMediaType.php
@@ -11,7 +11,10 @@ namespace Greenlight\Core\Artifact;
  */
 final readonly class AttachmentMediaType
 {
-    private const string PATTERN = '~^[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*/[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*(?:\s*;\s*[^=\s]+=(?:"[^"]*"|[^;\s]+))*$~';
+    private const string PARAMETER_TOKEN = '[a-zA-Z0-9!#$%&\'*+.^_|\x60\~-]+';
+
+    private const string PATTERN = '~^[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*/[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*(?:\s*;\s*'
+        . self::PARAMETER_TOKEN . '=(?:"[^"]*"|' . self::PARAMETER_TOKEN . '))*$~';
 
     /** @codeCoverageIgnore */
     private function __construct() {}

--- a/tests/Unit/Core/AttachmentMediaTypeContractTest.php
+++ b/tests/Unit/Core/AttachmentMediaTypeContractTest.php
@@ -53,6 +53,10 @@ final class AttachmentMediaTypeContractTest
     public static function invalidMediaTypes(): iterable
     {
         yield 'missing subtype' => ['text'];
+        yield 'parameter without a value' => ['text/plain; first;second=value'];
+        yield 'separator in parameter name' => ['text/plain; name/path=value'];
+        yield 'separator in unquoted value' => ['text/plain; name=left/right'];
+        yield 'second equals in unquoted value' => ['text/plain; name=left=right'];
         yield 'null byte' => ["text/plain; note=\"before\0after\""];
         yield 'tab' => ["text/plain; note=\"before\tafter\""];
         yield 'line feed' => ["text/plain; note=\"before\nafter\""];


### PR DESCRIPTION
## Summary

- require attachment media type parameter names to use token characters
- reject separators and extra equals signs in unquoted parameter values
- preserve valid quoted parameter values through construction and wire decoding