### PR TITLE
docs(hyperf): simplify bridge guide

### DIFF
--- a/docs/hyperf.md
+++ b/docs/hyperf.md
@@ -1,7 +1,6 @@
 # Hyperf applications
 
-The Hyperf bridge runs Greenlight tests in the Hyperf coroutine runtime. It
-does more than pass calls to a PSR-11 container.
+The Hyperf bridge runs each Greenlight test attempt in a Hyperf coroutine.
 
 The bridge supports Hyperf 3.2 with Swoole 5 or later. It does not support the
 Swow engine.
@@ -14,7 +13,7 @@ Install the Hyperf framework and dependency injector in the application:
 composer require hyperf/framework:^3.2 hyperf/di:^3.2
 ```
 
-Install the Swoole and pcntl extensions for the PHP command that runs
+Enable the Swoole and pcntl extensions for the PHP command that runs
 Greenlight.
 
 Register the plugin in `greenlight.php`:
@@ -28,18 +27,18 @@ return GreenlightConfig::create()
     ->plugins(new HyperfPlugin(dirname(__DIR__)));
 ```
 
-Give the plugin the application root directory. The directory must contain the
-standard `config/container.php` file.
+Pass the application root directory to the plugin. The directory MUST contain
+the standard `config/container.php` file.
 
-The container file must return a `Psr\Container\ContainerInterface` instance.
-It must create a new instance for the test-attempt container lifetime. The
-standard Hyperf container file has this behavior.
+The container file MUST return a `Psr\Container\ContainerInterface` instance.
+For the test-attempt container lifetime, the file MUST create a new instance.
+The standard Hyperf container file creates a new instance.
 
 ## Container lifetime
 
-The default `ContainerLifetime::Worker` mode models a long-running Hyperf
-worker. Greenlight boots one application container for each physical worker and
-reuses that container for all test attempts in the worker.
+The default `ContainerLifetime::Worker` mode uses one application container for
+each worker. Greenlight reuses the container for all test attempts in that
+worker.
 
 ```php
 use Greenlight\Hyperf\ContainerLifetime;
@@ -51,12 +50,11 @@ new HyperfPlugin(
 );
 ```
 
-Container singleton state can reach later tests in this mode. This behavior is
-intentional. It exposes request data that an application incorrectly stores in
-a worker service, global variable, or static property.
+Container singleton state can reach later tests in this mode. Request data in a
+worker service, global variable, or static property can also reach later tests.
 
-Use `ContainerLifetime::TestAttempt` for a new application container in each
-test attempt:
+Use `ContainerLifetime::TestAttempt` to create an application container for
+each test attempt:
 
 ```php
 new HyperfPlugin(
@@ -65,37 +63,35 @@ new HyperfPlugin(
 );
 ```
 
-This mode gives deterministic container isolation. It matches the fresh
-container strategy in Hyperf's testing helpers. It does not validate that
-container services are safe across requests in a long-running worker. Static
-properties and global variables still belong to the Greenlight worker process.
+This mode uses the fresh-container strategy from Hyperf test helpers. It does
+not test if container services are safe across requests in a long-running
+worker. Static properties and global variables remain in the Greenlight worker
+process.
 
 ## Worker bootstrap
 
 Each Greenlight worker calls `Hyperf\Di\ClassLoader::init()` once. This call
-loads scan configuration and generates the necessary AOP proxy classes.
+loads scan configuration and generates AOP proxy classes.
 
 The bridge locks `runtime/container/greenlight.scan.lock` during this call.
-The lock prevents parallel workers from writing the Hyperf scan cache at the
-same time.
+The lock prevents concurrent writes to the Hyperf scan cache.
 
-Normal Hyperf scan configuration applies. Keep `scan_cacheable` disabled during
-development. If you enable `scan_cacheable`, generate current scan caches before
-the test run.
+Keep `scan_cacheable` disabled during development. If you enable
+`scan_cacheable`, generate current scan caches before you run tests.
 
-The class-loader step occurs before Greenlight loads test classes in the
-worker. Composer can then select generated classes for application services.
+Greenlight initializes the class loader before it loads test classes. Composer
+can then load generated classes for application services.
 
-In worker-container mode, bootstrap also loads `config/container.php` and
-resolves `Hyperf\Contract\ApplicationInterface`. This operation boots the
-application once for the physical worker.
+In `ContainerLifetime::Worker` mode, bootstrap also loads
+`config/container.php`. It resolves `Hyperf\Contract\ApplicationInterface` to
+boot the application once for the worker.
 
 ## Worker-container lifecycle
 
 The default mode uses this lifecycle:
 
 1. Boot one application container during Greenlight worker bootstrap.
-2. Start one root Swoole coroutine runtime for the physical worker.
+2. Start one root Swoole coroutine for the worker.
 3. Start one child coroutine for each test attempt.
 4. Construct the test and run all hooks, plugins, and the test method.
 5. Close the Greenlight test service scope.
@@ -104,17 +100,17 @@ The default mode uses this lifecycle:
 8. Reuse the application container for the next test attempt.
 9. When the worker exits, call the disposal callback inside the root coroutine.
 10. Clear Swoole timers and resume Hyperf's worker-exit coordinator.
-11. End the root coroutine runtime.
+11. End the root coroutine.
 
-The root runtime contains all assignments that Greenlight sends to one
-physical worker. Worker recycling closes this runtime and gives the replacement
-worker a new application container.
+The root coroutine contains all assignments that Greenlight sends to one
+worker. Worker replacement closes this coroutine and creates a new application
+container.
 
 ## Test-attempt container lifecycle
 
 The isolated mode uses this lifecycle for each attempt:
 
-1. Start one root Swoole coroutine runtime.
+1. Start one root Swoole coroutine.
 2. Load `config/container.php` and activate its new container.
 3. Resolve `Hyperf\Contract\ApplicationInterface` to boot the application.
 4. Construct the test and run all hooks, plugins, and the test method.
@@ -122,12 +118,11 @@ The isolated mode uses this lifecycle for each attempt:
 6. Call the reset callback and disposal callback.
 7. Remove access to the discarded application container.
 8. Clear Swoole timers and resume Hyperf's worker-exit coordinator.
-9. End the coroutine runtime.
+9. End the coroutine.
 
-In both modes, the complete Greenlight attempt runs inside its own coroutine.
-This boundary includes constructor injection, hooks, test-scope disposal, and
-`afterTest()` plugins. Swoole destroys the coroutine context when the attempt
-ends.
+In both modes, the complete test attempt runs inside its own coroutine. This
+includes constructor injection, hooks, test-scope disposal, and `afterTest()`
+plugins. Swoole destroys the coroutine context when the attempt ends.
 
 ## Container services
 
@@ -141,7 +136,7 @@ final readonly class RegistrationTest
 ```
 
 Greenlight first checks its harness services. It then asks the active Hyperf
-container. Normal Hyperf container rules apply.
+container.
 
 Use `#[Service]` when the parameter type does not select the necessary ID:
 
@@ -156,18 +151,18 @@ public function __construct(
 The bridge checks the returned service type. A different type causes a test
 error.
 
-Tests can also receive `Psr\Container\ContainerInterface`. This service is
+A test can also receive `Psr\Container\ContainerInterface`. This service is
 available only during the current test attempt.
 
 ## Reset and disposal
 
-Hyperf does not define one reset operation for an arbitrary application object
-graph. The application MUST keep request state in coroutine context or reset
-that state explicitly. See Hyperf's
+Hyperf does not supply one reset operation for all application services. The
+application MUST keep request state in coroutine context or reset that state
+after each attempt. See Hyperf's
 [coroutine guidance](https://hyperf.wiki/3.1/#/en/coroutine).
 
-Use `reset` for project state that must change after every attempt. Use
-`dispose` for resources that belong to the selected container lifetime:
+Use `reset:` to reset project state after each attempt. Use
+`dispose:` for resources that belong to the selected container lifetime:
 
 ```php
 use Psr\Container\ContainerInterface;
@@ -190,28 +185,28 @@ The disposal callback runs before Greenlight discards its container. In worker
 mode, it runs once when the worker exits. In test-attempt mode, it runs after
 each attempt. It always runs inside a coroutine.
 
-The bridge does not reset arbitrary application static properties or global
-variables. Reset these values in an `#[After]` hook or the reset callback.
+The bridge does not reset application static properties or global variables.
+Reset these values in an `#[After]` hook or the `reset:` callback.
 
 The bridge does not isolate databases, queues, caches, or remote services.
 
 ## Parallel resources
 
 Workers run tests at the same time. Use `GREENLIGHT_CHANNEL` in Hyperf
-configuration to give each worker separate external resources.
+configuration to assign separate external resources to each worker.
 
-For example, add the channel to database names, cache prefixes, queue names,
-and temporary directories. The channel remains stable for the worker slot.
+Add the channel to database names, cache prefixes, queue names, and temporary
+directories. The channel remains stable for the worker slot.
 
-Use `#[RequiresResource]` when an external resource cannot use channels. See
-[configuration](configuration.md) for concurrency limits.
+If workers cannot use separate external resources, use `#[RequiresResource]`.
+See [configuration](configuration.md) for concurrency limits.
 
-## Supported surface
+## Supported features
 
-The bridge covers these runtime behaviors:
+The bridge provides:
 
 * Hyperf class scan and AOP proxy generation
-* One long-running Swoole runtime for each worker-container worker
+* One root Swoole coroutine for each worker container
 * Application boot for the selected container lifetime
 * One coroutine context for each complete test attempt
 * Persistent or isolated container singleton state
@@ -219,11 +214,11 @@ The bridge covers these runtime behaviors:
 * Hyperf timer and coordinator cleanup at the container lifetime boundary
 * Type-based and explicit-ID service injection
 
-The bridge does not cover these behaviors:
+The bridge does not provide:
 
 * A live Swoole HTTP server or server worker events
 * Concurrent test attempts inside one Greenlight worker
 * Hyperf `co-phpunit` or PHPUnit helper traits
 * Swow coroutine execution
 * Database transactions or schema creation
-* Automatic cleanup for arbitrary static state or external resources
+* Automatic cleanup of application static state or external resources


### PR DESCRIPTION
## Summary

- remove the PSR-11 comparison from the introduction
- describe setup, container lifetimes, and coroutine lifecycles in direct technical English
- clarify reset behavior, resource isolation, and supported features