### PR TITLE
refactor(test): reuse stream wrapper sandbox

### DIFF
--- a/tests/Unit/Cli/ApplicationStreamOutputTest.php
+++ b/tests/Unit/Cli/ApplicationStreamOutputTest.php
@@ -9,11 +9,14 @@ use Greenlight\Attribute\Test;
 use Greenlight\Cli\Application;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
+use Greenlight\Fixture\StreamWrapperSandbox;
 use Greenlight\Tests\Fixture\Reporting\PartialWriteStream;
 
-final class ApplicationStreamOutputTest
+final readonly class ApplicationStreamOutputTest
 {
     private const string SCHEME = 'greenlight-application-partial-write';
+
+    public function __construct(private StreamWrapperSandbox $streamWrappers) {}
 
     /**
      * @param list<string> $arguments
@@ -26,9 +29,7 @@ final class ApplicationStreamOutputTest
         string $expectedOutput,
         bool $useStderr,
     ): void {
-        if (!\stream_wrapper_register(self::SCHEME, PartialWriteStream::class)) {
-            Fail::because('Greenlight did not register the partial-write stream.');
-        }
+        $this->streamWrappers->register(self::SCHEME, PartialWriteStream::class);
 
         $partial = \fopen(self::SCHEME . '://partial', 'wb');
         $other = \fopen('php://memory', 'wb');
@@ -38,7 +39,6 @@ final class ApplicationStreamOutputTest
                 \fclose($partial);
             }
 
-            \stream_wrapper_unregister(self::SCHEME);
             Fail::because('Greenlight did not open the CLI test streams.');
         }
 
@@ -56,7 +56,6 @@ final class ApplicationStreamOutputTest
         } finally {
             \fclose($partial);
             \fclose($other);
-            \stream_wrapper_unregister(self::SCHEME);
         }
     }
 

--- a/tests/Unit/Coverage/HtmlExporterSourceFailureTest.php
+++ b/tests/Unit/Coverage/HtmlExporterSourceFailureTest.php
@@ -11,12 +11,15 @@ use Greenlight\Coverage\CoverageMap;
 use Greenlight\Coverage\Export\HtmlExporter;
 use Greenlight\Coverage\FileCoverage;
 use Greenlight\Expect\Expect;
+use Greenlight\Fixture\StreamWrapperSandbox;
 use Greenlight\Tests\Fixture\Coverage\UnreadableAfterStatStream;
 use Greenlight\Tests\Support\FilesystemRestriction;
 
 final readonly class HtmlExporterSourceFailureTest
 {
     private const string SCHEME = 'greenlight-unreadable-after-stat';
+
+    public function __construct(private StreamWrapperSandbox $streamWrappers) {}
 
     #[Test]
     #[Isolated]
@@ -46,35 +49,29 @@ final readonly class HtmlExporterSourceFailureTest
     #[Test]
     public function sourceReadFailureFallsBackToLineNumbersOnly(): void
     {
-        if (!\stream_wrapper_register(self::SCHEME, UnreadableAfterStatStream::class)) {
-            throw new \RuntimeException('Greenlight did not register the unreadable source stream.');
-        }
+        $this->streamWrappers->register(self::SCHEME, UnreadableAfterStatStream::class);
 
-        try {
-            $path = self::SCHEME . '://Source.php';
-            $map = new CoverageMap([
-                new FileCoverage($path, [2], [4]),
-            ]);
+        $path = self::SCHEME . '://Source.php';
+        $map = new CoverageMap([
+            new FileCoverage($path, [2], [4]),
+        ]);
 
-            Expect::that(\is_file($path) && \is_readable($path))
-                ->because('the source passes the exporter readability checks')
-                ->toBeTrue();
+        Expect::that(\is_file($path) && \is_readable($path))
+            ->because('the source passes the exporter readability checks')
+            ->toBeTrue();
 
-            $pages = ErrorTrap::run(
-                static fn(): array => new HtmlExporter()->export($map),
-                $warning,
-            );
-            $page = $pages[HtmlExporter::pageName($path)];
+        $pages = ErrorTrap::run(
+            static fn(): array => new HtmlExporter()->export($map),
+            $warning,
+        );
+        $page = $pages[HtmlExporter::pageName($path)];
 
-            Expect::that($warning)
-                ->because('a late source read failure MUST not leak an engine diagnostic')
-                ->toBeNull();
-            Expect::that($page)
-                ->because('a late read failure shows only coverage line numbers')
-                ->toContain('<span class="cov"><span class="num">2</span></span>')
-                ->toContain('<span class="unc"><span class="num">4</span></span>');
-        } finally {
-            \stream_wrapper_unregister(self::SCHEME);
-        }
+        Expect::that($warning)
+            ->because('a late source read failure MUST not leak an engine diagnostic')
+            ->toBeNull();
+        Expect::that($page)
+            ->because('a late read failure shows only coverage line numbers')
+            ->toContain('<span class="cov"><span class="num">2</span></span>')
+            ->toContain('<span class="unc"><span class="num">4</span></span>');
     }
 }

--- a/tests/Unit/Coverage/HtmlExporterUnreadableSourceTest.php
+++ b/tests/Unit/Coverage/HtmlExporterUnreadableSourceTest.php
@@ -9,44 +9,41 @@ use Greenlight\Coverage\CoverageMap;
 use Greenlight\Coverage\Export\HtmlExporter;
 use Greenlight\Coverage\FileCoverage;
 use Greenlight\Expect\Expect;
+use Greenlight\Fixture\StreamWrapperSandbox;
 use Greenlight\Tests\Fixture\Coverage\UnreadableSourceStream;
 
 final readonly class HtmlExporterUnreadableSourceTest
 {
     private const string SCHEME = 'greenlight-unreadable-source';
 
+    public function __construct(private StreamWrapperSandbox $streamWrappers) {}
+
     #[Test]
     public function unreadableSourceFallsBackBeforeOpeningTheFile(): void
     {
-        if (!\stream_wrapper_register(self::SCHEME, UnreadableSourceStream::class)) {
-            throw new \RuntimeException('Greenlight did not register the unreadable source stream.');
-        }
+        $this->streamWrappers->register(self::SCHEME, UnreadableSourceStream::class);
 
-        try {
-            $path = self::SCHEME . '://Source.php';
-            UnreadableSourceStream::$openCalls = 0;
+        $path = self::SCHEME . '://Source.php';
+        UnreadableSourceStream::$openCalls = 0;
 
-            Expect::that(\is_file($path))
-                ->because('the fixture MUST be a regular file')
-                ->toBeTrue();
-            Expect::that(\is_readable($path))
-                ->because('the fixture MUST reject reads')
-                ->toBeFalse();
+        Expect::that(\is_file($path))
+            ->because('the fixture MUST be a regular file')
+            ->toBeTrue();
+        Expect::that(\is_readable($path))
+            ->because('the fixture MUST reject reads')
+            ->toBeFalse();
 
-            $map = new CoverageMap([
-                new FileCoverage($path, [2], [4]),
-            ]);
-            $page = new HtmlExporter()->export($map)[HtmlExporter::pageName($path)];
+        $map = new CoverageMap([
+            new FileCoverage($path, [2], [4]),
+        ]);
+        $page = new HtmlExporter()->export($map)[HtmlExporter::pageName($path)];
 
-            Expect::that($page)
-                ->because('an unreadable source shows only coverage line numbers')
-                ->toContain('<span class="cov"><span class="num">2</span></span>')
-                ->toContain('<span class="unc"><span class="num">4</span></span>');
-            Expect::that(UnreadableSourceStream::$openCalls)
-                ->because('the exporter rejects an unreadable source before opening it')
-                ->toBe(0);
-        } finally {
-            \stream_wrapper_unregister(self::SCHEME);
-        }
+        Expect::that($page)
+            ->because('an unreadable source shows only coverage line numbers')
+            ->toContain('<span class="cov"><span class="num">2</span></span>')
+            ->toContain('<span class="unc"><span class="num">4</span></span>');
+        Expect::that(UnreadableSourceStream::$openCalls)
+            ->because('the exporter rejects an unreadable source before opening it')
+            ->toBe(0);
     }
 }

--- a/tests/Unit/Discovery/DiscoveryCacheTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheTest.php
@@ -11,6 +11,7 @@ use Greenlight\Discovery\TestDiscoverer;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\EnvironmentSandbox;
+use Greenlight\Fixture\StreamWrapperSandbox;
 use Greenlight\Tests\Fixture\Filesystem\StatableFileStream;
 use Greenlight\Tests\Support\DiscoveryCachePath;
 
@@ -18,7 +19,10 @@ final readonly class DiscoveryCacheTest
 {
     private const string STATABLE_FILE_SCHEME = 'greenlight-statable-file';
 
-    public function __construct(private EnvironmentSandbox $environment) {}
+    public function __construct(
+        private EnvironmentSandbox $environment,
+        private StreamWrapperSandbox $streamWrappers,
+    ) {}
 
     #[Test]
     public function hitsServeFromCacheAndAnyChangeInvalidates(): void
@@ -396,9 +400,7 @@ final readonly class DiscoveryCacheTest
         $directory = \sys_get_temp_dir() . '/greenlight-binary-path-' . \bin2hex(\random_bytes(6));
         $source = self::STATABLE_FILE_SCHEME . "://Invalid-\xFF-Test.php";
         $cacheFile = DiscoveryCachePath::forDirectories([$directory]);
-        if (!\stream_wrapper_register(self::STATABLE_FILE_SCHEME, StatableFileStream::class)) {
-            Fail::because('Expected to register the statable-file stream.');
-        }
+        $this->streamWrappers->register(self::STATABLE_FILE_SCHEME, StatableFileStream::class);
 
         $cache = DiscoveryCache::forDirectories([$directory]);
 
@@ -412,7 +414,6 @@ final readonly class DiscoveryCacheTest
                 ->because('failed cache encoding MUST not leave a cache document')
                 ->toBeFalse();
         } finally {
-            \stream_wrapper_unregister(self::STATABLE_FILE_SCHEME);
             @\unlink($cacheFile);
         }
     }

--- a/tests/Unit/Reporting/StreamOutputTest.php
+++ b/tests/Unit/Reporting/StreamOutputTest.php
@@ -6,13 +6,16 @@ namespace Greenlight\Tests\Unit\Reporting;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
+use Greenlight\Fixture\StreamWrapperSandbox;
 use Greenlight\Reporting\Output\StreamOutput;
 use Greenlight\Reporting\ReportingError;
 use Greenlight\Tests\Fixture\Reporting\PartialWriteStream;
 
-final class StreamOutputTest
+final readonly class StreamOutputTest
 {
     private const string PARTIAL_WRITE_SCHEME = 'greenlight-partial-write';
+
+    public function __construct(private StreamWrapperSandbox $streamWrappers) {}
 
     #[Test]
     public function writesAccumulateOnTheStream(): void
@@ -72,7 +75,6 @@ final class StreamOutputTest
                 ->toBe('complete reporter output');
         } finally {
             \fclose($stream);
-            \stream_wrapper_unregister(self::PARTIAL_WRITE_SCHEME);
         }
     }
 
@@ -92,7 +94,6 @@ final class StreamOutputTest
                 );
         } finally {
             \fclose($stream);
-            \stream_wrapper_unregister(self::PARTIAL_WRITE_SCHEME);
         }
     }
 
@@ -101,15 +102,11 @@ final class StreamOutputTest
      */
     private function openPartialWriteStream(string $path)
     {
-        if (!\stream_wrapper_register(self::PARTIAL_WRITE_SCHEME, PartialWriteStream::class)) {
-            throw new \RuntimeException('Greenlight did not register the partial-write stream.');
-        }
+        $this->streamWrappers->register(self::PARTIAL_WRITE_SCHEME, PartialWriteStream::class);
 
         $stream = \fopen(self::PARTIAL_WRITE_SCHEME . '://' . $path, 'wb');
 
         if ($stream === false) {
-            \stream_wrapper_unregister(self::PARTIAL_WRITE_SCHEME);
-
             throw new \RuntimeException('Greenlight did not open the partial-write stream.');
         }
 

--- a/tests/Unit/Runner/Protocol/SocketChannelEofReadFailureTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelEofReadFailureTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Unit\Runner\Protocol;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
+use Greenlight\Fixture\StreamWrapperSandbox;
 use Greenlight\Runner\Protocol\SocketChannel;
 use Greenlight\Tests\Fixture\Runner\Protocol\EofReadFailureStream;
 
@@ -14,17 +15,16 @@ final readonly class SocketChannelEofReadFailureTest
 {
     private const string STREAM_SCHEME = 'greenlight-eof-read-failure';
 
+    public function __construct(private StreamWrapperSandbox $streamWrappers) {}
+
     #[Test]
     public function aFailedReadAtPeerEofClosesTheChannelCleanly(): void
     {
-        if (!\stream_wrapper_register(self::STREAM_SCHEME, EofReadFailureStream::class)) {
-            Fail::because('The test could not register the EOF read-failure stream.');
-        }
+        $this->streamWrappers->register(self::STREAM_SCHEME, EofReadFailureStream::class);
 
         $stream = \fopen(self::STREAM_SCHEME . '://channel', 'r+');
 
         if ($stream === false) {
-            \stream_wrapper_unregister(self::STREAM_SCHEME);
             Fail::because('The test could not open the EOF read-failure stream.');
         }
 
@@ -37,7 +37,6 @@ final readonly class SocketChannelEofReadFailureTest
             Expect::that($channel->isEof())->toBeTrue();
         } finally {
             $channel->close();
-            \stream_wrapper_unregister(self::STREAM_SCHEME);
         }
     }
 }

--- a/tests/Unit/Runner/Protocol/SocketChannelFlushFailureTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelFlushFailureTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Unit\Runner\Protocol;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
+use Greenlight\Fixture\StreamWrapperSandbox;
 use Greenlight\Runner\Protocol\Messages\Drain;
 use Greenlight\Runner\Protocol\ProtocolError;
 use Greenlight\Runner\Protocol\SocketChannel;
@@ -16,17 +17,16 @@ final readonly class SocketChannelFlushFailureTest
 {
     private const string STREAM_SCHEME = 'greenlight-flush-failure';
 
+    public function __construct(private StreamWrapperSandbox $streamWrappers) {}
+
     #[Test]
     public function aFailedFlushRejectsTheSend(): void
     {
-        if (!\stream_wrapper_register(self::STREAM_SCHEME, FlushFailureStream::class)) {
-            Fail::because('The test could not register the flush-failure stream.');
-        }
+        $this->streamWrappers->register(self::STREAM_SCHEME, FlushFailureStream::class);
 
         $stream = \fopen(self::STREAM_SCHEME . '://channel', 'w+');
 
         if ($stream === false) {
-            \stream_wrapper_unregister(self::STREAM_SCHEME);
             Fail::because('The test could not open the flush-failure stream.');
         }
 
@@ -43,7 +43,6 @@ final readonly class SocketChannelFlushFailureTest
                 );
         } finally {
             $channel->close();
-            \stream_wrapper_unregister(self::STREAM_SCHEME);
         }
     }
 }

--- a/tests/Unit/Runner/Protocol/SocketChannelReadFailureTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelReadFailureTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Unit\Runner\Protocol;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
+use Greenlight\Fixture\StreamWrapperSandbox;
 use Greenlight\Runner\Protocol\ProtocolError;
 use Greenlight\Runner\Protocol\SocketChannel;
 use Greenlight\Tests\Fixture\Runner\Protocol\ReadFailureStream;
@@ -15,17 +16,16 @@ final readonly class SocketChannelReadFailureTest
 {
     private const string STREAM_SCHEME = 'greenlight-read-failure';
 
+    public function __construct(private StreamWrapperSandbox $streamWrappers) {}
+
     #[Test]
     public function aFailedReadRejectsTheChannel(): void
     {
-        if (!\stream_wrapper_register(self::STREAM_SCHEME, ReadFailureStream::class)) {
-            Fail::because('The test could not register the read-failure stream.');
-        }
+        $this->streamWrappers->register(self::STREAM_SCHEME, ReadFailureStream::class);
 
         $stream = \fopen(self::STREAM_SCHEME . '://channel', 'r+');
 
         if ($stream === false) {
-            \stream_wrapper_unregister(self::STREAM_SCHEME);
             Fail::because('The test could not open the read-failure stream.');
         }
 
@@ -40,7 +40,6 @@ final readonly class SocketChannelReadFailureTest
                 );
         } finally {
             $channel->close();
-            \stream_wrapper_unregister(self::STREAM_SCHEME);
         }
     }
 }

--- a/tests/Unit/Runner/Protocol/SocketChannelTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelTest.php
@@ -7,15 +7,18 @@ namespace Greenlight\Tests\Unit\Runner\Protocol;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
+use Greenlight\Fixture\StreamWrapperSandbox;
 use Greenlight\Runner\Protocol\Messages\Drain;
 use Greenlight\Runner\Protocol\ProtocolError;
 use Greenlight\Runner\Protocol\SocketChannel;
 use Greenlight\Tests\Fixture\Runner\Protocol\UnselectableStream;
 use Greenlight\Tests\Support\ConnectedStreamPair;
 
-final class SocketChannelTest
+final readonly class SocketChannelTest
 {
     private const string UNSELECTABLE_SCHEME = 'greenlight-unselectable';
+
+    public function __construct(private StreamWrapperSandbox $streamWrappers) {}
 
     #[Test]
     public function receiveTimeoutLeavesTheChannelOpenForLaterMessages(): void
@@ -135,14 +138,11 @@ final class SocketChannelTest
     #[Test]
     public function aSelectFailureEndsTheReceiveWithoutClosingTheChannel(): void
     {
-        if (!\stream_wrapper_register(self::UNSELECTABLE_SCHEME, UnselectableStream::class)) {
-            Fail::because('The test could not register the unselectable stream.');
-        }
+        $this->streamWrappers->register(self::UNSELECTABLE_SCHEME, UnselectableStream::class);
 
         $stream = \fopen(self::UNSELECTABLE_SCHEME . '://channel', 'r+');
 
         if ($stream === false) {
-            \stream_wrapper_unregister(self::UNSELECTABLE_SCHEME);
             Fail::because('The test could not open the unselectable stream.');
         }
 
@@ -157,7 +157,6 @@ final class SocketChannelTest
                 ->toBeFalse();
         } finally {
             $channel->close();
-            \stream_wrapper_unregister(self::UNSELECTABLE_SCHEME);
         }
     }
 


### PR DESCRIPTION
Route the remaining test-owned stream wrapper registrations through the per-test StreamWrapperSandbox fixture. This removes duplicated global cleanup paths and guarantees wrapper restoration when assertions or stream setup fail across CLI, coverage, discovery, reporting, and protocol tests.