### PR TITLE
fix(events): reject nonfinite timestamps

### DIFF
--- a/docs/api-events.md
+++ b/docs/api-events.md
@@ -132,7 +132,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L41)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L45)
 
 ### `fromWire()`
 
@@ -141,7 +141,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L52)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L56)
 
 ## `RunStarted`
 
@@ -230,7 +230,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunStarted.php#L59)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunStarted.php#L63)
 
 ### `fromWire()`
 
@@ -239,7 +239,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunStarted.php#L71)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunStarted.php#L75)
 
 ## `SuiteFinished`
 
@@ -290,7 +290,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteFinished.php#L28)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteFinished.php#L32)
 
 ### `fromWire()`
 
@@ -299,7 +299,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteFinished.php#L37)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteFinished.php#L41)
 
 ## `SuiteStarted`
 
@@ -350,7 +350,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteStarted.php#L28)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteStarted.php#L32)
 
 ### `fromWire()`
 
@@ -359,7 +359,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteStarted.php#L37)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/SuiteStarted.php#L41)
 
 ## `TestClassFinished`
 
@@ -423,7 +423,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassFinished.php#L34)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassFinished.php#L38)
 
 ### `fromWire()`
 
@@ -432,7 +432,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassFinished.php#L44)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassFinished.php#L48)
 
 ## `TestClassStarted`
 
@@ -496,7 +496,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassStarted.php#L34)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassStarted.php#L38)
 
 ### `fromWire()`
 
@@ -505,7 +505,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassStarted.php#L44)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassStarted.php#L48)
 
 ## `TestFinished`
 
@@ -548,7 +548,7 @@ public function __construct(public TestResult $result, public float $occurredAt)
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestFinished.php#L14)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestFinished.php#L19)
 
 ### `fromWire()`
 
@@ -557,7 +557,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestFinished.php#L23)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestFinished.php#L28)
 
 ## `TestStarted`
 
@@ -600,7 +600,7 @@ public function __construct(public TestId $id, public float $occurredAt)
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestStarted.php#L14)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestStarted.php#L19)
 
 ### `fromWire()`
 
@@ -609,7 +609,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestStarted.php#L23)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestStarted.php#L28)
 
 ## `WorkerRecycled`
 
@@ -672,7 +672,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerRecycled.php#L31)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerRecycled.php#L35)
 
 ### `fromWire()`
 
@@ -681,7 +681,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerRecycled.php#L41)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerRecycled.php#L45)
 
 ## `WorkerSpawned`
 
@@ -748,7 +748,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerSpawned.php#L41)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerSpawned.php#L45)
 
 ### `fromWire()`
 
@@ -757,4 +757,4 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerSpawned.php#L51)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerSpawned.php#L55)

--- a/src/Core/Event/RunFinished.php
+++ b/src/Core/Event/RunFinished.php
@@ -35,6 +35,10 @@ final readonly class RunFinished implements Event
             throw new \InvalidArgumentException('RunFinished duration cannot be negative.');
         }
 
+        if (!\is_finite($occurredAt)) {
+            throw new \InvalidArgumentException('Event timestamp MUST be finite.');
+        }
+
         $this->runId = $runId;
     }
 

--- a/src/Core/Event/RunStarted.php
+++ b/src/Core/Event/RunStarted.php
@@ -51,6 +51,10 @@ final readonly class RunStarted implements Event
             ));
         }
 
+        if (!\is_finite($occurredAt)) {
+            throw new \InvalidArgumentException('Event timestamp MUST be finite.');
+        }
+
         $this->runId = $runId;
         $this->plannedTests = $plannedTests;
         $this->workers = $workers;

--- a/src/Core/Event/SuiteFinished.php
+++ b/src/Core/Event/SuiteFinished.php
@@ -22,6 +22,10 @@ final readonly class SuiteFinished implements Event
             throw new \InvalidArgumentException('Suite name MUST NOT be empty.');
         }
 
+        if (!\is_finite($occurredAt)) {
+            throw new \InvalidArgumentException('Event timestamp MUST be finite.');
+        }
+
         $this->suite = $suite;
     }
 

--- a/src/Core/Event/SuiteStarted.php
+++ b/src/Core/Event/SuiteStarted.php
@@ -22,6 +22,10 @@ final readonly class SuiteStarted implements Event
             throw new \InvalidArgumentException('Suite name MUST NOT be empty.');
         }
 
+        if (!\is_finite($occurredAt)) {
+            throw new \InvalidArgumentException('Event timestamp MUST be finite.');
+        }
+
         $this->suite = $suite;
     }
 

--- a/src/Core/Event/TestClassFinished.php
+++ b/src/Core/Event/TestClassFinished.php
@@ -28,6 +28,10 @@ final readonly class TestClassFinished implements Event
             throw new \InvalidArgumentException('Test class name MUST NOT be empty.');
         }
 
+        if (!\is_finite($occurredAt)) {
+            throw new \InvalidArgumentException('Event timestamp MUST be finite.');
+        }
+
         $this->class = $class;
     }
 

--- a/src/Core/Event/TestClassStarted.php
+++ b/src/Core/Event/TestClassStarted.php
@@ -28,6 +28,10 @@ final readonly class TestClassStarted implements Event
             throw new \InvalidArgumentException('Test class name MUST NOT be empty.');
         }
 
+        if (!\is_finite($occurredAt)) {
+            throw new \InvalidArgumentException('Event timestamp MUST be finite.');
+        }
+
         $this->class = $class;
     }
 

--- a/src/Core/Event/TestFinished.php
+++ b/src/Core/Event/TestFinished.php
@@ -9,7 +9,12 @@ use Greenlight\Core\Wire\Wire;
 
 final readonly class TestFinished implements Event
 {
-    public function __construct(public TestResult $result, public float $occurredAt) {}
+    public function __construct(public TestResult $result, public float $occurredAt)
+    {
+        if (!\is_finite($occurredAt)) {
+            throw new \InvalidArgumentException('Event timestamp MUST be finite.');
+        }
+    }
 
     #[\Override]
     public function toWire(): array

--- a/src/Core/Event/TestStarted.php
+++ b/src/Core/Event/TestStarted.php
@@ -9,7 +9,12 @@ use Greenlight\Core\Wire\Wire;
 
 final readonly class TestStarted implements Event
 {
-    public function __construct(public TestId $id, public float $occurredAt) {}
+    public function __construct(public TestId $id, public float $occurredAt)
+    {
+        if (!\is_finite($occurredAt)) {
+            throw new \InvalidArgumentException('Event timestamp MUST be finite.');
+        }
+    }
 
     #[\Override]
     public function toWire(): array

--- a/src/Core/Event/WorkerRecycled.php
+++ b/src/Core/Event/WorkerRecycled.php
@@ -25,6 +25,10 @@ final readonly class WorkerRecycled implements Event
             throw new \InvalidArgumentException('Worker ID MUST NOT be empty.');
         }
 
+        if (!\is_finite($occurredAt)) {
+            throw new \InvalidArgumentException('Event timestamp MUST be finite.');
+        }
+
         $this->workerId = $workerId;
     }
 

--- a/src/Core/Event/WorkerSpawned.php
+++ b/src/Core/Event/WorkerSpawned.php
@@ -34,6 +34,10 @@ final readonly class WorkerSpawned implements Event
             throw new \InvalidArgumentException('Worker PID MUST be greater than zero.');
         }
 
+        if (!\is_finite($occurredAt)) {
+            throw new \InvalidArgumentException('Event timestamp MUST be finite.');
+        }
+
         $this->workerId = $workerId;
         $this->pid = $pid;
     }

--- a/tests/Unit/Core/EventTimestampValidationTest.php
+++ b/tests/Unit/Core/EventTimestampValidationTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\Event;
+use Greenlight\Core\Event\RecycleReason;
+use Greenlight\Core\Event\RunFinished;
+use Greenlight\Core\Event\RunStarted;
+use Greenlight\Core\Event\SuiteFinished;
+use Greenlight\Core\Event\SuiteStarted;
+use Greenlight\Core\Event\TestClassFinished;
+use Greenlight\Core\Event\TestClassStarted;
+use Greenlight\Core\Event\TestFinished;
+use Greenlight\Core\Event\TestStarted;
+use Greenlight\Core\Event\WorkerRecycled;
+use Greenlight\Core\Event\WorkerSpawned;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\ResultSummary;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+
+final readonly class EventTimestampValidationTest
+{
+    /**
+     * @param \Closure(float): Event $create
+     */
+    #[Test]
+    #[DataSet('eventFactories')]
+    public function directConstructionRejectsNonfiniteTimestamps(\Closure $create): void
+    {
+        Expect::that(static fn(): Event => $create(\INF))
+            ->because('direct and wire event construction MUST enforce the same timestamp invariant')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Event timestamp MUST be finite.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{\Closure(float): Event}>
+     */
+    public static function eventFactories(): iterable
+    {
+        $id = new TestId('Acme\TimestampTest', 'runs');
+        $result = new TestResult($id, Outcome::Passed, 0.0, 0);
+
+        yield 'run started' => [static fn(float $at): Event => new RunStarted('run-1', 1, 1, $at)];
+        yield 'run finished' => [static fn(float $at): Event => new RunFinished('run-1', new ResultSummary(), 0.0, $at)];
+        yield 'suite started' => [static fn(float $at): Event => new SuiteStarted('unit', $at)];
+        yield 'suite finished' => [static fn(float $at): Event => new SuiteFinished('unit', $at)];
+        yield 'test class started' => [static fn(float $at): Event => new TestClassStarted('Acme\TimestampTest', $at)];
+        yield 'test class finished' => [static fn(float $at): Event => new TestClassFinished('Acme\TimestampTest', $at)];
+        yield 'test started' => [static fn(float $at): Event => new TestStarted($id, $at)];
+        yield 'test finished' => [static fn(float $at): Event => new TestFinished($result, $at)];
+        yield 'worker spawned' => [static fn(float $at): Event => new WorkerSpawned('w-1', 1, $at)];
+        yield 'worker recycled' => [static fn(float $at): Event => new WorkerRecycled('w-1', RecycleReason::TestCount, $at)];
+    }
+}


### PR DESCRIPTION
Enforce the finite timestamp invariant during direct construction for every event type, matching the existing wire decoder contract. This prevents directly created events from reaching JSONL serialization or profile arithmetic with NaN or infinite timestamps.