### PR TITLE
feat(fixture): add autoloader sandbox

### DIFF
--- a/docs/api-fixtures-harness.md
+++ b/docs/api-fixtures-harness.md
@@ -6,6 +6,39 @@ This reference lists fixtures and harness service contracts.
 
 These signatures are the public API.
 
+## `AutoloaderSandbox`
+
+Namespace: `Greenlight\Fixture`
+
+Registers autoloaders and unregisters them when the test scope closes.
+
+```php
+final class AutoloaderSandbox implements Disposable
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/AutoloaderSandbox.php#L12)
+
+### `register()`
+
+```php
+public function register(callable $autoloader): void
+```
+
+PHPDoc:
+
+- `@param callable(string): void $autoloader`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/AutoloaderSandbox.php#L18)
+
+### `dispose()`
+
+```php
+[\Override]
+public function dispose(): void
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Fixture/AutoloaderSandbox.php#L24)
+
 ## `EnvironmentSandbox`
 
 Namespace: `Greenlight\Fixture`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -325,6 +325,10 @@ leak to other tests or workers.
   the directory after the test.
 * `EnvironmentSandbox` changes environment variables in `getenv`, `$_ENV`, and
   `$_SERVER`. It restores the original values after the test.
+* `AutoloaderSandbox` registers PHP autoloaders. It unregisters them in reverse
+  registration order after the test.
+* `StreamWrapperSandbox` registers PHP stream wrappers. It unregisters them in
+  reverse registration order after the test.
 
 ```php
 use Greenlight\Fixture\EnvironmentSandbox;

--- a/src/Fixture/AutoloaderSandbox.php
+++ b/src/Fixture/AutoloaderSandbox.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Fixture;
+
+use Greenlight\Harness\Disposable;
+
+/**
+ * Registers autoloaders and unregisters them when the test scope closes.
+ */
+final class AutoloaderSandbox implements Disposable
+{
+    /** @var list<callable(string): void> */
+    private array $autoloaders = [];
+
+    /** @param callable(string): void $autoloader */
+    public function register(callable $autoloader): void
+    {
+        \spl_autoload_register($autoloader);
+        $this->autoloaders[] = $autoloader;
+    }
+
+    #[\Override]
+    public function dispose(): void
+    {
+        foreach (\array_reverse($this->autoloaders) as $autoloader) {
+            \spl_autoload_unregister($autoloader);
+        }
+
+        $this->autoloaders = [];
+    }
+}

--- a/src/Runner/DefaultServices.php
+++ b/src/Runner/DefaultServices.php
@@ -9,6 +9,7 @@ use Greenlight\Core\Test\TestChannel;
 use Greenlight\Doubles\Doubles;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\ExpectationExtension;
+use Greenlight\Fixture\AutoloaderSandbox;
 use Greenlight\Fixture\EnvironmentSandbox;
 use Greenlight\Fixture\StreamWrapperSandbox;
 use Greenlight\Fixture\TempDirectory;
@@ -38,6 +39,7 @@ final class DefaultServices
         $registry = new HarnessRegistry([
             new ServiceDefinition(Doubles::class, Scope::PerTest, static fn(): Doubles => new Doubles()),
             new ServiceDefinition(TempDirectory::class, Scope::PerTest, static fn(): TempDirectory => new TempDirectory()),
+            new ServiceDefinition(AutoloaderSandbox::class, Scope::PerTest, static fn(): AutoloaderSandbox => new AutoloaderSandbox()),
             new ServiceDefinition(EnvironmentSandbox::class, Scope::PerTest, static fn(): EnvironmentSandbox => new EnvironmentSandbox()),
             new ServiceDefinition(StreamWrapperSandbox::class, Scope::PerTest, static fn(): StreamWrapperSandbox => new StreamWrapperSandbox()),
             new ServiceDefinition(IntegrationResources::class, Scope::PerRun, static fn(): IntegrationResources => $integrationResources),

--- a/tests/Unit/Discovery/TestDiscovererLoadedClassTest.php
+++ b/tests/Unit/Discovery/TestDiscovererLoadedClassTest.php
@@ -9,11 +9,15 @@ use Greenlight\Discovery\DiscoveryError;
 use Greenlight\Discovery\ExecutionPlan;
 use Greenlight\Discovery\TestDiscoverer;
 use Greenlight\Expect\Expect;
+use Greenlight\Fixture\AutoloaderSandbox;
 use Greenlight\Fixture\TempDirectory;
 
 final readonly class TestDiscovererLoadedClassTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private AutoloaderSandbox $autoloaders,
+    ) {}
 
     #[Test]
     public function unresolvedClassPathsCannotMasqueradeAsTheSameFile(): void
@@ -49,23 +53,19 @@ final readonly class TestDiscovererLoadedClassTest
                 \unlink($expectedFile);
             }
         };
-        \spl_autoload_register($loader);
+        $this->autoloaders->register($loader);
 
-        try {
-            Expect::that(
-                static fn(): ExecutionPlan => new TestDiscoverer()->discover([$expectedDirectory]),
-            )->because('discovery MUST reject class paths that it cannot resolve')->toThrow(
-                DiscoveryError::class,
-                message: \sprintf(
-                    'The autoloader loaded class "%s" from "%s". It expected the class in "%s". Only one file can declare a class.',
-                    $class,
-                    $actualFile,
-                    $expectedFile,
-                ),
-            );
-        } finally {
-            \spl_autoload_unregister($loader);
-        }
+        Expect::that(
+            static fn(): ExecutionPlan => new TestDiscoverer()->discover([$expectedDirectory]),
+        )->because('discovery MUST reject class paths that it cannot resolve')->toThrow(
+            DiscoveryError::class,
+            message: \sprintf(
+                'The autoloader loaded class "%s" from "%s". It expected the class in "%s". Only one file can declare a class.',
+                $class,
+                $actualFile,
+                $expectedFile,
+            ),
+        );
     }
 
     #[Test]
@@ -96,22 +96,18 @@ final readonly class TestDiscovererLoadedClassTest
                 require_once $actualFile;
             }
         };
-        \spl_autoload_register($loader);
+        $this->autoloaders->register($loader);
 
-        try {
-            Expect::that(
-                static fn(): ExecutionPlan => new TestDiscoverer()->discover([$expectedDirectory]),
-            )->because('discovery MUST reject a class that the autoloader loaded from another file')->toThrow(
-                DiscoveryError::class,
-                message: \sprintf(
-                    'The autoloader loaded class "%s" from "%s". It expected the class in "%s". Only one file can declare a class.',
-                    $class,
-                    $actualFile,
-                    $expectedFile,
-                ),
-            );
-        } finally {
-            \spl_autoload_unregister($loader);
-        }
+        Expect::that(
+            static fn(): ExecutionPlan => new TestDiscoverer()->discover([$expectedDirectory]),
+        )->because('discovery MUST reject a class that the autoloader loaded from another file')->toThrow(
+            DiscoveryError::class,
+            message: \sprintf(
+                'The autoloader loaded class "%s" from "%s". It expected the class in "%s". Only one file can declare a class.',
+                $class,
+                $actualFile,
+                $expectedFile,
+            ),
+        );
     }
 }

--- a/tests/Unit/Fixture/AutoloaderSandboxTest.php
+++ b/tests/Unit/Fixture/AutoloaderSandboxTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Fixture;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\AutoloaderSandbox;
+
+final readonly class AutoloaderSandboxTest
+{
+    #[Test]
+    public function disposalUnregistersEveryOwnedAutoloader(): void
+    {
+        $sandbox = new AutoloaderSandbox();
+        $calls = [];
+        $first = static function (string $class) use (&$calls): void {
+            $calls[] = 'first:' . $class;
+        };
+        $second = static function (string $class) use (&$calls): void {
+            $calls[] = 'second:' . $class;
+        };
+        $sandbox->register($first);
+        $sandbox->register($second);
+
+        try {
+            \class_exists('GreenlightAutoloaderSandboxBeforeDisposal');
+
+            Expect::that($calls)->toBe([
+                'first:GreenlightAutoloaderSandboxBeforeDisposal',
+                'second:GreenlightAutoloaderSandboxBeforeDisposal',
+            ]);
+
+            $sandbox->dispose();
+            $calls = [];
+            \class_exists('GreenlightAutoloaderSandboxAfterDisposal');
+
+            Expect::that($calls)
+                ->because('disposal MUST remove all autoloaders that the sandbox owns')
+                ->toBe([]);
+        } finally {
+            $sandbox->dispose();
+        }
+    }
+}

--- a/tests/Unit/Reporting/TeamCityReporterAutoloadCacheTest.php
+++ b/tests/Unit/Reporting/TeamCityReporterAutoloadCacheTest.php
@@ -9,10 +9,13 @@ use Greenlight\Core\Event\TestClassStarted;
 use Greenlight\Core\Event\TestStarted;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
+use Greenlight\Fixture\AutoloaderSandbox;
 use Greenlight\Reporting\TeamCityReporter;
 
 final readonly class TeamCityReporterAutoloadCacheTest
 {
+    public function __construct(private AutoloaderSandbox $autoloaders) {}
+
     #[Test]
     public function aFailedClassLookupIsCachedAcrossEvents(): void
     {
@@ -27,14 +30,10 @@ final readonly class TeamCityReporterAutoloadCacheTest
                 throw new \RuntimeException('autoload failed');
             }
         };
-        \spl_autoload_register($autoload);
+        $this->autoloaders->register($autoload);
 
-        try {
-            $reporter->onEvent(new TestClassStarted($class, 1.0, 'w-1'));
-            $reporter->onEvent(new TestStarted(new TestId($class, 'runs'), 1.1));
-        } finally {
-            \spl_autoload_unregister($autoload);
-        }
+        $reporter->onEvent(new TestClassStarted($class, 1.0, 'w-1'));
+        $reporter->onEvent(new TestStarted(new TestId($class, 'runs'), 1.1));
 
         Expect::that($autoloadCalls)
             ->because('a failed optional location lookup MUST not rerun the autoloader for each event')

--- a/tests/Unit/Reporting/TeamCityReporterTest.php
+++ b/tests/Unit/Reporting/TeamCityReporterTest.php
@@ -14,11 +14,14 @@ use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
+use Greenlight\Fixture\AutoloaderSandbox;
 use Greenlight\Reporting\TeamCityReporter;
 use Greenlight\Tests\Fixture\DiscoveryBasic\AlphaTest;
 
-final class TeamCityReporterTest
+final readonly class TeamCityReporterTest
 {
+    public function __construct(private AutoloaderSandbox $autoloaders) {}
+
     #[Test]
     public function cannedStreamRendersTheGoldenServiceMessages(): void
     {
@@ -202,13 +205,9 @@ final class TeamCityReporterTest
                 throw new \RuntimeException('autoload failed');
             }
         };
-        \spl_autoload_register($autoload);
+        $this->autoloaders->register($autoload);
 
-        try {
-            $reporter->onEvent(new TestClassStarted($class, 1.0, 'w-1'));
-        } finally {
-            \spl_autoload_unregister($autoload);
-        }
+        $reporter->onEvent(new TestClassStarted($class, 1.0, 'w-1'));
 
         Expect::that($output->buffer())
             ->because('an autoloader error omits the optional navigation hint')


### PR DESCRIPTION
## Summary

- add an injectable per-test autoloader sandbox with reverse-order cleanup
- migrate TeamCity and discovery tests away from local autoloader lifecycle blocks
- document the complete built-in sandbox fixture set