### PR TITLE
fix(attributes): reject nonfinite skip arguments

### DIFF
--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -355,14 +355,15 @@ PHPDoc:
 Namespace: `Greenlight\Attribute`
 
 A worker evaluates the condition. Because the worker protocol transfers the
-constructor arguments, use only scalar values or null.
+constructor arguments, use only scalar values or null. Float values must be
+finite.
 
 ```php
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS)]
 final readonly class SkipUnless
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/SkipUnless.php#L14)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/SkipUnless.php#L15)
 
 ### `$condition`
 
@@ -374,7 +375,7 @@ PHPDoc:
 
 - `@var class-string<Condition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/SkipUnless.php#L19)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/SkipUnless.php#L20)
 
 ### `$arguments`
 
@@ -386,7 +387,7 @@ PHPDoc:
 
 - `@var list<mixed>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/SkipUnless.php#L24)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/SkipUnless.php#L25)
 
 ### `__construct()`
 
@@ -401,7 +402,7 @@ PHPDoc:
 
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/SkipUnless.php#L29)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/SkipUnless.php#L30)
 
 ## `Test`
 

--- a/docs/api-test-contracts.md
+++ b/docs/api-test-contracts.md
@@ -420,7 +420,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L124)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L128)
 
 ### `fromWire()`
 
@@ -434,7 +434,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the decoded metadata violates a domain invariant`
 - `@throws InvalidWirePayload when a required field is missing or has the wrong type`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L150)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L154)
 
 ## `InvalidWirePayload`
 

--- a/src/Attribute/SkipUnless.php
+++ b/src/Attribute/SkipUnless.php
@@ -8,7 +8,8 @@ use Greenlight\Core\Condition;
 
 /**
  * A worker evaluates the condition. Because the worker protocol transfers the
- * constructor arguments, use only scalar values or null.
+ * constructor arguments, use only scalar values or null. Float values must be
+ * finite.
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS)]
 final readonly class SkipUnless
@@ -42,6 +43,12 @@ final readonly class SkipUnless
             throw new \InvalidArgumentException(
                 'SkipUnless condition MUST name an instantiable Condition class.',
             );
+        }
+
+        foreach ($arguments as $argument) {
+            if (\is_float($argument) && !\is_finite($argument)) {
+                throw new \InvalidArgumentException('SkipUnless arguments MUST use finite floats.');
+            }
         }
 
         $this->condition = $condition;

--- a/src/Core/Test/TestMetadata.php
+++ b/src/Core/Test/TestMetadata.php
@@ -106,6 +106,10 @@ final readonly class TestMetadata implements WireSerializable
                 ));
             }
 
+            if (\is_float($argument) && !\is_finite($argument)) {
+                throw new \InvalidArgumentException('Skip-unless arguments MUST use finite floats.');
+            }
+
             $validatedArguments[] = $argument;
         }
 
@@ -233,6 +237,14 @@ final readonly class TestMetadata implements WireSerializable
         foreach ($value as $argument) {
             if ($argument !== null && !\is_scalar($argument)) {
                 throw InvalidWirePayload::wrongType('skipUnlessArguments', 'a list of scalars or nulls', $argument);
+            }
+
+            if (\is_float($argument) && !\is_finite($argument)) {
+                throw InvalidWirePayload::wrongType(
+                    'skipUnlessArguments',
+                    'a list of scalars or nulls with finite floats',
+                    $argument,
+                );
             }
 
             $arguments[] = $argument;

--- a/src/PhpStan/AttributeArgumentRule.php
+++ b/src/PhpStan/AttributeArgumentRule.php
@@ -125,7 +125,23 @@ final class AttributeArgumentRule implements Rule
             ++$conditionArgumentNumber;
             $type = $scope->getType($argument->value);
 
-            if ($type->isNull()->yes() || $type->isScalar()->yes()) {
+            if ($type->isNull()->yes()) {
+                continue;
+            }
+
+            if ($type->isScalar()->yes()) {
+                $values = $type->getConstantScalarValues();
+
+                if (!\array_any($values, static fn(mixed $value): bool => \is_float($value) && !\is_finite($value))) {
+                    continue;
+                }
+
+                $errors[] = $this->error(
+                    \sprintf('#[SkipUnless] argument %d must be a finite float.', $conditionArgumentNumber),
+                    'skipUnless',
+                    $argument->getStartLine(),
+                );
+
                 continue;
             }
 

--- a/tests/Acceptance/PhpStanAttributeArgumentRuleTest.php
+++ b/tests/Acceptance/PhpStanAttributeArgumentRuleTest.php
@@ -51,6 +51,17 @@ final readonly class PhpStanAttributeArgumentRuleTest
             use Greenlight\Attribute\SkipUnless;
             use Greenlight\Attribute\Timeout;
             use Greenlight\Condition\EnvironmentVariableSet;
+            use Greenlight\Core\Condition;
+
+            final readonly class FloatCondition implements Condition
+            {
+                public function __construct(private float $value) {}
+
+                public function isSatisfied(): bool
+                {
+                    return is_finite($this->value);
+                }
+            }
 
             #[RequiresResource('Postgres primary')]
             #[Retry(0)]
@@ -65,15 +76,19 @@ final readonly class PhpStanAttributeArgumentRuleTest
             #[Retry(times: 0)]
             #[Timeout(seconds: 0.0)]
             final class BadNamedDomainAttributeArgumentProbe {}
+
+            #[SkipUnless(FloatCondition::class, 1.0e1000)]
+            final class BadNonFiniteSkipUnlessArgumentProbe {}
             PHP,
         );
 
         Expect::that($probe->exitCode)->because('attribute arguments must have valid values')->toBe(1);
         Expect::that($probe->goodPassed)->toBeTrue();
-        Expect::that(\count($probe->errors))->toBe(8);
+        Expect::that(\count($probe->errors))->toBe(9);
         Expect::that($probe->messages())->toContain('#[RequiresResource] name "Postgres primary" does not match')
             ->toContain('#[Retry] times must be at least 1')
             ->toContain('#[SkipUnless] argument 1 must be a scalar or null')
+            ->toContain('#[SkipUnless] argument 1 must be a finite float')
             ->not()->toContain('#[SkipUnless] argument 0')
             ->toContain('#[Timeout] seconds must be finite and greater than zero');
     }

--- a/tests/Unit/Attribute/SkipUnlessTest.php
+++ b/tests/Unit/Attribute/SkipUnlessTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Unit\Attribute;
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\SkipUnless;
 use Greenlight\Attribute\Test;
+use Greenlight\Condition\EnvironmentVariableSet;
 use Greenlight\Core\Condition;
 use Greenlight\Expect\Expect;
 
@@ -38,5 +39,29 @@ final class SkipUnlessTest
         yield 'unknown class' => ['Example\MissingCondition'];
 
         yield 'condition interface' => [Condition::class];
+    }
+
+    #[Test]
+    #[DataSet('nonFiniteFloats')]
+    public function nonFiniteFloatArgumentsAreRejected(float $argument): void
+    {
+        Expect::that(
+            static fn(): SkipUnless => new SkipUnless(EnvironmentVariableSet::class, $argument),
+        )
+            ->because('skip condition arguments MUST be safe for the JSON worker protocol')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'SkipUnless arguments MUST use finite floats.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{float}>
+     */
+    public static function nonFiniteFloats(): iterable
+    {
+        yield 'positive infinity' => [\INF];
+        yield 'negative infinity' => [-\INF];
+        yield 'not a number' => [\NAN];
     }
 }

--- a/tests/Unit/Core/TestMetadataWireTest.php
+++ b/tests/Unit/Core/TestMetadataWireTest.php
@@ -84,6 +84,34 @@ final class TestMetadataWireTest
             );
     }
 
+    #[Test]
+    #[DataSet('nonFiniteSkipUnlessArguments')]
+    public function nonFiniteSkipUnlessArgumentsAreRejectedOnBothSides(float $argument): void
+    {
+        Expect::that(
+            static fn(): TestMetadata => new TestMetadata(
+                'App\ExampleTest',
+                'checksValue',
+                skipUnlessArguments: [$argument],
+            ),
+        )
+            ->because('direct metadata MUST reject skip arguments that JSON cannot encode')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Skip-unless arguments MUST use finite floats.',
+            );
+
+        $payload = new TestMetadata('App\ExampleTest', 'checksValue')->toWire();
+        $payload['skipUnlessArguments'] = [$argument];
+
+        Expect::that(static fn(): TestMetadata => TestMetadata::fromWire($payload))
+            ->because('wire metadata MUST reject non-finite skip arguments')
+            ->toThrow(
+                InvalidWirePayload::class,
+                message: 'Wire payload key "skipUnlessArguments" must be a list of scalars or nulls with finite floats, got float.',
+            );
+    }
+
     /**
      * @return iterable<string, array{non-empty-string, mixed}>
      */
@@ -120,5 +148,15 @@ final class TestMetadataWireTest
         yield 'negative' => [-0.5, $positive];
         yield 'positive infinity' => [\INF, $finite];
         yield 'not a number' => [\NAN, $finite];
+    }
+
+    /**
+     * @return iterable<string, array{float}>
+     */
+    public static function nonFiniteSkipUnlessArguments(): iterable
+    {
+        yield 'positive infinity' => [\INF];
+        yield 'negative infinity' => [-\INF];
+        yield 'not a number' => [\NAN];
     }
 }


### PR DESCRIPTION
## Summary

- reject infinite and NaN SkipUnless arguments before worker-protocol encoding
- enforce the same invariant during direct metadata construction and wire decoding
- report constant non-finite attribute arguments through the PHPStan extension