### PR TITLE
fix(hyperf): contain path diagnostics

### DIFF
--- a/.github/fixtures/hyperf-bridge/verify-path-diagnostics.php
+++ b/.github/fixtures/hyperf-bridge/verify-path-diagnostics.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Greenlight\Core\Test\TestChannel;
+use Greenlight\Harness\IntegrationResources;
+use Greenlight\Hyperf\HyperfBridgeError;
+use Greenlight\Hyperf\HyperfPlugin;
+use Greenlight\Plugin\WorkerBootstrapContext;
+
+require __DIR__ . '/vendor/autoload.php';
+
+$restricted = \dirname(__DIR__);
+$temporaryDirectory = \sys_get_temp_dir();
+
+if (\ini_set('open_basedir', __DIR__ . \PATH_SEPARATOR . $temporaryDirectory) === false) {
+    throw new \RuntimeException('The Hyperf path verification did not set the filesystem restriction.');
+}
+
+$diagnostic = null;
+$error = null;
+\set_error_handler(static function (int $severity, string $message) use (&$diagnostic): bool {
+    $diagnostic = $message;
+
+    return true;
+});
+
+try {
+    new HyperfPlugin($restricted)->onWorkerBootstrap(new WorkerBootstrapContext(
+        'path-probe',
+        new TestChannel(1),
+        IntegrationResources::empty(),
+    ));
+} catch (HyperfBridgeError $caught) {
+    $error = $caught;
+} finally {
+    \restore_error_handler();
+}
+
+if ($diagnostic !== null) {
+    throw new \RuntimeException('The Hyperf path verification received an engine diagnostic: ' . $diagnostic);
+}
+
+$expected = HyperfBridgeError::basePathMissing($restricted)->getMessage();
+
+if (!$error instanceof HyperfBridgeError || $error->getMessage() !== $expected) {
+    throw new \RuntimeException('The Hyperf path verification did not receive the expected bridge error.');
+}
+
+\fwrite(STDOUT, "Verified restricted Hyperf path diagnostics.\n");

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,10 @@ jobs:
         working-directory: ".github/fixtures/hyperf-bridge"
         run: "composer update --no-interaction --no-progress --prefer-dist"
 
+      - name: "Verify restricted Hyperf path diagnostics"
+        working-directory: ".github/fixtures/hyperf-bridge"
+        run: "php verify-path-diagnostics.php"
+
       - name: "Run Hyperf worker-container acceptance tests"
         working-directory: ".github/fixtures/hyperf-bridge"
         env:

--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -129,7 +129,7 @@ PHPDoc:
 - `@return T`
 - `@throws HyperfBridgeError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L166)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L174)
 
 ### `runTestAttempt()`
 
@@ -145,7 +145,7 @@ PHPDoc:
 - `@return T`
 - `@throws HyperfBridgeError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L210)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L218)
 
 ## `Hyperf\Service`
 

--- a/src/Hyperf/HyperfPlugin.php
+++ b/src/Hyperf/HyperfPlugin.php
@@ -118,13 +118,21 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemp
     public function onWorkerBootstrap(WorkerBootstrapContext $context): void
     {
         HyperfFrameworkRequirement::check();
-        $basePath = \realpath($this->basePath);
+        [$basePath, $containerFileExists] = ErrorTrap::run(function (): array {
+            $basePath = \realpath($this->basePath);
 
-        if ($basePath === false || !\is_dir($basePath)) {
+            if ($basePath === false || !\is_dir($basePath)) {
+                return [false, false];
+            }
+
+            return [$basePath, \is_file($this->containerFile)];
+        });
+
+        if ($basePath === false) {
             throw HyperfBridgeError::basePathMissing($this->basePath);
         }
 
-        if (!\is_file($this->containerFile)) {
+        if (!$containerFileExists) {
             throw HyperfBridgeError::containerFileMissing($this->containerFile);
         }
 
@@ -135,7 +143,7 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemp
                 throw HyperfBridgeError::basePathConflict($basePath, \get_debug_type($defined));
             }
 
-            $definedPath = \realpath($defined);
+            $definedPath = ErrorTrap::run(static fn(): string|false => \realpath($defined));
 
             if ($definedPath === false || $definedPath !== $basePath) {
                 throw HyperfBridgeError::basePathConflict($basePath, $defined);


### PR DESCRIPTION
Contain the Hyperf application-path preflight and pre-defined BASE_PATH resolution with ErrorTrap. Restricted paths now produce the typed bridge diagnostic without leaking PHP engine warnings, and the real Hyperf bridge job verifies that behavior under open_basedir.