### PR TITLE
fix(artifact): contain source diagnostics

### DIFF
--- a/src/Runner/Artifact/ArtifactStore.php
+++ b/src/Runner/Artifact/ArtifactStore.php
@@ -214,11 +214,17 @@ final class ArtifactStore
         AttachmentRetention $retention,
         ArtifactConfiguration $configuration,
     ): StagedAttachment {
-        if (\is_link($sourcePath)) {
+        $source = ErrorTrap::run(static function () use ($sourcePath) {
+            if (\is_link($sourcePath)) {
+                return null;
+            }
+
+            return \fopen($sourcePath, 'rb');
+        });
+
+        if ($source === null) {
             throw AttachmentError::source($sourcePath, 'is a symbolic link. Use a source path that is not a symbolic link');
         }
-
-        $source = \fopen($sourcePath, 'rb');
 
         if ($source === false) {
             throw AttachmentError::source($sourcePath, 'is not a readable regular file');

--- a/tests/Unit/Artifact/ArtifactSourceValidationTest.php
+++ b/tests/Unit/Artifact/ArtifactSourceValidationTest.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -40,12 +41,21 @@ final readonly class ArtifactSourceValidationTest
         );
 
         try {
-            Expect::that(static fn() => $attachments->file('evidence.txt', $source))
+            $warning = null;
+            Expect::that(static function () use ($attachments, $source, &$warning): void {
+                ErrorTrap::run(
+                    static fn() => $attachments->file('evidence.txt', $source),
+                    $warning,
+                );
+            })
                 ->because('file attachments reject invalid sources')
                 ->toThrow(
                     AttachmentError::class,
                     message: \sprintf('Attachment source "%s" %s.', $source, $reason),
                 );
+            Expect::that($warning)
+                ->because('an invalid attachment source MUST not leak an engine diagnostic')
+                ->toBeNull();
             Expect::that($attachments->collected())
                 ->because('an invalid source does not create an attachment')
                 ->toBe([]);


### PR DESCRIPTION
Suppress PHP diagnostics while Greenlight validates and opens attachment source files. Preserve the distinct symbolic-link and unreadable-source errors, and cover invalid sources with a no-diagnostic regression oracle.