### PR TITLE
refactor(test): reuse watch clock fake

### DIFF
--- a/tests/Fixture/Cli/FakeWatchClock.php
+++ b/tests/Fixture/Cli/FakeWatchClock.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Cli;
+
+use Greenlight\Cli\Watch\WatchClock;
+use Greenlight\Doubles\Fake;
+
+final class FakeWatchClock implements WatchClock, Fake
+{
+    public float $time = 0.0;
+
+    /**
+     * @var list<float>
+     */
+    public array $sleeps = [];
+
+    #[\Override]
+    public function now(): float
+    {
+        return $this->time;
+    }
+
+    #[\Override]
+    public function sleep(float $seconds): void
+    {
+        $this->sleeps[] = $seconds;
+        $this->time += $seconds;
+    }
+}

--- a/tests/Unit/Cli/Watch/WatchLoopIdleTest.php
+++ b/tests/Unit/Cli/Watch/WatchLoopIdleTest.php
@@ -8,10 +8,10 @@ use Greenlight\Attribute\Test;
 use Greenlight\Cli\Watch\ChangeDetector;
 use Greenlight\Cli\Watch\Debouncer;
 use Greenlight\Cli\Watch\KeyInput;
-use Greenlight\Cli\Watch\WatchClock;
 use Greenlight\Cli\Watch\WatchLoop;
 use Greenlight\Doubles\Fake;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Cli\FakeWatchClock;
 
 final class WatchLoopIdleTest
 {
@@ -34,24 +34,7 @@ final class WatchLoopIdleTest
                 return ++$this->polls === 2 ? 'q' : null;
             }
         };
-        $clock = new class implements WatchClock, Fake {
-            /**
-             * @var list<float>
-             */
-            public array $sleeps = [];
-
-            #[\Override]
-            public function now(): float
-            {
-                return 0.0;
-            }
-
-            #[\Override]
-            public function sleep(float $seconds): void
-            {
-                $this->sleeps[] = $seconds;
-            }
-        };
+        $clock = new FakeWatchClock();
         $runs = 0;
 
         new WatchLoop(

--- a/tests/Unit/Cli/WatchTest.php
+++ b/tests/Unit/Cli/WatchTest.php
@@ -10,13 +10,13 @@ use Greenlight\Cli\Watch\Debouncer;
 use Greenlight\Cli\Watch\KeyInput;
 use Greenlight\Cli\Watch\StatChangeDetector;
 use Greenlight\Cli\Watch\SystemWatchClock;
-use Greenlight\Cli\Watch\WatchClock;
 use Greenlight\Cli\Watch\WatchLoop;
 use Greenlight\Core\GracefulShutdown;
 use Greenlight\Doubles\Fake;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Fixture\Cli\FakeWatchClock;
 
 final readonly class WatchTest
 {
@@ -140,19 +140,7 @@ final readonly class WatchTest
                 return null;
             }
         };
-        $clock = new class implements WatchClock, Fake {
-            #[\Override]
-            public function now(): float
-            {
-                return 1.0;
-            }
-
-            #[\Override]
-            public function sleep(float $seconds): void
-            {
-                Fail::because('A zero quiet period MUST run without sleeping.');
-            }
-        };
+        $clock = new FakeWatchClock();
         $output = '';
 
         new WatchLoop(
@@ -170,6 +158,9 @@ final readonly class WatchTest
         Expect::that($output)
             ->because('a multi-file watch batch MUST use the plural notification')
             ->toBe($ready . "Detected changes in 2 files.\n" . $ready);
+        Expect::that($clock->sleeps)
+            ->because('a zero quiet period MUST run without sleeping')
+            ->toBe([]);
     }
 
     #[Test]
@@ -275,21 +266,7 @@ final readonly class WatchTest
     public function loopDebouncesBurstsForcesOnEnterAndQuitsOnQ(): void
     {
         // Each scripted tick increases virtual time by 0.1 seconds.
-        $clock = new class implements WatchClock, Fake {
-            public float $time = 0.0;
-
-            #[\Override]
-            public function now(): float
-            {
-                return $this->time;
-            }
-
-            #[\Override]
-            public function sleep(float $seconds): void
-            {
-                $this->time += $seconds;
-            }
-        };
+        $clock = new FakeWatchClock();
 
         // Make two rapid changes, then no changes.
         $detector = new class implements ChangeDetector {


### PR DESCRIPTION
Add one reusable watch-clock fake for virtual time and sleep recording. Replace three anonymous clock adapters, and make the zero-debounce no-sleep behavior observable through the shared fake.