### PR TITLE
fix(fixture): translate directory traversal failures

### DIFF
--- a/src/Fixture/TempDirectory.php
+++ b/src/Fixture/TempDirectory.php
@@ -139,22 +139,26 @@ final class TempDirectory implements Disposable
             return;
         }
 
-        $entries = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
-            \RecursiveIteratorIterator::CHILD_FIRST,
-        );
+        try {
+            $entries = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::CHILD_FIRST,
+            );
 
-        ErrorTrap::run(static function () use ($entries, $path): void {
-            /** @var \SplFileInfo $entry */
-            foreach ($entries as $entry) {
-                $pathname = $entry->getPathname();
-                $removed = !$entry->isLink() && $entry->isDir() ? \rmdir($pathname) : \unlink($pathname);
+            ErrorTrap::run(static function () use ($entries, $path): void {
+                /** @var \SplFileInfo $entry */
+                foreach ($entries as $entry) {
+                    $pathname = $entry->getPathname();
+                    $removed = !$entry->isLink() && $entry->isDir() ? \rmdir($pathname) : \unlink($pathname);
 
-                if (!$removed) {
-                    throw TempDirectoryError::entryRemovalFailed($pathname, $path);
+                    if (!$removed) {
+                        throw TempDirectoryError::entryRemovalFailed($pathname, $path);
+                    }
                 }
-            }
-        });
+            });
+        } catch (\UnexpectedValueException $error) {
+            throw TempDirectoryError::rootRemovalFailed($path, $error->getMessage());
+        }
 
         if (!ErrorTrap::run(static fn(): bool => \rmdir($path), $warning)) {
             throw TempDirectoryError::rootRemovalFailed($path, $warning);

--- a/tests/Unit/Fixture/TempDirectoryNestedRestrictionTest.php
+++ b/tests/Unit/Fixture/TempDirectoryNestedRestrictionTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Fixture;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\ErrorTrap;
+use Greenlight\Core\Test\SkipTest;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Fixture\TempDirectoryError;
+
+final readonly class TempDirectoryNestedRestrictionTest
+{
+    public function __construct(private TempDirectory $directory) {}
+
+    #[Test]
+    public function unreadableNestedDirectoryProducesATypedCleanupError(): void
+    {
+        $directory = $this->directory;
+        $root = $directory->path();
+        $nested = $directory->subdirectory('restricted');
+
+        if (\file_put_contents($nested . '/evidence.txt', 'keep') === false || !\chmod($nested, 0o000)) {
+            Fail::because('Expected to create an unreadable nested directory.');
+        }
+
+        \clearstatcache(true, $nested);
+
+        try {
+            if (\is_readable($nested)) {
+                throw new SkipTest('The filesystem does not enforce directory read permissions.');
+            }
+
+            $warning = null;
+            Expect::that(static function () use ($directory, &$warning): void {
+                ErrorTrap::run(static fn() => $directory->dispose(), $warning);
+            })
+                ->because('fixture cleanup MUST translate directory traversal failures')
+                ->toThrow(
+                    TempDirectoryError::class,
+                    matching: \sprintf(
+                        '/^Failed to remove temp directory "%s": .*%s.*Permission denied\.$/',
+                        \preg_quote($root, '/'),
+                        \preg_quote($nested, '/'),
+                    ),
+                );
+            Expect::that($warning)
+                ->because('a nested traversal failure MUST not leak an engine diagnostic')
+                ->toBeNull();
+        } finally {
+            \chmod($nested, 0o700);
+            $directory->dispose();
+        }
+    }
+}


### PR DESCRIPTION
Translate SPL traversal failures during temporary-directory disposal into the declared TempDirectoryError for the fixture. Preserve the owned root and unreadable child diagnostic, and add a permission regression that proves no engine warning escapes.