### PR TITLE
fix(result): saturate summary count overflow

### DIFF
--- a/docs/api-results.md
+++ b/docs/api-results.md
@@ -550,7 +550,7 @@ public function isSuccessful(): bool
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ResultSummary.php#L87)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ResultSummary.php#L107)
 
 ### `fromWire()`
 
@@ -559,7 +559,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ResultSummary.php#L98)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Result/ResultSummary.php#L118)
 
 ## `SourceLocation`
 

--- a/src/Core/Result/ResultSummary.php
+++ b/src/Core/Result/ResultSummary.php
@@ -64,10 +64,10 @@ final readonly class ResultSummary implements WireSerializable
     public function add(Outcome $outcome): self
     {
         return new self(
-            $this->passed + ($outcome === Outcome::Passed ? 1 : 0),
-            $this->failed + ($outcome === Outcome::Failed ? 1 : 0),
-            $this->errored + ($outcome === Outcome::Errored ? 1 : 0),
-            $this->skipped + ($outcome === Outcome::Skipped ? 1 : 0),
+            $this->saturatedSum($this->passed, $outcome === Outcome::Passed ? 1 : 0),
+            $this->saturatedSum($this->failed, $outcome === Outcome::Failed ? 1 : 0),
+            $this->saturatedSum($this->errored, $outcome === Outcome::Errored ? 1 : 0),
+            $this->saturatedSum($this->skipped, $outcome === Outcome::Skipped ? 1 : 0),
         );
     }
 
@@ -76,12 +76,32 @@ final readonly class ResultSummary implements WireSerializable
      */
     public function total(): int
     {
-        return $this->passed + $this->failed + $this->errored + $this->skipped;
+        return $this->saturatedSum($this->passed, $this->failed, $this->errored, $this->skipped);
     }
 
     public function isSuccessful(): bool
     {
         return $this->failed === 0 && $this->errored === 0;
+    }
+
+    /**
+     * @param non-negative-int ...$counts
+     *
+     * @return non-negative-int
+     */
+    private function saturatedSum(int ...$counts): int
+    {
+        $total = 0;
+
+        foreach ($counts as $count) {
+            if ($count > \PHP_INT_MAX - $total) {
+                return \PHP_INT_MAX;
+            }
+
+            $total += $count;
+        }
+
+        return $total;
     }
 
     #[\Override]

--- a/tests/Unit/Core/ResultSummaryOutcomeTest.php
+++ b/tests/Unit/Core/ResultSummaryOutcomeTest.php
@@ -56,4 +56,14 @@ final class ResultSummaryOutcomeTest
             ['passed' => 1, 'failed' => 2, 'errored' => 3, 'skipped' => 5],
         ];
     }
+
+    #[Test]
+    public function addSaturatesTheSelectedOutcomeAtTheMachineMaximum(): void
+    {
+        $summary = new ResultSummary(passed: \PHP_INT_MAX);
+
+        Expect::that($summary->add(Outcome::Passed)->passed)
+            ->because('adding an outcome MUST NOT overflow its summary count')
+            ->toBe(\PHP_INT_MAX);
+    }
 }

--- a/tests/Unit/Core/ResultSummaryTotalTest.php
+++ b/tests/Unit/Core/ResultSummaryTotalTest.php
@@ -49,5 +49,9 @@ final readonly class ResultSummaryTotalTest
             new ResultSummary(passed: 2, failed: 3, errored: 4, skipped: 5),
             14,
         ];
+        yield 'overflowing outcomes' => [
+            new ResultSummary(passed: \PHP_INT_MAX, failed: 1),
+            \PHP_INT_MAX,
+        ];
     }
 }


### PR DESCRIPTION
Prevent valid machine-maximum outcome counts from overflowing into floats during summary aggregation. Reuse one saturating sum for outcome increments and total calculation, and cover both integer boundaries in the public result contract.