### PR TITLE
fix(artifact): prevent test quota overflow

### DIFF
--- a/src/Runner/Artifact/StagedAttachments.php
+++ b/src/Runner/Artifact/StagedAttachments.php
@@ -192,7 +192,9 @@ final class StagedAttachments implements Attachments
      */
     private function record(StagedAttachment $attachment): void
     {
-        if ($this->budget->bytes + $attachment->sizeBytes > $this->configuration->maxTestBytes) {
+        if ($attachment->sizeBytes > $this->configuration->maxTestBytes
+            || $this->budget->bytes > $this->configuration->maxTestBytes - $attachment->sizeBytes
+        ) {
             $this->store->discard($attachment);
 
             throw AttachmentError::limit(\sprintf(

--- a/tests/Unit/Artifact/ArtifactTestQuotaRollbackTest.php
+++ b/tests/Unit/Artifact/ArtifactTestQuotaRollbackTest.php
@@ -60,4 +60,55 @@ final readonly class ArtifactTestQuotaRollbackTest
             $store->cleanup();
         }
     }
+
+    #[Test]
+    public function aMachineMaximumTestBudgetRejectsWithoutOverflowAndReleasesTheRunQuota(): void
+    {
+        $root = $this->tempDirectory->subdirectory('test-quota-overflow');
+        $configuration = new ArtifactConfiguration(
+            $root,
+            maxAttachmentsPerTest: 2,
+            maxAttachmentBytes: 1,
+            maxTestBytes: \PHP_INT_MAX,
+            maxRunAttachments: 2,
+            maxRunBytes: 1,
+        );
+        $store = ArtifactStore::open($configuration, $root, 'run-1');
+        $budget = new TestArtifactBudget();
+        $budget->bytes = \PHP_INT_MAX;
+
+        try {
+            $first = $store->forAttempt(
+                new TestId('Example\EvidenceTest', 'first'),
+                1,
+                $budget,
+            );
+
+            Expect::that(static fn() => $first->text('rejected.txt', 'x'))
+                ->because('per-test quota arithmetic MUST NOT overflow')
+                ->toThrow(
+                    AttachmentError::class,
+                    message: \sprintf(
+                        'Attachments for this test exceed the limit of %d bytes.',
+                        \PHP_INT_MAX,
+                    ),
+                );
+            Expect::that($budget->bytes)
+                ->because('a rejected attachment MUST NOT change the test budget')
+                ->toBe(\PHP_INT_MAX);
+
+            $second = $store->forAttempt(
+                new TestId('Example\EvidenceTest', 'second'),
+                1,
+                new TestArtifactBudget(),
+            );
+            $second->text('accepted.txt', 'x');
+
+            Expect::that($second->collected())
+                ->because('an overflow-safe test quota rejection MUST release its run quota')
+                ->toHaveCount(1);
+        } finally {
+            $store->cleanup();
+        }
+    }
 }


### PR DESCRIPTION
Use overflow-safe subtraction when enforcing the per-test attachment byte budget. Preserve the typed quota error and release the run reservation at the machine-maximum boundary instead of leaking staged state through a property TypeError.