### PR TITLE
fix(condition): reject invalid environment names

### DIFF
--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -508,7 +508,7 @@ Namespace: `Greenlight\Condition`
 final readonly class EnvironmentVariableEquals implements Condition
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableEquals.php#L9)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableEquals.php#L10)
 
 ### `__construct()`
 
@@ -520,7 +520,7 @@ PHPDoc:
 
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableEquals.php#L19)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableEquals.php#L20)
 
 ### `isSatisfied()`
 
@@ -529,7 +529,7 @@ PHPDoc:
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableEquals.php#L28)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableEquals.php#L27)
 
 ## `EnvironmentVariableSet`
 
@@ -539,7 +539,7 @@ Namespace: `Greenlight\Condition`
 final readonly class EnvironmentVariableSet implements Condition
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableSet.php#L9)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableSet.php#L10)
 
 ### `__construct()`
 
@@ -551,7 +551,7 @@ PHPDoc:
 
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableSet.php#L19)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableSet.php#L20)
 
 ### `isSatisfied()`
 
@@ -560,7 +560,7 @@ PHPDoc:
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableSet.php#L28)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableSet.php#L27)
 
 ## `ExtensionLoaded`
 

--- a/src/Condition/EnvironmentVariableEquals.php
+++ b/src/Condition/EnvironmentVariableEquals.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Condition;
 
 use Greenlight\Core\Condition;
+use Greenlight\Core\EnvironmentVariableName;
 
 final readonly class EnvironmentVariableEquals implements Condition
 {
@@ -18,9 +19,7 @@ final readonly class EnvironmentVariableEquals implements Condition
      */
     public function __construct(string $name, private string $value)
     {
-        if ($name === '') {
-            throw new \InvalidArgumentException('Environment variable name MUST NOT be empty.');
-        }
+        EnvironmentVariableName::assertValid($name);
 
         $this->name = $name;
     }

--- a/src/Condition/EnvironmentVariableSet.php
+++ b/src/Condition/EnvironmentVariableSet.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Condition;
 
 use Greenlight\Core\Condition;
+use Greenlight\Core\EnvironmentVariableName;
 
 final readonly class EnvironmentVariableSet implements Condition
 {
@@ -18,9 +19,7 @@ final readonly class EnvironmentVariableSet implements Condition
      */
     public function __construct(string $name)
     {
-        if ($name === '') {
-            throw new \InvalidArgumentException('Environment variable name MUST NOT be empty.');
-        }
+        EnvironmentVariableName::assertValid($name);
 
         $this->name = $name;
     }

--- a/src/Core/EnvironmentBackup.php
+++ b/src/Core/EnvironmentBackup.php
@@ -22,7 +22,7 @@ final readonly class EnvironmentBackup
 
     public static function capture(string $name): self
     {
-        self::validateName($name);
+        EnvironmentVariableName::assertValid($name);
 
         return new self(
             $name,
@@ -72,12 +72,4 @@ final readonly class EnvironmentBackup
         }
     }
 
-    private static function validateName(string $name): void
-    {
-        if ($name === '' || \str_contains($name, '=') || \str_contains($name, "\0")) {
-            throw new \InvalidArgumentException(
-                'Environment variable names cannot be empty or contain "=" or a null byte.',
-            );
-        }
-    }
 }

--- a/src/Core/EnvironmentVariableName.php
+++ b/src/Core/EnvironmentVariableName.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Core;
+
+/** @internal */
+final class EnvironmentVariableName
+{
+    /** @codeCoverageIgnore */
+    private function __construct() {}
+
+    /**
+     * @phpstan-assert non-empty-string $name
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function assertValid(string $name): void
+    {
+        if ($name === '' || \str_contains($name, '=') || \str_contains($name, "\0")) {
+            throw new \InvalidArgumentException(
+                'Environment variable names cannot be empty or contain "=" or a null byte.',
+            );
+        }
+    }
+}

--- a/tests/Unit/Condition/EnvironmentVariableConditionValidationTest.php
+++ b/tests/Unit/Condition/EnvironmentVariableConditionValidationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Condition;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Condition\EnvironmentVariableEquals;
 use Greenlight\Condition\EnvironmentVariableSet;
@@ -12,19 +13,30 @@ use Greenlight\Expect\Expect;
 final readonly class EnvironmentVariableConditionValidationTest
 {
     #[Test]
-    public function rejectsAnEmptyEnvironmentVariableName(): void
+    #[DataSet('invalidNames')]
+    public function rejectsAnInvalidEnvironmentVariableName(string $name): void
     {
-        Expect::that(static fn(): EnvironmentVariableSet => new EnvironmentVariableSet(''))
-            ->because('a presence condition MUST identify the environment variable')
+        Expect::that(static fn(): EnvironmentVariableSet => new EnvironmentVariableSet($name))
+            ->because('a presence condition MUST reject a name that getenv() cannot safely read')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Environment variable name MUST NOT be empty.',
+                message: 'Environment variable names cannot be empty or contain "=" or a null byte.',
             );
-        Expect::that(static fn(): EnvironmentVariableEquals => new EnvironmentVariableEquals('', 'value'))
-            ->because('an equality condition MUST identify the environment variable')
+        Expect::that(static fn(): EnvironmentVariableEquals => new EnvironmentVariableEquals($name, 'value'))
+            ->because('an equality condition MUST reject a name that getenv() cannot safely read')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Environment variable name MUST NOT be empty.',
+                message: 'Environment variable names cannot be empty or contain "=" or a null byte.',
             );
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function invalidNames(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'assignment delimiter' => ['NAME=value'];
+        yield 'null byte' => ["NAME\0suffix"];
     }
 }


### PR DESCRIPTION
Reject environment variable names containing assignment delimiters or null bytes before condition evaluation reaches getenv(). Centralize the name invariant across both environment conditions and EnvironmentSandbox so every caller gets the same typed diagnostic.