### PR TITLE
refactor(test): reuse XML query helper

### DIFF
--- a/tests/Unit/Coverage/XmlExporterPathTest.php
+++ b/tests/Unit/Coverage/XmlExporterPathTest.php
@@ -11,6 +11,7 @@ use Greenlight\Coverage\Export\CloverExporter;
 use Greenlight\Coverage\Export\CoberturaExporter;
 use Greenlight\Coverage\FileCoverage;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\SimpleXml;
 
 final readonly class XmlExporterPathTest
 {
@@ -83,19 +84,17 @@ final readonly class XmlExporterPathTest
 
         $cloverDocument = new CloverExporter()->export($map)[CloverExporter::FILE_NAME];
         $clover = new \SimpleXMLElement($cloverDocument);
-        $cloverFiles = $clover->xpath('/coverage/project/file');
+        $cloverFiles = SimpleXml::xpath($clover, '/coverage/project/file');
         Expect::that($cloverFiles)
             ->because('the Clover document MUST contain exactly one file')
             ->toHaveCount(1);
-        \assert(\is_array($cloverFiles) && isset($cloverFiles[0]));
 
         $coberturaDocument = new CoberturaExporter()->export($map)[CoberturaExporter::FILE_NAME];
         $cobertura = new \SimpleXMLElement($coberturaDocument);
-        $coberturaClasses = $cobertura->xpath('/coverage/packages/package/classes/class');
+        $coberturaClasses = SimpleXml::xpath($cobertura, '/coverage/packages/package/classes/class');
         Expect::that($coberturaClasses)
             ->because('the Cobertura document MUST contain exactly one class')
             ->toHaveCount(1);
-        \assert(\is_array($coberturaClasses) && isset($coberturaClasses[0]));
 
         return [
             'cloverDocument' => $cloverDocument,

--- a/tests/Unit/Reporting/JUnitReporterTest.php
+++ b/tests/Unit/Reporting/JUnitReporterTest.php
@@ -15,6 +15,7 @@ use Greenlight\Core\Result\TestResult;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Reporting\JUnitReporter;
+use Greenlight\Tests\Support\SimpleXml;
 
 final class JUnitReporterTest
 {
@@ -70,11 +71,11 @@ final class JUnitReporterTest
         Expect::that((string) $document['failures'])->toBe('1');
         Expect::that((string) $document['errors'])->toBe('1');
         Expect::that((string) $document['skipped'])->toBe('1');
-        Expect::that($document->xpath('//testcase'))->toHaveCount(6);
-        Expect::that($document->xpath('//testsuite'))->toHaveCount(2);
-        Expect::that($document->xpath('//failure'))->toHaveCount(1);
-        Expect::that($document->xpath('//error'))->toHaveCount(1);
-        Expect::that($document->xpath('//skipped'))->toHaveCount(1);
+        Expect::that(SimpleXml::xpath($document, '//testcase'))->toHaveCount(6);
+        Expect::that(SimpleXml::xpath($document, '//testsuite'))->toHaveCount(2);
+        Expect::that(SimpleXml::xpath($document, '//failure'))->toHaveCount(1);
+        Expect::that(SimpleXml::xpath($document, '//error'))->toHaveCount(1);
+        Expect::that(SimpleXml::xpath($document, '//skipped'))->toHaveCount(1);
     }
 
     #[Test]
@@ -105,7 +106,7 @@ final class JUnitReporterTest
             return;
         }
 
-        $failures = $document->xpath('//failure');
+        $failures = SimpleXml::xpath($document, '//failure');
 
         Expect::that((string) $document['failures'])
             ->because('one failed test contributes one suite failure')
@@ -113,10 +114,6 @@ final class JUnitReporterTest
         Expect::that($failures)
             ->because('each failure detail remains visible to JUnit consumers')
             ->toHaveCount(2);
-
-        if (!\is_array($failures) || \count($failures) !== 2) {
-            return;
-        }
 
         Expect::that((string) $failures[0]['message'])
             ->because('failure details retain their encounter order')


### PR DESCRIPTION
Route coverage and JUnit XPath queries through the established SimpleXml test helper. Centralize query failure handling and remove runtime assertions and redundant type guards from the XML suites.