### PR TITLE
fix(reporting): saturate expectation totals

### DIFF
--- a/src/Reporting/JUnitReporter.php
+++ b/src/Reporting/JUnitReporter.php
@@ -34,7 +34,14 @@ final class JUnitReporter implements Reporter
     private array $casesByClass = [];
 
     /**
-     * @var array<string, array{tests: int, failures: int, errors: int, skipped: int, assertions: int, time: float}>
+     * @var array<string, array{
+     *     tests: non-negative-int,
+     *     failures: non-negative-int,
+     *     errors: non-negative-int,
+     *     skipped: non-negative-int,
+     *     assertions: non-negative-int,
+     *     time: float,
+     * }>
      */
     private array $countsByClass = [];
 
@@ -59,7 +66,7 @@ final class JUnitReporter implements Reporter
             $this->casesByClass[$class][] = $this->renderCase($result);
             $counts = $this->countsByClass[$class] ?? ['tests' => 0, 'failures' => 0, 'errors' => 0, 'skipped' => 0, 'assertions' => 0, 'time' => 0.0];
             ++$counts['tests'];
-            $counts['assertions'] += $result->expectations;
+            $counts['assertions'] = SaturatingCount::add($counts['assertions'], $result->expectations);
             $counts['time'] += $result->durationSeconds;
 
             match ($result->outcome) {

--- a/src/Reporting/PlainReporter.php
+++ b/src/Reporting/PlainReporter.php
@@ -93,7 +93,7 @@ final class PlainReporter implements Reporter
         if ($event instanceof TestFinished) {
             $this->slowTests->record($event);
             $result = $event->result;
-            $this->expectations += $result->expectations;
+            $this->expectations = SaturatingCount::add($this->expectations, $result->expectations);
             $attempts = $result->attempts > 1 ? \sprintf(' (attempts: %d)', $result->attempts) : '';
 
             $this->output->write(\sprintf(

--- a/src/Reporting/SaturatingCount.php
+++ b/src/Reporting/SaturatingCount.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Reporting;
+
+/**
+ * Adds nonnegative counts without integer overflow.
+ *
+ * @internal
+ */
+final class SaturatingCount
+{
+    /** @codeCoverageIgnore */
+    private function __construct() {}
+
+    /**
+     * @param non-negative-int $total
+     * @param non-negative-int $increment
+     *
+     * @return non-negative-int
+     */
+    public static function add(int $total, int $increment): int
+    {
+        return $increment > \PHP_INT_MAX - $total
+            ? \PHP_INT_MAX
+            : $total + $increment;
+    }
+}

--- a/src/Reporting/TtyReporter.php
+++ b/src/Reporting/TtyReporter.php
@@ -146,7 +146,7 @@ final class TtyReporter implements Reporter, Ticking
         if ($event instanceof TestFinished) {
             $this->slowTests->record($event);
             $result = $event->result;
-            $this->expectations += $result->expectations;
+            $this->expectations = SaturatingCount::add($this->expectations, $result->expectations);
             $class = $result->id->class;
             $this->lastEventAt = $event->occurredAt;
             ++$this->finishedTests;

--- a/tests/Unit/Reporting/ReporterExpectationOverflowTest.php
+++ b/tests/Unit/Reporting/ReporterExpectationOverflowTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\RunFinished;
+use Greenlight\Core\Event\TestFinished;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\ResultSummary;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\JUnitReporter;
+use Greenlight\Reporting\PlainReporter;
+use Greenlight\Reporting\Reporter;
+use Greenlight\Reporting\TtyReporter;
+
+final readonly class ReporterExpectationOverflowTest
+{
+    #[Test]
+    public function plainSummarySaturatesExpectationOverflow(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new PlainReporter($output);
+        $this->recordOverflowingExpectations($reporter);
+        $reporter->onEvent(new RunFinished('run-1', new ResultSummary(passed: 2), 0.0, 1.2));
+        $reporter->finish();
+
+        Expect::that($output->buffer())
+            ->because('the plain summary MUST keep an overflowing expectation total representable')
+            ->toContain(\sprintf('%d expectations', \PHP_INT_MAX));
+    }
+
+    #[Test]
+    public function ttySummarySaturatesExpectationOverflow(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new TtyReporter($output, color: false, cursor: false);
+        $this->recordOverflowingExpectations($reporter);
+        $reporter->onEvent(new RunFinished('run-1', new ResultSummary(passed: 2), 0.0, 1.2));
+        $reporter->finish();
+
+        Expect::that($output->buffer())
+            ->because('the TTY summary MUST keep an overflowing expectation total representable')
+            ->toContain(\sprintf('%d expectations', \PHP_INT_MAX));
+    }
+
+    #[Test]
+    public function junitSummarySaturatesExpectationOverflow(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new JUnitReporter($output);
+        $this->recordOverflowingExpectations($reporter);
+        $reporter->finish();
+
+        Expect::that($output->buffer())
+            ->because('the JUnit summary MUST keep an overflowing assertion total representable')
+            ->toContain(\sprintf('assertions="%d"', \PHP_INT_MAX));
+    }
+
+    private function recordOverflowingExpectations(Reporter $reporter): void
+    {
+        $reporter->onEvent(new TestFinished(new TestResult(
+            new TestId('Acme\\OverflowTest', 'maximum'),
+            Outcome::Passed,
+            0.0,
+            0,
+            expectations: \PHP_INT_MAX,
+        ), 1.0));
+        $reporter->onEvent(new TestFinished(new TestResult(
+            new TestId('Acme\\OverflowTest', 'oneMore'),
+            Outcome::Passed,
+            0.0,
+            0,
+            expectations: 1,
+        ), 1.1));
+    }
+}


### PR DESCRIPTION
Prevent valid expectation counts from overflowing plain and TTY reporter state. Route plain, TTY, and JUnit accumulation through one saturating counter so every format keeps totals representable and JUnit preserves its integer state contract.