### PR TITLE
refactor(test): construct reporting IDs directly

### DIFF
--- a/tests/Unit/Reporting/SlowTestsTest.php
+++ b/tests/Unit/Reporting/SlowTestsTest.php
@@ -19,7 +19,7 @@ final class SlowTestsTest
     public function fastRunsRenderNothing(): void
     {
         $slow = new SlowTests();
-        $slow->record($this->finished('Acme\FastTest::quick', 0.4));
+        $slow->record($this->finished('Acme\FastTest', 'quick', 0.4));
 
         Expect::that($slow->render(new Style(ansi: false)))->because('fast runs render nothing')->toBe('');
     }
@@ -30,7 +30,7 @@ final class SlowTestsTest
         $slow = new SlowTests();
 
         for ($i = 1; $i <= 8; ++$i) {
-            $slow->record($this->finished(\sprintf('Acme\SlowTest::case%02d', $i), 0.5 + $i / 100));
+            $slow->record($this->finished('Acme\SlowTest', \sprintf('case%02d', $i), 0.5 + $i / 100));
         }
 
         $rendered = $slow->render(new Style(ansi: false));
@@ -52,7 +52,7 @@ final class SlowTestsTest
         $slow = new SlowTests(extended: true);
 
         for ($i = 1; $i <= 8; ++$i) {
-            $slow->record($this->finished(\sprintf('Acme\SlowTest::case%02d', $i), 0.5 + $i / 100));
+            $slow->record($this->finished('Acme\SlowTest', \sprintf('case%02d', $i), 0.5 + $i / 100));
         }
 
         Expect::that($slow->render(new Style(ansi: false)))->because('extended mode keeps more entries')->toContain('case01');
@@ -64,7 +64,7 @@ final class SlowTestsTest
         $slow = new SlowTests(extended: true);
 
         for ($i = 1; $i <= 26; ++$i) {
-            $slow->record($this->finished(\sprintf('Acme\SlowTest::case%02d', $i), 0.5 + $i / 100));
+            $slow->record($this->finished('Acme\SlowTest', \sprintf('case%02d', $i), 0.5 + $i / 100));
         }
 
         $rendered = $slow->render(new Style(ansi: false));
@@ -88,11 +88,11 @@ final class SlowTestsTest
         $slow = new SlowTests();
 
         for ($i = 1; $i <= 21; ++$i) {
-            $slow->record($this->finished(\sprintf('Acme\SlowTest::case%02d', $i), 0.5 + $i / 100));
+            $slow->record($this->finished('Acme\SlowTest', \sprintf('case%02d', $i), 0.5 + $i / 100));
         }
 
-        $slow->record($this->finished('Acme\SlowTest::lateSlowest', 0.95));
-        $slow->record($this->finished('Acme\SlowTest::lateButFaster', 0.51));
+        $slow->record($this->finished('Acme\SlowTest', 'lateSlowest', 0.95));
+        $slow->record($this->finished('Acme\SlowTest', 'lateButFaster', 0.51));
         $rendered = $slow->render(new Style(ansi: false));
 
         Expect::that($rendered)
@@ -110,19 +110,17 @@ final class SlowTestsTest
     public function durationsAreColoredThroughTheStyle(): void
     {
         $slow = new SlowTests();
-        $slow->record($this->finished('Acme\SlowTest::crawls', 1.5));
+        $slow->record($this->finished('Acme\SlowTest', 'crawls', 1.5));
 
         Expect::that($slow->render(new Style(ansi: true)))->because('durations are colored through the style')->toContain("\x1b[33m1.500s\x1b[0m");
     }
 
     /**
-     * @param non-empty-string $id
+     * @param non-empty-string $class
+     * @param non-empty-string $method
      */
-    private function finished(string $id, float $duration): TestFinished
+    private function finished(string $class, string $method, float $duration): TestFinished
     {
-        [$class, $method] = \explode('::', $id);
-        \assert($class !== '' && $method !== '');
-
         return new TestFinished(new TestResult(new TestId($class, $method), Outcome::Passed, $duration, 0), 1.0);
     }
 }

--- a/tests/Unit/Reporting/SummaryFormatTest.php
+++ b/tests/Unit/Reporting/SummaryFormatTest.php
@@ -51,8 +51,8 @@ final class SummaryFormatTest
     public function aSingleTestPerReasonStaysInline(): void
     {
         $block = SummaryFormat::skipped([
-            $this->skip('App\AlphaTest::one', 'needs redis'),
-            $this->skip('App\BetaTest::two', null),
+            $this->skip('App\AlphaTest', 'one', 'needs redis'),
+            $this->skip('App\BetaTest', 'two', null),
         ], new Style(ansi: false));
 
         Expect::that($block)->because('a single test per reason stays inline')->toBe(
@@ -66,7 +66,7 @@ final class SummaryFormatTest
     public function zeroStringSkipReasonsRemainDistinctFromNoReason(): void
     {
         $block = SummaryFormat::skipped([
-            $this->skip('App\AlphaTest::one', '0'),
+            $this->skip('App\AlphaTest', 'one', '0'),
         ], new Style(ansi: false));
 
         Expect::that($block)
@@ -83,7 +83,7 @@ final class SummaryFormatTest
         $results = [];
 
         for ($i = 1; $i <= 7; ++$i) {
-            $results[] = $this->skip(\sprintf('App\GammaTest::case%d', $i), 'xdebug not loaded');
+            $results[] = $this->skip('App\GammaTest', \sprintf('case%d', $i), 'xdebug not loaded');
         }
 
         $block = SummaryFormat::skipped($results, new Style(ansi: false));
@@ -100,7 +100,7 @@ final class SummaryFormatTest
         $five = [];
 
         for ($i = 1; $i <= 5; ++$i) {
-            $five[] = $this->skip(\sprintf('App\DeltaTest::case%d', $i), 'shared reason');
+            $five[] = $this->skip('App\DeltaTest', \sprintf('case%d', $i), 'shared reason');
         }
 
         Expect::that(SummaryFormat::skipped($five, new Style(ansi: false)))->because('exactly five lists all without overflow')->toBe(
@@ -120,7 +120,7 @@ final class SummaryFormatTest
         $six = [];
 
         for ($i = 1; $i <= 6; ++$i) {
-            $six[] = $this->skip(\sprintf('App\DeltaTest::case%d', $i), 'shared reason');
+            $six[] = $this->skip('App\DeltaTest', \sprintf('case%d', $i), 'shared reason');
         }
 
         Expect::that(SummaryFormat::skipped($six, new Style(ansi: false)))->because('six lists five and reports one overflow')->toBe(
@@ -192,13 +192,11 @@ final class SummaryFormatTest
     }
 
     /**
-     * @param non-empty-string $id
+     * @param non-empty-string $class
+     * @param non-empty-string $method
      */
-    private function skip(string $id, ?string $reason): TestResult
+    private function skip(string $class, string $method, ?string $reason): TestResult
     {
-        [$class, $method] = \explode('::', $id);
-        \assert($class !== '' && $method !== '');
-
         return new TestResult(new TestId($class, $method), Outcome::Skipped, 0.0, 0, skipReason: $reason);
     }
 }


### PR DESCRIPTION
Pass test class and method directly into the summary and slow-test fixture factories. Remove the intermediate \`Class::method\` parse/reassembly step and its runtime assertions so fixture validity does not depend on PHP assertion settings.