### PR TITLE
refactor(harness): preserve resolved service types

### DIFF
--- a/src/Harness/HarnessScopes.php
+++ b/src/Harness/HarnessScopes.php
@@ -35,9 +35,13 @@ final class HarnessScopes
     }
 
     /**
-     * @param class-string $type
+     * @template T of object
+     *
+     * @param class-string<T> $type
      * @param non-empty-string $consumer
      * @param list<object> $attributes
+     *
+     * @return T
      *
      * @throws ServiceResolutionError when a service resolver cannot supply a valid service
      * @throws UnresolvableService
@@ -47,7 +51,13 @@ final class HarnessScopes
         $definition = $this->registry->find($type);
 
         if ($definition instanceof ServiceDefinition) {
-            return $this->containerFor($definition->scope)->get($definition);
+            $service = $this->containerFor($definition->scope)->get($definition);
+
+            if (!$service instanceof $type) {
+                throw UnresolvableService::factoryTypeMismatch($type, $service::class);
+            }
+
+            return $service;
         }
 
         foreach ($this->resolvers as $resolver) {

--- a/tests/Unit/Harness/HarnessScopesTest.php
+++ b/tests/Unit/Harness/HarnessScopesTest.php
@@ -58,10 +58,6 @@ final class HarnessScopesTest
         $scopes = new HarnessScopes($registry, [$resolver]);
         $resolved = $scopes->resolve(\ArrayObject::class, 'test');
 
-        Expect::that($resolved)
-            ->because('HarnessScopes::resolve() MUST return ArrayObject.')
-            ->toBeInstanceOf(\ArrayObject::class);
-
         $values = $resolved->getArrayCopy();
 
         Expect::that($values)
@@ -237,10 +233,6 @@ final class HarnessScopesTest
         $scopes->openTest();
 
         $first = $scopes->resolve(\ArrayObject::class, 'test');
-
-        Expect::that($first)
-            ->because('HarnessScopes::resolve() MUST return ArrayObject.')
-            ->toBeInstanceOf(\ArrayObject::class);
 
         $first->append('first scope');
         $scopes->closeTest();

--- a/tests/Unit/Harness/HarnessServiceFactoryContractTest.php
+++ b/tests/Unit/Harness/HarnessServiceFactoryContractTest.php
@@ -70,10 +70,6 @@ final class HarnessServiceFactoryContractTest
     {
         $scopes = $this->scopesFor(FactoryContractTarget::class);
         $service = $scopes->resolve(FactoryContractTarget::class, 'probe');
-        Expect::that($service)
-            ->because('the lazy service MUST match the registered type before initialization')
-            ->toBeInstanceOf(FactoryContractTarget::class);
-
         Expect::that(static fn(): string => $service->value())
             ->because('a lazy harness factory MUST return its registered type when initialized')
             ->toThrow(

--- a/tests/Unit/Psr15/Psr15PluginTest.php
+++ b/tests/Unit/Psr15/Psr15PluginTest.php
@@ -47,10 +47,10 @@ final class Psr15PluginTest
         $scopes = $this->scopes($plugin);
 
         $scopes->openTest();
-        $this->harness($scopes)->send(new ServerRequest([], [], '/first', 'GET'));
+        $scopes->resolve(HttpHarness::class, self::class)->send(new ServerRequest([], [], '/first', 'GET'));
         $scopes->closeTest();
         $scopes->openTest();
-        $this->harness($scopes)->send(new ServerRequest([], [], '/second', 'GET'));
+        $scopes->resolve(HttpHarness::class, self::class)->send(new ServerRequest([], [], '/second', 'GET'));
         $scopes->closeTest();
 
         Expect::that($created)->toBe(2);
@@ -77,11 +77,11 @@ final class Psr15PluginTest
         $scopes = $this->scopes($plugin);
 
         $scopes->openTest();
-        $first = $this->harness($scopes);
+        $first = $scopes->resolve(HttpHarness::class, self::class);
         $first->send(new ServerRequest([], [], '/first', 'GET'));
         $scopes->closeTest();
         $scopes->openTest();
-        $second = $this->harness($scopes);
+        $second = $scopes->resolve(HttpHarness::class, self::class);
         $second->send(new ServerRequest([], [], '/second', 'GET'));
         $scopes->closeTest();
 
@@ -103,7 +103,7 @@ final class Psr15PluginTest
         );
         $scopes = $this->scopes($plugin);
         $scopes->openTest();
-        $this->harness($scopes)->send(new ServerRequest([], [], '/status', 'GET'));
+        $scopes->resolve(HttpHarness::class, self::class)->send(new ServerRequest([], [], '/status', 'GET'));
 
         Expect::that($scopes->closeTest())->toBe([]);
         Expect::that($released)->toBe($handler);
@@ -121,7 +121,7 @@ final class Psr15PluginTest
         );
         $scopes = $this->scopes($plugin);
         $scopes->openTest();
-        $this->harness($scopes)->send(new ServerRequest([], [], '/status', 'GET'));
+        $scopes->resolve(HttpHarness::class, self::class)->send(new ServerRequest([], [], '/status', 'GET'));
 
         $failures = $scopes->closeTest();
 
@@ -144,15 +144,5 @@ final class Psr15PluginTest
     private function scopes(Psr15Plugin $plugin): HarnessScopes
     {
         return new HarnessScopes(new HarnessRegistry($plugin->services()));
-    }
-
-    private function harness(HarnessScopes $scopes): HttpHarness
-    {
-        $harness = $scopes->resolve(HttpHarness::class, self::class);
-        Expect::that($harness)
-            ->because('the resolved service MUST be the requested HTTP harness')
-            ->toBeInstanceOf(HttpHarness::class);
-
-        return $harness;
     }
 }

--- a/tests/Unit/Runner/DefaultServicesTest.php
+++ b/tests/Unit/Runner/DefaultServicesTest.php
@@ -31,10 +31,6 @@ final readonly class DefaultServicesTest
         try {
             $channel = $scopes->resolve(TestChannel::class, self::class);
 
-            Expect::that($channel)
-                ->because('The default service MUST resolve TestChannel.')
-                ->toBeInstanceOf(TestChannel::class);
-
             Expect::that($channel->number)
                 ->because('the default channel service MUST always use a positive number')
                 ->toBe($expected);


### PR DESCRIPTION
Express the existing HarnessScopes type guarantee as a generic resolve contract and enforce it at the registered-service boundary. Callers now receive the requested class type directly, which removes redundant runtime narrowing and assertion-dependent test helpers.