### PR TITLE
refactor(test): reuse class source lookup

### DIFF
--- a/tests/Support/ClassFile.php
+++ b/tests/Support/ClassFile.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Support;
+
+final class ClassFile
+{
+    private function __construct() {}
+
+    /**
+     * @param class-string $class
+     *
+     * @return non-empty-string
+     */
+    public static function of(string $class): string
+    {
+        $file = new \ReflectionClass($class)->getFileName();
+
+        if ($file === false) {
+            throw new \RuntimeException(\sprintf('Class "%s" does not have a source file.', $class));
+        }
+
+        return $file;
+    }
+}

--- a/tests/Unit/Coverage/HtmlExporterTest.php
+++ b/tests/Unit/Coverage/HtmlExporterTest.php
@@ -12,6 +12,7 @@ use Greenlight\Coverage\FileCoverage;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Tests\Fixture\Coverage\Adder;
+use Greenlight\Tests\Support\ClassFile;
 
 final readonly class HtmlExporterTest
 {
@@ -148,8 +149,7 @@ final readonly class HtmlExporterTest
     #[Test]
     public function filePageColorsSourceLinesByCoverageStatus(): void
     {
-        $fixture = (string) new \ReflectionClass(Adder::class)->getFileName();
-        \assert($fixture !== '');
+        $fixture = ClassFile::of(Adder::class);
         $map = new CoverageMap([
             new FileCoverage($fixture, [Adder::ADD_RETURN_LINE], [Adder::NEVER_RETURN_LINE]),
         ]);
@@ -165,8 +165,7 @@ final readonly class HtmlExporterTest
     #[Test]
     public function filePageSyntaxHighlightsPhpSource(): void
     {
-        $fixture = (string) new \ReflectionClass(Adder::class)->getFileName();
-        \assert($fixture !== '');
+        $fixture = ClassFile::of(Adder::class);
         $map = new CoverageMap([
             new FileCoverage($fixture, [Adder::ADD_RETURN_LINE], []),
         ]);

--- a/tests/Unit/Coverage/XdebugDriverTest.php
+++ b/tests/Unit/Coverage/XdebugDriverTest.php
@@ -14,6 +14,7 @@ use Greenlight\Coverage\PathFilter;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\Coverage\Adder;
 use Greenlight\Tests\Fixture\Coverage\FakeXdebugRuntime;
+use Greenlight\Tests\Support\ClassFile;
 
 final class XdebugDriverTest
 {
@@ -135,7 +136,7 @@ final class XdebugDriverTest
             throw new SkipTest('xdebug with coverage mode is not available');
         }
 
-        $fixtureFile = (string) new \ReflectionClass(Adder::class)->getFileName();
+        $fixtureFile = ClassFile::of(Adder::class);
         $fixtureDir = \dirname($fixtureFile);
 
         $driver = new XdebugDriver();

--- a/tests/Unit/Support/ClassFileTest.php
+++ b/tests/Unit/Support/ClassFileTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Support;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\ClassFile;
+
+final class ClassFileTest
+{
+    #[Test]
+    public function returnsTheDeclaringFileForAUserClass(): void
+    {
+        Expect::that(ClassFile::of(self::class))
+            ->because('a user class has a reusable source path')
+            ->toBe(__FILE__);
+    }
+
+    #[Test]
+    public function rejectsAnInternalClassWithoutASourceFile(): void
+    {
+        Expect::that(static fn(): string => ClassFile::of(\stdClass::class))
+            ->because('a missing class source file fails explicitly')
+            ->toThrow(\RuntimeException::class, message: 'Class "stdClass" does not have a source file.');
+    }
+}


### PR DESCRIPTION
Add a fail-fast ClassFile support helper for reflected user-class source paths. Reuse it in the HTML exporter and Xdebug coverage tests so fixture lookup no longer depends on casts or PHP assertion settings.