### PR TITLE
fix(artifact): avoid empty destination on source failure

### DIFF
--- a/src/Runner/Artifact/NativeFileCopier.php
+++ b/src/Runner/Artifact/NativeFileCopier.php
@@ -19,38 +19,38 @@ final readonly class NativeFileCopier implements FileCopier
     public function copy(string $sourcePath, string $destinationPath): void
     {
         $source = ErrorTrap::run(static fn() => \fopen($sourcePath, 'rb'));
-        $destination = ErrorTrap::run(static fn() => \fopen($destinationPath, 'xb'));
 
-        if ($source === false || $destination === false) {
-            if (\is_resource($source)) {
-                \fclose($source);
-            }
-
-            if (\is_resource($destination)) {
-                \fclose($destination);
-            }
-
+        if ($source === false) {
             throw AttachmentError::storage('Failed to copy attachment into its output directory');
         }
 
         try {
-            while (!\feof($source)) {
-                $chunk = \fread($source, self::COPY_CHUNK_BYTES);
+            $destination = ErrorTrap::run(static fn() => \fopen($destinationPath, 'xb'));
 
-                if ($chunk === false) {
-                    throw AttachmentError::storage('Failed to read attachment staging content');
-                }
-
-                if ($chunk !== '') {
-                    StreamWriter::writeFully($destination, $chunk);
-                }
+            if ($destination === false) {
+                throw AttachmentError::storage('Failed to copy attachment into its output directory');
             }
 
-            if (!\fflush($destination)) {
-                throw AttachmentError::storage('Failed to flush the published attachment');
+            try {
+                while (!\feof($source)) {
+                    $chunk = \fread($source, self::COPY_CHUNK_BYTES);
+
+                    if ($chunk === false) {
+                        throw AttachmentError::storage('Failed to read attachment staging content');
+                    }
+
+                    if ($chunk !== '') {
+                        StreamWriter::writeFully($destination, $chunk);
+                    }
+                }
+
+                if (!\fflush($destination)) {
+                    throw AttachmentError::storage('Failed to flush the published attachment');
+                }
+            } finally {
+                \fclose($destination);
             }
         } finally {
-            \fclose($destination);
             \fclose($source);
         }
     }

--- a/tests/Unit/Artifact/ArtifactCopyOpenFailureTest.php
+++ b/tests/Unit/Artifact/ArtifactCopyOpenFailureTest.php
@@ -23,35 +23,10 @@ final readonly class ArtifactCopyOpenFailureTest
     ) {}
 
     #[Test]
-    public function copyOpenFailuresCloseTheOtherStream(): void
+    public function aDestinationOpenFailureClosesTheSource(): void
     {
         $this->streamWrappers->register(self::SCHEME, TrackedOpenStream::class);
         $root = $this->tempDirectory->subdirectory('copy-open-failures');
-
-        TrackedOpenStream::reset();
-
-        $sourceWarning = null;
-        Expect::that(static function () use ($root, &$sourceWarning): void {
-            ErrorTrap::run(
-                static fn() => new NativeFileCopier()->copy(
-                    $root . '/missing-source.txt',
-                    self::SCHEME . '://destination',
-                ),
-                $sourceWarning,
-            );
-        })
-            ->because('a missing source MUST fail the attachment copy')
-            ->toThrow(
-                AttachmentError::class,
-                message: 'Failed to copy attachment into its output directory.',
-            );
-        Expect::that($sourceWarning)
-            ->because('a source open failure MUST not leak an engine diagnostic')
-            ->toBeNull();
-
-        Expect::that(TrackedOpenStream::closedStreams())
-            ->because('a source open failure MUST close the destination stream')
-            ->toBe(1);
 
         TrackedOpenStream::reset();
 
@@ -77,5 +52,25 @@ final readonly class ArtifactCopyOpenFailureTest
         Expect::that(TrackedOpenStream::closedStreams())
             ->because('a destination open failure MUST close the source stream')
             ->toBe(1);
+    }
+
+    #[Test]
+    public function aMissingSourceDoesNotCreateTheDestination(): void
+    {
+        $root = $this->tempDirectory->subdirectory('missing-copy-source');
+        $destination = $root . '/destination.txt';
+
+        Expect::that(static fn() => new NativeFileCopier()->copy(
+            $root . '/missing-source.txt',
+            $destination,
+        ))
+            ->because('a missing source MUST fail before the destination is opened')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Failed to copy attachment into its output directory.',
+            );
+        Expect::that(\file_exists($destination))
+            ->because('a source open failure MUST not leave an empty destination')
+            ->toBeFalse();
     }
 }


### PR DESCRIPTION
Open the copy source before the exclusive destination and scope each resource closure to its successful acquisition. A missing source now fails without leaving an empty destination, while destination, read, and flush failures retain cleanup.