### PR TITLE
refactor(test): reuse plan entry fixture

### DIFF
--- a/tests/Support/PlanEntryFixture.php
+++ b/tests/Support/PlanEntryFixture.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Support;
+
+use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Discovery\PlanEntry;
+
+/** Creates a plan entry with matching identifier and metadata fields. */
+final class PlanEntryFixture
+{
+    private function __construct() {}
+
+    /**
+     * @param non-empty-string $class
+     * @param non-empty-string $method
+     * @param non-empty-string|null $dataSetKey
+     * @param list<non-empty-string> $resources
+     */
+    public static function create(
+        string $class,
+        string $method = 'runs',
+        ?string $dataSetKey = null,
+        array $resources = [],
+        bool $isolated = false,
+    ): PlanEntry {
+        return new PlanEntry(
+            new TestId($class, $method, $dataSetKey),
+            new TestMetadata($class, $method, isolated: $isolated, resources: $resources),
+        );
+    }
+}

--- a/tests/Support/SchedulingFixture.php
+++ b/tests/Support/SchedulingFixture.php
@@ -4,10 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Support;
 
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Runner\Orchestrator\DispatchKind;
@@ -30,10 +27,8 @@ final class SchedulingFixture
      */
     public static function unit(string $class, array $resources = [], bool $isolated = false): SchedulingUnit
     {
-        $id = new TestId($class, 'runs');
-
         return new SchedulingUnit(new ExecutionPlan([
-            new PlanEntry($id, new TestMetadata($class, 'runs', resources: $resources)),
+            PlanEntryFixture::create($class, resources: $resources),
         ]), $isolated);
     }
 

--- a/tests/Unit/Discovery/DiscoveryCacheContentFingerprintTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheContentFingerprintTest.php
@@ -13,6 +13,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Tests\Support\DiscoveryCachePath;
+use Greenlight\Tests\Support\PlanEntryFixture;
 
 final readonly class DiscoveryCacheContentFingerprintTest
 {
@@ -34,8 +35,7 @@ final readonly class DiscoveryCacheContentFingerprintTest
         }
 
         \clearstatcache(true, $source);
-        $id = new TestId('Example\\ContentProbeTest', 'runs');
-        $entry = new PlanEntry($id, new TestMetadata($id->class, $id->method));
+        $entry = PlanEntryFixture::create('Example\\ContentProbeTest');
         $cache = DiscoveryCache::forDirectories([$directory]);
         $cache->store($source, [$entry]);
 

--- a/tests/Unit/Discovery/DiscoveryCacheDirectoryOrderTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheDirectoryOrderTest.php
@@ -5,13 +5,11 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Discovery;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\DiscoveryCache;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Tests\Support\DiscoveryCachePath;
+use Greenlight\Tests\Support\PlanEntryFixture;
 
 final readonly class DiscoveryCacheDirectoryOrderTest
 {
@@ -25,11 +23,7 @@ final readonly class DiscoveryCacheDirectoryOrderTest
         $source = $first . '/OrderProbeTest.php';
         \file_put_contents($source, '<?php');
 
-        $id = new TestId('Fixture\OrderProbeTest', 'probe');
-        $entry = new PlanEntry(
-            $id,
-            new TestMetadata($id->class, $id->method),
-        );
+        $entry = PlanEntryFixture::create('Fixture\OrderProbeTest', 'probe');
         $directories = [$first, $second];
         $cacheFile = DiscoveryCachePath::forDirectories($directories);
 

--- a/tests/Unit/Discovery/ExecutionPlanGroupingTest.php
+++ b/tests/Unit/Discovery/ExecutionPlanGroupingTest.php
@@ -5,11 +5,10 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Discovery;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\ExecutionPlan;
 use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\PlanEntryFixture;
 
 final readonly class ExecutionPlanGroupingTest
 {
@@ -17,9 +16,9 @@ final readonly class ExecutionPlanGroupingTest
     public function groupingPreservesClassAndTestOrder(): void
     {
         $plan = new ExecutionPlan([
-            $this->entry('Acme\\AlphaTest', 'first'),
-            $this->entry('Acme\\AlphaTest', 'second', 'row two'),
-            $this->entry('Acme\\BetaTest', 'third'),
+            PlanEntryFixture::create('Acme\\AlphaTest', 'first'),
+            PlanEntryFixture::create('Acme\\AlphaTest', 'second', 'row two'),
+            PlanEntryFixture::create('Acme\\BetaTest', 'third'),
         ]);
 
         $idsByClass = \array_map(
@@ -41,17 +40,5 @@ final readonly class ExecutionPlanGroupingTest
                     'Acme\\BetaTest::third',
                 ],
             ]);
-    }
-
-    /**
-     * @param non-empty-string $class
-     * @param non-empty-string $method
-     */
-    private function entry(string $class, string $method, ?string $dataSetKey = null): PlanEntry
-    {
-        return new PlanEntry(
-            new TestId($class, $method, $dataSetKey),
-            new TestMetadata($class, $method),
-        );
     }
 }

--- a/tests/Unit/Discovery/ExecutionPlanTest.php
+++ b/tests/Unit/Discovery/ExecutionPlanTest.php
@@ -5,32 +5,21 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Discovery;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Core\Wire\InvalidWirePayload;
 use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Support\JsonWire;
+use Greenlight\Tests\Support\PlanEntryFixture;
 
 final class ExecutionPlanTest
 {
-    /**
-     * @param non-empty-string $class
-     * @param non-empty-string $method
-     */
-    private static function entry(string $class, string $method, ?string $dataSetKey = null): PlanEntry
-    {
-        return new PlanEntry(new TestId($class, $method, $dataSetKey), new TestMetadata($class, $method));
-    }
-
     #[Test]
     public function exposesEntriesClassesAndCounts(): void
     {
         $plan = new ExecutionPlan([
-            self::entry('App\FooTest', 'a'),
-            self::entry('App\FooTest', 'b', 'first'),
-            self::entry('App\BarTest', 'c'),
+            PlanEntryFixture::create('App\FooTest', 'a'),
+            PlanEntryFixture::create('App\FooTest', 'b', 'first'),
+            PlanEntryFixture::create('App\BarTest', 'c'),
         ], 7);
 
         Expect::that($plan)->because('exposes entries classes and counts')->toHaveCount(3);
@@ -48,9 +37,9 @@ final class ExecutionPlanTest
     {
         Expect::that(
             static fn(): ExecutionPlan => new ExecutionPlan([
-                self::entry('App\FooTest', 'a'),
-                self::entry('App\BarTest', 'c'),
-                self::entry('App\FooTest', 'b'),
+                PlanEntryFixture::create('App\FooTest', 'a'),
+                PlanEntryFixture::create('App\BarTest', 'c'),
+                PlanEntryFixture::create('App\FooTest', 'b'),
             ]),
         )->because('rejects entries not grouped by class')->toThrow(
             \InvalidArgumentException::class,
@@ -61,7 +50,7 @@ final class ExecutionPlanTest
     #[Test]
     public function rejectsDuplicateTestIdsFromConstructionAndTheWire(): void
     {
-        $entry = self::entry('App\FooTest', 'a', 'first');
+        $entry = PlanEntryFixture::create('App\FooTest', 'a', 'first');
         $message = 'Execution plan test ID "App\FooTest::a[first]" occurs more than once.';
 
         Expect::that(static fn(): ExecutionPlan => new ExecutionPlan([$entry, $entry]))
@@ -82,8 +71,8 @@ final class ExecutionPlanTest
     public function survivesTheWire(): void
     {
         $plan = new ExecutionPlan([
-            self::entry('App\FooTest', 'a'),
-            self::entry('App\FooTest', 'b', 'first case'),
+            PlanEntryFixture::create('App\FooTest', 'a'),
+            PlanEntryFixture::create('App\FooTest', 'b', 'first case'),
         ], 42);
 
         $restored = ExecutionPlan::fromWire(JsonWire::roundTrip($plan->toWire()));
@@ -97,14 +86,14 @@ final class ExecutionPlanTest
     #[Test]
     public function missingWireKeysFailLoudly(): void
     {
-        $payload = new ExecutionPlan([self::entry('App\FooTest', 'a')])->toWire();
+        $payload = new ExecutionPlan([PlanEntryFixture::create('App\FooTest', 'a')])->toWire();
         unset($payload['seed']);
 
         Expect::that(
             static fn(): ExecutionPlan => ExecutionPlan::fromWire($payload),
         )->because('missing wire keys cause an error')->toThrow(InvalidWirePayload::class);
 
-        $payload = new ExecutionPlan([self::entry('App\FooTest', 'a')])->toWire();
+        $payload = new ExecutionPlan([PlanEntryFixture::create('App\FooTest', 'a')])->toWire();
         unset($payload['entries']);
 
         Expect::that(

--- a/tests/Unit/Runner/Orchestrator/DistributorPartitionTest.php
+++ b/tests/Unit/Runner/Orchestrator/DistributorPartitionTest.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner\Orchestrator;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\ExecutionPlan;
 use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\Orchestrator\Distributor;
 use Greenlight\Runner\Orchestrator\SchedulingUnit;
+use Greenlight\Tests\Support\PlanEntryFixture;
 
 final readonly class DistributorPartitionTest
 {
@@ -19,11 +18,11 @@ final readonly class DistributorPartitionTest
     public function mixedEntriesRemainCompleteAndOrdered(): void
     {
         $plan = new ExecutionPlan([
-            $this->entry('Acme\\AlphaTest', 'first'),
-            $this->entry('Acme\\AlphaTest', 'isolated', isolated: true),
-            $this->entry('Acme\\AlphaTest', 'third'),
-            $this->entry('Acme\\BetaTest', 'isolated', isolated: true),
-            $this->entry('Acme\\BetaTest', 'second'),
+            PlanEntryFixture::create('Acme\\AlphaTest', 'first'),
+            PlanEntryFixture::create('Acme\\AlphaTest', 'isolated', isolated: true),
+            PlanEntryFixture::create('Acme\\AlphaTest', 'third'),
+            PlanEntryFixture::create('Acme\\BetaTest', 'isolated', isolated: true),
+            PlanEntryFixture::create('Acme\\BetaTest', 'second'),
         ], seed: 4242);
 
         [$pooled, $isolated] = new Distributor()->units($plan);
@@ -71,17 +70,5 @@ final readonly class DistributorPartitionTest
             'seed' => $unit->plan->seed,
             'isolated' => $unit->isolated,
         ];
-    }
-
-    /**
-     * @param non-empty-string $class
-     * @param non-empty-string $method
-     */
-    private function entry(string $class, string $method, bool $isolated = false): PlanEntry
-    {
-        return new PlanEntry(
-            new TestId($class, $method),
-            new TestMetadata($class, $method, isolated: $isolated),
-        );
     }
 }

--- a/tests/Unit/Runner/Orchestrator/DistributorTest.php
+++ b/tests/Unit/Runner/Orchestrator/DistributorTest.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner\Orchestrator;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\Orchestrator\Distributor;
+use Greenlight\Tests\Support\PlanEntryFixture;
 
 final class DistributorTest
 {
@@ -18,10 +16,10 @@ final class DistributorTest
     public function isolatedEntriesBecomeSingletonUnitsInPlanOrder(): void
     {
         $plan = new ExecutionPlan([
-            $this->entry('ExampleTest', 'pooled', []),
-            $this->entry('ExampleTest', 'isolatedOne', [], isolated: true),
-            $this->entry('ExampleTest', 'isolatedTwo', [], isolated: true),
-            $this->entry('OtherTest', 'pooled', []),
+            PlanEntryFixture::create('ExampleTest', 'pooled'),
+            PlanEntryFixture::create('ExampleTest', 'isolatedOne', isolated: true),
+            PlanEntryFixture::create('ExampleTest', 'isolatedTwo', isolated: true),
+            PlanEntryFixture::create('OtherTest', 'pooled'),
         ], 42);
 
         [$pooled, $isolated] = new Distributor()->units($plan);
@@ -55,9 +53,9 @@ final class DistributorTest
     public function classUnitsHoldTheUnionOfEveryEntryRequirement(): void
     {
         $plan = new ExecutionPlan([
-            $this->entry('ExampleTest', 'one', ['postgres']),
-            $this->entry('ExampleTest', 'two', ['redis', 'postgres']),
-            $this->entry('OtherTest', 'isolated', ['sandbox'], isolated: true),
+            PlanEntryFixture::create('ExampleTest', 'one', resources: ['postgres']),
+            PlanEntryFixture::create('ExampleTest', 'two', resources: ['redis', 'postgres']),
+            PlanEntryFixture::create('OtherTest', 'isolated', resources: ['sandbox'], isolated: true),
         ], 42);
 
         [$pooled, $isolated] = new Distributor()->units($plan);
@@ -69,18 +67,5 @@ final class DistributorTest
         Expect::that($isolated)->because('class units hold the union of every entry requirement')->toHaveCount(1);
         Expect::that($isolated[0]->resources)->because('class units hold the union of every entry requirement')->toBe(['sandbox']);
         Expect::that($isolated[0]->isolated)->because('class units hold the union of every entry requirement')->toBeTrue();
-    }
-
-    /**
-     * @param non-empty-string $class
-     * @param non-empty-string $method
-     * @param list<non-empty-string> $resources
-     */
-    private function entry(string $class, string $method, array $resources, bool $isolated = false): PlanEntry
-    {
-        return new PlanEntry(
-            new TestId($class, $method),
-            new TestMetadata($class, $method, isolated: $isolated, resources: $resources),
-        );
     }
 }

--- a/tests/Unit/Runner/Orchestrator/OrchestratorIsolatedRemainderTest.php
+++ b/tests/Unit/Runner/Orchestrator/OrchestratorIsolatedRemainderTest.php
@@ -8,15 +8,13 @@ use Greenlight\Attribute\Test;
 use Greenlight\Attribute\Timeout;
 use Greenlight\Core\Event\TestClassStarted;
 use Greenlight\Core\Result\ResultSummary;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\Orchestrator\Orchestrator;
 use Greenlight\Tests\Fixture\LeakSuite\CleanTest;
 use Greenlight\Tests\Fixture\Runner\Orchestrator\RecycleBeforeIsolatedWorker;
 use Greenlight\Tests\Support\CollectingEventSink;
+use Greenlight\Tests\Support\PlanEntryFixture;
 
 final class OrchestratorIsolatedRemainderTest
 {
@@ -35,9 +33,8 @@ final class OrchestratorIsolatedRemainderTest
             workingDirectory: $root,
         );
         $sink = new CollectingEventSink();
-        $id = new TestId(CleanTest::class, 'passesAndIsCollectable');
         $plan = new ExecutionPlan([
-            new PlanEntry($id, new TestMetadata($id->class, $id->method, isolated: true)),
+            PlanEntryFixture::create(CleanTest::class, 'passesAndIsCollectable', isolated: true),
         ]);
 
         $summary = $orchestrator->run($plan, $sink, 1);

--- a/tests/Unit/Runner/Orchestrator/SchedulingUnitTest.php
+++ b/tests/Unit/Runner/Orchestrator/SchedulingUnitTest.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner\Orchestrator;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\Orchestrator\SchedulingUnit;
+use Greenlight\Tests\Support\PlanEntryFixture;
 
 final class SchedulingUnitTest
 {
@@ -25,26 +23,12 @@ final class SchedulingUnitTest
     public function resourcesAreUniqueAcrossEveryEntryInTheClass(): void
     {
         $unit = new SchedulingUnit(new ExecutionPlan([
-            $this->entry('first', ['database', 'cache']),
-            $this->entry('second', ['database']),
+            PlanEntryFixture::create('ExampleTest', 'first', resources: ['database', 'cache']),
+            PlanEntryFixture::create('ExampleTest', 'second', resources: ['database']),
         ]), false);
 
         Expect::that($unit->resources)
             ->because('one class MUST acquire each required resource once')
             ->toBe(['database', 'cache']);
-    }
-
-    /**
-     * @param non-empty-string $method
-     * @param list<non-empty-string> $resources
-     */
-    private function entry(string $method, array $resources): PlanEntry
-    {
-        $class = 'ExampleTest';
-
-        return new PlanEntry(
-            new TestId($class, $method),
-            new TestMetadata($class, $method, resources: $resources),
-        );
     }
 }

--- a/tests/Unit/Runner/Orchestrator/WorkerHandleAssignmentLifecycleTest.php
+++ b/tests/Unit/Runner/Orchestrator/WorkerHandleAssignmentLifecycleTest.php
@@ -7,14 +7,13 @@ namespace Greenlight\Tests\Unit\Runner\Orchestrator;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Result\ResultSummary;
 use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\Orchestrator\ResourceLease;
 use Greenlight\Runner\Orchestrator\SchedulingUnit;
 use Greenlight\Runner\Orchestrator\WorkerHandle;
 use Greenlight\Tests\Support\MemoryStream;
+use Greenlight\Tests\Support\PlanEntryFixture;
 
 final readonly class WorkerHandleAssignmentLifecycleTest
 {
@@ -104,12 +103,10 @@ final readonly class WorkerHandleAssignmentLifecycleTest
 
     private function lease(): ResourceLease
     {
-        $id = new TestId('Acme\\ExampleTest', 'runs');
         $plan = new ExecutionPlan([
-            new PlanEntry($id, new TestMetadata($id->class, $id->method)),
+            PlanEntryFixture::create('Acme\\ExampleTest'),
         ]);
 
         return new ResourceLease(41, new SchedulingUnit($plan, isolated: true));
     }
-
 }

--- a/tests/Unit/Runner/Orchestrator/WorkerHandleTest.php
+++ b/tests/Unit/Runner/Orchestrator/WorkerHandleTest.php
@@ -6,14 +6,12 @@ namespace Greenlight\Tests\Unit\Runner\Orchestrator;
 
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\Orchestrator\WorkerHandle;
 use Greenlight\Tests\Support\ConnectedStreamPair;
 use Greenlight\Tests\Support\MemoryStream;
+use Greenlight\Tests\Support\PlanEntryFixture;
 
 final class WorkerHandleTest
 {
@@ -60,9 +58,9 @@ final class WorkerHandleTest
             ->because('a worker without an assignment has no unfinished tests')
             ->toBe([]);
 
-        $finished = $this->entry('finished');
-        $inFlight = $this->entry('inFlight');
-        $remaining = $this->entry('remaining');
+        $finished = PlanEntryFixture::create('Example\WorkerTest', 'finished');
+        $inFlight = PlanEntryFixture::create('Example\WorkerTest', 'inFlight');
+        $remaining = PlanEntryFixture::create('Example\WorkerTest', 'remaining');
         $handle->assigned = new ExecutionPlan([$finished, $inFlight, $remaining]);
         $handle->finished[(string) $finished->id] = true;
         $handle->inFlight = $inFlight->id;
@@ -166,16 +164,6 @@ final class WorkerHandleTest
         yield 'surrogate prefix' => ["\xED\xA0"];
         yield 'overlong four-byte prefix' => ["\xF0\x80"];
         yield 'out-of-range prefix' => ["\xF4\x90"];
-    }
-
-    /**
-     * @param non-empty-string $method
-     */
-    private function entry(string $method): PlanEntry
-    {
-        $id = new TestId('Example\WorkerTest', $method);
-
-        return new PlanEntry($id, new TestMetadata($id->class, $id->method));
     }
 
     private function handle(): WorkerHandle

--- a/tests/Unit/Runner/PlanOrderClassIntegrityTest.php
+++ b/tests/Unit/Runner/PlanOrderClassIntegrityTest.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\ExecutionPlan;
 use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\PlanOrder;
+use Greenlight\Tests\Support\PlanEntryFixture;
 
 final class PlanOrderClassIntegrityTest
 {
@@ -18,10 +17,10 @@ final class PlanOrderClassIntegrityTest
     public function classPriorityPreservesMethodOrderAndThePlanSeed(): void
     {
         $plan = new ExecutionPlan([
-            $this->entry('Acme\\AlphaTest', 'first'),
-            $this->entry('Acme\\AlphaTest', 'second'),
-            $this->entry('Acme\\BetaTest', 'first'),
-            $this->entry('Acme\\BetaTest', 'second'),
+            PlanEntryFixture::create('Acme\\AlphaTest', 'first'),
+            PlanEntryFixture::create('Acme\\AlphaTest', 'second'),
+            PlanEntryFixture::create('Acme\\BetaTest', 'first'),
+            PlanEntryFixture::create('Acme\\BetaTest', 'second'),
         ], seed: 4242);
 
         $ordered = PlanOrder::schedule($plan, ['Acme\\BetaTest'], []);
@@ -41,17 +40,5 @@ final class PlanOrderClassIntegrityTest
         Expect::that($ordered->seed)
             ->because('class priority MUST preserve the reproducible plan seed')
             ->toBe(4242);
-    }
-
-    /**
-     * @param non-empty-string $class
-     * @param non-empty-string $method
-     */
-    private function entry(string $class, string $method): PlanEntry
-    {
-        return new PlanEntry(
-            new TestId($class, $method),
-            new TestMetadata($class, $method),
-        );
     }
 }

--- a/tests/Unit/Runner/PlanOrderDurationTieTest.php
+++ b/tests/Unit/Runner/PlanOrderDurationTieTest.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\PlanOrder;
+use Greenlight\Tests\Support\PlanEntryFixture;
 
 final readonly class PlanOrderDurationTieTest
 {
@@ -18,9 +16,9 @@ final readonly class PlanOrderDurationTieTest
     public function equalDurationsPreserveDiscoveryOrder(): void
     {
         $plan = new ExecutionPlan([
-            $this->entry('Acme\\GammaTest'),
-            $this->entry('Acme\\AlphaTest'),
-            $this->entry('Acme\\BetaTest'),
+            PlanEntryFixture::create('Acme\\GammaTest'),
+            PlanEntryFixture::create('Acme\\AlphaTest'),
+            PlanEntryFixture::create('Acme\\BetaTest'),
         ]);
 
         $ordered = PlanOrder::schedule($plan, [], [
@@ -36,16 +34,5 @@ final readonly class PlanOrderDurationTieTest
                 'Acme\\AlphaTest',
                 'Acme\\BetaTest',
             ]);
-    }
-
-    /**
-     * @param non-empty-string $class
-     */
-    private function entry(string $class): PlanEntry
-    {
-        return new PlanEntry(
-            new TestId($class, 'runs'),
-            new TestMetadata($class, 'runs'),
-        );
     }
 }

--- a/tests/Unit/Runner/PlanOrderPrioritySequenceTest.php
+++ b/tests/Unit/Runner/PlanOrderPrioritySequenceTest.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\PlanOrder;
+use Greenlight\Tests\Support\PlanEntryFixture;
 
 final class PlanOrderPrioritySequenceTest
 {
@@ -18,10 +16,10 @@ final class PlanOrderPrioritySequenceTest
     public function distinctPriorityClassesRetainTheCallerSequence(): void
     {
         $plan = new ExecutionPlan([
-            $this->entry('Acme\\AlphaTest'),
-            $this->entry('Acme\\BetaTest'),
-            $this->entry('Acme\\GammaTest'),
-            $this->entry('Acme\\DeltaTest'),
+            PlanEntryFixture::create('Acme\\AlphaTest', 'probe'),
+            PlanEntryFixture::create('Acme\\BetaTest', 'probe'),
+            PlanEntryFixture::create('Acme\\GammaTest', 'probe'),
+            PlanEntryFixture::create('Acme\\DeltaTest', 'probe'),
         ], seed: 4242);
 
         $ordered = PlanOrder::schedule(
@@ -44,16 +42,5 @@ final class PlanOrderPrioritySequenceTest
         Expect::that($ordered->seed)
             ->because('priority ordering MUST preserve the plan seed')
             ->toBe(4242);
-    }
-
-    /**
-     * @param non-empty-string $class
-     */
-    private function entry(string $class): PlanEntry
-    {
-        return new PlanEntry(
-            new TestId($class, 'probe'),
-            new TestMetadata($class, 'probe'),
-        );
     }
 }

--- a/tests/Unit/Runner/PlanOrderStalePriorityTest.php
+++ b/tests/Unit/Runner/PlanOrderStalePriorityTest.php
@@ -6,12 +6,11 @@ namespace Greenlight\Tests\Unit\Runner;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Core\ErrorTrap;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\ExecutionPlan;
 use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\PlanOrder;
+use Greenlight\Tests\Support\PlanEntryFixture;
 
 final class PlanOrderStalePriorityTest
 {
@@ -19,8 +18,8 @@ final class PlanOrderStalePriorityTest
     public function aStalePriorityClassIsIgnored(): void
     {
         $plan = new ExecutionPlan([
-            $this->entry('Acme\\AlphaTest'),
-            $this->entry('Acme\\BetaTest'),
+            PlanEntryFixture::create('Acme\\AlphaTest', 'probe'),
+            PlanEntryFixture::create('Acme\\BetaTest', 'probe'),
         ], seed: 4242);
 
         $ordered = ErrorTrap::run(
@@ -41,16 +40,5 @@ final class PlanOrderStalePriorityTest
         Expect::that($warning)
             ->because('stale priority data MUST NOT cause a warning')
             ->toBeNull();
-    }
-
-    /**
-     * @param non-empty-string $class
-     */
-    private function entry(string $class): PlanEntry
-    {
-        return new PlanEntry(
-            new TestId($class, 'probe'),
-            new TestMetadata($class, 'probe'),
-        );
     }
 }

--- a/tests/Unit/Runner/PlanOrderTest.php
+++ b/tests/Unit/Runner/PlanOrderTest.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\PlanOrder;
+use Greenlight\Tests\Support\PlanEntryFixture;
 
 final class PlanOrderTest
 {
@@ -68,7 +66,7 @@ final class PlanOrderTest
         $entries = [];
 
         foreach ($classes as $class) {
-            $entries[] = new PlanEntry(new TestId($class, 'probe'), new TestMetadata($class, 'probe'));
+            $entries[] = PlanEntryFixture::create($class, 'probe');
         }
 
         return new ExecutionPlan($entries);

--- a/tests/Unit/Runner/PlanOrderZeroDurationTest.php
+++ b/tests/Unit/Runner/PlanOrderZeroDurationTest.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\PlanOrder;
+use Greenlight\Tests\Support\PlanEntryFixture;
 
 final readonly class PlanOrderZeroDurationTest
 {
@@ -18,8 +16,8 @@ final readonly class PlanOrderZeroDurationTest
     public function zeroDurationRemainsKnown(): void
     {
         $plan = new ExecutionPlan([
-            $this->entry('Acme\\UnknownTest'),
-            $this->entry('Acme\\InstantTest'),
+            PlanEntryFixture::create('Acme\\UnknownTest'),
+            PlanEntryFixture::create('Acme\\InstantTest'),
         ]);
 
         $ordered = PlanOrder::schedule($plan, [], [
@@ -32,16 +30,5 @@ final readonly class PlanOrderZeroDurationTest
                 'Acme\\InstantTest',
                 'Acme\\UnknownTest',
             ]);
-    }
-
-    /**
-     * @param non-empty-string $class
-     */
-    private function entry(string $class): PlanEntry
-    {
-        return new PlanEntry(
-            new TestId($class, 'runs'),
-            new TestMetadata($class, 'runs'),
-        );
     }
 }

--- a/tests/Unit/Runner/PlanShardSeedTest.php
+++ b/tests/Unit/Runner/PlanShardSeedTest.php
@@ -5,12 +5,10 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner;
 
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\PlanShard;
+use Greenlight\Tests\Support\PlanEntryFixture;
 
 final class PlanShardSeedTest
 {
@@ -18,10 +16,7 @@ final class PlanShardSeedTest
     public function selectingAShardPreservesThePlanSeed(): void
     {
         $plan = new ExecutionPlan([
-            new PlanEntry(
-                new TestId('Acme\\PaymentTest', 'charges'),
-                new TestMetadata('Acme\\PaymentTest', 'charges'),
-            ),
+            PlanEntryFixture::create('Acme\\PaymentTest', 'charges'),
         ], seed: 86420);
 
         Expect::that(PlanShard::select($plan, index: 1, count: 2)->seed)

--- a/tests/Unit/Runner/PlanShardTest.php
+++ b/tests/Unit/Runner/PlanShardTest.php
@@ -7,12 +7,11 @@ namespace Greenlight\Tests\Unit\Runner;
 use Greenlight\Attribute\DataRow;
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
-use Greenlight\Core\Test\TestId;
-use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\ExecutionPlan;
 use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\PlanShard;
+use Greenlight\Tests\Support\PlanEntryFixture;
 
 final class PlanShardTest
 {
@@ -126,7 +125,7 @@ final class PlanShardTest
             $class = \sprintf('Acme\Gen%03dTest', $i);
 
             foreach (['one', 'two'] as $method) {
-                $entries[] = new PlanEntry(new TestId($class, $method), new TestMetadata($class, $method));
+                $entries[] = PlanEntryFixture::create($class, $method);
             }
         }
 

--- a/tests/Unit/Runner/Worker/RetryDeciderAttachmentTest.php
+++ b/tests/Unit/Runner/Worker/RetryDeciderAttachmentTest.php
@@ -7,10 +7,8 @@ namespace Greenlight\Tests\Unit\Runner\Worker;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Result\TestResult;
-use Greenlight\Core\Test\TestId;
 use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Doubles\Fake;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -21,6 +19,7 @@ use Greenlight\Runner\Artifact\ArtifactStore;
 use Greenlight\Runner\Worker\Worker;
 use Greenlight\Tests\Fixture\Runner\Worker\RetryAttachmentTest;
 use Greenlight\Tests\Support\CollectingEventSink;
+use Greenlight\Tests\Support\PlanEntryFixture;
 
 final readonly class RetryDeciderAttachmentTest
 {
@@ -46,9 +45,8 @@ final readonly class RetryDeciderAttachmentTest
                 return false;
             }
         };
-        $id = new TestId(RetryAttachmentTest::class, 'failsWithEvidence');
         $plan = new ExecutionPlan([
-            new PlanEntry($id, new TestMetadata($id->class, $id->method)),
+            PlanEntryFixture::create(RetryAttachmentTest::class, 'failsWithEvidence'),
         ]);
         $sink = new CollectingEventSink();
 

--- a/tests/Unit/Support/PlanEntryFixtureTest.php
+++ b/tests/Unit/Support/PlanEntryFixtureTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Support;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\PlanEntryFixture;
+
+final readonly class PlanEntryFixtureTest
+{
+    #[Test]
+    public function createsADefaultRunnableEntry(): void
+    {
+        $entry = PlanEntryFixture::create('Acme\\ExampleTest');
+
+        Expect::that((string) $entry->id)
+            ->because('the fixture default MUST create a runnable method identifier')
+            ->toBe('Acme\\ExampleTest::runs');
+        Expect::that([$entry->metadata->class, $entry->metadata->method])
+            ->toBe(['Acme\\ExampleTest', 'runs']);
+        Expect::that($entry->metadata->resources)
+            ->toBe([]);
+        Expect::that($entry->metadata->isolated)
+            ->toBeFalse();
+    }
+
+    #[Test]
+    public function createsConsistentEntriesWithSchedulingOptions(): void
+    {
+        $entry = PlanEntryFixture::create(
+            'Acme\\ExampleTest',
+            'checksValue',
+            'invalid value',
+            resources: ['database', 'cache', 'database'],
+            isolated: true,
+        );
+
+        Expect::that((string) $entry->id)
+            ->because('the fixture MUST retain the complete test identifier')
+            ->toBe('Acme\\ExampleTest::checksValue[invalid value]');
+        Expect::that([$entry->metadata->class, $entry->metadata->method])
+            ->because('the fixture MUST keep identifier and metadata fields equal')
+            ->toBe([$entry->id->class, $entry->id->method]);
+        Expect::that($entry->metadata->resources)
+            ->toBe(['database', 'cache']);
+        Expect::that($entry->metadata->isolated)
+            ->toBeTrue();
+    }
+}


### PR DESCRIPTION
Add one plan-entry fixture that keeps test IDs and metadata identity fields aligned while supporting data-set, resource, and isolation variants. Replace repeated local builders and direct default constructions across planning and scheduling tests.