### PR TITLE
fix(config): contain file-open diagnostics

### DIFF
--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -35,7 +35,7 @@ final class ConfigLoader
         }
 
         try {
-            $returned = (static fn(): mixed => require $file)();
+            $returned = ErrorTrap::run(static fn(): mixed => require $file);
         } catch (\Throwable $cause) {
             throw ConfigFileError::threw($file, $cause);
         }

--- a/tests/Unit/Config/ConfigLoaderOpenFailureTest.php
+++ b/tests/Unit/Config/ConfigLoaderOpenFailureTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Config;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ConfigFileError;
+use Greenlight\Config\ConfigLoader;
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Core\ErrorTrap;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\StreamWrapperSandbox;
+use Greenlight\Tests\Fixture\Filesystem\StatableFileStream;
+
+final readonly class ConfigLoaderOpenFailureTest
+{
+    private const string SCHEME = 'greenlight-config-open-failure';
+
+    public function __construct(private StreamWrapperSandbox $streamWrappers) {}
+
+    #[Test]
+    public function openFailureIsWrappedWithoutEngineDiagnostics(): void
+    {
+        $this->streamWrappers->register(self::SCHEME, StatableFileStream::class);
+        $file = self::SCHEME . '://greenlight.php';
+
+        Expect::that(
+            static function () use ($file, &$warning): void {
+                ErrorTrap::run(
+                    static fn(): GreenlightConfig => new ConfigLoader()->loadFile($file),
+                    $warning,
+                );
+            },
+        )
+            ->because('a configuration open failure MUST become only a configuration error')
+            ->toThrow(
+                static function (ConfigFileError $error) use ($file): void {
+                    Expect::that($error->getMessage())
+                        ->toContain(\sprintf('Configuration file "%s" threw Error:', $file));
+                    Expect::that($error->getPrevious())
+                        ->toBeInstanceOf(\Error::class);
+                },
+            );
+        Expect::that($warning)
+            ->because('a configuration open failure MUST not leak an engine diagnostic')
+            ->toBeNull();
+    }
+}


### PR DESCRIPTION
Trap diagnostics from the configuration require operation so a file that becomes unreadable after the existence check yields only ConfigFileError. Add a deterministic stream-wrapper regression that proves the original Error remains the cause and the engine warning does not escape.