### PR TITLE
fix(cli): fall back when exec is unavailable

### DIFF
--- a/src/Cli/TerminalRowsResolver.php
+++ b/src/Cli/TerminalRowsResolver.php
@@ -25,7 +25,9 @@ final class TerminalRowsResolver
             return $lines;
         }
 
-        $probed = ErrorTrap::run(static fn(): string|false => \exec('tput lines 2>/dev/null'));
+        $probed = \function_exists('exec')
+            ? ErrorTrap::run(static fn(): string|false => \exec('tput lines 2>/dev/null'))
+            : false;
 
         return self::positiveRows($probed) ?? 24;
     }

--- a/tests/Unit/Cli/TerminalRowsResolverUnavailableExecTest.php
+++ b/tests/Unit/Cli/TerminalRowsResolverUnavailableExecTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\Subprocess;
+
+final readonly class TerminalRowsResolverUnavailableExecTest
+{
+    #[Test]
+    public function unavailableExecUsesDefaultRows(): void
+    {
+        $root = \dirname(__DIR__, 3);
+        $result = Subprocess::run(
+            $root,
+            [
+                \PHP_BINARY,
+                '-n',
+                '-d',
+                'disable_functions=exec',
+                '-r',
+                <<<'PHP'
+                require $argv[1];
+
+                fwrite(STDOUT, (string) Greenlight\Cli\TerminalRowsResolver::resolve());
+                PHP,
+                $root . '/vendor/autoload.php',
+            ],
+            ['LINES' => ''],
+        );
+
+        Expect::that($result->exitCode)
+            ->because('an unavailable terminal probe MUST not fail row resolution')
+            ->toBe(0);
+        Expect::that($result->stdout)
+            ->because('an unavailable terminal probe MUST use the default row count')
+            ->toBe('24');
+        Expect::that($result->stderr)
+            ->toBe('');
+    }
+}


### PR DESCRIPTION
Guard the optional tput probe when hosting disables exec so terminal-row resolution uses its documented 24-row fallback instead of raising Error. Add a real PHP subprocess regression with disable_functions=exec that asserts the clean fallback result.