### PR TITLE
fix(core): match Unicode plain patterns consistently

### DIFF
--- a/src/Core/Wildcard.php
+++ b/src/Core/Wildcard.php
@@ -22,7 +22,7 @@ final class Wildcard
     {
         if (!\str_contains($pattern, '*') && !\str_contains($pattern, '?')) {
             return $caseInsensitive
-                ? \stripos($subject, $pattern) !== false
+                ? \preg_match('/' . \preg_quote($pattern, '/') . '/isu', $subject) === 1
                 : \str_contains($subject, $pattern);
         }
 

--- a/tests/Unit/Core/WildcardTest.php
+++ b/tests/Unit/Core/WildcardTest.php
@@ -57,6 +57,13 @@ final class WildcardTest
             true,
         ];
 
+        yield 'plain pattern can ignore Unicode case' => [
+            'Acme\ÄpfelTest::works',
+            'äpfel',
+            true,
+            true,
+        ];
+
         yield 'plain case-insensitive pattern matches at the subject start' => [
             'InvoiceTotalsTest',
             'invoice',
@@ -172,6 +179,13 @@ final class WildcardTest
         yield 'wildcard pattern can ignore case' => [
             'Acme\BravoTest::alpha',
             '*BRAVOTEST::ALPHA',
+            true,
+            true,
+        ];
+
+        yield 'wildcard pattern can ignore Unicode case' => [
+            'Acme\ÄpfelTest::works',
+            '*äpfel*',
             true,
             true,
         ];


### PR DESCRIPTION
Use Unicode-aware case folding for plain case-insensitive patterns, matching the existing wildcard behavior. This keeps filter and retry-policy results consistent when IDs or messages contain non-ASCII letters, with regression cases for both pattern forms.