### PR TITLE
fix(test): normalize zero cursor-up distance

### DIFF
--- a/tests/Support/TerminalEmulator.php
+++ b/tests/Support/TerminalEmulator.php
@@ -116,7 +116,7 @@ final class TerminalEmulator
 
     private function cursorUp(int $rows): void
     {
-        $this->cursorRow = \max(0, $this->cursorRow - $rows);
+        $this->cursorRow = \max(0, $this->cursorRow - \max(1, $rows));
     }
 
     private function clearLine(): void

--- a/tests/Unit/Reporting/TerminalEmulatorTest.php
+++ b/tests/Unit/Reporting/TerminalEmulatorTest.php
@@ -38,6 +38,17 @@ final class TerminalEmulatorTest
     }
 
     #[Test]
+    public function zeroCursorUpDistanceUsesTheDefaultOneRow(): void
+    {
+        $terminal = new TerminalEmulator();
+        $terminal->write("top\nbottom\x1b[0A\rreplaced");
+
+        Expect::that($terminal->visibleLines())
+            ->because('a zero cursor-up distance MUST have the same effect as the default distance')
+            ->toBe(['replaced', 'bottom']);
+    }
+
+    #[Test]
     public function clearLineErasesOnlyTheCurrentRow(): void
     {
         $terminal = new TerminalEmulator();


### PR DESCRIPTION
Normalize a zero CSI cursor-up parameter to the default one-row distance in the terminal emulator. This keeps the TTY test oracle faithful to terminal control semantics and adds a focused regression for the previously incorrect rewrite position.