### PR TITLE
fix(expect): reject invalid within tolerances

### DIFF
--- a/docs/api-expectations.md
+++ b/docs/api-expectations.md
@@ -623,7 +623,8 @@ PHPDoc:
 ### `toBeWithin()`
 
 Passes when the absolute difference between the numeric subject and
-`$of` is not more than `$delta`.
+`$of` is not more than `$delta`. The tolerance MUST be finite and zero
+or more.
 
 ```php
 public function toBeWithin(float $delta, float $of): self
@@ -634,7 +635,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L639)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L640)
 
 ### `toMatch()`
 
@@ -648,7 +649,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L662)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L667)
 
 ### `toStartWith()`
 
@@ -661,7 +662,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L678)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L683)
 
 ### `toEndWith()`
 
@@ -674,7 +675,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L692)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L697)
 
 ### `toBeJson()`
 
@@ -690,7 +691,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L709)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L714)
 
 ### `toMatchJson()`
 
@@ -708,7 +709,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L728)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L733)
 
 ### `toThrow()`
 
@@ -747,7 +748,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L787)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L792)
 
 ## `ExpectationExtension`
 

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -123,7 +123,8 @@ Numeric matchers accept integer or float subjects:
 * `toBeWithin(float $delta, float $of)`
 
 `toBeWithin()` passes when the absolute difference between the subject and
-`$of` is no greater than `$delta`.
+`$of` is no greater than `$delta`. The tolerance MUST be finite and zero or
+more.
 
 ### JSON
 

--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -630,7 +630,8 @@ final class Expectation
 
     /**
      * Passes when the absolute difference between the numeric subject and
-     * `$of` is not more than `$delta`.
+     * `$of` is not more than `$delta`. The tolerance MUST be finite and zero
+     * or more.
      *
      * @return self<T>
      *
@@ -639,6 +640,10 @@ final class Expectation
     public function toBeWithin(float $delta, float $of): self
     {
         $subject = $this->numericSubject('toBeWithin');
+
+        if (!\is_finite($delta) || $delta < 0.0) {
+            $this->usageFailure('toBeWithin() requires a finite tolerance of zero or more.');
+        }
 
         $bounds = \sprintf(
             'within %s of %s',

--- a/tests/Unit/Expect/NumericMatchersTest.php
+++ b/tests/Unit/Expect/NumericMatchersTest.php
@@ -207,6 +207,19 @@ final class NumericMatchersTest
             ->toBe('toBeWithin() requires an int or float subject. The subject type is string.');
     }
 
+    #[Test]
+    #[DataSet('invalidTolerances')]
+    public function toBeWithinRejectsAnInvalidTolerance(float $tolerance): void
+    {
+        $detail = FailureProbe::detailOf(
+            static fn() => Expect::that(1.0)->toBeWithin($tolerance, 1.0),
+        );
+
+        Expect::that($detail->message)
+            ->because('toBeWithin() MUST reject a tolerance that cannot define a numeric range')
+            ->toBe('toBeWithin() requires a finite tolerance of zero or more.');
+    }
+
     /**
      * @return iterable<string, array{float}>
      */
@@ -214,5 +227,16 @@ final class NumericMatchersTest
     {
         yield 'lower boundary' => [0.9];
         yield 'upper boundary' => [1.1];
+    }
+
+    /**
+     * @return iterable<string, array{float}>
+     */
+    public static function invalidTolerances(): iterable
+    {
+        yield 'negative' => [-0.1];
+        yield 'positive infinity' => [\INF];
+        yield 'negative infinity' => [-\INF];
+        yield 'not a number' => [\NAN];
     }
 }


### PR DESCRIPTION
Reject negative and non-finite `toBeWithin()` tolerances through the matcher usage-failure path.

Document the finite, non-negative tolerance contract and cover negative, infinite, and NaN inputs.