### PR TITLE
fix(expect): escape rendered control characters

### DIFF
--- a/src/Expect/ValueRenderer.php
+++ b/src/Expect/ValueRenderer.php
@@ -99,14 +99,7 @@ final class ValueRenderer
             }
 
             $character = $matches[0];
-            $escaped = \strtr($character, [
-                '\\' => '\\\\',
-                "'" => "\\'",
-                "\n" => '\n',
-                "\r" => '\r',
-                "\t" => '\t',
-                "\0" => '\0',
-            ]);
+            $escaped = $this->escapeCharacter($character);
             $escapedCharacters = $this->codePointLength($escaped);
 
             if ($printableCharacters + $escapedCharacters > self::MAX_STRING_CHARS) {
@@ -134,6 +127,28 @@ final class ValueRenderer
         $length = \preg_match_all('/./us', $value);
 
         return $length === false ? \strlen($value) : $length;
+    }
+
+    private function escapeCharacter(string $character): string
+    {
+        $escaped = \strtr($character, [
+            '\\' => '\\\\',
+            "'" => "\\'",
+            "\n" => '\n',
+            "\r" => '\r',
+            "\t" => '\t',
+            "\0" => '\0',
+        ]);
+
+        if ($escaped !== $character || \preg_match('/^\p{Cc}$/u', $character) !== 1) {
+            return $escaped;
+        }
+
+        $codePoint = \strlen($character) === 1
+            ? \ord($character)
+            : ((\ord($character[0]) & 0x1f) << 6) | (\ord($character[1]) & 0x3f);
+
+        return \sprintf('\\u{%04X}', $codePoint);
     }
 
     /**

--- a/tests/Unit/Expect/ValueRendererTest.php
+++ b/tests/Unit/Expect/ValueRendererTest.php
@@ -43,6 +43,16 @@ final class ValueRendererTest
     }
 
     #[Test]
+    public function escapesRemainingUnicodeControlCharactersInStrings(): void
+    {
+        $rendered = new ValueRenderer()->render("\u{0001}\u{001B}\u{007F}\u{0085}");
+
+        Expect::that($rendered)
+            ->because('diagnostic strings MUST NOT preserve terminal or line control characters')
+            ->toBe("'\\u{0001}\\u{001B}\\u{007F}\\u{0085}'");
+    }
+
+    #[Test]
     public function escapesTheStringDelimiter(): void
     {
         Expect::that(new ValueRenderer()->render("can't"))


### PR DESCRIPTION
Escape every Unicode control character that does not already have a short diagnostic escape.

This keeps failure values single-line and prevents raw terminal, DEL, and C1 controls from reaching reporter output.