### PR TITLE
fix(cli): reject non-finite debounce periods

### DIFF
--- a/src/Cli/Watch/Debouncer.php
+++ b/src/Cli/Watch/Debouncer.php
@@ -19,7 +19,7 @@ final class Debouncer
 
     public function __construct(private readonly float $quietSeconds)
     {
-        if ($quietSeconds < 0.0) {
+        if (!\is_finite($quietSeconds) || $quietSeconds < 0.0) {
             throw new \InvalidArgumentException('Set the quiet period to zero seconds or more.');
         }
     }

--- a/tests/Unit/Cli/Watch/DebouncerValidationTest.php
+++ b/tests/Unit/Cli/Watch/DebouncerValidationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli\Watch;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\Watch\Debouncer;
+use Greenlight\Expect\Expect;
+
+final readonly class DebouncerValidationTest
+{
+    #[Test]
+    #[DataSet('nonFiniteQuietPeriods')]
+    public function rejectsANonFiniteQuietPeriod(float $quietSeconds): void
+    {
+        Expect::that(static fn(): Debouncer => new Debouncer($quietSeconds))
+            ->because('a non-finite quiet period MUST NOT disable future watch runs')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Set the quiet period to zero seconds or more.',
+            );
+    }
+
+    /**
+     * @return iterable<string, array{float}>
+     */
+    public static function nonFiniteQuietPeriods(): iterable
+    {
+        yield 'not a number' => [\NAN];
+        yield 'positive infinity' => [\INF];
+        yield 'negative infinity' => [-\INF];
+    }
+}


### PR DESCRIPTION
Reject NaN and infinite watch quiet periods before they can make the debouncer permanently unable to fire.

Cover every non-finite float while preserving zero as a valid immediate quiet period.