### PR TITLE
fix(expect): correct eventual duration guidance

### DIFF
--- a/src/Expect/PendingEventually.php
+++ b/src/Expect/PendingEventually.php
@@ -37,7 +37,7 @@ final class PendingEventually
      */
     public function pollEvery(float $seconds): self
     {
-        $this->requireDuration($seconds, 'Polling interval', minimum: 0.001);
+        $this->requireDuration($seconds, 'Polling interval', minimum: 0.001, inclusive: true);
         $this->intervalSeconds = $seconds;
 
         return $this;
@@ -79,13 +79,21 @@ final class PendingEventually
         );
     }
 
-    private function requireDuration(float $seconds, string $label, float $minimum = 0.0): void
-    {
-        if (!\is_finite($seconds) || $seconds <= 0.0 || $seconds < $minimum) {
+    private function requireDuration(
+        float $seconds,
+        string $label,
+        float $minimum = 0.0,
+        bool $inclusive = false,
+    ): void {
+        if (!\is_finite($seconds) || ($inclusive ? $seconds < $minimum : $seconds <= $minimum)) {
+            $constraint = $inclusive
+                ? \sprintf('of at least %.3f seconds', $minimum)
+                : \sprintf('greater than %.3f seconds', $minimum);
+
             throw new \InvalidArgumentException(\sprintf(
-                'Set %s to a finite value of at least %.3f seconds.',
+                'Set %s to a finite value %s.',
                 $label,
-                $minimum,
+                $constraint,
             ));
         }
     }

--- a/tests/Unit/Expect/TemporalExpectationTest.php
+++ b/tests/Unit/Expect/TemporalExpectationTest.php
@@ -438,7 +438,7 @@ final class TemporalExpectationTest
         Expect::that(static fn() => Expect::eventually(static fn(): int => 1)->within(0.0))->because('polling durations and exception types are validated') // @phpstan-ignore greenlight.expectationArgument.duration (deliberately invalid: tests runtime validation)
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Set Eventually duration to a finite value of at least 0.000 seconds.',
+                message: 'Set Eventually duration to a finite value greater than 0.000 seconds.',
             );
         Expect::that(static fn() => Expect::eventually(static fn(): int => 1)->pollEvery(0.0009))->because('polling durations and exception types are validated') // @phpstan-ignore greenlight.expectationArgument.duration (deliberately invalid: tests runtime validation)
             ->toThrow(


### PR DESCRIPTION
Describe the strict `eventually()->within()` boundary accurately when zero is rejected.

Make strict and inclusive temporal boundaries explicit so runtime validation and its guidance cannot diverge, while preserving the inclusive polling minimum.