### PR TITLE
fix(test): reject non-finite subprocess timeouts

### DIFF
--- a/tests/Support/Subprocess.php
+++ b/tests/Support/Subprocess.php
@@ -143,10 +143,12 @@ final class Subprocess
     }
 
     /**
+     * @throws \InvalidArgumentException when the timeout is not finite
      * @throws \RuntimeException when the expected output is not seen before the deadline
      */
     public function readStdoutUntil(string $needle, float $timeoutSeconds): string
     {
+        $deadline = $this->deadline($timeoutSeconds);
         $offset = \strlen($this->stdout);
 
         if ($this->finished) {
@@ -157,8 +159,6 @@ final class Subprocess
                 $this->stderr,
             ));
         }
-
-        $deadline = $this->monotonicTime() + $timeoutSeconds;
 
         while ($this->monotonicTime() < $deadline) {
             $this->pump();
@@ -215,11 +215,12 @@ final class Subprocess
     }
 
     /**
+     * @throws \InvalidArgumentException when the timeout is not finite
      * @throws \RuntimeException when the process does not exit before the deadline
      */
     public function wait(float $timeoutSeconds): ProcessResult
     {
-        $deadline = $this->monotonicTime() + $timeoutSeconds;
+        $deadline = $this->deadline($timeoutSeconds);
 
         try {
             while ($this->monotonicTime() < $deadline) {
@@ -363,6 +364,15 @@ final class Subprocess
     private function normalize(string $output): string
     {
         return \rtrim(\str_replace("\r\n", "\n", $output), "\n");
+    }
+
+    private function deadline(float $timeoutSeconds): float
+    {
+        if (!\is_finite($timeoutSeconds)) {
+            throw new \InvalidArgumentException('Subprocess timeout must be finite.');
+        }
+
+        return $this->monotonicTime() + $timeoutSeconds;
     }
 
     private function monotonicTime(): float

--- a/tests/Unit/Support/SubprocessTest.php
+++ b/tests/Unit/Support/SubprocessTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Support;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Test\SkipTest;
 use Greenlight\Expect\Expect;
@@ -162,6 +163,47 @@ final readonly class SubprocessTest
                 ->toThrow(\RuntimeException::class, '/Timed out after 0.1s/');
         } finally {
             $process->terminate();
+        }
+    }
+
+    #[Test]
+    #[DataSet('nonFiniteTimeouts')]
+    public function deadlineOperationsRejectNonFiniteTimeouts(string $operation, float $timeoutSeconds): void
+    {
+        $process = Subprocess::start(
+            $this->workspace->path(),
+            [
+                \PHP_BINARY,
+                '-r',
+                $operation === 'wait' ? 'exit(0);' : 'fwrite(STDOUT, "ready");',
+            ],
+        );
+
+        try {
+            $call = $operation === 'wait'
+                ? static fn(): ProcessResult => $process->wait($timeoutSeconds)
+                : static fn(): string => $process->readStdoutUntil('ready', $timeoutSeconds);
+
+            Expect::that($call)
+                ->because('a non-finite timeout MUST NOT create an unbounded subprocess wait')
+                ->toThrow(
+                    \InvalidArgumentException::class,
+                    message: 'Subprocess timeout must be finite.',
+                );
+        } finally {
+            $process->terminate();
+        }
+    }
+
+    /**
+     * @return iterable<string, array{string, float}>
+     */
+    public static function nonFiniteTimeouts(): iterable
+    {
+        foreach (['read stdout', 'wait'] as $operation) {
+            yield $operation . ', not a number' => [$operation, \NAN];
+            yield $operation . ', positive infinity' => [$operation, \INF];
+            yield $operation . ', negative infinity' => [$operation, -\INF];
         }
     }
 


### PR DESCRIPTION
Reject NaN and infinite deadlines in the shared Subprocess test helper before polling starts.

Use one deadline constructor for wait and stdout reads, and cover both operations across every non-finite float. This prevents silent success, malformed timeout diagnostics, and unbounded test waits.