### PR TITLE
refactor(test): reuse source-only PHP command

### DIFF
--- a/tests/Support/SourceOnlyPhp.php
+++ b/tests/Support/SourceOnlyPhp.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Support;
+
+/**
+ * Builds PHP commands that load Greenlight directly from its source tree.
+ */
+final readonly class SourceOnlyPhp
+{
+    private const string AUTOLOAD = <<<'PHP'
+        $source = %s;
+
+        spl_autoload_register(static function (string $class) use ($source): void {
+            $prefix = 'Greenlight\\';
+
+            if (!str_starts_with($class, $prefix)) {
+                return;
+            }
+
+            $path = $source . '/' . str_replace('\\', '/', substr($class, strlen($prefix))) . '.php';
+
+            if (is_file($path)) {
+                require $path;
+            }
+        });
+        PHP;
+
+    private function __construct() {}
+
+    /**
+     * @param non-empty-string $sourceDirectory
+     * @param non-empty-string $program
+     * @param list<string> $phpOptions
+     * @param list<string> $arguments
+     *
+     * @return non-empty-list<string>
+     */
+    public static function command(
+        string $sourceDirectory,
+        string $program,
+        array $phpOptions = [],
+        array $arguments = [],
+    ): array {
+        return [
+            \PHP_BINARY,
+            '-n',
+            ...$phpOptions,
+            '-r',
+            \sprintf(self::AUTOLOAD, \var_export($sourceDirectory, true)) . "\n" . $program,
+            ...$arguments,
+        ];
+    }
+}

--- a/tests/Unit/Laravel/LaravelFrameworkUnavailableTest.php
+++ b/tests/Unit/Laravel/LaravelFrameworkUnavailableTest.php
@@ -6,6 +6,7 @@ namespace Greenlight\Tests\Unit\Laravel;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\SourceOnlyPhp;
 use Greenlight\Tests\Support\Subprocess;
 
 final readonly class LaravelFrameworkUnavailableTest
@@ -15,27 +16,9 @@ final readonly class LaravelFrameworkUnavailableTest
     {
         $root = \dirname(__DIR__, 3);
 
-        $result = Subprocess::run($root, [
-            \PHP_BINARY,
-            '-n',
-            '-r',
+        $result = Subprocess::run($root, SourceOnlyPhp::command(
+            $root . '/src',
             <<<'PHP'
-            $source = $argv[1];
-
-            spl_autoload_register(static function (string $class) use ($source): void {
-                $prefix = 'Greenlight\\';
-
-                if (!str_starts_with($class, $prefix)) {
-                    return;
-                }
-
-                $path = $source . '/' . str_replace('\\', '/', substr($class, strlen($prefix))) . '.php';
-
-                if (is_file($path)) {
-                    require $path;
-                }
-            });
-
             if (class_exists(\Illuminate\Foundation\Application::class)) {
                 exit(2);
             }
@@ -49,8 +32,7 @@ final readonly class LaravelFrameworkUnavailableTest
 
             exit(3);
             PHP,
-            $root . '/src',
-        ]);
+        ));
 
         Expect::that($result->exitCode)
             ->because('the public framework probe MUST reject an installation without Laravel')

--- a/tests/Unit/Runner/CpuCoresTest.php
+++ b/tests/Unit/Runner/CpuCoresTest.php
@@ -18,6 +18,7 @@ use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Fixture\Runner\FakeCpuCoreCounter;
 use Greenlight\Tests\Fixture\Runner\FakeNumberOfCpuCoreNotFound;
 use Greenlight\Tests\Support\ProcessResult;
+use Greenlight\Tests\Support\SourceOnlyPhp;
 use Greenlight\Tests\Support\Subprocess;
 
 final readonly class CpuCoresTest
@@ -119,34 +120,15 @@ final readonly class CpuCoresTest
     {
         $root = \dirname(__DIR__, 3);
 
-        return Subprocess::run($root, [
-            \PHP_BINARY,
-            '-n',
-            '-r',
+        return Subprocess::run($root, SourceOnlyPhp::command(
+            $root . '/src',
             <<<'PHP'
-            $source = $argv[1];
-
-            spl_autoload_register(static function (string $class) use ($source): void {
-                $prefix = 'Greenlight\\';
-
-                if (!str_starts_with($class, $prefix)) {
-                    return;
-                }
-
-                $path = $source . '/' . str_replace('\\', '/', substr($class, strlen($prefix))) . '.php';
-
-                if (is_file($path)) {
-                    require $path;
-                }
-            });
-
             if (class_exists(\Fidry\CpuCoreCounter\CpuCoreCounter::class)) {
                 exit(2);
             }
 
             echo \Greenlight\Runner\CpuCores::count();
             PHP,
-            $root . '/src',
-        ], $environment);
+        ), $environment);
     }
 }

--- a/tests/Unit/Runner/SubprocessCoverageTest.php
+++ b/tests/Unit/Runner/SubprocessCoverageTest.php
@@ -19,6 +19,7 @@ use Greenlight\Tests\Fixture\Coverage\AvailableFakeDriver;
 use Greenlight\Tests\Fixture\Coverage\RecordingFakeDriver;
 use Greenlight\Tests\Fixture\Coverage\UnavailableFakeDriver;
 use Greenlight\Tests\Support\CoverageJson;
+use Greenlight\Tests\Support\SourceOnlyPhp;
 use Greenlight\Tests\Support\Subprocess;
 
 final readonly class SubprocessCoverageTest
@@ -60,30 +61,10 @@ final readonly class SubprocessCoverageTest
             ->toBe(7);
 
         $root = \dirname(__DIR__, 3);
-        $result = Subprocess::run($root, [
-            \PHP_BINARY,
-            '-n',
-            '-d',
-            'sys_temp_dir=' . $blocker,
-            '-r',
+        $result = Subprocess::run($root, SourceOnlyPhp::command(
+            $root . '/src',
             <<<'PHP'
-            $source = $argv[1];
-
-            spl_autoload_register(static function (string $class) use ($source): void {
-                $prefix = 'Greenlight\\';
-
-                if (!str_starts_with($class, $prefix)) {
-                    return;
-                }
-
-                $path = $source . '/' . str_replace('\\', '/', substr($class, strlen($prefix))) . '.php';
-
-                if (is_file($path)) {
-                    require $path;
-                }
-            });
-
-            $blocker = $argv[2];
+            $blocker = $argv[1];
             $message = '/^Failed to create shared coverage directory "'
                 . preg_quote($blocker, '/')
                 . '\/greenlight-coverage-[0-9a-f]{12}": mkdir\(\): Not a directory\.$/D';
@@ -97,9 +78,9 @@ final readonly class SubprocessCoverageTest
 
             fwrite(STDOUT, 'matched');
             PHP,
-            $root . '/src',
-            $blocker,
-        ]);
+            phpOptions: ['-d', 'sys_temp_dir=' . $blocker],
+            arguments: [$blocker],
+        ));
 
         Expect::that($result->exitCode)
             ->because('coverage setup MUST fail before it exports a nonexistent relay directory')

--- a/tests/Unit/Tempest/TempestFrameworkUnavailableTest.php
+++ b/tests/Unit/Tempest/TempestFrameworkUnavailableTest.php
@@ -6,6 +6,7 @@ namespace Greenlight\Tests\Unit\Tempest;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\SourceOnlyPhp;
 use Greenlight\Tests\Support\Subprocess;
 
 final readonly class TempestFrameworkUnavailableTest
@@ -15,27 +16,9 @@ final readonly class TempestFrameworkUnavailableTest
     {
         $root = \dirname(__DIR__, 3);
 
-        $result = Subprocess::run($root, [
-            \PHP_BINARY,
-            '-n',
-            '-r',
+        $result = Subprocess::run($root, SourceOnlyPhp::command(
+            $root . '/src',
             <<<'PHP'
-            $source = $argv[1];
-
-            spl_autoload_register(static function (string $class) use ($source): void {
-                $prefix = 'Greenlight\\';
-
-                if (!str_starts_with($class, $prefix)) {
-                    return;
-                }
-
-                $path = $source . '/' . str_replace('\\', '/', substr($class, strlen($prefix))) . '.php';
-
-                if (is_file($path)) {
-                    require $path;
-                }
-            });
-
             if (class_exists(\Tempest\Core\FrameworkKernel::class)) {
                 exit(2);
             }
@@ -49,8 +32,7 @@ final readonly class TempestFrameworkUnavailableTest
 
             exit(3);
             PHP,
-            $root . '/src',
-        ]);
+        ));
 
         Expect::that($result->exitCode)
             ->because('the public framework probe MUST reject an installation without Tempest')


### PR DESCRIPTION
Centralize the repeated `php -n` command and Greenlight source-tree autoloader behind one test-support interface.

Reuse it across Laravel and Tempest absence probes, CPU fallback coverage, and shared coverage setup while preserving PHP options, child arguments, and each behavioral oracle.