### PR TITLE
fix(artifact): validate quoted media parameters

### DIFF
--- a/src/Core/Artifact/AttachmentMediaType.php
+++ b/src/Core/Artifact/AttachmentMediaType.php
@@ -13,8 +13,10 @@ final readonly class AttachmentMediaType
 {
     private const string PARAMETER_TOKEN = '[a-zA-Z0-9!#$%&\'*+.^_|\x60\~-]+';
 
+    private const string QUOTED_PARAMETER_VALUE = '"(?:[\x20-\x21\x23-\x5B\x5D-\x7E\x80-\xFF]|\\\\[\x20-\x7E\x80-\xFF])*"';
+
     private const string PATTERN = '~^[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*/[a-zA-Z0-9][a-zA-Z0-9!#$&^_.+-]*(?:\s*;\s*'
-        . self::PARAMETER_TOKEN . '=(?:"[^"]*"|' . self::PARAMETER_TOKEN . '))*$~';
+        . self::PARAMETER_TOKEN . '=(?:' . self::QUOTED_PARAMETER_VALUE . '|' . self::PARAMETER_TOKEN . '))*$~';
 
     /** @codeCoverageIgnore */
     private function __construct() {}

--- a/tests/Unit/Core/AttachmentMediaTypeContractTest.php
+++ b/tests/Unit/Core/AttachmentMediaTypeContractTest.php
@@ -57,6 +57,7 @@ final class AttachmentMediaTypeContractTest
         yield 'separator in parameter name' => ['text/plain; name/path=value'];
         yield 'separator in unquoted value' => ['text/plain; name=left/right'];
         yield 'second equals in unquoted value' => ['text/plain; name=left=right'];
+        yield 'dangling escape in quoted value' => ['text/plain; note="left' . '\\' . '"'];
         yield 'null byte' => ["text/plain; note=\"before\0after\""];
         yield 'tab' => ["text/plain; note=\"before\tafter\""];
         yield 'line feed' => ["text/plain; note=\"before\nafter\""];

--- a/tests/Unit/Core/AttachmentValidMediaTypeTest.php
+++ b/tests/Unit/Core/AttachmentValidMediaTypeTest.php
@@ -42,5 +42,7 @@ final readonly class AttachmentValidMediaTypeTest
     {
         yield 'vendor type with a structured suffix' => ['application/vnd.api+json'];
         yield 'quoted parameter containing a semicolon' => ['text/plain; note="left;right"'];
+        yield 'quoted parameter containing an escaped quote' => ['text/plain; note="left\"right"'];
+        yield 'quoted parameter containing an escaped backslash' => ['text/plain; note="left\\\\right"'];
     }
 }


### PR DESCRIPTION
Accept quoted attachment media-type parameters that escape visible characters, including quotes and backslashes.

Reject quoted values whose final quote is consumed by a dangling escape, while preserving Greenlight’s control-byte restrictions.