### PR TITLE
refactor(test): reuse shared fixture paths

### DIFF
--- a/tests/Support/FixturePath.php
+++ b/tests/Support/FixturePath.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Support;
+
+/** Builds validated paths inside the shared test fixture directory. */
+final class FixturePath
+{
+    private function __construct() {}
+
+    /**
+     * @return non-empty-string
+     */
+    public static function get(string $relative): string
+    {
+        if ($relative === ''
+            || \str_starts_with($relative, '/')
+            || \str_contains($relative, '\\')
+            || \str_contains($relative, "\0")
+        ) {
+            throw self::invalid($relative);
+        }
+
+        foreach (\explode('/', $relative) as $segment) {
+            if (\in_array($segment, ['', '.', '..'], true)) {
+                throw self::invalid($relative);
+            }
+        }
+
+        return \dirname(__DIR__) . '/Fixture/' . $relative;
+    }
+
+    private static function invalid(string $relative): \InvalidArgumentException
+    {
+        return new \InvalidArgumentException(\sprintf(
+            'Fixture path "%s" must be a relative path of plain segments.',
+            $relative,
+        ));
+    }
+}

--- a/tests/Unit/Discovery/AttributeMergeTest.php
+++ b/tests/Unit/Discovery/AttributeMergeTest.php
@@ -18,6 +18,7 @@ use Greenlight\Tests\Fixture\DiscoveryAttributes\AlwaysTrue;
 use Greenlight\Tests\Fixture\DiscoveryAttributes\MergedTest;
 use Greenlight\Tests\Fixture\DiscoveryAttributes\PlainTest;
 use Greenlight\Tests\Fixture\DiscoveryGroupInvalid\EmptyGroupTest;
+use Greenlight\Tests\Support\FixturePath;
 
 final class AttributeMergeTest
 {
@@ -26,7 +27,7 @@ final class AttributeMergeTest
      */
     private function metadataByTest(): array
     {
-        $dir = \dirname(__DIR__, 2) . '/Fixture/DiscoveryAttributes';
+        $dir = FixturePath::get('DiscoveryAttributes');
         $map = [];
 
         foreach (new TestDiscoverer()->discover([$dir])->entries as $entry) {
@@ -85,7 +86,7 @@ final class AttributeMergeTest
     #[Test]
     public function skipUnlessArgumentsInheritFromTheClassAndAreOverriddenTogether(): void
     {
-        $dir = \dirname(__DIR__, 2) . '/Fixture/DiscoveryAttributeArguments';
+        $dir = FixturePath::get('DiscoveryAttributeArguments');
         $map = [];
 
         foreach (new TestDiscoverer()->discover([$dir])->entries as $entry) {
@@ -105,7 +106,7 @@ final class AttributeMergeTest
     #[Test]
     public function nonScalarSkipUnlessArgumentsAreRejectedAtDiscovery(): void
     {
-        $dir = \dirname(__DIR__, 2) . '/Fixture/DiscoveryAttributeArgumentsInvalid';
+        $dir = FixturePath::get('DiscoveryAttributeArgumentsInvalid');
 
         Expect::that(static fn(): ExecutionPlan => new TestDiscoverer()->discover([$dir]))
             ->toThrow(static function (DiscoveryError $error): void {
@@ -120,7 +121,7 @@ final class AttributeMergeTest
     #[Test]
     public function invalidResourceNamesAreRejectedAtDiscoveryWithTheirLocation(): void
     {
-        $dir = \dirname(__DIR__, 2) . '/Fixture/DiscoveryResourceInvalid';
+        $dir = FixturePath::get('DiscoveryResourceInvalid');
 
         Expect::that(static fn(): ExecutionPlan => new TestDiscoverer()->discover([$dir]))
             ->toThrow(static function (DiscoveryError $error): void {
@@ -135,7 +136,7 @@ final class AttributeMergeTest
     #[Test]
     public function anEmptyGroupNameIsReportedAsAnInvalidAttribute(): void
     {
-        $dir = \dirname(__DIR__, 2) . '/Fixture/DiscoveryGroupInvalid';
+        $dir = FixturePath::get('DiscoveryGroupInvalid');
 
         Expect::that(
             static fn(): ExecutionPlan => new TestDiscoverer()->discover([$dir]),

--- a/tests/Unit/Discovery/DataRowTest.php
+++ b/tests/Unit/Discovery/DataRowTest.php
@@ -16,6 +16,7 @@ use Greenlight\Tests\Fixture\DataRowsControlLabel\ControlLabelRowTest;
 use Greenlight\Tests\Fixture\DataRowsDuplicateInline\DuplicateInlineRowKeyTest;
 use Greenlight\Tests\Fixture\DataRowsInvalid\EmptyDataRowLabelTest;
 use Greenlight\Tests\Fixture\DataRowsZeroLabel\ZeroLabelRowTest;
+use Greenlight\Tests\Support\FixturePath;
 
 final class DataRowTest
 {
@@ -33,7 +34,7 @@ final class DataRowTest
     public function aZeroStringInlineLabelRemainsThePlanDataSetKey(): void
     {
         $plan = new TestDiscoverer()->discover(
-            [\dirname(__DIR__, 2) . '/Fixture/DataRowsZeroLabel'],
+            [FixturePath::get('DataRowsZeroLabel')],
             Filter::all(),
         );
         $ids = \array_map(static fn($entry): string => (string) $entry->id, $plan->entries);
@@ -124,7 +125,7 @@ final class DataRowTest
     public function discovererExpandsInlineRowsIntoThePlan(): void
     {
         $plan = new TestDiscoverer()->discover(
-            [\dirname(__DIR__, 2) . '/Fixture/DataRows'],
+            [FixturePath::get('DataRows')],
             new Filter(includeMethods: ['addsUp']),
         );
 

--- a/tests/Unit/Discovery/DataSetExpansionTest.php
+++ b/tests/Unit/Discovery/DataSetExpansionTest.php
@@ -15,17 +15,10 @@ use Greenlight\Tests\Fixture\Discovery\FakeMonotonicClock;
 use Greenlight\Tests\Fixture\DiscoveryDataSets\InvalidKeyProvider;
 use Greenlight\Tests\Fixture\DiscoveryDataSets\ProviderKeysTest;
 use Greenlight\Tests\Fixture\DiscoveryProviderDuplicate\DuplicateKeysTest;
+use Greenlight\Tests\Support\FixturePath;
 
 final class DataSetExpansionTest
 {
-    /**
-     * @return non-empty-string
-     */
-    private function fixtureDir(string $name): string
-    {
-        return \dirname(__DIR__, 2) . '/Fixture/' . $name;
-    }
-
     /**
      * @return list<string|null>
      */
@@ -47,7 +40,7 @@ final class DataSetExpansionTest
      */
     private function discoverFixture(string $fixture, float $budgetSeconds = 5.0): \Closure
     {
-        $directory = $this->fixtureDir($fixture);
+        $directory = FixturePath::get($fixture);
 
         return static fn(): ExecutionPlan => new TestDiscoverer($budgetSeconds)->discover([$directory]);
     }
@@ -55,7 +48,7 @@ final class DataSetExpansionTest
     #[Test]
     public function printableStringKeysAreUsedAsIs(): void
     {
-        $plan = new TestDiscoverer()->discover([$this->fixtureDir('DiscoveryDataSets')]);
+        $plan = new TestDiscoverer()->discover([FixturePath::get('DiscoveryDataSets')]);
 
         Expect::that($this->keysFor($plan, 'withStringKeys'))->because('printable string keys are used as is')->toBe(['first case', 'second case']);
     }
@@ -63,7 +56,7 @@ final class DataSetExpansionTest
     #[Test]
     public function integerKeysBecomeOrdinalStrings(): void
     {
-        $plan = new TestDiscoverer()->discover([$this->fixtureDir('DiscoveryDataSets')]);
+        $plan = new TestDiscoverer()->discover([FixturePath::get('DiscoveryDataSets')]);
 
         Expect::that($this->keysFor($plan, 'withIntegerKeys'))->because('integer keys become ordinal strings')->toBe(['#0', '#1', '#2']);
     }
@@ -71,7 +64,7 @@ final class DataSetExpansionTest
     #[Test]
     public function nonPrintableAndEmptyKeysBecomeStableHashPrefixes(): void
     {
-        $plan = new TestDiscoverer()->discover([$this->fixtureDir('DiscoveryDataSets')]);
+        $plan = new TestDiscoverer()->discover([FixturePath::get('DiscoveryDataSets')]);
 
         $expected = [
             \substr(\hash('sha256', "tab\tseparated"), 0, 8),
@@ -128,7 +121,7 @@ final class DataSetExpansionTest
     #[Test]
     public function expandedIdsRenderWithTheirKeys(): void
     {
-        $plan = new TestDiscoverer()->discover([$this->fixtureDir('DiscoveryDataSets')]);
+        $plan = new TestDiscoverer()->discover([FixturePath::get('DiscoveryDataSets')]);
         $rendered = \array_map(static fn(PlanEntry $entry): string => (string) $entry->id, $plan->entries);
 
         Expect::that($rendered)->because('expanded IDs render with their keys')->toContain(
@@ -261,7 +254,7 @@ final class DataSetExpansionTest
     #[Test]
     public function slowProviderPassesUnderAGenerousBudget(): void
     {
-        $plan = new TestDiscoverer(5.0)->discover([$this->fixtureDir('DiscoveryProviderSlow')]);
+        $plan = new TestDiscoverer(5.0)->discover([FixturePath::get('DiscoveryProviderSlow')]);
 
         Expect::that($plan->count())->because('slow provider passes under a generous budget')->toBe(3);
     }
@@ -281,7 +274,7 @@ final class DataSetExpansionTest
     {
         Expect::that(
             fn(): ExecutionPlan => new TestDiscoverer()->discover([
-                $this->fixtureDir('DiscoveryProviderDuplicate'),
+                FixturePath::get('DiscoveryProviderDuplicate'),
             ]),
         )
             ->because('a data-set provider MUST NOT yield the same key more than once')

--- a/tests/Unit/Discovery/FilterTest.php
+++ b/tests/Unit/Discovery/FilterTest.php
@@ -9,17 +9,10 @@ use Greenlight\Discovery\ExecutionPlan;
 use Greenlight\Discovery\Filter;
 use Greenlight\Discovery\TestDiscoverer;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\FixturePath;
 
 final class FilterTest
 {
-    /**
-     * @return non-empty-string
-     */
-    private function basicDir(): string
-    {
-        return \dirname(__DIR__, 2) . '/Fixture/DiscoveryBasic';
-    }
-
     /**
      * @return list<string>
      */
@@ -106,14 +99,14 @@ final class FilterTest
     #[Test]
     public function discovererAppliesGroupFilters(): void
     {
-        $plan = new TestDiscoverer()->discover([$this->basicDir()], new Filter(includeGroups: ['slow']));
+        $plan = new TestDiscoverer()->discover([FixturePath::get('DiscoveryBasic')], new Filter(includeGroups: ['slow']));
 
         Expect::that($this->ids($plan))->because('discoverer applies group filters')->toBe([
             'Greenlight\Tests\Fixture\DiscoveryBasic\AlphaTest::two',
             'Greenlight\Tests\Fixture\DiscoveryBasic\CharlieTest::crawls',
         ]);
 
-        $plan = new TestDiscoverer()->discover([$this->basicDir()], new Filter(excludeGroups: ['slow']));
+        $plan = new TestDiscoverer()->discover([FixturePath::get('DiscoveryBasic')], new Filter(excludeGroups: ['slow']));
 
         Expect::that($this->ids($plan))->because('discoverer applies group filters')->toBe([
             'Greenlight\Tests\Fixture\DiscoveryBasic\AlphaTest::one',
@@ -127,11 +120,11 @@ final class FilterTest
     #[Test]
     public function discovererAppliesClassAndMethodFilters(): void
     {
-        $plan = new TestDiscoverer()->discover([$this->basicDir()], new Filter(includeClasses: ['BravoTest']));
+        $plan = new TestDiscoverer()->discover([FixturePath::get('DiscoveryBasic')], new Filter(includeClasses: ['BravoTest']));
 
         Expect::that($plan->count())->because('discoverer applies class and method filters')->toBe(3);
 
-        $plan = new TestDiscoverer()->discover([$this->basicDir()], new Filter(includeMethods: ['alpha']));
+        $plan = new TestDiscoverer()->discover([FixturePath::get('DiscoveryBasic')], new Filter(includeMethods: ['alpha']));
 
         Expect::that($this->ids($plan))->because('discoverer applies class and method filters')->toBe(['Greenlight\Tests\Fixture\DiscoveryBasic\BravoTest::alpha']);
     }
@@ -200,7 +193,7 @@ final class FilterTest
     #[Test]
     public function discovererAppliesIdFilters(): void
     {
-        $plan = new TestDiscoverer()->discover([$this->basicDir()], new Filter(includeIds: ['bravotest::alpha']));
+        $plan = new TestDiscoverer()->discover([FixturePath::get('DiscoveryBasic')], new Filter(includeIds: ['bravotest::alpha']));
 
         Expect::that($this->ids($plan))->because('discoverer applies ID filters')->toBe(['Greenlight\Tests\Fixture\DiscoveryBasic\BravoTest::alpha']);
     }
@@ -208,11 +201,11 @@ final class FilterTest
     #[Test]
     public function discovererAppliesPathPrefixFilters(): void
     {
-        $real = \realpath($this->basicDir());
+        $real = \realpath(FixturePath::get('DiscoveryBasic'));
         Expect::that(\is_string($real))->because('discoverer applies path prefix filters')->toBeTrue();
         \assert(\is_string($real));
 
-        $plan = new TestDiscoverer()->discover([$this->basicDir()], new Filter(includePaths: [$real . '/Alpha']));
+        $plan = new TestDiscoverer()->discover([FixturePath::get('DiscoveryBasic')], new Filter(includePaths: [$real . '/Alpha']));
 
         Expect::that($this->ids($plan))->because('discoverer applies path prefix filters')->toBe([
             'Greenlight\Tests\Fixture\DiscoveryBasic\AlphaTest::one',

--- a/tests/Unit/Discovery/Psr4ViolationTest.php
+++ b/tests/Unit/Discovery/Psr4ViolationTest.php
@@ -13,6 +13,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Tests\Fixture\SomewhereElse\MismatchTest;
+use Greenlight\Tests\Support\FixturePath;
 
 final readonly class Psr4ViolationTest
 {
@@ -23,7 +24,7 @@ final readonly class Psr4ViolationTest
      */
     private function discoverFixture(string $fixture): \Closure
     {
-        $directory = \dirname(__DIR__, 2) . '/Fixture/' . $fixture;
+        $directory = FixturePath::get($fixture);
 
         return static fn(): ExecutionPlan => new TestDiscoverer()->discover([$directory]);
     }
@@ -65,7 +66,7 @@ final readonly class Psr4ViolationTest
     #[Test]
     public function unreadableClassFileProducesATypedErrorNamingTheFile(): void
     {
-        $missing = \dirname(__DIR__, 2) . '/Fixture/MissingTest.php';
+        $missing = FixturePath::get('MissingTest.php');
 
         Expect::that(static fn(): array => ClassFileParser::declarationsIn($missing))
             ->because('an unreadable class file produces a typed error naming the file')

--- a/tests/Unit/Discovery/TestDiscovererTest.php
+++ b/tests/Unit/Discovery/TestDiscovererTest.php
@@ -13,18 +13,11 @@ use Greenlight\Discovery\ExecutionPlan;
 use Greenlight\Discovery\TestDiscoverer;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Support\FilesystemRestriction;
+use Greenlight\Tests\Support\FixturePath;
 use Greenlight\Tests\Support\JsonWire;
 
 final class TestDiscovererTest
 {
-    /**
-     * @return non-empty-string
-     */
-    private function fixtureDir(string $name): string
-    {
-        return \dirname(__DIR__, 2) . '/Fixture/' . $name;
-    }
-
     /**
      * @return list<string>
      */
@@ -66,7 +59,7 @@ final class TestDiscovererTest
     #[Test]
     public function discoversBasicSuiteInFileOrderWithoutSeed(): void
     {
-        $plan = new TestDiscoverer()->discover([$this->fixtureDir('DiscoveryBasic')]);
+        $plan = new TestDiscoverer()->discover([FixturePath::get('DiscoveryBasic')]);
 
         Expect::that($this->ids($plan))->because('discovers basic suite in file order without seed')->toBe([
             'Greenlight\Tests\Fixture\DiscoveryBasic\AlphaTest::one',
@@ -85,7 +78,7 @@ final class TestDiscovererTest
     #[Test]
     public function abstractClassesAndClassesWithoutTestsAreSkipped(): void
     {
-        $plan = new TestDiscoverer()->discover([$this->fixtureDir('DiscoveryBasic')]);
+        $plan = new TestDiscoverer()->discover([FixturePath::get('DiscoveryBasic')]);
 
         foreach ($plan->classes() as $class) {
             Expect::that($class)
@@ -98,8 +91,8 @@ final class TestDiscovererTest
     public function sameSeedProducesByteIdenticalPlans(): void
     {
         $discoverer = new TestDiscoverer();
-        $first = $discoverer->discover([$this->fixtureDir('DiscoveryBasic')], null, 1234);
-        $second = $discoverer->discover([$this->fixtureDir('DiscoveryBasic')], null, 1234);
+        $first = $discoverer->discover([FixturePath::get('DiscoveryBasic')], null, 1234);
+        $second = $discoverer->discover([FixturePath::get('DiscoveryBasic')], null, 1234);
 
         Expect::that(\json_encode($second->toWire(), \JSON_THROW_ON_ERROR))->because('same seed produces byte identical plans')
             ->toBe(\json_encode($first->toWire(), \JSON_THROW_ON_ERROR));
@@ -113,7 +106,7 @@ final class TestDiscovererTest
         $orders = [];
 
         foreach ([1, 2, 3, 4, 5] as $seed) {
-            $orders[] = \implode(',', $discoverer->discover([$this->fixtureDir('DiscoveryBasic')], null, $seed)->classes());
+            $orders[] = \implode(',', $discoverer->discover([FixturePath::get('DiscoveryBasic')], null, $seed)->classes());
         }
 
         Expect::that(\count(\array_unique($orders)))->because('different seeds produce different class order')->toBeGreaterThan(1);
@@ -122,7 +115,7 @@ final class TestDiscovererTest
     #[Test]
     public function seededPlanKeepsMethodDeclarationOrderWithinClass(): void
     {
-        $plan = new TestDiscoverer()->discover([$this->fixtureDir('DiscoveryBasic')], null, 42);
+        $plan = new TestDiscoverer()->discover([FixturePath::get('DiscoveryBasic')], null, 42);
         $bravoMethods = [];
 
         foreach ($plan->entries as $entry) {
@@ -137,7 +130,7 @@ final class TestDiscovererTest
     #[Test]
     public function seededPlanSurvivesTheWire(): void
     {
-        $plan = new TestDiscoverer()->discover([$this->fixtureDir('DiscoveryBasic')], null, 99);
+        $plan = new TestDiscoverer()->discover([FixturePath::get('DiscoveryBasic')], null, 99);
         $restored = ExecutionPlan::fromWire(JsonWire::roundTrip($plan->toWire()));
 
         Expect::that(\json_encode($restored->toWire(), \JSON_THROW_ON_ERROR))->because('seeded plan survives the wire')
@@ -147,7 +140,7 @@ final class TestDiscovererTest
     #[Test]
     public function unknownDirectoryFailsLoudly(): void
     {
-        $directory = $this->fixtureDir('DoesNotExist');
+        $directory = FixturePath::get('DoesNotExist');
 
         Expect::that(
             static fn(): ExecutionPlan => new TestDiscoverer()->discover([$directory]),
@@ -185,7 +178,7 @@ final class TestDiscovererTest
     #[Test]
     public function overlappingDirectoriesDoNotDuplicateEntries(): void
     {
-        $dir = $this->fixtureDir('DiscoveryBasic');
+        $dir = FixturePath::get('DiscoveryBasic');
         $plan = new TestDiscoverer()->discover([$dir, $dir]);
 
         Expect::that($plan->count())->because('overlapping directories do not duplicate entries')->toBe(7);

--- a/tests/Unit/Support/FixturePathTest.php
+++ b/tests/Unit/Support/FixturePathTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Support;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\FixturePath;
+
+final readonly class FixturePathTest
+{
+    #[Test]
+    public function resolvesAFileInsideTheSharedFixtureDirectory(): void
+    {
+        Expect::that(FixturePath::get('DiscoveryBasic/AlphaTest.php'))
+            ->because('fixture paths MUST use the shared fixture directory')
+            ->toBe(\dirname(__DIR__, 2) . '/Fixture/DiscoveryBasic/AlphaTest.php');
+    }
+
+    #[Test]
+    #[DataSet('unsafePaths')]
+    public function rejectsPathsThatCanEscapeOrVaryByPlatform(string $relative): void
+    {
+        Expect::that(static fn(): string => FixturePath::get($relative))
+            ->because('fixture paths MUST stay inside the shared fixture directory')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: \sprintf(
+                    'Fixture path "%s" must be a relative path of plain segments.',
+                    $relative,
+                ),
+            );
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function unsafePaths(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'absolute' => ['/DiscoveryBasic'];
+        yield 'backslash' => ['DiscoveryBasic\\AlphaTest.php'];
+        yield 'null byte' => ["DiscoveryBasic\0AlphaTest.php"];
+        yield 'empty segment' => ['DiscoveryBasic//AlphaTest.php'];
+        yield 'current directory' => ['DiscoveryBasic/./AlphaTest.php'];
+        yield 'traversal' => ['DiscoveryBasic/../AlphaTest.php'];
+    }
+}


### PR DESCRIPTION
Centralize shared test-fixture path construction behind one validated test-support interface.

Reuse it across the discovery suites so repository layout and portable relative-path rules no longer live in individual tests.