### PR TITLE
refactor(test): reuse memory stream fixture

### DIFF
--- a/tests/Unit/Cli/ApplicationCoverageCleanupTest.php
+++ b/tests/Unit/Cli/ApplicationCoverageCleanupTest.php
@@ -7,12 +7,12 @@ namespace Greenlight\Tests\Unit\Cli;
 use Greenlight\Attribute\Test;
 use Greenlight\Cli\Application;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
 use Greenlight\Fixture\EnvironmentSandbox;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Reporting\ReportingError;
 use Greenlight\Runner\SubprocessCoverage;
 use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\MemoryStream;
 
 final readonly class ApplicationCoverageCleanupTest
 {
@@ -57,12 +57,8 @@ final readonly class ApplicationCoverageCleanupTest
             \var_export($fixtureDirectory, true),
             \var_export($fixtureDirectory, true),
         ));
-        $stdout = \fopen('php://memory', 'w');
-        $stderr = \fopen('php://memory', 'w');
-
-        if ($stdout === false || $stderr === false) {
-            Fail::because('Greenlight did not open the CLI test streams.');
-        }
+        $stdout = MemoryStream::open();
+        $stderr = MemoryStream::open();
 
         try {
             Expect::that(fn() => Application::forStreams($stdout, $stderr)->run(
@@ -72,8 +68,7 @@ final readonly class ApplicationCoverageCleanupTest
                 ->because('a run event failure MUST propagate after coverage cleanup')
                 ->toThrow(ReportingError::class);
         } finally {
-            \fclose($stdout);
-            \fclose($stderr);
+            MemoryStream::close($stdout, $stderr);
         }
 
         Expect::that(\getenv(SubprocessCoverage::DIRECTORY_ENV))

--- a/tests/Unit/Cli/ApplicationReporterStreamTest.php
+++ b/tests/Unit/Cli/ApplicationReporterStreamTest.php
@@ -7,10 +7,10 @@ namespace Greenlight\Tests\Unit\Cli;
 use Greenlight\Attribute\Test;
 use Greenlight\Cli\Application;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
 use Greenlight\Fixture\EnvironmentSandbox;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\MemoryStream;
 
 final readonly class ApplicationReporterStreamTest
 {
@@ -27,12 +27,8 @@ final readonly class ApplicationReporterStreamTest
             $this->tempDirectory,
             'application-reporter-stream',
         );
-        $stdout = \fopen('php://memory', 'w+');
-        $stderr = \fopen('php://memory', 'w+');
-
-        if ($stdout === false || $stderr === false) {
-            Fail::because('Greenlight did not open the CLI test streams.');
-        }
+        $stdout = MemoryStream::open();
+        $stderr = MemoryStream::open();
 
         try {
             $exit = Application::forStreams($stdout, $stderr)->run(
@@ -44,8 +40,7 @@ final readonly class ApplicationReporterStreamTest
             $output = \stream_get_contents($stdout);
             $errors = \stream_get_contents($stderr);
         } finally {
-            \fclose($stdout);
-            \fclose($stderr);
+            MemoryStream::close($stdout, $stderr);
         }
 
         Expect::that($exit)

--- a/tests/Unit/Cli/ApplicationWorkerBinPathTest.php
+++ b/tests/Unit/Cli/ApplicationWorkerBinPathTest.php
@@ -9,11 +9,11 @@ use Greenlight\Attribute\Test;
 use Greenlight\Cli\Application;
 use Greenlight\Core\ErrorTrap;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
 use Greenlight\Fixture\EnvironmentSandbox;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
 use Greenlight\Tests\Support\FilesystemRestriction;
+use Greenlight\Tests\Support\MemoryStream;
 
 final readonly class ApplicationWorkerBinPathTest
 {
@@ -31,12 +31,8 @@ final readonly class ApplicationWorkerBinPathTest
             $this->tempDirectory,
             'application-worker-bin-path',
         );
-        $stdout = \fopen('php://memory', 'w+');
-        $stderr = \fopen('php://memory', 'w+');
-
-        if ($stdout === false || $stderr === false) {
-            Fail::because('Greenlight did not open the CLI test streams.');
-        }
+        $stdout = MemoryStream::open();
+        $stderr = MemoryStream::open();
 
         $root = \dirname(__DIR__, 3);
         $restrictedBin = \dirname($root);
@@ -54,8 +50,7 @@ final readonly class ApplicationWorkerBinPathTest
             \rewind($stderr);
             $errors = \stream_get_contents($stderr);
         } finally {
-            \fclose($stdout);
-            \fclose($stderr);
+            MemoryStream::close($stdout, $stderr);
         }
 
         Expect::that($exit)

--- a/tests/Unit/Runner/Protocol/JsonFrameCodecTest.php
+++ b/tests/Unit/Runner/Protocol/JsonFrameCodecTest.php
@@ -10,6 +10,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Runner\Protocol\JsonFrameCodec;
 use Greenlight\Runner\Protocol\ProtocolError;
+use Greenlight\Tests\Support\MemoryStream;
 
 final class JsonFrameCodecTest
 {
@@ -51,11 +52,7 @@ final class JsonFrameCodecTest
     #[Test]
     public function unsupportedPayloadValuesProduceAProtocolError(): void
     {
-        $stream = \fopen('php://memory', 'r');
-
-        if ($stream === false) {
-            Fail::because('Expected PHP to open the in-memory stream.');
-        }
+        $stream = MemoryStream::open();
 
         try {
             Expect::that(static fn(): string => new JsonFrameCodec()->encode(['stream' => $stream]))
@@ -65,7 +62,7 @@ final class JsonFrameCodecTest
                     matching: '/Malformed frame: Greenlight cannot encode the payload as JSON:/',
                 );
         } finally {
-            \fclose($stream);
+            MemoryStream::close($stream);
         }
     }
 


### PR DESCRIPTION
Route ordinary in-memory CLI and protocol streams through the shared fail-fast MemoryStream fixture.

Remove repeated open-failure branches and centralize idempotent stream cleanup while preserving each suite's behavioral assertions.