### PR TITLE
refactor(test): reuse coverage JSON reader

### DIFF
--- a/tests/Acceptance/CoverageIgnoreRunTest.php
+++ b/tests/Acceptance/CoverageIgnoreRunTest.php
@@ -9,6 +9,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\CoverageJson;
 use Greenlight\Tests\Support\GreenlightCli;
 
 final readonly class CoverageIgnoreRunTest
@@ -29,28 +30,20 @@ final readonly class CoverageIgnoreRunTest
         Expect::that($result->exitCode)->because('ignored lines are excluded from totals and exports')->toBe(0);
         Expect::that($result->output())->toContain('Coverage: 100.00%');
 
-        $json = \file_get_contents($outDir . '/coverage.json');
-
-        if ($json === false) {
-            Fail::because(\sprintf(
-                'Expected a readable coverage JSON export at "%s".',
-                $outDir . '/coverage.json',
-            ));
-        }
-
-        /** @var array{files: array<string, array{covered: list<int>, uncovered: list<int>}>} $decoded */
-        $decoded = \json_decode($json, true, 512, \JSON_THROW_ON_ERROR);
         $gadget = null;
 
-        foreach ($decoded['files'] as $file => $lines) {
+        foreach (CoverageJson::read($outDir . '/coverage.json')->files() as $file => $coverage) {
             if (\str_ends_with($file, 'CoverageIgnoreLib/Gadget.php')) {
-                $gadget = $lines;
+                $gadget = $coverage;
             }
         }
 
-        Expect::that($gadget)->because('ignored lines are excluded from totals and exports')->not()->toBeNull();
-        Expect::that($gadget['uncovered'] ?? null)->toBe([]);
-        Expect::that($gadget['covered'] ?? [])->not()->toHaveCount(0);
+        if ($gadget === null) {
+            Fail::because('Expected the coverage export to contain CoverageIgnoreLib/Gadget.php.');
+        }
+
+        Expect::that($gadget->uncoveredLines)->toBe([]);
+        Expect::that($gadget->coveredLines)->not()->toHaveCount(0);
     }
 
     private function writeProject(): AcceptanceProject

--- a/tests/Acceptance/GeneratedCoveragePathTest.php
+++ b/tests/Acceptance/GeneratedCoveragePathTest.php
@@ -9,6 +9,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\CoverageJson;
 use Greenlight\Tests\Support\GreenlightCli;
 
 final readonly class GeneratedCoveragePathTest
@@ -35,27 +36,14 @@ final readonly class GeneratedCoveragePathTest
             ->because('coverage MUST collect source generated during the run')
             ->toBe(0);
 
-        $json = \file_get_contents($project->path('coverage.json'));
+        $generatedFile = CoverageJson::read($project->path('coverage.json'))
+            ->files()[$generatedDirectory . '/RuntimeSource.php'] ?? null;
 
-        if ($json === false) {
-            Fail::because('Expected a readable coverage JSON export.');
+        if ($generatedFile === null) {
+            Fail::because('Expected the coverage export to contain generated/RuntimeSource.php.');
         }
 
-        /** @var array{files: array<string, array{covered: list<int>}>} $decoded */
-        $decoded = \json_decode($json, true, 512, \JSON_THROW_ON_ERROR);
-        $generatedFile = null;
-
-        foreach ($decoded['files'] as $file => $lines) {
-            if ($file === $generatedDirectory . '/RuntimeSource.php') {
-                $generatedFile = $lines;
-            }
-        }
-
-        Expect::that($generatedFile)
-            ->because('the export MUST contain the generated source')
-            ->not()
-            ->toBeNull();
-        Expect::that($generatedFile['covered'] ?? [])
+        Expect::that($generatedFile->coveredLines)
             ->because('the generated source MUST contain covered lines')
             ->not()
             ->toHaveCount(0);

--- a/tests/Support/CoverageJson.php
+++ b/tests/Support/CoverageJson.php
@@ -13,6 +13,24 @@ final class CoverageJson
 {
     private function __construct() {}
 
+    public static function read(string $path): CoverageMap
+    {
+        $json = ErrorTrap::run(
+            static fn(): string|false => \file_get_contents($path),
+            $warning,
+        );
+
+        if (!\is_string($json)) {
+            Fail::because(\sprintf(
+                'Expected to read coverage JSON document "%s"%s.',
+                $path,
+                $warning === null ? '' : ': ' . $warning,
+            ));
+        }
+
+        return JsonExporter::import($json);
+    }
+
     public static function write(string $path, CoverageMap $map): void
     {
         $documents = new JsonExporter()->export($map);

--- a/tests/Unit/Support/CoverageJsonTest.php
+++ b/tests/Unit/Support/CoverageJsonTest.php
@@ -6,7 +6,6 @@ namespace Greenlight\Tests\Unit\Support;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Coverage\CoverageMap;
-use Greenlight\Coverage\Export\JsonExporter;
 use Greenlight\Coverage\FileCoverage;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\ExpectationFailed;
@@ -18,7 +17,7 @@ final readonly class CoverageJsonTest
     public function __construct(private TempDirectory $workspace) {}
 
     #[Test]
-    public function writeCreatesAnImportableCoverageFixture(): void
+    public function writeAndReadPreserveTheCoverageMap(): void
     {
         $path = $this->workspace->path() . '/coverage.json';
         $map = new CoverageMap([
@@ -27,9 +26,26 @@ final readonly class CoverageJsonTest
 
         CoverageJson::write($path, $map);
 
-        Expect::that(JsonExporter::import((string) \file_get_contents($path))->toWire())
-            ->because('the shared fixture writer MUST preserve the coverage map')
+        Expect::that(CoverageJson::read($path)->toWire())
+            ->because('the shared coverage JSON fixture MUST preserve the coverage map')
             ->toBe($map->toWire());
+    }
+
+    #[Test]
+    public function readFailsExplicitlyWhenTheSourceIsUnavailable(): void
+    {
+        $path = $this->workspace->path() . '/missing/coverage.json';
+
+        Expect::that(static function () use ($path): void {
+            CoverageJson::read($path);
+        })
+            ->because('a coverage JSON read failure MUST identify its source')
+            ->toThrow(
+                ExpectationFailed::class,
+                matching: '/Expected to read coverage JSON document "'
+                    . \preg_quote($path, '/')
+                    . '"/',
+            );
     }
 
     #[Test]

--- a/tests/Unit/Support/CoverageJsonTest.php
+++ b/tests/Unit/Support/CoverageJsonTest.php
@@ -36,9 +36,7 @@ final readonly class CoverageJsonTest
     {
         $path = $this->workspace->path() . '/missing/coverage.json';
 
-        Expect::that(static function () use ($path): void {
-            CoverageJson::read($path);
-        })
+        Expect::that(static fn(): CoverageMap => CoverageJson::read($path))
             ->because('a coverage JSON read failure MUST identify its source')
             ->toThrow(
                 ExpectationFailed::class,


### PR DESCRIPTION
Add a fail-fast CoverageJson reader that delegates schema parsing to the canonical JsonExporter importer.

Use the shared reader in coverage acceptance tests so they assert through CoverageMap and FileCoverage instead of duplicating file-read and JSON-shape handling.