### PR TITLE
fix(cli): reject invalid option names

### DIFF
--- a/src/Cli/OptionSpec.php
+++ b/src/Cli/OptionSpec.php
@@ -30,6 +30,13 @@ final readonly class OptionSpec
             throw new \InvalidArgumentException('Option names cannot be empty.');
         }
 
+        if (\preg_match('/^[A-Za-z0-9][A-Za-z0-9-]*$/D', $name) !== 1) {
+            throw new \InvalidArgumentException(\sprintf(
+                'Option name "%s" MUST start with an ASCII letter or digit and MUST contain only ASCII letters, digits, or hyphens.',
+                $name,
+            ));
+        }
+
         if ($short !== null && \preg_match('/^[A-Za-z]$/D', $short) !== 1) {
             throw new \InvalidArgumentException(\sprintf(
                 'Short option alias "%s" MUST be one ASCII letter.',

--- a/tests/Unit/Cli/OptionSpecTest.php
+++ b/tests/Unit/Cli/OptionSpecTest.php
@@ -44,6 +44,26 @@ final readonly class OptionSpecTest
             null,
             'Option names cannot be empty.',
         ];
+        yield 'long name with leading hyphen' => [
+            '-workers',
+            null,
+            'Option name "-workers" MUST start with an ASCII letter or digit and MUST contain only ASCII letters, digits, or hyphens.',
+        ];
+        yield 'long name with value delimiter' => [
+            'workers=fast',
+            null,
+            'Option name "workers=fast" MUST start with an ASCII letter or digit and MUST contain only ASCII letters, digits, or hyphens.',
+        ];
+        yield 'long name with whitespace' => [
+            'worker count',
+            null,
+            'Option name "worker count" MUST start with an ASCII letter or digit and MUST contain only ASCII letters, digits, or hyphens.',
+        ];
+        yield 'long name with non-ASCII letter' => [
+            'wörkers',
+            null,
+            'Option name "wörkers" MUST start with an ASCII letter or digit and MUST contain only ASCII letters, digits, or hyphens.',
+        ];
         yield 'empty short alias' => [
             'help',
             '',


### PR DESCRIPTION
Reject long option definitions that the parser cannot address unambiguously or completion scripts cannot render as portable shell tokens.

Preserve zero-string names while requiring an ASCII alphanumeric first character followed by ASCII alphanumeric characters or hyphens.