### PR TITLE
fix(reporting): contain stream write diagnostics

### DIFF
--- a/src/Reporting/Output/StreamOutput.php
+++ b/src/Reporting/Output/StreamOutput.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Reporting\Output;
 
+use Greenlight\Core\ErrorTrap;
 use Greenlight\Reporting\ReportingError;
 
 /**
@@ -25,7 +26,7 @@ final class StreamOutput implements Output
     public function write(string $text): void
     {
         while ($text !== '') {
-            $written = \fwrite($this->stream, $text);
+            $written = ErrorTrap::run(fn(): int|false => \fwrite($this->stream, $text));
 
             if ($written === false || $written === 0) {
                 throw ReportingError::writeFailed();

--- a/tests/Fixture/Reporting/PartialWriteStream.php
+++ b/tests/Fixture/Reporting/PartialWriteStream.php
@@ -7,7 +7,7 @@ namespace Greenlight\Tests\Fixture\Reporting;
 use Greenlight\Doubles\Fake;
 
 /**
- * Accepts at most three bytes from each write, or simulates a stalled stream.
+ * Accepts at most three bytes from each write, or simulates a failed stream.
  */
 final class PartialWriteStream implements Fake
 {
@@ -16,6 +16,8 @@ final class PartialWriteStream implements Fake
     private static string $contents = '';
 
     private bool $stalled = false;
+
+    private bool $warns = false;
 
     public static function contents(): string
     {
@@ -30,12 +32,19 @@ final class PartialWriteStream implements Fake
     ): bool {
         self::$contents = '';
         $this->stalled = \str_ends_with($path, '/stalled');
+        $this->warns = \str_ends_with($path, '/warning');
 
         return $mode === 'wb';
     }
 
     public function stream_write(string $data): int
     {
+        if ($this->warns) {
+            \trigger_error('Simulated stream write failure.', \E_USER_WARNING);
+
+            return 0;
+        }
+
         if ($this->stalled) {
             return 0;
         }

--- a/tests/Unit/Reporting/StreamOutputDiagnosticTest.php
+++ b/tests/Unit/Reporting/StreamOutputDiagnosticTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Fixture\StreamWrapperSandbox;
+use Greenlight\Reporting\Output\StreamOutput;
+use Greenlight\Reporting\ReportingError;
+use Greenlight\Tests\Fixture\Reporting\PartialWriteStream;
+
+final readonly class StreamOutputDiagnosticTest
+{
+    private const string SCHEME = 'greenlight-stream-output-warning';
+
+    public function __construct(private StreamWrapperSandbox $streamWrappers) {}
+
+    #[Test]
+    public function aStreamWriteDiagnosticIsContainedByTheReportingError(): void
+    {
+        $this->streamWrappers->register(self::SCHEME, PartialWriteStream::class);
+        $stream = \fopen(self::SCHEME . '://warning', 'wb');
+
+        if ($stream === false) {
+            Fail::because('Greenlight did not open the warning stream.');
+        }
+
+        $diagnostic = null;
+        \set_error_handler(static function (int $severity, string $message) use (&$diagnostic): bool {
+            $diagnostic = $message;
+
+            return true;
+        });
+
+        try {
+            $output = new StreamOutput($stream);
+
+            Expect::that(static fn() => $output->write('cannot be written'))
+                ->because('a stream diagnostic becomes only a reporting error')
+                ->toThrow(
+                    ReportingError::class,
+                    message: 'Greenlight did not write reporter output to the stream.',
+                );
+        } finally {
+            \restore_error_handler();
+            \fclose($stream);
+        }
+
+        Expect::that($diagnostic)
+            ->because('reporter write diagnostics MUST NOT reach the host error handler')
+            ->toBeNull();
+    }
+}


### PR DESCRIPTION
Contain engine diagnostics from reporter stream writes before converting a failed or stalled write into ReportingError.

Add a warning-emitting stream fixture and an independent failure-path oracle that proves the host error handler stays untouched.