### PR TITLE
fix(runner): preserve cleanup after capture failure

### DIFF
--- a/src/Runner/Worker/TestExecutor.php
+++ b/src/Runner/Worker/TestExecutor.php
@@ -279,50 +279,58 @@ final readonly class TestExecutor
             $cause = $threw;
             $error = ThrowableDetail::fromThrowable($threw);
         } finally {
-            $captured = $capture?->stop();
-            $cleanupFailures = $cleanup->close();
-            $disposalFailures = $this->scopes->closeTest();
+            try {
+                $captured = $capture?->stop();
+            } finally {
+                try {
+                    $cleanupFailures = $cleanup->close();
 
-            foreach ($cleanupFailures as $cleanupFailure) {
-                if (!$cause instanceof \Throwable) {
-                    $cause = $cleanupFailure;
-                    $skipReason = null;
+                    foreach ($cleanupFailures as $cleanupFailure) {
+                        if (!$cause instanceof \Throwable) {
+                            $cause = $cleanupFailure;
+                            $skipReason = null;
 
-                    if ($cleanupFailure instanceof ExpectationFailed) {
-                        $failures = $cleanupFailure->details;
-                    } else {
-                        $error = ThrowableDetail::fromThrowable($cleanupFailure);
+                            if ($cleanupFailure instanceof ExpectationFailed) {
+                                $failures = $cleanupFailure->details;
+                            } else {
+                                $error = ThrowableDetail::fromThrowable($cleanupFailure);
+                            }
+
+                            continue;
+                        }
+
+                        if ($cleanupFailure instanceof ExpectationFailed) {
+                            $failures = [...$failures, ...$cleanupFailure->details];
+
+                            continue;
+                        }
+
+                        $failures[] = new FailureDetail(\sprintf(
+                            'Cleanup callback caused an error: %s',
+                            $cleanupFailure->getMessage(),
+                        ));
                     }
+                } finally {
+                    try {
+                        $disposalFailures = $this->scopes->closeTest();
 
-                    continue;
-                }
+                        if ($disposalFailures !== [] && !$cause instanceof \Throwable && $skipReason === null) {
+                            $cause = $disposalFailures[0];
 
-                if ($cleanupFailure instanceof ExpectationFailed) {
-                    $failures = [...$failures, ...$cleanupFailure->details];
-
-                    continue;
-                }
-
-                $failures[] = new FailureDetail(\sprintf(
-                    'Cleanup callback caused an error: %s',
-                    $cleanupFailure->getMessage(),
-                ));
-            }
-
-            if ($disposalFailures !== [] && !$cause instanceof \Throwable && $skipReason === null) {
-                $cause = $disposalFailures[0];
-
-                // An ExpectationFailed from disposal is a verification step.
-                // Automatic double verification uses this path. It fails the
-                // test with differences instead of an error.
-                if ($cause instanceof ExpectationFailed) {
-                    $failures = $cause->details;
-                } else {
-                    $error = ThrowableDetail::fromThrowable($cause);
+                            // An ExpectationFailed from disposal is a verification step.
+                            // Automatic double verification uses this path. It fails the
+                            // test with differences instead of an error.
+                            if ($cause instanceof ExpectationFailed) {
+                                $failures = $cause->details;
+                            } else {
+                                $error = ThrowableDetail::fromThrowable($cause);
+                            }
+                        }
+                    } finally {
+                        ExpectationRuntime::leaveAttempt();
+                    }
                 }
             }
-
-            ExpectationRuntime::leaveAttempt();
         }
 
         $durationSeconds = (\hrtime(true) - $startedAt) / 1_000_000_000;

--- a/tests/Unit/Runner/WorkerCaptureCleanupTest.php
+++ b/tests/Unit/Runner/WorkerCaptureCleanupTest.php
@@ -25,7 +25,7 @@ final readonly class WorkerCaptureCleanupTest
                 public static int $cleanups = 0;
 
                 public function __construct(
-                    private Greenlight\Core\Test\Cleanup $cleanup,
+                    private Greenlight\Test\Cleanup $cleanup,
                     private Greenlight\Tests\Fixture\Harness\RecordingDisposable $disposable,
                 ) {}
 

--- a/tests/Unit/Runner/WorkerCaptureCleanupTest.php
+++ b/tests/Unit/Runner/WorkerCaptureCleanupTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\Subprocess;
+
+final readonly class WorkerCaptureCleanupTest
+{
+    #[Test]
+    public function captureFailureStillRunsAllCleanupStages(): void
+    {
+        $root = \dirname(__DIR__, 3);
+        $process = Subprocess::start($root, [
+            \PHP_BINARY,
+            '-r',
+            <<<'PHP_WRAP'
+            require $argv[1];
+
+            final class CaptureCleanupProbe
+            {
+                public static int $cleanups = 0;
+
+                public function __construct(
+                    private Greenlight\Core\Test\Cleanup $cleanup,
+                    private Greenlight\Tests\Fixture\Harness\RecordingDisposable $disposable,
+                ) {}
+
+                public function leavesNonRemovableBuffer(): void
+                {
+                    $this->cleanup->defer(static function (): void {
+                        ++self::$cleanups;
+                    });
+                    ob_start(null, 0, PHP_OUTPUT_HANDLER_STDFLAGS & ~PHP_OUTPUT_HANDLER_REMOVABLE);
+                }
+            }
+
+            Greenlight\Tests\Fixture\Harness\RecordingDisposable::reset();
+            $id = new Greenlight\Core\Test\TestId(CaptureCleanupProbe::class, 'leavesNonRemovableBuffer');
+            $plan = new Greenlight\Discovery\ExecutionPlan([
+                new Greenlight\Discovery\PlanEntry(
+                    $id,
+                    new Greenlight\Core\Test\TestMetadata(
+                        $id->class,
+                        $id->method,
+                        timeoutSeconds: 1.0,
+                    ),
+                ),
+            ]);
+            $registry = new Greenlight\Harness\HarnessRegistry([
+                new Greenlight\Harness\ServiceDefinition(
+                    Greenlight\Tests\Fixture\Harness\RecordingDisposable::class,
+                    Greenlight\Harness\Scope::PerTest,
+                    static fn() => new Greenlight\Tests\Fixture\Harness\RecordingDisposable(),
+                ),
+            ]);
+
+            new Greenlight\Runner\Worker\Worker($registry)->run(
+                $plan,
+                new Greenlight\Tests\Support\CollectingEventSink(),
+            );
+
+            fwrite(
+                STDERR,
+                sprintf(
+                    '%d:%d:%s',
+                    CaptureCleanupProbe::$cleanups,
+                    Greenlight\Tests\Fixture\Harness\RecordingDisposable::disposals(),
+                    Greenlight\Expect\ExpectationRuntime::deadline() === null ? 'clear' : 'set',
+                ),
+            );
+            PHP_WRAP,
+            $root . '/vendor/autoload.php',
+        ]);
+
+        try {
+            $result = $process->wait(2.0);
+
+            Expect::that($result->exitCode)
+                ->because('capture cleanup MUST complete without terminating the worker')
+                ->toBe(0);
+            Expect::that($result->stderr)
+                ->because('capture failure MUST run callbacks, close the test scope, and clear the temporal deadline')
+                ->toBe('1:1:clear');
+        } finally {
+            $process->terminate();
+        }
+    }
+}


### PR DESCRIPTION
Close the per-test harness scope and clear the temporal deadline even when output capture cannot remove a nested user buffer.

Preserve the capture failure as the primary error while guaranteeing both cleanup operations.