### PR TITLE
fix(coverage): preserve relay include paths

### DIFF
--- a/src/Runner/CoverageRelayPaths.php
+++ b/src/Runner/CoverageRelayPaths.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Runner;
+
+/**
+ * Encodes coverage include paths for an environment variable.
+ *
+ * @internal
+ */
+final class CoverageRelayPaths
+{
+    /** @codeCoverageIgnore */
+    private function __construct() {}
+
+    /**
+     * @param list<non-empty-string> $paths
+     */
+    public static function encode(array $paths): string
+    {
+        $separator = '%' . \strtoupper(\bin2hex(\PATH_SEPARATOR));
+
+        return \implode(\PATH_SEPARATOR, \array_map(
+            static fn(string $path): string => \str_replace(
+                ['%', \PATH_SEPARATOR, "\0"],
+                ['%25', $separator, '%00'],
+                $path,
+            ),
+            $paths,
+        ));
+    }
+
+    /** @return list<non-empty-string> */
+    public static function decode(string $encoded): array
+    {
+        $paths = [];
+
+        foreach (\explode(\PATH_SEPARATOR, $encoded) as $path) {
+            if ($path === '') {
+                continue;
+            }
+
+            $paths[] = \rawurldecode($path);
+        }
+
+        return $paths;
+    }
+}

--- a/src/Runner/SharedCoverageDirectory.php
+++ b/src/Runner/SharedCoverageDirectory.php
@@ -23,9 +23,7 @@ final readonly class SharedCoverageDirectory
         private string|false $previousInclude,
     ) {}
 
-    /**
-     * @throws CoverageError
-     */
+    /** @throws CoverageError */
     public static function open(CoverageSettings $settings): self
     {
         $directory = \rtrim(\sys_get_temp_dir(), '/') . '/greenlight-coverage-' . \bin2hex(\random_bytes(6));
@@ -38,7 +36,7 @@ final readonly class SharedCoverageDirectory
         $previousInclude = \getenv(SubprocessCoverage::INCLUDE_ENV);
 
         \putenv(SubprocessCoverage::DIRECTORY_ENV . '=' . $directory);
-        \putenv(SubprocessCoverage::INCLUDE_ENV . '=' . \implode(\PATH_SEPARATOR, $settings->includePaths));
+        \putenv(SubprocessCoverage::INCLUDE_ENV . '=' . CoverageRelayPaths::encode($settings->includePaths));
 
         return new self($directory, $previousDirectory, $previousInclude);
     }

--- a/src/Runner/SubprocessCoverage.php
+++ b/src/Runner/SubprocessCoverage.php
@@ -46,15 +46,7 @@ final readonly class SubprocessCoverage
         }
 
         $include = \getenv(self::INCLUDE_ENV);
-        $paths = [];
-
-        if (\is_string($include)) {
-            foreach (\explode(\PATH_SEPARATOR, $include) as $path) {
-                if ($path !== '') {
-                    $paths[] = $path;
-                }
-            }
-        }
+        $paths = \is_string($include) ? CoverageRelayPaths::decode($include) : [];
 
         $collector = CoverageCollector::create(new CoverageSettings($paths), selector: $selector);
 

--- a/tests/Unit/Runner/CoverageRelayPathsTest.php
+++ b/tests/Unit/Runner/CoverageRelayPathsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\CoverageRelayPaths;
+
+final readonly class CoverageRelayPathsTest
+{
+    /** @param non-empty-string $path */
+    #[Test]
+    #[DataSet('reservedPaths')]
+    public function reservedPathBytesRoundTripWithoutLoss(string $path): void
+    {
+        $encoded = CoverageRelayPaths::encode([$path]);
+
+        Expect::that($encoded)
+            ->because('the relay environment value MUST not contain reserved bytes')
+            ->not()->toContain(\PATH_SEPARATOR)
+            ->not()->toContain("\0");
+        Expect::that(CoverageRelayPaths::decode($encoded))
+            ->because('the child process MUST receive the exact include path')
+            ->toBe([$path]);
+    }
+
+    #[Test]
+    public function ordinaryPathsKeepTheExistingEnvironmentFormat(): void
+    {
+        $encoded = '/project/src' . \PATH_SEPARATOR . '/project/lib';
+
+        Expect::that(CoverageRelayPaths::encode(['/project/src', '/project/lib']))
+            ->because('ordinary relay values remain compatible')
+            ->toBe($encoded);
+        Expect::that(CoverageRelayPaths::decode($encoded))
+            ->toBe(['/project/src', '/project/lib']);
+    }
+
+    /** @return iterable<string, array{non-empty-string}> */
+    public static function reservedPaths(): iterable
+    {
+        yield 'null byte' => ["/project/src\0generated"];
+        yield 'path separator' => ['/project/src' . \PATH_SEPARATOR . 'generated'];
+        yield 'literal escape' => ['/project/%00/generated'];
+    }
+}


### PR DESCRIPTION
## Summary

- encode reserved include-path bytes before exporting the coverage relay environment
- decode include paths in child processes without changing the ordinary relay format
- cover path separators, null bytes, and literal escape sequences