### PR TITLE
fix(artifact): contain stream write diagnostics

### DIFF
--- a/src/Runner/Artifact/StreamWriter.php
+++ b/src/Runner/Artifact/StreamWriter.php
@@ -6,6 +6,7 @@ namespace Greenlight\Runner\Artifact;
 
 use Greenlight\Attribute\CoverageIgnore;
 use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Core\ErrorTrap;
 
 /**
  * Writes complete byte strings to streams.
@@ -24,7 +25,7 @@ final class StreamWriter
         $length = \strlen($bytes);
 
         while ($offset < $length) {
-            $written = \fwrite($stream, \substr($bytes, $offset));
+            $written = ErrorTrap::run(static fn(): int|false => \fwrite($stream, \substr($bytes, $offset)));
 
             if ($written === false || $written === 0) {
                 throw AttachmentError::storage('Failed to write the complete attachment');

--- a/tests/Fixture/Artifact/WarningWriteStream.php
+++ b/tests/Fixture/Artifact/WarningWriteStream.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Artifact;
+
+use Greenlight\Doubles\Fake;
+
+/** Simulates a stream that emits a warning and cannot write bytes. */
+final class WarningWriteStream implements Fake
+{
+    public mixed $context;
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        return true;
+    }
+
+    public function stream_write(string $data): int
+    {
+        \trigger_error('The fixture could not write attachment bytes.', \E_USER_WARNING);
+
+        return 0;
+    }
+}

--- a/tests/Unit/Artifact/ArtifactStreamWriteDiagnosticTest.php
+++ b/tests/Unit/Artifact/ArtifactStreamWriteDiagnosticTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Fixture\StreamWrapperSandbox;
+use Greenlight\Runner\Artifact\StreamWriter;
+use Greenlight\Tests\Fixture\Artifact\WarningWriteStream;
+
+final readonly class ArtifactStreamWriteDiagnosticTest
+{
+    private const string SCHEME = 'greenlight-artifact-write-warning';
+
+    public function __construct(private StreamWrapperSandbox $streamWrappers) {}
+
+    #[Test]
+    public function aStreamWriteDiagnosticIsContainedByTheAttachmentError(): void
+    {
+        $this->streamWrappers->register(self::SCHEME, WarningWriteStream::class);
+        $stream = \fopen(self::SCHEME . '://attachment', 'wb');
+
+        if ($stream === false) {
+            Fail::because('Greenlight did not open the warning stream.');
+        }
+
+        $diagnostic = null;
+        \set_error_handler(static function (int $severity, string $message) use (&$diagnostic): bool {
+            $diagnostic = $message;
+
+            return true;
+        });
+
+        try {
+            Expect::that(static fn() => StreamWriter::writeFully($stream, 'evidence'))
+                ->because('a stream diagnostic becomes only an attachment error')
+                ->toThrow(
+                    AttachmentError::class,
+                    message: 'Failed to write the complete attachment.',
+                );
+        } finally {
+            \restore_error_handler();
+            \fclose($stream);
+        }
+
+        Expect::that($diagnostic)
+            ->because('attachment write diagnostics MUST NOT reach the host error handler')
+            ->toBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- suppress native stream diagnostics while writing attachment bytes
- preserve partial-write retries and the existing attachment storage error
- add a warning-emitting stream regression fixture