### PR TITLE
fix(watch): tolerate directory scan races

### DIFF
--- a/src/Cli/Watch/StatChangeDetector.php
+++ b/src/Cli/Watch/StatChangeDetector.php
@@ -68,25 +68,42 @@ final class StatChangeDetector implements ChangeDetector
         $snapshot = [];
 
         foreach ($this->directories as $directory) {
-            if (!ErrorTrap::run(static fn(): bool => \is_dir($directory))) {
+            try {
+                $files = ErrorTrap::run(fn(): array => $this->scanDirectory($directory));
+            } catch (\UnexpectedValueException) {
                 continue;
             }
 
-            $iterator = new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
-            );
+            $snapshot = [...$snapshot, ...$files];
+        }
 
-            foreach ($iterator as $file) {
-                if (!$file instanceof \SplFileInfo || $file->getExtension() !== 'php') {
-                    continue;
-                }
+        return $snapshot;
+    }
 
-                $path = $file->getPathname();
-                $fingerprint = $this->fingerprint($path);
+    /**
+     * @return array<string, string>
+     */
+    private function scanDirectory(string $directory): array
+    {
+        if (!\is_dir($directory)) {
+            return [];
+        }
 
-                if ($fingerprint !== null) {
-                    $snapshot[$path] = $fingerprint;
-                }
+        $snapshot = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
+        );
+
+        foreach ($iterator as $file) {
+            if (!$file instanceof \SplFileInfo || $file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $path = $file->getPathname();
+            $fingerprint = $this->fingerprint($path);
+
+            if ($fingerprint !== null) {
+                $snapshot[$path] = $fingerprint;
             }
         }
 

--- a/tests/Fixture/Filesystem/VanishingDirectoryStream.php
+++ b/tests/Fixture/Filesystem/VanishingDirectoryStream.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Filesystem;
+
+use Greenlight\Doubles\Fake;
+
+/** Simulates a directory that disappears after its metadata is read. */
+final class VanishingDirectoryStream implements Fake
+{
+    public mixed $context;
+
+    /** @return array{mode: int} */
+    public function url_stat(string $path, int $flags): array
+    {
+        return ['mode' => 0o040700];
+    }
+
+    public function dir_opendir(string $path, int $options): false
+    {
+        return false;
+    }
+}

--- a/tests/Unit/Cli/StatChangeDetectorDirectoryRaceTest.php
+++ b/tests/Unit/Cli/StatChangeDetectorDirectoryRaceTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\Watch\StatChangeDetector;
+use Greenlight\Core\ErrorTrap;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\StreamWrapperSandbox;
+use Greenlight\Tests\Fixture\Filesystem\VanishingDirectoryStream;
+
+final readonly class StatChangeDetectorDirectoryRaceTest
+{
+    private const string SCHEME = 'greenlight-vanishing-directory';
+
+    public function __construct(private StreamWrapperSandbox $streamWrappers) {}
+
+    #[Test]
+    public function aDirectoryThatVanishesDuringTheScanIsIgnored(): void
+    {
+        $this->streamWrappers->register(self::SCHEME, VanishingDirectoryStream::class);
+        $detector = new StatChangeDetector([self::SCHEME . '://root']);
+
+        $changed = ErrorTrap::run(static fn(): array => $detector->poll(), $warning);
+
+        Expect::that($changed)
+            ->because('a directory that vanishes during a scan MUST behave as a missing directory')
+            ->toBe([]);
+        Expect::that($warning)
+            ->because('a directory race MUST NOT leak an engine diagnostic')
+            ->toBeNull();
+    }
+}


### PR DESCRIPTION
## Summary

- keep watch mode alive when a watched directory disappears between its metadata check and recursive traversal
- collect each directory snapshot atomically and contain native diagnostics
- add a deterministic stream-wrapper regression for the directory race