### PR TITLE
fix(reporting): scrub CI command streams

### DIFF
--- a/src/Reporting/GithubReporter.php
+++ b/src/Reporting/GithubReporter.php
@@ -10,6 +10,7 @@ use Greenlight\Core\Event\TestFinished;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Core\Result\ThrowableDetail;
+use Greenlight\Core\Wire\Utf8;
 use Greenlight\Reporting\Output\Output;
 
 /**
@@ -152,11 +153,15 @@ final class GithubReporter implements Reporter
 
     private function escapeData(string $value): string
     {
-        return \str_replace(['%', "\r", "\n"], ['%25', '%0D', '%0A'], $value);
+        return \str_replace(['%', "\r", "\n"], ['%25', '%0D', '%0A'], Utf8::scrub($value));
     }
 
     private function escapeProperty(string $value): string
     {
-        return \str_replace(['%', "\r", "\n", ':', ','], ['%25', '%0D', '%0A', '%3A', '%2C'], $value);
+        return \str_replace(
+            ['%', "\r", "\n", ':', ','],
+            ['%25', '%0D', '%0A', '%3A', '%2C'],
+            Utf8::scrub($value),
+        );
     }
 }

--- a/src/Reporting/TeamCityReporter.php
+++ b/src/Reporting/TeamCityReporter.php
@@ -13,6 +13,7 @@ use Greenlight\Core\Event\TestStarted;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Core\Result\ThrowableDetail;
+use Greenlight\Core\Wire\Utf8;
 use Greenlight\Reporting\Output\Output;
 
 /**
@@ -300,7 +301,7 @@ final class TeamCityReporter implements Reporter
         return \str_replace(
             ['|', "'", "\n", "\r", '[', ']'],
             ['||', "|'", '|n', '|r', '|[', '|]'],
-            $value,
+            Utf8::scrub($value),
         );
     }
 }

--- a/tests/Unit/Reporting/CiReporterInvalidUtf8Test.php
+++ b/tests/Unit/Reporting/CiReporterInvalidUtf8Test.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\TestFinished;
+use Greenlight\Core\Result\FailureDetail;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\GithubReporter;
+use Greenlight\Reporting\Reporter;
+use Greenlight\Reporting\TeamCityReporter;
+
+final class CiReporterInvalidUtf8Test
+{
+    /** @param \Closure(BufferOutput): Reporter $create */
+    #[Test]
+    #[DataSet('reporters')]
+    public function commandStreamsScrubInvalidUtf8(\Closure $create): void
+    {
+        $output = new BufferOutput();
+        $reporter = $create($output);
+        $result = new TestResult(
+            new TestId('Acme\EncodingTest', 'reports'),
+            Outcome::Failed,
+            0.001,
+            0,
+            failures: [new FailureDetail("invalid \xFF byte")],
+        );
+
+        $reporter->onEvent(new TestFinished($result, 1.0));
+
+        Expect::that($output->buffer())
+            ->because('a CI command stream MUST replace invalid UTF-8')
+            ->toContain("invalid \u{FFFD} byte");
+        Expect::that(\preg_match('//u', $output->buffer()))
+            ->because('a CI command stream MUST contain only valid UTF-8')
+            ->toBe(1);
+    }
+
+    /**
+     * @return iterable<string, array{\Closure(BufferOutput): Reporter}>
+     */
+    public static function reporters(): iterable
+    {
+        yield 'GitHub' => [static fn(BufferOutput $output): Reporter => new GithubReporter($output)];
+        yield 'TeamCity' => [static fn(BufferOutput $output): Reporter => new TeamCityReporter($output)];
+    }
+}


### PR DESCRIPTION
## Summary

- repair invalid UTF-8 before GitHub workflow-command escaping
- repair invalid UTF-8 before TeamCity service-message escaping
- cover both CI reporters with one shared data-driven regression