### PR TITLE
fix(capture): restore error handler stack

### DIFF
--- a/src/Capture/OutputCapture.php
+++ b/src/Capture/OutputCapture.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Capture;
 
+use Greenlight\Core\ErrorHandlerStack;
 use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Result\CapturedOutput;
 use Greenlight\Core\Result\Diagnostic;
@@ -188,13 +189,13 @@ final class OutputCapture
 
     private function restoreErrorHandler(): void
     {
-        $active = \set_error_handler(null);
-        \restore_error_handler();
+        $handler = $this->errorHandler;
+        $this->errorHandler = null;
 
-        if ($active === $this->errorHandler) {
-            \restore_error_handler();
+        if (!$handler instanceof \Closure) {
+            return;
         }
 
-        $this->errorHandler = null;
+        ErrorHandlerStack::remove($handler);
     }
 }

--- a/tests/Unit/Capture/OutputCaptureTest.php
+++ b/tests/Unit/Capture/OutputCaptureTest.php
@@ -149,16 +149,24 @@ final class OutputCaptureTest
     }
 
     #[Test]
-    public function stopPreservesAnErrorHandlerInstalledDuringCapture(): void
+    public function stopPreservesErrorHandlersInstalledDuringCapture(): void
     {
         $baselineHandler = $this->activeErrorHandler();
-        $messages = [];
+        $lowerMessages = [];
+        $upperMessages = [];
         $capture = new OutputCapture();
         $capture->start();
 
         \set_error_handler(
-            static function (int $severity, string $message) use (&$messages): bool {
-                $messages[] = [$severity, $message];
+            static function (int $severity, string $message) use (&$lowerMessages): bool {
+                $lowerMessages[] = [$severity, $message];
+
+                return true;
+            },
+        );
+        \set_error_handler(
+            static function (int $severity, string $message) use (&$upperMessages): bool {
+                $upperMessages[] = [$severity, $message];
 
                 return true;
             },
@@ -166,11 +174,21 @@ final class OutputCaptureTest
 
         try {
             $capture->stop();
-            \trigger_error('after capture', \E_USER_NOTICE);
+            \trigger_error('upper handler', \E_USER_NOTICE);
+            \restore_error_handler();
+            \trigger_error('lower handler', \E_USER_NOTICE);
+            \restore_error_handler();
+            $restored = $this->activeErrorHandler();
 
-            Expect::that($messages)
-                ->because('stop preserves an error handler installed during capture')
-                ->toBe([[\E_USER_NOTICE, 'after capture']]);
+            Expect::that($upperMessages)
+                ->because('stop preserves the newest error handler installed during capture')
+                ->toBe([[\E_USER_NOTICE, 'upper handler']]);
+            Expect::that($lowerMessages)
+                ->because('stop preserves the complete user error-handler stack')
+                ->toBe([[\E_USER_NOTICE, 'lower handler']]);
+            Expect::that($restored)
+                ->because('restoring the user handlers MUST reveal the pre-capture handler')
+                ->toBe($baselineHandler);
         } finally {
             $this->restoreErrorHandler($baselineHandler);
         }


### PR DESCRIPTION
## Summary

- remove Greenlight’s capture handler from beneath handlers installed by test code
- restore user-installed handlers in their original order after capture stops
- verify that restoring those handlers reveals the pre-capture handler