### PR TITLE
fix(core): preserve error handler stack

### DIFF
--- a/src/Core/ErrorHandlerStack.php
+++ b/src/Core/ErrorHandlerStack.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Core;
+
+/**
+ * Removes a selected PHP error handler and reinstalls handlers that were above it.
+ *
+ * @internal
+ */
+final class ErrorHandlerStack
+{
+    /** @codeCoverageIgnore */
+    private function __construct() {}
+
+    public static function remove(callable $handler): void
+    {
+        $laterHandlers = [];
+
+        while (($active = self::active()) !== null) {
+            \restore_error_handler();
+
+            if ($active === $handler) {
+                self::restore($laterHandlers);
+
+                return;
+            }
+
+            $laterHandlers[] = $active;
+        }
+
+        self::restore($laterHandlers);
+    }
+
+    private static function active(): ?callable
+    {
+        $probe = static fn(): bool => true;
+        $active = \set_error_handler($probe);
+        \restore_error_handler();
+
+        return $active;
+    }
+
+    /** @param list<callable> $handlers */
+    private static function restore(array $handlers): void
+    {
+        foreach (\array_reverse($handlers) as $handler) {
+            \set_error_handler($handler);
+        }
+    }
+}

--- a/src/Core/ErrorTrap.php
+++ b/src/Core/ErrorTrap.php
@@ -38,16 +38,18 @@ final class ErrorTrap
     public static function run(\Closure $operation, ?string &$warning = null): mixed
     {
         $warning = null;
-        \set_error_handler(static function (int $severity, string $message) use (&$warning): bool {
+        $handler = static function (int $severity, string $message) use (&$warning): bool {
             $warning = $message;
 
             return true;
-        });
+        };
+
+        \set_error_handler($handler);
 
         try {
             return $operation();
         } finally {
-            \restore_error_handler();
+            ErrorHandlerStack::remove($handler);
         }
     }
 }

--- a/tests/Unit/Core/ErrorTrapTest.php
+++ b/tests/Unit/Core/ErrorTrapTest.php
@@ -114,4 +114,79 @@ final class ErrorTrapTest
             \restore_error_handler();
         }
     }
+
+    #[Test]
+    public function preservesHandlersInstalledByTheOperation(): void
+    {
+        $baseline = static fn(): bool => true;
+        $first = static fn(): bool => true;
+        $second = static fn(): bool => true;
+
+        \set_error_handler($baseline);
+
+        try {
+            ErrorTrap::run(static function () use ($first, $second): void {
+                \set_error_handler($first);
+                \set_error_handler($second);
+            });
+
+            Expect::that($this->activeErrorHandler())
+                ->because('the trap MUST preserve the last handler installed by the operation')
+                ->toBe($second);
+
+            \restore_error_handler();
+
+            Expect::that($this->activeErrorHandler())
+                ->because('the trap MUST preserve installed handlers in their original order')
+                ->toBe($first);
+
+            \restore_error_handler();
+
+            Expect::that($this->activeErrorHandler())
+                ->because('restoring the installed handlers MUST reveal the pre-trap handler')
+                ->toBe($baseline);
+        } finally {
+            $this->restoreErrorHandlersThrough($baseline);
+        }
+    }
+
+    #[Test]
+    public function doesNotPopThePreviousHandlerWhenTheOperationRemovesTheTrap(): void
+    {
+        $baseline = static fn(): bool => true;
+
+        \set_error_handler($baseline);
+
+        try {
+            ErrorTrap::run(static function (): void {
+                \restore_error_handler();
+            });
+
+            Expect::that($this->activeErrorHandler())
+                ->because('trap cleanup MUST preserve the handler stack left by the operation')
+                ->toBe($baseline);
+        } finally {
+            $this->restoreErrorHandlersThrough($baseline);
+        }
+    }
+
+    private function activeErrorHandler(): ?callable
+    {
+        $probe = static fn(): bool => true;
+        $active = \set_error_handler($probe);
+        \restore_error_handler();
+
+        return $active;
+    }
+
+    private function restoreErrorHandlersThrough(callable $last): void
+    {
+        while (($active = $this->activeErrorHandler()) !== null) {
+            \restore_error_handler();
+
+            if ($active === $last) {
+                return;
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- remove only Greenlight's diagnostic handler after a trapped operation
- preserve handlers installed by the operation in their original order
- keep the operation's resulting stack intact if it removes the trap itself