### PR TITLE
fix(psr15): release supplied handlers

### DIFF
--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -462,7 +462,7 @@ PHPDoc:
 
 - `@throws Psr15Error`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/HttpHarness.php#L41)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/HttpHarness.php#L46)
 
 ### `dispose()`
 
@@ -475,7 +475,7 @@ PHPDoc:
 
 - `@throws Psr15Error`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/HttpHarness.php#L66)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/HttpHarness.php#L71)
 
 ## `Psr15Error`
 

--- a/src/Psr15/HttpHarness.php
+++ b/src/Psr15/HttpHarness.php
@@ -15,8 +15,8 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 final class HttpHarness implements Disposable
 {
-    /** @var \Closure(): mixed */
-    private readonly \Closure $factory;
+    /** @var null|\Closure(): mixed */
+    private readonly ?\Closure $factory;
 
     private ?RequestHandlerInterface $handler = null;
 
@@ -30,9 +30,14 @@ final class HttpHarness implements Disposable
         RequestHandlerInterface|\Closure $handler,
         private readonly ?\Closure $release = null,
     ) {
-        $this->factory = $handler instanceof RequestHandlerInterface
-            ? static fn(): RequestHandlerInterface => $handler
-            : $handler;
+        if ($handler instanceof RequestHandlerInterface) {
+            $this->handler = $handler;
+            $this->factory = null;
+
+            return;
+        }
+
+        $this->factory = $handler;
     }
 
     /**
@@ -94,8 +99,11 @@ final class HttpHarness implements Disposable
             return $this->handler;
         }
 
+        $factory = $this->factory;
+        \assert($factory instanceof \Closure);
+
         try {
-            $handler = ($this->factory)();
+            $handler = $factory();
         } catch (\Throwable $threw) {
             throw Psr15Error::factoryFailed($threw);
         }

--- a/tests/Unit/Psr15/HttpHarnessTest.php
+++ b/tests/Unit/Psr15/HttpHarnessTest.php
@@ -126,7 +126,7 @@ final class HttpHarnessTest
     }
 
     #[Test]
-    public function releasesTheActiveHandlerOnlyOnce(): void
+    public function releasesTheSuppliedHandlerOnlyOnce(): void
     {
         $handler = $this->textHandler();
         $released = [];
@@ -136,8 +136,6 @@ final class HttpHarnessTest
                 $released[] = $active;
             },
         );
-        $harness->send(new ServerRequest([], [], '/status', 'GET'));
-
         $harness->dispose();
         $harness->dispose();
 


### PR DESCRIPTION
## Summary

- treat a supplied PSR-15 handler instance as active when the harness takes ownership
- release supplied handlers even when no request is sent
- keep closure factories lazy and release only handlers they construct