### PR TITLE
fix(worker): restore interrupt handler

### DIFF
--- a/src/Runner/Worker/WorkerProcess.php
+++ b/src/Runner/Worker/WorkerProcess.php
@@ -59,10 +59,31 @@ final readonly class WorkerProcess
         // The terminal sends Ctrl+C to the complete process group. Workers
         // ignore SIGINT. Thus, the orchestrator can control an orderly drain.
         // Crash containment does not report active tests as crashes from SIGINT.
+        $interruptHandler = \function_exists('pcntl_signal_get_handler')
+            ? \pcntl_signal_get_handler(\SIGINT)
+            : null;
+
         if (\function_exists('pcntl_signal')) {
             \pcntl_signal(\SIGINT, \SIG_IGN);
         }
 
+        try {
+            return $this->runWhileIgnoringInterrupt($address, $workerId, $token);
+        } finally {
+            if ($interruptHandler !== null && \function_exists('pcntl_signal')) {
+                \pcntl_signal(\SIGINT, $interruptHandler);
+            }
+        }
+    }
+
+    /**
+     * @param non-empty-string $address
+     * @param non-empty-string $workerId
+     * @param non-empty-string $token
+     * @throws ProtocolError
+     */
+    private function runWhileIgnoringInterrupt(string $address, string $workerId, string $token): int
+    {
         $stream = ErrorTrap::run(static function () use ($address, &$errorCode, &$errorMessage) {
             return \stream_socket_client($address, $errorCode, $errorMessage, 10.0);
         });

--- a/tests/Unit/Runner/Worker/WorkerProcessTest.php
+++ b/tests/Unit/Runner/Worker/WorkerProcessTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner\Worker;
 
 use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\SkipUnless;
 use Greenlight\Attribute\Test;
 use Greenlight\Attribute\Timeout;
+use Greenlight\Condition\FunctionAvailable;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\EnvironmentSandbox;
@@ -48,6 +50,29 @@ final readonly class WorkerProcessTest
             ->toBe(1);
         Expect::that($result->stderr)
             ->toContain('The worker did not connect to ' . $address . ':');
+    }
+
+    #[Test]
+    #[SkipUnless(FunctionAvailable::class, 'pcntl_signal_get_handler')]
+    public function runRestoresTheCallingProcessInterruptHandler(): void
+    {
+        $before = \pcntl_signal_get_handler(\SIGINT);
+        $callerHandler = static function (): void {};
+
+        try {
+            \pcntl_signal(\SIGINT, $callerHandler);
+
+            $address = 'unix://' . $this->tempDirectory->path() . '/missing-worker.sock';
+
+            Expect::that(new WorkerProcess()->run($address, 'worker-under-test', 'token'))
+                ->because('a connection failure MUST return control to the calling process')
+                ->toBe(1);
+            Expect::that(\pcntl_signal_get_handler(\SIGINT))
+                ->because('an in-process worker run MUST restore the caller SIGINT handler')
+                ->toBe($callerHandler);
+        } finally {
+            \pcntl_signal(\SIGINT, $before);
+        }
     }
 
     #[Test]


### PR DESCRIPTION
WorkerProcess::run() changes the calling process SIGINT handler to SIG_IGN. An in-process call therefore leaves later test and application code unable to receive the caller's interrupt handler.

Capture the existing handler before the worker policy starts and restore it from a finally block after every return or failure path. Add a regression that covers the early connection-failure return.