### PR TITLE
fix(plugin): report exact fixture cycles

### DIFF
--- a/src/Runner/Integration/IntegrationFixtureManager.php
+++ b/src/Runner/Integration/IntegrationFixtureManager.php
@@ -151,7 +151,17 @@ final class IntegrationFixtureManager
         }
 
         if (($state[$definition->id] ?? 0) === 1) {
-            $cycle = [...$path, $definition->id];
+            $reversedCycle = [$definition->id];
+
+            foreach (\array_reverse($path) as $ancestor) {
+                $reversedCycle[] = $ancestor;
+
+                if ($ancestor === $definition->id) {
+                    break;
+                }
+            }
+
+            $cycle = \array_reverse($reversedCycle);
 
             throw new IntegrationFixtureError('Integration fixture dependency cycle: ' . \implode(' -> ', $cycle) . '.');
         }

--- a/tests/Unit/Runner/Integration/IntegrationFixtureManagerTest.php
+++ b/tests/Unit/Runner/Integration/IntegrationFixtureManagerTest.php
@@ -224,6 +224,29 @@ final class IntegrationFixtureManagerTest
     }
 
     #[Test]
+    public function cycleDiagnosticsExcludeAcyclicDependencyPrefixes(): void
+    {
+        $provider = $this->provider([
+            new IntegrationFixtureDefinition('entry', static function (): void {}, ['alpha']),
+            new IntegrationFixtureDefinition('alpha', static function (): void {}, ['bravo']),
+            new IntegrationFixtureDefinition('bravo', static function (): void {}, ['alpha']),
+        ]);
+
+        Expect::that(fn() => IntegrationFixtureManager::provision(
+            PluginRegistry::orchestratorSide([$provider]),
+            'run-cycle-prefix',
+            1,
+            1,
+            null,
+        ))
+            ->because('a dependency-cycle diagnostic MUST identify only the cyclic path')
+            ->toThrow(
+                IntegrationFixtureError::class,
+                message: 'Integration fixture dependency cycle: alpha -> bravo -> alpha.',
+            );
+    }
+
+    #[Test]
     public function invalidChannelDataFailsProvisioningAndStillCleansUp(): void
     {
         $cleaned = false;


### PR DESCRIPTION
## Summary

- exclude acyclic dependency prefixes from integration-fixture cycle diagnostics
- add a regression for a cycle reached through an entry fixture