### PR TITLE
refactor(test): deduplicate PHP version validation

### DIFF
--- a/tests/Unit/Condition/ConditionsTest.php
+++ b/tests/Unit/Condition/ConditionsTest.php
@@ -199,27 +199,4 @@ final readonly class ConditionsTest
             );
     }
 
-    /**
-     * @param class-string<PhpVersionAtLeast|PhpVersionLessThan> $condition
-     */
-    #[Test]
-    #[DataSet('phpVersionConditions')]
-    public function phpVersionConditionsRejectAnEmptyVersion(string $condition): void
-    {
-        Expect::that(static fn(): object => new $condition(''))
-            ->because('a PHP version condition MUST identify a version')
-            ->toThrow(
-                \InvalidArgumentException::class,
-                message: 'PHP version MUST NOT be empty.',
-            );
-    }
-
-    /**
-     * @return iterable<string, array{class-string<PhpVersionAtLeast|PhpVersionLessThan>}>
-     */
-    public static function phpVersionConditions(): iterable
-    {
-        yield 'at least' => [PhpVersionAtLeast::class];
-        yield 'less than' => [PhpVersionLessThan::class];
-    }
 }


### PR DESCRIPTION
## Summary

- remove the duplicate empty-version matrix from the broad condition behavior test
- keep PHP version validation and zero-value boundaries in the dedicated validation class