### PR TITLE
fix(runner): stabilize shard hashes across architectures

### DIFF
--- a/src/Runner/PlanShard.php
+++ b/src/Runner/PlanShard.php
@@ -48,12 +48,65 @@ final class PlanShard
             return $plan;
         }
 
+        /** @var array<non-empty-string, int<0, max>> $shards */
+        $shards = [];
+
         /** @var list<PlanEntry> $entries */
         $entries = \array_values(\array_filter(
             $plan->entries,
-            static fn(PlanEntry $entry): bool => \crc32($entry->id->class) % $count === $index - 1,
+            static function (PlanEntry $entry) use (&$shards, $count, $index): bool {
+                $class = $entry->id->class;
+                $shard = $shards[$class] ??= self::shardIndex($class, $count);
+
+                return $shard === $index - 1;
+            },
         ));
 
         return new ExecutionPlan($entries, $plan->seed);
+    }
+
+    /**
+     * Returns the unsigned CRC32 remainder without exceeding the PHP integer
+     * range. crc32() returns negative values for high-bit checksums on 32-bit
+     * PHP.
+     *
+     * @param non-empty-string $class
+     * @param positive-int $count
+     *
+     * @return int<0, max>
+     */
+    private static function shardIndex(string $class, int $count): int
+    {
+        $remainder = 0;
+        $checksum = \hash('crc32b', $class);
+
+        for ($offset = 0; $offset < 8; ++$offset) {
+            for ($shift = 0; $shift < 4; ++$shift) {
+                $remainder = self::addModulo($remainder, $remainder, $count);
+            }
+
+            $digit = \max(0, \intval($checksum[$offset], 16));
+            $remainder = self::addModulo($remainder, $digit % $count, $count);
+        }
+
+        return $remainder;
+    }
+
+    /**
+     * @param int<0, max> $left
+     * @param int<0, max> $right
+     * @param positive-int $modulus
+     *
+     * @return int<0, max>
+     */
+    private static function addModulo(int $left, int $right, int $modulus): int
+    {
+        $distance = $modulus - $right;
+
+        if ($left >= $distance) {
+            return \max(0, $left - $distance);
+        }
+
+        return \max(0, $left + $right);
     }
 }

--- a/tests/Unit/Runner/PlanShardArchitectureTest.php
+++ b/tests/Unit/Runner/PlanShardArchitectureTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Discovery\ExecutionPlan;
+use Greenlight\Discovery\PlanEntry;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\PlanShard;
+
+final readonly class PlanShardArchitectureTest
+{
+    #[Test]
+    public function highBitChecksumsKeepTheSameShardAcrossIntegerWidths(): void
+    {
+        $class = 'Acme\\BetaTest';
+        $entry = new PlanEntry(new TestId($class, 'probe'), new TestMetadata($class, 'probe'));
+
+        Expect::that(\hash('crc32b', $class))
+            ->because('the portability regression MUST use a CRC32 value with its high bit set')
+            ->toBe('d795afeb');
+        Expect::that(PlanShard::select(
+            new ExecutionPlan([$entry]),
+            index: 1_616_911_340,
+            count: 2_000_000_000,
+        )->entries)
+            ->because('shard selection MUST use the unsigned CRC32 value on each PHP integer width')
+            ->toBe([$entry]);
+    }
+}


### PR DESCRIPTION
## Summary

- derive shard buckets from the architecture-neutral CRC32 hexadecimal representation
- calculate the remainder without overflowing 32-bit PHP integers
- cache one bucket per test class and cover a high-bit checksum regression