### PR TITLE
fix(cli): keep run state reads consistent

### DIFF
--- a/src/Cli/RunState.php
+++ b/src/Cli/RunState.php
@@ -14,9 +14,16 @@ use Greenlight\Core\ErrorTrap;
  *
  * @internal
  */
-final readonly class RunState
+final class RunState
 {
-    private function __construct(private string $file) {}
+    private bool $loaded = false;
+
+    /**
+     * @var array<mixed>|null
+     */
+    private ?array $snapshot = null;
+
+    private function __construct(private readonly string $file) {}
 
     public static function forFile(string $file): self
     {
@@ -66,6 +73,11 @@ final readonly class RunState
      */
     private function decoded(): ?array
     {
+        if ($this->loaded) {
+            return $this->snapshot;
+        }
+
+        $this->loaded = true;
         $file = $this->file;
 
         if (!ErrorTrap::run(static fn(): bool => \is_file($file))) {
@@ -84,7 +96,7 @@ final readonly class RunState
             return null;
         }
 
-        return \is_array($decoded) ? $decoded : null;
+        return $this->snapshot = \is_array($decoded) ? $decoded : null;
     }
 
     /**
@@ -143,6 +155,9 @@ final readonly class RunState
         } catch (AtomicFileError) {
             return false;
         }
+
+        $this->loaded = true;
+        $this->snapshot = ['failed' => $failedTests, 'classSeconds' => $classSeconds];
 
         return true;
     }

--- a/tests/Unit/Cli/RunStateTest.php
+++ b/tests/Unit/Cli/RunStateTest.php
@@ -113,6 +113,29 @@ final readonly class RunStateTest
     }
 
     #[Test]
+    public function failuresAndDurationsComeFromOneStateSnapshot(): void
+    {
+        $file = $this->stateFile();
+        \file_put_contents($file, \json_encode([
+            'failed' => ['Acme\AlphaTest::one'],
+            'classSeconds' => ['Acme\AlphaTest' => 1.25],
+        ], \JSON_THROW_ON_ERROR));
+
+        $state = RunState::forFile($file);
+
+        Expect::that($state->failedTests())->toBe(['Acme\AlphaTest::one']);
+
+        \file_put_contents($file, \json_encode([
+            'failed' => ['Acme\BetaTest::two'],
+            'classSeconds' => ['Acme\BetaTest' => 2.5],
+        ], \JSON_THROW_ON_ERROR));
+
+        Expect::that($state->classSeconds())
+            ->because('one command MUST use failures and durations from the same state snapshot')
+            ->toBe(['Acme\AlphaTest' => 1.25]);
+    }
+
+    #[Test]
     public function unreadableStateReadsAsAbsent(): void
     {
         $file = $this->stateFile();


### PR DESCRIPTION
## Summary

- cache one decoded run-state snapshot per command instance
- refresh the snapshot after a successful state record
- cover concurrent file replacement between failure and duration reads