### PR TITLE
fix(reporting): keep profile durations finite

### DIFF
--- a/src/Reporting/ProfileAggregator.php
+++ b/src/Reporting/ProfileAggregator.php
@@ -78,7 +78,10 @@ final class ProfileAggregator
             $span = $this->worker($event->workerId)->classFinished($event->occurredAt);
 
             if ($span !== null) {
-                $this->classDurations[$event->class] = ($this->classDurations[$event->class] ?? 0.0) + $span;
+                $this->classDurations[$event->class] = ProfileDuration::add(
+                    $this->classDurations[$event->class] ?? 0.0,
+                    $span,
+                );
             }
 
             return;
@@ -127,7 +130,7 @@ final class ProfileAggregator
         if ($bootLatencies !== []) {
             $lines[] = \sprintf(
                 '  Boot latency: %.3fs average (spawn to first class, %s)',
-                \array_sum($bootLatencies) / \count($bootLatencies),
+                ProfileDuration::average($bootLatencies),
                 Plural::count(\count($bootLatencies), 'worker'),
             );
         }
@@ -153,7 +156,7 @@ final class ProfileAggregator
         if (\count($finishTimes) > 1) {
             $lines[] = \sprintf(
                 '  Makespan spread: %.3fs between first and last worker finish',
-                \max($finishTimes) - \min($finishTimes),
+                ProfileDuration::between(\min($finishTimes), \max($finishTimes)),
             );
         }
 

--- a/src/Reporting/ProfileDuration.php
+++ b/src/Reporting/ProfileDuration.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Reporting;
+
+/**
+ * Calculates finite, nonnegative profile durations.
+ *
+ * @internal
+ */
+final class ProfileDuration
+{
+    /** @codeCoverageIgnore */
+    private function __construct() {}
+
+    public static function between(float $start, float $finish): float
+    {
+        return self::normalize($finish - $start);
+    }
+
+    public static function add(float $left, float $right): float
+    {
+        $left = self::normalize($left);
+        $right = self::normalize($right);
+
+        if ($left > \PHP_FLOAT_MAX - $right) {
+            return \PHP_FLOAT_MAX;
+        }
+
+        return $left + $right;
+    }
+
+    /**
+     * @param list<float> $durations
+     */
+    public static function average(array $durations): float
+    {
+        $average = 0.0;
+
+        foreach ($durations as $index => $duration) {
+            $average += (self::normalize($duration) - $average) / ($index + 1);
+        }
+
+        return self::normalize($average);
+    }
+
+    private static function normalize(float $duration): float
+    {
+        if (\is_nan($duration) || $duration <= 0.0) {
+            return 0.0;
+        }
+
+        return \is_finite($duration) ? $duration : \PHP_FLOAT_MAX;
+    }
+}

--- a/src/Reporting/WorkerProfile.php
+++ b/src/Reporting/WorkerProfile.php
@@ -37,8 +37,8 @@ final class WorkerProfile
         $span = null;
 
         if ($this->openAt !== null) {
-            $span = \max(0.0, $at - $this->openAt);
-            $this->busy += $span;
+            $span = ProfileDuration::between($this->openAt, $at);
+            $this->busy = ProfileDuration::add($this->busy, $span);
             $this->openAt = null;
         }
 
@@ -60,7 +60,7 @@ final class WorkerProfile
             return null;
         }
 
-        return \max(0.0, $this->firstClassAt - $this->spawnedAt);
+        return ProfileDuration::between($this->spawnedAt, $this->firstClassAt);
     }
 
     /**
@@ -76,7 +76,7 @@ final class WorkerProfile
             return 0.0;
         }
 
-        return \max(0.0, $this->lastFinishAt - $start);
+        return ProfileDuration::between($start, $this->lastFinishAt);
     }
 
     /**

--- a/tests/Unit/Reporting/ProfileFiniteDurationTest.php
+++ b/tests/Unit/Reporting/ProfileFiniteDurationTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\RunFinished;
+use Greenlight\Core\Event\RunStarted;
+use Greenlight\Core\Event\TestClassFinished;
+use Greenlight\Core\Event\TestClassStarted;
+use Greenlight\Core\Event\WorkerSpawned;
+use Greenlight\Core\Result\ResultSummary;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\ProfileAggregator;
+use Greenlight\Reporting\Style;
+
+final readonly class ProfileFiniteDurationTest
+{
+    #[Test]
+    public function extremeFiniteTimestampsKeepEveryProfileMetricFinite(): void
+    {
+        $aggregator = new ProfileAggregator();
+        $events = [
+            new RunStarted('run-1', 3, 3, 0.0),
+            new WorkerSpawned('w-1', 11, -\PHP_FLOAT_MAX),
+            new WorkerSpawned('w-2', 12, -\PHP_FLOAT_MAX),
+            new WorkerSpawned('w-3', 13, -\PHP_FLOAT_MAX),
+            new TestClassStarted('Acme\ExtremeTest', 0.0, 'w-1'),
+            new TestClassStarted('Acme\ExtremeTest', 0.0, 'w-2'),
+            new TestClassStarted('Acme\ExtremeTest', -\PHP_FLOAT_MAX, 'w-3'),
+            new TestClassFinished('Acme\ExtremeTest', -\PHP_FLOAT_MAX, 'w-3'),
+            new TestClassFinished('Acme\ExtremeTest', \PHP_FLOAT_MAX, 'w-1'),
+            new TestClassFinished('Acme\ExtremeTest', \PHP_FLOAT_MAX, 'w-2'),
+            new RunFinished('run-1', new ResultSummary(passed: 3), \PHP_FLOAT_MAX, \PHP_FLOAT_MAX),
+        ];
+
+        foreach ($events as $event) {
+            $aggregator->onEvent($event);
+        }
+
+        Expect::that($aggregator->render(new Style(ansi: false)))
+            ->because('finite event timestamps MUST produce only finite profile metrics')
+            ->not()
+            ->toContain('INF')
+            ->not()
+            ->toContain('NAN');
+    }
+}


### PR DESCRIPTION
## Summary

- keep profile time differences finite for extreme valid timestamps
- saturate worker and class duration accumulation before floating-point overflow
- calculate boot averages and makespan spread without nonfinite output