### PR TITLE
fix(config): reject unknown coverage exports

### DIFF
--- a/src/Config/CoverageExport.php
+++ b/src/Config/CoverageExport.php
@@ -7,6 +7,8 @@ namespace Greenlight\Config;
 /** @internal */
 final readonly class CoverageExport
 {
+    private const array FORMATS = ['json', 'lcov', 'clover', 'cobertura', 'html'];
+
     /**
      * @var non-empty-string
      */
@@ -24,6 +26,13 @@ final readonly class CoverageExport
     {
         if ($format === '' || $target === '') {
             throw new InvalidConfiguration('Coverage exports need a non-empty format and target.');
+        }
+
+        if (!\in_array($format, self::FORMATS, true)) {
+            throw new InvalidConfiguration(\sprintf(
+                'Unknown coverage export format "%s". Use "json", "lcov", "clover", "cobertura", or "html".',
+                $format,
+            ));
         }
 
         if (\str_contains($target, "\0")) {

--- a/tests/Unit/Config/CoverageBuilderTest.php
+++ b/tests/Unit/Config/CoverageBuilderTest.php
@@ -83,7 +83,7 @@ final class CoverageBuilderTest
         $configuration = new CoverageBuilder()
             ->include('0')
             ->driver('0')
-            ->export('0', '0')
+            ->export('json', '0')
             ->toConfiguration();
 
         Expect::that($configuration->includePaths)
@@ -93,8 +93,7 @@ final class CoverageBuilderTest
             ->because('a zero-string coverage driver is not empty')
             ->toBe('0');
         Expect::that($configuration->exports[0]->format)
-            ->because('a zero-string coverage export format is not empty')
-            ->toBe('0');
+            ->toBe('json');
         Expect::that($configuration->exports[0]->target)
             ->because('a zero-string coverage export target is not empty')
             ->toBe('0');

--- a/tests/Unit/Config/CoverageExportTest.php
+++ b/tests/Unit/Config/CoverageExportTest.php
@@ -34,25 +34,39 @@ final class CoverageExportTest
     }
 
     #[Test]
-    #[DataSet('zeroStringValues')]
-    public function preservesNonemptyZeroStrings(string $format, string $target): void
+    #[DataSet('unknownFormats')]
+    public function rejectsAnUnknownFormat(string $format): void
     {
-        $export = new CoverageExport($format, $target);
+        Expect::that(static fn(): CoverageExport => new CoverageExport($format, 'coverage.out'))
+            ->because('coverage exports MUST use a format that Greenlight can write')
+            ->toThrow(
+                InvalidConfiguration::class,
+                message: \sprintf(
+                    'Unknown coverage export format "%s". Use "json", "lcov", "clover", "cobertura", or "html".',
+                    $format,
+                ),
+            );
+    }
+
+    #[Test]
+    public function preservesANonemptyZeroStringTarget(): void
+    {
+        $export = new CoverageExport('json', '0');
 
         Expect::that($export->format)
-            ->because('a zero-string coverage export format is not empty')
-            ->toBe($format);
+            ->toBe('json');
         Expect::that($export->target)
             ->because('a zero-string coverage export target is not empty')
-            ->toBe($target);
+            ->toBe('0');
     }
 
     /**
-     * @return iterable<string, array{string, string}>
+     * @return iterable<string, array{string}>
      */
-    public static function zeroStringValues(): iterable
+    public static function unknownFormats(): iterable
     {
-        yield 'format' => ['0', 'coverage.json'];
-        yield 'target' => ['json', '0'];
+        yield 'zero string' => ['0'];
+        yield 'misspelled JSON' => ['jsno'];
+        yield 'uppercase HTML' => ['HTML'];
     }
 }


### PR DESCRIPTION
## Summary

- validate coverage export formats when configuration is constructed
- reject unsupported values before Greenlight runs the test suite
- retain zero-string support for valid export targets