### PR TITLE
fix(expect): bound native polling sleeps

### DIFF
--- a/src/Expect/SystemPollingClock.php
+++ b/src/Expect/SystemPollingClock.php
@@ -7,10 +7,24 @@ namespace Greenlight\Expect;
 /**
  * Uses hrtime() for monotonic time and usleep() between polls.
  *
+ * One native sleep call is at most one second. TemporalExpectation repeats
+ * the call until it reaches the requested poll time.
+ *
  * @internal
  */
 final readonly class SystemPollingClock implements PollingClock
 {
+    private const float MAX_SLEEP_SECONDS = 1.0;
+
+    /** @var \Closure(int): void */
+    private \Closure $sleep;
+
+    /** @param (\Closure(int): void)|null $sleep */
+    public function __construct(?\Closure $sleep = null)
+    {
+        $this->sleep = $sleep ?? \usleep(...);
+    }
+
     #[\Override]
     public function now(): float
     {
@@ -24,6 +38,7 @@ final readonly class SystemPollingClock implements PollingClock
             return;
         }
 
-        \usleep(\max(1, (int) \ceil($seconds * 1_000_000)));
+        $microseconds = (int) \ceil(\min($seconds, self::MAX_SLEEP_SECONDS) * 1_000_000);
+        ($this->sleep)(\max(1, $microseconds));
     }
 }

--- a/tests/Unit/Expect/SystemPollingClockTest.php
+++ b/tests/Unit/Expect/SystemPollingClockTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Expect;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\SystemPollingClock;
@@ -11,15 +12,52 @@ use Greenlight\Expect\SystemPollingClock;
 final class SystemPollingClockTest
 {
     #[Test]
-    public function negativeSleepReturnsControlToTheCaller(): void
+    #[DataSet('nonpositiveDurations')]
+    public function nonpositiveSleepDoesNotCallTheNativeSleeper(float $seconds): void
     {
-        $reachedAfterSleep = false;
+        $microseconds = [];
+        $clock = new SystemPollingClock(static function (int $duration) use (&$microseconds): void {
+            $microseconds[] = $duration;
+        });
 
-        new SystemPollingClock()->sleep(-0.001);
-        $reachedAfterSleep = true;
+        $clock->sleep($seconds);
 
-        Expect::that($reachedAfterSleep)
-            ->because('a negative sleep returns before calling usleep')
-            ->toBeTrue();
+        Expect::that($microseconds)
+            ->because('a nonpositive delay MUST return before calling the native sleeper')
+            ->toBe([]);
+    }
+
+    /** @return iterable<string, array{float}> */
+    public static function nonpositiveDurations(): iterable
+    {
+        yield 'zero' => [0.0];
+        yield 'negative' => [-0.001];
+    }
+
+    #[Test]
+    #[DataSet('positiveDurations')]
+    public function positiveSleepUsesAPortableNativeChunk(float $seconds, int $expectedMicroseconds): void
+    {
+        $microseconds = [];
+        $clock = new SystemPollingClock(static function (int $duration) use (&$microseconds): void {
+            $microseconds[] = $duration;
+        });
+
+        $clock->sleep($seconds);
+
+        Expect::that($microseconds)
+            ->because('one native sleep call MUST be between one microsecond and one second')
+            ->toBe([$expectedMicroseconds]);
+    }
+
+    /** @return iterable<string, array{float, positive-int}> */
+    public static function positiveDurations(): iterable
+    {
+        yield 'sub-microsecond' => [0.000_000_1, 1];
+        yield 'fractional microsecond rounds up' => [0.000_001_1, 2];
+        yield 'regular poll interval' => [0.025, 25_000];
+        yield 'one second' => [1.0, 1_000_000];
+        yield 'multiple seconds' => [2.0, 1_000_000];
+        yield 'largest finite duration' => [\PHP_FLOAT_MAX, 1_000_000];
     }
 }


### PR DESCRIPTION
## Summary

- cap each native polling sleep at PHP’s portable one-second usleep range
- let the existing deadline loop carry longer waits without integer overflow or a busy loop
- inject the native sleeper for deterministic microsecond-boundary regression coverage