### PR TITLE
fix(watch): bound native sleep calls

### DIFF
--- a/src/Cli/Watch/SystemWatchClock.php
+++ b/src/Cli/Watch/SystemWatchClock.php
@@ -5,10 +5,26 @@ declare(strict_types=1);
 namespace Greenlight\Cli\Watch;
 
 /**
+ * Uses hrtime() for monotonic time and usleep() between watch polls.
+ *
+ * One native sleep call is at most one second. Longer delays use multiple
+ * calls because some operating systems do not support larger usleep() values.
+ *
  * @internal
  */
 final readonly class SystemWatchClock implements WatchClock
 {
+    private const float MAX_SLEEP_SECONDS = 1.0;
+
+    /** @var \Closure(int): void */
+    private \Closure $sleep;
+
+    /** @param (\Closure(int): void)|null $sleep */
+    public function __construct(?\Closure $sleep = null)
+    {
+        $this->sleep = $sleep ?? \usleep(...);
+    }
+
     #[\Override]
     public function now(): float
     {
@@ -18,6 +34,15 @@ final readonly class SystemWatchClock implements WatchClock
     #[\Override]
     public function sleep(float $seconds): void
     {
-        \usleep((int) \round($seconds * 1_000_000));
+        if (!\is_finite($seconds)) {
+            throw new \InvalidArgumentException('The sleep duration must be finite.');
+        }
+
+        while ($seconds > 0.0) {
+            $chunk = \min($seconds, self::MAX_SLEEP_SECONDS);
+            $microseconds = (int) \ceil($chunk * 1_000_000);
+            ($this->sleep)(\max(1, $microseconds));
+            $seconds -= $chunk;
+        }
     }
 }

--- a/tests/Unit/Cli/Watch/SystemWatchClockTest.php
+++ b/tests/Unit/Cli/Watch/SystemWatchClockTest.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Cli\Watch;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Cli\Watch\SystemWatchClock;
 use Greenlight\Expect\Expect;
 
-final readonly class SystemWatchClockTest
+final class SystemWatchClockTest
 {
     #[Test]
     public function nowUsesTheMonotonicSystemClock(): void
@@ -21,5 +22,73 @@ final readonly class SystemWatchClockTest
             ->because('watch debounce timing MUST use the monotonic system clock')
             ->toBeGreaterThanOrEqual($before)
             ->toBeLessThanOrEqual($after);
+    }
+
+    #[Test]
+    #[DataSet('nonpositiveDurations')]
+    public function nonpositiveSleepDoesNotCallTheNativeSleeper(float $seconds): void
+    {
+        $microseconds = [];
+        $clock = new SystemWatchClock(static function (int $duration) use (&$microseconds): void {
+            $microseconds[] = $duration;
+        });
+
+        $clock->sleep($seconds);
+
+        Expect::that($microseconds)
+            ->because('a nonpositive delay MUST return before calling the native sleeper')
+            ->toBe([]);
+    }
+
+    /** @return iterable<string, array{float}> */
+    public static function nonpositiveDurations(): iterable
+    {
+        yield 'zero' => [0.0];
+        yield 'negative' => [-0.001];
+    }
+
+    /** @param list<positive-int> $expectedMicroseconds */
+    #[Test]
+    #[DataSet('positiveDurations')]
+    public function positiveSleepUsesPortableNativeChunks(float $seconds, array $expectedMicroseconds): void
+    {
+        $microseconds = [];
+        $clock = new SystemWatchClock(static function (int $duration) use (&$microseconds): void {
+            $microseconds[] = $duration;
+        });
+
+        $clock->sleep($seconds);
+
+        Expect::that($microseconds)
+            ->because('each native sleep call MUST be between one microsecond and one second')
+            ->toBe($expectedMicroseconds);
+    }
+
+    /** @return iterable<string, array{float, list<positive-int>}> */
+    public static function positiveDurations(): iterable
+    {
+        yield 'sub-microsecond' => [0.000_000_1, [1]];
+        yield 'fractional microsecond rounds up' => [0.000_001_1, [2]];
+        yield 'watch poll interval' => [0.1, [100_000]];
+        yield 'one second' => [1.0, [1_000_000]];
+        yield 'multiple seconds' => [2.25, [1_000_000, 1_000_000, 250_000]];
+    }
+
+    #[Test]
+    #[DataSet('nonfiniteDurations')]
+    public function nonfiniteSleepIsRejected(float $seconds): void
+    {
+        $clock = new SystemWatchClock(static function (int $microseconds): void {});
+
+        Expect::that(static fn() => $clock->sleep($seconds))
+            ->toThrow(\InvalidArgumentException::class, '/^The sleep duration must be finite\.$/D');
+    }
+
+    /** @return iterable<string, array{float}> */
+    public static function nonfiniteDurations(): iterable
+    {
+        yield 'positive infinity' => [\INF];
+        yield 'negative infinity' => [-\INF];
+        yield 'not a number' => [\NAN];
     }
 }


### PR DESCRIPTION
## Summary

- split watch delays into portable native sleep calls of at most one second
- preserve longer requested delays while avoiding float-to-integer overflow
- reject non-finite delays and cover the boundary behavior with an injected sleeper