### PR TITLE
fix(cli): fall back without worker runtime functions

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,8 +12,8 @@ Greenlight requires PHP 8.4 or later. It does not require a PHP extension.
 The parallel runner uses core stream sockets and `proc_open`. Coverage requires
 `ext-pcov` or Xdebug in coverage mode.
 
-If the system disables `proc_open`, Greenlight uses an in-process sequential
-run.
+If PHP disables a process or stream function that the parallel runner requires,
+Greenlight uses an in-process sequential run.
 
 Install Greenlight as a development dependency:
 

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -83,6 +83,20 @@ final readonly class Application
     private const int EXIT_FAILURE = 1;
     private const int EXIT_USAGE = 64;
 
+    /** @var list<non-empty-string> */
+    private const array WORKER_RUNTIME_FUNCTIONS = [
+        'proc_open',
+        'proc_get_status',
+        'proc_terminate',
+        'proc_close',
+        'stream_socket_server',
+        'stream_socket_get_name',
+        'stream_socket_accept',
+        'stream_socket_client',
+        'stream_select',
+        'stream_set_blocking',
+    ];
+
     private const string HELP = <<<'HELP'
         Greenlight
 
@@ -1251,14 +1265,16 @@ final readonly class Application
     }
 
     /**
-     * Greenlight starts worker processes with proc_open and core stream
-     * sockets. This operation does not require an extension. If
-     * disable_functions contains proc_open, Greenlight uses a sequential
-     * in-process run.
+     * Greenlight starts and controls workers with process and stream functions.
+     * This operation does not require an extension. If PHP disables a required
+     * function, Greenlight uses a sequential in-process run.
      */
     private function canSpawnWorkers(): bool
     {
-        return \function_exists('proc_open') && \function_exists('stream_socket_server');
+        return \array_all(
+            self::WORKER_RUNTIME_FUNCTIONS,
+            static fn(string $function): bool => \function_exists($function),
+        );
     }
 
     /** @return non-empty-string|false */

--- a/tests/Acceptance/SequentialFallbackTest.php
+++ b/tests/Acceptance/SequentialFallbackTest.php
@@ -41,6 +41,14 @@ final readonly class SequentialFallbackTest
     public static function unavailableParallelCapabilities(): iterable
     {
         yield 'process creation' => ['proc_open'];
+        yield 'process status' => ['proc_get_status'];
+        yield 'process termination' => ['proc_terminate'];
+        yield 'process close' => ['proc_close'];
         yield 'socket server' => ['stream_socket_server'];
+        yield 'socket name' => ['stream_socket_get_name'];
+        yield 'socket accept' => ['stream_socket_accept'];
+        yield 'socket client' => ['stream_socket_client'];
+        yield 'socket selection' => ['stream_select'];
+        yield 'socket blocking mode' => ['stream_set_blocking'];
     }
 }


### PR DESCRIPTION
## Summary

- require every process and stream function used by the parallel worker runtime before selecting it
- fall back to the in-process runner instead of entering a worker crash loop when a capability is disabled
- cover each parallel-only function independently and document the complete fallback contract