### PR TITLE
fix(coverage): close paired markers in one comment

### DIFF
--- a/src/Coverage/Ignore/IgnoreScanner.php
+++ b/src/Coverage/Ignore/IgnoreScanner.php
@@ -56,14 +56,18 @@ final readonly class IgnoreScanner
             $token = $tokens[$i];
 
             if ($token->is([\T_COMMENT, \T_DOC_COMMENT])) {
-                if (\str_contains($token->text, self::START)) {
-                    $rangeStart ??= $token->line;
-                } elseif (\str_contains($token->text, self::END)) {
-                    if ($rangeStart !== null) {
+                $rangeMarkers = $this->rangeMarkers($token->text);
+
+                foreach ($rangeMarkers as $rangeMarker) {
+                    if ($rangeMarker === self::START) {
+                        $rangeStart ??= $token->line;
+                    } elseif ($rangeStart !== null) {
                         $this->addRange($ignored, $rangeStart, $this->lastLine($token));
                         $rangeStart = null;
                     }
-                } elseif (\str_contains($token->text, self::IGNORE)) {
+                }
+
+                if ($rangeMarkers === [] && \str_contains($token->text, self::IGNORE)) {
                     $declaration = $this->declarationRange($tokens, $i + 1);
 
                     if ($declaration === null) {
@@ -96,6 +100,27 @@ final readonly class IgnoreScanner
         }
 
         return $ignored;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function rangeMarkers(string $comment): array
+    {
+        $markers = [];
+
+        foreach ([self::START, self::END] as $marker) {
+            $offset = 0;
+
+            while (($position = \strpos($comment, $marker, $offset)) !== false) {
+                $markers[$position] = $marker;
+                $offset = $position + \strlen($marker);
+            }
+        }
+
+        \ksort($markers, \SORT_NUMERIC);
+
+        return \array_values($markers);
     }
 
     /**

--- a/tests/Unit/Coverage/IgnoreScannerSameCommentRangeTest.php
+++ b/tests/Unit/Coverage/IgnoreScannerSameCommentRangeTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\Ignore\IgnoreScanner;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+
+final readonly class IgnoreScannerSameCommentRangeTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function pairedMarkerNamesInOneCommentDoNotIgnoreTheRemainingFile(): void
+    {
+        $path = $this->tempDirectory->path() . '/subject.php';
+        \file_put_contents($path, <<<'PHP'
+            <?php
+            /*
+             * A pair of "@codeCoverageIgnoreStart" and "@codeCoverageIgnoreEnd"
+             * identifies a bounded range.
+             */
+            $kept = 1;
+            PHP);
+
+        Expect::that(\array_keys(new IgnoreScanner()->ignoredLines($path)))
+            ->because('range markers in one comment MUST close before later source lines')
+            ->toBe([2, 3, 4, 5]);
+    }
+}


### PR DESCRIPTION
## Summary

- process coverage range markers in their textual order within each comment
- close same-comment start and end pairs instead of ignoring the remaining file
- cover documentation-style marker mentions with a focused regression