### PR TITLE
fix(discovery): wrap provider iteration errors

### DIFF
--- a/src/Discovery/DataSetExpander.php
+++ b/src/Discovery/DataSetExpander.php
@@ -162,24 +162,18 @@ final readonly class DataSetExpander
 
         $dataSets = [];
 
-        try {
-            foreach ($result as $key => $value) {
-                if (($this->monotonicTime)() - $startedAt > $budgetNanoseconds) {
-                    throw DiscoveryError::providerTooSlow($providerClassName, $provider, $budgetSeconds);
-                }
-
-                $derived = $this->deriveKey($providerClassName, $provider, $key);
-
-                if (\array_key_exists($derived, $dataSets)) {
-                    throw DiscoveryError::duplicateDataSetKey($testClassName, $testMethod, $derived);
-                }
-
-                $dataSets[$derived] = $value;
+        foreach ($this->providerRows($result, $providerClassName, $provider) as $key => $value) {
+            if (($this->monotonicTime)() - $startedAt > $budgetNanoseconds) {
+                throw DiscoveryError::providerTooSlow($providerClassName, $provider, $budgetSeconds);
             }
-        } catch (DiscoveryError $e) {
-            throw $e;
-        } catch (\Throwable $e) {
-            throw DiscoveryError::providerThrew($providerClassName, $provider, $e);
+
+            $derived = $this->deriveKey($providerClassName, $provider, $key);
+
+            if (\array_key_exists($derived, $dataSets)) {
+                throw DiscoveryError::duplicateDataSetKey($testClassName, $testMethod, $derived);
+            }
+
+            $dataSets[$derived] = $value;
         }
 
         if (($this->monotonicTime)() - $startedAt > $budgetNanoseconds) {
@@ -191,6 +185,24 @@ final readonly class DataSetExpander
         }
 
         return $dataSets;
+    }
+
+    /**
+     * Keeps provider iteration failures separate from expander validation failures.
+     *
+     * @param iterable<mixed, mixed> $rows
+     *
+     * @return iterable<mixed, mixed>
+     *
+     * @throws DiscoveryError
+     */
+    private function providerRows(iterable $rows, string $providerClass, string $provider): iterable
+    {
+        try {
+            yield from $rows;
+        } catch (\Throwable $e) {
+            throw DiscoveryError::providerThrew($providerClass, $provider, $e);
+        }
     }
 
     /**

--- a/tests/Unit/Discovery/DataSetProviderDiscoveryErrorTest.php
+++ b/tests/Unit/Discovery/DataSetProviderDiscoveryErrorTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\DataSetExpander;
+use Greenlight\Discovery\DiscoveryError;
+use Greenlight\Expect\Expect;
+
+final readonly class DataSetProviderDiscoveryErrorTest
+{
+    #[Test]
+    public function providerDiscoveryErrorsDuringIterationRetainProviderContext(): void
+    {
+        $testMethod = __FUNCTION__;
+
+        Expect::that(static fn(): array => new DataSetExpander()->rowsFor(
+            new \ReflectionClass(self::class),
+            $testMethod,
+            'rowsThatThrowDiscoveryError',
+            5.0,
+        ))
+            ->because('a provider-thrown framework error MUST remain a provider failure')
+            ->toThrow(static function (DiscoveryError $error): void {
+                $cause = $error->getPrevious();
+
+                Expect::that($error->getMessage())->toBe(
+                    'Data-set provider ' . self::class . '::rowsThatThrowDiscoveryError() threw '
+                    . DiscoveryError::class . ': Data-set provider MisleadingProvider::rows() produced no data sets. '
+                    . 'Produce at least one data set.',
+                );
+                Expect::that($cause)
+                    ->because('the provider wrapper MUST retain the exception from user code')
+                    ->toBeInstanceOf(DiscoveryError::class);
+                Expect::that($cause->getMessage())->toBe(
+                    'Data-set provider MisleadingProvider::rows() produced no data sets. Produce at least one data set.',
+                );
+            });
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function rowsThatThrowDiscoveryError(): iterable
+    {
+        yield 'first' => [1];
+
+        throw DiscoveryError::providerYieldedNothing('MisleadingProvider', 'rows');
+    }
+}


### PR DESCRIPTION
## Summary

- isolate iterable advancement from data-set validation
- wrap every exception thrown by provider iteration with the provider class and method
- retain the original exception as the cause while preserving Greenlight validation diagnostics