### PR TITLE
fix(harness): normalize service type names

### DIFF
--- a/src/Harness/HarnessRegistry.php
+++ b/src/Harness/HarnessRegistry.php
@@ -5,14 +5,15 @@ declare(strict_types=1);
 namespace Greenlight\Harness;
 
 /**
- * Stores registered harness services by their exact types.
+ * Stores registered harness services by their exact PHP types. Type names do
+ * not use letter case for identity.
  *
  * @internal
  */
 final class HarnessRegistry
 {
     /**
-     * @var array<class-string, ServiceDefinition>
+     * @var array<string, ServiceDefinition>
      */
     private array $definitions = [];
 
@@ -28,14 +29,16 @@ final class HarnessRegistry
 
     public function register(ServiceDefinition $definition): void
     {
-        if (isset($this->definitions[$definition->type])) {
+        $key = $this->typeKey($definition->type);
+
+        if (isset($this->definitions[$key])) {
             throw new \LogicException(\sprintf(
                 'A harness service for %s is already registered.',
                 $definition->type,
             ));
         }
 
-        $this->definitions[$definition->type] = $definition;
+        $this->definitions[$key] = $definition;
     }
 
     /**
@@ -43,6 +46,11 @@ final class HarnessRegistry
      */
     public function find(string $type): ?ServiceDefinition
     {
-        return $this->definitions[$type] ?? null;
+        return $this->definitions[$this->typeKey($type)] ?? null;
+    }
+
+    private function typeKey(string $type): string
+    {
+        return \strtolower($type);
     }
 }

--- a/tests/Unit/Harness/HarnessRegistryTypeCaseTest.php
+++ b/tests/Unit/Harness/HarnessRegistryTypeCaseTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Harness;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Harness\HarnessRegistry;
+use Greenlight\Harness\HarnessScopes;
+use Greenlight\Harness\Scope;
+use Greenlight\Harness\ServiceDefinition;
+
+final readonly class HarnessRegistryTypeCaseTest
+{
+    #[Test]
+    public function serviceTypeNamesFollowPhpCaseInsensitivity(): void
+    {
+        $service = new \ArrayObject();
+        $registry = new HarnessRegistry([
+            new ServiceDefinition(
+                $this->uppercaseClassName(\ArrayObject::class),
+                Scope::PerRun,
+                static fn(): \ArrayObject => $service,
+            ),
+        ]);
+
+        Expect::that(new HarnessScopes($registry)->resolve(\ArrayObject::class, self::class))
+            ->because('harness service identity MUST follow PHP type-name identity')
+            ->toBe($service);
+    }
+
+    #[Test]
+    public function caseOnlyDuplicateServiceTypesAreRejected(): void
+    {
+        $registry = new HarnessRegistry([
+            new ServiceDefinition(
+                \ArrayObject::class,
+                Scope::PerRun,
+                static fn(): \ArrayObject => new \ArrayObject(),
+            ),
+        ]);
+        $duplicate = new ServiceDefinition(
+            $this->uppercaseClassName(\ArrayObject::class),
+            Scope::PerTest,
+            static fn(): \ArrayObject => new \ArrayObject(),
+        );
+
+        Expect::that(static function () use ($duplicate, $registry): void {
+            $registry->register($duplicate);
+        })
+            ->because('one PHP type MUST have only one harness service definition')
+            ->toThrow(
+                \LogicException::class,
+                message: 'A harness service for ARRAYOBJECT is already registered.',
+            );
+    }
+
+    /**
+     * @param class-string $type
+     *
+     * @return class-string
+     */
+    private function uppercaseClassName(string $type): string
+    {
+        $uppercase = \strtoupper($type);
+
+        if (!\class_exists($uppercase)) {
+            throw new \LogicException(\sprintf('Class %s is unavailable.', $uppercase));
+        }
+
+        return $uppercase;
+    }
+}


### PR DESCRIPTION
## Summary

- key harness services without type-name case sensitivity
- resolve valid case-variant class-string registrations through canonical constructor types
- reject case-only duplicate service definitions