### PR TITLE
refactor(test): reuse spawned worker event selector

### DIFF
--- a/tests/Acceptance/ChannelTest.php
+++ b/tests/Acceptance/ChannelTest.php
@@ -7,7 +7,6 @@ namespace Greenlight\Tests\Acceptance;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Event\Event;
 use Greenlight\Core\Event\TestFinished;
-use Greenlight\Core\Event\WorkerSpawned;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
@@ -52,7 +51,7 @@ final readonly class ChannelTest
         $events = JsonlEvents::from($result);
         $channels = $this->reportedChannels($events);
         Expect::that($result->exitCode)->because('recycled workers reuse freed channels')->toBe(0);
-        Expect::that(\count($this->spawnedWorkers($events)))->toBeGreaterThan(2);
+        Expect::that(\count(JsonlEvents::spawnedWorkerIds($events)))->toBeGreaterThan(2);
         Expect::that(\count($channels))->toBe(4);
         Expect::that(\array_values(\array_unique($channels)))->toBe([1, 2]);
     }
@@ -81,24 +80,6 @@ final readonly class ChannelTest
         \sort($channels);
 
         return $channels;
-    }
-
-    /**
-     * @param list<Event> $events
-     *
-     * @return list<string>
-     */
-    private function spawnedWorkers(array $events): array
-    {
-        $workers = [];
-
-        foreach ($events as $event) {
-            if ($event instanceof WorkerSpawned) {
-                $workers[] = $event->workerId;
-            }
-        }
-
-        return $workers;
     }
 
     private function writeProject(?int $recycleAfterTests = null, int $expectedChannels = 2): AcceptanceProject

--- a/tests/Acceptance/SchedulingTest.php
+++ b/tests/Acceptance/SchedulingTest.php
@@ -8,7 +8,6 @@ use Greenlight\Attribute\Test;
 use Greenlight\Cli\RunState;
 use Greenlight\Core\Event\Event;
 use Greenlight\Core\Event\TestClassStarted;
-use Greenlight\Core\Event\WorkerSpawned;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
@@ -32,7 +31,7 @@ final readonly class SchedulingTest
         $result = $this->run($project);
         $events = JsonlEvents::from($result);
         $firstStarts = $this->firstClassStartedByWorker($events);
-        $spawnedWorkers = $this->spawnedWorkers($events);
+        $spawnedWorkers = JsonlEvents::spawnedWorkerIds($events);
         $startedClasses = $this->startedClasses($events);
         \sort($startedClasses);
 
@@ -88,24 +87,6 @@ final readonly class SchedulingTest
         }
 
         return $classes;
-    }
-
-    /**
-     * @param list<Event> $events
-     *
-     * @return list<string>
-     */
-    private function spawnedWorkers(array $events): array
-    {
-        $workers = [];
-
-        foreach ($events as $event) {
-            if ($event instanceof WorkerSpawned) {
-                $workers[] = $event->workerId;
-            }
-        }
-
-        return $workers;
     }
 
     private function writeProject(): AcceptanceProject

--- a/tests/Support/JsonlEvents.php
+++ b/tests/Support/JsonlEvents.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Support;
 use Greenlight\Core\Event\Event;
 use Greenlight\Core\Event\EventTags;
 use Greenlight\Core\Event\TestFinished;
+use Greenlight\Core\Event\WorkerSpawned;
 use Greenlight\Core\Wire\Wire;
 
 /**
@@ -87,6 +88,24 @@ final class JsonlEvents
         foreach (self::from($result) as $event) {
             if ($event instanceof TestFinished) {
                 $ids[] = (string) $event->result->id;
+            }
+        }
+
+        return $ids;
+    }
+
+    /**
+     * @param list<Event> $events
+     *
+     * @return list<string>
+     */
+    public static function spawnedWorkerIds(array $events): array
+    {
+        $ids = [];
+
+        foreach ($events as $event) {
+            if ($event instanceof WorkerSpawned) {
+                $ids[] = $event->workerId;
             }
         }
 

--- a/tests/Unit/Support/JsonlEventsTest.php
+++ b/tests/Unit/Support/JsonlEventsTest.php
@@ -83,6 +83,20 @@ final class JsonlEventsTest
     }
 
     #[Test]
+    public function spawnedWorkerIdsPreserveEventOrderAndIgnoreOtherEvents(): void
+    {
+        $events = [
+            new WorkerSpawned('worker-2', 42, 1.0),
+            new TestClassStarted('ExampleTest', 1.1, 'worker-2'),
+            new WorkerSpawned('worker-1', 43, 1.2),
+        ];
+
+        Expect::that(JsonlEvents::spawnedWorkerIds($events))
+            ->because('spawned worker extraction MUST preserve event order')
+            ->toBe(['worker-2', 'worker-1']);
+    }
+
+    #[Test]
     public function malformedJsonNamesItsStdoutLine(): void
     {
         $valid = $this->line('worker-spawned', new WorkerSpawned('worker-1', 1, 1.0)->toWire());


### PR DESCRIPTION
## Summary

- add one ordered spawned-worker selector to the shared JSONL event support
- replace duplicate event scans in scheduling and channel acceptance tests
- specify that the selector ignores unrelated events and preserves event order