### PR TITLE
feat(test): add deferred cleanup callbacks

### DIFF
--- a/docs/api-test-contracts.md
+++ b/docs/api-test-contracts.md
@@ -30,6 +30,39 @@ public function isSatisfied(): bool;
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Condition.php#L16)
 
+## `Cleanup`
+
+Namespace: `Greenlight\Core\Test`
+
+Stores cleanup callbacks for one test attempt. Greenlight runs the callbacks
+in reverse registration order after the `After` hooks. Per-test service
+disposal starts after the callbacks finish.
+
+Greenlight runs all callbacks if one fails. A cleanup failure errors a passed
+or skipped test. It does not replace an earlier test failure or error.
+
+```php
+final class Cleanup
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/Cleanup.php#L15)
+
+### `defer()`
+
+Register cleanup immediately after the test acquires a resource. This
+makes cleanup available if a later operation fails.
+
+```php
+public function defer(\Closure $cleanup): void
+```
+
+PHPDoc:
+
+- `@param \Closure(): void $cleanup`
+- `@throws \LogicException If test cleanup has started.`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/Cleanup.php#L32)
+
 ## `SkipTest`
 
 Namespace: `Greenlight\Core\Test`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -352,6 +352,37 @@ final class ExporterTest
 Each test receives separate instances. Each `TempDirectory` instance has a
 unique directory.
 
+## Defer test cleanup
+
+Ask for `Greenlight\Core\Test\Cleanup` through constructor injection. Call
+`defer()` immediately after the test acquires a resource.
+
+```php
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\Cleanup;
+
+final readonly class ServerTest
+{
+    public function __construct(private Cleanup $cleanup) {}
+
+    #[Test]
+    public function acceptsAConnection(): void
+    {
+        $server = TestServer::start();
+        $this->cleanup->defer(static fn() => $server->stop());
+
+        // Test the server.
+    }
+}
+```
+
+Greenlight runs cleanup callbacks once in reverse registration order. It runs
+them after `After` hooks and before per-test fixture disposal.
+
+A callback failure does not prevent the remaining callbacks. A cleanup failure
+errors a passed or skipped test. An earlier test failure or error remains
+primary.
+
 ## Exit codes
 
 Greenlight uses three exit codes:

--- a/src/Core/Test/Cleanup.php
+++ b/src/Core/Test/Cleanup.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Core\Test;
+
+/**
+ * Stores cleanup callbacks for one test attempt. Greenlight runs the callbacks
+ * in reverse registration order after the `After` hooks. Per-test service
+ * disposal starts after the callbacks finish.
+ *
+ * Greenlight runs all callbacks if one fails. A cleanup failure errors a passed
+ * or skipped test. It does not replace an earlier test failure or error.
+ */
+final class Cleanup
+{
+    /**
+     * @var list<\Closure(): void>
+     */
+    private array $callbacks = [];
+
+    private bool $closed = false;
+
+    /**
+     * Register cleanup immediately after the test acquires a resource. This
+     * makes cleanup available if a later operation fails.
+     *
+     * @param \Closure(): void $cleanup
+     *
+     * @throws \LogicException If test cleanup has started.
+     */
+    public function defer(\Closure $cleanup): void
+    {
+        if ($this->closed) {
+            throw new \LogicException('Cleanup cannot be registered after test cleanup starts.');
+        }
+
+        $this->callbacks[] = $cleanup;
+    }
+
+    /**
+     * Runs each callback and returns its failures.
+     *
+     * @internal
+     *
+     * @return list<\Throwable>
+     */
+    public function close(): array
+    {
+        if ($this->closed) {
+            return [];
+        }
+
+        $this->closed = true;
+        $callbacks = \array_reverse($this->callbacks);
+        $this->callbacks = [];
+        $failures = [];
+
+        foreach ($callbacks as $callback) {
+            try {
+                $callback();
+            } catch (\Throwable $failure) {
+                $failures[] = $failure;
+            }
+        }
+
+        return $failures;
+    }
+}

--- a/src/Runner/Worker/TestExecutor.php
+++ b/src/Runner/Worker/TestExecutor.php
@@ -15,6 +15,7 @@ use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\ResultPolicy;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Core\Result\ThrowableDetail;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\ExpectationCounter;
 use Greenlight\Core\Test\SkipTest;
 use Greenlight\Core\Test\TestId;
@@ -38,6 +39,7 @@ use Greenlight\Runner\Artifact\TestArtifactBudget;
  * - `Before` hooks
  * - The test method
  * - `After` hooks
+ * - Deferred cleanup callbacks
  * - Test-scope teardown
  * - Timeout enforcement
  * - `afterTest()` subscribers
@@ -204,6 +206,7 @@ final readonly class TestExecutor
         $capture = $metadata->capture ? new OutputCapture() : null;
         $stagedAttachments = $this->artifactStore?->forAttempt($entry->id, $attempt, $artifactBudget);
         $attachments = $stagedAttachments ?? new UnavailableAttachments();
+        $cleanup = new Cleanup();
         $memoryBefore = \memory_get_usage(true);
         $startedAt = \hrtime(true);
         $capture?->start();
@@ -214,7 +217,7 @@ final readonly class TestExecutor
         );
 
         try {
-            $instance = $this->instantiate($metadata->class, $attachments);
+            $instance = $this->instantiate($metadata->class, $attachments, $cleanup);
             $context = new TestContext($instance, $entry->id, $metadata, $this->scopes, $attachments);
             $instance = null;
 
@@ -277,7 +280,34 @@ final readonly class TestExecutor
             $error = ThrowableDetail::fromThrowable($threw);
         } finally {
             $captured = $capture?->stop();
+            $cleanupFailures = $cleanup->close();
             $disposalFailures = $this->scopes->closeTest();
+
+            foreach ($cleanupFailures as $cleanupFailure) {
+                if (!$cause instanceof \Throwable) {
+                    $cause = $cleanupFailure;
+                    $skipReason = null;
+
+                    if ($cleanupFailure instanceof ExpectationFailed) {
+                        $failures = $cleanupFailure->details;
+                    } else {
+                        $error = ThrowableDetail::fromThrowable($cleanupFailure);
+                    }
+
+                    continue;
+                }
+
+                if ($cleanupFailure instanceof ExpectationFailed) {
+                    $failures = [...$failures, ...$cleanupFailure->details];
+
+                    continue;
+                }
+
+                $failures[] = new FailureDetail(\sprintf(
+                    'Cleanup callback caused an error: %s',
+                    $cleanupFailure->getMessage(),
+                ));
+            }
 
             if ($disposalFailures !== [] && !$cause instanceof \Throwable && $skipReason === null) {
                 $cause = $disposalFailures[0];
@@ -418,7 +448,7 @@ final readonly class TestExecutor
      * @throws UnresolvableService
      * @throws ServiceResolutionError
      */
-    private function instantiate(string $class, Attachments $attachments): object
+    private function instantiate(string $class, Attachments $attachments, Cleanup $cleanup): object
     {
         $constructor = $this->context->reflection->getConstructor();
         $arguments = [];
@@ -441,6 +471,12 @@ final readonly class TestExecutor
 
             if ($serviceType === Attachments::class) {
                 $arguments[] = $attachments;
+
+                continue;
+            }
+
+            if ($serviceType === Cleanup::class) {
+                $arguments[] = $cleanup;
 
                 continue;
             }

--- a/tests/Fixture/Lifecycle/CleanupCallbacks/CleanupCallbacksTest.php
+++ b/tests/Fixture/Lifecycle/CleanupCallbacks/CleanupCallbacksTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Lifecycle\CleanupCallbacks;
+
+use Greenlight\Attribute\After;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\Cleanup;
+use Greenlight\Tests\Fixture\Lifecycle\TraceLog;
+
+final readonly class CleanupCallbacksTest
+{
+    public function __construct(
+        private Cleanup $cleanup,
+        private CleanupOrderProbe $probe,
+    ) {}
+
+    #[Test]
+    public function registersCallbacks(): void
+    {
+        $probe = $this->probe;
+        $this->cleanup->defer(static fn() => $probe->record('first cleanup'));
+        $this->cleanup->defer(static fn() => $probe->record('second cleanup'));
+        TraceLog::add('test');
+    }
+
+    #[After]
+    public function recordsAfterHook(): void
+    {
+        TraceLog::add('after');
+    }
+}

--- a/tests/Fixture/Lifecycle/CleanupCallbacks/CleanupOrderProbe.php
+++ b/tests/Fixture/Lifecycle/CleanupCallbacks/CleanupOrderProbe.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Lifecycle\CleanupCallbacks;
+
+use Greenlight\Harness\Disposable;
+use Greenlight\Tests\Fixture\Lifecycle\TraceLog;
+
+final readonly class CleanupOrderProbe implements Disposable
+{
+    public function record(string $entry): void
+    {
+        TraceLog::add($entry);
+    }
+
+    #[\Override]
+    public function dispose(): void
+    {
+        TraceLog::add('fixture disposal');
+    }
+}

--- a/tests/Fixture/Lifecycle/CleanupFailures/CleanupFailuresTest.php
+++ b/tests/Fixture/Lifecycle/CleanupFailures/CleanupFailuresTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Lifecycle\CleanupFailures;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\Cleanup;
+use Greenlight\Core\Test\SkipTest;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Lifecycle\TraceLog;
+
+final readonly class CleanupFailuresTest
+{
+    public function __construct(private Cleanup $cleanup) {}
+
+    #[Test]
+    public function passesBeforeCleanupFails(): void
+    {
+        $this->cleanup->defer(static fn() => throw new \RuntimeException('cleanup broke after pass'));
+    }
+
+    #[Test]
+    public function errorsBeforeCleanupFails(): never
+    {
+        $this->cleanup->defer(static function (): void {
+            TraceLog::add('last cleanup');
+        });
+        $this->cleanup->defer(static function (): never {
+            TraceLog::add('failing cleanup');
+
+            throw new \RuntimeException('cleanup broke after error');
+        });
+        $this->cleanup->defer(static function (): void {
+            TraceLog::add('first cleanup');
+        });
+
+        throw new \RuntimeException('test broke');
+    }
+
+    #[Test]
+    public function skipsBeforeCleanupFails(): never
+    {
+        $this->cleanup->defer(static fn() => throw new \RuntimeException('cleanup broke after skip'));
+
+        throw new SkipTest('skip requested');
+    }
+
+    #[Test]
+    public function passesBeforeCleanupExpectationFails(): void
+    {
+        $this->cleanup->defer(static function (): void {
+            Expect::that('actual')->toBe('expected');
+        });
+    }
+}

--- a/tests/Fixture/Lifecycle/CleanupRetries/CleanupRetriesTest.php
+++ b/tests/Fixture/Lifecycle/CleanupRetries/CleanupRetriesTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Lifecycle\CleanupRetries;
+
+use Greenlight\Attribute\Retry;
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\Cleanup;
+use Greenlight\Tests\Fixture\Lifecycle\TraceLog;
+
+final class CleanupRetriesTest
+{
+    public static int $attempts = 0;
+
+    public function __construct(private Cleanup $cleanup) {}
+
+    #[Test]
+    #[Retry(times: 1)]
+    public function eachAttemptReceivesCleanup(): void
+    {
+        ++self::$attempts;
+        $attempt = self::$attempts;
+        TraceLog::add('test ' . $attempt);
+        $this->cleanup->defer(static fn() => TraceLog::add('cleanup ' . $attempt));
+
+        if ($attempt === 1) {
+            throw new \RuntimeException('retry the test');
+        }
+    }
+}

--- a/tests/Unit/Core/Test/CleanupTest.php
+++ b/tests/Unit/Core/Test/CleanupTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core\Test;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\Cleanup;
+use Greenlight\Expect\Expect;
+
+final readonly class CleanupTest
+{
+    #[Test]
+    public function closeRunsCallbacksOnceInReverseRegistrationOrder(): void
+    {
+        $cleanup = new Cleanup();
+        $trace = [];
+        $cleanup->defer(static function () use (&$trace): void {
+            $trace[] = 'first';
+        });
+        $cleanup->defer(static function () use (&$trace): void {
+            $trace[] = 'second';
+        });
+
+        $firstFailures = $cleanup->close();
+        $secondFailures = $cleanup->close();
+
+        Expect::that($trace)
+            ->because('cleanup callbacks run once in reverse registration order')
+            ->toBe(['second', 'first']);
+        Expect::that($firstFailures)->toBe([]);
+        Expect::that($secondFailures)->toBe([]);
+    }
+
+    #[Test]
+    public function closeContinuesAfterACallbackFailure(): void
+    {
+        $cleanup = new Cleanup();
+        $trace = [];
+        $failure = new \RuntimeException('cleanup broke');
+        $cleanup->defer(static function () use (&$trace): void {
+            $trace[] = 'last';
+        });
+        $cleanup->defer(static function () use (&$trace, $failure): never {
+            $trace[] = 'failure';
+
+            throw $failure;
+        });
+        $cleanup->defer(static function () use (&$trace): void {
+            $trace[] = 'first';
+        });
+
+        $failures = $cleanup->close();
+
+        Expect::that($trace)
+            ->because('a callback failure MUST NOT prevent later cleanup')
+            ->toBe(['first', 'failure', 'last']);
+        Expect::that($failures)->toBe([$failure]);
+    }
+
+    #[Test]
+    public function deferRejectsRegistrationAfterCleanupStarts(): void
+    {
+        $cleanup = new Cleanup();
+        $cleanup->close();
+
+        Expect::that(static fn() => $cleanup->defer(static function (): void {}))
+            ->because('a closed cleanup stack cannot accept callbacks')
+            ->toThrow(
+                \LogicException::class,
+                message: 'Cleanup cannot be registered after test cleanup starts.',
+            );
+    }
+}

--- a/tests/Unit/Runner/WorkerTest.php
+++ b/tests/Unit/Runner/WorkerTest.php
@@ -24,6 +24,8 @@ use Greenlight\Runner\Worker\LeakDetector;
 use Greenlight\Runner\Worker\Worker;
 use Greenlight\Runner\Worker\WorkerBudget;
 use Greenlight\Tests\Fixture\LeakSuite\LeakyTest;
+use Greenlight\Tests\Fixture\Lifecycle\CleanupCallbacks\CleanupOrderProbe;
+use Greenlight\Tests\Fixture\Lifecycle\CleanupRetries\CleanupRetriesTest;
 use Greenlight\Tests\Fixture\Lifecycle\DisposeFails\FailingDisposalProbe;
 use Greenlight\Tests\Fixture\Lifecycle\Injection\InjectedProbe;
 use Greenlight\Tests\Fixture\Lifecycle\PerTestDisposeFails\FailingPerTestDisposal;
@@ -84,6 +86,86 @@ final class WorkerTest
         Expect::that($results[0]->error?->message)
             ->because('the first teardown error MUST remain primary')
             ->toBe('after broke');
+    }
+
+    #[Test]
+    public function deferredCleanupRunsAfterHooksAndBeforeFixtureDisposal(): void
+    {
+        TraceLog::drain();
+        $registry = $this->registry();
+        $registry->register(new ServiceDefinition(
+            CleanupOrderProbe::class,
+            Scope::PerTest,
+            static fn(): CleanupOrderProbe => new CleanupOrderProbe(),
+        ));
+
+        [, $results] = $this->runFixture('CleanupCallbacks', $registry);
+
+        Expect::that(TraceLog::drain())
+            ->because('deferred cleanup runs after hooks and before fixture disposal')
+            ->toBe(['test', 'after', 'second cleanup', 'first cleanup', 'fixture disposal']);
+        Expect::that($results[0]->outcome)->toBe(Outcome::Passed);
+    }
+
+    #[Test]
+    public function cleanupFailuresPreserveEarlierErrorsAndOverrideSkips(): void
+    {
+        TraceLog::drain();
+        [, $results] = $this->runFixture('CleanupFailures');
+        $byMethod = [];
+
+        foreach ($results as $result) {
+            $byMethod[$result->id->method] = $result;
+        }
+
+        Expect::that($byMethod['passesBeforeCleanupFails']->outcome)
+            ->because('a cleanup failure errors a passing test')
+            ->toBe(Outcome::Errored);
+        Expect::that($byMethod['passesBeforeCleanupFails']->error?->message)
+            ->toBe('cleanup broke after pass');
+        Expect::that($byMethod['passesBeforeCleanupExpectationFails']->outcome)
+            ->because('an expectation failure during cleanup fails the test')
+            ->toBe(Outcome::Failed);
+        Expect::that($byMethod['passesBeforeCleanupExpectationFails']->error)
+            ->toBeNull();
+        Expect::that($byMethod['passesBeforeCleanupExpectationFails']->failures[0]->expected)
+            ->toBe("'expected'");
+        Expect::that($byMethod['passesBeforeCleanupExpectationFails']->failures[0]->actual)
+            ->toBe("'actual'");
+        Expect::that($byMethod['errorsBeforeCleanupFails']->outcome)
+            ->because('the test error remains primary when cleanup also fails')
+            ->toBe(Outcome::Errored);
+        Expect::that($byMethod['errorsBeforeCleanupFails']->error?->message)
+            ->toBe('test broke');
+        Expect::that($byMethod['errorsBeforeCleanupFails']->failures[0]->message)
+            ->toBe('Cleanup callback caused an error: cleanup broke after error');
+        Expect::that($byMethod['skipsBeforeCleanupFails']->outcome)
+            ->because('a cleanup failure overrides a skip')
+            ->toBe(Outcome::Errored);
+        Expect::that($byMethod['skipsBeforeCleanupFails']->skipReason)
+            ->toBeNull();
+        Expect::that($byMethod['skipsBeforeCleanupFails']->error?->message)
+            ->toBe('cleanup broke after skip');
+        Expect::that(TraceLog::drain())
+            ->because('a cleanup failure MUST NOT prevent later callbacks')
+            ->toBe(['first cleanup', 'failing cleanup', 'last cleanup']);
+    }
+
+    #[Test]
+    public function eachRetryReceivesAFreshCleanupStack(): void
+    {
+        CleanupRetriesTest::$attempts = 0;
+        TraceLog::drain();
+
+        [, $results] = $this->runFixture('CleanupRetries');
+
+        Expect::that($results[0]->outcome)
+            ->because('each retry receives a fresh cleanup stack')
+            ->toBe(Outcome::Passed);
+        Expect::that($results[0]->attempts)
+            ->toBe(2);
+        Expect::that(TraceLog::drain())
+            ->toBe(['test 1', 'cleanup 1', 'test 2', 'cleanup 2']);
     }
 
     #[Test]


### PR DESCRIPTION
Adds an injectable per-attempt Cleanup contract for deferred test cleanup. Callbacks run once in reverse registration order after After hooks and before per-test service disposal. Cleanup failures run to completion, retain earlier test failures or errors, and override skips when cleanup integrity fails. Includes lifecycle coverage and public documentation.