### PR TITLE
docs(psr): name PSR-11 container guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ for the complete model.
 * [Test Symfony applications](docs/symfony.md)
 * [Test Laravel applications](docs/laravel.md)
 * [Test Hyperf applications](docs/hyperf.md)
-* [Test PSR applications](docs/psr.md)
+* [Test with PSR-11 containers](docs/psr.md)
 * [Test PSR-15 applications](docs/psr15.md)
 * [Test Tempest applications](docs/tempest.md)
 * [Move from PHPUnit](docs/migrating-from-phpunit.md)

--- a/website/src/lib/docs.ts
+++ b/website/src/lib/docs.ts
@@ -68,7 +68,7 @@ export const docSections = [
       },
       {
         id: 'psr',
-        title: 'PSR applications',
+        title: 'PSR-11 containers',
         description: 'This guide explains how tests receive services from a PSR-11 container.',
       },
       {


### PR DESCRIPTION
## Summary

- label the guide as PSR-11 containers in the documentation menu
- use the same terminology in the README documentation list