### PR TITLE
refactor(test): defer temporal matcher cleanup

### DIFF
--- a/src/Expect/Expect.php
+++ b/src/Expect/Expect.php
@@ -80,9 +80,16 @@ final class Expect
      * @internal
      *
      * @param list<ExpectationExtension> $extensions
+     *
+     * @return \Closure(): void A callback that restores the previous extension list.
      */
-    public static function install(array $extensions): void
+    public static function install(array $extensions): \Closure
     {
+        $previous = self::$extensions;
         self::$extensions = $extensions;
+
+        return static function () use ($previous): void {
+            self::$extensions = $previous;
+        };
     }
 }

--- a/tests/Unit/Expect/ExpectTest.php
+++ b/tests/Unit/Expect/ExpectTest.php
@@ -69,4 +69,20 @@ final class ExpectTest
         Expect::that(static fn() => Expect::that(4)->__call('toBeEven', []))->because('chains created before an install keep their extensions')
             ->toThrow(\BadMethodCallException::class);
     }
+
+    #[Test]
+    public function installReturnsCleanupThatRestoresThePreviousExtensions(): void
+    {
+        $restoreEmpty = Expect::install([new EvenNumbersExtension()]);
+        $restoreEvenNumbers = Expect::install([]);
+
+        $restoreEvenNumbers();
+        $chain = Expect::that(4);
+        $restoreEmpty();
+
+        $chain->__call('toBeEven', []);
+        Expect::that(static fn() => Expect::that(4)->__call('toBeEven', []))
+            ->because('install cleanup restores the exact previous extension list')
+            ->toThrow(\BadMethodCallException::class);
+    }
 }

--- a/tests/Unit/Expect/TemporalExpectationTest.php
+++ b/tests/Unit/Expect/TemporalExpectationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Expect;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\ExpectationCounter;
 use Greenlight\Expect\EventuallyExpectation;
 use Greenlight\Expect\Expect;
@@ -17,8 +18,10 @@ use Greenlight\Tests\Fixture\Expect\FakePollingClock;
 use Greenlight\Tests\Fixture\Expect\PositiveNumbersExtension;
 use Greenlight\Tests\Fixture\Expect\TransientProbeFailure;
 
-final class TemporalExpectationTest
+final readonly class TemporalExpectationTest
 {
+    public function __construct(private Cleanup $cleanup) {}
+
     #[Test]
     public function temporalAndImmediateExpectationsExposeTheSameNativeMatchers(): void
     {
@@ -361,20 +364,17 @@ final class TemporalExpectationTest
     {
         $clock = new FakePollingClock();
         $subjects = [-1, 2];
-        Expect::install([new PositiveNumbersExtension()]);
+        $restoreExtensions = Expect::install([new PositiveNumbersExtension()]);
+        $this->cleanup->defer($restoreExtensions);
 
-        try {
-            ExpectationRuntime::withClock(
-                $clock,
-                static fn() => Expect::eventually(static function () use (&$subjects): int {
-                    return \array_shift($subjects) ?? 2;
-                })
-                    ->within(0.100)
-                    ->__call('toBePositive', []),
-            );
-        } finally {
-            Expect::install([]);
-        }
+        ExpectationRuntime::withClock(
+            $clock,
+            static fn() => Expect::eventually(static function () use (&$subjects): int {
+                return \array_shift($subjects) ?? 2;
+            })
+                ->within(0.100)
+                ->__call('toBePositive', []),
+        );
 
         Expect::that($clock->sleeps)
             ->because('the extension matcher MUST reject the negative probe before it accepts the positive probe')


### PR DESCRIPTION
## Summary

- return a cleanup callback from Expect::install() that restores the exact previous extension set
- register that callback with the test-owned Cleanup service in the temporal matcher test
- cover nested installation and restoration behavior