### PR TITLE
docs: remove redundant new expression parentheses

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -342,7 +342,7 @@ final class ExporterTest
     {
         $this->env->set('EXPORT_DIR', $this->tmp->path());
 
-        (new Exporter())->run();
+        new Exporter()->run();
 
         Expect::that(\file_exists($this->tmp->path() . '/export.csv'))->toBeTrue();
     }

--- a/docs/psr15.md
+++ b/docs/psr15.md
@@ -85,7 +85,7 @@ final readonly class StatusTest
     #[Test]
     public function statusIsReady(): void
     {
-        $request = (new Psr17Factory())->createServerRequest(
+        $request = new Psr17Factory()->createServerRequest(
             'GET',
             'https://example.test/status',
         );


### PR DESCRIPTION
## Summary

Remove redundant parentheses around chained object creation in PHP examples now that Greenlight requires PHP 8.4.