### PR TITLE
refactor(test): defer expectation extension cleanup

### DIFF
--- a/tests/Unit/Expect/BecauseTest.php
+++ b/tests/Unit/Expect/BecauseTest.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Expect;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\ExpectationExtension;
 
-final class BecauseTest
+final readonly class BecauseTest
 {
+    public function __construct(private Cleanup $cleanup) {}
+
     #[Test]
     public function becauseAddsTheReasonToTheFailureMessage(): void
     {
@@ -104,7 +107,7 @@ final class BecauseTest
     #[Test]
     public function extensionMatchersCarryTheReason(): void
     {
-        Expect::install([
+        $restoreExtensions = Expect::install([
             new class implements ExpectationExtension {
                 #[\Override]
                 public function matchers(): array
@@ -115,14 +118,11 @@ final class BecauseTest
                 }
             },
         ]);
+        $this->cleanup->defer($restoreExtensions);
 
-        try {
-            $detail = FailureProbe::detailOf(
-                static fn() => Expect::that(2)->because('the id must be odd')->__call('toBeOdd', []),
-            );
-        } finally {
-            Expect::install([]);
-        }
+        $detail = FailureProbe::detailOf(
+            static fn() => Expect::that(2)->because('the id must be odd')->__call('toBeOdd', []),
+        );
 
         Expect::that($detail->message)->because('extension matchers carry the reason')
             ->toBe('Expected 2 to satisfy the extension matcher toBeOdd because the id must be odd.');

--- a/tests/Unit/Expect/ExpectTest.php
+++ b/tests/Unit/Expect/ExpectTest.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Expect;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\ExpectationFailed;
 use Greenlight\Tests\Fixture\Expect\EvenNumbersExtension;
 
-final class ExpectTest
+final readonly class ExpectTest
 {
+    public function __construct(private Cleanup $cleanup) {}
+
     #[Test]
     public function notAppliesOnlyToTheNextMatcher(): void
     {
@@ -45,14 +48,11 @@ final class ExpectTest
     #[Test]
     public function installedExtensionsAreDispatchedByChains(): void
     {
-        Expect::install([new EvenNumbersExtension()]);
+        $restoreExtensions = Expect::install([new EvenNumbersExtension()]);
+        $this->cleanup->defer($restoreExtensions);
 
-        try {
-            Expect::that(4)->toBeEven();
-            Expect::that(3)->not()->toBeEven();
-        } finally {
-            Expect::install([]);
-        }
+        Expect::that(4)->toBeEven();
+        Expect::that(3)->not()->toBeEven();
     }
 
     #[Test]

--- a/tests/Unit/PhpStan/ExtensionMatcherDispatchTest.php
+++ b/tests/Unit/PhpStan/ExtensionMatcherDispatchTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\PhpStan;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\PhpStanExtension\DigestExtension;
 
@@ -12,19 +13,18 @@ use Greenlight\Tests\Fixture\PhpStanExtension\DigestExtension;
  * PHPStan checks these calls through the extension. Runtime dispatch uses
  * Expectation::__call.
  */
-final class ExtensionMatcherDispatchTest
+final readonly class ExtensionMatcherDispatchTest
 {
+    public function __construct(private Cleanup $cleanup) {}
+
     #[Test]
     public function fixtureMatchersDispatchAndAnalyze(): void
     {
-        Expect::install([new DigestExtension()]);
+        $restoreExtensions = Expect::install([new DigestExtension()]);
+        $this->cleanup->defer($restoreExtensions);
 
-        try {
-            Expect::that('c0ffee')->toBeHexadecimal()
-                ->toHaveDigestLength(6);
-            Expect::that('not hex!')->not()->toBeHexadecimal();
-        } finally {
-            Expect::install([]);
-        }
+        Expect::that('c0ffee')->toBeHexadecimal()
+            ->toHaveDigestLength(6);
+        Expect::that('not hex!')->not()->toBeHexadecimal();
     }
 }


### PR DESCRIPTION
## Summary

- inject the per-test Cleanup service into expectation extension tests
- register the exact extension restoration callback immediately after installation
- retain lexical restoration in tests that inspect state before and after uninstalling extensions