### PR TITLE
refactor(test): defer reporting stream cleanup

### DIFF
--- a/tests/Unit/Cli/ApplicationStreamOutputTest.php
+++ b/tests/Unit/Cli/ApplicationStreamOutputTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Unit\Cli;
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Cli\Application;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\StreamWrapperSandbox;
@@ -16,7 +17,10 @@ final readonly class ApplicationStreamOutputTest
 {
     private const string SCHEME = 'greenlight-application-partial-write';
 
-    public function __construct(private StreamWrapperSandbox $streamWrappers) {}
+    public function __construct(
+        private StreamWrapperSandbox $streamWrappers,
+        private Cleanup $cleanup,
+    ) {}
 
     /**
      * @param list<string> $arguments
@@ -32,31 +36,31 @@ final readonly class ApplicationStreamOutputTest
         $this->streamWrappers->register(self::SCHEME, PartialWriteStream::class);
 
         $partial = \fopen(self::SCHEME . '://partial', 'wb');
-        $other = \fopen('php://memory', 'wb');
-
-        if ($partial === false || $other === false) {
-            if (\is_resource($partial)) {
-                \fclose($partial);
-            }
-
+        if ($partial === false) {
             Fail::because('Greenlight did not open the CLI test streams.');
         }
-
-        try {
-            $application = $useStderr
-                ? Application::forStreams($other, $partial)
-                : Application::forStreams($partial, $other);
-
-            Expect::that($application->run($arguments, __DIR__))
-                ->because('a CLI write through a partial stream MUST preserve the exit code')
-                ->toBe($expectedExit);
-            Expect::that(PartialWriteStream::contents())
-                ->because('a short CLI stream write MUST NOT truncate output')
-                ->toBe($expectedOutput);
-        } finally {
+        $this->cleanup->defer(static function () use ($partial): void {
             \fclose($partial);
-            \fclose($other);
+        });
+
+        $other = \fopen('php://memory', 'wb');
+        if ($other === false) {
+            Fail::because('Greenlight did not open the CLI test streams.');
         }
+        $this->cleanup->defer(static function () use ($other): void {
+            \fclose($other);
+        });
+
+        $application = $useStderr
+            ? Application::forStreams($other, $partial)
+            : Application::forStreams($partial, $other);
+
+        Expect::that($application->run($arguments, __DIR__))
+            ->because('a CLI write through a partial stream MUST preserve the exit code')
+            ->toBe($expectedExit);
+        Expect::that(PartialWriteStream::contents())
+            ->because('a short CLI stream write MUST NOT truncate output')
+            ->toBe($expectedOutput);
     }
 
     /**

--- a/tests/Unit/Reporting/StreamOutputTest.php
+++ b/tests/Unit/Reporting/StreamOutputTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Reporting;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\StreamWrapperSandbox;
 use Greenlight\Reporting\Output\StreamOutput;
@@ -15,7 +16,10 @@ final readonly class StreamOutputTest
 {
     private const string PARTIAL_WRITE_SCHEME = 'greenlight-partial-write';
 
-    public function __construct(private StreamWrapperSandbox $streamWrappers) {}
+    public function __construct(
+        private StreamWrapperSandbox $streamWrappers,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function writesAccumulateOnTheStream(): void
@@ -25,6 +29,9 @@ final readonly class StreamOutputTest
         if ($stream === false) {
             throw new \RuntimeException('Could not open an in-memory stream.');
         }
+        $this->cleanup->defer(static function () use ($stream): void {
+            \fclose($stream);
+        });
 
         $output = new StreamOutput($stream);
         $output->write('first ');
@@ -33,8 +40,6 @@ final readonly class StreamOutputTest
         \rewind($stream);
 
         Expect::that(\stream_get_contents($stream))->because('writes accumulate on the stream')->toBe('first second');
-
-        \fclose($stream);
     }
 
     #[Test]
@@ -45,21 +50,20 @@ final readonly class StreamOutputTest
         if ($stream === false) {
             throw new \RuntimeException('Could not open a read-only in-memory stream.');
         }
-
-        try {
-            $output = new StreamOutput($stream);
-
-            Expect::that(static function () use ($output): void {
-                $output->write('cannot be written');
-            })
-                ->because('a stream write failure becomes a reporting error')
-                ->toThrow(
-                    ReportingError::class,
-                    message: 'Greenlight did not write reporter output to the stream.',
-                );
-        } finally {
+        $this->cleanup->defer(static function () use ($stream): void {
             \fclose($stream);
-        }
+        });
+
+        $output = new StreamOutput($stream);
+
+        Expect::that(static function () use ($output): void {
+            $output->write('cannot be written');
+        })
+            ->because('a stream write failure becomes a reporting error')
+            ->toThrow(
+                ReportingError::class,
+                message: 'Greenlight did not write reporter output to the stream.',
+            );
     }
 
     #[Test]
@@ -67,15 +71,11 @@ final readonly class StreamOutputTest
     {
         $stream = $this->openPartialWriteStream('partial');
 
-        try {
-            new StreamOutput($stream)->write('complete reporter output');
+        new StreamOutput($stream)->write('complete reporter output');
 
-            Expect::that(PartialWriteStream::contents())
-                ->because('a short stream write MUST NOT truncate reporter output')
-                ->toBe('complete reporter output');
-        } finally {
-            \fclose($stream);
-        }
+        Expect::that(PartialWriteStream::contents())
+            ->because('a short stream write MUST NOT truncate reporter output')
+            ->toBe('complete reporter output');
     }
 
     #[Test]
@@ -83,18 +83,14 @@ final readonly class StreamOutputTest
     {
         $stream = $this->openPartialWriteStream('stalled');
 
-        try {
-            $output = new StreamOutput($stream);
+        $output = new StreamOutput($stream);
 
-            Expect::that(static fn() => $output->write('cannot make progress'))
-                ->because('a zero-byte write MUST stop instead of retrying without a limit')
-                ->toThrow(
-                    ReportingError::class,
-                    message: 'Greenlight did not write reporter output to the stream.',
-                );
-        } finally {
-            \fclose($stream);
-        }
+        Expect::that(static fn() => $output->write('cannot make progress'))
+            ->because('a zero-byte write MUST stop instead of retrying without a limit')
+            ->toThrow(
+                ReportingError::class,
+                message: 'Greenlight did not write reporter output to the stream.',
+            );
     }
 
     /**
@@ -109,6 +105,9 @@ final readonly class StreamOutputTest
         if ($stream === false) {
             throw new \RuntimeException('Greenlight did not open the partial-write stream.');
         }
+        $this->cleanup->defer(static function () use ($stream): void {
+            \fclose($stream);
+        });
 
         return $stream;
     }


### PR DESCRIPTION
## Summary

- register reporting streams for deferred cleanup immediately after each successful open
- remove end-of-test stream try/finally blocks from StreamOutput and CLI output tests
- preserve stream-wrapper disposal ordering through the test-owned Cleanup service