### PR TITLE
fix(test): accept cleanup callback returns

### DIFF
--- a/docs/api-test-contracts.md
+++ b/docs/api-test-contracts.md
@@ -51,6 +51,7 @@ final class Cleanup
 
 Register cleanup immediately after the test acquires a resource. This
 makes cleanup available if a later operation fails.
+Greenlight ignores the callback return value.
 
 ```php
 public function defer(\Closure $cleanup): void
@@ -58,10 +59,11 @@ public function defer(\Closure $cleanup): void
 
 PHPDoc:
 
-- `@param \Closure(): void $cleanup`
+- `@template TReturn`
+- `@param \Closure(): TReturn $cleanup`
 - `@throws \LogicException If test cleanup has started.`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/Cleanup.php#L32)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/Cleanup.php#L33)
 
 ## `SkipTest`
 

--- a/src/Core/Test/Cleanup.php
+++ b/src/Core/Test/Cleanup.php
@@ -14,9 +14,7 @@ namespace Greenlight\Core\Test;
  */
 final class Cleanup
 {
-    /**
-     * @var list<\Closure(): void>
-     */
+    /** @var list<\Closure> */
     private array $callbacks = [];
 
     private bool $closed = false;
@@ -24,8 +22,11 @@ final class Cleanup
     /**
      * Register cleanup immediately after the test acquires a resource. This
      * makes cleanup available if a later operation fails.
+     * Greenlight ignores the callback return value.
      *
-     * @param \Closure(): void $cleanup
+     * @template TReturn
+     *
+     * @param \Closure(): TReturn $cleanup
      *
      * @throws \LogicException If test cleanup has started.
      */

--- a/tests/Unit/Core/Test/CleanupTest.php
+++ b/tests/Unit/Core/Test/CleanupTest.php
@@ -59,6 +59,26 @@ final readonly class CleanupTest
     }
 
     #[Test]
+    public function closeIgnoresCallbackReturnValues(): void
+    {
+        $cleanup = new Cleanup();
+        $trace = [];
+        $cleanup->defer(static function () use (&$trace): void {
+            $trace[] = 'void';
+        });
+        $cleanup->defer(static function () use (&$trace): string {
+            $trace[] = 'value';
+
+            return 'ignored';
+        });
+
+        $failures = $cleanup->close();
+
+        Expect::that($trace)->toBe(['value', 'void']);
+        Expect::that($failures)->toBe([]);
+    }
+
+    #[Test]
     public function deferRejectsRegistrationAfterCleanupStarts(): void
     {
         $cleanup = new Cleanup();


### PR DESCRIPTION
## Summary

- preserve the zero-argument closure contract while accepting any callback return type
- erase heterogeneous return types only after callback registration
- prove that cleanup runs void-returning and value-returning callbacks and ignores their values