### PR TITLE
refactor(test): defer subprocess cleanup

### DIFF
--- a/tests/Acceptance/InterruptionTest.php
+++ b/tests/Acceptance/InterruptionTest.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Event\Event;
 use Greenlight\Core\Event\WorkerSpawned;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\SkipTest;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
@@ -21,7 +22,10 @@ final readonly class InterruptionTest
 {
     private const float DEADLINE_SECONDS = 30.0;
 
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     /**
      * @param list<string> $expectedDiagnostics
@@ -48,69 +52,66 @@ final readonly class InterruptionTest
             ['run', '--workers=2', '--reporter=jsonl'],
             ['TMPDIR' => $tmp],
         );
+        $this->cleanup->defer($process->terminate(...));
 
-        try {
-            $deadline = \microtime(true) + self::DEADLINE_SECONDS;
+        $deadline = \microtime(true) + self::DEADLINE_SECONDS;
 
-            // A marker makes standard output available before the buffer is
-            // full. A test-finished line can delay SIGINT until after the run
-            // ends.
-            while (\microtime(true) < $deadline && \glob($markerDir . '/*.started') === []) {
-                $process->pump();
-                \usleep(5_000);
-            }
-
-            if (\glob($markerDir . '/*.started') === []) {
-                Fail::because(\sprintf(
-                    'Timed out after %.1fs waiting for a fixture test to start.',
-                    self::DEADLINE_SECONDS,
-                ));
-            }
-
-            $process->signal(\SIGINT);
-            $result = $process->wait(self::DEADLINE_SECONDS);
-
-            Expect::that($result->stdout)
-                ->because('The interrupted run MUST report a finished test.')
-                ->toContain('"test-finished"');
-            Expect::that($result->exitCode)
-                ->because('SIGINT MUST produce exit code 130.')
-                ->toBe(130);
-
-            foreach ($expectedDiagnostics as $diagnostic) {
-                Expect::that($result->stderr)
-                    ->because('SIGINT MUST report each interruption diagnostic.')
-                    ->toContain($diagnostic);
-            }
-
-            $workerPids = $this->spawnedWorkerPids(JsonlEvents::from($result));
-            Expect::that($workerPids)
-                ->because('The interrupted run MUST start at least one worker.')
-                ->not()
-                ->toBeEmpty();
-
-            foreach ($workerPids as $pid) {
-                $alive = Subprocess::run($root, ['ps', '-p', (string) $pid, '-o', 'pid=']);
-                Expect::that(\trim($alive->stdout))
-                    ->because(\sprintf('Worker process %d MUST NOT exist after the run exits.', $pid))
-                    ->toBe('');
-            }
-
-            $sockets = \glob($tmp . '/greenlight-*/orchestrator.sock');
-            Expect::that(\is_array($sockets) ? $sockets : [])
-                ->because('The interrupted run MUST remove its orchestrator socket.')
-                ->toBe([]);
-            $cleaned = \file($markerDir . '/cleaned.log', \FILE_IGNORE_NEW_LINES);
-            Expect::that(\is_array($cleaned) ? $cleaned : [])
-                ->because('The interrupted run MUST clean its integration fixtures.')
-                ->toBe(['cleaned']);
-            $resources = \glob($markerDir . '/resource-*');
-            Expect::that(\is_array($resources) ? $resources : [])
-                ->because('The interrupted run MUST remove its integration fixture resources.')
-                ->toBe([]);
-        } finally {
-            $process->terminate();
+        // A marker makes standard output available before the buffer is
+        // full. A test-finished line can delay SIGINT until after the run
+        // ends.
+        while (\microtime(true) < $deadline && \glob($markerDir . '/*.started') === []) {
+            $process->pump();
+            \usleep(5_000);
         }
+
+        if (\glob($markerDir . '/*.started') === []) {
+            Fail::because(\sprintf(
+                'Timed out after %.1fs waiting for a fixture test to start.',
+                self::DEADLINE_SECONDS,
+            ));
+        }
+
+        $process->signal(\SIGINT);
+        $result = $process->wait(self::DEADLINE_SECONDS);
+
+        Expect::that($result->stdout)
+            ->because('The interrupted run MUST report a finished test.')
+            ->toContain('"test-finished"');
+        Expect::that($result->exitCode)
+            ->because('SIGINT MUST produce exit code 130.')
+            ->toBe(130);
+
+        foreach ($expectedDiagnostics as $diagnostic) {
+            Expect::that($result->stderr)
+                ->because('SIGINT MUST report each interruption diagnostic.')
+                ->toContain($diagnostic);
+        }
+
+        $workerPids = $this->spawnedWorkerPids(JsonlEvents::from($result));
+        Expect::that($workerPids)
+            ->because('The interrupted run MUST start at least one worker.')
+            ->not()
+            ->toBeEmpty();
+
+        foreach ($workerPids as $pid) {
+            $alive = Subprocess::run($root, ['ps', '-p', (string) $pid, '-o', 'pid=']);
+            Expect::that(\trim($alive->stdout))
+                ->because(\sprintf('Worker process %d MUST NOT exist after the run exits.', $pid))
+                ->toBe('');
+        }
+
+        $sockets = \glob($tmp . '/greenlight-*/orchestrator.sock');
+        Expect::that(\is_array($sockets) ? $sockets : [])
+            ->because('The interrupted run MUST remove its orchestrator socket.')
+            ->toBe([]);
+        $cleaned = \file($markerDir . '/cleaned.log', \FILE_IGNORE_NEW_LINES);
+        Expect::that(\is_array($cleaned) ? $cleaned : [])
+            ->because('The interrupted run MUST clean its integration fixtures.')
+            ->toBe(['cleaned']);
+        $resources = \glob($markerDir . '/resource-*');
+        Expect::that(\is_array($resources) ? $resources : [])
+            ->because('The interrupted run MUST remove its integration fixture resources.')
+            ->toBe([]);
     }
 
     /**

--- a/tests/Acceptance/WatchDiscoveryErrorTest.php
+++ b/tests/Acceptance/WatchDiscoveryErrorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Acceptance;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
@@ -12,7 +13,10 @@ use Greenlight\Tests\Support\GreenlightCli;
 
 final readonly class WatchDiscoveryErrorTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function watchReportsDiscoveryErrorsAndKeepsWaiting(): void
@@ -38,41 +42,38 @@ final readonly class WatchDiscoveryErrorTest
             $project->directory,
             ['run', '--watch', '--reporter=plain'],
         );
+        $this->cleanup->defer($process->terminate(...));
 
-        try {
-            $output = $process->readStdoutUntil('Waiting for changes', 20.0);
+        $output = $process->readStdoutUntil('Waiting for changes', 20.0);
 
-            Expect::that($output)
-                ->because('watch mode MUST complete its initial valid run')
-                ->toContain('1 test, 1 passed');
+        Expect::that($output)
+            ->because('watch mode MUST complete its initial valid run')
+            ->toContain('1 test, 1 passed');
 
-            $project->writeFile('tests/BrokenTest.php', <<<'PHP'
-                <?php
+        $project->writeFile('tests/BrokenTest.php', <<<'PHP'
+            <?php
 
-                declare(strict_types=1);
+            declare(strict_types=1);
 
-                namespace WatchDiscoveryError;
+            namespace WatchDiscoveryError;
 
-                final class WrongName {}
-                PHP);
-            $output = $process->readStdoutUntil('Waiting for changes', 20.0);
+            final class WrongName {}
+            PHP);
+        $output = $process->readStdoutUntil('Waiting for changes', 20.0);
 
-            Expect::that($output)
-                ->because('watch mode MUST continue after a discovery error')
-                ->toContain('Detected changes');
+        Expect::that($output)
+            ->because('watch mode MUST continue after a discovery error')
+            ->toContain('Detected changes');
 
-            $process->write('q');
-            $result = $process->wait(10.0);
+        $process->write('q');
+        $result = $process->wait(10.0);
 
-            Expect::that($result->exitCode)
-                ->because('watch mode MUST remain available after a discovery error')
-                ->toBe(0);
-            Expect::that($result->stderr)
-                ->because('watch mode MUST report the discovery error')
-                ->toContain('BrokenTest.php')
-                ->toContain('WrongName');
-        } finally {
-            $process->terminate();
-        }
+        Expect::that($result->exitCode)
+            ->because('watch mode MUST remain available after a discovery error')
+            ->toBe(0);
+        Expect::that($result->stderr)
+            ->because('watch mode MUST report the discovery error')
+            ->toContain('BrokenTest.php')
+            ->toContain('WrongName');
     }
 }

--- a/tests/Acceptance/WatchModeTest.php
+++ b/tests/Acceptance/WatchModeTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Acceptance;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
@@ -12,7 +13,10 @@ use Greenlight\Tests\Support\GreenlightCli;
 
 final readonly class WatchModeTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function reRunsOnFileChangesAndQuitsOnQ(): void
@@ -26,30 +30,27 @@ final readonly class WatchModeTest
         }
 
         $process = GreenlightCli::start($project->directory, ['run', '--watch', '--reporter=plain']);
+        $this->cleanup->defer($process->terminate(...));
 
-        try {
-            $output = $process->readStdoutUntil('Waiting for changes', 20.0);
-            Expect::that($output)->toContain('1 test, 1 passed');
+        $output = $process->readStdoutUntil('Waiting for changes', 20.0);
+        Expect::that($output)->toContain('1 test, 1 passed');
 
-            // Append a comment to make a synthetic change. The size changes, but
-            // the modification time can remain equal.
-            $project->writeFile('tests/WatchProbeTest.php', $original . "// touched\n");
+        // Append a comment to make a synthetic change. The size changes, but
+        // the modification time can remain equal.
+        $project->writeFile('tests/WatchProbeTest.php', $original . "// touched\n");
 
-            $output = $process->readStdoutUntil('Waiting for changes', 20.0);
-            Expect::that($output)->toContain('Detected changes')
-                ->toContain('1 test, 1 passed');
+        $output = $process->readStdoutUntil('Waiting for changes', 20.0);
+        Expect::that($output)->toContain('Detected changes')
+            ->toContain('1 test, 1 passed');
 
-            $process->write('q');
-            $result = $process->wait(10.0);
-            $provisioned = \file($project->path('markers/provisioned.log'), \FILE_IGNORE_NEW_LINES);
-            $cleaned = \file($project->path('markers/cleaned.log'), \FILE_IGNORE_NEW_LINES);
+        $process->write('q');
+        $result = $process->wait(10.0);
+        $provisioned = \file($project->path('markers/provisioned.log'), \FILE_IGNORE_NEW_LINES);
+        $cleaned = \file($project->path('markers/cleaned.log'), \FILE_IGNORE_NEW_LINES);
 
-            Expect::that($result->exitCode)->toBe(0);
-            Expect::that(\is_array($provisioned) ? $provisioned : [])->toHaveCount(2);
-            Expect::that(\is_array($cleaned) ? $cleaned : [])->toBe(['cleaned', 'cleaned']);
-        } finally {
-            $process->terminate();
-        }
+        Expect::that($result->exitCode)->toBe(0);
+        Expect::that(\is_array($provisioned) ? $provisioned : [])->toHaveCount(2);
+        Expect::that(\is_array($cleaned) ? $cleaned : [])->toBe(['cleaned', 'cleaned']);
     }
 
     #[Test]
@@ -61,23 +62,20 @@ final readonly class WatchModeTest
             ['run', '--watch', '--reporter=plain'],
             phpArguments: ['-d', 'disable_functions=shell_exec'],
         );
+        $this->cleanup->defer($process->terminate(...));
 
-        try {
-            $output = $process->readStdoutUntil('Waiting for changes', 20.0);
+        $output = $process->readStdoutUntil('Waiting for changes', 20.0);
 
-            Expect::that($output)
-                ->because('watch mode starts when PHP disables shell_exec')
-                ->toContain('1 test, 1 passed');
+        Expect::that($output)
+            ->because('watch mode starts when PHP disables shell_exec')
+            ->toContain('1 test, 1 passed');
 
-            $process->write('q');
-            $result = $process->wait(10.0);
+        $process->write('q');
+        $result = $process->wait(10.0);
 
-            Expect::that($result->exitCode)
-                ->because('watch mode exits cleanly when PHP disables shell_exec')
-                ->toBe(0);
-        } finally {
-            $process->terminate();
-        }
+        Expect::that($result->exitCode)
+            ->because('watch mode exits cleanly when PHP disables shell_exec')
+            ->toBe(0);
     }
 
     #[Test]
@@ -88,26 +86,23 @@ final readonly class WatchModeTest
             $project->directory,
             ['run', '--watch', '--reporter=plain'],
         );
+        $this->cleanup->defer($process->terminate(...));
 
-        try {
-            $process->readStdoutUntil('Waiting for changes', 20.0);
+        $process->readStdoutUntil('Waiting for changes', 20.0);
 
-            $process->write('q');
-            $result = $process->wait(10.0);
+        $process->write('q');
+        $result = $process->wait(10.0);
 
-            Expect::that($result->exitCode)
-                ->because('watch mode MUST remain interactive after a fixture cleanup failure')
-                ->toBe(0);
-            Expect::that($result->output())
-                ->because('watch mode MUST report integration fixture cleanup failures')
-                ->toContain('Integration fixture teardown failed.')
-                ->toContain('intentional fixture cleanup failure');
-            Expect::that($this->matches($project->path('markers/resource-*')))
-                ->because('watch mode MUST remove orchestrator-owned resources after cleanup failures')
-                ->toBe([]);
-        } finally {
-            $process->terminate();
-        }
+        Expect::that($result->exitCode)
+            ->because('watch mode MUST remain interactive after a fixture cleanup failure')
+            ->toBe(0);
+        Expect::that($result->output())
+            ->because('watch mode MUST report integration fixture cleanup failures')
+            ->toContain('Integration fixture teardown failed.')
+            ->toContain('intentional fixture cleanup failure');
+        Expect::that($this->matches($project->path('markers/resource-*')))
+            ->because('watch mode MUST remove orchestrator-owned resources after cleanup failures')
+            ->toBe([]);
     }
 
     #[Test]
@@ -119,31 +114,28 @@ final readonly class WatchModeTest
             $project->directory,
             ['run', '--watch', '--reporter=plain'],
         );
+        $this->cleanup->defer($process->terminate(...));
 
-        try {
-            $output = $process->readStdoutUntil('Waiting for changes', 20.0);
+        $output = $process->readStdoutUntil('Waiting for changes', 20.0);
 
-            Expect::that($output)
-                ->because('watch mode MUST complete its initial coverage run')
-                ->toContain('1 test, 1 passed');
+        Expect::that($output)
+            ->because('watch mode MUST complete its initial coverage run')
+            ->toContain('1 test, 1 passed');
 
-            $project->writeFile('source/Observed.php', "<?php\n// changed\n");
-            $output = $process->readStdoutUntil('Waiting for changes', 20.0);
+        $project->writeFile('source/Observed.php', "<?php\n// changed\n");
+        $output = $process->readStdoutUntil('Waiting for changes', 20.0);
 
-            Expect::that($output)
-                ->because('watch mode MUST observe configured coverage include paths')
-                ->toContain('Detected changes')
-                ->toContain('1 test, 1 passed');
+        Expect::that($output)
+            ->because('watch mode MUST observe configured coverage include paths')
+            ->toContain('Detected changes')
+            ->toContain('1 test, 1 passed');
 
-            $process->write('q');
-            $result = $process->wait(10.0);
+        $process->write('q');
+        $result = $process->wait(10.0);
 
-            Expect::that($result->exitCode)
-                ->because('watch mode exits cleanly after a coverage source change')
-                ->toBe(0);
-        } finally {
-            $process->terminate();
-        }
+        Expect::that($result->exitCode)
+            ->because('watch mode exits cleanly after a coverage source change')
+            ->toBe(0);
     }
 
     private function writeProject(

--- a/tests/Support/Subprocess.php
+++ b/tests/Support/Subprocess.php
@@ -7,9 +7,9 @@ namespace Greenlight\Tests\Support;
 use Greenlight\Core\ErrorTrap;
 
 /**
- * The caller of start() owns the active process handle. It MUST call
- * terminate() in a finally block. After wait() collects the result,
- * terminate() has no effect.
+ * The caller of start() owns the active process handle. After start() returns,
+ * the caller MUST immediately guarantee that terminate() will run. After
+ * wait() collects the result, terminate() has no effect.
  */
 final class Subprocess
 {


### PR DESCRIPTION
## Summary

- register long-running acceptance subprocesses for deferred cleanup immediately after startup
- remove end-of-test process termination `try`/`finally` blocks
- document that callers MUST immediately guarantee termination after process startup