### PR TITLE
docs(bridges): remove obvious unsupported features

### DIFF
--- a/docs/hyperf.md
+++ b/docs/hyperf.md
@@ -188,8 +188,6 @@ each attempt. It always runs inside a coroutine.
 The bridge does not reset application static properties or global variables.
 Reset these values in an `#[After]` hook or the `reset:` callback.
 
-The bridge does not isolate databases, queues, caches, or remote services.
-
 ## Parallel resources
 
 Workers run tests at the same time. Use `GREENLIGHT_CHANNEL` in Hyperf
@@ -218,7 +216,4 @@ The bridge does not provide:
 
 * A live Swoole HTTP server or server worker events
 * Concurrent test attempts inside one Greenlight worker
-* Hyperf `co-phpunit` or PHPUnit helper traits
 * Swow coroutine execution
-* Database transactions or schema creation
-* Automatic cleanup of application static state or external resources

--- a/docs/tempest.md
+++ b/docs/tempest.md
@@ -130,8 +130,6 @@ the same kernel.
 Use Tempest's `Resettable` interface to reset container state after each test.
 Reset state outside the container in an `#[After]` hook.
 
-The bridge does not isolate databases or other external services.
-
 ## Parallel resources
 
 Each worker uses `.tempest/greenlight/<channel>` for Tempest internal storage.
@@ -143,12 +141,3 @@ assign separate databases, cache paths, queues, and other external resources.
 If workers cannot use separate external resources, use `#[RequiresResource]`.
 Configure the safe concurrency limit in `greenlight.php`. See
 [configuration](configuration.md) for concurrency limits.
-
-## Unsupported features
-
-The bridge does not supply:
-
-* `IntegrationTest` or PHPUnit integration
-* HTTP, console, mail, event, storage, or database tester objects
-* database creation, migration, or transaction rollback
-* replacement container bindings for Greenlight doubles


### PR DESCRIPTION
## Summary

- remove the Tempest unsupported-features section and obvious external-resource disclaimer
- remove PHPUnit, database-management, and external-resource disclaimers from the Hyperf guide
- retain Hyperf runtime boundaries that can change test behavior