### PR TITLE
test(phpstan): configure even matcher analysis

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -48,6 +48,7 @@ parameters:
     greenlight:
         configFiles:
             - tests/Fixture/PhpStanExtension/greenlight.php
+            - tests/Fixture/PhpStanExtension/even-numbers.php
 
 services:
     exceptionTypeResolver!:

--- a/tests/Fixture/PhpStanExtension/even-numbers.php
+++ b/tests/Fixture/PhpStanExtension/even-numbers.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Tests\Fixture\Expect\EvenNumbersExtension;
+
+return GreenlightConfig::create()
+    ->paths([__DIR__ . '/../DiscoveryBasic'])
+    ->plugins(new EvenNumbersExtension());

--- a/tests/Unit/Expect/ExpectTest.php
+++ b/tests/Unit/Expect/ExpectTest.php
@@ -48,10 +48,8 @@ final class ExpectTest
         Expect::install([new EvenNumbersExtension()]);
 
         try {
-            // Dispatch directly through __call. Static analysis knows only the
-            // matchers in configured greenlight.php files.
-            Expect::that(4)->__call('toBeEven', []);
-            Expect::that(3)->not()->__call('toBeEven', []);
+            Expect::that(4)->toBeEven();
+            Expect::that(3)->not()->toBeEven();
         } finally {
             Expect::install([]);
         }
@@ -64,9 +62,9 @@ final class ExpectTest
         $chain = Expect::that(4);
         Expect::install([]);
 
-        $chain->__call('toBeEven', []);
+        $chain->toBeEven();
 
-        Expect::that(static fn() => Expect::that(4)->__call('toBeEven', []))->because('chains created before an install keep their extensions')
+        Expect::that(static fn() => Expect::that(4)->toBeEven())->because('chains created before an install keep their extensions')
             ->toThrow(\BadMethodCallException::class);
     }
 
@@ -80,8 +78,8 @@ final class ExpectTest
         $chain = Expect::that(4);
         $restoreEmpty();
 
-        $chain->__call('toBeEven', []);
-        Expect::that(static fn() => Expect::that(4)->__call('toBeEven', []))
+        $chain->toBeEven();
+        Expect::that(static fn() => Expect::that(4)->toBeEven())
             ->because('install cleanup restores the exact previous extension list')
             ->toThrow(\BadMethodCallException::class);
     }

--- a/tests/Unit/Plugin/PluginTest.php
+++ b/tests/Unit/Plugin/PluginTest.php
@@ -426,13 +426,11 @@ final class PluginTest
         Expect::install([new EvenNumbersExtension()]);
 
         try {
-            // Dispatch uses __call because static analysis cannot resolve dynamic
-            // matchers.
-            Expect::that(4)->__call('toBeEven', []);
-            Expect::that(3)->not()->__call('toBeEven', []);
+            Expect::that(4)->toBeEven();
+            Expect::that(3)->not()->toBeEven();
 
             Expect::that(static function (): void {
-                Expect::that(3)->__call('toBeEven', []);
+                Expect::that(3)->toBeEven();
             })->toThrow(ExpectationFailed::class, matching: '/extension matcher toBeEven/');
 
             Expect::that(static fn(): Expectation => Expect::that(3)->__call('toBeSomethingUnknown', []))


### PR DESCRIPTION
## Summary

- register the test-only even-number extension through Greenlight’s existing PHPStan configuration input
- replace explicit dynamic dispatch with fluent `toBeEven()` calls in expectation and plugin tests
- retain explicit `__call()` only where the test intentionally exercises an unknown matcher

This uses the extension’s supported project-level matcher discovery instead of attempting unsound statement-order inference from `Expect::install()`.