### PR TITLE
refactor(test): defer application stream cleanup

### DIFF
--- a/tests/Unit/Cli/ApplicationCoverageCleanupTest.php
+++ b/tests/Unit/Cli/ApplicationCoverageCleanupTest.php
@@ -6,6 +6,7 @@ namespace Greenlight\Tests\Unit\Cli;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Cli\Application;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\EnvironmentSandbox;
 use Greenlight\Fixture\TempDirectory;
@@ -19,6 +20,7 @@ final readonly class ApplicationCoverageCleanupTest
     public function __construct(
         private TempDirectory $tempDirectory,
         private EnvironmentSandbox $environment,
+        private Cleanup $cleanup,
     ) {}
 
     #[Test]
@@ -58,18 +60,16 @@ final readonly class ApplicationCoverageCleanupTest
             \var_export($fixtureDirectory, true),
         ));
         $stdout = MemoryStream::open();
+        $this->cleanup->defer(static fn() => MemoryStream::close($stdout));
         $stderr = MemoryStream::open();
+        $this->cleanup->defer(static fn() => MemoryStream::close($stderr));
 
-        try {
-            Expect::that(fn() => Application::forStreams($stdout, $stderr)->run(
-                ['run', '--reporter=plain', '--no-ansi'],
-                $project->directory,
-            ))
-                ->because('a run event failure MUST propagate after coverage cleanup')
-                ->toThrow(ReportingError::class);
-        } finally {
-            MemoryStream::close($stdout, $stderr);
-        }
+        Expect::that(fn() => Application::forStreams($stdout, $stderr)->run(
+            ['run', '--reporter=plain', '--no-ansi'],
+            $project->directory,
+        ))
+            ->because('a run event failure MUST propagate after coverage cleanup')
+            ->toThrow(ReportingError::class);
 
         Expect::that(\getenv(SubprocessCoverage::DIRECTORY_ENV))
             ->because('a failed run MUST restore an absent coverage relay directory')

--- a/tests/Unit/Cli/ApplicationReporterStreamTest.php
+++ b/tests/Unit/Cli/ApplicationReporterStreamTest.php
@@ -6,6 +6,7 @@ namespace Greenlight\Tests\Unit\Cli;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Cli\Application;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\EnvironmentSandbox;
 use Greenlight\Fixture\TempDirectory;
@@ -17,6 +18,7 @@ final readonly class ApplicationReporterStreamTest
     public function __construct(
         private TempDirectory $tempDirectory,
         private EnvironmentSandbox $environment,
+        private Cleanup $cleanup,
     ) {}
 
     #[Test]
@@ -28,20 +30,18 @@ final readonly class ApplicationReporterStreamTest
             'application-reporter-stream',
         );
         $stdout = MemoryStream::open();
+        $this->cleanup->defer(static fn() => MemoryStream::close($stdout));
         $stderr = MemoryStream::open();
+        $this->cleanup->defer(static fn() => MemoryStream::close($stderr));
 
-        try {
-            $exit = Application::forStreams($stdout, $stderr)->run(
-                ['run', '--workers=1', '--reporter=plain', '--no-ansi'],
-                $project->directory,
-            );
-            \rewind($stdout);
-            \rewind($stderr);
-            $output = \stream_get_contents($stdout);
-            $errors = \stream_get_contents($stderr);
-        } finally {
-            MemoryStream::close($stdout, $stderr);
-        }
+        $exit = Application::forStreams($stdout, $stderr)->run(
+            ['run', '--workers=1', '--reporter=plain', '--no-ansi'],
+            $project->directory,
+        );
+        \rewind($stdout);
+        \rewind($stderr);
+        $output = \stream_get_contents($stdout);
+        $errors = \stream_get_contents($stderr);
 
         Expect::that($exit)
             ->because('a run through configured streams MUST preserve the reporter exit code')


### PR DESCRIPTION
## Summary

- register CLI application streams for deferred cleanup immediately after opening each stream
- remove cleanup-only `try`/`finally` blocks from coverage and reporter stream tests
- keep stream reads and environment assertions at their existing points in each test