### PR TITLE
refactor(test): defer socket channel cleanup

### DIFF
--- a/tests/Unit/Runner/Protocol/SocketChannelEofReadFailureTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelEofReadFailureTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner\Protocol;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\StreamWrapperSandbox;
@@ -15,7 +16,10 @@ final readonly class SocketChannelEofReadFailureTest
 {
     private const string STREAM_SCHEME = 'greenlight-eof-read-failure';
 
-    public function __construct(private StreamWrapperSandbox $streamWrappers) {}
+    public function __construct(
+        private StreamWrapperSandbox $streamWrappers,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function aFailedReadAtPeerEofClosesTheChannelCleanly(): void
@@ -29,14 +33,11 @@ final readonly class SocketChannelEofReadFailureTest
         }
 
         $channel = new SocketChannel($stream);
+        $this->cleanup->defer($channel->close(...));
 
-        try {
-            Expect::that($channel->poll())
-                ->because('a failed read that reaches peer EOF MUST end polling cleanly')
-                ->toBeNull();
-            Expect::that($channel->isEof())->toBeTrue();
-        } finally {
-            $channel->close();
-        }
+        Expect::that($channel->poll())
+            ->because('a failed read that reaches peer EOF MUST end polling cleanly')
+            ->toBeNull();
+        Expect::that($channel->isEof())->toBeTrue();
     }
 }

--- a/tests/Unit/Runner/Protocol/SocketChannelFlushFailureTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelFlushFailureTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner\Protocol;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\StreamWrapperSandbox;
@@ -17,7 +18,10 @@ final readonly class SocketChannelFlushFailureTest
 {
     private const string STREAM_SCHEME = 'greenlight-flush-failure';
 
-    public function __construct(private StreamWrapperSandbox $streamWrappers) {}
+    public function __construct(
+        private StreamWrapperSandbox $streamWrappers,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function aFailedFlushRejectsTheSend(): void
@@ -31,18 +35,15 @@ final readonly class SocketChannelFlushFailureTest
         }
 
         $channel = new SocketChannel($stream);
+        $this->cleanup->defer($channel->close(...));
 
-        try {
-            Expect::that(static function () use ($channel): void {
-                $channel->send(new Drain());
-            })
-                ->because('a failed flush MUST reject an incomplete send')
-                ->toThrow(
-                    ProtocolError::class,
-                    message: 'Malformed frame: peer closed the connection during a write.',
-                );
-        } finally {
-            $channel->close();
-        }
+        Expect::that(static function () use ($channel): void {
+            $channel->send(new Drain());
+        })
+            ->because('a failed flush MUST reject an incomplete send')
+            ->toThrow(
+                ProtocolError::class,
+                message: 'Malformed frame: peer closed the connection during a write.',
+            );
     }
 }

--- a/tests/Unit/Runner/Protocol/SocketChannelReadFailureTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelReadFailureTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner\Protocol;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\StreamWrapperSandbox;
@@ -16,7 +17,10 @@ final readonly class SocketChannelReadFailureTest
 {
     private const string STREAM_SCHEME = 'greenlight-read-failure';
 
-    public function __construct(private StreamWrapperSandbox $streamWrappers) {}
+    public function __construct(
+        private StreamWrapperSandbox $streamWrappers,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function aFailedReadRejectsTheChannel(): void
@@ -30,16 +34,13 @@ final readonly class SocketChannelReadFailureTest
         }
 
         $channel = new SocketChannel($stream);
+        $this->cleanup->defer($channel->close(...));
 
-        try {
-            Expect::that(static fn() => $channel->poll())
-                ->because('a failed read MUST not masquerade as an idle channel')
-                ->toThrow(
-                    ProtocolError::class,
-                    message: 'Malformed frame: peer connection failed during a read.',
-                );
-        } finally {
-            $channel->close();
-        }
+        Expect::that(static fn() => $channel->poll())
+            ->because('a failed read MUST not masquerade as an idle channel')
+            ->toThrow(
+                ProtocolError::class,
+                message: 'Malformed frame: peer connection failed during a read.',
+            );
     }
 }

--- a/tests/Unit/Runner/Protocol/SocketChannelTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner\Protocol;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\StreamWrapperSandbox;
@@ -18,32 +19,32 @@ final readonly class SocketChannelTest
 {
     private const string UNSELECTABLE_SCHEME = 'greenlight-unselectable';
 
-    public function __construct(private StreamWrapperSandbox $streamWrappers) {}
+    public function __construct(
+        private StreamWrapperSandbox $streamWrappers,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function receiveTimeoutLeavesTheChannelOpenForLaterMessages(): void
     {
         [$stream, $peer] = ConnectedStreamPair::open();
         $receiver = new SocketChannel($stream);
+        $this->cleanup->defer($receiver->close(...));
         $sender = new SocketChannel($peer);
+        $this->cleanup->defer($sender->close(...));
 
-        try {
-            Expect::that($receiver->receive(0.0))
-                ->because('an empty receive can reach its deadline')
-                ->toBeNull();
-            Expect::that($receiver->isEof())
-                ->because('a receive deadline MUST NOT mark an open channel as EOF')
-                ->toBeFalse();
+        Expect::that($receiver->receive(0.0))
+            ->because('an empty receive can reach its deadline')
+            ->toBeNull();
+        Expect::that($receiver->isEof())
+            ->because('a receive deadline MUST NOT mark an open channel as EOF')
+            ->toBeFalse();
 
-            $sender->send(new Drain());
+        $sender->send(new Drain());
 
-            Expect::that($receiver->receive(0.0))
-                ->because('a channel remains usable after a receive deadline')
-                ->toBeInstanceOf(Drain::class);
-        } finally {
-            $sender->close();
-            $receiver->close();
-        }
+        Expect::that($receiver->receive(0.0))
+            ->because('a channel remains usable after a receive deadline')
+            ->toBeInstanceOf(Drain::class);
     }
 
     #[Test]
@@ -51,24 +52,21 @@ final readonly class SocketChannelTest
     {
         [$stream, $peer] = ConnectedStreamPair::open();
         $receiver = new SocketChannel($stream);
+        $this->cleanup->defer($receiver->close(...));
         $sender = new SocketChannel($peer);
+        $this->cleanup->defer($sender->close(...));
 
-        try {
-            $sender->send(new Drain());
-            $sender->close();
+        $sender->send(new Drain());
+        $sender->close();
 
-            Expect::that($receiver->poll())
-                ->because('a complete final frame MUST be delivered before peer EOF')
-                ->toBeInstanceOf(Drain::class);
-            Expect::that($receiver->poll())
-                ->because('the channel reaches clean EOF after the final frame')
-                ->toBeNull();
-            Expect::that($receiver->isEof())
-                ->toBeTrue();
-        } finally {
-            $sender->close();
-            $receiver->close();
-        }
+        Expect::that($receiver->poll())
+            ->because('a complete final frame MUST be delivered before peer EOF')
+            ->toBeInstanceOf(Drain::class);
+        Expect::that($receiver->poll())
+            ->because('the channel reaches clean EOF after the final frame')
+            ->toBeNull();
+        Expect::that($receiver->isEof())
+            ->toBeTrue();
     }
 
     #[Test]
@@ -147,17 +145,14 @@ final readonly class SocketChannelTest
         }
 
         $channel = new SocketChannel($stream);
+        $this->cleanup->defer($channel->close(...));
 
-        try {
-            Expect::that($channel->receive(1.0))
-                ->because('a stream-select failure MUST end the receive wait')
-                ->toBeNull();
-            Expect::that($channel->isEof())
-                ->because('a stream-select failure MUST NOT mark the channel as EOF')
-                ->toBeFalse();
-        } finally {
-            $channel->close();
-        }
+        Expect::that($channel->receive(1.0))
+            ->because('a stream-select failure MUST end the receive wait')
+            ->toBeNull();
+        Expect::that($channel->isEof())
+            ->because('a stream-select failure MUST NOT mark the channel as EOF')
+            ->toBeFalse();
     }
 
 }

--- a/tests/Unit/Runner/Worker/SocketEventSinkTest.php
+++ b/tests/Unit/Runner/Worker/SocketEventSinkTest.php
@@ -6,6 +6,7 @@ namespace Greenlight\Tests\Unit\Runner\Worker;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Event\SuiteStarted;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Runner\Protocol\Messages\EventEnvelope;
@@ -13,35 +14,34 @@ use Greenlight\Runner\Protocol\SocketChannel;
 use Greenlight\Runner\Worker\SocketEventSink;
 use Greenlight\Tests\Support\ConnectedStreamPair;
 
-final class SocketEventSinkTest
+final readonly class SocketEventSinkTest
 {
+    public function __construct(private Cleanup $cleanup) {}
+
     #[Test]
     public function emittedEventsCrossTheWorkerChannelInAnEventEnvelope(): void
     {
         [$senderStream, $receiverStream] = ConnectedStreamPair::open();
         $sender = new SocketChannel($senderStream);
         $receiver = new SocketChannel($receiverStream);
+        $this->cleanup->defer($receiver->close(...));
+        $this->cleanup->defer($sender->close(...));
         $sink = new SocketEventSink($sender);
         $event = new SuiteStarted('unit', 1.0);
 
-        try {
-            $sink->emit($event);
-            $message = $receiver->poll();
+        $sink->emit($event);
+        $message = $receiver->poll();
 
-            if (!$message instanceof EventEnvelope) {
-                Fail::because(\sprintf(
-                    'Expected SocketEventSink to send EventEnvelope, got %s.',
-                    \get_debug_type($message),
-                ));
-            }
-
-            Expect::that($message->event)
-                ->because('the worker event sink MUST transport the emitted event')
-                ->toEqual($event);
-        } finally {
-            $sender->close();
-            $receiver->close();
+        if (!$message instanceof EventEnvelope) {
+            Fail::because(\sprintf(
+                'Expected SocketEventSink to send EventEnvelope, got %s.',
+                \get_debug_type($message),
+            ));
         }
+
+        Expect::that($message->event)
+            ->because('the worker event sink MUST transport the emitted event')
+            ->toEqual($event);
     }
 
 }


### PR DESCRIPTION
## Summary

- register socket channels for deferred cleanup immediately after construction
- remove cleanup-only `try`/`finally` blocks from protocol and event-sink tests
- retain lexical cleanup where raw stream closure or signal-process restoration is part of the scenario