### PR TITLE
chore(ci): limit concurrent local checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,10 @@ make docs-check
 
 CI runs the same checks. All three MUST pass locally.
 
+The Composer CI commands use one shared local slot by default. The slot applies
+across Git worktrees. Set `GREENLIGHT_LOCAL_CI_MAX_PARALLELISM` to a positive
+integer to permit more concurrent commands. Hosted CI does not use this limit.
+
 ## Commits and pull requests
 
 Submit changes in pull requests to `main`.

--- a/composer.json
+++ b/composer.json
@@ -95,14 +95,15 @@
         "lint": [
             "parallel-lint src tests tools bin"
         ],
-        "memory-gate": "php tools/memory-gate.php",
+        "memory-gate": "@php tools/local-ci-lock.php -- @php tools/memory-gate.php",
         "phpstan": "phpstan analyse --ansi --no-progress --memory-limit=-1",
         "phpstan:stubs": "@php tools/extract-phpstan-api.php",
         "prose:check": "@php tools/prose-check.php check",
         "prose:review": "@php tools/prose-check.php review",
         "rector:check": "rector --dry-run --ansi --no-progress-bar",
         "rector:fix": "rector --ansi --no-progress-bar",
-        "static-analysis": [
+        "static-analysis": "@php tools/local-ci-lock.php -- @composer static-analysis:unlocked",
+        "static-analysis:unlocked": [
             "@composer validate --strict",
             "@composer normalize --dry-run",
             "@lint",
@@ -113,8 +114,9 @@
             "@rector:check",
             "@deptrac"
         ],
-        "tests": "@php bin/greenlight run",
-        "tests:coverage": "XDEBUG_MODE=coverage php bin/greenlight run --config=greenlight.coverage.php",
+        "tests": "@php tools/local-ci-lock.php -- @php bin/greenlight run",
+        "tests:coverage": "@php tools/local-ci-lock.php -- @composer tests:coverage:unlocked",
+        "tests:coverage:unlocked": "XDEBUG_MODE=coverage php bin/greenlight run --config=greenlight.coverage.php",
         "workflow-shell:check": "@php tools/workflow-shell-check.php"
     }
 }

--- a/tests/Acceptance/LocalCiLockTest.php
+++ b/tests/Acceptance/LocalCiLockTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Fixture\TempDirectory;
+use Greenlight\Tests\Support\Subprocess;
+
+final readonly class LocalCiLockTest
+{
+    public function __construct(private TempDirectory $tempDirectory) {}
+
+    #[Test]
+    public function serializesLocalCommandsAcrossOneSharedSlot(): void
+    {
+        $lockDirectory = $this->tempDirectory->subdirectory('locks');
+        $startedMarker = $this->tempDirectory->path() . '/second-started';
+        $environment = [
+            'CI' => '0',
+            'GREENLIGHT_LOCAL_CI_LOCK_DIRECTORY' => $lockDirectory,
+            'GREENLIGHT_LOCAL_CI_MAX_PARALLELISM' => '1',
+        ];
+        $first = Subprocess::start(
+            $this->tempDirectory->path(),
+            $this->lockCommand([
+                \PHP_BINARY,
+                '-r',
+                'fwrite(STDOUT, "ready\\n"); fflush(STDOUT); fgets(STDIN);',
+            ]),
+            $environment,
+        );
+        $second = null;
+
+        try {
+            $first->readStdoutUntil('ready', 2.0);
+            $second = Subprocess::start(
+                $this->tempDirectory->path(),
+                $this->lockCommand([
+                    \PHP_BINARY,
+                    '-r',
+                    'file_put_contents($argv[1], "started");',
+                    $startedMarker,
+                ]),
+                $environment,
+            );
+
+            \usleep(250_000);
+            Expect::that(\file_exists($startedMarker))
+                ->because('the second command MUST wait while the only slot is in use')
+                ->toBeFalse();
+
+            $first->write("continue\n");
+            Expect::that($first->wait(2.0)->exitCode)->toBe(0);
+            Expect::that($second->wait(2.0)->exitCode)->toBe(0);
+            Expect::that(\file_get_contents($startedMarker))->toBe('started');
+        } finally {
+            $first->terminate();
+            $second?->terminate();
+        }
+    }
+
+    #[Test]
+    public function hostedCiBypassesTheLocalLock(): void
+    {
+        $invalidLockDirectory = $this->tempDirectory->path() . '/not-a-directory';
+        \file_put_contents($invalidLockDirectory, 'file');
+        $result = Subprocess::run(
+            $this->tempDirectory->path(),
+            $this->lockCommand([\PHP_BINARY, '-r', 'exit(7);']),
+            [
+                'CI' => 'true',
+                'GREENLIGHT_LOCAL_CI_LOCK_DIRECTORY' => $invalidLockDirectory,
+            ],
+        );
+
+        Expect::that($result->exitCode)->because('hosted CI bypasses the local lock')->toBe(7);
+    }
+
+    #[Test]
+    public function permitsCommandsUpToTheConfiguredParallelism(): void
+    {
+        $environment = [
+            'CI' => '0',
+            'GREENLIGHT_LOCAL_CI_LOCK_DIRECTORY' => $this->tempDirectory->subdirectory('two-locks'),
+            'GREENLIGHT_LOCAL_CI_MAX_PARALLELISM' => '2',
+        ];
+        $first = Subprocess::start(
+            $this->tempDirectory->path(),
+            $this->lockCommand([
+                \PHP_BINARY,
+                '-r',
+                'fwrite(STDOUT, "ready\\n"); fflush(STDOUT); fgets(STDIN);',
+            ]),
+            $environment,
+        );
+
+        try {
+            $first->readStdoutUntil('ready', 2.0);
+            $second = Subprocess::run(
+                $this->tempDirectory->path(),
+                $this->lockCommand([\PHP_BINARY, '-r', 'exit(9);']),
+                $environment,
+            );
+
+            Expect::that($second->exitCode)
+                ->because('the second command can use the configured second slot')
+                ->toBe(9);
+            $first->write("continue\n");
+            Expect::that($first->wait(2.0)->exitCode)->toBe(0);
+        } finally {
+            $first->terminate();
+        }
+    }
+
+    /**
+     * @param non-empty-list<string> $command
+     *
+     * @return non-empty-list<string>
+     */
+    private function lockCommand(array $command): array
+    {
+        return [
+            \PHP_BINARY,
+            \dirname(__DIR__, 2) . '/tools/local-ci-lock.php',
+            '--',
+            ...$command,
+        ];
+    }
+}

--- a/tools/local-ci-lock.php
+++ b/tools/local-ci-lock.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+const DEFAULT_MAX_PARALLELISM = 1;
+const MAX_PARALLELISM_ENVIRONMENT_VARIABLE = 'GREENLIGHT_LOCAL_CI_MAX_PARALLELISM';
+const LOCK_DIRECTORY_ENVIRONMENT_VARIABLE = 'GREENLIGHT_LOCAL_CI_LOCK_DIRECTORY';
+
+/**
+ * Limits concurrent local CI commands from Git worktrees. Hosted CI bypasses
+ * the limit because each job has independent resources.
+ *
+ * @param list<string> $arguments
+ */
+function main(array $arguments): int
+{
+    $command = \command($arguments);
+
+    if (\isTruthyEnvironmentValue(\getenv('CI'))) {
+        return \run($command);
+    }
+
+    $maxParallelism = \maxParallelism();
+    $lockDirectory = \lockDirectory();
+    $lock = \acquireLock($lockDirectory, $maxParallelism);
+
+    try {
+        return \run($command);
+    } finally {
+        \flock($lock, \LOCK_UN);
+        \fclose($lock);
+    }
+}
+
+/**
+ * @param list<string> $arguments
+ *
+ * @return non-empty-list<string>
+ */
+function command(array $arguments): array
+{
+    \array_shift($arguments);
+
+    if (($arguments[0] ?? null) === '--') {
+        \array_shift($arguments);
+    }
+
+    if ($arguments === []) {
+        \fail('The local CI lock requires a command after "--".');
+    }
+
+    if ($arguments[0] === '@php') {
+        $arguments[0] = \PHP_BINARY;
+    } elseif ($arguments[0] === '@composer') {
+        $composerBinary = \getenv('COMPOSER_BINARY');
+        $arguments[0] = $composerBinary === false || $composerBinary === '' ? 'composer' : $composerBinary;
+    }
+
+    /** @var non-empty-list<string> $arguments */
+    return $arguments;
+}
+
+/** @return list<string> */
+function cliArguments(mixed $rawArguments): array
+{
+    if (!\is_array($rawArguments)) {
+        \fail('The local CI lock could not read the command arguments.');
+    }
+
+    $arguments = [];
+
+    foreach ($rawArguments as $argument) {
+        if (!\is_string($argument)) {
+            \fail('The local CI lock received an invalid command argument.');
+        }
+
+        $arguments[] = $argument;
+    }
+
+    return $arguments;
+}
+
+function isTruthyEnvironmentValue(string|false $value): bool
+{
+    if ($value === false) {
+        return false;
+    }
+
+    return !\in_array(\strtolower(\trim($value)), ['', '0', 'false', 'no', 'off'], true);
+}
+
+/** @return positive-int */
+function maxParallelism(): int
+{
+    $configured = \getenv(MAX_PARALLELISM_ENVIRONMENT_VARIABLE);
+
+    if ($configured === false || $configured === '') {
+        return DEFAULT_MAX_PARALLELISM;
+    }
+
+    if (\preg_match('/^[1-9][0-9]*$/D', $configured) !== 1) {
+        \fail(\sprintf(
+            'The %s value must be a positive integer.',
+            MAX_PARALLELISM_ENVIRONMENT_VARIABLE,
+        ));
+    }
+
+    $maximum = (int) $configured;
+
+    if ($maximum < 1 || $maximum > 64) {
+        \fail(\sprintf(
+            'The %s value must not be more than 64.',
+            MAX_PARALLELISM_ENVIRONMENT_VARIABLE,
+        ));
+    }
+
+    return $maximum;
+}
+
+function lockDirectory(): string
+{
+    $configured = \getenv(LOCK_DIRECTORY_ENVIRONMENT_VARIABLE);
+
+    if ($configured !== false && $configured !== '') {
+        return $configured;
+    }
+
+    $repositoryRoot = \dirname(__DIR__);
+    $gitPath = $repositoryRoot . '/.git';
+    $commonGitDirectory = $gitPath;
+
+    if (\is_file($gitPath)) {
+        $gitFile = \file_get_contents($gitPath);
+
+        if ($gitFile === false || \preg_match('/^gitdir: (.+)$/D', \trim($gitFile), $matches) !== 1) {
+            \fail('The local CI lock could not read the Git worktree metadata.');
+        }
+
+        $worktreeGitDirectory = $matches[1];
+
+        if (!\str_starts_with($worktreeGitDirectory, '/')) {
+            $worktreeGitDirectory = $repositoryRoot . '/' . $worktreeGitDirectory;
+        }
+
+        $resolvedWorktreeGitDirectory = \realpath($worktreeGitDirectory);
+
+        if ($resolvedWorktreeGitDirectory === false) {
+            \fail('The local CI lock could not resolve the Git worktree metadata.');
+        }
+
+        $commonGitDirectory = \basename(\dirname($resolvedWorktreeGitDirectory)) === 'worktrees'
+            ? \dirname($resolvedWorktreeGitDirectory, 2)
+            : $resolvedWorktreeGitDirectory;
+    }
+
+    $resolvedCommonGitDirectory = \realpath($commonGitDirectory);
+
+    if ($resolvedCommonGitDirectory === false) {
+        \fail('The local CI lock could not resolve the common Git directory.');
+    }
+
+    return \sys_get_temp_dir()
+        . '/greenlight-local-ci-'
+        . \substr(\hash('sha256', $resolvedCommonGitDirectory), 0, 16);
+}
+
+/** @return resource */
+function acquireLock(string $directory, int $maxParallelism)
+{
+    if (!\is_dir($directory) && !\mkdir($directory, 0700, true) && !\is_dir($directory)) {
+        \fail(\sprintf('The local CI lock could not create directory "%s".', $directory));
+    }
+
+    $reportedWait = false;
+
+    while (true) {
+        for ($slot = 1; $slot <= $maxParallelism; $slot++) {
+            $handle = \fopen($directory . '/slot-' . $slot . '.lock', 'c+');
+
+            if ($handle === false) {
+                \fail(\sprintf('The local CI lock could not open slot %d.', $slot));
+            }
+
+            if (\flock($handle, \LOCK_EX | \LOCK_NB)) {
+                return $handle;
+            }
+
+            \fclose($handle);
+        }
+
+        if (!$reportedWait) {
+            \fwrite(\STDERR, \sprintf(
+                "All local CI slots are in use. The maximum parallelism is %d.\n",
+                $maxParallelism,
+            ));
+            $reportedWait = true;
+        }
+
+        \usleep(100_000);
+    }
+}
+
+/** @param non-empty-list<string> $command */
+function run(array $command): int
+{
+    $process = \proc_open(
+        $command,
+        [
+            0 => \STDIN,
+            1 => \STDOUT,
+            2 => \STDERR,
+        ],
+        $pipes,
+        options: ['bypass_shell' => true],
+    );
+
+    if (!\is_resource($process)) {
+        \fail(\sprintf('The local CI lock could not start command "%s".', $command[0]));
+    }
+
+    return \proc_close($process);
+}
+
+function fail(string $message): never
+{
+    \fwrite(\STDERR, $message . "\n");
+    exit(2);
+}
+
+exit(\main(\cliArguments($_SERVER['argv'] ?? null)));


### PR DESCRIPTION
## Summary

- serialize resource-heavy local Composer CI commands across Git worktrees
- allow an explicit maximum through GREENLIGHT_LOCAL_CI_MAX_PARALLELISM
- bypass the local semaphore on hosted CI and keep Greenlight runtime behavior unchanged