### PR TITLE
refactor(test): defer native resource cleanup

### DIFF
--- a/tests/Unit/Cli/TerminalTest.php
+++ b/tests/Unit/Cli/TerminalTest.php
@@ -6,11 +6,14 @@ namespace Greenlight\Tests\Unit\Cli;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Cli\Terminal;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 
-final class TerminalTest
+final readonly class TerminalTest
 {
+    public function __construct(private Cleanup $cleanup) {}
+
     #[Test]
     public function aNonTtyProbeDoesNotConsumeOrCloseTheStream(): void
     {
@@ -20,21 +23,19 @@ final class TerminalTest
             Fail::because('Expected php://temp to open.');
         }
 
-        try {
-            \fwrite($stream, 'sentinel');
-            \rewind($stream);
+        $this->cleanup->defer(static fn(): bool => \fclose($stream));
 
-            Expect::that(Terminal::isTty($stream))
-                ->because('an in-memory stream is not a TTY')
-                ->toBeFalse();
-            Expect::that(\stream_get_contents($stream))
-                ->because('the terminal probe MUST leave stream content unchanged')
-                ->toBe('sentinel');
-            Expect::that(\is_resource($stream))
-                ->because('the terminal probe MUST leave the stream open')
-                ->toBeTrue();
-        } finally {
-            \fclose($stream);
-        }
+        \fwrite($stream, 'sentinel');
+        \rewind($stream);
+
+        Expect::that(Terminal::isTty($stream))
+            ->because('an in-memory stream is not a TTY')
+            ->toBeFalse();
+        Expect::that(\stream_get_contents($stream))
+            ->because('the terminal probe MUST leave stream content unchanged')
+            ->toBe('sentinel');
+        Expect::that(\is_resource($stream))
+            ->because('the terminal probe MUST leave the stream open')
+            ->toBeTrue();
     }
 }

--- a/tests/Unit/Expect/CanonicalizingTest.php
+++ b/tests/Unit/Expect/CanonicalizingTest.php
@@ -5,11 +5,14 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Expect;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\Expect\CanonicalNode;
 
-final class CanonicalizingTest
+final readonly class CanonicalizingTest
 {
+    public function __construct(private Cleanup $cleanup) {}
+
     #[Test]
     public function toEqualCanonicalizingIgnoresListOrder(): void
     {
@@ -89,22 +92,25 @@ final class CanonicalizingTest
         $firstClosure = static fn(): string => 'first';
         $secondClosure = static fn(): string => 'second';
         $firstStream = \fopen('php://memory', 'r');
-        $secondStream = \fopen('php://memory', 'r');
 
-        if ($firstStream === false || $secondStream === false) {
+        if ($firstStream === false) {
             throw new \RuntimeException('Could not open in-memory streams.');
         }
 
-        try {
-            Expect::that([$secondClosure, $firstClosure])
-                ->because('canonical closure ordering uses object identity')
-                ->toEqualCanonicalizing([$firstClosure, $secondClosure]);
-            Expect::that([$secondStream, $firstStream])
-                ->because('canonical resource ordering uses resource identity')
-                ->toEqualCanonicalizing([$firstStream, $secondStream]);
-        } finally {
-            \fclose($firstStream);
-            \fclose($secondStream);
+        $this->cleanup->defer(static fn(): bool => \fclose($firstStream));
+        $secondStream = \fopen('php://memory', 'r');
+
+        if ($secondStream === false) {
+            throw new \RuntimeException('Could not open in-memory streams.');
         }
+
+        $this->cleanup->defer(static fn(): bool => \fclose($secondStream));
+
+        Expect::that([$secondClosure, $firstClosure])
+            ->because('canonical closure ordering uses object identity')
+            ->toEqualCanonicalizing([$firstClosure, $secondClosure]);
+        Expect::that([$secondStream, $firstStream])
+            ->because('canonical resource ordering uses resource identity')
+            ->toEqualCanonicalizing([$firstStream, $secondStream]);
     }
 }

--- a/tests/Unit/Runner/Orchestrator/ServerSocketTest.php
+++ b/tests/Unit/Runner/Orchestrator/ServerSocketTest.php
@@ -5,37 +5,33 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Runner\Orchestrator;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Runner\Orchestrator\ServerSocket;
 
-final class ServerSocketTest
+final readonly class ServerSocketTest
 {
+    public function __construct(private Cleanup $cleanup) {}
+
     #[Test]
     public function tcpFallbackListensWhenTheUnixSocketCannotOpen(): void
     {
         $temporaryDirectory = \is_dir('/tmp') ? '/tmp' : \sys_get_temp_dir();
         $blocked = \tempnam($temporaryDirectory, 'greenlight-socket-');
-        $socket = null;
 
-        try {
-            if (!\is_string($blocked)) {
-                Fail::because('Could not create the blocked socket directory fixture.');
-            }
-
-            $socket = ServerSocket::listen($blocked);
-
-            Expect::that($socket->address)
-                ->because('the orchestrator MUST use TCP when its Unix socket cannot open')
-                ->toStartWith('tcp://127.0.0.1:');
-            Expect::that(\is_resource($socket->stream()))
-                ->toBeTrue();
-        } finally {
-            $socket?->close();
-
-            if (\is_string($blocked)) {
-                \unlink($blocked);
-            }
+        if (!\is_string($blocked)) {
+            Fail::because('Could not create the blocked socket directory fixture.');
         }
+
+        $this->cleanup->defer(static fn(): bool => \unlink($blocked));
+        $socket = ServerSocket::listen($blocked);
+        $this->cleanup->defer($socket->close(...));
+
+        Expect::that($socket->address)
+            ->because('the orchestrator MUST use TCP when its Unix socket cannot open')
+            ->toStartWith('tcp://127.0.0.1:');
+        Expect::that(\is_resource($socket->stream()))
+            ->toBeTrue();
     }
 }


### PR DESCRIPTION
## Summary

- dogfood value-returning cleanup callbacks with `fclose()` and `unlink()`
- register native resources immediately after successful acquisition
- preserve server socket cleanup order while removing cleanup-only `try`/`finally` blocks