### PR TITLE
ci: lint Markdown style

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,25 @@ jobs:
         with:
           args: "-color -shellcheck=shellcheck"
 
+  markdownlint:
+    name: "Markdown style"
+    runs-on: "ubuntu-latest"
+    timeout-minutes: 10
+    permissions:
+      contents: "read"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7
+        with:
+          persist-credentials: false
+
+      - name: "Run markdownlint"
+        uses: "DavidAnson/markdownlint-cli2-action@21c1be1b93ad9ed58fa840aacc3f279cde2a72ff" # v24.2.0
+        with:
+          config: ".markdownlint-cli2.jsonc"
+          globs: "**/*.md"
+
   installed-package:
     name: "Installed package"
     runs-on: "ubuntu-latest"
@@ -627,6 +646,7 @@ jobs:
       - "renovate-config"
       - "zizmor"
       - "actionlint"
+      - "markdownlint"
       - "installed-package"
       - "ci"
       - "macos-portability"
@@ -648,6 +668,7 @@ jobs:
           DOCUMENTATION_RESULT: "${{ needs.documentation.result }}"
           INSTALLED_PACKAGE_RESULT: "${{ needs.installed-package.result }}"
           MACOS_PORTABILITY_RESULT: "${{ needs.macos-portability.result }}"
+          MARKDOWNLINT_RESULT: "${{ needs.markdownlint.result }}"
           MEMORY_RESULT: "${{ needs.memory.result }}"
           PCOV_RESULT: "${{ needs.pcov.result }}"
           RENOVATE_CONFIG_RESULT: "${{ needs.renovate-config.result }}"
@@ -659,6 +680,7 @@ jobs:
           test "${RENOVATE_CONFIG_RESULT}" = "success"
           test "${ZIZMOR_RESULT}" = "success"
           test "${ACTIONLINT_RESULT}" = "success"
+          test "${MARKDOWNLINT_RESULT}" = "success"
           test "${INSTALLED_PACKAGE_RESULT}" = "success"
           test "${CI_RESULT}" = "success"
           test "${MACOS_PORTABILITY_RESULT}" = "success"

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,25 @@
+{
+  "config": {
+    "MD013": false,
+    "MD024": {
+      "siblings_only": true
+    },
+    "MD033": {
+      "allowed_elements": [
+        "a",
+        "img"
+      ]
+    }
+  },
+  "overrides": [
+    {
+      "filter": [
+        ".github/PULL_REQUEST_TEMPLATE.md"
+      ],
+      "config": {
+        "MD041": false
+      },
+      "combine": "merge"
+    }
+  ]
+}

--- a/docs/architecture/jsonl.md
+++ b/docs/architecture/jsonl.md
@@ -55,18 +55,18 @@ guarantees, and incomplete-output behavior.
 
 ## Event tags
 
-| Tag               | Event                      | Payload keys                                        |
-| ----------------- | -------------------------- | --------------------------------------------------- |
-| `run-started`     | Run begins                 | `runId`, `plannedTests`, `workers`, `occurredAt`, `artifactsDirectory` |
-| `run-finished`    | Run ends                   | `runId`, `summary`, `durationSeconds`, `occurredAt` |
-| `suite-started`   | Suite begins               | `suite`, `occurredAt`                               |
-| `suite-finished`  | Suite ends                 | `suite`, `occurredAt`                               |
-| `class-started`   | Test class begins          | `class`, `occurredAt`, `workerId`                   |
-| `class-finished`  | Test class ends            | `class`, `occurredAt`, `workerId`                   |
-| `test-started`    | Test begins                | `id`, `occurredAt`                                  |
-| `test-finished`   | Test ends                  | `result`, `occurredAt`                              |
-| `worker-spawned`  | Worker process starts      | `workerId`, `pid`, `occurredAt`                     |
-| `worker-recycled` | Greenlight replaces a worker process | `workerId`, `reason`, `occurredAt`                  |
+| Tag               | Event                                | Payload keys                                                           |
+| ----------------- | ------------------------------------ | ---------------------------------------------------------------------- |
+| `run-started`     | Run begins                           | `runId`, `plannedTests`, `workers`, `occurredAt`, `artifactsDirectory` |
+| `run-finished`    | Run ends                             | `runId`, `summary`, `durationSeconds`, `occurredAt`                    |
+| `suite-started`   | Suite begins                         | `suite`, `occurredAt`                                                  |
+| `suite-finished`  | Suite ends                           | `suite`, `occurredAt`                                                  |
+| `class-started`   | Test class begins                    | `class`, `occurredAt`, `workerId`                                      |
+| `class-finished`  | Test class ends                      | `class`, `occurredAt`, `workerId`                                      |
+| `test-started`    | Test begins                          | `id`, `occurredAt`                                                     |
+| `test-finished`   | Test ends                            | `result`, `occurredAt`                                                 |
+| `worker-spawned`  | Worker process starts                | `workerId`, `pid`, `occurredAt`                                        |
+| `worker-recycled` | Greenlight replaces a worker process | `workerId`, `reason`, `occurredAt`                                     |
 
 `run-finished.summary` contains the passed, failed, errored, and skipped totals.
 

--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -310,7 +310,7 @@ Providers shared by multiple test classes receive the same checks:
 
 Typical messages:
 
-```
+```text
 Data provider sums() for adds() does not exist on PriceTest.
 Data provider PriceTest::sums() must be public and static.
 Data provider PriceTest::sums() must return an iterable of argument arrays, returns string.


### PR DESCRIPTION
## Summary

- add Markdown style linting as a required CI job
- configure markdownlint for the repository conventions
- fix the existing Markdown table and code-fence style findings