### PR TITLE
refactor(test): defer process state cleanup

### DIFF
--- a/tests/Unit/Cli/SystemSignalOperationsTest.php
+++ b/tests/Unit/Cli/SystemSignalOperationsTest.php
@@ -7,11 +7,14 @@ namespace Greenlight\Tests\Unit\Cli;
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Cli\SystemSignalOperations;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Support\Subprocess;
 
-final class SystemSignalOperationsTest
+final readonly class SystemSignalOperationsTest
 {
+    public function __construct(private Cleanup $cleanup) {}
+
     #[Test]
     public function availableOperationsUpdateTheNativePcntlState(): void
     {
@@ -29,21 +32,18 @@ final class SystemSignalOperationsTest
         $asyncBefore = \pcntl_async_signals();
         $handlerBefore = \pcntl_signal_get_handler(\SIGUSR1);
         $handler = static function (): void {};
+        $this->cleanup->defer(static fn(): bool => \pcntl_async_signals($asyncBefore));
+        $this->cleanup->defer(static fn(): bool => \pcntl_signal(\SIGUSR1, $handlerBefore));
 
-        try {
-            $operations->enableAsync();
-            $operations->register(\SIGUSR1, $handler);
+        $operations->enableAsync();
+        $operations->register(\SIGUSR1, $handler);
 
-            Expect::that(\pcntl_async_signals())
-                ->because('native signal operations MUST enable asynchronous delivery')
-                ->toBeTrue();
-            Expect::that(\pcntl_signal_get_handler(\SIGUSR1))
-                ->because('native signal operations MUST register the exact handler')
-                ->toBe($handler);
-        } finally {
-            \pcntl_signal(\SIGUSR1, $handlerBefore);
-            \pcntl_async_signals($asyncBefore);
-        }
+        Expect::that(\pcntl_async_signals())
+            ->because('native signal operations MUST enable asynchronous delivery')
+            ->toBeTrue();
+        Expect::that(\pcntl_signal_get_handler(\SIGUSR1))
+            ->because('native signal operations MUST register the exact handler')
+            ->toBe($handler);
     }
 
     #[Test]

--- a/tests/Unit/Doubles/DoublesWorkingDirectoryTest.php
+++ b/tests/Unit/Doubles/DoublesWorkingDirectoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Doubles;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Doubles\Doubles;
 use Greenlight\Doubles\DoublesError;
 use Greenlight\Expect\Expect;
@@ -13,7 +14,10 @@ use Greenlight\Fixture\TempDirectory;
 
 final readonly class DoublesWorkingDirectoryTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function missingWorkingDirectoryGivesExactGuidance(): void
@@ -25,22 +29,19 @@ final readonly class DoublesWorkingDirectoryTest
         }
 
         $deleted = $this->tempDirectory->subdirectory('deleted-working-directory');
+        $this->cleanup->defer(static fn(): bool => \chdir($original));
 
-        try {
-            Expect::that(\chdir($deleted))
-                ->because('the test enters its temporary directory')
-                ->toBeTrue();
-            Expect::that(\rmdir($deleted))
-                ->because('the current temporary directory can be removed')
-                ->toBeTrue();
-            Expect::that(static fn(): Doubles => new Doubles())
-                ->because('the default proxy directory needs a current working directory')
-                ->toThrow(
-                    DoublesError::class,
-                    message: 'Doubles could not resolve the working directory. Pass a proxy directory explicitly.',
-                );
-        } finally {
-            \chdir($original);
-        }
+        Expect::that(\chdir($deleted))
+            ->because('the test enters its temporary directory')
+            ->toBeTrue();
+        Expect::that(\rmdir($deleted))
+            ->because('the current temporary directory can be removed')
+            ->toBeTrue();
+        Expect::that(static fn(): Doubles => new Doubles())
+            ->because('the default proxy directory needs a current working directory')
+            ->toThrow(
+                DoublesError::class,
+                message: 'Doubles could not resolve the working directory. Pass a proxy directory explicitly.',
+            );
     }
 }


### PR DESCRIPTION
## Summary

- defer restoration of the working directory and native signal state
- preserve signal restoration order through the cleanup stack
- remove cleanup-only `try`/`finally` blocks while keeping restoration before test-scope disposal