### PR TITLE
refactor(test): defer artifact store cleanup

### DIFF
--- a/tests/Unit/Artifact/ArtifactRecoveryOrderTest.php
+++ b/tests/Unit/Artifact/ArtifactRecoveryOrderTest.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -16,43 +17,43 @@ use Greenlight\Runner\Artifact\TestArtifactBudget;
 
 final readonly class ArtifactRecoveryOrderTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function recoveredAttachmentsUseAttemptOrder(): void
     {
         $root = $this->tempDirectory->subdirectory('recovery-order');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-order');
+        $this->cleanup->defer($store->cleanup(...));
         $id = new TestId('Example\EvidenceTest', 'crashesOnRetry');
         $budget = new TestArtifactBudget();
 
-        try {
-            $tenth = $store->forAttempt($id, 10, $budget);
-            $tenth->text('tenth.txt', 'attempt ten');
-            $second = $store->forAttempt($id, 2, $budget);
-            $second->text('second.txt', 'attempt two');
+        $tenth = $store->forAttempt($id, 10, $budget);
+        $tenth->text('tenth.txt', 'attempt ten');
+        $second = $store->forAttempt($id, 2, $budget);
+        $second->text('second.txt', 'attempt two');
 
-            $recovered = $store->recover(new TestResult(
-                $id,
-                Outcome::Errored,
-                0.0,
-                0,
-                attempts: 10,
-            ));
+        $recovered = $store->recover(new TestResult(
+            $id,
+            Outcome::Errored,
+            0.0,
+            0,
+            attempts: 10,
+        ));
 
-            Expect::that($recovered->attachments)
-                ->because('crash recovery orders evidence by numeric attempt')
-                ->toHaveCount(2);
-            Expect::that(\array_map(
-                static fn($attachment): array => [$attachment->attempt, $attachment->name],
-                $recovered->attachments,
-            ))
-                ->toBe([
-                    [2, 'second.txt'],
-                    [10, 'tenth.txt'],
-                ]);
-        } finally {
-            $store->cleanup();
-        }
+        Expect::that($recovered->attachments)
+            ->because('crash recovery orders evidence by numeric attempt')
+            ->toHaveCount(2);
+        Expect::that(\array_map(
+            static fn($attachment): array => [$attachment->attempt, $attachment->name],
+            $recovered->attachments,
+        ))
+            ->toBe([
+                [2, 'second.txt'],
+                [10, 'tenth.txt'],
+            ]);
     }
 }

--- a/tests/Unit/Artifact/ArtifactStorePublicationTest.php
+++ b/tests/Unit/Artifact/ArtifactStorePublicationTest.php
@@ -9,6 +9,7 @@ use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -17,13 +18,17 @@ use Greenlight\Runner\Artifact\TestArtifactBudget;
 
 final readonly class ArtifactStorePublicationTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function publishedMetadataCannotBePublishedAgain(): void
     {
         $root = $this->tempDirectory->subdirectory('published-metadata');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-plain-metadata');
+        $this->cleanup->defer($store->cleanup(...));
         $id = new TestId('Example\EvidenceTest', 'fails');
         $attempt = $store->forAttempt($id, 1, new TestArtifactBudget());
         $attempt->text('evidence.txt', 'evidence');
@@ -36,16 +41,12 @@ final readonly class ArtifactStorePublicationTest
             attachments: [$attachment],
         );
 
-        try {
-            Expect::that(static fn(): TestResult => $store->publish($result))
-                ->because('published attachment metadata has no staging coordinate')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: 'Attachment metadata does not contain a staging coordinate.',
-                );
-        } finally {
-            $store->cleanup();
-        }
+        Expect::that(static fn(): TestResult => $store->publish($result))
+            ->because('published attachment metadata has no staging coordinate')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Attachment metadata does not contain a staging coordinate.',
+            );
     }
 
     #[Test]
@@ -54,6 +55,7 @@ final readonly class ArtifactStorePublicationTest
         $root = $this->tempDirectory->subdirectory('worker-publication');
         $configuration = new ArtifactConfiguration($root);
         $coordinator = ArtifactStore::open($configuration, $root, 'run-worker-publication');
+        $this->cleanup->defer($coordinator->cleanup(...));
         $worker = ArtifactStore::fromSession($coordinator->session(), $configuration);
         $id = new TestId('Example\EvidenceTest', 'fails');
         $attempt = $worker->forAttempt($id, 1, new TestArtifactBudget());
@@ -66,21 +68,17 @@ final readonly class ArtifactStorePublicationTest
             attachments: $attempt->seal(),
         );
 
-        try {
-            Expect::that(static fn(): TestResult => $worker->publish($result))
-                ->because('only the coordinator can publish attachment evidence')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: 'A worker attempted to publish attachments.',
-                );
+        Expect::that(static fn(): TestResult => $worker->publish($result))
+            ->because('only the coordinator can publish attachment evidence')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'A worker attempted to publish attachments.',
+            );
 
-            $published = $coordinator->publish($result);
+        $published = $coordinator->publish($result);
 
-            Expect::that($published->attachments)
-                ->because('a rejected worker publication leaves the evidence intact')
-                ->toHaveCount(1);
-        } finally {
-            $coordinator->cleanup();
-        }
+        Expect::that($published->attachments)
+            ->because('a rejected worker publication leaves the evidence intact')
+            ->toHaveCount(1);
     }
 }

--- a/tests/Unit/Artifact/ArtifactTestDirectoryCollisionTest.php
+++ b/tests/Unit/Artifact/ArtifactTestDirectoryCollisionTest.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -16,51 +17,51 @@ use Greenlight\Runner\Artifact\TestArtifactBudget;
 
 final readonly class ArtifactTestDirectoryCollisionTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function testIdsWithTheSameSlugKeepDistinctEvidence(): void
     {
         $root = $this->tempDirectory->subdirectory('test-directory-collision');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-1');
+        $this->cleanup->defer($store->cleanup(...));
         $spaced = new TestId('Example\EvidenceTest', 'usesData', 'a b');
         $hyphenated = new TestId('Example\EvidenceTest', 'usesData', 'a-b');
 
-        try {
-            $firstAttempt = $store->forAttempt($spaced, 1, new TestArtifactBudget());
-            $firstAttempt->text('evidence.txt', 'spaced data-set key');
-            $first = $store->publish(new TestResult(
-                $spaced,
-                Outcome::Failed,
-                0.1,
-                0,
-                attachments: $firstAttempt->seal(),
-            ));
+        $firstAttempt = $store->forAttempt($spaced, 1, new TestArtifactBudget());
+        $firstAttempt->text('evidence.txt', 'spaced data-set key');
+        $first = $store->publish(new TestResult(
+            $spaced,
+            Outcome::Failed,
+            0.1,
+            0,
+            attachments: $firstAttempt->seal(),
+        ));
 
-            $secondAttempt = $store->forAttempt($hyphenated, 1, new TestArtifactBudget());
-            $secondAttempt->text('evidence.txt', 'hyphenated data-set key');
-            $second = $store->publish(new TestResult(
-                $hyphenated,
-                Outcome::Failed,
-                0.1,
-                0,
-                attachments: $secondAttempt->seal(),
-            ));
+        $secondAttempt = $store->forAttempt($hyphenated, 1, new TestArtifactBudget());
+        $secondAttempt->text('evidence.txt', 'hyphenated data-set key');
+        $second = $store->publish(new TestResult(
+            $hyphenated,
+            Outcome::Failed,
+            0.1,
+            0,
+            attachments: $secondAttempt->seal(),
+        ));
 
-            Expect::that($first->attachments)
-                ->because('test IDs with the same filesystem slug MUST keep distinct evidence')
-                ->toHaveCount(1);
-            Expect::that($second->attachments)
-                ->toHaveCount(1);
-            Expect::that($first->attachments[0]->path)
-                ->not()
-                ->toBe($second->attachments[0]->path);
-            Expect::that((string) \file_get_contents($first->attachments[0]->path))
-                ->toBe('spaced data-set key');
-            Expect::that((string) \file_get_contents($second->attachments[0]->path))
-                ->toBe('hyphenated data-set key');
-        } finally {
-            $store->cleanup();
-        }
+        Expect::that($first->attachments)
+            ->because('test IDs with the same filesystem slug MUST keep distinct evidence')
+            ->toHaveCount(1);
+        Expect::that($second->attachments)
+            ->toHaveCount(1);
+        Expect::that($first->attachments[0]->path)
+            ->not()
+            ->toBe($second->attachments[0]->path);
+        Expect::that((string) \file_get_contents($first->attachments[0]->path))
+            ->toBe('spaced data-set key');
+        Expect::that((string) \file_get_contents($second->attachments[0]->path))
+            ->toBe('hyphenated data-set key');
     }
 }

--- a/tests/Unit/Artifact/ArtifactTestQuotaRollbackTest.php
+++ b/tests/Unit/Artifact/ArtifactTestQuotaRollbackTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Unit\Artifact;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -15,7 +16,10 @@ use Greenlight\Runner\Artifact\TestArtifactBudget;
 
 final readonly class ArtifactTestQuotaRollbackTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function aTestQuotaRejectionReleasesTheRunQuota(): void
@@ -30,35 +34,32 @@ final readonly class ArtifactTestQuotaRollbackTest
             maxRunBytes: 6,
         );
         $store = ArtifactStore::open($configuration, $root, 'run-1');
+        $this->cleanup->defer($store->cleanup(...));
 
-        try {
-            $first = $store->forAttempt(
-                new TestId('Example\EvidenceTest', 'first'),
-                1,
-                new TestArtifactBudget(),
+        $first = $store->forAttempt(
+            new TestId('Example\EvidenceTest', 'first'),
+            1,
+            new TestArtifactBudget(),
+        );
+        $first->text('accepted.txt', '1234');
+
+        Expect::that(static fn() => $first->text('rejected.txt', '12'))
+            ->because('the per-test byte limit MUST reject excess evidence')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Attachments for this test exceed the limit of 4 bytes.',
             );
-            $first->text('accepted.txt', '1234');
 
-            Expect::that(static fn() => $first->text('rejected.txt', '12'))
-                ->because('the per-test byte limit MUST reject excess evidence')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: 'Attachments for this test exceed the limit of 4 bytes.',
-                );
+        $second = $store->forAttempt(
+            new TestId('Example\EvidenceTest', 'second'),
+            1,
+            new TestArtifactBudget(),
+        );
+        $second->text('accepted.txt', '12');
 
-            $second = $store->forAttempt(
-                new TestId('Example\EvidenceTest', 'second'),
-                1,
-                new TestArtifactBudget(),
-            );
-            $second->text('accepted.txt', '12');
-
-            Expect::that($second->collected())
-                ->because('a test quota rejection MUST release its run quota')
-                ->toHaveCount(1);
-        } finally {
-            $store->cleanup();
-        }
+        Expect::that($second->collected())
+            ->because('a test quota rejection MUST release its run quota')
+            ->toHaveCount(1);
     }
 
     #[Test]

--- a/tests/Unit/Artifact/ArtifactTransformedOutcomeRetentionTest.php
+++ b/tests/Unit/Artifact/ArtifactTransformedOutcomeRetentionTest.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -16,13 +17,17 @@ use Greenlight\Runner\Artifact\TestArtifactBudget;
 
 final readonly class ArtifactTransformedOutcomeRetentionTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function passingTransformationsRetainEvidenceFromTheFailedOutcome(): void
     {
         $root = $this->tempDirectory->subdirectory('transformed-retention');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-1');
+        $this->cleanup->defer($store->cleanup(...));
         $id = new TestId('Example\EvidenceTest', 'quarantinedFailure');
         $attempt = $store->forAttempt($id, 1, new TestArtifactBudget());
         $attempt->text('failure.txt', 'original failure evidence');
@@ -34,19 +39,15 @@ final readonly class ArtifactTransformedOutcomeRetentionTest
             attachments: $attempt->seal(),
         )->withOutcome(Outcome::Passed, 'quarantine-plugin');
 
-        try {
-            $published = $store->publish($result);
+        $published = $store->publish($result);
 
-            Expect::that($published->attachments)
-                ->because('a passing transformation MUST retain evidence from its failed source')
-                ->toHaveCount(1);
-            Expect::that($published->attachments[0]->name)
-                ->toBe('failure.txt');
-            Expect::that((string) \file_get_contents($published->attachments[0]->path))
-                ->toBe('original failure evidence');
-        } finally {
-            $store->cleanup();
-        }
+        Expect::that($published->attachments)
+            ->because('a passing transformation MUST retain evidence from its failed source')
+            ->toHaveCount(1);
+        Expect::that($published->attachments[0]->name)
+            ->toBe('failure.txt');
+        Expect::that((string) \file_get_contents($published->attachments[0]->path))
+            ->toBe('original failure evidence');
     }
 
     #[Test]
@@ -54,6 +55,7 @@ final readonly class ArtifactTransformedOutcomeRetentionTest
     {
         $root = $this->tempDirectory->subdirectory('successful-transformation');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-2');
+        $this->cleanup->defer($store->cleanup(...));
         $id = new TestId('Example\EvidenceTest', 'quarantinedPass');
         $attempt = $store->forAttempt($id, 1, new TestArtifactBudget());
         $attempt->text('passing.txt', 'successful evidence');
@@ -65,16 +67,12 @@ final readonly class ArtifactTransformedOutcomeRetentionTest
             attachments: $attempt->seal(),
         )->withOutcome(Outcome::Skipped, 'quarantine-plugin');
 
-        try {
-            $published = $store->publish($result);
+        $published = $store->publish($result);
 
-            Expect::that($published->attachments)
-                ->because('a transformation between successful outcomes MUST discard on-failure evidence')
-                ->toBe([]);
-            Expect::that(\file_exists($store->publicDirectory()))
-                ->toBeFalse();
-        } finally {
-            $store->cleanup();
-        }
+        Expect::that($published->attachments)
+            ->because('a transformation between successful outcomes MUST discard on-failure evidence')
+            ->toBe([]);
+        Expect::that(\file_exists($store->publicDirectory()))
+            ->toBeFalse();
     }
 }

--- a/tests/Unit/Artifact/AttachmentSourcePathValidationTest.php
+++ b/tests/Unit/Artifact/AttachmentSourcePathValidationTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Unit\Artifact;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -15,7 +16,10 @@ use Greenlight\Runner\Artifact\TestArtifactBudget;
 
 final readonly class AttachmentSourcePathValidationTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function nullBytesAreRejectedBeforeFileSystemAccess(): void
@@ -23,21 +27,18 @@ final readonly class AttachmentSourcePathValidationTest
         $root = $this->tempDirectory->subdirectory('null-source-path');
         $configuration = new ArtifactConfiguration($root);
         $store = ArtifactStore::open($configuration, $root, 'run-null-source');
+        $this->cleanup->defer($store->cleanup(...));
         $attachments = $store->forAttempt(
             new TestId('Example\EvidenceTest', 'invalidSource'),
             1,
             new TestArtifactBudget(),
         );
 
-        try {
-            Expect::that(static fn() => $attachments->file('copy.bin', "source\0hidden.txt"))
-                ->because('attachment source paths MUST be valid file-system paths')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: 'Attachment source "source\0hidden.txt" contains a null byte.',
-                );
-        } finally {
-            $store->cleanup();
-        }
+        Expect::that(static fn() => $attachments->file('copy.bin', "source\0hidden.txt"))
+            ->because('attachment source paths MUST be valid file-system paths')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Attachment source "source\0hidden.txt" contains a null byte.',
+            );
     }
 }

--- a/tests/Unit/Artifact/StagedAttachmentNamingTest.php
+++ b/tests/Unit/Artifact/StagedAttachmentNamingTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Unit\Artifact;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Artifact\StagedAttachment;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -15,32 +16,32 @@ use Greenlight\Runner\Artifact\TestArtifactBudget;
 
 final readonly class StagedAttachmentNamingTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function duplicateExtensionlessNamesGainANumericSuffix(): void
     {
         $root = $this->tempDirectory->subdirectory('extensionless-names');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-1');
+        $this->cleanup->defer($store->cleanup(...));
 
-        try {
-            $attachments = $store->forAttempt(
-                new TestId('Example\EvidenceTest', 'captures'),
-                1,
-                new TestArtifactBudget(),
-            );
-            $attachments->text('evidence', 'first');
-            $attachments->text('evidence', 'second');
-            $names = \array_map(
-                static fn(StagedAttachment $attachment): string => \basename($attachment->storageKey),
-                $attachments->seal(),
-            );
+        $attachments = $store->forAttempt(
+            new TestId('Example\EvidenceTest', 'captures'),
+            1,
+            new TestArtifactBudget(),
+        );
+        $attachments->text('evidence', 'first');
+        $attachments->text('evidence', 'second');
+        $names = \array_map(
+            static fn(StagedAttachment $attachment): string => \basename($attachment->storageKey),
+            $attachments->seal(),
+        );
 
-            Expect::that($names)
-                ->because('duplicate extensionless attachment names MUST remain distinct')
-                ->toBe(['01-evidence', '02-evidence-2']);
-        } finally {
-            $store->cleanup();
-        }
+        Expect::that($names)
+            ->because('duplicate extensionless attachment names MUST remain distinct')
+            ->toBe(['01-evidence', '02-evidence-2']);
     }
 }

--- a/tests/Unit/Artifact/StagedAttachmentSanitizedNameCollisionTest.php
+++ b/tests/Unit/Artifact/StagedAttachmentSanitizedNameCollisionTest.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Artifact\StagedAttachment;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -16,7 +17,10 @@ use Greenlight\Runner\Artifact\TestArtifactBudget;
 
 final readonly class StagedAttachmentSanitizedNameCollisionTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     /**
      * @param list<string> $expected
@@ -30,29 +34,26 @@ final readonly class StagedAttachmentSanitizedNameCollisionTest
     ): void {
         $root = $this->tempDirectory->subdirectory('sanitized-name-collision');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-1');
+        $this->cleanup->defer($store->cleanup(...));
 
-        try {
-            $attachments = $store->forAttempt(
-                new TestId('Example\EvidenceTest', 'captures'),
-                1,
-                new TestArtifactBudget(),
-            );
-            $attachments->text($first, 'first');
-            $attachments->text($second, 'second');
-            $names = \array_map(
-                static fn(StagedAttachment $attachment): string => \basename($attachment->storageKey),
-                $attachments->seal(),
-            );
+        $attachments = $store->forAttempt(
+            new TestId('Example\EvidenceTest', 'captures'),
+            1,
+            new TestArtifactBudget(),
+        );
+        $attachments->text($first, 'first');
+        $attachments->text($second, 'second');
+        $names = \array_map(
+            static fn(StagedAttachment $attachment): string => \basename($attachment->storageKey),
+            $attachments->seal(),
+        );
 
-            Expect::that($names)
-                ->because(
-                    'distinct attachment names that sanitize to the same storage name '
-                    . 'MUST remain distinct',
-                )
-                ->toBe($expected);
-        } finally {
-            $store->cleanup();
-        }
+        Expect::that($names)
+            ->because(
+                'distinct attachment names that sanitize to the same storage name '
+                . 'MUST remain distinct',
+            )
+            ->toBe($expected);
     }
 
     /**


### PR DESCRIPTION
## Summary

- register artifact stores for deferred cleanup immediately after opening them
- remove cleanup-only `try`/`finally` blocks from focused artifact lifecycle tests
- keep artifact cleanup behavior tests and mixed permission/symlink restoration lexical