### PR TITLE
docs: classify PHP examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Greenlight runs its own test suite with `bin/greenlight run`.
 
 ## Example test
 
+<!-- php-example {"example":"readme-example-01","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 <?php
 
@@ -84,6 +85,7 @@ composer require --dev greenlight/greenlight
 
 Create `greenlight.php` in the project root:
 
+<!-- php-example {"example":"readme-example-02","file":"snippet.php","mode":"file","tools":["phpstan","rector"]} -->
 ```php
 <?php
 

--- a/docs/architecture/conventions.md
+++ b/docs/architecture/conventions.md
@@ -68,6 +68,7 @@ from another throwable, preserve that text and its punctuation.
 
 An error message **MUST** enclose an interpolated identifier in double quotes:
 
+<!-- php-example {"mode":"display","reason":"Shows an error-message template rather than an executable statement."} -->
 ```php
 'Configuration file "%s" does not exist.'
 ```
@@ -114,6 +115,7 @@ or phase numbers. They **MUST** state the applicable constraint directly.
 Test method names **MUST** use sentence-style camelCase. Each name **MUST**
 describe the behavior:
 
+<!-- php-example {"mode":"display","reason":"Shows a test ID rather than an executable statement."} -->
 ```php
 bailStopsTheRunAfterTheThreshold
 ```

--- a/docs/architecture/documentation-php-examples.md
+++ b/docs/architecture/documentation-php-examples.md
@@ -37,16 +37,19 @@ Use `file` when the fence represents a PHP file. The extractor adds `<?php` if
 the fence omits it.
 
 Use `statements` for statements that need a function body. The extractor puts
-the statements in a synthetic static closure.
+the statements in a synthetic static closure. It supplies a synthetic receiver
+for a fluent chain that starts with `->`, and it adds a final semicolon when the
+fragment omits one.
 
 Use `class-members` for properties or methods that need a class body. The
-extractor puts the members in a synthetic final class.
+extractor puts the members in a synthetic final class. Imports can precede the
+members. The extractor keeps the imports outside the class.
 
 Use `display` only when analysis would make the example less useful. A display
-example MUST give a nonempty `reason` and does not use the other fields. An
-unclassified PHP fence is also not checked, but the command reports the number
-of unclassified fences. This count supports gradual adoption without silently
-claiming full coverage.
+example MUST give a nonempty `reason` and does not use the other fields. Every
+PHP fence in a manually maintained document MUST have metadata. The command
+fails when metadata is absent. Generated reference documents are excluded from
+the inventory because their source generator owns their PHP examples.
 
 Undefined names in an otherwise complete example SHOULD be supplied in another
 file in the same virtual project. A short analysis-only support file MAY be in a
@@ -95,6 +98,13 @@ examples. Their caches are separate from normal source analysis. The Rector
 configuration shares only the rule policy with the repository configuration.
 The PHPStan configuration does not inherit repository-only checked-exception
 rules that do not apply to consumer examples.
+
+The documentation Rector configuration skips transformations that need the
+complete class or file. These transformations include strict-type declarations,
+closure simplification, readonly inference, unused promoted properties and
+variables, and dynamic property completion. Documentation fragments omit
+opening boilerplate and can show only the members that explain one feature.
+Other repository Rector rules still apply.
 
 `composer static-analysis` runs the documentation check before normal PHPStan,
 Rector, and dependency analysis. CI caches the documentation tool caches, but

--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -8,6 +8,7 @@ text, bytes, or files that already exist.
 
 Ask for `Greenlight\Core\Artifact\Attachments` through constructor injection:
 
+<!-- php-example {"example":"attachments-example-01","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Artifact\AttachmentRetention;
@@ -49,6 +50,7 @@ rule includes a successful attempt that a result policy changes to another
 outcome. To retain an attachment from a successful attempt, set its retention to
 `AttachmentRetention::Always`:
 
+<!-- php-example {"example":"attachments-example-02","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 $attachments->text(
     'timing.txt',
@@ -68,6 +70,7 @@ By default, Greenlight writes retained attachments to a unique run directory
 below `build/greenlight-artifacts`. A run with no retained attachments does not
 create an empty directory. Change the parent directory in `greenlight.php`:
 
+<!-- php-example {"example":"attachments-example-03","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Config\ArtifactBuilder;
 

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -12,6 +12,7 @@ Target: method.
 
 Parameters:
 
+<!-- php-example {"mode":"display","reason":"Shows attribute parameters without the surrounding declaration."} -->
 ```php
 bool $capture = true
 ```
@@ -33,6 +34,7 @@ Set `capture: false` only when a test needs to control PHP's output buffer or
 error handler itself. With capture disabled, Greenlight does not record output
 or diagnostics for that test.
 
+<!-- php-example {"mode":"display","reason":"Uses an ellipsis to omit code that is not relevant to the example."} -->
 ```php
 #[Test]
 public function totalsAreRounded(): void { ... }
@@ -76,6 +78,7 @@ Target: method.
 
 Parameters:
 
+<!-- php-example {"mode":"display","reason":"Shows attribute parameters without the surrounding declaration."} -->
 ```php
 string $provider
 ?string $method = null
@@ -87,12 +90,14 @@ argument is its public static method:
 
 Provider class and method names MUST NOT be empty.
 
+<!-- php-example {"example":"attributes-example-04","file":"snippet.php","mode":"class-members","tools":["rector"]} -->
 ```php
 #[DataSet('currencies')]
 ```
 
 or:
 
+<!-- php-example {"example":"attributes-example-05","file":"snippet.php","mode":"class-members","tools":["rector"]} -->
 ```php
 #[DataSet(CurrencyDataSets::class, 'currencies')]
 ```
@@ -105,6 +110,7 @@ state in a provider.
 Each provider key names a data set and appears in test IDs and reports. Each
 provider value is the argument list for one test invocation.
 
+<!-- php-example {"mode":"display","reason":"Uses an ellipsis to omit code that is not relevant to the example."} -->
 ```php
 #[Test]
 #[DataSet('currencies')]
@@ -120,6 +126,7 @@ public static function currencies(): iterable
 
 Use the two-argument form to share a provider between test classes:
 
+<!-- php-example {"mode":"display","reason":"Uses an ellipsis to omit code that is not relevant to the example."} -->
 ```php
 final class CurrencyDataSets
 {
@@ -150,6 +157,7 @@ Repeatable.
 
 Parameters:
 
+<!-- php-example {"mode":"display","reason":"Shows attribute parameters without the surrounding declaration."} -->
 ```php
 array $arguments
 ?string $label = null
@@ -170,6 +178,7 @@ calculated rows, ranges, or objects.
 You can use `#[DataRow]` and `#[DataSet]` on the same method. They use one
 data-set key space. Thus, duplicate keys cause a discovery error.
 
+<!-- php-example {"mode":"display","reason":"Uses an ellipsis to omit code that is not relevant to the example."} -->
 ```php
 #[Test]
 #[DataRow([1, 2, 3], label: 'small')]
@@ -198,6 +207,7 @@ Repeatable.
 
 Parameters:
 
+<!-- php-example {"mode":"display","reason":"Shows attribute parameters without the surrounding declaration."} -->
 ```php
 string $name
 ```
@@ -207,6 +217,7 @@ Tags a test method, or every test in a class, with a group name.
 Select groups at run time with `--group=<name>`. The flag is
 repeatable. `list-tests` applies the same filter.
 
+<!-- php-example {"mode":"display","reason":"Uses an ellipsis to omit code that is not relevant to the example."} -->
 ```php
 #[Group('slow')]
 #[Group('io')]
@@ -219,6 +230,7 @@ Target: method or class.
 
 Parameters:
 
+<!-- php-example {"mode":"display","reason":"Shows attribute parameters without the surrounding declaration."} -->
 ```php
 string $reason
 ```
@@ -235,6 +247,7 @@ Target: method or class.
 
 Parameters:
 
+<!-- php-example {"mode":"display","reason":"Shows attribute parameters without the surrounding declaration."} -->
 ```php
 string $condition
 mixed ...$arguments
@@ -251,6 +264,7 @@ parallel workers. Another argument type causes a discovery error. The
 constructor MUST only store the arguments. The `isSatisfied()` method MUST
 evaluate the condition without side effects:
 
+<!-- php-example {"example":"attributes-example-14","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 interface Condition
 {
@@ -264,6 +278,7 @@ services.
 
 If the condition throws, the test has an error. Greenlight does not skip it.
 
+<!-- php-example {"mode":"display","reason":"Uses an ellipsis to omit code that is not relevant to the example."} -->
 ```php
 #[Test]
 #[SkipUnless(RedisIsRunning::class)]
@@ -302,6 +317,7 @@ Target: method or class.
 
 Parameters:
 
+<!-- php-example {"mode":"display","reason":"Shows attribute parameters without the surrounding declaration."} -->
 ```php
 int $times
 ?string $onlyOn = null
@@ -322,6 +338,7 @@ Each retry also starts `eventually()` and `consistently()` with a new deadline
 and an empty observation log. `retryOnException()` retries a probe within the
 same test attempt, while `#[Retry]` starts the whole test again.
 
+<!-- php-example {"mode":"display","reason":"Uses an ellipsis to omit code that is not relevant to the example."} -->
 ```php
 #[Test]
 #[Retry(times: 2, onlyOn: NetworkException::class)]
@@ -334,6 +351,7 @@ Target: method or class.
 
 Parameters:
 
+<!-- php-example {"mode":"display","reason":"Shows attribute parameters without the surrounding declaration."} -->
 ```php
 float $seconds
 ```
@@ -353,6 +371,7 @@ timeout. If the test timeout occurs first, the failure gives the requested
 duration. A blocked probe remains subject to the orchestrator hard-kill grace
 period.
 
+<!-- php-example {"mode":"display","reason":"Uses an ellipsis to omit code that is not relevant to the example."} -->
 ```php
 #[Test]
 #[Timeout(seconds: 5.0)]
@@ -365,6 +384,7 @@ Target: method or class. Repeatable.
 
 Parameters:
 
+<!-- php-example {"mode":"display","reason":"Shows attribute parameters without the surrounding declaration."} -->
 ```php
 string $name
 ```
@@ -373,6 +393,7 @@ Marks a test that requires one slot of a named resource. A name must start with
 a lowercase letter or digit. After the first character, the name accepts dots,
 underscores, and hyphens.
 
+<!-- php-example {"mode":"display","reason":"Uses an ellipsis to omit code that is not relevant to the example."} -->
 ```php
 #[RequiresResource('postgres')]
 #[RequiresResource('payments-sandbox')]
@@ -421,6 +442,7 @@ Excludes the declaration from coverage. Greenlight removes ignored lines from
 the covered and executable totals. Thus, they do not change a percentage,
 export, or baseline diff.
 
+<!-- php-example {"mode":"display","reason":"Uses an ellipsis to omit code that is not relevant to the example."} -->
 ```php
 final class Config
 {
@@ -429,6 +451,7 @@ final class Config
 }
 ```
 
+<!-- php-example {"mode":"display","reason":"Uses an ellipsis to omit code that is not relevant to the example."} -->
 ```php
 #[CoverageIgnore]
 function dumpDebugState(): void { ... }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -18,6 +18,7 @@ Later layers override earlier ones.
 
 For example, use this configuration:
 
+<!-- php-example {"example":"configuration-example-01","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 ->workers('auto')
 ```
@@ -34,6 +35,7 @@ runs with one worker.
 
 Create the builder with:
 
+<!-- php-example {"example":"configuration-example-02","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 GreenlightConfig::create()
 ```
@@ -63,6 +65,7 @@ Each run includes every named suite. Suite names and tags are descriptive. The
 
 A second declaration with the same suite name causes an error.
 
+<!-- php-example {"example":"configuration-example-03","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 ->suite('unit', fn ($s) => $s->in('tests/Unit'))
 ->suite('integration', fn ($s) => $s->in('tests/Integration')->tag('io'))
@@ -115,6 +118,7 @@ Default: `1` for a resource used by `#[RequiresResource]`.
 Limits how many assignments in one Greenlight run can use the named resource at
 once.
 
+<!-- php-example {"example":"configuration-example-04","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 return GreenlightConfig::create()
     ->resourceLimit('postgres', 3)
@@ -158,6 +162,7 @@ accumulate.
   `$target` is a file path, or a directory for multi-file formats such as
   `html`. Repeatable.
 
+<!-- php-example {"example":"configuration-example-05","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 ->coverage(fn ($c) => $c
     ->include('src')
@@ -199,6 +204,7 @@ The configurator receives a `WatchBuilder`.
 A rerun starts after the configured period has no file changes. Thus, a group
 of save operations starts only one run.
 
+<!-- php-example {"example":"configuration-example-06","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 ->watch(fn ($w) => $w->debounceMilliseconds(500))
 ```
@@ -276,6 +282,7 @@ Default: output below `build/greenlight-artifacts`, with failure-only retention.
 Greenlight gives an `ArtifactBuilder` to the configurator. Repeated calls use
 the same builder.
 
+<!-- php-example {"example":"configuration-example-07","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 ->artifacts(fn ($artifacts) => $artifacts
     ->directory('build/test-evidence')

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -3,6 +3,7 @@
 A Greenlight expectation starts with a subject value. It applies one or more
 typed matchers to that value:
 
+<!-- php-example {"example":"expectations-example-01","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Expect\Expect;
 
@@ -17,6 +18,7 @@ them.
 
 Matchers in a chain use the same subject:
 
+<!-- php-example {"example":"expectations-example-02","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 Expect::that($response->body())
     ->toBeString()
@@ -27,6 +29,7 @@ Start a separate expectation for each subject.
 
 `not()` negates the next matcher only:
 
+<!-- php-example {"example":"expectations-example-03","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 Expect::that($errors)
     ->not()->toBeEmpty()
@@ -35,6 +38,7 @@ Expect::that($errors)
 
 `because()` adds a reason to the next matcher only:
 
+<!-- php-example {"example":"expectations-example-04","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 Expect::that($order->isOpen())
     ->because('a refund requires an open order')
@@ -137,6 +141,7 @@ structures with `toEqual()` semantics. JSON object key order does not matter.
 
 `toThrow()` invokes a callable subject and checks the throwable type:
 
+<!-- php-example {"example":"expectations-example-05","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 Expect::that(fn() => $service->load('missing'))
     ->toThrow(NotFound::class);
@@ -144,6 +149,7 @@ Expect::that(fn() => $service->load('missing'))
 
 Pass a Throwable instance to require the callable to throw that exact object:
 
+<!-- php-example {"example":"expectations-example-06","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 $failure = new DomainException('Order is closed.');
 
@@ -153,6 +159,7 @@ Expect::that(fn() => throw $failure)
 
 Constrain the message by exact value or regular expression:
 
+<!-- php-example {"example":"expectations-example-07","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 Expect::that($callback)->toThrow(
     DomainException::class,
@@ -172,6 +179,7 @@ object.
 A typed callback can specify the throwable type and check the caught
 throwable. Greenlight runs it only after the throwable type matches:
 
+<!-- php-example {"example":"expectations-example-08","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 Expect::that(fn() => $fixtureManager->start())
     ->toThrow(
@@ -202,6 +210,7 @@ instance. It passes when the callable throws the specified object.
 `Expect::eventually()` calls a probe immediately. It then polls until its
 matcher passes or `within()` expires:
 
+<!-- php-example {"example":"expectations-example-09","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 Expect::eventually(fn() => $repository->find($id))
     ->pollEvery(0.100)
@@ -212,6 +221,7 @@ Expect::eventually(fn() => $repository->find($id))
 The default poll interval is 25 ms. A probe exception stops the polls unless
 `retryOnException()` lists its type:
 
+<!-- php-example {"example":"expectations-example-10","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 Expect::eventually(fn() => $client->fetch($id))
     ->retryOnException(NotFoundYet::class)
@@ -224,6 +234,7 @@ Expect::eventually(fn() => $client->fetch($id))
 `Expect::consistently()` requires the first probe result to match, then checks
 for the full duration:
 
+<!-- php-example {"example":"expectations-example-11","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 Expect::consistently(fn() => $outbox->messagesFor($id))
     ->pollEvery(0.050)
@@ -242,6 +253,7 @@ duration. The worker timeout remains the hard limit for a blocked probe.
 If a test reaches an invalid state that does not fit a matcher, use
 `Fail::because()`:
 
+<!-- php-example {"example":"expectations-example-12","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Expect\Fail;
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -46,6 +46,7 @@ return GreenlightConfig::create()
 
 These values are defaults. Thus, this configuration has the same result:
 
+<!-- php-example {"example":"getting-started-example-02","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 return GreenlightConfig::create();
 ```
@@ -263,6 +264,7 @@ typed connection data through `Greenlight\Harness\IntegrationResources`.
 That keeps setup and teardown alive even when a worker crashes or is recycled.
 See [Writing plugins](plugins.md#integrationfixtureprovider).
 
+<!-- php-example {"example":"getting-started-example-05","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 final class OrderRepositoryTest
 {
@@ -285,11 +287,13 @@ and `app_test_2` do not conflict.
 Use `#[RequiresResource]` when several workers use one dependency with limited
 capacity:
 
+<!-- php-example {"mode":"display","reason":"Uses an ellipsis to omit code that is not relevant to the example."} -->
 ```php
 #[RequiresResource('payments-sandbox')]
 final class PaymentGatewayTest { ... }
 ```
 
+<!-- php-example {"example":"getting-started-example-07","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 return GreenlightConfig::create()
     ->workers(8)
@@ -333,6 +337,7 @@ leak to other tests or workers.
 * `StreamWrapperSandbox` registers PHP stream wrappers. It unregisters them in
   reverse registration order after the test.
 
+<!-- php-example {"example":"getting-started-example-08","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Fixture\EnvironmentSandbox;
 use Greenlight\Fixture\TempDirectory;
@@ -364,6 +369,7 @@ unique directory.
 Ask for `Greenlight\Core\Test\Cleanup` through constructor injection. Call
 `defer()` immediately after the test acquires a resource.
 
+<!-- php-example {"example":"getting-started-example-09","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Test\Cleanup;

--- a/docs/hyperf.md
+++ b/docs/hyperf.md
@@ -18,6 +18,7 @@ Greenlight.
 
 Register the plugin in `greenlight.php`:
 
+<!-- php-example {"example":"hyperf-example-01","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Config\GreenlightConfig;
 use Greenlight\Hyperf\HyperfPlugin;
@@ -40,6 +41,7 @@ The default `ContainerLifetime::Worker` mode uses one application container for
 each worker. Greenlight reuses the container for all test attempts in that
 worker.
 
+<!-- php-example {"example":"hyperf-example-02","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Hyperf\ContainerLifetime;
 use Greenlight\Hyperf\HyperfPlugin;
@@ -56,6 +58,7 @@ worker service, global variable, or static property can also reach later tests.
 Use `ContainerLifetime::TestAttempt` to create an application container for
 each test attempt:
 
+<!-- php-example {"example":"hyperf-example-03","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 new HyperfPlugin(
     dirname(__DIR__),
@@ -128,6 +131,7 @@ plugins. Swoole destroys the coroutine context when the attempt ends.
 
 Declare a service dependency by type:
 
+<!-- php-example {"example":"hyperf-example-04","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 final readonly class RegistrationTest
 {
@@ -140,6 +144,7 @@ container.
 
 Use `#[Service]` when the parameter type does not select the necessary ID:
 
+<!-- php-example {"example":"hyperf-example-05","file":"snippet.php","mode":"class-members","tools":["rector"]} -->
 ```php
 use Greenlight\Hyperf\Service;
 
@@ -164,6 +169,7 @@ after each attempt. See Hyperf's
 Use `reset:` to reset project state after each attempt. Use
 `dispose:` for resources that belong to the selected container lifetime:
 
+<!-- php-example {"example":"hyperf-example-06","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Psr\Container\ContainerInterface;
 

--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -12,6 +12,7 @@ Laravel.
 
 Register the plugin in `greenlight.php` with your application bootstrap file:
 
+<!-- php-example {"example":"laravel-example-01","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Config\GreenlightConfig;
 use Greenlight\Laravel\LaravelPlugin;
@@ -25,6 +26,7 @@ The bootstrap file is the standard Laravel entry point. It returns the result
 of `Application::configure(...)->create()`. Use a closure when the application
 needs custom construction:
 
+<!-- php-example {"example":"laravel-example-02","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 new LaravelPlugin(static fn(): Application => Application::configure(basePath: __DIR__)
     ->withProviders([App\Providers\AppServiceProvider::class])
@@ -50,6 +52,7 @@ individual `illuminate/*` components.
 
 Declare the dependency by type:
 
+<!-- php-example {"example":"laravel-example-03","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 final class RegistrationTest
 {
@@ -76,6 +79,7 @@ Type alone cannot select some services. Examples include string-id-only
 services, interfaces with multiple implementations, and aliased services. Use
 `#[Service]` to name the service explicitly:
 
+<!-- php-example {"example":"laravel-example-04","file":"snippet.php","mode":"class-members","tools":["rector"]} -->
 ```php
 use Greenlight\Laravel\Service;
 
@@ -94,6 +98,7 @@ service. The service scope is per-test, or per-run when `refreshBetweenTests`
 is false. Tests can use it to inspect the environment or the container
 directly:
 
+<!-- php-example {"example":"laravel-example-05","file":"snippet.php","mode":"class-members","tools":["rector"]} -->
 ```php
 public function __construct(private readonly Application $app) {}
 ```
@@ -137,6 +142,7 @@ Greenlight sets `GREENLIGHT_CHANNEL` in every worker process. It is a stable
 number from 1 through the worker count, and no two concurrent tests use the same
 channel. Use it in normal Laravel configuration to key shared resources:
 
+<!-- php-example {"mode":"display","reason":"Shows one entry from a larger PHP configuration array."} -->
 ```php
 // config/database.php
 'database' => env('DB_DATABASE', 'app') . '_test_' . env('GREENLIGHT_CHANNEL', '1'),
@@ -153,11 +159,13 @@ remain for the complete test run.
 If a service cannot be split per channel, mark the classes that use it with
 `#[RequiresResource]`. Configure its safe concurrency:
 
+<!-- php-example {"mode":"display","reason":"Uses an ellipsis to omit code that is not relevant to the example."} -->
 ```php
 #[RequiresResource('payments-sandbox')]
 final class PaymentGatewayTest { ... }
 ```
 
+<!-- php-example {"example":"laravel-example-08","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 return GreenlightConfig::create()
     ->resourceLimit('payments-sandbox', 2);

--- a/docs/migrating-from-phpunit.md
+++ b/docs/migrating-from-phpunit.md
@@ -20,6 +20,7 @@ blocks, `markTestSkipped()`, and `fail()`.
 
 Register the rule in a `rector.php` file that selects your test directories:
 
+<!-- php-example {"example":"migrating-from-phpunit-example-01","file":"snippet.php","mode":"file","tools":["phpstan","rector"]} -->
 ```php
 <?php
 
@@ -56,6 +57,7 @@ A custom failure message on an assertion has no Greenlight equivalent. By
 default, a message prevents the conversion of the class. Use this
 configuration to remove the messages:
 
+<!-- php-example {"example":"migrating-from-phpunit-example-02","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
     ->withConfiguredRule(PhpUnitToGreenlightRector::class, [
         PhpUnitToGreenlightRector::DROP_ASSERTION_MESSAGES => true,
@@ -121,6 +123,7 @@ enable parallel workers.
 Expectations start with `Expect::that()`. They do not use methods on the test
 class.
 
+<!-- php-example {"mode":"display","reason":"Compares partial PHPUnit and Greenlight expressions side by side."} -->
 ```php
 // PHPUnit                                                // Greenlight
 $this->assertSame('a', $value);                           Expect::that($value)->toBe('a');
@@ -176,6 +179,7 @@ previous throwable, and other throwable state.
 
 Replace this pattern:
 
+<!-- php-example {"example":"migrating-from-phpunit-example-04","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 try {
     $fixtureManager->start();
@@ -190,6 +194,7 @@ try {
 
 Use this expectation:
 
+<!-- php-example {"example":"migrating-from-phpunit-example-05","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 Expect::that(fn() => $fixtureManager->start())
     ->toThrow(
@@ -204,6 +209,7 @@ The callback runs only after the throwable type matches.
 
 Replace manual `sleep()` calls or retry loops with `eventually()`:
 
+<!-- php-example {"example":"migrating-from-phpunit-example-06","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 Expect::eventually(fn() => $repository->find($id))
     ->within(2.0)
@@ -236,6 +242,7 @@ callback receives the call arguments.
 
 Replace argument constraints with `Greenlight\Doubles\Argument`:
 
+<!-- php-example {"mode":"display","reason":"Compares partial PHPUnit and Greenlight expressions side by side."} -->
 ```php
 // PHPUnit                                          // Greenlight
 $mock->method('save')->with($this->anything());     $plan->expects('save')->with(Argument::any());
@@ -246,6 +253,7 @@ $this->equalTo($expected)                           Argument::equals($expected)
 
 Use a captured argument instead of callback inspection:
 
+<!-- php-example {"example":"migrating-from-phpunit-example-08","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 $captor = $plan->expects('save')->once()->andReturns(true)->captureArgument(0);
 // ... exercise the subject ...
@@ -263,6 +271,7 @@ does not create a return value.
 Read records with `$this->doubles->callsTo($spy, 'method')`. Check the records
 with `Expect`.
 
+<!-- php-example {"example":"migrating-from-phpunit-example-09","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 $gateway = $this->doubles->mock(PaymentGateway::class, function (MockPlan $plan) use ($amount, $ok) {
     $plan->expects('charge')->with($amount)->once()->andReturns($ok);

--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -33,6 +33,7 @@ matcher rules work without it.
 The extension checks a constant method name in `Doubles::callsTo()` against the
 doubled type:
 
+<!-- php-example {"example":"phpstan-example-01","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 $events = $doubles->spy(EventPublisher::class);
 
@@ -48,6 +49,7 @@ Method errors use the `greenlight.doubles.callsToMethod` identifier.
 For a constant method name, the extension also supplies the declared argument
 types for each recorded call:
 
+<!-- php-example {"example":"phpstan-example-02","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 $calls = $doubles->callsTo($events, 'publish');
 $event = $calls[0][0]; // the declared type of EventPublisher::publish() argument 1
@@ -84,6 +86,7 @@ parameter.
 regular expression. A Throwable instance requires the exact object. A typed
 callback can specify and check the throwable:
 
+<!-- php-example {"example":"phpstan-example-03","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 Expect::that($callback)->toThrow(DomainException::class, message: 'Exact message');
 Expect::that($callback)->toThrow(DomainException::class, matching: '/message/i');
@@ -112,6 +115,7 @@ at run time.
 The subject for `toThrow()` must be callable. The extension reports a known
 incompatible subject before the test runs:
 
+<!-- php-example {"example":"phpstan-example-04","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 Expect::that(42)->toThrow(DomainException::class);
 ```
@@ -161,6 +165,7 @@ the real signature.
 
 For example, use a plugin with these matchers:
 
+<!-- php-example {"example":"phpstan-example-05","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 final class DigestMatchers implements ExpectationExtension
 {
@@ -178,6 +183,7 @@ final class DigestMatchers implements ExpectationExtension
 
 The extension checks calls against those closure signatures:
 
+<!-- php-example {"example":"phpstan-example-06","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 Expect::that($id)->toBeValidUuid();     // checked: name, arguments, types
 Expect::that($id)->toBeValidUuuid();    // fails analysis: unknown matcher
@@ -193,6 +199,7 @@ receive the same subject type.
 
 The same checks apply to temporal expectations:
 
+<!-- php-example {"example":"phpstan-example-07","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 Expect::eventually(fn(): string => $hash)
     ->within(1.0)
@@ -216,6 +223,7 @@ vendor/bin/greenlight ide-helper
 PHPStan narrows the original subject after a synchronous type expectation
 passes:
 
+<!-- php-example {"example":"phpstan-subject-refinement","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 /** @var FileCoverage|null $file */
 Expect::that($file)->not()->toBeNull();
@@ -315,6 +323,7 @@ first, PHPStan reports a broken provider before a test can report the error:
 * Constant inline row labels must be unique. An explicit label must not
   duplicate a generated positional label such as `#0`.
 
+<!-- php-example {"mode":"display","reason":"Uses an ellipsis to omit code that is not relevant to the example."} -->
 ```php
 #[Test]
 #[DataSet('sums')]
@@ -330,6 +339,7 @@ public static function sums(): iterable
 
 Providers shared by multiple test classes receive the same checks:
 
+<!-- php-example {"example":"phpstan-example-09","file":"snippet.php","mode":"class-members","tools":["rector"]} -->
 ```php
 #[DataSet(ArithmeticDataSets::class, 'sums')]
 ```
@@ -352,6 +362,7 @@ Errors have identifiers under `greenlight.dataProvider.*` (`provider`,
 `parameters`, `returnType`, `keyType`, `empty`, `duplicateKey`, `arity`,
 `argument`). Thus, you can suppress a deliberate exception inline:
 
+<!-- php-example {"example":"phpstan-example-10","file":"snippet.php","mode":"class-members","tools":["rector"]} -->
 ```php
 #[DataSet('doesNotExist')] // @phpstan-ignore greenlight.dataProvider.provider (proves the runtime error path)
 ```

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -8,6 +8,7 @@ interface.
 Plugin capabilities run either in the orchestrator or in workers. Each
 capability section below names its side.
 
+<!-- php-example {"example":"plugins-example-01","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 return GreenlightConfig::create()
     ->paths(['tests'])
@@ -39,6 +40,7 @@ Orchestrator-side.
 Integration fixtures own external infrastructure that must outlive a worker
 process, such as a database server, broker, container, or remote test tenant.
 
+<!-- php-example {"example":"plugins-example-02","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Harness\FixtureResource;
 use Greenlight\Plugin\IntegrationFixtureContext;
@@ -82,6 +84,7 @@ Greenlight provisions after discovery, selection, and sharding, but before
 
 Definitions can depend on other fixtures:
 
+<!-- php-example {"example":"plugins-example-03","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 new IntegrationFixtureDefinition(
     'schema',
@@ -118,6 +121,7 @@ each worker's complete resource payload to 1 MiB.
 
 Tests can inject `IntegrationResources` directly:
 
+<!-- php-example {"example":"plugins-example-04","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 final class PublishesMessageTest
 {
@@ -170,6 +174,7 @@ This hook runs once per physical worker after resources arrive and before
 Greenlight uses `HarnessProvider::services()` or `ServiceResolver`. It can turn
 serializable resource data into worker-local services:
 
+<!-- php-example {"example":"plugins-example-05","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 final class BrokerPlugin implements WorkerBootstrapSubscriber, HarnessProvider
 {
@@ -207,6 +212,7 @@ run first. An exception fails the run before tests begin.
 
 Worker-side.
 
+<!-- php-example {"mode":"display","reason":"Shows one method signature without its interface declaration."} -->
 ```php
 public function runWorker(\Closure $worker): mixed;
 ```
@@ -230,6 +236,7 @@ runtime. See [Hyperf applications](hyperf.md).
 
 Worker-side.
 
+<!-- php-example {"example":"plugins-example-07","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Plugin\TestContext;
 use Greenlight\Plugin\TestLifecycleSubscriber;
@@ -282,6 +289,7 @@ per-test scope closes before `afterTest()`, so `service()` throws in that hook.
 
 Worker-side.
 
+<!-- php-example {"mode":"display","reason":"Shows one method signature without its interface declaration."} -->
 ```php
 public function runTestAttempt(\Closure $attempt): mixed;
 ```
@@ -303,6 +311,7 @@ coroutine. See [Hyperf applications](hyperf.md).
 
 Worker-side.
 
+<!-- php-example {"mode":"display","reason":"Shows one method signature without its interface declaration."} -->
 ```php
 public function shouldRetry(TestMetadata $metadata, TestResult $result, int $attempt, ?\Throwable $cause): bool;
 ```
@@ -321,6 +330,7 @@ The built-in `#[Retry]` attribute uses this interface.
 
 Orchestrator-side.
 
+<!-- php-example {"mode":"display","reason":"Shows one method signature without its interface declaration."} -->
 ```php
 public function onRunEvent(Event $event): void;
 ```
@@ -335,6 +345,7 @@ throws, the run fails and fixtures are still torn down.
 
 ### HarnessProvider
 
+<!-- php-example {"example":"plugins-example-11","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Harness\Scope;
 use Greenlight\Harness\ServiceDefinition;
@@ -368,6 +379,7 @@ doubles use this mechanism.
 
 In `Greenlight\Harness`.
 
+<!-- php-example {"mode":"display","reason":"Shows one method signature without its interface declaration."} -->
 ```php
 public function resolve(string $type, array $attributes): ?object;
 ```
@@ -393,6 +405,7 @@ The framework bridges use this interface to inject container services. See
 
 In `Greenlight\Expect`.
 
+<!-- php-example {"example":"plugins-example-13","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 final class UuidMatchers implements ExpectationExtension
 {
@@ -408,6 +421,7 @@ final class UuidMatchers implements ExpectationExtension
 
 Call extension matchers through the expectation chain:
 
+<!-- php-example {"example":"plugins-example-14","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 Expect::that($id)->toBeValidUuid();
 ```
@@ -471,6 +485,7 @@ process. Each worker also runs the plugin constructors.
 
 A plugin can also implement `Greenlight\Plugin\Prioritized`:
 
+<!-- php-example {"mode":"display","reason":"Shows one method signature without its interface declaration."} -->
 ```php
 public function priority(): int;
 ```

--- a/docs/psr.md
+++ b/docs/psr.md
@@ -11,6 +11,7 @@ install a container implementation.
 
 Register `Psr11Plugin` with a factory that returns the application container:
 
+<!-- php-example {"example":"psr-example-01","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Config\GreenlightConfig;
 use Greenlight\Psr\Psr11Plugin;
@@ -38,6 +39,7 @@ The plugin also works with
 
 Declare the dependency by type:
 
+<!-- php-example {"example":"psr-example-02","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 final class RegistrationTest
 {
@@ -60,6 +62,7 @@ reports a type mismatch before the test runs.
 
 Use `#[Service]` when the container ID differs from the parameter type:
 
+<!-- php-example {"example":"psr-example-03","file":"snippet.php","mode":"class-members","tools":["rector"]} -->
 ```php
 use Greenlight\Psr\Service;
 
@@ -76,6 +79,7 @@ type-based ID lets the next service resolver try to supply the parameter.
 
 Greenlight supplies `Psr\Container\ContainerInterface` as a harness service:
 
+<!-- php-example {"example":"psr-example-04","file":"snippet.php","mode":"class-members","tools":["rector"]} -->
 ```php
 public function __construct(private readonly ContainerInterface $container) {}
 ```
@@ -90,6 +94,7 @@ The next test creates a new container from the factory.
 
 Use `reset:` to reset container state before the bridge discards the container:
 
+<!-- php-example {"example":"psr-example-05","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 new Psr11Plugin(
     static fn(): ContainerInterface => require __DIR__ . '/config/container.php',
@@ -105,6 +110,7 @@ container even if the callback throws.
 If services keep no test state or `reset:` removes all state, set
 `refreshBetweenTests` to `false`. The worker then keeps one container:
 
+<!-- php-example {"example":"psr-example-06","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 new Psr11Plugin(
     static fn(): ContainerInterface => require __DIR__ . '/config/container.php',

--- a/docs/psr15.md
+++ b/docs/psr15.md
@@ -19,6 +19,7 @@ composer require --dev psr/http-message psr/http-server-handler nyholm/psr7
 
 Register `Psr15Plugin` with a request-handler factory:
 
+<!-- php-example {"example":"psr15-example-01","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Config\GreenlightConfig;
 use Greenlight\Psr15\Psr15Plugin;
@@ -43,12 +44,13 @@ handler from the factory.
 applications. A Mezzio `Application` implements `RequestHandlerInterface`.
 Return the application from the factory:
 
+<!-- php-example {"example":"psr15-example-02","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Mezzio\Application;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 
-static function (): RequestHandlerInterface {
+return static function (): RequestHandlerInterface {
     /** @var ContainerInterface $container */
     $container = require __DIR__ . '/config/container.php';
     $application = $container->get(Application::class);
@@ -58,7 +60,7 @@ static function (): RequestHandlerInterface {
     }
 
     return $application;
-}
+};
 ```
 
 This factory uses the PSR-11 container to get the Mezzio request handler.
@@ -72,6 +74,7 @@ If tests need application services, also register the
 Declare `HttpHarness` in the test constructor. Build requests with the
 application's PSR-7 implementation:
 
+<!-- php-example {"example":"psr15-example-03","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
@@ -113,6 +116,7 @@ the same handler object.
 
 Use a release callback when the handler owns resources:
 
+<!-- php-example {"example":"psr15-example-04","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 new Psr15Plugin(
     handler: static fn(): RequestHandlerInterface => createApplication(),
@@ -134,6 +138,7 @@ Greenlight reports a test error and keeps the throwable as its cause.
 
 If handler state can remain between tests, use `Scope::PerRun`:
 
+<!-- php-example {"example":"psr15-example-05","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Harness\Scope;
 

--- a/docs/symfony.md
+++ b/docs/symfony.md
@@ -12,6 +12,7 @@ Symfony.
 
 Register the plugin in `greenlight.php` with your kernel class:
 
+<!-- php-example {"example":"symfony-example-01","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Config\GreenlightConfig;
 use Greenlight\Symfony\SymfonyPlugin;
@@ -23,6 +24,7 @@ return GreenlightConfig::create()
 
 Use a closure when the kernel needs custom construction:
 
+<!-- php-example {"example":"symfony-example-02","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 new SymfonyPlugin(static fn(): KernelInterface => new App\Kernel('test', false));
 ```
@@ -44,6 +46,7 @@ error with a correction. It does not use weaker isolation.
 
 Declare the dependency by type:
 
+<!-- php-example {"example":"symfony-example-03","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 final class RegistrationTest
 {
@@ -71,6 +74,7 @@ Type alone cannot select some services. Examples include string-ID-only
 services, interfaces with multiple implementations, and decorated services.
 Use `#[Service]` to name the service explicitly:
 
+<!-- php-example {"example":"symfony-example-04","file":"snippet.php","mode":"class-members","tools":["rector"]} -->
 ```php
 use Greenlight\Symfony\Service;
 
@@ -87,6 +91,7 @@ instance of the declared type, the test fails and does not receive the object.
 Greenlight supplies `KernelInterface` as a per-run harness service. Tests can
 use it to inspect boot parameters or the container directly:
 
+<!-- php-example {"example":"symfony-example-05","file":"snippet.php","mode":"class-members","tools":["rector"]} -->
 ```php
 public function __construct(private readonly KernelInterface $kernel) {}
 ```
@@ -142,11 +147,13 @@ remain for the complete test run.
 If you cannot split a service per channel, mark the classes that use it with
 `#[RequiresResource]`. Configure its safe concurrency:
 
+<!-- php-example {"mode":"display","reason":"Uses an ellipsis to omit code that is not relevant to the example."} -->
 ```php
 #[RequiresResource('payments-sandbox')]
 final class PaymentGatewayTest { ... }
 ```
 
+<!-- php-example {"example":"symfony-example-07","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 return GreenlightConfig::create()
     ->resourceLimit('payments-sandbox', 2);

--- a/docs/tempest.md
+++ b/docs/tempest.md
@@ -23,6 +23,7 @@ composer require tempest/framework:^3.18
 
 Register the plugin in `greenlight.php` with the application root:
 
+<!-- php-example {"example":"tempest-example-01","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Config\GreenlightConfig;
 use Greenlight\Tempest\TempestPlugin;
@@ -51,6 +52,7 @@ test. A test can replace this request in the container.
 Tempest discovers application and package namespaces from Composer metadata.
 Pass additional locations when test fixtures are outside these namespaces:
 
+<!-- php-example {"example":"tempest-example-02","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Tempest\Discovery\DiscoveryLocation;
 
@@ -68,6 +70,7 @@ Tempest adds these locations during discovery.
 
 Declare application dependencies by type:
 
+<!-- php-example {"example":"tempest-example-03","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 final class RegistrationTest
 {
@@ -90,6 +93,7 @@ error contains the Tempest container error as its cause.
 
 Use the Tempest `#[Tag]` attribute to select a tagged service:
 
+<!-- php-example {"example":"tempest-example-04","file":"snippet.php","mode":"class-members","tools":["rector"]} -->
 ```php
 use Tempest\Container\Tag;
 
@@ -106,6 +110,7 @@ have the declared parameter type.
 Greenlight supplies `Tempest\Core\Kernel` and
 `Tempest\Container\Container` as harness services for each run:
 
+<!-- php-example {"example":"tempest-example-05","file":"snippet.php","mode":"class-members","tools":["rector"]} -->
 ```php
 public function __construct(
     private readonly Kernel $kernel,

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -4,6 +4,7 @@ Greenlight provides strict mocks, inert stubs, and spies that record calls. The
 per-test `Doubles` service supplies these doubles. Request this service through
 constructor injection:
 
+<!-- php-example {"example":"test-doubles-example-01","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Attribute\Test;
 use Greenlight\Doubles\Doubles;
@@ -51,6 +52,7 @@ A call to a spy method that returns a value fails the test.
 
 The plan passed to `mock()` declares expectations with `expects()`:
 
+<!-- php-example {"example":"test-doubles-example-02","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 $plan->expects('reserve')
     ->with($sku, 2)
@@ -81,6 +83,7 @@ does not declare.
 
 Each mock method that returns a value needs an explicit response:
 
+<!-- php-example {"example":"test-doubles-example-03","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 $plan->expects('nextId')->andReturns('id-1');
 
@@ -102,12 +105,14 @@ reports an error if a call occurs after the sequence is empty.
 
 Bare values passed to `with()` use the same deep equality as `toEqual()`:
 
+<!-- php-example {"example":"test-doubles-example-04","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 $plan->expects('save')->with($expectedOrder);
 ```
 
 Use `withNoArguments()` to require a call that supplies no arguments:
 
+<!-- php-example {"example":"test-doubles-example-05","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 $plan->expects('loadDefaults')->withNoArguments();
 ```
@@ -117,6 +122,7 @@ This constraint is useful when a method has optional or variadic parameters.
 
 Use `Argument` matchers for broader constraints:
 
+<!-- php-example {"example":"test-doubles-example-06","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Doubles\Argument;
 
@@ -142,6 +148,7 @@ Available matchers are:
 
 Capture one argument from every matched call:
 
+<!-- php-example {"example":"test-doubles-example-07","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 $captor = $plan->expects('save')
     ->times(2)
@@ -164,6 +171,7 @@ If a plan must capture more than one argument, put an explicit
 
 `callsTo()` returns argument lists in call order:
 
+<!-- php-example {"example":"test-doubles-example-08","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 $events = $this->doubles->spy(EventPublisher::class);
 

--- a/rector.docs.php
+++ b/rector.docs.php
@@ -7,4 +7,13 @@ require_once __DIR__ . '/tools/rector-config.php';
 return \greenlightRectorConfig(
     [__DIR__ . '/build/docs-php'],
     __DIR__ . '/build/cache/rector-docs',
+    [
+        Rector\CodeQuality\Rector\Class_\CompleteDynamicPropertiesRector::class,
+        Rector\DeadCode\Rector\Assign\RemoveUnusedVariableAssignRector::class,
+        Rector\DeadCode\Rector\ClassMethod\RemoveUnusedPromotedPropertyRector::class,
+        Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector::class,
+        Rector\Php81\Rector\Property\ReadOnlyPropertyRector::class,
+        Rector\Php82\Rector\Class_\ReadOnlyClassRector::class,
+        Rector\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector::class,
+    ],
 );

--- a/src/Documentation/PhpExample/Checker.php
+++ b/src/Documentation/PhpExample/Checker.php
@@ -36,9 +36,13 @@ final readonly class Checker
                 $diagnostics = [
                     ...$diagnostics,
                     ...$this->toolAnalyser->phpStan($root, $phpstan, $group),
-                    ...$this->toolAnalyser->rector($root, $rector, $group),
                 ];
             }
+
+            $diagnostics = [
+                ...$diagnostics,
+                ...$this->toolAnalyser->rector($root, $rector, $materialized),
+            ];
         }
 
         return new CheckResult($extraction, $materialized, $diagnostics);

--- a/src/Documentation/PhpExample/Command.php
+++ b/src/Documentation/PhpExample/Command.php
@@ -34,11 +34,12 @@ final readonly class Command
             $result = $checker->check($options['root'], $options['phpstan'], $options['rector']);
             self::renderDiagnostics($result->diagnostics);
             echo \sprintf(
-                'Documentation PHP: %d fence(s), %d checked file(s), %d display-only fence(s), %d unclassified fence(s), %d generated document(s).',
+                'Documentation PHP: %d fence(s), %d checked file(s), %d PHPStan file(s), %d Rector file(s), %d display-only fence(s), %d generated document(s).',
                 $result->extraction->phpFences,
                 \count($result->materialized),
+                self::toolFileCount($result->materialized, 'phpstan'),
+                self::toolFileCount($result->materialized, 'rector'),
                 $result->extraction->displayFences,
-                $result->extraction->unclassifiedFences,
                 $result->extraction->generatedDocuments,
             ), "\n";
 
@@ -48,6 +49,17 @@ final readonly class Command
 
             return 1;
         }
+    }
+
+    /**
+     * @param list<MaterializedSnippet> $snippets
+     */
+    private static function toolFileCount(array $snippets, string $tool): int
+    {
+        return \count(\array_filter(
+            $snippets,
+            static fn(MaterializedSnippet $snippet): bool => \in_array($tool, $snippet->source->tools, true),
+        ));
     }
 
     /**

--- a/src/Documentation/PhpExample/Extraction.php
+++ b/src/Documentation/PhpExample/Extraction.php
@@ -17,7 +17,6 @@ final readonly class Extraction
     public function __construct(
         public array $snippets,
         public int $phpFences,
-        public int $unclassifiedFences,
         public int $displayFences,
         public int $generatedDocuments,
     ) {}

--- a/src/Documentation/PhpExample/Extractor.php
+++ b/src/Documentation/PhpExample/Extractor.php
@@ -15,7 +15,6 @@ final readonly class Extractor
     {
         $snippets = [];
         $phpFences = 0;
-        $unclassifiedFences = 0;
         $displayFences = 0;
         $generatedDocuments = 0;
         $virtualFiles = [];
@@ -76,10 +75,11 @@ final readonly class Extractor
                 $metadata = $this->metadata($metadataLine, $relativePath, $index);
 
                 if ($metadata === null) {
-                    ++$unclassifiedFences;
-                    $index = $closingIndex;
-
-                    continue;
+                    throw new DocumentationExampleError(\sprintf(
+                        '%s:%d: PHP fence requires php-example metadata.',
+                        $relativePath,
+                        $index + 1,
+                    ));
                 }
 
                 $mode = $this->stringField($metadata, 'mode', $relativePath, $index);
@@ -171,7 +171,6 @@ final readonly class Extractor
         return new Extraction(
             snippets: $snippets,
             phpFences: $phpFences,
-            unclassifiedFences: $unclassifiedFences,
             displayFences: $displayFences,
             generatedDocuments: $generatedDocuments,
         );

--- a/src/Documentation/PhpExample/MaterializedSnippet.php
+++ b/src/Documentation/PhpExample/MaterializedSnippet.php
@@ -25,6 +25,12 @@ final readonly class MaterializedSnippet
 
     public function sourceLine(int $generatedLine): ?int
     {
+        foreach ($this->syntheticRanges as $range) {
+            if ($generatedLine >= $range['startLine'] && $generatedLine <= $range['endLine']) {
+                return null;
+            }
+        }
+
         if ($generatedLine < $this->generatedStartLine || $generatedLine > $this->generatedEndLine) {
             return null;
         }

--- a/src/Documentation/PhpExample/ToolAnalyser.php
+++ b/src/Documentation/PhpExample/ToolAnalyser.php
@@ -141,27 +141,43 @@ final readonly class ToolAnalyser
     }
 
     /**
-     * @param list<MaterializedSnippet> $group
+     * @param list<MaterializedSnippet> $snippets
      *
      * @return list<Diagnostic>
      */
-    public function rector(string $root, string $binary, array $group): array
+    public function rector(string $root, string $binary, array $snippets): array
     {
-        if (!\in_array('rector', $group[0]->source->tools, true)) {
+        $selected = \array_values(\array_filter(
+            $snippets,
+            static fn(MaterializedSnippet $snippet): bool => \in_array(
+                'rector',
+                $snippet->source->tools,
+                true,
+            ),
+        ));
+
+        if ($selected === []) {
             return [];
         }
 
+        $directories = [];
+
+        foreach ($selected as $snippet) {
+            $directories[$snippet->source->example] = $root . '/build/docs-php/' . $snippet->source->example;
+        }
+
+        \ksort($directories, \SORT_STRING);
         $command = [
             ...$this->binaryCommand($binary),
             'process',
-            $root . '/build/docs-php/' . $group[0]->source->example,
+            ...\array_values($directories),
             '--config=' . $root . '/rector.docs.php',
             '--dry-run',
             '--output-format=json',
             '--no-progress-bar',
         ];
         $result = $this->processRunner->run($root, $command);
-        $payload = $this->jsonOutput('Rector', $result, $group[0]);
+        $payload = $this->jsonOutput('Rector', $result, $selected[0]);
         $diagnostics = [];
         $fatalErrors = $payload['fatal_errors'] ?? [];
 
@@ -175,8 +191,8 @@ final readonly class ToolAnalyser
             }
 
             $diagnostics[] = new Diagnostic(
-                sourcePath: $group[0]->source->sourcePath,
-                line: $group[0]->source->fenceLine,
+                sourcePath: $selected[0]->source->sourcePath,
+                line: $selected[0]->source->fenceLine,
                 tool: 'Rector',
                 message: $fatalError,
             );
@@ -193,7 +209,7 @@ final readonly class ToolAnalyser
                 throw new DocumentationExampleError('Rector JSON file diff is invalid.');
             }
 
-            $snippet = $this->generatedSnippet($root, $fileDiff['file'], $group);
+            $snippet = $this->generatedSnippet($root, $fileDiff['file'], $selected);
             $rectors = $fileDiff['applied_rectors'] ?? [];
             $names = [];
 
@@ -225,8 +241,8 @@ final readonly class ToolAnalyser
 
         if (\is_array($totals) && \is_int($totals['errors'] ?? null) && $totals['errors'] > 0) {
             $diagnostics[] = new Diagnostic(
-                sourcePath: $group[0]->source->sourcePath,
-                line: $group[0]->source->fenceLine,
+                sourcePath: $selected[0]->source->sourcePath,
+                line: $selected[0]->source->fenceLine,
                 tool: 'Rector',
                 message: \sprintf('Rector reported %d processing error(s).', $totals['errors']),
             );

--- a/src/Documentation/PhpExample/Workspace.php
+++ b/src/Documentation/PhpExample/Workspace.php
@@ -91,17 +91,22 @@ final readonly class Workspace
             );
         }
 
-        $indented = $this->indent($snippet->body);
-
         if ($snippet->mode === 'statements') {
-            $prefix = "<?php\n\n(static function (): void {\n";
-            $generatedStartLine = 4;
+            $body = $this->completeStatement($snippet->body);
+            $leadingChain = \str_starts_with(\ltrim($body), '->');
+            $prefix = "<?php\n\n(static function () {\n";
+
+            if ($leadingChain) {
+                $prefix .= "    \$value\n";
+            }
+
+            $generatedStartLine = $leadingChain ? 5 : 4;
             $generatedEndLine = $generatedStartLine + $sourceLines - 1;
 
             return new MaterializedSnippet(
                 source: $snippet,
                 generatedPath: $generatedPath,
-                contents: $prefix . $indented . "})();\n",
+                contents: $prefix . $this->indent($body) . "})();\n",
                 generatedStartLine: $generatedStartLine,
                 generatedEndLine: $generatedEndLine,
                 syntheticRanges: [
@@ -112,20 +117,86 @@ final readonly class Workspace
         }
 
         $class = 'DocsExample_' . \substr(\sha1($snippet->example . '/' . $snippet->virtualFile), 0, 12);
+        $importedMembers = \preg_match(
+            '/\A((?:use [^;\n]+;\n)+)\n(?=(?:#\[|public |protected |private |static |readonly |var ))/',
+            $snippet->body,
+            $imports,
+        ) === 1;
+
+        if ($importedMembers) {
+            $importLines = \substr_count($imports[1], "\n");
+            $classLine = 2 + $importLines;
+            $members = \substr($snippet->body, \strlen($imports[0]));
+            $generatedStartLine = 2;
+            $generatedEndLine = $generatedStartLine + $sourceLines - 1;
+
+            return new MaterializedSnippet(
+                source: $snippet,
+                generatedPath: $generatedPath,
+                contents: "<?php\n" . $imports[1] . "final class {$class} {\n" . $this->indent($members) . "}\n",
+                generatedStartLine: $generatedStartLine,
+                generatedEndLine: $generatedEndLine,
+                syntheticRanges: [
+                    ['startLine' => 1, 'endLine' => 1],
+                    ['startLine' => $classLine, 'endLine' => $classLine],
+                    ['startLine' => $generatedEndLine + 1, 'endLine' => $generatedEndLine + 1],
+                ],
+            );
+        }
+
         $prefix = "<?php\n\nfinal class {$class}\n{\n";
         $generatedStartLine = 5;
         $generatedEndLine = $generatedStartLine + $sourceLines - 1;
+        $suffix = "}";
+        $syntheticEndLine = $generatedEndLine + 1;
+
+        if ($this->containsOnlyAttributes($snippet->body)) {
+            $suffix = "    public function example(): void {}\n}";
+            $syntheticEndLine = $generatedEndLine + 2;
+        }
 
         return new MaterializedSnippet(
             source: $snippet,
             generatedPath: $generatedPath,
-            contents: $prefix . $indented . "}\n",
+            contents: $prefix . $this->indent($snippet->body) . $suffix . "\n",
             generatedStartLine: $generatedStartLine,
             generatedEndLine: $generatedEndLine,
             syntheticRanges: [
                 ['startLine' => 1, 'endLine' => 4],
-                ['startLine' => $generatedEndLine + 1, 'endLine' => $generatedEndLine + 1],
+                ['startLine' => $generatedEndLine + 1, 'endLine' => $syntheticEndLine],
             ],
+        );
+    }
+
+    private function completeStatement(string $body): string
+    {
+        $trimmed = \trim($body);
+
+        if ($trimmed === '') {
+            return $body;
+        }
+
+        $last = $trimmed[\strlen($trimmed) - 1];
+        $needsSemicolon = !\in_array($last, [';', '}', ':'], true)
+            || (\str_starts_with($trimmed, 'static function') && $last === '}');
+
+        if (!$needsSemicolon) {
+            return $body;
+        }
+
+        return \rtrim($body, "\n") . ";\n";
+    }
+
+    private function containsOnlyAttributes(string $body): bool
+    {
+        $lines = \array_filter(
+            \array_map(\trim(...), \explode("\n", $body)),
+            static fn(string $line): bool => $line !== '',
+        );
+
+        return $lines !== [] && \array_all(
+            $lines,
+            static fn(string $line): bool => \str_starts_with($line, '#['),
         );
     }
 
@@ -139,7 +210,7 @@ final readonly class Workspace
                 continue;
             }
 
-            $indented .= '    ' . $line . "\n";
+            $indented .= $line === '' ? "\n" : '    ' . $line . "\n";
         }
 
         return $indented;

--- a/tests/Acceptance/DocsPhpCheckTest.php
+++ b/tests/Acceptance/DocsPhpCheckTest.php
@@ -122,6 +122,41 @@ final readonly class DocsPhpCheckTest
     }
 
     #[Test]
+    public function wrapsLeadingFluentChainsAndImportedClassMembers(): void
+    {
+        $project = $this->project('fragment-wrappers');
+        $project->write(
+            'docs/example.md',
+            <<<'MARKDOWN'
+            <!-- php-example {"example":"chain","file":"chain.php","mode":"statements","tools":[]} -->
+            ```php
+            ->first()
+                ->second()
+            ```
+
+            <!-- php-example {"example":"member","file":"member.php","mode":"class-members","tools":[]} -->
+            ```php
+            use Example\Dependency;
+
+            public function __construct(private Dependency $dependency) {}
+            ```
+
+            MARKDOWN,
+        );
+
+        $result = $this->run($project, 'extract');
+        Expect::that($result->exitCode)->because('wraps common documentation fragments')->toBe(0);
+        Expect::that($this->read($project, 'build/docs-php/chain/chain.php'))->toBe(
+            "<?php\n\n(static function () {\n    \$value\n    ->first()\n        ->second();\n})();\n",
+        );
+        Expect::that($this->read($project, 'build/docs-php/member/member.php'))->toContain(
+            "use Example\\Dependency;\nfinal class DocsExample_",
+        )->toContain(
+            "    public function __construct(private Dependency \$dependency) {}\n}\n",
+        );
+    }
+
+    #[Test]
     public function rendersGithubAnnotationsWhenRequested(): void
     {
         $project = $this->project('github-annotations');
@@ -178,7 +213,7 @@ final readonly class DocsPhpCheckTest
     }
 
     #[Test]
-    public function excludesGeneratedDocumentsAndReportsUnclassifiedFences(): void
+    public function excludesGeneratedDocumentsAndRejectsUnclassifiedFences(): void
     {
         $project = $this->project('inventory');
         $project->write(
@@ -203,9 +238,9 @@ final readonly class DocsPhpCheckTest
         );
 
         $result = $this->run($project, 'check');
-        Expect::that($result->exitCode)->because('skips PHP fences without analysis metadata')->toBe(0);
-        Expect::that($result->stdout)->toContain(
-            'Documentation PHP: 1 fence(s), 0 checked file(s), 0 display-only fence(s), 1 unclassified fence(s), 1 generated document(s).',
+        Expect::that($result->exitCode)->because('requires a decision for each manual PHP fence')->toBe(1);
+        Expect::that($result->stderr)->toContain(
+            'docs/manual.md:1: PHP fence requires php-example metadata.',
         );
     }
 

--- a/tests/Acceptance/ProseCheckBehaviorTest.php
+++ b/tests/Acceptance/ProseCheckBehaviorTest.php
@@ -728,7 +728,7 @@ final readonly class ProseCheckBehaviorTest
     }
 
     #[Test]
-    public function excludesGeneratedToolCaches(): void
+    public function excludesGeneratedAnalysisFiles(): void
     {
         $root = $this->workspace('tool-cache-exclusion');
         $this->write(
@@ -736,9 +736,14 @@ final readonly class ProseCheckBehaviorTest
             'build/cache/phpstan/cache.php',
             "<?php\n\n// The worker doesn't use the configured colour; it stops.\n",
         );
+        $this->write(
+            $root,
+            'build/docs-php/example/snippet.php',
+            "<?php\n\n// The worker doesn't use the configured colour; it stops.\n",
+        );
 
         $result = $this->run('check', $root);
-        Expect::that($result->exitCode)->because('excludes generated tool caches')->toBe(0);
+        Expect::that($result->exitCode)->because('excludes generated analysis files')->toBe(0);
     }
 
     #[Test]

--- a/tools/prose-check.php
+++ b/tools/prose-check.php
@@ -7,6 +7,7 @@ const PROSE_EXCLUDED_DIRECTORIES = [
     '.git',
     '.phpstan-api-stubs',
     'build/cache',
+    'build/docs-php',
     'tests/Fixture',
     'website/.astro',
     'website/dist',

--- a/tools/rector-config.php
+++ b/tools/rector-config.php
@@ -12,9 +12,13 @@ use Rector\Php55\Rector\String_\StringClassNameToClassConstantRector;
  * Creates the shared Rector policy for one set of paths.
  *
  * @param non-empty-list<string> $paths
+ * @param list<class-string> $additionalSkips
  */
-function greenlightRectorConfig(array $paths, string $cacheDirectory): RectorConfigBuilder
-{
+function greenlightRectorConfig(
+    array $paths,
+    string $cacheDirectory,
+    array $additionalSkips = [],
+): RectorConfigBuilder {
     return RectorConfig::configure()
         ->withPaths($paths)
         ->withCache(
@@ -24,6 +28,7 @@ function greenlightRectorConfig(array $paths, string $cacheDirectory): RectorCon
         ->withSkip([
             // Empty test methods and hooks have a purpose in a test framework.
             RemoveEmptyClassMethodRector::class,
+            ...$additionalSkips,
             // Fixtures contain deliberate patterns. Without this exclusion, Rector changes some of these patterns.
             __DIR__ . '/../tests/Fixture',
             StringClassNameToClassConstantRector::class => [__DIR__ . '/../src/Rector'],


### PR DESCRIPTION
## Summary

- Classify every PHP fence in manually maintained documentation with explicit analysis or display metadata.
- Reject future unclassified fences and report exact PHPStan, Rector, and display-only coverage.
- Support common fluent-chain, imported-member, and standalone-attribute fragments without changing the rendered examples.
- Batch Rector analysis to keep the complete documentation check within the Composer timeout.
- Exclude context-dependent Rector transformations and the disposable generated workspace from unrelated prose analysis.

## Current inventory

- 138 PHP fences
- 103 syntax-checked and Rector-checked generated files
- 5 files also checked by PHPStan
- 35 explicit display-only fragments with reasons
- 13 generated reference documents excluded at their source boundary