### PR TITLE
feat(core): wrap trapped operation failures

### DIFF
--- a/src/Core/ErrorTrap.php
+++ b/src/Core/ErrorTrap.php
@@ -12,6 +12,8 @@ namespace Greenlight\Core;
  * handler.
  * The return value of the operation still identifies a failure. The recorded
  * message gives more information for an error that the caller raises.
+ * If the operation throws, an optional wrap callback can replace its throwable.
+ * run() restores the previous handler before it invokes this callback.
  *
  * This operation replaces the @ operator. That operator sends the diagnostic
  * to an installed error handler that ignores error_reporting(). It also
@@ -30,13 +32,18 @@ final class ErrorTrap
      * @param \Closure(): T $operation
      * @param string|null $warning The last engine message from the operation,
      *   or null if there was no message
+     * @param (\Closure(\Throwable): \Throwable)|null $wrap Creates a replacement
+     *   for a throwable from the operation
      *
      * @param-out string|null $warning
      *
      * @return T
      */
-    public static function run(\Closure $operation, ?string &$warning = null): mixed
-    {
+    public static function run(
+        \Closure $operation,
+        ?string &$warning = null,
+        ?\Closure $wrap = null,
+    ): mixed {
         $warning = null;
         $handler = static function (int $severity, string $message) use (&$warning): bool {
             $warning = $message;
@@ -48,8 +55,14 @@ final class ErrorTrap
 
         try {
             return $operation();
+        } catch (\Throwable $failure) {
+            if (!$wrap instanceof \Closure) {
+                throw $failure;
+            }
         } finally {
             ErrorHandlerStack::remove($handler);
         }
+
+        throw $wrap($failure);
     }
 }

--- a/tests/Unit/Core/ErrorTrapTest.php
+++ b/tests/Unit/Core/ErrorTrapTest.php
@@ -116,6 +116,45 @@ final class ErrorTrapTest
     }
 
     #[Test]
+    public function wrapsAnOperationThrowableAfterItRestoresThePreviousHandler(): void
+    {
+        $handled = null;
+        $failure = new \RuntimeException('operation failed');
+
+        \set_error_handler(static function (int $severity, string $message) use (&$handled): bool {
+            $handled = [$severity, $message];
+
+            return true;
+        });
+
+        try {
+            Expect::that(static fn(): mixed => ErrorTrap::run(
+                operation: static fn(): never => throw $failure,
+                wrap: static function (\Throwable $cause): \Throwable {
+                    \trigger_error('wrap warning', \E_USER_WARNING);
+
+                    return new \LogicException('wrapped operation failure', previous: $cause);
+                },
+            ))
+                ->because('the trap MUST replace an operation error after it restores the previous handler')
+                ->toThrow(
+                    static function (\LogicException $error) use ($failure): void {
+                        Expect::that($error->getMessage())->toBe('wrapped operation failure');
+                        Expect::that($error->getPrevious())
+                            ->because('the replacement error MUST preserve the operation error')
+                            ->toBe($failure);
+                    },
+                );
+
+            Expect::that($handled)
+                ->because('the wrap callback MUST run after the trap restores the previous handler')
+                ->toBe([\E_USER_WARNING, 'wrap warning']);
+        } finally {
+            \restore_error_handler();
+        }
+    }
+
+    #[Test]
     public function preservesHandlersInstalledByTheOperation(): void
     {
         $baseline = static fn(): bool => true;


### PR DESCRIPTION
Add an optional third `wrap` argument to `ErrorTrap::run()`. Callers can omit the warning output and supply the callback by name.

Restore the previous error handler before the callback runs. Preserve transparent propagation when no callback is supplied.

This lets #1393 translate proxy-load failures without a separate catch block.