### PR TITLE
refactor(test): simplify reporting cleanup callbacks

### DIFF
--- a/tests/Unit/Cli/ApplicationStreamOutputTest.php
+++ b/tests/Unit/Cli/ApplicationStreamOutputTest.php
@@ -39,17 +39,13 @@ final readonly class ApplicationStreamOutputTest
         if ($partial === false) {
             Fail::because('Greenlight did not open the CLI test streams.');
         }
-        $this->cleanup->defer(static function () use ($partial): void {
-            \fclose($partial);
-        });
+        $this->cleanup->defer(static fn(): bool => \fclose($partial));
 
         $other = \fopen('php://memory', 'wb');
         if ($other === false) {
             Fail::because('Greenlight did not open the CLI test streams.');
         }
-        $this->cleanup->defer(static function () use ($other): void {
-            \fclose($other);
-        });
+        $this->cleanup->defer(static fn(): bool => \fclose($other));
 
         $application = $useStderr
             ? Application::forStreams($other, $partial)

--- a/tests/Unit/Reporting/StreamOutputTest.php
+++ b/tests/Unit/Reporting/StreamOutputTest.php
@@ -29,9 +29,7 @@ final readonly class StreamOutputTest
         if ($stream === false) {
             throw new \RuntimeException('Could not open an in-memory stream.');
         }
-        $this->cleanup->defer(static function () use ($stream): void {
-            \fclose($stream);
-        });
+        $this->cleanup->defer(static fn(): bool => \fclose($stream));
 
         $output = new StreamOutput($stream);
         $output->write('first ');
@@ -50,9 +48,7 @@ final readonly class StreamOutputTest
         if ($stream === false) {
             throw new \RuntimeException('Could not open a read-only in-memory stream.');
         }
-        $this->cleanup->defer(static function () use ($stream): void {
-            \fclose($stream);
-        });
+        $this->cleanup->defer(static fn(): bool => \fclose($stream));
 
         $output = new StreamOutput($stream);
 
@@ -105,9 +101,7 @@ final readonly class StreamOutputTest
         if ($stream === false) {
             throw new \RuntimeException('Greenlight did not open the partial-write stream.');
         }
-        $this->cleanup->defer(static function () use ($stream): void {
-            \fclose($stream);
-        });
+        $this->cleanup->defer(static fn(): bool => \fclose($stream));
 
         return $stream;
     }


### PR DESCRIPTION
## Summary

- use direct arrow callbacks for deferred stream cleanup
- rely on `Cleanup` ignoring callback return values
- remove closure wrappers that existed only to discard `fclose()` results