### PR TITLE
refactor(doubles): dogfood trapped failure wrapping

### DIFF
--- a/src/Doubles/ProxyGenerator.php
+++ b/src/Doubles/ProxyGenerator.php
@@ -53,13 +53,13 @@ final readonly class ProxyGenerator
                 $this->write($file, $this->renderFile($reflection, $shortName, $body));
             }
 
-            try {
-                ErrorTrap::run(static function () use ($file): void {
+            ErrorTrap::run(
+                operation: static function () use ($file): void {
                     require $file;
-                });
-            } catch (\Throwable $failure) {
-                throw DoublesError::proxyFileNotLoaded($file, $failure);
-            }
+                },
+                wrap: static fn(\Throwable $failure): DoublesError =>
+                    DoublesError::proxyFileNotLoaded($file, $failure),
+            );
 
             if (!\class_exists($proxyClass, false)) {
                 throw DoublesError::proxyFileNotLoaded($file);


### PR DESCRIPTION
Use the new named `wrap` argument when Greenlight loads a generated proxy file. This removes the surrounding exception-translation catch while preserving the original throwable as the `DoublesError` cause.

This is the only safe current production consumer. Configuration loading executes user-owned PHP, so routing it through `ErrorTrap` would also suppress user diagnostics.