### PR TITLE
refactor(test): narrow reporting stream types

### DIFF
--- a/tests/Unit/Cli/ApplicationStreamOutputTest.php
+++ b/tests/Unit/Cli/ApplicationStreamOutputTest.php
@@ -7,9 +7,9 @@ namespace Greenlight\Tests\Unit\Cli;
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Cli\Application;
+use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
 use Greenlight\Fixture\StreamWrapperSandbox;
 use Greenlight\Tests\Fixture\Reporting\PartialWriteStream;
 
@@ -35,16 +35,18 @@ final readonly class ApplicationStreamOutputTest
     ): void {
         $this->streamWrappers->register(self::SCHEME, PartialWriteStream::class);
 
-        $partial = \fopen(self::SCHEME . '://partial', 'wb');
-        if ($partial === false) {
-            Fail::because('Greenlight did not open the CLI test streams.');
-        }
+        $partial = ErrorTrap::run(static fn() => \fopen(self::SCHEME . '://partial', 'wb'));
+        Expect::that($partial)
+            ->because('Greenlight MUST open the partial-write CLI test stream.')
+            ->not()
+            ->toBeFalse();
         $this->cleanup->defer(static fn(): bool => \fclose($partial));
 
-        $other = \fopen('php://memory', 'wb');
-        if ($other === false) {
-            Fail::because('Greenlight did not open the CLI test streams.');
-        }
+        $other = ErrorTrap::run(static fn() => \fopen('php://memory', 'wb'));
+        Expect::that($other)
+            ->because('Greenlight MUST open the comparison CLI test stream.')
+            ->not()
+            ->toBeFalse();
         $this->cleanup->defer(static fn(): bool => \fclose($other));
 
         $application = $useStderr

--- a/tests/Unit/Discovery/DiscoveryCacheTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheTest.php
@@ -9,6 +9,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Discovery\DiscoveryCache;
 use Greenlight\Discovery\TestDiscoverer;
 use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
 use Greenlight\Fixture\AutoloaderSandbox;
 use Greenlight\Fixture\EnvironmentSandbox;
 use Greenlight\Fixture\StreamWrapperSandbox;

--- a/tests/Unit/Reporting/StreamOutputTest.php
+++ b/tests/Unit/Reporting/StreamOutputTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Reporting;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\StreamWrapperSandbox;
@@ -24,11 +25,12 @@ final readonly class StreamOutputTest
     #[Test]
     public function writesAccumulateOnTheStream(): void
     {
-        $stream = \fopen('php://memory', 'r+');
+        $stream = ErrorTrap::run(static fn() => \fopen('php://memory', 'r+'));
 
-        if ($stream === false) {
-            throw new \RuntimeException('Could not open an in-memory stream.');
-        }
+        Expect::that($stream)
+            ->because('Greenlight MUST open the in-memory stream.')
+            ->not()
+            ->toBeFalse();
         $this->cleanup->defer(static fn(): bool => \fclose($stream));
 
         $output = new StreamOutput($stream);
@@ -43,11 +45,12 @@ final readonly class StreamOutputTest
     #[Test]
     public function aStreamWriteFailureBecomesAReportingError(): void
     {
-        $stream = \fopen('php://memory', 'r');
+        $stream = ErrorTrap::run(static fn() => \fopen('php://memory', 'r'));
 
-        if ($stream === false) {
-            throw new \RuntimeException('Could not open a read-only in-memory stream.');
-        }
+        Expect::that($stream)
+            ->because('Greenlight MUST open the read-only in-memory stream.')
+            ->not()
+            ->toBeFalse();
         $this->cleanup->defer(static fn(): bool => \fclose($stream));
 
         $output = new StreamOutput($stream);
@@ -96,11 +99,12 @@ final readonly class StreamOutputTest
     {
         $this->streamWrappers->register(self::PARTIAL_WRITE_SCHEME, PartialWriteStream::class);
 
-        $stream = \fopen(self::PARTIAL_WRITE_SCHEME . '://' . $path, 'wb');
+        $stream = ErrorTrap::run(static fn() => \fopen(self::PARTIAL_WRITE_SCHEME . '://' . $path, 'wb'));
 
-        if ($stream === false) {
-            throw new \RuntimeException('Greenlight did not open the partial-write stream.');
-        }
+        Expect::that($stream)
+            ->because('Greenlight MUST open the partial-write stream.')
+            ->not()
+            ->toBeFalse();
         $this->cleanup->defer(static fn(): bool => \fclose($stream));
 
         return $stream;


### PR DESCRIPTION
## Summary

- replace manual `fopen()` failure guards with Greenlight expectations
- use the PHPStan expectation type-specifying extension to narrow streams from `resource|false` to `resource`
- retain deferred cleanup for every opened stream