### PR TITLE
fix(ci): repair PHPStan analysis failures

### DIFF
--- a/src/Documentation/PhpExample/ToolAnalyser.php
+++ b/src/Documentation/PhpExample/ToolAnalyser.php
@@ -68,6 +68,7 @@ final readonly class ToolAnalyser
             '--error-format=json',
             '--no-progress',
             '--memory-limit=-1',
+            $root . '/src/PhpStan',
             $root . '/build/docs-php/' . $group[0]->source->example,
         ];
         $result = $this->processRunner->run($root, $command);

--- a/tests/Acceptance/DocsPhpCheckTest.php
+++ b/tests/Acceptance/DocsPhpCheckTest.php
@@ -157,6 +157,49 @@ final readonly class DocsPhpCheckTest
     }
 
     #[Test]
+    public function phpStanAnalysesTheProjectExtensionSources(): void
+    {
+        $project = $this->project('phpstan-extension-sources');
+        $project->write(
+            'docs/example.md',
+            <<<'MARKDOWN'
+            <!-- php-example {"example":"example","file":"example.php","mode":"file","tools":["phpstan"]} -->
+            ```php
+            return true;
+            ```
+
+            MARKDOWN,
+        );
+        $project->write(
+            'phpstan.php',
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            file_put_contents(__DIR__ . '/phpstan-arguments.txt', implode("\n", array_slice($argv, 1)));
+            echo json_encode([
+                'totals' => ['errors' => 0, 'file_errors' => 0],
+                'files' => [],
+                'errors' => [],
+            ], JSON_THROW_ON_ERROR);
+
+            PHP,
+        );
+
+        $result = $this->run(
+            $project,
+            'check',
+            '--phpstan-bin=' . $project->path('phpstan.php'),
+        );
+
+        Expect::that($result->exitCode)->because('checks the selected PHP fence')->toBe(0);
+        Expect::that($this->read($project, 'phpstan-arguments.txt'))->toContain(
+            $project->path('src/PhpStan') . "\n" . $project->path('build/docs-php/example'),
+        );
+    }
+
+    #[Test]
     public function rendersGithubAnnotationsWhenRequested(): void
     {
         $project = $this->project('github-annotations');

--- a/tests/Unit/Discovery/DiscoveryCacheTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheTest.php
@@ -9,6 +9,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Discovery\DiscoveryCache;
 use Greenlight\Discovery\TestDiscoverer;
 use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
 use Greenlight\Fixture\AutoloaderSandbox;
 use Greenlight\Fixture\EnvironmentSandbox;
 use Greenlight\Fixture\StreamWrapperSandbox;


### PR DESCRIPTION
The documentation PHPStan run loaded Greenlight custom extensions without analysing their source files. A restored result cache could therefore fail when an extension source changed, while a cold cache passed. Include src/PhpStan in each documentation analysis so PHPStan can invalidate the cache correctly. Add an acceptance test that checks the extension-source path in the analysis command.\n\nThe latest main branch also used Greenlight\Expect\Fail in DiscoveryCacheTest without importing it. The missing import caused the locked PHP 8.4 PHPStan job to report the unknown class and cascading array-shape errors. Import the failure helper so PHPStan can resolve the never return type and narrow the decoded cache payload.