### PR TITLE
refactor(core): expand trapped failure wrapping

### DIFF
--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -34,11 +34,10 @@ final class ConfigLoader
             throw ConfigFileError::notFound($file);
         }
 
-        try {
-            $returned = ErrorTrap::run(static fn() => require $file);
-        } catch (\Throwable $cause) {
-            throw ConfigFileError::threw($file, $cause);
-        }
+        $returned = ErrorTrap::run(
+            static fn() => require $file,
+            wrap: static fn(\Throwable $cause): ConfigFileError => ConfigFileError::threw($file, $cause),
+        );
 
         if (!$returned instanceof GreenlightConfig) {
             throw ConfigFileError::didNotReturnBuilder($file, $returned);

--- a/src/Discovery/DataSetExpander.php
+++ b/src/Discovery/DataSetExpander.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Discovery;
 
 use Greenlight\Attribute\DataRow;
+use Greenlight\Core\ErrorTrap;
 
 /**
  * Invokes a #[DataSet] provider when Greenlight makes the execution plan.
@@ -69,11 +70,13 @@ final readonly class DataSetExpander
         $position = 0;
 
         foreach ($class->getMethod($testMethod)->getAttributes(DataRow::class) as $attribute) {
-            try {
-                $row = $attribute->newInstance();
-            } catch (\Throwable $e) {
-                throw DiscoveryError::invalidAttribute($className . '::' . $testMethod . '()', $e);
-            }
+            $row = ErrorTrap::run(
+                static fn() => $attribute->newInstance(),
+                wrap: static fn(\Throwable $error): DiscoveryError => DiscoveryError::invalidAttribute(
+                    $className . '::' . $testMethod . '()',
+                    $error,
+                ),
+            );
 
             $key = $row->label === null
                 ? \sprintf('#%d', $position)

--- a/src/Discovery/MetadataFactory.php
+++ b/src/Discovery/MetadataFactory.php
@@ -14,6 +14,7 @@ use Greenlight\Attribute\Skip;
 use Greenlight\Attribute\SkipUnless;
 use Greenlight\Attribute\Test;
 use Greenlight\Attribute\Timeout;
+use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Test\TestMetadata;
 
 /**
@@ -139,11 +140,11 @@ final class MetadataFactory
         $names = [];
 
         foreach ($reflector->getAttributes(Group::class) as $attribute) {
-            try {
-                $names[] = $attribute->newInstance()->name;
-            } catch (\Throwable $e) {
-                throw DiscoveryError::invalidAttribute($where, $e);
-            }
+            $names[] = ErrorTrap::run(
+                static fn() => $attribute->newInstance(),
+                wrap: static fn(\Throwable $error): DiscoveryError =>
+                    DiscoveryError::invalidAttribute($where, $error),
+            )->name;
         }
 
         return $names;
@@ -160,11 +161,11 @@ final class MetadataFactory
         $names = [];
 
         foreach ($reflector->getAttributes(RequiresResource::class) as $attribute) {
-            try {
-                $names[] = $attribute->newInstance()->name;
-            } catch (\Throwable $e) {
-                throw DiscoveryError::invalidAttribute($where, $e);
-            }
+            $names[] = ErrorTrap::run(
+                static fn() => $attribute->newInstance(),
+                wrap: static fn(\Throwable $error): DiscoveryError =>
+                    DiscoveryError::invalidAttribute($where, $error),
+            )->name;
         }
 
         return $names;
@@ -187,10 +188,10 @@ final class MetadataFactory
             return null;
         }
 
-        try {
-            return $attributes[0]->newInstance();
-        } catch (\Throwable $e) {
-            throw DiscoveryError::invalidAttribute($where, $e);
-        }
+        return ErrorTrap::run(
+            static fn() => $attributes[0]->newInstance(),
+            wrap: static fn(\Throwable $error): DiscoveryError =>
+                DiscoveryError::invalidAttribute($where, $error),
+        );
     }
 }

--- a/src/Doubles/ProxyGenerator.php
+++ b/src/Doubles/ProxyGenerator.php
@@ -54,7 +54,7 @@ final readonly class ProxyGenerator
             }
 
             ErrorTrap::run(
-                operation: static function () use ($file) {
+                static function () use ($file) {
                     require $file;
                 },
                 wrap: static fn(\Throwable $failure): DoublesError =>


### PR DESCRIPTION
## Summary

- Pass the `ErrorTrap::run()` operation as the positional argument when cached proxy loading wraps a failure.
- Use the `wrap` callback for `Group`, `RequiresResource`, metadata, and inline `DataRow` attribute construction.
- Use the `wrap` callback for configuration-file failures that already run inside `ErrorTrap`.
- Keep the existing location-specific causes.

## Scope

User-owned handlers, providers, and plugin callbacks keep explicit catches. Moving those seams into `ErrorTrap` would also suppress diagnostics from user code. Typed catches around diagnostic-free native operations also remain explicit to avoid adding handler-installation overhead solely for exception translation.