### PR TITLE
refactor(core): infer ErrorTrap operation return types

### DIFF
--- a/src/Capture/OutputCapture.php
+++ b/src/Capture/OutputCapture.php
@@ -117,7 +117,7 @@ final class OutputCapture
 
         while (\ob_get_level() > $level) {
             $previousLevel = \ob_get_level();
-            $removed = ErrorTrap::run(static fn(): bool => \ob_end_flush());
+            $removed = ErrorTrap::run(static fn() => \ob_end_flush());
 
             if (!$removed || \ob_get_level() >= $previousLevel) {
                 $this->restoreErrorHandler();

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -773,7 +773,7 @@ final readonly class Application
             $target = $this->absolutePath($export->target, $workingDirectory);
 
             if (\count($files) === 1) {
-                ErrorTrap::run(static fn(): bool => \mkdir(\dirname($target), 0o777, true));
+                ErrorTrap::run(static fn() => \mkdir(\dirname($target), 0o777, true));
 
                 try {
                     AtomicFile::write($target, \reset($files));
@@ -783,7 +783,7 @@ final readonly class Application
                     return false;
                 }
             } else {
-                ErrorTrap::run(static fn(): bool => \mkdir($target, 0o777, true));
+                ErrorTrap::run(static fn() => \mkdir($target, 0o777, true));
 
                 foreach ($files as $name => $content) {
                     try {
@@ -829,7 +829,7 @@ final readonly class Application
 
         foreach (['baseline' => $baselinePath, 'current' => $currentPath] as $label => $path) {
             $absolute = $this->absolutePath($path, $workingDirectory);
-            $json = ErrorTrap::run(static fn(): string|false => \file_get_contents($absolute), $warning);
+            $json = ErrorTrap::run(static fn() => \file_get_contents($absolute), $warning);
 
             if ($json === false) {
                 $this->printError(\sprintf('Greenlight could not read the %s coverage export at "%s"%s.', $label, $path, $warning === null ? '' : ': ' . $warning), $arguments->has('no-ansi'));
@@ -1016,7 +1016,7 @@ final readonly class Application
         }
 
         $path = $this->absolutePath($input, $workingDirectory);
-        $raw = ErrorTrap::run(static fn(): string|false => \file_get_contents($path), $warning);
+        $raw = ErrorTrap::run(static fn() => \file_get_contents($path), $warning);
 
         if (!\is_string($raw)) {
             ($this->err)(\sprintf("Greenlight could not read \"%s\"%s.\n", $path, $warning === null ? '' : ': ' . $warning));
@@ -1252,7 +1252,7 @@ final readonly class Application
 
         foreach ($prefixes as $prefix) {
             $absolute = $this->absolutePath($prefix, $workingDirectory);
-            $real = ErrorTrap::run(static fn(): string|false => \realpath($absolute));
+            $real = ErrorTrap::run(static fn() => \realpath($absolute));
 
             if ($real !== false) {
                 $resolved[] = $real;
@@ -1284,7 +1284,7 @@ final readonly class Application
             return false;
         }
 
-        return ErrorTrap::run(static fn(): string|false => \realpath($binPath));
+        return ErrorTrap::run(static fn() => \realpath($binPath));
     }
 
     /**

--- a/src/Cli/CoverageSettingsResolver.php
+++ b/src/Cli/CoverageSettingsResolver.php
@@ -29,7 +29,7 @@ final class CoverageSettingsResolver
             $absolute = \str_starts_with($path, '/')
                 ? $path
                 : \rtrim($workingDirectory, '/') . '/' . $path;
-            $real = ErrorTrap::run(static fn(): string|false => \realpath($absolute));
+            $real = ErrorTrap::run(static fn() => \realpath($absolute));
 
             if ($real !== false) {
                 $include[] = $real;

--- a/src/Cli/RunState.php
+++ b/src/Cli/RunState.php
@@ -80,11 +80,11 @@ final class RunState
         $this->loaded = true;
         $file = $this->file;
 
-        if (!ErrorTrap::run(static fn(): bool => \is_file($file))) {
+        if (!ErrorTrap::run(static fn() => \is_file($file))) {
             return null;
         }
 
-        $raw = ErrorTrap::run(static fn(): string|false => \file_get_contents($file));
+        $raw = ErrorTrap::run(static fn() => \file_get_contents($file));
 
         if (!\is_string($raw)) {
             return null;

--- a/src/Cli/Terminal.php
+++ b/src/Cli/Terminal.php
@@ -22,6 +22,6 @@ final class Terminal
      */
     public static function isTty($stream): bool
     {
-        return ErrorTrap::run(static fn(): bool => \stream_isatty($stream));
+        return ErrorTrap::run(static fn() => \stream_isatty($stream));
     }
 }

--- a/src/Cli/TerminalRowsResolver.php
+++ b/src/Cli/TerminalRowsResolver.php
@@ -26,7 +26,7 @@ final class TerminalRowsResolver
         }
 
         $probed = \function_exists('exec')
-            ? ErrorTrap::run(static fn(): string|false => \exec('tput lines 2>/dev/null'))
+            ? ErrorTrap::run(static fn() => \exec('tput lines 2>/dev/null'))
             : false;
 
         return self::positiveRows($probed) ?? 24;

--- a/src/Cli/Watch/StatChangeDetector.php
+++ b/src/Cli/Watch/StatChangeDetector.php
@@ -69,7 +69,7 @@ final class StatChangeDetector implements ChangeDetector
 
         foreach ($this->directories as $directory) {
             try {
-                $files = ErrorTrap::run(fn(): array => $this->scanDirectory($directory));
+                $files = ErrorTrap::run(fn() => $this->scanDirectory($directory));
             } catch (\UnexpectedValueException) {
                 continue;
             }
@@ -114,7 +114,7 @@ final class StatChangeDetector implements ChangeDetector
     {
         \clearstatcache(true, $path);
 
-        return ErrorTrap::run(static function () use ($path): ?string {
+        return ErrorTrap::run(static function () use ($path) {
             $mtime = \filemtime($path);
             $size = \filesize($path);
             $contentHash = \sha1_file($path);

--- a/src/Cli/Watch/StdinKeyInput.php
+++ b/src/Cli/Watch/StdinKeyInput.php
@@ -62,7 +62,7 @@ final class StdinKeyInput implements KeyInput
         }
 
         if ($isTty() && $runShellCommand instanceof \Closure) {
-            ErrorTrap::run(static fn(): string|false|null => $runShellCommand(self::ENABLE_RAW_MODE_COMMAND));
+            ErrorTrap::run(static fn() => $runShellCommand(self::ENABLE_RAW_MODE_COMMAND));
             $this->rawMode = true;
         }
     }
@@ -79,7 +79,7 @@ final class StdinKeyInput implements KeyInput
     {
         if ($this->rawMode && $this->runShellCommand instanceof \Closure) {
             ErrorTrap::run(
-                fn(): string|false|null => ($this->runShellCommand)(self::RESTORE_CANONICAL_MODE_COMMAND),
+                fn() => ($this->runShellCommand)(self::RESTORE_CANONICAL_MODE_COMMAND),
             );
             $this->rawMode = false;
         }

--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -18,7 +18,7 @@ final class ConfigLoader
     {
         $file = \rtrim($directory, '/') . '/' . self::FILE_NAME;
 
-        if (!ErrorTrap::run(static fn(): bool => \is_file($file))) {
+        if (!ErrorTrap::run(static fn() => \is_file($file))) {
             throw ConfigFileError::noneInDirectory($directory);
         }
 
@@ -30,12 +30,12 @@ final class ConfigLoader
      */
     public function loadFile(string $file): GreenlightConfig
     {
-        if (!ErrorTrap::run(static fn(): bool => \is_file($file))) {
+        if (!ErrorTrap::run(static fn() => \is_file($file))) {
             throw ConfigFileError::notFound($file);
         }
 
         try {
-            $returned = ErrorTrap::run(static fn(): mixed => require $file);
+            $returned = ErrorTrap::run(static fn() => require $file);
         } catch (\Throwable $cause) {
             throw ConfigFileError::threw($file, $cause);
         }

--- a/src/Core/AtomicFile.php
+++ b/src/Core/AtomicFile.php
@@ -36,14 +36,14 @@ final class AtomicFile
 
         $temp = \sprintf('%s.tmp-%s-%s', $path, (int) \getmypid(), $suffix);
 
-        if (ErrorTrap::run(static fn(): int|false => \file_put_contents($temp, $contents), $warning) === false) {
-            ErrorTrap::run(static fn(): bool => \unlink($temp));
+        if (ErrorTrap::run(static fn() => \file_put_contents($temp, $contents), $warning) === false) {
+            ErrorTrap::run(static fn() => \unlink($temp));
 
             throw AtomicFileError::cannotWriteTemporary($temp, $warning);
         }
 
-        if (ErrorTrap::run(static fn(): bool => \rename($temp, $path), $warning) === false) {
-            ErrorTrap::run(static fn(): bool => \unlink($temp));
+        if (ErrorTrap::run(static fn() => \rename($temp, $path), $warning) === false) {
+            ErrorTrap::run(static fn() => \unlink($temp));
 
             throw AtomicFileError::cannotRename($temp, $path, $warning);
         }

--- a/src/Coverage/Export/HtmlExporter.php
+++ b/src/Coverage/Export/HtmlExporter.php
@@ -200,7 +200,7 @@ final readonly class HtmlExporter implements CoverageExporter
      */
     private function highlightedLines(string $path): ?array
     {
-        $content = ErrorTrap::run(static function () use ($path): string|false {
+        $content = ErrorTrap::run(static function () use ($path) {
             if (!\is_file($path) || !\is_readable($path)) {
                 return false;
             }

--- a/src/Coverage/Ignore/IgnoreScanner.php
+++ b/src/Coverage/Ignore/IgnoreScanner.php
@@ -41,7 +41,7 @@ final readonly class IgnoreScanner
             return [];
         }
 
-        $source = ErrorTrap::run(static fn(): string|false => \file_get_contents($path), $warning);
+        $source = ErrorTrap::run(static fn() => \file_get_contents($path), $warning);
 
         if (!\is_string($source)) {
             return [];

--- a/src/Discovery/ClassFileParser.php
+++ b/src/Discovery/ClassFileParser.php
@@ -26,7 +26,7 @@ final class ClassFileParser
      */
     public static function declarationsIn(string $file): array
     {
-        $code = ErrorTrap::run(static fn(): string|false => \file_get_contents($file), $warning);
+        $code = ErrorTrap::run(static fn() => \file_get_contents($file), $warning);
 
         if ($code === false) {
             throw DiscoveryError::unreadableFile($file, $warning);

--- a/src/Discovery/DiscoveryCache.php
+++ b/src/Discovery/DiscoveryCache.php
@@ -172,7 +172,7 @@ final class DiscoveryCache
     {
         \clearstatcache(true, $file);
 
-        return ErrorTrap::run(static function () use ($file): ?array {
+        return ErrorTrap::run(static function () use ($file) {
             $mtime = \filemtime($file);
             $size = \filesize($file);
             $contentHash = \sha1_file($file);
@@ -226,7 +226,7 @@ final class DiscoveryCache
 
         $this->loaded = true;
         $file = $this->file;
-        $raw = ErrorTrap::run(static fn(): string|false => \file_get_contents($file));
+        $raw = ErrorTrap::run(static fn() => \file_get_contents($file));
 
         if (!\is_string($raw)) {
             return;

--- a/src/Discovery/TestDiscoverer.php
+++ b/src/Discovery/TestDiscoverer.php
@@ -211,7 +211,7 @@ final readonly class TestDiscoverer
 
             $actualFile = new \ReflectionClass($fqcn)->getFileName();
             [$resolvedActualFile, $resolvedExpectedFile] = ErrorTrap::run(
-                static fn(): array => [
+                static fn() => [
                     $actualFile === false ? false : \realpath($actualFile),
                     \realpath($file),
                 ],
@@ -250,7 +250,7 @@ final readonly class TestDiscoverer
         $files = [];
 
         foreach ($directories as $directory) {
-            $real = ErrorTrap::run(static fn(): string|false => \realpath($directory));
+            $real = ErrorTrap::run(static fn() => \realpath($directory));
 
             if ($real === false || !\is_dir($real)) {
                 throw DiscoveryError::directoryNotFound($directory);

--- a/src/Doubles/ProxyGenerator.php
+++ b/src/Doubles/ProxyGenerator.php
@@ -49,12 +49,12 @@ final readonly class ProxyGenerator
         if (!\class_exists($proxyClass, false)) {
             $file = $this->directory . '/' . $shortName . '.php';
 
-            if (!ErrorTrap::run(static fn(): bool => \is_file($file))) {
+            if (!ErrorTrap::run(static fn() => \is_file($file))) {
                 $this->write($file, $this->renderFile($reflection, $shortName, $body));
             }
 
             ErrorTrap::run(
-                operation: static function () use ($file): void {
+                operation: static function () use ($file) {
                     require $file;
                 },
                 wrap: static fn(\Throwable $failure): DoublesError =>
@@ -403,10 +403,10 @@ final readonly class ProxyGenerator
     {
         $directory = $this->directory;
 
-        $directoryExists = ErrorTrap::run(static fn(): bool => \is_dir($directory));
+        $directoryExists = ErrorTrap::run(static fn() => \is_dir($directory));
 
-        if (!$directoryExists && !ErrorTrap::run(static fn(): bool => \mkdir($directory, 0o777, true), $warning)) {
-            $directoryExists = ErrorTrap::run(static fn(): bool => \is_dir($directory));
+        if (!$directoryExists && !ErrorTrap::run(static fn() => \mkdir($directory, 0o777, true), $warning)) {
+            $directoryExists = ErrorTrap::run(static fn() => \is_dir($directory));
 
             if (!$directoryExists) {
                 throw DoublesError::proxyDirectoryNotCreated($directory, $warning);

--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -1089,7 +1089,7 @@ final class Expectation
      */
     private function requireValidPattern(string $pattern, string $matcher): void
     {
-        if (ErrorTrap::run(static fn(): int|false => \preg_match($pattern, ''), $warning) === false) {
+        if (ErrorTrap::run(static fn() => \preg_match($pattern, ''), $warning) === false) {
             throw new \InvalidArgumentException(\sprintf(
                 'The pattern for %s() is an invalid regular expression: %s%s',
                 $matcher,

--- a/src/Fixture/StreamWrapperSandbox.php
+++ b/src/Fixture/StreamWrapperSandbox.php
@@ -27,7 +27,7 @@ final class StreamWrapperSandbox implements Disposable
         }
 
         if (!ErrorTrap::run(
-            static fn(): bool => \stream_wrapper_register($scheme, $wrapper),
+            static fn() => \stream_wrapper_register($scheme, $wrapper),
             $warning,
         )) {
             throw StreamWrapperError::registrationFailed($scheme, $warning);
@@ -43,7 +43,7 @@ final class StreamWrapperSandbox implements Disposable
         $failures = [];
 
         foreach (\array_reverse($this->schemes) as $scheme) {
-            if (!ErrorTrap::run(static fn(): bool => \stream_wrapper_unregister($scheme), $warning)) {
+            if (!ErrorTrap::run(static fn() => \stream_wrapper_unregister($scheme), $warning)) {
                 $failures[] = [$scheme, $warning];
             }
         }

--- a/src/Fixture/TempDirectory.php
+++ b/src/Fixture/TempDirectory.php
@@ -33,11 +33,11 @@ final class TempDirectory implements Disposable
     {
         if ($this->path === null) {
             $systemTemporaryRoot = $this->temporaryRoot ?? \sys_get_temp_dir();
-            $resolvedTemporaryRoot = ErrorTrap::run(static fn(): string|false => \realpath($systemTemporaryRoot));
+            $resolvedTemporaryRoot = ErrorTrap::run(static fn() => \realpath($systemTemporaryRoot));
             $temporaryRoot = $resolvedTemporaryRoot === false ? $systemTemporaryRoot : $resolvedTemporaryRoot;
             $path = $temporaryRoot . '/greenlight-' . \bin2hex(\random_bytes(8));
 
-            if (!ErrorTrap::run(static fn(): bool => \mkdir($path, 0700), $warning)) {
+            if (!ErrorTrap::run(static fn() => \mkdir($path, 0700), $warning)) {
                 throw TempDirectoryError::rootCreationFailed($path, $warning);
             }
 
@@ -87,7 +87,7 @@ final class TempDirectory implements Disposable
 
         $path = $root . '/' . $name;
 
-        if (!\is_dir($path) && !ErrorTrap::run(static fn(): bool => \mkdir($path, 0700, true), $warning)) {
+        if (!\is_dir($path) && !ErrorTrap::run(static fn() => \mkdir($path, 0700, true), $warning)) {
             throw TempDirectoryError::subdirectoryCreationFailed($path, $warning);
         }
 
@@ -111,14 +111,14 @@ final class TempDirectory implements Disposable
         }
 
         $path = $this->path;
-        $isLink = ErrorTrap::run(static fn(): bool => \is_link($path), $warning);
+        $isLink = ErrorTrap::run(static fn() => \is_link($path), $warning);
 
         if ($warning !== null) {
             throw TempDirectoryError::rootRemovalFailed($path, $warning);
         }
 
         if ($isLink) {
-            if (!ErrorTrap::run(static fn(): bool => \unlink($path), $warning)) {
+            if (!ErrorTrap::run(static fn() => \unlink($path), $warning)) {
                 throw TempDirectoryError::rootLinkRemovalFailed($path, $warning);
             }
 
@@ -127,7 +127,7 @@ final class TempDirectory implements Disposable
             return;
         }
 
-        $isDirectory = ErrorTrap::run(static fn(): bool => \is_dir($path), $warning);
+        $isDirectory = ErrorTrap::run(static fn() => \is_dir($path), $warning);
 
         if ($warning !== null) {
             throw TempDirectoryError::rootRemovalFailed($path, $warning);
@@ -145,7 +145,7 @@ final class TempDirectory implements Disposable
                 \RecursiveIteratorIterator::CHILD_FIRST,
             );
 
-            ErrorTrap::run(static function () use ($entries, $path): void {
+            ErrorTrap::run(static function () use ($entries, $path) {
                 /** @var \SplFileInfo $entry */
                 foreach ($entries as $entry) {
                     $pathname = $entry->getPathname();
@@ -160,7 +160,7 @@ final class TempDirectory implements Disposable
             throw TempDirectoryError::rootRemovalFailed($path, $error->getMessage());
         }
 
-        if (!ErrorTrap::run(static fn(): bool => \rmdir($path), $warning)) {
+        if (!ErrorTrap::run(static fn() => \rmdir($path), $warning)) {
             throw TempDirectoryError::rootRemovalFailed($path, $warning);
         }
 

--- a/src/Hyperf/HyperfPlugin.php
+++ b/src/Hyperf/HyperfPlugin.php
@@ -118,7 +118,7 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemp
     public function onWorkerBootstrap(WorkerBootstrapContext $context): void
     {
         HyperfFrameworkRequirement::check();
-        [$basePath, $containerFileExists] = ErrorTrap::run(function (): array {
+        [$basePath, $containerFileExists] = ErrorTrap::run(function () {
             $basePath = \realpath($this->basePath);
 
             if ($basePath === false || !\is_dir($basePath)) {
@@ -143,7 +143,7 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemp
                 throw HyperfBridgeError::basePathConflict($basePath, \get_debug_type($defined));
             }
 
-            $definedPath = ErrorTrap::run(static fn(): string|false => \realpath($defined));
+            $definedPath = ErrorTrap::run(static fn() => \realpath($defined));
 
             if ($definedPath === false || $definedPath !== $basePath) {
                 throw HyperfBridgeError::basePathConflict($basePath, $defined);
@@ -235,7 +235,7 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemp
         $runtimeDirectory = $basePath . '/runtime/container';
 
         if (!\is_dir($runtimeDirectory)
-            && !ErrorTrap::run(static fn(): bool => \mkdir($runtimeDirectory, 0o755, true), $warning)
+            && !ErrorTrap::run(static fn() => \mkdir($runtimeDirectory, 0o755, true), $warning)
         ) {
             throw HyperfBridgeError::scanLockUnavailable($runtimeDirectory . '/greenlight.scan.lock');
         }
@@ -248,13 +248,13 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemp
         }
 
         try {
-            if (!ErrorTrap::run(static fn(): bool => \flock($lock, \LOCK_EX), $warning)) {
+            if (!ErrorTrap::run(static fn() => \flock($lock, \LOCK_EX), $warning)) {
                 throw HyperfBridgeError::scanLockFailed($lockPath);
             }
 
             ClassLoader::init();
         } finally {
-            ErrorTrap::run(static fn(): bool => \flock($lock, \LOCK_UN), $warning);
+            ErrorTrap::run(static fn() => \flock($lock, \LOCK_UN), $warning);
             \fclose($lock);
         }
     }

--- a/src/Laravel/LaravelPlugin.php
+++ b/src/Laravel/LaravelPlugin.php
@@ -52,7 +52,7 @@ final class LaravelPlugin implements HarnessProvider, ServiceResolver, TestLifec
         $this->factory = $application instanceof \Closure
             ? $application
             : static function () use ($application): mixed {
-                if (!ErrorTrap::run(static fn(): bool => \is_file($application))) {
+                if (!ErrorTrap::run(static fn() => \is_file($application))) {
                     throw LaravelBridgeError::bootstrapFileMissing($application);
                 }
 

--- a/src/PhpStan/ExpectationArgumentRule.php
+++ b/src/PhpStan/ExpectationArgumentRule.php
@@ -90,7 +90,7 @@ final class ExpectationArgumentRule implements Rule
         }
 
         foreach ($scope->getType($argument->value)->getConstantStrings() as $pattern) {
-            if (ErrorTrap::run(static fn(): int|false => \preg_match($pattern->getValue(), ''), $warning) !== false) {
+            if (ErrorTrap::run(static fn() => \preg_match($pattern->getValue(), ''), $warning) !== false) {
                 continue;
             }
 

--- a/src/Reporting/Output/StreamOutput.php
+++ b/src/Reporting/Output/StreamOutput.php
@@ -26,7 +26,7 @@ final class StreamOutput implements Output
     public function write(string $text): void
     {
         while ($text !== '') {
-            $written = ErrorTrap::run(fn(): int|false => \fwrite($this->stream, $text));
+            $written = ErrorTrap::run(fn() => \fwrite($this->stream, $text));
 
             if ($written === false || $written === 0) {
                 throw ReportingError::writeFailed();

--- a/src/Runner/Artifact/ArtifactStore.php
+++ b/src/Runner/Artifact/ArtifactStore.php
@@ -55,13 +55,13 @@ final class ArtifactStore
         }
 
         if (\str_starts_with($configured, '/')
-            && ($resolved = ErrorTrap::run(static fn(): string|false => \realpath($configured))) !== false
+            && ($resolved = ErrorTrap::run(static fn() => \realpath($configured))) !== false
         ) {
             $configured = $resolved;
         }
 
         $public = $configured . '/' . $runId;
-        $resolvedWorkingDirectory = ErrorTrap::run(static fn(): string|false => \realpath($workingDirectory));
+        $resolvedWorkingDirectory = ErrorTrap::run(static fn() => \realpath($workingDirectory));
         $workingDirectory = $resolvedWorkingDirectory === false ? $workingDirectory : $resolvedWorkingDirectory;
         $output = \str_starts_with($configured, '/')
             ? $public
@@ -284,7 +284,7 @@ final class ArtifactStore
                     || $after['size'] !== $before['size']
                     || $after['mtime'] !== $before['mtime']
                 ) {
-                    ErrorTrap::run(static fn(): bool => \unlink($part));
+                    ErrorTrap::run(static fn() => \unlink($part));
 
                     throw AttachmentError::source($sourcePath, 'changed while it was being copied');
                 }
@@ -401,13 +401,13 @@ final class ArtifactStore
                     throw AttachmentError::storage('Failed to publish attachment');
                 }
             } catch (\Throwable $error) {
-                ErrorTrap::run(static fn(): bool => \unlink($part));
+                ErrorTrap::run(static fn() => \unlink($part));
 
                 throw $error;
             }
 
-            ErrorTrap::run(static fn(): bool => \unlink($source));
-            ErrorTrap::run(fn(): bool => \unlink($this->metadataPath($storageKey)));
+            ErrorTrap::run(static fn() => \unlink($source));
+            ErrorTrap::run(fn() => \unlink($this->metadataPath($storageKey)));
             $published[] = $attachment->published();
         }
 
@@ -428,7 +428,7 @@ final class ArtifactStore
         }
 
         $attemptRecord = ErrorTrap::run(
-            static fn(): string|false => \file_get_contents($directory . '/.attempt'),
+            static fn() => \file_get_contents($directory . '/.attempt'),
         );
         $attempt = DecimalInteger::parse(\trim((string) $attemptRecord));
 
@@ -506,13 +506,13 @@ final class ArtifactStore
             $path = $entry->getPathname();
 
             if (!$entry->isLink() && $entry->isDir()) {
-                ErrorTrap::run(static fn(): bool => \rmdir($path));
+                ErrorTrap::run(static fn() => \rmdir($path));
             } else {
-                ErrorTrap::run(static fn(): bool => \unlink($path));
+                ErrorTrap::run(static fn() => \unlink($path));
             }
         }
 
-        ErrorTrap::run(static fn(): bool => \rmdir($directory));
+        ErrorTrap::run(static fn() => \rmdir($directory));
     }
 
     /**
@@ -542,7 +542,7 @@ final class ArtifactStore
         $path = $this->session->stagingDirectory . '/' . $storageKey;
         $parent = \dirname($path);
 
-        if (!\is_dir($parent) && !ErrorTrap::run(static fn(): bool => \mkdir($parent, 0o700, true), $warning)) {
+        if (!\is_dir($parent) && !ErrorTrap::run(static fn() => \mkdir($parent, 0o700, true), $warning)) {
             throw AttachmentError::storage('Failed to create attachment staging subdirectory' . ($warning === null ? '' : ': ' . $warning));
         }
 
@@ -685,7 +685,7 @@ final class ArtifactStore
         );
 
         if (\file_put_contents($part, $encoded . "\n", \LOCK_EX) === false) {
-            ErrorTrap::run(static fn(): bool => \unlink($part));
+            ErrorTrap::run(static fn() => \unlink($part));
 
             throw AttachmentError::storage('Greenlight did not write attachment recovery metadata');
         }
@@ -693,7 +693,7 @@ final class ArtifactStore
         \chmod($part, 0o600);
 
         if (!\rename($part, $path)) {
-            ErrorTrap::run(static fn(): bool => \unlink($part));
+            ErrorTrap::run(static fn() => \unlink($part));
 
             throw AttachmentError::storage('Failed to finalize attachment recovery metadata');
         }
@@ -708,7 +708,7 @@ final class ArtifactStore
         $directory = $this->session->stagingDirectory . '/' . self::testDirectory($id);
 
         if (!\is_dir($directory)
-            && !ErrorTrap::run(static fn(): bool => \mkdir($directory, 0o700, true), $warning)
+            && !ErrorTrap::run(static fn() => \mkdir($directory, 0o700, true), $warning)
             && !\is_dir($directory)
         ) {
             throw AttachmentError::storage('Failed to create attachment staging subdirectory' . ($warning === null ? '' : ': ' . $warning));
@@ -718,7 +718,7 @@ final class ArtifactStore
         $part = $path . '.part-' . \bin2hex(\random_bytes(4));
 
         if (\file_put_contents($part, $attempt . "\n", \LOCK_EX) === false) {
-            ErrorTrap::run(static fn(): bool => \unlink($part));
+            ErrorTrap::run(static fn() => \unlink($part));
 
             throw AttachmentError::storage('Failed to record the current test attempt');
         }
@@ -726,7 +726,7 @@ final class ArtifactStore
         \chmod($part, 0o600);
 
         if (!\rename($part, $path)) {
-            ErrorTrap::run(static fn(): bool => \unlink($part));
+            ErrorTrap::run(static fn() => \unlink($part));
 
             throw AttachmentError::storage('Greenlight did not finalize the current test attempt record');
         }
@@ -744,7 +744,7 @@ final class ArtifactStore
         }
 
         if (!\is_dir($directory)
-            && !ErrorTrap::run(static fn(): bool => \mkdir($directory, 0o700), $warning)
+            && !ErrorTrap::run(static fn() => \mkdir($directory, 0o700), $warning)
             && !\is_dir($directory)
         ) {
             throw AttachmentError::storage('Failed to create attachment staging directory' . ($warning === null ? '' : ': ' . $warning));
@@ -833,7 +833,7 @@ final class ArtifactStore
                 throw AttachmentError::storage('Attachment output path contains a non-directory entry');
             }
 
-            if (!ErrorTrap::run(static fn(): bool => \mkdir($current, 0o700), $warning)) {
+            if (!ErrorTrap::run(static fn() => \mkdir($current, 0o700), $warning)) {
                 throw AttachmentError::storage('Failed to create attachment output directory' . ($warning === null ? '' : ': ' . $warning));
             }
         }

--- a/src/Runner/Artifact/StreamWriter.php
+++ b/src/Runner/Artifact/StreamWriter.php
@@ -25,7 +25,7 @@ final class StreamWriter
         $length = \strlen($bytes);
 
         while ($offset < $length) {
-            $written = ErrorTrap::run(static fn(): int|false => \fwrite($stream, \substr($bytes, $offset)));
+            $written = ErrorTrap::run(static fn() => \fwrite($stream, \substr($bytes, $offset)));
 
             if ($written === false || $written === 0) {
                 throw AttachmentError::storage('Failed to write the complete attachment');

--- a/src/Runner/CpuCores.php
+++ b/src/Runner/CpuCores.php
@@ -35,7 +35,7 @@ final class CpuCores
     {
         if (\class_exists(CpuCoreCounter::class)) {
             try {
-                return ErrorTrap::run(static fn(): int => new CpuCoreCounter()->getCount());
+                return ErrorTrap::run(static fn() => new CpuCoreCounter()->getCount());
             } catch (NumberOfCpuCoreNotFound) {
             }
         }
@@ -48,8 +48,8 @@ final class CpuCores
      */
     private static function probe(): int
     {
-        if (ErrorTrap::run(static fn(): bool => \is_file('/proc/cpuinfo'))) {
-            $cpuinfo = ErrorTrap::run(static fn(): string|false => \file_get_contents('/proc/cpuinfo'));
+        if (ErrorTrap::run(static fn() => \is_file('/proc/cpuinfo'))) {
+            $cpuinfo = ErrorTrap::run(static fn() => \file_get_contents('/proc/cpuinfo'));
 
             if (\is_string($cpuinfo)) {
                 $count = LinuxCpuInfo::processorCount($cpuinfo);
@@ -61,7 +61,7 @@ final class CpuCores
         }
 
         if (\PHP_OS_FAMILY === 'Darwin' && \function_exists('shell_exec')) {
-            $output = ErrorTrap::run(static fn(): string|false|null => \shell_exec('sysctl -n hw.logicalcpu 2>/dev/null'));
+            $output = ErrorTrap::run(static fn() => \shell_exec('sysctl -n hw.logicalcpu 2>/dev/null'));
 
             if (\is_string($output)) {
                 $count = DecimalInteger::parse(\trim($output));

--- a/src/Runner/Orchestrator/Orchestrator.php
+++ b/src/Runner/Orchestrator/Orchestrator.php
@@ -1017,7 +1017,7 @@ final class Orchestrator
                 \usleep(10_000);
             }
 
-            ErrorTrap::run(static function () use ($handle): void {
+            ErrorTrap::run(static function () use ($handle) {
                 if ($handle->isRunning()) {
                     \proc_terminate($handle->process, 9);
                 }

--- a/src/Runner/Orchestrator/ServerSocket.php
+++ b/src/Runner/Orchestrator/ServerSocket.php
@@ -51,7 +51,7 @@ final class ServerSocket
                 return new self($server, 'unix://' . $socketPath, $socketPath);
             }
 
-            ErrorTrap::run(static function () use ($server, $boundPath, $socketPath): void {
+            ErrorTrap::run(static function () use ($server, $boundPath, $socketPath) {
                 if (\is_string($boundPath)) {
                     \unlink($boundPath);
                 }
@@ -61,7 +61,7 @@ final class ServerSocket
             });
         }
 
-        ErrorTrap::run(static fn(): bool => \rmdir($socketDirectory));
+        ErrorTrap::run(static fn() => \rmdir($socketDirectory));
 
         $server = ErrorTrap::run(static function () use ($runtime, &$errorMessage) {
             return $runtime->listen('tcp://127.0.0.1:0', $errorMessage);
@@ -76,7 +76,7 @@ final class ServerSocket
         $name = $runtime->name($server);
 
         if ($name === false || $name === '') {
-            ErrorTrap::run(static fn(): bool => \fclose($server));
+            ErrorTrap::run(static fn() => \fclose($server));
 
             throw ProtocolError::malformedFrame(
                 'Greenlight did not resolve the orchestrator socket address',
@@ -96,7 +96,7 @@ final class ServerSocket
 
     public function close(): void
     {
-        ErrorTrap::run(function (): void {
+        ErrorTrap::run(function () {
             if (\is_resource($this->stream)) {
                 \fclose($this->stream);
             }

--- a/src/Runner/Orchestrator/WorkerHandle.php
+++ b/src/Runner/Orchestrator/WorkerHandle.php
@@ -121,7 +121,7 @@ final class WorkerHandle
      */
     public function drainPipes(): void
     {
-        ErrorTrap::run(function (): void {
+        ErrorTrap::run(function () {
             foreach ([$this->stdout, $this->stderr] as $index => $pipe) {
                 if (!\is_resource($pipe)) {
                     continue;
@@ -219,7 +219,7 @@ final class WorkerHandle
         $this->channel?->close();
 
         if (\is_resource($this->process)) {
-            ErrorTrap::run(function (): void {
+            ErrorTrap::run(function () {
                 \proc_terminate($this->process, 9);
                 \proc_close($this->process);
             });

--- a/src/Runner/Protocol/SocketChannel.php
+++ b/src/Runner/Protocol/SocketChannel.php
@@ -51,7 +51,7 @@ final class SocketChannel
 
         $bytes = $this->codec->encode(MessageRegistry::envelope($message));
 
-        $completed = ErrorTrap::run(function () use ($bytes): bool {
+        $completed = ErrorTrap::run(function () use ($bytes) {
             $remaining = \strlen($bytes);
 
             while ($remaining > 0) {
@@ -106,7 +106,7 @@ final class SocketChannel
 
             try {
                 $ready = ErrorTrap::run(
-                    static fn(): int|false => \stream_select($read, $write, $except, 0, \max(1, $microseconds)),
+                    static fn() => \stream_select($read, $write, $except, 0, \max(1, $microseconds)),
                 );
             } catch (\ValueError) {
                 return null;
@@ -151,7 +151,7 @@ final class SocketChannel
 
         \stream_set_blocking($this->stream, false);
 
-        [$bytes, $reachedEof] = ErrorTrap::run(function (): array {
+        [$bytes, $reachedEof] = ErrorTrap::run(function () {
             $bytes = \fread($this->stream, 65536);
 
             return [$bytes, ($bytes === false || $bytes === '') && \feof($this->stream)];
@@ -205,7 +205,7 @@ final class SocketChannel
         $this->eof = true;
 
         if (\is_resource($this->stream)) {
-            ErrorTrap::run(fn(): bool => \fclose($this->stream));
+            ErrorTrap::run(fn() => \fclose($this->stream));
         }
     }
 }

--- a/src/Runner/SharedCoverageDirectory.php
+++ b/src/Runner/SharedCoverageDirectory.php
@@ -28,7 +28,7 @@ final readonly class SharedCoverageDirectory
     {
         $directory = \rtrim(\sys_get_temp_dir(), '/') . '/greenlight-coverage-' . \bin2hex(\random_bytes(6));
 
-        if (!ErrorTrap::run(static fn(): bool => \mkdir($directory, 0o700, true), $warning)) {
+        if (!ErrorTrap::run(static fn() => \mkdir($directory, 0o700, true), $warning)) {
             throw CoverageError::sharedDirectoryCreationFailed($directory, $warning);
         }
 
@@ -48,7 +48,7 @@ final readonly class SharedCoverageDirectory
 
         $dumps = \glob($this->directory . '/*.json');
 
-        $map = ErrorTrap::run(static function () use ($dumps): ?CoverageMap {
+        $map = ErrorTrap::run(static function () use ($dumps) {
             $map = null;
 
             foreach ($dumps === false ? [] : $dumps as $file) {
@@ -71,7 +71,7 @@ final readonly class SharedCoverageDirectory
             return $map;
         });
 
-        ErrorTrap::run(fn(): bool => \rmdir($this->directory));
+        ErrorTrap::run(fn() => \rmdir($this->directory));
 
         return $map;
     }

--- a/src/Runner/SubprocessCoverage.php
+++ b/src/Runner/SubprocessCoverage.php
@@ -76,6 +76,6 @@ final readonly class SubprocessCoverage
             \bin2hex(\random_bytes(4)),
         );
 
-        ErrorTrap::run(static fn(): int|false => \file_put_contents($file, \reset($export)));
+        ErrorTrap::run(static fn() => \file_put_contents($file, \reset($export)));
     }
 }

--- a/tests/Support/CoverageJson.php
+++ b/tests/Support/CoverageJson.php
@@ -16,7 +16,7 @@ final class CoverageJson
     public static function read(string $path): CoverageMap
     {
         $json = ErrorTrap::run(
-            static fn(): string|false => \file_get_contents($path),
+            static fn() => \file_get_contents($path),
             $warning,
         );
 
@@ -36,7 +36,7 @@ final class CoverageJson
         $documents = new JsonExporter()->export($map);
         $json = $documents[JsonExporter::FILE_NAME];
         $written = ErrorTrap::run(
-            static fn(): int|false => \file_put_contents($path, $json),
+            static fn() => \file_put_contents($path, $json),
             $warning,
         );
 

--- a/tests/Support/ProjectFiles.php
+++ b/tests/Support/ProjectFiles.php
@@ -48,7 +48,7 @@ final readonly class ProjectFiles
         $parent = \dirname($path);
 
         if (!\is_dir($parent)
-            && !ErrorTrap::run(static fn(): bool => \mkdir($parent, 0o777, true), $warning)
+            && !ErrorTrap::run(static fn() => \mkdir($parent, 0o777, true), $warning)
             && !\is_dir($parent)
         ) {
             throw new \RuntimeException(\sprintf(
@@ -60,7 +60,7 @@ final readonly class ProjectFiles
         }
 
         $written = ErrorTrap::run(
-            static fn(): int|false => \file_put_contents($path, $contents),
+            static fn() => \file_put_contents($path, $contents),
             $warning,
         );
 

--- a/tests/Support/Subprocess.php
+++ b/tests/Support/Subprocess.php
@@ -101,7 +101,7 @@ final class Subprocess
         $length = \strlen($input);
 
         while ($offset < $length) {
-            $written = ErrorTrap::run(static fn(): int|false => \fwrite($stdin, \substr($input, $offset)));
+            $written = ErrorTrap::run(static fn() => \fwrite($stdin, \substr($input, $offset)));
 
             if ($written === false || $written === 0) {
                 throw new \RuntimeException('Could not write to process stdin.');
@@ -110,7 +110,7 @@ final class Subprocess
             $offset += $written;
         }
 
-        if (!ErrorTrap::run(static fn(): bool => \fflush($stdin))) {
+        if (!ErrorTrap::run(static fn() => \fflush($stdin))) {
             throw new \RuntimeException('Could not write to process stdin.');
         }
     }
@@ -262,10 +262,10 @@ final class Subprocess
         $status = \proc_get_status($this->process);
 
         if ($status['running']) {
-            ErrorTrap::run(fn(): bool => \proc_terminate($this->process, 9));
+            ErrorTrap::run(fn() => \proc_terminate($this->process, 9));
         }
 
-        ErrorTrap::run(fn(): int => \proc_close($this->process));
+        ErrorTrap::run(fn() => \proc_close($this->process));
         $this->finished = true;
     }
 
@@ -346,7 +346,7 @@ final class Subprocess
         $pipe = $this->pipes[$index] ?? null;
 
         if (\is_resource($pipe)) {
-            ErrorTrap::run(static fn(): bool => \fclose($pipe));
+            ErrorTrap::run(static fn() => \fclose($pipe));
         }
 
         unset($this->pipes[$index]);

--- a/tests/Unit/Artifact/ArtifactBestEffortCleanupDiagnosticTest.php
+++ b/tests/Unit/Artifact/ArtifactBestEffortCleanupDiagnosticTest.php
@@ -40,7 +40,7 @@ final readonly class ArtifactBestEffortCleanupDiagnosticTest
         try {
             Expect::that(static function () use ($store, $id, $staged, &$warning): TestResult {
                 return ErrorTrap::run(
-                    static fn(): TestResult => $store->publish(new TestResult(
+                    static fn() => $store->publish(new TestResult(
                         $id,
                         Outcome::Failed,
                         0.1,

--- a/tests/Unit/Artifact/ArtifactOutputSafetyTest.php
+++ b/tests/Unit/Artifact/ArtifactOutputSafetyTest.php
@@ -50,7 +50,7 @@ final readonly class ArtifactOutputSafetyTest
         FilesystemRestriction::toProject($root);
 
         $absoluteStore = ErrorTrap::run(
-            static fn(): ArtifactStore => ArtifactStore::open(
+            static fn() => ArtifactStore::open(
                 new ArtifactConfiguration($restricted),
                 $root,
                 'run-output',
@@ -58,7 +58,7 @@ final readonly class ArtifactOutputSafetyTest
             $absoluteWarning,
         );
         $workingDirectoryStore = ErrorTrap::run(
-            static fn(): ArtifactStore => ArtifactStore::open(
+            static fn() => ArtifactStore::open(
                 new ArtifactConfiguration('artifacts'),
                 $restricted,
                 'run-working-directory',

--- a/tests/Unit/Artifact/ArtifactRecoveryAttemptFloorTest.php
+++ b/tests/Unit/Artifact/ArtifactRecoveryAttemptFloorTest.php
@@ -96,7 +96,7 @@ final readonly class ArtifactRecoveryAttemptFloorTest
         );
 
         $recovered = ErrorTrap::run(
-            static fn(): TestResult => $store->recover(new TestResult(
+            static fn() => $store->recover(new TestResult(
                 $id,
                 Outcome::Errored,
                 0.0,

--- a/tests/Unit/Cli/ApplicationWorkerBinPathTest.php
+++ b/tests/Unit/Cli/ApplicationWorkerBinPathTest.php
@@ -40,7 +40,7 @@ final readonly class ApplicationWorkerBinPathTest
 
         try {
             $exit = ErrorTrap::run(
-                static fn(): int => Application::forStreams($stdout, $stderr)->run(
+                static fn() => Application::forStreams($stdout, $stderr)->run(
                     ['run', '--workers=2', '--reporter=plain', '--no-ansi'],
                     $project->directory,
                     $restrictedBin,

--- a/tests/Unit/Cli/CoverageMissingIncludePathTest.php
+++ b/tests/Unit/Cli/CoverageMissingIncludePathTest.php
@@ -63,7 +63,7 @@ final class CoverageMissingIncludePathTest
 
         $configuration = new CoverageConfiguration([$outside], null, []);
         $settings = ErrorTrap::run(
-            static fn(): ?CoverageSettings => CoverageSettingsResolver::resolve($configuration, $root),
+            static fn() => CoverageSettingsResolver::resolve($configuration, $root),
             $warning,
         );
 

--- a/tests/Unit/Cli/RunStateTest.php
+++ b/tests/Unit/Cli/RunStateTest.php
@@ -161,7 +161,7 @@ final readonly class RunStateTest
         FilesystemRestriction::toProject($root);
 
         $failedTests = ErrorTrap::run(
-            static fn(): ?array => RunState::forFile($file)->failedTests(),
+            static fn() => RunState::forFile($file)->failedTests(),
             $warning,
         );
 

--- a/tests/Unit/Cli/StatChangeDetectorDirectoryRaceTest.php
+++ b/tests/Unit/Cli/StatChangeDetectorDirectoryRaceTest.php
@@ -23,7 +23,7 @@ final readonly class StatChangeDetectorDirectoryRaceTest
         $this->streamWrappers->register(self::SCHEME, VanishingDirectoryStream::class);
         $detector = new StatChangeDetector([self::SCHEME . '://root']);
 
-        $changed = ErrorTrap::run(static fn(): array => $detector->poll(), $warning);
+        $changed = ErrorTrap::run(static fn() => $detector->poll(), $warning);
 
         Expect::that($changed)
             ->because('a directory that vanishes during a scan MUST behave as a missing directory')

--- a/tests/Unit/Cli/StatChangeDetectorTest.php
+++ b/tests/Unit/Cli/StatChangeDetectorTest.php
@@ -49,7 +49,7 @@ final readonly class StatChangeDetectorTest
         FilesystemRestriction::toProject($root);
 
         $detector = new StatChangeDetector([$directory]);
-        $changed = ErrorTrap::run(static fn(): array => $detector->poll(), $warning);
+        $changed = ErrorTrap::run(static fn() => $detector->poll(), $warning);
 
         Expect::that($changed)
             ->because('a restricted watch directory MUST behave as a missing directory')

--- a/tests/Unit/Config/ConfigLoaderOpenFailureTest.php
+++ b/tests/Unit/Config/ConfigLoaderOpenFailureTest.php
@@ -7,7 +7,6 @@ namespace Greenlight\Tests\Unit\Config;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\ConfigFileError;
 use Greenlight\Config\ConfigLoader;
-use Greenlight\Config\GreenlightConfig;
 use Greenlight\Core\ErrorTrap;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\StreamWrapperSandbox;
@@ -28,7 +27,7 @@ final readonly class ConfigLoaderOpenFailureTest
         Expect::that(
             static function () use ($file, &$warning): void {
                 ErrorTrap::run(
-                    static fn(): GreenlightConfig => new ConfigLoader()->loadFile($file),
+                    static fn() => new ConfigLoader()->loadFile($file),
                     $warning,
                 );
             },

--- a/tests/Unit/Config/ConfigLoaderTest.php
+++ b/tests/Unit/Config/ConfigLoaderTest.php
@@ -69,7 +69,7 @@ final class ConfigLoaderTest
         Expect::that(
             static function () use ($loader, $restrictedDirectory, &$directoryWarning): void {
                 ErrorTrap::run(
-                    static fn(): GreenlightConfig => $loader->loadFromDirectory($restrictedDirectory),
+                    static fn() => $loader->loadFromDirectory($restrictedDirectory),
                     $directoryWarning,
                 );
             },
@@ -78,7 +78,7 @@ final class ConfigLoaderTest
         Expect::that(
             static function () use ($loader, $restrictedFile, &$fileWarning): void {
                 ErrorTrap::run(
-                    static fn(): GreenlightConfig => $loader->loadFile($restrictedFile),
+                    static fn() => $loader->loadFile($restrictedFile),
                     $fileWarning,
                 );
             },

--- a/tests/Unit/Core/ErrorTrapTest.php
+++ b/tests/Unit/Core/ErrorTrapTest.php
@@ -15,7 +15,7 @@ final class ErrorTrapTest
     {
         $warning = 'stale';
 
-        $value = ErrorTrap::run(static fn(): string => 'result', $warning);
+        $value = ErrorTrap::run(static fn() => 'result', $warning);
 
         Expect::that($value)
             ->because('the trapped operation return value MUST be preserved')
@@ -28,7 +28,7 @@ final class ErrorTrapTest
     #[Test]
     public function capturesTheLastWarning(): void
     {
-        ErrorTrap::run(static function (): void {
+        ErrorTrap::run(static function () {
             \trigger_error('first warning', \E_USER_WARNING);
             \trigger_error('last warning', \E_USER_WARNING);
         }, $warning);
@@ -50,7 +50,7 @@ final class ErrorTrapTest
         });
 
         try {
-            ErrorTrap::run(static function (): void {
+            ErrorTrap::run(static function () {
                 \trigger_error('trapped warning', \E_USER_WARNING);
             }, $warning);
 
@@ -68,10 +68,10 @@ final class ErrorTrapTest
     #[Test]
     public function nestedTrapsKeepTheirWarningsSeparateAndRestoreTheOuterTrap(): void
     {
-        ErrorTrap::run(static function () use (&$innerWarning): void {
+        ErrorTrap::run(static function () use (&$innerWarning) {
             \trigger_error('outer before inner', \E_USER_WARNING);
 
-            ErrorTrap::run(static function (): void {
+            ErrorTrap::run(static function () {
                 \trigger_error('inner warning', \E_USER_WARNING);
             }, $innerWarning);
 
@@ -100,7 +100,7 @@ final class ErrorTrapTest
 
         try {
             Expect::that(static fn(): mixed => ErrorTrap::run(
-                static fn(): never => throw $failure,
+                static fn() => throw $failure,
             ))
                 ->because('the trap MUST propagate an operation error')
                 ->toThrow($failure);
@@ -129,7 +129,7 @@ final class ErrorTrapTest
 
         try {
             Expect::that(static fn(): mixed => ErrorTrap::run(
-                operation: static fn(): never => throw $failure,
+                operation: static fn() => throw $failure,
                 wrap: static function (\Throwable $cause): \Throwable {
                     \trigger_error('wrap warning', \E_USER_WARNING);
 
@@ -164,7 +164,7 @@ final class ErrorTrapTest
         \set_error_handler($baseline);
 
         try {
-            ErrorTrap::run(static function () use ($first, $second): void {
+            ErrorTrap::run(static function () use ($first, $second) {
                 \set_error_handler($first);
                 \set_error_handler($second);
             });
@@ -197,7 +197,7 @@ final class ErrorTrapTest
         \set_error_handler($baseline);
 
         try {
-            ErrorTrap::run(static function (): void {
+            ErrorTrap::run(static function () {
                 \restore_error_handler();
             });
 

--- a/tests/Unit/Coverage/HtmlExporterSourceFailureTest.php
+++ b/tests/Unit/Coverage/HtmlExporterSourceFailureTest.php
@@ -33,7 +33,7 @@ final readonly class HtmlExporterSourceFailureTest
             new FileCoverage($path, [2], [4]),
         ]);
         $pages = ErrorTrap::run(
-            static fn(): array => new HtmlExporter()->export($map),
+            static fn() => new HtmlExporter()->export($map),
             $warning,
         );
 
@@ -61,7 +61,7 @@ final readonly class HtmlExporterSourceFailureTest
             ->toBeTrue();
 
         $pages = ErrorTrap::run(
-            static fn(): array => new HtmlExporter()->export($map),
+            static fn() => new HtmlExporter()->export($map),
             $warning,
         );
         $page = $pages[HtmlExporter::pageName($path)];

--- a/tests/Unit/Discovery/TestDiscovererTest.php
+++ b/tests/Unit/Discovery/TestDiscovererTest.php
@@ -161,7 +161,7 @@ final class TestDiscovererTest
         Expect::that(
             static function () use ($directory, &$warning): void {
                 ErrorTrap::run(
-                    static fn(): array => new TestDiscoverer()->testFiles([$directory]),
+                    static fn() => new TestDiscoverer()->testFiles([$directory]),
                     $warning,
                 );
             },

--- a/tests/Unit/Doubles/ProxyStorageTest.php
+++ b/tests/Unit/Doubles/ProxyStorageTest.php
@@ -55,7 +55,7 @@ final readonly class ProxyStorageTest
         Expect::that(
             static function () use ($doubles, &$warning): void {
                 ErrorTrap::run(
-                    static fn(): object => $doubles->stub(ProxyStorageContract::class),
+                    static fn() => $doubles->stub(ProxyStorageContract::class),
                     $warning,
                 );
             },

--- a/tests/Unit/Fixture/TempDirectoryRestrictedDisposalTest.php
+++ b/tests/Unit/Fixture/TempDirectoryRestrictedDisposalTest.php
@@ -32,7 +32,7 @@ final readonly class TempDirectoryRestrictedDisposalTest
 
                 try {
                     Greenlight\Core\ErrorTrap::run(
-                        static function () use ($directory): void {
+                        static function () use ($directory) {
                             $directory->dispose();
                         },
                         $warning,

--- a/tests/Unit/Fixture/TempDirectoryTest.php
+++ b/tests/Unit/Fixture/TempDirectoryTest.php
@@ -120,7 +120,7 @@ final class TempDirectoryTest
 
         Expect::that(
             static function () use ($directory, &$warning): void {
-                ErrorTrap::run(static fn(): string => $directory->path(), $warning);
+                ErrorTrap::run(static fn() => $directory->path(), $warning);
             },
         )->because('a restricted temporary root causes a fixture error')->toThrow(TempDirectoryError::class);
         Expect::that($warning)

--- a/tests/Unit/Laravel/LaravelPluginTest.php
+++ b/tests/Unit/Laravel/LaravelPluginTest.php
@@ -167,7 +167,7 @@ final class LaravelPluginTest
         Expect::that(
             static function () use ($plugin, &$warning): void {
                 ErrorTrap::run(
-                    static fn(): ?object => $plugin->resolve(Greeter::class, []),
+                    static fn() => $plugin->resolve(Greeter::class, []),
                     $warning,
                 );
             },

--- a/tests/Unit/Runner/CpuCoresFallbackTest.php
+++ b/tests/Unit/Runner/CpuCoresFallbackTest.php
@@ -25,7 +25,7 @@ final readonly class CpuCoresFallbackTest
         FilesystemRestriction::toProject($root);
 
         $count = ErrorTrap::run(
-            static fn(): int => CpuCores::count(),
+            static fn() => CpuCores::count(),
             $warning,
         );
 

--- a/tests/Unit/Runner/Orchestrator/WorkerHandleTerminationTest.php
+++ b/tests/Unit/Runner/Orchestrator/WorkerHandleTerminationTest.php
@@ -75,13 +75,13 @@ final readonly class WorkerHandleTerminationTest
 
             foreach ($resources as $resource) {
                 if (\is_resource($resource)) {
-                    ErrorTrap::run(static fn(): bool => \fclose($resource));
+                    ErrorTrap::run(static fn() => \fclose($resource));
                 }
             }
 
             if (\is_resource($process)) {
-                ErrorTrap::run(static fn(): bool => \proc_terminate($process, 9));
-                ErrorTrap::run(static fn(): int => \proc_close($process));
+                ErrorTrap::run(static fn() => \proc_terminate($process, 9));
+                ErrorTrap::run(static fn() => \proc_close($process));
             }
         }
     }

--- a/tests/Unit/Runner/PlanOrderStalePriorityTest.php
+++ b/tests/Unit/Runner/PlanOrderStalePriorityTest.php
@@ -23,7 +23,7 @@ final class PlanOrderStalePriorityTest
         ], seed: 4242);
 
         $ordered = ErrorTrap::run(
-            static fn(): ExecutionPlan => PlanOrder::schedule($plan, ['Acme\\RemovedTest'], []),
+            static fn() => PlanOrder::schedule($plan, ['Acme\\RemovedTest'], []),
             $warning,
         );
         $ids = \array_map(


### PR DESCRIPTION
## Summary

- remove explicit return types from closures passed as operations to ErrorTrap::run
- rely on PHP inference for native calls and multi-statement operations
- remove the unused import exposed by the cleanup