### PR TITLE
fix(reporting): distinguish isolated profile workers

### DIFF
--- a/docs/api-events.md
+++ b/docs/api-events.md
@@ -472,6 +472,14 @@ public string $workerId
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassStarted.php#L25)
 
+### `$isolated`
+
+```php
+public bool $isolated
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassStarted.php#L26)
+
 ### `__construct()`
 
 ```php
@@ -479,6 +487,7 @@ public function __construct(
     string $class,
     public float $occurredAt,
     public string $workerId = '',
+    public bool $isolated = false,
 )
 ```
 
@@ -496,7 +505,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassStarted.php#L38)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassStarted.php#L39)
 
 ### `fromWire()`
 
@@ -505,7 +514,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassStarted.php#L48)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/TestClassStarted.php#L50)
 
 ## `TestFinished`
 

--- a/docs/architecture/jsonl.md
+++ b/docs/architecture/jsonl.md
@@ -61,7 +61,7 @@ guarantees, and incomplete-output behavior.
 | `run-finished`    | Run ends                             | `runId`, `summary`, `durationSeconds`, `occurredAt`                    |
 | `suite-started`   | Suite begins                         | `suite`, `occurredAt`                                                  |
 | `suite-finished`  | Suite ends                           | `suite`, `occurredAt`                                                  |
-| `class-started`   | Test class begins                    | `class`, `occurredAt`, `workerId`                                      |
+| `class-started`   | Test class begins                    | `class`, `occurredAt`, `workerId`, `isolated`                          |
 | `class-finished`  | Test class ends                      | `class`, `occurredAt`, `workerId`                                      |
 | `test-started`    | Test begins                          | `id`, `occurredAt`                                                     |
 | `test-finished`   | Test ends                            | `result`, `occurredAt`                                                 |
@@ -83,6 +83,8 @@ data-set key.
 
 `class-started.workerId` and `class-finished.workerId` name the worker that
 ran the class.
+
+`class-started.isolated` is true when the worker runs an isolated test.
 
 `worker-recycled.reason` has one of these values:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -695,7 +695,8 @@ The profile includes:
 * workers spawned
 * workers recycled
 * average boot latency, measured from spawn to first class
-* per-worker busy time and utilization
+* per-worker class count, busy time, and utilization for non-isolated workers
+* workers that run isolated tests
 * makespan spread between the first and last worker to finish
 * the ten slowest classes
 

--- a/resources/schema/jsonl-v2.schema.json
+++ b/resources/schema/jsonl-v2.schema.json
@@ -129,7 +129,8 @@
             "properties": {
                 "class": {"type": "string", "minLength": 1},
                 "occurredAt": {"$ref": "#/definitions/occurredAt"},
-                "workerId": {"type": "string"}
+                "workerId": {"type": "string"},
+                "isolated": {"type": "boolean"}
             }
         },
         "testStarted": {

--- a/src/Core/Event/TestClassStarted.php
+++ b/src/Core/Event/TestClassStarted.php
@@ -23,6 +23,7 @@ final readonly class TestClassStarted implements Event
         string $class,
         public float $occurredAt,
         public string $workerId = '',
+        public bool $isolated = false,
     ) {
         if ($class === '') {
             throw new \InvalidArgumentException('Test class name MUST NOT be empty.');
@@ -42,6 +43,7 @@ final readonly class TestClassStarted implements Event
             'class' => $this->class,
             'occurredAt' => $this->occurredAt,
             'workerId' => $this->workerId,
+            ...($this->isolated ? ['isolated' => true] : []),
         ];
     }
 
@@ -52,6 +54,7 @@ final readonly class TestClassStarted implements Event
             Wire::nonEmptyString($payload, 'class'),
             Wire::float($payload, 'occurredAt'),
             \array_key_exists('workerId', $payload) ? Wire::string($payload, 'workerId') : '',
+            \array_key_exists('isolated', $payload) ? Wire::bool($payload, 'isolated') : false,
         );
     }
 }

--- a/src/Core/Event/TestClassStarted.php
+++ b/src/Core/Event/TestClassStarted.php
@@ -54,7 +54,7 @@ final readonly class TestClassStarted implements Event
             Wire::nonEmptyString($payload, 'class'),
             Wire::float($payload, 'occurredAt'),
             \array_key_exists('workerId', $payload) ? Wire::string($payload, 'workerId') : '',
-            \array_key_exists('isolated', $payload) ? Wire::bool($payload, 'isolated') : false,
+            \array_key_exists('isolated', $payload) && Wire::bool($payload, 'isolated'),
         );
     }
 }

--- a/src/Reporting/ProfileAggregator.php
+++ b/src/Reporting/ProfileAggregator.php
@@ -21,12 +21,10 @@ use Greenlight\Core\Event\WorkerSpawned;
  * clocks. These clocks use host wall time. Thus, boot latency can
  * include a scheduler delay.
  *
- * Worker busy time is the sum of its test-class periods. The worker period
- * starts at process start or the first test class, if process start is
- * unknown. It ends at the last completed test class. Utilization is busy time
- * divided by the worker period. Boot latency is the time from process
- * start to the first test class. It includes the hello exchange and the wait
- * for the first assignment.
+ * Worker busy time is the sum of its test-class periods. Utilization is busy
+ * time divided by the worker period for a non-isolated worker. Boot latency is
+ * the time from process start to the first test class. It includes the hello
+ * exchange and the wait for the first assignment.
  *
  * @internal
  */
@@ -69,7 +67,7 @@ final class ProfileAggregator
         }
 
         if ($event instanceof TestClassStarted && $event->workerId !== '') {
-            $this->worker($event->workerId)->classStarted($event->occurredAt);
+            $this->worker($event->workerId)->classStarted($event->occurredAt, $event->isolated);
 
             return;
         }
@@ -103,14 +101,20 @@ final class ProfileAggregator
 
         $lines = ["\nProfile:"];
         $spawned = \count(\array_filter($this->workers, static fn(WorkerProfile $worker): bool => $worker->spawnedAt !== null));
+        $isolated = \count(\array_filter($this->workers, static fn(WorkerProfile $worker): bool => $worker->isolated));
         $recycled = \array_sum(\array_column($this->workers, 'recycled'));
 
-        $lines[] = \sprintf(
-            '  Workers: %d requested, %d spawned, %d recycled',
+        $workerSummary = \sprintf(
+            '  Workers: %d requested, %d spawned',
             $this->runStarted instanceof RunStarted ? $this->runStarted->workers : 0,
             $spawned,
-            $recycled,
         );
+
+        if ($isolated > 0) {
+            $workerSummary .= \sprintf(', %d isolated', $isolated);
+        }
+
+        $lines[] = $workerSummary . \sprintf(', %d recycled', $recycled);
 
         $bootLatencies = [];
         $finishTimes = [];
@@ -142,13 +146,19 @@ final class ProfileAggregator
                 continue;
             }
 
-            $rows[] = [$id, (string) $worker->classes, \sprintf('%.3fs', $worker->busy), $worker->utilizationPercent()];
+            $rows[] = [
+                $id,
+                (string) $worker->classes,
+                \sprintf('%.3fs', $worker->busy),
+                $worker->isolated ? null : $worker->utilizationPercent(),
+                $worker->isolated,
+            ];
         }
 
         if ($rows !== []) {
             $lines[] = '';
 
-            foreach ($this->workerTable($style, $rows) as $line) {
+            foreach ($this->workerTable($style, $rows, $isolated > 0) as $line) {
                 $lines[] = $line;
             }
         }
@@ -185,11 +195,11 @@ final class ProfileAggregator
      * Worker IDs align left, and numeric columns align right. The data determines
      * the column widths.
      *
-     * @param list<array{string, string, string, ?int}> $rows
+     * @param list<array{string, string, string, ?int, bool}> $rows
      *
      * @return list<string>
      */
-    private function workerTable(Style $style, array $rows): array
+    private function workerTable(Style $style, array $rows, bool $showIsolation): array
     {
         $workerWidth = \max(\strlen('Worker'), ...\array_map(static fn(array $row): int => \strlen($row[0]), $rows));
         $classesWidth = \max(\strlen('Classes'), ...\array_map(static fn(array $row): int => \strlen($row[1]), $rows));
@@ -197,26 +207,28 @@ final class ProfileAggregator
         $utilWidth = \max(\strlen('Util'), ...\array_map(static fn(array $row): int => \strlen($row[3] . '%'), $rows));
 
         $lines = [\rtrim(\sprintf(
-            '  %s  %s  %s  %s',
+            '  %s  %s  %s  %s%s',
             \str_pad('Worker', $workerWidth),
             \str_pad('Classes', $classesWidth, ' ', \STR_PAD_LEFT),
             \str_pad('Busy', $busyWidth, ' ', \STR_PAD_LEFT),
             \str_pad('Util', $utilWidth, ' ', \STR_PAD_LEFT),
+            $showIsolation ? '  Isolated' : '',
         ))];
 
-        foreach ($rows as [$id, $classes, $busy, $percent]) {
+        foreach ($rows as [$id, $classes, $busy, $percent, $isolated]) {
             // Add space outside the color codes. Thus, escape sequences cannot
             // change the alignment.
             $util = $percent === null
-                ? ''
+                ? \str_repeat(' ', $utilWidth)
                 : \str_repeat(' ', $utilWidth - \strlen($percent . '%')) . $this->utilization($style, $percent);
 
             $lines[] = \rtrim(\sprintf(
-                '  %s  %s  %s  %s',
+                '  %s  %s  %s  %s%s',
                 \str_pad($id, $workerWidth),
                 \str_pad($classes, $classesWidth, ' ', \STR_PAD_LEFT),
                 \str_pad($busy, $busyWidth, ' ', \STR_PAD_LEFT),
                 $util,
+                $showIsolation ? '  ' . ($isolated ? 'yes' : '') : '',
             ));
         }
 

--- a/src/Reporting/WorkerProfile.php
+++ b/src/Reporting/WorkerProfile.php
@@ -21,15 +21,18 @@ final class WorkerProfile
 
     public int $recycled = 0;
 
+    public bool $isolated = false;
+
     public function spawned(float $at): void
     {
         $this->spawnedAt ??= $at;
     }
 
-    public function classStarted(float $at): void
+    public function classStarted(float $at, bool $isolated = false): void
     {
         $this->openAt = $at;
         $this->firstClassAt ??= $at;
+        $this->isolated = $this->isolated || $isolated;
     }
 
     public function classFinished(float $at): ?float
@@ -94,4 +97,5 @@ final class WorkerProfile
 
         return (int) \round(100 * \min(1.0, $this->busy / $window));
     }
+
 }

--- a/src/Runner/Worker/Worker.php
+++ b/src/Runner/Worker/Worker.php
@@ -81,7 +81,8 @@ final readonly class Worker
                 continue;
             }
 
-            $sink->emit(new TestClassStarted($class, \microtime(true), $this->workerId));
+            $isolated = \count($entries) === 1 && $entries[0]->metadata->isolated;
+            $sink->emit(new TestClassStarted($class, \microtime(true), $this->workerId, $isolated));
             $scopes->openClass();
             $lastIndex = \count($entries) - 1;
 

--- a/tests/Unit/Core/EventsTest.php
+++ b/tests/Unit/Core/EventsTest.php
@@ -40,7 +40,7 @@ final class EventsTest
             new RunFinished('run-1', $summary, 12.5, $at),
             new SuiteStarted('unit', $at),
             new SuiteFinished('unit', $at),
-            new TestClassStarted('App\FooTest', $at),
+            new TestClassStarted('App\FooTest', $at, isolated: true),
             new TestClassFinished('App\FooTest', $at),
             new TestStarted($id, $at),
             new TestFinished($result, $at),
@@ -156,6 +156,9 @@ final class EventsTest
         Expect::that($started->workerId)
             ->because('legacy class-started events have no worker attribution')
             ->toBe('');
+        Expect::that($started->isolated)
+            ->because('legacy class-started events have no isolation marker')
+            ->toBeFalse();
         Expect::that($finished->workerId)
             ->because('legacy class-finished events have no worker attribution')
             ->toBe('');

--- a/tests/Unit/Reporting/ProfileAggregatorTest.php
+++ b/tests/Unit/Reporting/ProfileAggregatorTest.php
@@ -22,7 +22,7 @@ use Greenlight\Reporting\Style;
 final class ProfileAggregatorTest
 {
     #[Test]
-    public function derivesUtilizationBootLatencyAndSpreadFromACannedStream(): void
+    public function derivesWorkerStatisticsBootLatencyAndSpreadFromACannedStream(): void
     {
         $aggregator = new ProfileAggregator();
 
@@ -48,7 +48,7 @@ final class ProfileAggregatorTest
 
             TEXT;
 
-        Expect::that($aggregator->render(new Style(ansi: false)))->because('derives utilization boot latency and spread from a canned stream')->toBe($expected);
+        Expect::that($aggregator->render(new Style(ansi: false)))->because('derives worker statistics, boot latency, and spread from a canned stream')->toBe($expected);
     }
 
     #[Test]
@@ -87,13 +87,38 @@ final class ProfileAggregatorTest
 
         $rendered = $aggregator->render(new Style(ansi: true));
 
-        // A value of 78% is in the middle band (yellow), and 50% is in the low
-        // band (red). The 2.5-second class exceeds the slow limit (yellow).
-        // Spaces outside color codes keep column alignment unchanged when the
-        // output contains escape sequences.
-        Expect::that($rendered)->because('utilization bands and slow durations color with ANSI')->toContain("3.500s   \x1b[33m78%\x1b[0m\n")
+        Expect::that($rendered)->because('utilization bands and slow durations color with ANSI')
+            ->toContain("3.500s   \x1b[33m78%\x1b[0m\n")
             ->toContain("1.000s   \x1b[31m50%\x1b[0m\n")
             ->toContain("\x1b[33m2.500s\x1b[0m  Acme\AlphaTest");
+    }
+
+    #[Test]
+    public function isolatedWorkersAreMarkedInTheSummaryAndTable(): void
+    {
+        $aggregator = new ProfileAggregator();
+
+        $events = [
+            new RunStarted('run-1', 2, 2, 100.0),
+            new WorkerSpawned('w-1', 11, 100.0),
+            new WorkerSpawned('w-2', 12, 100.0),
+            new TestClassStarted('Acme\AlphaTest', 100.0, 'w-1'),
+            new TestClassStarted('Acme\BetaTest', 100.0, 'w-2', isolated: true),
+            new TestClassFinished('Acme\AlphaTest', 100.5, 'w-1'),
+            new TestClassFinished('Acme\BetaTest', 100.5, 'w-2'),
+            new RunFinished('run-1', new ResultSummary(passed: 2), 0.5, 100.5),
+        ];
+
+        foreach ($events as $event) {
+            $aggregator->onEvent($event);
+        }
+
+        Expect::that($aggregator->render(new Style(ansi: false)))
+            ->because('isolated workers MUST be distinct from worker pool processes')
+            ->toContain("Workers: 2 requested, 2 spawned, 1 isolated, 0 recycled\n")
+            ->toContain("  Worker  Classes    Busy  Util  Isolated\n")
+            ->toContain("  w-1           1  0.500s  100%\n")
+            ->toContain("  w-2           1  0.500s        yes\n");
     }
 
     #[Test]
@@ -195,7 +220,7 @@ final class ProfileAggregatorTest
         }
 
         Expect::that($aggregator->render(new Style(ansi: false)))
-            ->because('a missing worker period must not invent a utilization percentage')
+            ->because('a missing worker period MUST NOT invent a utilization percentage')
             ->toContain("\n  Worker  Classes    Busy  Util\n")
             ->toContain($expectedRow . "\n")
             ->not()
@@ -228,10 +253,8 @@ final class ProfileAggregatorTest
     }
 
     /**
-     * Worker w-1 starts in 0.5 seconds and runs two classes with a gap. It is
-     * active for 3.5 seconds of a 4.5-second period. Worker w-2 starts in 1.0
-     * second and is active for 1 second of a 2-second period. It finishes 2
-     * seconds before w-1.
+     * Worker w-1 starts in 0.5 seconds and runs two classes. Worker w-2 starts
+     * in 1 second and runs one class. It finishes 2.5 seconds before w-1.
      *
      * @return list<Event>
      */

--- a/tests/Unit/Reporting/WorkerProfileTest.php
+++ b/tests/Unit/Reporting/WorkerProfileTest.php
@@ -46,6 +46,8 @@ final class WorkerProfileTest
         Expect::that($profile->utilizationPercent())
             ->because('utilization is rounded from accumulated busy time')
             ->toBe(52);
+        Expect::that($profile->isolated)
+            ->toBeFalse();
     }
 
     #[Test]
@@ -120,5 +122,16 @@ final class WorkerProfileTest
             ->toBe(0.0);
         Expect::that($profile->utilizationPercent())
             ->toBeNull();
+    }
+
+    #[Test]
+    public function isolatedClassMarksTheWorker(): void
+    {
+        $profile = new WorkerProfile();
+        $profile->classStarted(10.0, isolated: true);
+
+        Expect::that($profile->isolated)
+            ->because('an isolated class MUST mark its worker')
+            ->toBeTrue();
     }
 }

--- a/tests/Unit/Runner/WorkerTest.php
+++ b/tests/Unit/Runner/WorkerTest.php
@@ -6,6 +6,7 @@ namespace Greenlight\Tests\Unit\Runner;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Event\RecycleReason;
+use Greenlight\Core\Event\TestClassStarted;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\ResultSummary;
 use Greenlight\Core\Result\TestResult;
@@ -41,6 +42,29 @@ use Greenlight\Tests\Support\CollectingEventSink;
 
 final class WorkerTest
 {
+    #[Test]
+    public function isolatedPlanEntryMarksTheClassEvent(): void
+    {
+        $id = new TestId(OptionalConstructorProbe::class, 'usesDeclaredDefault');
+        $plan = new ExecutionPlan([
+            new PlanEntry($id, new TestMetadata($id->class, $id->method, isolated: true)),
+        ]);
+        $sink = new CollectingEventSink();
+
+        new Worker($this->registry())->run($plan, $sink);
+
+        $classEvents = \array_values(\array_filter(
+            $sink->events,
+            static fn(object $event): bool => $event instanceof TestClassStarted,
+        ));
+
+        Expect::that($classEvents)
+            ->because('an isolated plan entry MUST mark its class event')
+            ->toHaveCount(1);
+        Expect::that($classEvents[0]->isolated)
+            ->toBeTrue();
+    }
+
     #[Test]
     public function lifecycleRunsInTheFrozenOrder(): void
     {


### PR DESCRIPTION
## Summary

- Mark workers that execute isolated tests in run profiles.
- Preserve utilization for reusable workers and leave it blank for isolated workers.
- Carry the optional isolation marker through JSONL for offline profile parity.