### PR TITLE
refactor(fixture): wrap trapped iterator failures

### DIFF
--- a/src/Fixture/TempDirectory.php
+++ b/src/Fixture/TempDirectory.php
@@ -139,13 +139,13 @@ final class TempDirectory implements Disposable
             return;
         }
 
-        try {
-            $entries = new \RecursiveIteratorIterator(
-                new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
-                \RecursiveIteratorIterator::CHILD_FIRST,
-            );
+        ErrorTrap::run(
+            static function () use ($path) {
+                $entries = new \RecursiveIteratorIterator(
+                    new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+                    \RecursiveIteratorIterator::CHILD_FIRST,
+                );
 
-            ErrorTrap::run(static function () use ($entries, $path) {
                 /** @var \SplFileInfo $entry */
                 foreach ($entries as $entry) {
                     $pathname = $entry->getPathname();
@@ -155,10 +155,11 @@ final class TempDirectory implements Disposable
                         throw TempDirectoryError::entryRemovalFailed($pathname, $path);
                     }
                 }
-            });
-        } catch (\UnexpectedValueException $error) {
-            throw TempDirectoryError::rootRemovalFailed($path, $error->getMessage());
-        }
+            },
+            wrap: static fn(\Throwable $error): \Throwable => $error instanceof \UnexpectedValueException
+                ? TempDirectoryError::rootRemovalFailed($path, $error->getMessage())
+                : $error,
+        );
 
         if (!ErrorTrap::run(static fn() => \rmdir($path), $warning)) {
             throw TempDirectoryError::rootRemovalFailed($path, $warning);


### PR DESCRIPTION
## Summary

- Construct and consume the recursive directory iterator inside the existing `ErrorTrap` operation.
- Translate `UnexpectedValueException` through `wrap:` after the diagnostic handler is restored.
- Propagate unrelated failures unchanged, including typed entry-removal failures.

## Scope

This is the remaining production translation that already ran inside `ErrorTrap`. Other catches either recover with a value, execute user code, or would require a new handler installation solely for exception translation.