### PR TITLE
test(expect): use subject type narrowing in tests

### DIFF
--- a/tests/Unit/Harness/HarnessServiceFactoryContractTest.php
+++ b/tests/Unit/Harness/HarnessServiceFactoryContractTest.php
@@ -70,7 +70,9 @@ final class HarnessServiceFactoryContractTest
     {
         $scopes = $this->scopesFor(FactoryContractTarget::class);
         $service = $scopes->resolve(FactoryContractTarget::class, 'probe');
-        \assert($service instanceof FactoryContractTarget);
+        Expect::that($service)
+            ->because('the lazy service MUST match the registered type before initialization')
+            ->toBeInstanceOf(FactoryContractTarget::class);
 
         Expect::that(static fn(): string => $service->value())
             ->because('a lazy harness factory MUST return its registered type when initialized')

--- a/tests/Unit/Psr15/Psr15PluginTest.php
+++ b/tests/Unit/Psr15/Psr15PluginTest.php
@@ -149,7 +149,9 @@ final class Psr15PluginTest
     private function harness(HarnessScopes $scopes): HttpHarness
     {
         $harness = $scopes->resolve(HttpHarness::class, self::class);
-        \assert($harness instanceof HttpHarness);
+        Expect::that($harness)
+            ->because('the resolved service MUST be the requested HTTP harness')
+            ->toBeInstanceOf(HttpHarness::class);
 
         return $harness;
     }


### PR DESCRIPTION
Replace the final test-side PHP assert() type guards with synchronous Greenlight expectations. These expectations add runtime oracles and narrow the original subjects for PHPStan.

Production assertions are unchanged.