### PR TITLE
test: defer cleanup safety nets

### DIFF
--- a/tests/Acceptance/LocalCiLockTest.php
+++ b/tests/Acceptance/LocalCiLockTest.php
@@ -5,13 +5,17 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Acceptance;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Tests\Support\Subprocess;
 
 final readonly class LocalCiLockTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function serializesLocalCommandsAcrossOneSharedSlot(): void
@@ -32,34 +36,35 @@ final readonly class LocalCiLockTest
             ]),
             $environment,
         );
-        $second = null;
+        $processes = [$first];
+        $this->cleanup->defer(static function () use (&$processes): void {
+            foreach ($processes as $process) {
+                $process->terminate();
+            }
+        });
 
-        try {
-            $first->readStdoutUntil('ready', 2.0);
-            $second = Subprocess::start(
-                $this->tempDirectory->path(),
-                $this->lockCommand([
-                    \PHP_BINARY,
-                    '-r',
-                    'file_put_contents($argv[1], "started");',
-                    $startedMarker,
-                ]),
-                $environment,
-            );
+        $first->readStdoutUntil('ready', 2.0);
+        $second = Subprocess::start(
+            $this->tempDirectory->path(),
+            $this->lockCommand([
+                \PHP_BINARY,
+                '-r',
+                'file_put_contents($argv[1], "started");',
+                $startedMarker,
+            ]),
+            $environment,
+        );
+        $processes[] = $second;
 
-            \usleep(250_000);
-            Expect::that(\file_exists($startedMarker))
-                ->because('the second command MUST wait while the only slot is in use')
-                ->toBeFalse();
+        \usleep(250_000);
+        Expect::that(\file_exists($startedMarker))
+            ->because('the second command MUST wait while the only slot is in use')
+            ->toBeFalse();
 
-            $first->write("continue\n");
-            Expect::that($first->wait(2.0)->exitCode)->toBe(0);
-            Expect::that($second->wait(2.0)->exitCode)->toBe(0);
-            Expect::that(\file_get_contents($startedMarker))->toBe('started');
-        } finally {
-            $first->terminate();
-            $second?->terminate();
-        }
+        $first->write("continue\n");
+        Expect::that($first->wait(2.0)->exitCode)->toBe(0);
+        Expect::that($second->wait(2.0)->exitCode)->toBe(0);
+        Expect::that(\file_get_contents($startedMarker))->toBe('started');
     }
 
     #[Test]
@@ -96,23 +101,20 @@ final readonly class LocalCiLockTest
             ]),
             $environment,
         );
+        $this->cleanup->defer($first->terminate(...));
 
-        try {
-            $first->readStdoutUntil('ready', 2.0);
-            $second = Subprocess::run(
-                $this->tempDirectory->path(),
-                $this->lockCommand([\PHP_BINARY, '-r', 'exit(9);']),
-                $environment,
-            );
+        $first->readStdoutUntil('ready', 2.0);
+        $second = Subprocess::run(
+            $this->tempDirectory->path(),
+            $this->lockCommand([\PHP_BINARY, '-r', 'exit(9);']),
+            $environment,
+        );
 
-            Expect::that($second->exitCode)
-                ->because('the second command can use the configured second slot')
-                ->toBe(9);
-            $first->write("continue\n");
-            Expect::that($first->wait(2.0)->exitCode)->toBe(0);
-        } finally {
-            $first->terminate();
-        }
+        Expect::that($second->exitCode)
+            ->because('the second command can use the configured second slot')
+            ->toBe(9);
+        $first->write("continue\n");
+        Expect::that($first->wait(2.0)->exitCode)->toBe(0);
     }
 
     /**

--- a/tests/Acceptance/LocalCiLockTest.php
+++ b/tests/Acceptance/LocalCiLockTest.php
@@ -36,12 +36,7 @@ final readonly class LocalCiLockTest
             ]),
             $environment,
         );
-        $processes = [$first];
-        $this->cleanup->defer(static function () use (&$processes): void {
-            foreach ($processes as $process) {
-                $process->terminate();
-            }
-        });
+        $this->cleanup->defer($first->terminate(...));
 
         $first->readStdoutUntil('ready', 2.0);
         $second = Subprocess::start(
@@ -54,7 +49,7 @@ final readonly class LocalCiLockTest
             ]),
             $environment,
         );
-        $processes[] = $second;
+        $this->cleanup->defer($second->terminate(...));
 
         \usleep(250_000);
         Expect::that(\file_exists($startedMarker))

--- a/tests/Unit/Artifact/ArtifactBestEffortCleanupDiagnosticTest.php
+++ b/tests/Unit/Artifact/ArtifactBestEffortCleanupDiagnosticTest.php
@@ -10,6 +10,7 @@ use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -19,7 +20,10 @@ use Greenlight\Tests\Fixture\Artifact\DirectoryCreatingFileCopier;
 
 final readonly class ArtifactBestEffortCleanupDiagnosticTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function aFailedPublicationCleanupDoesNotLeakEngineDiagnostics(): void
@@ -32,39 +36,37 @@ final readonly class ArtifactBestEffortCleanupDiagnosticTest
             'run-cleanup-diagnostic',
             $copier,
         );
+        $this->cleanup->defer($store->cleanup(...));
+        $this->cleanup->defer(static function () use ($copier): void {
+            if ($copier->destination !== null) {
+                \rmdir($copier->destination);
+            }
+        });
         $id = new TestId('Example\EvidenceTest', 'fails');
         $attachments = $store->forAttempt($id, 1, new TestArtifactBudget());
         $attachments->text('evidence.txt', 'evidence');
         $staged = $attachments->seal()[0];
 
-        try {
-            Expect::that(static function () use ($store, $id, $staged, &$warning): TestResult {
-                return ErrorTrap::run(
-                    static fn() => $store->publish(new TestResult(
-                        $id,
-                        Outcome::Failed,
-                        0.1,
-                        0,
-                        attachments: [$staged],
-                    )),
-                    $warning,
-                );
-            })
-                ->because('publication MUST preserve the copier failure')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: 'The fake copier stopped after it created a directory.',
-                );
+        Expect::that(static function () use ($store, $id, $staged, &$warning): TestResult {
+            return ErrorTrap::run(
+                static fn() => $store->publish(new TestResult(
+                    $id,
+                    Outcome::Failed,
+                    0.1,
+                    0,
+                    attachments: [$staged],
+                )),
+                $warning,
+            );
+        })
+            ->because('publication MUST preserve the copier failure')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'The fake copier stopped after it created a directory.',
+            );
 
-            Expect::that($warning)
-                ->because('best-effort publication cleanup MUST not leak an engine diagnostic')
-                ->toBeNull();
-        } finally {
-            if ($copier->destination !== null) {
-                \rmdir($copier->destination);
-            }
-
-            $store->cleanup();
-        }
+        Expect::that($warning)
+            ->because('best-effort publication cleanup MUST not leak an engine diagnostic')
+            ->toBeNull();
     }
 }

--- a/tests/Unit/Artifact/ArtifactCleanupIdempotenceTest.php
+++ b/tests/Unit/Artifact/ArtifactCleanupIdempotenceTest.php
@@ -6,48 +6,51 @@ namespace Greenlight\Tests\Unit\Artifact;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
 use Greenlight\Runner\Artifact\ArtifactStore;
 
 final readonly class ArtifactCleanupIdempotenceTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function repeatedCleanupDoesNotDeleteReplacementState(): void
     {
         $root = $this->tempDirectory->subdirectory('cleanup-idempotence');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-cleanup');
+        $this->cleanup->defer($store->cleanup(...));
         $staging = $store->session()->stagingDirectory;
         $replacement = $staging . '/replacement.txt';
-
-        try {
-            \mkdir($staging, 0o700, true);
-            \file_put_contents($staging . '/original.txt', 'original state');
-
-            $store->cleanup();
-
-            Expect::that(\is_dir($staging))
-                ->because('the owning store MUST remove its original staging directory')
-                ->toBeFalse();
-
-            \mkdir($staging, 0o700, true);
-            \file_put_contents($replacement, 'replacement state');
-
-            $store->cleanup();
-
-            Expect::that(\is_file($replacement))
-                ->because('a spent store MUST NOT delete replacement state at the same path')
-                ->toBeTrue();
-
-            Expect::that((string) \file_get_contents($replacement))
-                ->because('replacement staging content MUST remain intact')
-                ->toBe('replacement state');
-        } finally {
+        $this->cleanup->defer(static function () use ($replacement, $staging): void {
             @\unlink($replacement);
             @\rmdir($staging);
-            $store->cleanup();
-        }
+        });
+
+        \mkdir($staging, 0o700, true);
+        \file_put_contents($staging . '/original.txt', 'original state');
+
+        $store->cleanup();
+
+        Expect::that(\is_dir($staging))
+            ->because('the owning store MUST remove its original staging directory')
+            ->toBeFalse();
+
+        \mkdir($staging, 0o700, true);
+        \file_put_contents($replacement, 'replacement state');
+
+        $store->cleanup();
+
+        Expect::that(\is_file($replacement))
+            ->because('a spent store MUST NOT delete replacement state at the same path')
+            ->toBeTrue();
+
+        Expect::that((string) \file_get_contents($replacement))
+            ->because('replacement staging content MUST remain intact')
+            ->toBe('replacement state');
     }
 }

--- a/tests/Unit/Artifact/ArtifactCleanupSymlinkTest.php
+++ b/tests/Unit/Artifact/ArtifactCleanupSymlinkTest.php
@@ -6,6 +6,7 @@ namespace Greenlight\Tests\Unit\Artifact;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\TempDirectory;
@@ -13,7 +14,10 @@ use Greenlight\Runner\Artifact\ArtifactStore;
 
 final readonly class ArtifactCleanupSymlinkTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function cleanupRemovesDirectoryLinksWithoutChangingTheirTargets(): void
@@ -25,6 +29,7 @@ final readonly class ArtifactCleanupSymlinkTest
             $root,
             'run-cleanup-symlink',
         );
+        $this->cleanup->defer($store->cleanup(...));
         $staging = $store->session()->stagingDirectory;
         $link = $staging . '/external';
         $sentinel = $target . '/sentinel.txt';

--- a/tests/Unit/Artifact/ArtifactIntermittentReadTest.php
+++ b/tests/Unit/Artifact/ArtifactIntermittentReadTest.php
@@ -6,6 +6,7 @@ namespace Greenlight\Tests\Unit\Artifact;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\StreamWrapperSandbox;
@@ -21,6 +22,7 @@ final readonly class ArtifactIntermittentReadTest
     public function __construct(
         private TempDirectory $tempDirectory,
         private StreamWrapperSandbox $streamWrappers,
+        private Cleanup $cleanup,
     ) {}
 
     #[Test]
@@ -28,40 +30,35 @@ final readonly class ArtifactIntermittentReadTest
     {
         $this->streamWrappers->register(self::SCHEME, IntermittentFileReadStream::class);
 
-        $store = null;
+        $root = $this->tempDirectory->subdirectory('source-intermittent-read');
+        $store = ArtifactStore::open(
+            new ArtifactConfiguration($root),
+            $root,
+            'run-source-intermittent-read',
+        );
+        $this->cleanup->defer($store->cleanup(...));
+        $attachments = $store->forAttempt(
+            new TestId('Example\EvidenceTest', 'copiesAfterEmptyRead'),
+            1,
+            new TestArtifactBudget(),
+        );
 
-        try {
-            $root = $this->tempDirectory->subdirectory('source-intermittent-read');
-            $store = ArtifactStore::open(
-                new ArtifactConfiguration($root),
-                $root,
-                'run-source-intermittent-read',
-            );
-            $attachments = $store->forAttempt(
-                new TestId('Example\EvidenceTest', 'copiesAfterEmptyRead'),
-                1,
-                new TestArtifactBudget(),
-            );
+        $attachments->file('evidence.txt', self::SCHEME . '://evidence', 'text/plain');
+        $collected = $attachments->collected();
 
-            $attachments->file('evidence.txt', self::SCHEME . '://evidence', 'text/plain');
-            $collected = $attachments->collected();
+        Expect::that($collected)
+            ->because('the intermittent source MUST produce one staged attachment')
+            ->toHaveCount(1);
 
-            Expect::that($collected)
-                ->because('the intermittent source MUST produce one staged attachment')
-                ->toHaveCount(1);
+        $attachment = $collected[0];
+        $stagedPath = $store->session()->stagingDirectory . '/' . $attachment->storageKey;
 
-            $attachment = $collected[0];
-            $stagedPath = $store->session()->stagingDirectory . '/' . $attachment->storageKey;
-
-            Expect::that(\file_get_contents($stagedPath))
-                ->because('a transient empty source read MUST not truncate the staged attachment')
-                ->toBe('evidence');
-            Expect::that($attachment->sizeBytes)
-                ->toBe(8);
-            Expect::that($attachment->sha256)
-                ->toBe(\hash('sha256', 'evidence'));
-        } finally {
-            $store?->cleanup();
-        }
+        Expect::that(\file_get_contents($stagedPath))
+            ->because('a transient empty source read MUST not truncate the staged attachment')
+            ->toBe('evidence');
+        Expect::that($attachment->sizeBytes)
+            ->toBe(8);
+        Expect::that($attachment->sha256)
+            ->toBe(\hash('sha256', 'evidence'));
     }
 }

--- a/tests/Unit/Artifact/ArtifactOutputSafetyTest.php
+++ b/tests/Unit/Artifact/ArtifactOutputSafetyTest.php
@@ -12,6 +12,7 @@ use Greenlight\Core\Artifact\StagedAttachment;
 use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\SkipTest;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
@@ -22,7 +23,10 @@ use Greenlight\Tests\Support\FilesystemRestriction;
 
 final readonly class ArtifactOutputSafetyTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function outputDirectoriesRejectNullBytesBeforeFilesystemUse(): void
@@ -84,32 +88,29 @@ final readonly class ArtifactOutputSafetyTest
         $outside = $this->tempDirectory->subdirectory('outside-output');
         \mkdir($root . '/published');
         [$store, $id, $staged] = $this->stageEvidence($root, $root . '/published');
+        $this->cleanup->defer($store->cleanup(...));
         $firstSegment = \explode('/', $staged->storageKey)[0];
         \mkdir($store->publicDirectory(), 0o777, true);
         \symlink($outside, $store->publicDirectory() . '/' . $firstSegment);
 
-        try {
-            Expect::that(static fn(): TestResult => $store->publish(new TestResult(
-                $id,
-                Outcome::Failed,
-                0.1,
-                0,
-                attachments: [$staged],
-            )))
-                ->because('artifact publication MUST NOT follow output directory symbolic links')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: 'Attachment output directory contains a symbolic link.',
-                );
-            Expect::that(\glob($outside . '/*'))
-                ->because('a rejected publication MUST NOT write outside its output directory')
-                ->toBe([]);
-            Expect::that(\is_file($store->session()->stagingDirectory . '/' . $staged->storageKey))
-                ->because('rejected evidence remains available for recovery')
-                ->toBeTrue();
-        } finally {
-            $store->cleanup();
-        }
+        Expect::that(static fn(): TestResult => $store->publish(new TestResult(
+            $id,
+            Outcome::Failed,
+            0.1,
+            0,
+            attachments: [$staged],
+        )))
+            ->because('artifact publication MUST NOT follow output directory symbolic links')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Attachment output directory contains a symbolic link.',
+            );
+        Expect::that(\glob($outside . '/*'))
+            ->because('a rejected publication MUST NOT write outside its output directory')
+            ->toBe([]);
+        Expect::that(\is_file($store->session()->stagingDirectory . '/' . $staged->storageKey))
+            ->because('rejected evidence remains available for recovery')
+            ->toBeTrue();
     }
 
     #[Test]
@@ -118,33 +119,30 @@ final readonly class ArtifactOutputSafetyTest
         $root = $this->tempDirectory->subdirectory('output-entry');
         \mkdir($root . '/published');
         [$store, $id, $staged] = $this->stageEvidence($root, $root . '/published');
+        $this->cleanup->defer($store->cleanup(...));
         $firstSegment = \explode('/', $staged->storageKey)[0];
         \mkdir($store->publicDirectory(), 0o777, true);
         $blocker = $store->publicDirectory() . '/' . $firstSegment;
         \file_put_contents($blocker, 'keep');
 
-        try {
-            Expect::that(static fn(): TestResult => $store->publish(new TestResult(
-                $id,
-                Outcome::Failed,
-                0.1,
-                0,
-                attachments: [$staged],
-            )))
-                ->because('artifact publication requires directory-only output path segments')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: 'Attachment output path contains a non-directory entry.',
-                );
-            Expect::that((string) \file_get_contents($blocker))
-                ->because('a rejected publication MUST NOT replace the blocking entry')
-                ->toBe('keep');
-            Expect::that(\is_file($store->session()->stagingDirectory . '/' . $staged->storageKey))
-                ->because('rejected evidence remains available for recovery')
-                ->toBeTrue();
-        } finally {
-            $store->cleanup();
-        }
+        Expect::that(static fn(): TestResult => $store->publish(new TestResult(
+            $id,
+            Outcome::Failed,
+            0.1,
+            0,
+            attachments: [$staged],
+        )))
+            ->because('artifact publication requires directory-only output path segments')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Attachment output path contains a non-directory entry.',
+            );
+        Expect::that((string) \file_get_contents($blocker))
+            ->because('a rejected publication MUST NOT replace the blocking entry')
+            ->toBe('keep');
+        Expect::that(\is_file($store->session()->stagingDirectory . '/' . $staged->storageKey))
+            ->because('rejected evidence remains available for recovery')
+            ->toBeTrue();
     }
 
     #[Test]
@@ -162,27 +160,24 @@ final readonly class ArtifactOutputSafetyTest
         }
 
         [$store, $id, $staged] = $this->stageEvidence($root, $readOnly . '/artifacts');
+        $this->cleanup->defer($store->cleanup(...));
+        $this->cleanup->defer(static fn(): bool => \chmod($readOnly, 0o700));
 
-        try {
-            Expect::that(static fn(): TestResult => $store->publish(new TestResult(
-                $id,
-                Outcome::Failed,
-                0.1,
-                0,
-                attachments: [$staged],
-            )))
-                ->because('an unwritable output parent MUST reject attachment publication')
-                ->toThrow(
-                    AttachmentError::class,
-                    matching: '/^Failed to create attachment output directory/',
-                );
-            Expect::that(\is_file($store->session()->stagingDirectory . '/' . $staged->storageKey))
-                ->because('rejected evidence MUST remain available for recovery')
-                ->toBeTrue();
-        } finally {
-            \chmod($readOnly, 0o700);
-            $store->cleanup();
-        }
+        Expect::that(static fn(): TestResult => $store->publish(new TestResult(
+            $id,
+            Outcome::Failed,
+            0.1,
+            0,
+            attachments: [$staged],
+        )))
+            ->because('an unwritable output parent MUST reject attachment publication')
+            ->toThrow(
+                AttachmentError::class,
+                matching: '/^Failed to create attachment output directory/',
+            );
+        Expect::that(\is_file($store->session()->stagingDirectory . '/' . $staged->storageKey))
+            ->because('rejected evidence MUST remain available for recovery')
+            ->toBeTrue();
     }
 
     /**

--- a/tests/Unit/Artifact/ArtifactPostCopyIntegrityTest.php
+++ b/tests/Unit/Artifact/ArtifactPostCopyIntegrityTest.php
@@ -9,6 +9,7 @@ use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -18,7 +19,10 @@ use Greenlight\Tests\Fixture\Artifact\CorruptingFileCopier;
 
 final readonly class ArtifactPostCopyIntegrityTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function postCopyCorruptionRejectsPublicationAndRemovesThePartialFile(): void
@@ -30,6 +34,7 @@ final readonly class ArtifactPostCopyIntegrityTest
             'run-post-copy-integrity',
             new CorruptingFileCopier(),
         );
+        $this->cleanup->defer($store->cleanup(...));
         $id = new TestId('Example\EvidenceTest', 'fails');
         $attempt = $store->forAttempt($id, 1, new TestArtifactBudget());
         $attempt->text('evidence.txt', 'evidence');
@@ -42,21 +47,17 @@ final readonly class ArtifactPostCopyIntegrityTest
             attachments: [$staged],
         );
 
-        try {
-            Expect::that(static fn(): TestResult => $store->publish($result))
-                ->because('post-copy corruption MUST reject attachment publication')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: 'Published attachment content does not match its metadata.',
-                );
-            Expect::that(\is_file($staged->path))
-                ->because('a rejected publication MUST NOT leave the final attachment')
-                ->toBeFalse();
-            Expect::that(\glob($staged->path . '.part-*'))
-                ->because('a rejected publication MUST remove its partial attachment')
-                ->toBe([]);
-        } finally {
-            $store->cleanup();
-        }
+        Expect::that(static fn(): TestResult => $store->publish($result))
+            ->because('post-copy corruption MUST reject attachment publication')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Published attachment content does not match its metadata.',
+            );
+        Expect::that(\is_file($staged->path))
+            ->because('a rejected publication MUST NOT leave the final attachment')
+            ->toBeFalse();
+        Expect::that(\glob($staged->path . '.part-*'))
+            ->because('a rejected publication MUST remove its partial attachment')
+            ->toBe([]);
     }
 }

--- a/tests/Unit/Artifact/ArtifactRecoveryAttemptFloorTest.php
+++ b/tests/Unit/Artifact/ArtifactRecoveryAttemptFloorTest.php
@@ -10,6 +10,7 @@ use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -19,39 +20,39 @@ use Greenlight\Runner\Artifact\TestArtifactBudget;
 
 final readonly class ArtifactRecoveryAttemptFloorTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function aStaleAttemptMarkerDoesNotReduceTheResultAttempt(): void
     {
         $root = $this->tempDirectory->subdirectory('recovery-attempt-floor');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-attempt-floor');
+        $this->cleanup->defer($store->cleanup(...));
         $id = new TestId('Example\\EvidenceTest', 'crashesAfterReporting');
 
-        try {
-            $attachments = $store->forAttempt($id, 2, new TestArtifactBudget());
-            $attachments->text('evidence.txt', 'completed evidence');
+        $attachments = $store->forAttempt($id, 2, new TestArtifactBudget());
+        $attachments->text('evidence.txt', 'completed evidence');
 
-            $recovered = $store->recover(new TestResult(
-                $id,
-                Outcome::Errored,
-                0.0,
-                0,
-                attempts: 10,
-            ));
+        $recovered = $store->recover(new TestResult(
+            $id,
+            Outcome::Errored,
+            0.0,
+            0,
+            attempts: 10,
+        ));
 
-            Expect::that($recovered->attempts)
-                ->because('stale recovery metadata MUST NOT reduce a reported attempt count')
-                ->toBe(10);
-            Expect::that($recovered->attachments)
-                ->toHaveCount(1);
-            Expect::that($recovered->attachments[0]->name)
-                ->toBe('evidence.txt');
-            Expect::that((string) \file_get_contents($recovered->attachments[0]->path))
-                ->toBe('completed evidence');
-        } finally {
-            $store->cleanup();
-        }
+        Expect::that($recovered->attempts)
+            ->because('stale recovery metadata MUST NOT reduce a reported attempt count')
+            ->toBe(10);
+        Expect::that($recovered->attachments)
+            ->toHaveCount(1);
+        Expect::that($recovered->attachments[0]->name)
+            ->toBe('evidence.txt');
+        Expect::that((string) \file_get_contents($recovered->attachments[0]->path))
+            ->toBe('completed evidence');
     }
 
     #[Test]

--- a/tests/Unit/Artifact/ArtifactSourceMutationTest.php
+++ b/tests/Unit/Artifact/ArtifactSourceMutationTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Unit\Artifact;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\StreamWrapperSandbox;
@@ -25,6 +26,7 @@ final readonly class ArtifactSourceMutationTest
     public function __construct(
         private TempDirectory $tempDirectory,
         private StreamWrapperSandbox $streamWrappers,
+        private Cleanup $cleanup,
     ) {}
 
     #[Test]
@@ -32,42 +34,37 @@ final readonly class ArtifactSourceMutationTest
     {
         $this->streamWrappers->register(self::SCHEME, ChangingFileStream::class);
 
-        $store = null;
+        $root = $this->tempDirectory->subdirectory('source-mutation');
+        $configuration = new ArtifactConfiguration(
+            $root,
+            maxRunAttachments: 1,
+        );
+        $store = ArtifactStore::open($configuration, $root, 'run-source-mutation');
+        $this->cleanup->defer($store->cleanup(...));
+        $attachments = $store->forAttempt(
+            new TestId('Example\EvidenceTest', 'rejectsChangingSource'),
+            1,
+            new TestArtifactBudget(),
+        );
+        $source = self::SCHEME . '://evidence';
 
-        try {
-            $root = $this->tempDirectory->subdirectory('source-mutation');
-            $configuration = new ArtifactConfiguration(
-                $root,
-                maxRunAttachments: 1,
+        Expect::that(static fn() => $attachments->file('evidence.txt', $source))
+            ->because('a file attachment source must stay unchanged while Greenlight copies it')
+            ->toThrow(
+                AttachmentError::class,
+                message: \sprintf(
+                    'Attachment source "%s" changed while it was being copied.',
+                    $source,
+                ),
             );
-            $store = ArtifactStore::open($configuration, $root, 'run-source-mutation');
-            $attachments = $store->forAttempt(
-                new TestId('Example\EvidenceTest', 'rejectsChangingSource'),
-                1,
-                new TestArtifactBudget(),
-            );
-            $source = self::SCHEME . '://evidence';
 
-            Expect::that(static fn() => $attachments->file('evidence.txt', $source))
-                ->because('a file attachment source must stay unchanged while Greenlight copies it')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: \sprintf(
-                        'Attachment source "%s" changed while it was being copied.',
-                        $source,
-                    ),
-                );
+        $attachments->text('replacement.txt', 'replacement');
 
-            $attachments->text('replacement.txt', 'replacement');
-
-            Expect::that($attachments->collected())
-                ->because('a rejected source releases its run quota')
-                ->toHaveCount(1);
-            Expect::that($attachments->collected()[0]->name)
-                ->toBe('replacement.txt');
-        } finally {
-            $store?->cleanup();
-        }
+        Expect::that($attachments->collected())
+            ->because('a rejected source releases its run quota')
+            ->toHaveCount(1);
+        Expect::that($attachments->collected()[0]->name)
+            ->toBe('replacement.txt');
     }
 
     #[Test]
@@ -75,53 +72,48 @@ final readonly class ArtifactSourceMutationTest
     {
         $this->streamWrappers->register(self::FAILING_READ_SCHEME, FailingFileReadStream::class);
 
-        $store = null;
+        $root = $this->tempDirectory->subdirectory('source-read-failure');
+        $configuration = new ArtifactConfiguration(
+            $root,
+            maxRunAttachments: 1,
+        );
+        $store = ArtifactStore::open($configuration, $root, 'run-source-read-failure');
+        $this->cleanup->defer($store->cleanup(...));
+        $id = new TestId('Example\EvidenceTest', 'rejectsUnreadableSource');
+        $attachments = $store->forAttempt(
+            $id,
+            1,
+            new TestArtifactBudget(),
+        );
+        $source = self::FAILING_READ_SCHEME . '://evidence';
 
-        try {
-            $root = $this->tempDirectory->subdirectory('source-read-failure');
-            $configuration = new ArtifactConfiguration(
-                $root,
-                maxRunAttachments: 1,
+        Expect::that(static fn() => $attachments->file('evidence.txt', $source))
+            ->because('a file attachment read failure MUST reject the incomplete copy')
+            ->toThrow(
+                AttachmentError::class,
+                message: \sprintf('Attachment source "%s" could not be read.', $source),
             );
-            $store = ArtifactStore::open($configuration, $root, 'run-source-read-failure');
-            $id = new TestId('Example\EvidenceTest', 'rejectsUnreadableSource');
-            $attachments = $store->forAttempt(
-                $id,
-                1,
-                new TestArtifactBudget(),
-            );
-            $source = self::FAILING_READ_SCHEME . '://evidence';
 
-            Expect::that(static fn() => $attachments->file('evidence.txt', $source))
-                ->because('a file attachment read failure MUST reject the incomplete copy')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: \sprintf('Attachment source "%s" could not be read.', $source),
-                );
+        $failedPath = $store->session()->stagingDirectory
+            . '/' . ArtifactStore::testDirectory($id)
+            . '/attempt-1/01-evidence.txt';
 
-            $failedPath = $store->session()->stagingDirectory
-                . '/' . ArtifactStore::testDirectory($id)
-                . '/attempt-1/01-evidence.txt';
+        Expect::that(\file_exists($failedPath))
+            ->because('a failed source read MUST remove the incomplete staging file')
+            ->toBeFalse();
+        Expect::that(\file_exists($failedPath . '.part'))
+            ->because('a failed source read MUST remove the partial staging file')
+            ->toBeFalse();
+        Expect::that(\file_exists($failedPath . '.meta.json'))
+            ->because('a failed source read MUST not leave recovery metadata')
+            ->toBeFalse();
 
-            Expect::that(\file_exists($failedPath))
-                ->because('a failed source read MUST remove the incomplete staging file')
-                ->toBeFalse();
-            Expect::that(\file_exists($failedPath . '.part'))
-                ->because('a failed source read MUST remove the partial staging file')
-                ->toBeFalse();
-            Expect::that(\file_exists($failedPath . '.meta.json'))
-                ->because('a failed source read MUST not leave recovery metadata')
-                ->toBeFalse();
+        $attachments->text('replacement.txt', 'replacement');
 
-            $attachments->text('replacement.txt', 'replacement');
-
-            Expect::that($attachments->collected())
-                ->because('a failed source read MUST release its run quota')
-                ->toHaveCount(1);
-            Expect::that($attachments->collected()[0]->name)
-                ->toBe('replacement.txt');
-        } finally {
-            $store?->cleanup();
-        }
+        Expect::that($attachments->collected())
+            ->because('a failed source read MUST release its run quota')
+            ->toHaveCount(1);
+        Expect::that($attachments->collected()[0]->name)
+            ->toBe('replacement.txt');
     }
 }

--- a/tests/Unit/Artifact/ArtifactSourceValidationTest.php
+++ b/tests/Unit/Artifact/ArtifactSourceValidationTest.php
@@ -9,6 +9,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Core\ErrorTrap;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -17,7 +18,10 @@ use Greenlight\Runner\Artifact\TestArtifactBudget;
 
 final readonly class ArtifactSourceValidationTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     #[DataSet('invalidSources')]
@@ -34,34 +38,31 @@ final readonly class ArtifactSourceValidationTest
         }
 
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-source-validation');
+        $this->cleanup->defer($store->cleanup(...));
         $attachments = $store->forAttempt(
             new TestId('Example\AttachmentTest', 'rejectsInvalidSource'),
             1,
             new TestArtifactBudget(),
         );
 
-        try {
-            $warning = null;
-            Expect::that(static function () use ($attachments, $source, &$warning): void {
-                ErrorTrap::run(
-                    static fn() => $attachments->file('evidence.txt', $source),
-                    $warning,
-                );
-            })
-                ->because('file attachments reject invalid sources')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: \sprintf('Attachment source "%s" %s.', $source, $reason),
-                );
-            Expect::that($warning)
-                ->because('an invalid attachment source MUST not leak an engine diagnostic')
-                ->toBeNull();
-            Expect::that($attachments->collected())
-                ->because('an invalid source does not create an attachment')
-                ->toBe([]);
-        } finally {
-            $store->cleanup();
-        }
+        $warning = null;
+        Expect::that(static function () use ($attachments, $source, &$warning): void {
+            ErrorTrap::run(
+                static fn() => $attachments->file('evidence.txt', $source),
+                $warning,
+            );
+        })
+            ->because('file attachments reject invalid sources')
+            ->toThrow(
+                AttachmentError::class,
+                message: \sprintf('Attachment source "%s" %s.', $source, $reason),
+            );
+        Expect::that($warning)
+            ->because('an invalid attachment source MUST not leak an engine diagnostic')
+            ->toBeNull();
+        Expect::that($attachments->collected())
+            ->because('an invalid source does not create an attachment')
+            ->toBe([]);
     }
 
     /**

--- a/tests/Unit/Artifact/ArtifactStorageKeyTest.php
+++ b/tests/Unit/Artifact/ArtifactStorageKeyTest.php
@@ -13,6 +13,7 @@ use Greenlight\Core\Artifact\AttachmentRetention;
 use Greenlight\Core\Artifact\StagedAttachment;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -20,7 +21,10 @@ use Greenlight\Runner\Artifact\ArtifactStore;
 
 final readonly class ArtifactStorageKeyTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     #[DataSet('unsafeStorageKeys')]
@@ -28,6 +32,7 @@ final readonly class ArtifactStorageKeyTest
     {
         $root = $this->tempDirectory->subdirectory('storage-key-' . $case);
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-storage-key');
+        $this->cleanup->defer($store->cleanup(...));
         $attachment = new StagedAttachment(
             'evidence.txt',
             AttachmentKind::Text,
@@ -47,19 +52,15 @@ final readonly class ArtifactStorageKeyTest
             attachments: [$attachment],
         );
 
-        try {
-            Expect::that(static fn(): TestResult => $store->publish($result))
-                ->because('publication rejects an unsafe storage key')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: 'Attachment metadata contains an unsafe storage key.',
-                );
-            Expect::that(\file_exists($store->publicDirectory()))
-                ->because('an unsafe storage key cannot create an output path')
-                ->toBeFalse();
-        } finally {
-            $store->cleanup();
-        }
+        Expect::that(static fn(): TestResult => $store->publish($result))
+            ->because('publication rejects an unsafe storage key')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Attachment metadata contains an unsafe storage key.',
+            );
+        Expect::that(\file_exists($store->publicDirectory()))
+            ->because('an unsafe storage key cannot create an output path')
+            ->toBeFalse();
     }
 
     #[Test]
@@ -71,10 +72,12 @@ final readonly class ArtifactStorageKeyTest
             $root,
             'run-unsafe-discard',
         );
+        $this->cleanup->defer($store->cleanup(...));
         $staging = $store->session()->stagingDirectory;
         $sentinelName = \basename($staging) . '-sentinel';
         $sentinel = \dirname($staging) . '/' . $sentinelName;
         $storageKey = '../' . $sentinelName;
+        $this->cleanup->defer(static fn(): bool => @\unlink($sentinel));
         $attachment = new StagedAttachment(
             'evidence.txt',
             AttachmentKind::Text,
@@ -94,23 +97,18 @@ final readonly class ArtifactStorageKeyTest
             attachments: [$attachment],
         );
 
-        try {
-            Expect::that(\file_put_contents($sentinel, 'preserve'))
-                ->because('the sentinel file MUST exist before publication')
-                ->toBe(8);
-            Expect::that(static fn(): TestResult => $store->publish($result))
-                ->because('discard MUST validate a staging coordinate before removing files')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: 'Attachment metadata contains an unsafe storage key.',
-                );
-            Expect::that(\file_get_contents($sentinel))
-                ->because('unsafe metadata MUST NOT remove files outside staging')
-                ->toBe('preserve');
-        } finally {
-            @\unlink($sentinel);
-            $store->cleanup();
-        }
+        Expect::that(\file_put_contents($sentinel, 'preserve'))
+            ->because('the sentinel file MUST exist before publication')
+            ->toBe(8);
+        Expect::that(static fn(): TestResult => $store->publish($result))
+            ->because('discard MUST validate a staging coordinate before removing files')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Attachment metadata contains an unsafe storage key.',
+            );
+        Expect::that(\file_get_contents($sentinel))
+            ->because('unsafe metadata MUST NOT remove files outside staging')
+            ->toBe('preserve');
     }
 
     /**

--- a/tests/Unit/Artifact/ArtifactStoreIntegrityTest.php
+++ b/tests/Unit/Artifact/ArtifactStoreIntegrityTest.php
@@ -11,6 +11,7 @@ use Greenlight\Core\Artifact\AttachmentKind;
 use Greenlight\Core\Artifact\StagedAttachment;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -19,7 +20,10 @@ use Greenlight\Runner\Artifact\TestArtifactBudget;
 
 final readonly class ArtifactStoreIntegrityTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function workerSideStoresCannotPublishAttachments(): void
@@ -27,28 +31,25 @@ final readonly class ArtifactStoreIntegrityTest
         $root = $this->tempDirectory->subdirectory('worker-publication');
         $configuration = new ArtifactConfiguration($root);
         $owner = ArtifactStore::open($configuration, $root, 'run-1');
+        $this->cleanup->defer($owner->cleanup(...));
 
-        try {
-            $id = new TestId('Example\EvidenceTest', 'fails');
-            $attachments = $owner->forAttempt($id, 1, new TestArtifactBudget());
-            $attachments->text('evidence.txt', 'body');
-            $worker = ArtifactStore::fromSession($owner->session(), $configuration);
+        $id = new TestId('Example\EvidenceTest', 'fails');
+        $attachments = $owner->forAttempt($id, 1, new TestArtifactBudget());
+        $attachments->text('evidence.txt', 'body');
+        $worker = ArtifactStore::fromSession($owner->session(), $configuration);
 
-            Expect::that(static fn(): TestResult => $worker->publish(new TestResult(
-                $id,
-                Outcome::Failed,
-                0.1,
-                0,
-                attachments: $attachments->seal(),
-            )))
-                ->because('only the orchestrator-owned store MAY publish attachments')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: 'A worker attempted to publish attachments.',
-                );
-        } finally {
-            $owner->cleanup();
-        }
+        Expect::that(static fn(): TestResult => $worker->publish(new TestResult(
+            $id,
+            Outcome::Failed,
+            0.1,
+            0,
+            attachments: $attachments->seal(),
+        )))
+            ->because('only the orchestrator-owned store MAY publish attachments')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'A worker attempted to publish attachments.',
+            );
     }
 
     #[Test]
@@ -57,21 +58,18 @@ final readonly class ArtifactStoreIntegrityTest
         $root = $this->tempDirectory->subdirectory('worker-cleanup');
         $configuration = new ArtifactConfiguration($root);
         $owner = ArtifactStore::open($configuration, $root, 'run-worker-cleanup');
+        $this->cleanup->defer($owner->cleanup(...));
         $id = new TestId('Example\EvidenceTest', 'keepsStaging');
         $attachments = $owner->forAttempt($id, 1, new TestArtifactBudget());
         $attachments->text('evidence.txt', 'body');
         $stagingDirectory = $owner->session()->stagingDirectory;
         $worker = ArtifactStore::fromSession($owner->session(), $configuration);
 
-        try {
-            $worker->cleanup();
+        $worker->cleanup();
 
-            Expect::that(\is_dir($stagingDirectory))
-                ->because('only the orchestrator-owned store MAY remove shared staging')
-                ->toBeTrue();
-        } finally {
-            $owner->cleanup();
-        }
+        Expect::that(\is_dir($stagingDirectory))
+            ->because('only the orchestrator-owned store MAY remove shared staging')
+            ->toBeTrue();
     }
 
     #[Test]
@@ -79,6 +77,7 @@ final readonly class ArtifactStoreIntegrityTest
     {
         $root = $this->tempDirectory->subdirectory('unsafe-storage-key');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-2');
+        $this->cleanup->defer($store->cleanup(...));
         $id = new TestId('Example\EvidenceTest', 'fails');
         $forged = new StagedAttachment(
             'evidence.txt',
@@ -91,23 +90,19 @@ final readonly class ArtifactStoreIntegrityTest
             storageKey: '../escaped.txt',
         );
 
-        try {
-            Expect::that(static fn(): TestResult => $store->publish(new TestResult(
-                $id,
-                Outcome::Failed,
-                0.1,
-                0,
-                attachments: [$forged],
-            )))
-                ->because('attachment storage keys MUST stay inside the publication directory')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: 'Attachment metadata contains an unsafe storage key.',
-                );
-            Expect::that(\file_exists($root . '/escaped.txt'))
-                ->toBeFalse();
-        } finally {
-            $store->cleanup();
-        }
+        Expect::that(static fn(): TestResult => $store->publish(new TestResult(
+            $id,
+            Outcome::Failed,
+            0.1,
+            0,
+            attachments: [$forged],
+        )))
+            ->because('attachment storage keys MUST stay inside the publication directory')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Attachment metadata contains an unsafe storage key.',
+            );
+        Expect::that(\file_exists($root . '/escaped.txt'))
+            ->toBeFalse();
     }
 }

--- a/tests/Unit/Artifact/ArtifactTestQuotaRollbackTest.php
+++ b/tests/Unit/Artifact/ArtifactTestQuotaRollbackTest.php
@@ -75,41 +75,38 @@ final readonly class ArtifactTestQuotaRollbackTest
             maxRunBytes: 1,
         );
         $store = ArtifactStore::open($configuration, $root, 'run-1');
+        $this->cleanup->defer($store->cleanup(...));
         $budget = new TestArtifactBudget();
         $budget->bytes = \PHP_INT_MAX;
 
-        try {
-            $first = $store->forAttempt(
-                new TestId('Example\EvidenceTest', 'first'),
-                1,
-                $budget,
+        $first = $store->forAttempt(
+            new TestId('Example\EvidenceTest', 'first'),
+            1,
+            $budget,
+        );
+
+        Expect::that(static fn() => $first->text('rejected.txt', 'x'))
+            ->because('per-test quota arithmetic MUST NOT overflow')
+            ->toThrow(
+                AttachmentError::class,
+                message: \sprintf(
+                    'Attachments for this test exceed the limit of %d bytes.',
+                    \PHP_INT_MAX,
+                ),
             );
+        Expect::that($budget->bytes)
+            ->because('a rejected attachment MUST NOT change the test budget')
+            ->toBe(\PHP_INT_MAX);
 
-            Expect::that(static fn() => $first->text('rejected.txt', 'x'))
-                ->because('per-test quota arithmetic MUST NOT overflow')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: \sprintf(
-                        'Attachments for this test exceed the limit of %d bytes.',
-                        \PHP_INT_MAX,
-                    ),
-                );
-            Expect::that($budget->bytes)
-                ->because('a rejected attachment MUST NOT change the test budget')
-                ->toBe(\PHP_INT_MAX);
+        $second = $store->forAttempt(
+            new TestId('Example\EvidenceTest', 'second'),
+            1,
+            new TestArtifactBudget(),
+        );
+        $second->text('accepted.txt', 'x');
 
-            $second = $store->forAttempt(
-                new TestId('Example\EvidenceTest', 'second'),
-                1,
-                new TestArtifactBudget(),
-            );
-            $second->text('accepted.txt', 'x');
-
-            Expect::that($second->collected())
-                ->because('an overflow-safe test quota rejection MUST release its run quota')
-                ->toHaveCount(1);
-        } finally {
-            $store->cleanup();
-        }
+        Expect::that($second->collected())
+            ->because('an overflow-safe test quota rejection MUST release its run quota')
+            ->toHaveCount(1);
     }
 }

--- a/tests/Unit/Artifact/ArtifactUnknownSizeTest.php
+++ b/tests/Unit/Artifact/ArtifactUnknownSizeTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Unit\Artifact;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\StreamWrapperSandbox;
@@ -22,6 +23,7 @@ final readonly class ArtifactUnknownSizeTest
     public function __construct(
         private TempDirectory $tempDirectory,
         private StreamWrapperSandbox $streamWrappers,
+        private Cleanup $cleanup,
     ) {}
 
     #[Test]
@@ -29,29 +31,24 @@ final readonly class ArtifactUnknownSizeTest
     {
         $this->streamWrappers->register(self::SCHEME, UnknownSizeFileStream::class);
 
-        $store = null;
+        $root = $this->tempDirectory->subdirectory('unknown-size');
+        $configuration = new ArtifactConfiguration($root);
+        $store = ArtifactStore::open($configuration, $root, 'run-unknown-size');
+        $this->cleanup->defer($store->cleanup(...));
+        $attachments = $store->forAttempt(
+            new TestId('Example\EvidenceTest', 'rejectsUnknownSize'),
+            1,
+            new TestArtifactBudget(),
+        );
 
-        try {
-            $root = $this->tempDirectory->subdirectory('unknown-size');
-            $configuration = new ArtifactConfiguration($root);
-            $store = ArtifactStore::open($configuration, $root, 'run-unknown-size');
-            $attachments = $store->forAttempt(
-                new TestId('Example\EvidenceTest', 'rejectsUnknownSize'),
-                1,
-                new TestArtifactBudget(),
+        Expect::that(static fn() => $attachments->file(
+            'evidence.txt',
+            self::SCHEME . '://evidence',
+        ))
+            ->because('an attachment source MUST report a nonnegative size')
+            ->toThrow(
+                AttachmentError::class,
+                message: 'Attachment size could not be determined.',
             );
-
-            Expect::that(static fn() => $attachments->file(
-                'evidence.txt',
-                self::SCHEME . '://evidence',
-            ))
-                ->because('an attachment source MUST report a nonnegative size')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: 'Attachment size could not be determined.',
-                );
-        } finally {
-            $store?->cleanup();
-        }
     }
 }

--- a/tests/Unit/Artifact/AttachmentMediaTypeValidationTest.php
+++ b/tests/Unit/Artifact/AttachmentMediaTypeValidationTest.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Artifact\AttachmentError;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -16,7 +17,10 @@ use Greenlight\Runner\Artifact\TestArtifactBudget;
 
 final readonly class AttachmentMediaTypeValidationTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     #[DataSet('mediaTypesWithControlBytes')]
@@ -24,6 +28,7 @@ final readonly class AttachmentMediaTypeValidationTest
     {
         $root = $this->tempDirectory->subdirectory('media-type-control-bytes');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-1');
+        $this->cleanup->defer($store->cleanup(...));
         $budget = new TestArtifactBudget();
         $attachments = $store->forAttempt(
             new TestId('Example\EvidenceTest', 'captures'),
@@ -31,31 +36,27 @@ final readonly class AttachmentMediaTypeValidationTest
             $budget,
         );
 
-        try {
-            Expect::that(static fn() => $attachments->text(
-                'report.txt',
-                'body',
-                $mediaType,
-            ))
-                ->because('attachment media types MUST NOT contain control bytes')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: \sprintf(
-                        'Attachment media type "%s" is invalid.',
-                        $mediaType,
-                    ),
-                );
-            Expect::that($attachments->collected())
-                ->toBe([]);
-            Expect::that($budget->attachments)
-                ->because('an invalid media type MUST NOT consume the shared attachment count')
-                ->toBe(0);
-            Expect::that($budget->bytes)
-                ->because('an invalid media type MUST NOT consume the shared byte count')
-                ->toBe(0);
-        } finally {
-            $store->cleanup();
-        }
+        Expect::that(static fn() => $attachments->text(
+            'report.txt',
+            'body',
+            $mediaType,
+        ))
+            ->because('attachment media types MUST NOT contain control bytes')
+            ->toThrow(
+                AttachmentError::class,
+                message: \sprintf(
+                    'Attachment media type "%s" is invalid.',
+                    $mediaType,
+                ),
+            );
+        Expect::that($attachments->collected())
+            ->toBe([]);
+        Expect::that($budget->attachments)
+            ->because('an invalid media type MUST NOT consume the shared attachment count')
+            ->toBe(0);
+        Expect::that($budget->bytes)
+            ->because('an invalid media type MUST NOT consume the shared byte count')
+            ->toBe(0);
     }
 
     /**

--- a/tests/Unit/Artifact/AttachmentNameValidationTest.php
+++ b/tests/Unit/Artifact/AttachmentNameValidationTest.php
@@ -9,6 +9,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Core\Artifact\StagedAttachment;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -17,13 +18,17 @@ use Greenlight\Runner\Artifact\TestArtifactBudget;
 
 final readonly class AttachmentNameValidationTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function acceptsANameAtTheMaximumLength(): void
     {
         $root = $this->tempDirectory->subdirectory('maximum-name');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-valid-name');
+        $this->cleanup->defer($store->cleanup(...));
         $budget = new TestArtifactBudget();
         $attachments = $store->forAttempt(
             new TestId('Example\EvidenceTest', 'validName'),
@@ -32,24 +37,20 @@ final readonly class AttachmentNameValidationTest
         );
         $name = \str_repeat('a', 120);
 
-        try {
-            $attachments->text($name, 'body');
+        $attachments->text($name, 'body');
 
-            Expect::that(\array_map(
-                static fn(StagedAttachment $attachment): string => $attachment->name,
-                $attachments->collected(),
-            ))
-                ->because('an attachment name MAY contain 120 bytes')
-                ->toBe([$name]);
-            Expect::that($budget->attachments)
-                ->because('a valid attachment MUST consume one shared attachment slot')
-                ->toBe(1);
-            Expect::that($budget->bytes)
-                ->because('a valid attachment MUST consume its bytes from the shared budget')
-                ->toBe(4);
-        } finally {
-            $store->cleanup();
-        }
+        Expect::that(\array_map(
+            static fn(StagedAttachment $attachment): string => $attachment->name,
+            $attachments->collected(),
+        ))
+            ->because('an attachment name MAY contain 120 bytes')
+            ->toBe([$name]);
+        Expect::that($budget->attachments)
+            ->because('a valid attachment MUST consume one shared attachment slot')
+            ->toBe(1);
+        Expect::that($budget->bytes)
+            ->because('a valid attachment MUST consume its bytes from the shared budget')
+            ->toBe(4);
     }
 
     #[Test]
@@ -58,6 +59,7 @@ final readonly class AttachmentNameValidationTest
     {
         $root = $this->tempDirectory->subdirectory('unsafe-name');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-invalid-name');
+        $this->cleanup->defer($store->cleanup(...));
         $budget = new TestArtifactBudget();
         $attachments = $store->forAttempt(
             new TestId('Example\EvidenceTest', 'invalidName'),
@@ -65,29 +67,25 @@ final readonly class AttachmentNameValidationTest
             $budget,
         );
 
-        try {
-            Expect::that(static fn() => $attachments->text($name, 'body'))
-                ->because('an unsafe attachment name MUST fail before staging')
-                ->toThrow(
-                    AttachmentError::class,
-                    message: \sprintf(
-                        'Attachment name "%s" is not a safe non-empty name.',
-                        $name,
-                    ),
-                );
-            Expect::that($attachments->collected())
-                ->toBe([]);
-            Expect::that($budget->attachments)
-                ->because('an unsafe attachment name MUST NOT consume an attachment slot')
-                ->toBe(0);
-            Expect::that($budget->bytes)
-                ->because('an unsafe attachment name MUST NOT consume the byte budget')
-                ->toBe(0);
-            Expect::that(\file_exists($store->session()->stagingDirectory))
-                ->toBeFalse();
-        } finally {
-            $store->cleanup();
-        }
+        Expect::that(static fn() => $attachments->text($name, 'body'))
+            ->because('an unsafe attachment name MUST fail before staging')
+            ->toThrow(
+                AttachmentError::class,
+                message: \sprintf(
+                    'Attachment name "%s" is not a safe non-empty name.',
+                    $name,
+                ),
+            );
+        Expect::that($attachments->collected())
+            ->toBe([]);
+        Expect::that($budget->attachments)
+            ->because('an unsafe attachment name MUST NOT consume an attachment slot')
+            ->toBe(0);
+        Expect::that($budget->bytes)
+            ->because('an unsafe attachment name MUST NOT consume the byte budget')
+            ->toBe(0);
+        Expect::that(\file_exists($store->session()->stagingDirectory))
+            ->toBeFalse();
     }
 
     /**

--- a/tests/Unit/Artifact/AttachmentsTest.php
+++ b/tests/Unit/Artifact/AttachmentsTest.php
@@ -13,6 +13,7 @@ use Greenlight\Core\Artifact\AttachmentRetention;
 use Greenlight\Core\Artifact\StagedAttachment;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -23,7 +24,10 @@ use Greenlight\Runner\Artifact\TestArtifactBudget;
 
 final readonly class AttachmentsTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function stagesPublishesAndHashesEveryAttachmentKind(): void
@@ -31,6 +35,7 @@ final readonly class AttachmentsTest
         $root = $this->tempDirectory->subdirectory('published');
         $configuration = new ArtifactConfiguration($root);
         $store = ArtifactStore::open($configuration, $root, 'run-1');
+        $this->cleanup->defer($store->cleanup(...));
         $attachments = $store->forAttempt(new TestId('Example\EvidenceTest', 'fails'), 1, new TestArtifactBudget());
         $source = $this->tempDirectory->path() . '/source.bin';
         \file_put_contents($source, "\x00file");
@@ -71,7 +76,6 @@ final readonly class AttachmentsTest
         Expect::that((string) \file_get_contents($this->absolute($root, $published->attachments[4]->path)))->because('stages publishes and hashes every attachment kind')
             ->toBe("\x00file");
 
-        $store->cleanup();
     }
 
     #[Test]
@@ -79,6 +83,7 @@ final readonly class AttachmentsTest
     {
         $root = $this->tempDirectory->subdirectory('retention');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-2');
+        $this->cleanup->defer($store->cleanup(...));
         $attachments = $store->forAttempt(new TestId('Example\EvidenceTest', 'passes'), 1, new TestArtifactBudget());
         $attachments->text('discarded.txt', 'discard me');
         $attachments->text('kept.txt', 'keep me', retention: AttachmentRetention::Always);
@@ -94,7 +99,6 @@ final readonly class AttachmentsTest
         Expect::that($published->attachments)->because('passing attempts discard on failure attachments but keep always')->toHaveCount(1);
         Expect::that($published->attachments[0]->name)->because('passing attempts discard on failure attachments but keep always')->toBe('kept.txt');
 
-        $store->cleanup();
     }
 
     #[Test]
@@ -102,6 +106,7 @@ final readonly class AttachmentsTest
     {
         $root = $this->tempDirectory->subdirectory('lazy-output');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-lazy');
+        $this->cleanup->defer($store->cleanup(...));
         $output = $store->publicDirectory();
 
         Expect::that(\file_exists($output))->because('output directory is created only when evidence is published')->toBeFalse();
@@ -123,7 +128,6 @@ final readonly class AttachmentsTest
         Expect::that($published->attachments)->because('output directory is created only when evidence is published')->toBe([]);
         Expect::that(\file_exists($output))->toBeFalse();
 
-        $store->cleanup();
     }
 
     /**
@@ -135,19 +139,16 @@ final readonly class AttachmentsTest
     {
         $root = $this->tempDirectory->subdirectory('invalid-writes');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-invalid');
+        $this->cleanup->defer($store->cleanup(...));
         $attachments = $store->forAttempt(
             new TestId('Example\EvidenceTest', 'invalid'),
             1,
             new TestArtifactBudget(),
         );
 
-        try {
-            Expect::that(static fn() => $write($attachments))
-                ->because('an invalid attachment write gives exact guidance')
-                ->toThrow(AttachmentError::class, message: $message);
-        } finally {
-            $store->cleanup();
-        }
+        Expect::that(static fn() => $write($attachments))
+            ->because('an invalid attachment write gives exact guidance')
+            ->toThrow(AttachmentError::class, message: $message);
     }
 
     /**
@@ -207,6 +208,7 @@ final readonly class AttachmentsTest
             maxRunBytes: 4,
         );
         $store = ArtifactStore::open($configuration, $root, 'run-3');
+        $this->cleanup->defer($store->cleanup(...));
         $id = new TestId('Example\EvidenceTest', 'limits');
         $budget = new TestArtifactBudget();
         $attachments = $store->forAttempt($id, 1, $budget);
@@ -254,7 +256,6 @@ final readonly class AttachmentsTest
                 ),
             );
 
-        $store->cleanup();
     }
 
     #[Test]
@@ -270,6 +271,7 @@ final readonly class AttachmentsTest
             maxRunBytes: 10,
         );
         $testStore = ArtifactStore::open($testConfiguration, $testRoot, 'run-test-limit');
+        $this->cleanup->defer($testStore->cleanup(...));
         $testAttachments = $testStore->forAttempt(
             new TestId('Example\EvidenceTest', 'testByteLimit'),
             1,
@@ -295,6 +297,7 @@ final readonly class AttachmentsTest
             maxRunBytes: 4,
         );
         $runStore = ArtifactStore::open($runConfiguration, $runRoot, 'run-run-limit');
+        $this->cleanup->defer($runStore->cleanup(...));
         $runStore->forAttempt(
             new TestId('Example\EvidenceTest', 'first'),
             1,
@@ -455,6 +458,7 @@ final readonly class AttachmentsTest
     {
         $root = $this->tempDirectory->subdirectory('existing-output');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-output');
+        $this->cleanup->defer($store->cleanup(...));
         $id = new TestId('Example\EvidenceTest', 'fails');
         $attachments = $store->forAttempt($id, 1, new TestArtifactBudget());
         $attachments->text('evidence.txt', 'evidence');
@@ -474,7 +478,6 @@ final readonly class AttachmentsTest
             message: 'An attachment output path already exists.',
         );
 
-        $store->cleanup();
     }
 
     #[Test]
@@ -482,6 +485,7 @@ final readonly class AttachmentsTest
     {
         $root = $this->tempDirectory->subdirectory('tampered-staging');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-tampered');
+        $this->cleanup->defer($store->cleanup(...));
         $id = new TestId('Example\EvidenceTest', 'fails');
         $attachments = $store->forAttempt($id, 1, new TestArtifactBudget());
         $attachments->text('evidence.txt', 'original');
@@ -502,7 +506,6 @@ final readonly class AttachmentsTest
             message: 'Attachment staging content does not match its metadata.',
         );
 
-        $store->cleanup();
     }
 
     #[Test]
@@ -510,6 +513,7 @@ final readonly class AttachmentsTest
     {
         $root = $this->tempDirectory->subdirectory('recovery');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-4');
+        $this->cleanup->defer($store->cleanup(...));
         $id = new TestId('Example\EvidenceTest', 'crashes');
         $attachments = $store->forAttempt($id, 1, new TestArtifactBudget());
         $attachments->text('last-response.txt', 'completed before crash');
@@ -520,7 +524,6 @@ final readonly class AttachmentsTest
         Expect::that($recovered->attachments[0]->name)->toBe('last-response.txt');
         Expect::that(\is_file($recovered->attachments[0]->path))->toBeTrue();
 
-        $store->cleanup();
     }
 
     #[Test]
@@ -528,6 +531,7 @@ final readonly class AttachmentsTest
     {
         $root = $this->tempDirectory->subdirectory('corrupt-recovery');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-corrupt');
+        $this->cleanup->defer($store->cleanup(...));
         $id = new TestId('Example\EvidenceTest', 'crashes');
         $attachments = $store->forAttempt($id, 1, new TestArtifactBudget());
         $attachments->text('completed.txt', 'complete before crash');
@@ -544,7 +548,6 @@ final readonly class AttachmentsTest
         Expect::that(\is_file($recovered->attachments[0]->path))
             ->toBeTrue();
 
-        $store->cleanup();
     }
 
     #[Test]
@@ -552,6 +555,7 @@ final readonly class AttachmentsTest
     {
         $root = $this->tempDirectory->subdirectory('attempt-recovery');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-5');
+        $this->cleanup->defer($store->cleanup(...));
         $id = new TestId('Example\EvidenceTest', 'crashesOnRetry');
         $budget = new TestArtifactBudget();
         $first = $store->forAttempt($id, 1, $budget);
@@ -565,7 +569,6 @@ final readonly class AttachmentsTest
         Expect::that($recovered->attachments)->toHaveCount(1);
         Expect::that($recovered->attachments[0]->attempt)->toBe(1);
 
-        $store->cleanup();
     }
 
     private function absolute(string $workingDirectory, string $publishedPath): string

--- a/tests/Unit/Artifact/PublishingEventSinkTest.php
+++ b/tests/Unit/Artifact/PublishingEventSinkTest.php
@@ -10,6 +10,7 @@ use Greenlight\Core\Event\RunStarted;
 use Greenlight\Core\Event\TestFinished;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -20,13 +21,17 @@ use Greenlight\Tests\Support\CollectingEventSink;
 
 final readonly class PublishingEventSinkTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function completedTestsPublishAttachmentsBeforeTheyReachTheInnerSink(): void
     {
         $root = $this->tempDirectory->subdirectory('publishing-sink');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-publishing-sink');
+        $this->cleanup->defer($store->cleanup(...));
         $inner = new CollectingEventSink();
         $sink = new PublishingEventSink($store, $inner);
         $id = new TestId('Example\EvidenceTest', 'fails');
@@ -41,43 +46,39 @@ final readonly class PublishingEventSinkTest
         );
         $started = new RunStarted('run-publishing-sink', 1, 1, 10.0);
 
-        try {
-            $sink->emit($started);
-            $sink->emit(new TestFinished($result, 11.0));
+        $sink->emit($started);
+        $sink->emit(new TestFinished($result, 11.0));
 
-            Expect::that($inner->sequence())
-                ->because('the publishing sink MUST preserve event order')
-                ->toBe(['RunStarted', 'TestFinished']);
-            Expect::that($inner->events[0])
-                ->because('events without test results MUST pass through unchanged')
-                ->toBe($started);
+        Expect::that($inner->sequence())
+            ->because('the publishing sink MUST preserve event order')
+            ->toBe(['RunStarted', 'TestFinished']);
+        Expect::that($inner->events[0])
+            ->because('events without test results MUST pass through unchanged')
+            ->toBe($started);
 
-            $finished = $inner->events[1];
+        $finished = $inner->events[1];
 
-            Expect::that($finished)
-                ->because('The second event MUST be TestFinished.')
-                ->toBeInstanceOf(TestFinished::class);
+        Expect::that($finished)
+            ->because('The second event MUST be TestFinished.')
+            ->toBeInstanceOf(TestFinished::class);
 
-            $publishedPath = $finished->result->attachments[0]->path;
+        $publishedPath = $finished->result->attachments[0]->path;
 
-            Expect::that($finished->result)
-                ->because('a completed event MUST replace its staged result with the published result')
-                ->not()
-                ->toBe($result);
-            Expect::that($finished->occurredAt)
-                ->because('publishing MUST preserve the event timestamp')
-                ->toBe(11.0);
-            Expect::that($finished->result->attachments)
-                ->because('the inner sink MUST receive published attachment metadata')
-                ->toHaveCount(1);
-            Expect::that($finished->result->attachments[0]->path)
-                ->toContain('run-publishing-sink');
-            Expect::that((string) \file_get_contents(
-                \str_starts_with($publishedPath, '/') ? $publishedPath : $root . '/' . $publishedPath,
-            ))
-                ->toBe('published evidence');
-        } finally {
-            $store->cleanup();
-        }
+        Expect::that($finished->result)
+            ->because('a completed event MUST replace its staged result with the published result')
+            ->not()
+            ->toBe($result);
+        Expect::that($finished->occurredAt)
+            ->because('publishing MUST preserve the event timestamp')
+            ->toBe(11.0);
+        Expect::that($finished->result->attachments)
+            ->because('the inner sink MUST receive published attachment metadata')
+            ->toHaveCount(1);
+        Expect::that($finished->result->attachments[0]->path)
+            ->toContain('run-publishing-sink');
+        Expect::that((string) \file_get_contents(
+            \str_starts_with($publishedPath, '/') ? $publishedPath : $root . '/' . $publishedPath,
+        ))
+            ->toBe('published evidence');
     }
 }

--- a/tests/Unit/Capture/OutputCaptureTest.php
+++ b/tests/Unit/Capture/OutputCaptureTest.php
@@ -9,11 +9,14 @@ use Greenlight\Attribute\Test;
 use Greenlight\Capture\CaptureError;
 use Greenlight\Capture\OutputCapture;
 use Greenlight\Core\Result\DiagnosticSeverity;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Support\Subprocess;
 
-final class OutputCaptureTest
+final readonly class OutputCaptureTest
 {
+    public function __construct(private Cleanup $cleanup) {}
+
     #[Test]
     public function echoInsideTheWindowIsCapturedAndDoesNotReachTheOuterStream(): void
     {
@@ -384,18 +387,15 @@ final class OutputCaptureTest
             PHP_WRAP,
             $root . '/vendor/autoload.php',
         ]);
+        $this->cleanup->defer($process->terminate(...));
 
-        try {
-            $result = $process->wait(2.0);
+        $result = $process->wait(2.0);
 
-            Expect::that($result->exitCode)
-                ->because('a blocked nested output buffer MUST fail without hanging the worker')
-                ->toBe(23);
-            Expect::that($result->stderr)
-                ->toBe('Output capture cannot stop because a nested output buffer cannot be removed.');
-        } finally {
-            $process->terminate();
-        }
+        Expect::that($result->exitCode)
+            ->because('a blocked nested output buffer MUST fail without hanging the worker')
+            ->toBe(23);
+        Expect::that($result->stderr)
+            ->toBe('Output capture cannot stop because a nested output buffer cannot be removed.');
     }
 
     #[Test]

--- a/tests/Unit/Runner/Worker/RetryDeciderAttachmentTest.php
+++ b/tests/Unit/Runner/Worker/RetryDeciderAttachmentTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Unit\Runner\Worker;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\ExecutionPlan;
 use Greenlight\Doubles\Fake;
@@ -23,13 +24,17 @@ use Greenlight\Tests\Support\PlanEntryFixture;
 
 final readonly class RetryDeciderAttachmentTest
 {
-    public function __construct(private TempDirectory $tempDirectory) {}
+    public function __construct(
+        private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function retryDecidersReceiveAttemptAttachmentMetadata(): void
     {
         $root = $this->tempDirectory->subdirectory('retry-decider-attachments');
         $store = ArtifactStore::open(new ArtifactConfiguration($root), $root, 'run-1');
+        $this->cleanup->defer($store->cleanup(...));
         $decider = new class implements RetryDecider, Fake {
             /** @var list<TestResult> */
             public array $results = [];
@@ -50,25 +55,21 @@ final readonly class RetryDeciderAttachmentTest
         ]);
         $sink = new CollectingEventSink();
 
-        try {
-            new Worker(
-                new HarnessRegistry([]),
-                PluginRegistry::forWorker([$decider]),
-                artifactStore: $store,
-            )->run($plan, $sink);
+        new Worker(
+            new HarnessRegistry([]),
+            PluginRegistry::forWorker([$decider]),
+            artifactStore: $store,
+        )->run($plan, $sink);
 
-            Expect::that($decider->results)
-                ->because('a retry decider MUST receive the unsuccessful attempt result')
-                ->toHaveCount(1);
-            Expect::that($decider->results[0]->attachments)
-                ->because('a retry decider MUST receive attachment metadata before it decides')
-                ->toHaveCount(1);
-            Expect::that($decider->results[0]->attachments[0]->name)
-                ->toBe('failure.txt');
-            Expect::that($decider->results[0]->attachments[0]->sizeBytes)
-                ->toBe(14);
-        } finally {
-            $store->cleanup();
-        }
+        Expect::that($decider->results)
+            ->because('a retry decider MUST receive the unsuccessful attempt result')
+            ->toHaveCount(1);
+        Expect::that($decider->results[0]->attachments)
+            ->because('a retry decider MUST receive attachment metadata before it decides')
+            ->toHaveCount(1);
+        Expect::that($decider->results[0]->attachments[0]->name)
+            ->toBe('failure.txt');
+        Expect::that($decider->results[0]->attachments[0]->sizeBytes)
+            ->toBe(14);
     }
 }

--- a/tests/Unit/Runner/Worker/WorkerArtifactSessionTest.php
+++ b/tests/Unit/Runner/Worker/WorkerArtifactSessionTest.php
@@ -6,6 +6,7 @@ namespace Greenlight\Tests\Unit\Runner\Worker;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Attribute\Timeout;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\EnvironmentSandbox;
@@ -18,6 +19,7 @@ final readonly class WorkerArtifactSessionTest
     public function __construct(
         private EnvironmentSandbox $environment,
         private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
     ) {}
 
     #[Test]
@@ -124,20 +126,17 @@ final readonly class WorkerArtifactSessionTest
             $root . '/vendor/autoload.php',
             $artifactRoot,
         ]);
+        $this->cleanup->defer($server->terminate(...));
 
-        try {
-            $address = \trim($server->readStdoutUntil("\n", 2.0));
+        $address = \trim($server->readStdoutUntil("\n", 2.0));
 
-            if ($address === '') {
-                Fail::because('Worker protocol server did not publish its address.');
-            }
-
-            $this->environment->set('GREENLIGHT_CHANNEL', '1');
-            $workerExit = new WorkerProcess(0.01)->run($address, 'worker-under-test', 'token');
-            $serverExit = $server->wait(2.0)->exitCode;
-        } finally {
-            $server->terminate();
+        if ($address === '') {
+            Fail::because('Worker protocol server did not publish its address.');
         }
+
+        $this->environment->set('GREENLIGHT_CHANNEL', '1');
+        $workerExit = new WorkerProcess(0.01)->run($address, 'worker-under-test', 'token');
+        $serverExit = $server->wait(2.0)->exitCode;
 
         Expect::that($workerExit)
             ->because('a worker with artifact settings MUST complete its assignment')

--- a/tests/Unit/Runner/Worker/WorkerProcessFatalSendFailureTest.php
+++ b/tests/Unit/Runner/Worker/WorkerProcessFatalSendFailureTest.php
@@ -6,6 +6,7 @@ namespace Greenlight\Tests\Unit\Runner\Worker;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Attribute\Timeout;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\EnvironmentSandbox;
@@ -18,6 +19,7 @@ final readonly class WorkerProcessFatalSendFailureTest
     public function __construct(
         private EnvironmentSandbox $environment,
         private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
     ) {}
 
     #[Test]
@@ -147,26 +149,23 @@ final readonly class WorkerProcessFatalSendFailureTest
             $ready,
             $release,
         ]);
+        $this->cleanup->defer($server->terminate(...));
 
-        try {
-            $address = \trim($server->readStdoutUntil("\n", 2.0));
+        $address = \trim($server->readStdoutUntil("\n", 2.0));
 
-            if ($address === '') {
-                Fail::because('Worker protocol server did not publish its address.');
-            }
-
-            $this->environment->set('GREENLIGHT_CHANNEL', '1');
-            $workerExit = new WorkerProcess()->run($address, 'worker-under-test', 'token');
-            $serverResult = $server->wait(3.0);
-
-            Expect::that($workerExit)
-                ->because('a failed final report MUST not escape the worker process')
-                ->toBe(1);
-            Expect::that($serverResult->exitCode)
-                ->because('the protocol fixture MUST reset the channel before it releases the assignment failure')
-                ->toBe(0);
-        } finally {
-            $server->terminate();
+        if ($address === '') {
+            Fail::because('Worker protocol server did not publish its address.');
         }
+
+        $this->environment->set('GREENLIGHT_CHANNEL', '1');
+        $workerExit = new WorkerProcess()->run($address, 'worker-under-test', 'token');
+        $serverResult = $server->wait(3.0);
+
+        Expect::that($workerExit)
+            ->because('a failed final report MUST not escape the worker process')
+            ->toBe(1);
+        Expect::that($serverResult->exitCode)
+            ->because('the protocol fixture MUST reset the channel before it releases the assignment failure')
+            ->toBe(0);
     }
 }

--- a/tests/Unit/Runner/Worker/WorkerProcessTest.php
+++ b/tests/Unit/Runner/Worker/WorkerProcessTest.php
@@ -9,6 +9,7 @@ use Greenlight\Attribute\SkipUnless;
 use Greenlight\Attribute\Test;
 use Greenlight\Attribute\Timeout;
 use Greenlight\Condition\FunctionAvailable;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Fixture\EnvironmentSandbox;
@@ -21,6 +22,7 @@ final readonly class WorkerProcessTest
     public function __construct(
         private EnvironmentSandbox $environment,
         private TempDirectory $tempDirectory,
+        private Cleanup $cleanup,
     ) {}
 
     #[Test]
@@ -127,30 +129,27 @@ final readonly class WorkerProcessTest
             $root . '/vendor/autoload.php',
             $missingConfig,
         ]);
+        $this->cleanup->defer($server->terminate(...));
 
-        try {
-            $address = \trim($server->readStdoutUntil("\n", 2.0));
+        $address = \trim($server->readStdoutUntil("\n", 2.0));
 
-            if ($address === '') {
-                Fail::because('Worker protocol server did not publish its address.');
-            }
-
-            $this->environment->set('GREENLIGHT_CHANNEL', '1');
-            $workerExit = new WorkerProcess()->run($address, 'worker-under-test', 'token');
-            $serverResult = $server->wait(2.0);
-
-            Expect::that($workerExit)
-                ->because('an assignment setup failure MUST stop the worker abnormally')
-                ->toBe(1);
-            Expect::that($serverResult->exitCode)
-                ->because('the orchestrator fixture MUST receive the worker fatal message')
-                ->toBe(0);
-            Expect::that($serverResult->stdout)
-                ->toContain("Greenlight\\Config\\ConfigFileError\n")
-                ->toContain('Configuration file "' . $missingConfig . '" does not exist.');
-        } finally {
-            $server->terminate();
+        if ($address === '') {
+            Fail::because('Worker protocol server did not publish its address.');
         }
+
+        $this->environment->set('GREENLIGHT_CHANNEL', '1');
+        $workerExit = new WorkerProcess()->run($address, 'worker-under-test', 'token');
+        $serverResult = $server->wait(2.0);
+
+        Expect::that($workerExit)
+            ->because('an assignment setup failure MUST stop the worker abnormally')
+            ->toBe(1);
+        Expect::that($serverResult->exitCode)
+            ->because('the orchestrator fixture MUST receive the worker fatal message')
+            ->toBe(0);
+        Expect::that($serverResult->stdout)
+            ->toContain("Greenlight\\Config\\ConfigFileError\n")
+            ->toContain('Configuration file "' . $missingConfig . '" does not exist.');
     }
 
     #[Test]
@@ -499,21 +498,18 @@ final readonly class WorkerProcessTest
             $root . '/vendor/autoload.php',
             $scenario,
         ]);
+        $this->cleanup->defer($server->terminate(...));
 
-        try {
-            $address = \trim($server->readStdoutUntil("\n", 2.0));
+        $address = \trim($server->readStdoutUntil("\n", 2.0));
 
-            if ($address === '') {
-                Fail::because('Worker protocol server did not publish its address.');
-            }
-
-            $this->environment->set('GREENLIGHT_CHANNEL', $environmentChannel);
-            $workerExit = new WorkerProcess(0.01)->run($address, 'worker-under-test', 'token');
-            $serverResult = $server->wait(2.0);
-
-            return [$workerExit, $serverResult->exitCode];
-        } finally {
-            $server->terminate();
+        if ($address === '') {
+            Fail::because('Worker protocol server did not publish its address.');
         }
+
+        $this->environment->set('GREENLIGHT_CHANNEL', $environmentChannel);
+        $workerExit = new WorkerProcess(0.01)->run($address, 'worker-under-test', 'token');
+        $serverResult = $server->wait(2.0);
+
+        return [$workerExit, $serverResult->exitCode];
     }
 }

--- a/tests/Unit/Support/SubprocessTest.php
+++ b/tests/Unit/Support/SubprocessTest.php
@@ -6,6 +6,7 @@ namespace Greenlight\Tests\Unit\Support;
 
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
+use Greenlight\Core\Test\Cleanup;
 use Greenlight\Core\Test\SkipTest;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
@@ -14,7 +15,10 @@ use Greenlight\Tests\Support\Subprocess;
 
 final readonly class SubprocessTest
 {
-    public function __construct(private TempDirectory $workspace) {}
+    public function __construct(
+        private TempDirectory $workspace,
+        private Cleanup $cleanup,
+    ) {}
 
     #[Test]
     public function runCapturesTheResultAndHonorsItsExecutionContext(): void
@@ -83,19 +87,16 @@ final readonly class SubprocessTest
                 PHP,
             ],
         );
+        $this->cleanup->defer($process->terminate(...));
 
-        try {
-            $ready = $process->readStdoutUntil('ready', 2.0);
-            $process->write("payload\n");
-            $result = $process->wait(2.0);
+        $ready = $process->readStdoutUntil('ready', 2.0);
+        $process->write("payload\n");
+        $result = $process->wait(2.0);
 
-            Expect::that($ready)->toBe("ready\n");
-            Expect::that($result->exitCode)->toBe(3);
-            Expect::that($result->stdout)->toBe("ready\nreceived:payload");
-            Expect::that($result->stderr)->toBe('note');
-        } finally {
-            $process->terminate();
-        }
+        Expect::that($ready)->toBe("ready\n");
+        Expect::that($result->exitCode)->toBe(3);
+        Expect::that($result->stdout)->toBe("ready\nreceived:payload");
+        Expect::that($result->stderr)->toBe('note');
     }
 
     #[Test]
@@ -113,19 +114,16 @@ final readonly class SubprocessTest
                 PHP,
             ],
         );
+        $this->cleanup->defer($process->terminate(...));
 
-        try {
-            $process->write($input);
-            $result = $process->complete();
+        $process->write($input);
+        $result = $process->complete();
 
-            Expect::that($result->exitCode)
-                ->because('a subprocess MUST receive the complete input before stdin closes')
-                ->toBe(0);
-            Expect::that($result->stdout)
-                ->toBe(\hash('sha256', $input));
-        } finally {
-            $process->terminate();
-        }
+        Expect::that($result->exitCode)
+            ->because('a subprocess MUST receive the complete input before stdin closes')
+            ->toBe(0);
+        Expect::that($result->stdout)
+            ->toBe(\hash('sha256', $input));
     }
 
     #[Test]
@@ -135,18 +133,15 @@ final readonly class SubprocessTest
             $this->workspace->path(),
             [\PHP_BINARY, '-r', 'fwrite(STDERR, "failed\n"); exit(9);'],
         );
+        $this->cleanup->defer($process->terminate(...));
 
-        try {
-            $result = $process->complete();
+        $result = $process->complete();
 
-            Expect::that($result->exitCode)->toBe(9);
-            Expect::that($result->stderr)->toBe('failed');
+        Expect::that($result->exitCode)->toBe(9);
+        Expect::that($result->stderr)->toBe('failed');
 
-            Expect::that(static fn(): string => $process->readStdoutUntil('ready', 2.0))
-                ->toThrow(\RuntimeException::class, '/Process exited before stdout contained/');
-        } finally {
-            $process->terminate();
-        }
+        Expect::that(static fn(): string => $process->readStdoutUntil('ready', 2.0))
+            ->toThrow(\RuntimeException::class, '/Process exited before stdout contained/');
     }
 
     #[Test]
@@ -156,13 +151,10 @@ final readonly class SubprocessTest
             $this->workspace->path(),
             [\PHP_BINARY, '-r', 'usleep(2_000_000);'],
         );
+        $this->cleanup->defer($process->terminate(...));
 
-        try {
-            Expect::that(static fn(): ProcessResult => $process->wait(0.05))
-                ->toThrow(\RuntimeException::class, '/Timed out after 0.1s/');
-        } finally {
-            $process->terminate();
-        }
+        Expect::that(static fn(): ProcessResult => $process->wait(0.05))
+            ->toThrow(\RuntimeException::class, '/Timed out after 0.1s/');
     }
 
     #[Test]
@@ -177,21 +169,18 @@ final readonly class SubprocessTest
                 $operation === 'wait' ? 'exit(0);' : 'fwrite(STDOUT, "ready");',
             ],
         );
+        $this->cleanup->defer($process->terminate(...));
 
-        try {
-            $call = $operation === 'wait'
-                ? static fn(): ProcessResult => $process->wait($timeoutSeconds)
-                : static fn(): string => $process->readStdoutUntil('ready', $timeoutSeconds);
+        $call = $operation === 'wait'
+            ? static fn(): ProcessResult => $process->wait($timeoutSeconds)
+            : static fn(): string => $process->readStdoutUntil('ready', $timeoutSeconds);
 
-            Expect::that($call)
-                ->because('a non-finite timeout MUST NOT create an unbounded subprocess wait')
-                ->toThrow(
-                    \InvalidArgumentException::class,
-                    message: 'Subprocess timeout must be finite.',
-                );
-        } finally {
-            $process->terminate();
-        }
+        Expect::that($call)
+            ->because('a non-finite timeout MUST NOT create an unbounded subprocess wait')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Subprocess timeout must be finite.',
+            );
     }
 
     /**
@@ -235,20 +224,17 @@ final readonly class SubprocessTest
                 PHP,
             ],
         );
+        $this->cleanup->defer($process->terminate(...));
 
-        try {
-            $process->readStdoutUntil('parent exited', 5.0);
-            $started = \hrtime(true);
-            $result = $process->wait(0.5);
-            $elapsedSeconds = (\hrtime(true) - $started) / 1_000_000_000;
+        $process->readStdoutUntil('parent exited', 5.0);
+        $started = \hrtime(true);
+        $result = $process->wait(0.5);
+        $elapsedSeconds = (\hrtime(true) - $started) / 1_000_000_000;
 
-            Expect::that($result->exitCode)->toBe(7);
-            Expect::that($result->stdout)->toBe('parent exited');
-            Expect::that($elapsedSeconds)
-                ->because('wait MUST NOT drain a pipe inherited by a descendant past its deadline')
-                ->toBeLessThan(1.0);
-        } finally {
-            $process->terminate();
-        }
+        Expect::that($result->exitCode)->toBe(7);
+        Expect::that($result->stdout)->toBe('parent exited');
+        Expect::that($elapsedSeconds)
+            ->because('wait MUST NOT drain a pipe inherited by a descendant past its deadline')
+            ->toBeLessThan(1.0);
     }
 }


### PR DESCRIPTION
## Summary

- inject the per-test Cleanup service for remaining ArtifactStore and subprocess safety nets
- preserve cleanup ordering, permission restoration, sentinel removal, and nullable process acquisition
- retain explicit cleanup only where cleanup behavior or resource lifetime is part of the test