### PR TITLE
feat(phpstan): validate expectation value arguments

### DIFF
--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -253,12 +253,14 @@ use:
 * `toMatch()` and the `matching:` argument of `toThrow()` require a valid
   regular expression.
 * The expected value for `toMatchJson()` must contain valid JSON.
+* `toBeWithin()` requires a finite tolerance of zero or more.
+* A constant `because()` reason must contain a non-whitespace character.
 * `pollEvery()` requires a finite duration of at least 0.001 seconds.
 * `within()` and `for()` require a finite duration greater than zero.
 
 Errors have identifiers under `greenlight.expectationArgument.*` (`pattern`,
-`json`, `duration`). Greenlight checks values that PHPStan cannot resolve at run
-time.
+`json`, `tolerance`, `reason`, `duration`). PHPStan checks constant values before
+run time. Greenlight checks unresolved values at run time.
 
 ## Test method checks
 

--- a/src/PhpStan/ExpectationArgumentRule.php
+++ b/src/PhpStan/ExpectationArgumentRule.php
@@ -51,6 +51,8 @@ final class ExpectationArgumentRule implements Rule
                 'toMatch' => $this->patternErrors($node, $scope, $method, 'pattern', 0),
                 'toThrow' => $this->patternErrors($node, $scope, $method, 'matching', 1),
                 'toMatchJson' => $this->jsonErrors($node, $scope),
+                'toBeWithin' => $this->toleranceErrors($node, $scope),
+                'because' => $this->reasonErrors($node, $scope),
                 default => [],
             };
         }
@@ -68,6 +70,61 @@ final class ExpectationArgumentRule implements Rule
                 || $this->isType($scope, $node, PendingConsistently::class))
         ) {
             return $this->durationErrors($node, $scope, $method, 0.001, true);
+        }
+
+        return [];
+    }
+
+    /**
+     * @return list<IdentifierRuleError>
+     */
+    private function toleranceErrors(MethodCall $call, Scope $scope): array
+    {
+        $argument = $this->argument($call, 'delta', 0);
+
+        if (!$argument instanceof Arg) {
+            return [];
+        }
+
+        foreach ($scope->getType($argument->value)->getConstantScalarValues() as $delta) {
+            if ((\is_int($delta) || \is_float($delta))
+                && \is_finite((float) $delta)
+                && $delta >= 0.0
+            ) {
+                continue;
+            }
+
+            return [RuleErrorBuilder::message('toBeWithin() requires a finite tolerance of zero or more.')
+                ->identifier('greenlight.expectationArgument.tolerance')
+                ->line($call->getStartLine())
+                ->build()];
+        }
+
+        return [];
+    }
+
+    /**
+     * @return list<IdentifierRuleError>
+     */
+    private function reasonErrors(MethodCall $call, Scope $scope): array
+    {
+        $argument = $this->argument($call, 'reason', 0);
+
+        if (!$argument instanceof Arg) {
+            return [];
+        }
+
+        foreach ($scope->getType($argument->value)->getConstantStrings() as $reason) {
+            $value = $reason->getValue();
+
+            if ($value === '' || \trim($value) !== '') {
+                continue;
+            }
+
+            return [RuleErrorBuilder::message('because() requires a non-empty reason.')
+                ->identifier('greenlight.expectationArgument.reason')
+                ->line($call->getStartLine())
+                ->build()];
         }
 
         return [];

--- a/tests/Acceptance/PhpStanExpectationArgumentRuleTest.php
+++ b/tests/Acceptance/PhpStanExpectationArgumentRuleTest.php
@@ -74,4 +74,60 @@ final readonly class PhpStanExpectationArgumentRuleTest
         Expect::that($probe->messages())->toContain('toMatchJson() requires valid expected JSON');
         Expect::that($probe->messages())->toContain('within() requires a finite duration greater than 0.000 seconds');
     }
+
+    #[Test]
+    public function toleranceAndReasonArgumentsMustMatchRuntimeConstraints(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Expect\Expect;
+
+            /**
+             * @param non-empty-string $reason
+             */
+            function greenlightGoodToleranceAndReasonProbe(float $delta, string $reason): void
+            {
+                Expect::that(1.0)->toBeWithin(0.0, 1.0);
+                Expect::that(1.0)->toBeWithin($delta, 1.0);
+                Expect::that(true)->because('0')->toBeTrue();
+                Expect::that(true)->because($reason)->toBeTrue();
+                Expect::eventually(static fn(): bool => true)
+                    ->within(0.001)
+                    ->because($reason)
+                    ->toBeTrue();
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Expect\Expect;
+
+            function greenlightBadToleranceAndReasonProbe(): void
+            {
+                Expect::that(1.0)->toBeWithin(-0.1, 1.0);
+                Expect::that(1.0)->toBeWithin(delta: INF, of: 1.0);
+                Expect::that(1.0)->toBeWithin(-INF, 1.0);
+                Expect::that(1.0)->toBeWithin(NAN, 1.0);
+                Expect::that(true)->because('   ')->toBeTrue();
+                Expect::eventually(static fn(): bool => true)
+                    ->within(0.001)
+                    ->because("\t\n")
+                    ->toBeTrue();
+            }
+            PHP,
+        );
+
+        Expect::that($probe->exitCode)->because('constant tolerances and reasons must satisfy runtime constraints')->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(6);
+        Expect::that($probe->messages())->toContain('toBeWithin() requires a finite tolerance of zero or more');
+        Expect::that($probe->messages())->toContain('because() requires a non-empty reason');
+    }
 }

--- a/tests/Unit/Expect/BecauseTest.php
+++ b/tests/Unit/Expect/BecauseTest.php
@@ -88,7 +88,9 @@ final readonly class BecauseTest
 
         Expect::that($empty->message)->because('an empty reason is a usage failure')->toBe('because() requires a non-empty reason.');
 
-        $blank = FailureProbe::detailOf(static fn() => Expect::that(true)->because('   '));
+        $blank = FailureProbe::detailOf(
+            static fn() => Expect::that(true)->because('   '), // @phpstan-ignore greenlight.expectationArgument.reason (deliberately invalid: tests runtime validation)
+        );
 
         Expect::that($blank->message)->because('an empty reason is a usage failure')->toBe('because() requires a non-empty reason.');
     }

--- a/tests/Unit/Expect/TemporalExpectationTest.php
+++ b/tests/Unit/Expect/TemporalExpectationTest.php
@@ -539,7 +539,7 @@ final readonly class TemporalExpectationTest
     public function temporalBecauseRequiresANonEmptyReason(): void
     {
         $detail = FailureProbe::detailOf(
-            static fn() => Expect::eventually(static fn(): bool => true)->within(0.030)->because('   '),
+            static fn() => Expect::eventually(static fn(): bool => true)->within(0.030)->because('   '), // @phpstan-ignore greenlight.expectationArgument.reason (deliberately invalid: tests runtime validation)
         );
 
         Expect::that($detail->message)->because('temporal because requires a non empty reason')->toBe('because() requires a non-empty reason.');


### PR DESCRIPTION
Reject invalid constant tolerances for toBeWithin() and whitespace-only constant reasons for because(). Document the checks and preserve runtime validation coverage with explained PHPStan suppressions.