### PR TITLE
fix(phpstan): validate attribute contracts

### DIFF
--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -86,7 +86,7 @@ PHPDoc:
 public array $arguments
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataRow.php#L28)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataRow.php#L29)
 
 ### `__construct()`
 
@@ -100,9 +100,10 @@ public function __construct(
 PHPDoc:
 
 - `@param array<mixed> $arguments`
+- `@param non-empty-string|null $label`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataRow.php#L27)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataRow.php#L28)
 
 ## `DataSet`
 
@@ -189,9 +190,10 @@ public function __construct(string $name)
 
 PHPDoc:
 
+- `@param non-empty-string $name`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Group.php#L18)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Group.php#L20)
 
 ## `Isolated`
 
@@ -311,9 +313,10 @@ public function __construct(
 
 PHPDoc:
 
+- `@param class-string<\Throwable>|null $onlyOn`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Retry.php#L28)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Retry.php#L30)
 
 ## `Skip`
 
@@ -346,9 +349,10 @@ public function __construct(string $reason)
 
 PHPDoc:
 
+- `@param non-empty-string $reason`
 - `@throws \InvalidArgumentException If $reason is empty.`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Skip.php#L18)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Skip.php#L20)
 
 ## `SkipUnless`
 
@@ -400,9 +404,10 @@ public function __construct(
 
 PHPDoc:
 
+- `@param class-string<Condition> $condition`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/SkipUnless.php#L30)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/SkipUnless.php#L32)
 
 ## `Test`
 

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -7,6 +7,7 @@ includes:
 parameters:
     level: max
     checkMissingCallableSignature: true
+    treatPhpDocTypesAsCertain: false
     tmpDir: build/cache/phpstan
     exceptions:
         checkedExceptionClasses:

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -48,6 +48,7 @@ parameters:
     excludePaths:
         analyse:
             - tests/Fixture/DataRowsDuplicateInline
+            - tests/Fixture/DataRowsInvalid/EmptyDataRowLabelTest.php
             - tests/Fixture/DiscoveryAttributeArgumentsInvalid
             - tests/Fixture/DiscoveryGroupInvalid
             - tests/Fixture/DiscoveryInvalidMethods

--- a/src/Attribute/DataRow.php
+++ b/src/Attribute/DataRow.php
@@ -29,20 +29,19 @@ final readonly class DataRow
         public array $arguments,
         ?string $label = null,
     ) {
-        $this->label = $this->validatedLabel($label);
+        $this->assertValidLabel($label);
+        $this->label = $label;
     }
 
     /**
-     * @return non-empty-string|null
+     * @phpstan-assert non-empty-string|null $label
      *
      * @throws \InvalidArgumentException
      */
-    private function validatedLabel(?string $label): ?string
+    private function assertValidLabel(?string $label): void
     {
         if ($label === '') {
             throw new \InvalidArgumentException('Data row label must not be empty.');
         }
-
-        return $label;
     }
 }

--- a/src/Attribute/DataRow.php
+++ b/src/Attribute/DataRow.php
@@ -29,19 +29,10 @@ final readonly class DataRow
         public array $arguments,
         ?string $label = null,
     ) {
-        $this->assertValidLabel($label);
-        $this->label = $label;
-    }
-
-    /**
-     * @phpstan-assert non-empty-string|null $label
-     *
-     * @throws \InvalidArgumentException
-     */
-    private function assertValidLabel(?string $label): void
-    {
         if ($label === '') {
             throw new \InvalidArgumentException('Data row label must not be empty.');
         }
+
+        $this->label = $label;
     }
 }

--- a/src/Attribute/DataRow.php
+++ b/src/Attribute/DataRow.php
@@ -21,6 +21,7 @@ final readonly class DataRow
 
     /**
      * @param array<mixed> $arguments
+     * @param non-empty-string|null $label
      *
      * @throws \InvalidArgumentException
      */
@@ -28,10 +29,20 @@ final readonly class DataRow
         public array $arguments,
         ?string $label = null,
     ) {
+        $this->label = $this->validatedLabel($label);
+    }
+
+    /**
+     * @return non-empty-string|null
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function validatedLabel(?string $label): ?string
+    {
         if ($label === '') {
             throw new \InvalidArgumentException('Data row label must not be empty.');
         }
 
-        $this->label = $label;
+        return $label;
     }
 }

--- a/src/Attribute/Group.php
+++ b/src/Attribute/Group.php
@@ -19,20 +19,19 @@ final readonly class Group
      */
     public function __construct(string $name)
     {
-        $this->name = $this->validatedName($name);
+        $this->assertValidName($name);
+        $this->name = $name;
     }
 
     /**
-     * @return non-empty-string
+     * @phpstan-assert non-empty-string $name
      *
      * @throws \InvalidArgumentException
      */
-    private function validatedName(string $name): string
+    private function assertValidName(string $name): void
     {
         if ($name === '') {
             throw new \InvalidArgumentException('Group names cannot be empty.');
         }
-
-        return $name;
     }
 }

--- a/src/Attribute/Group.php
+++ b/src/Attribute/Group.php
@@ -19,19 +19,10 @@ final readonly class Group
      */
     public function __construct(string $name)
     {
-        $this->assertValidName($name);
-        $this->name = $name;
-    }
-
-    /**
-     * @phpstan-assert non-empty-string $name
-     *
-     * @throws \InvalidArgumentException
-     */
-    private function assertValidName(string $name): void
-    {
         if ($name === '') {
             throw new \InvalidArgumentException('Group names cannot be empty.');
         }
+
+        $this->name = $name;
     }
 }

--- a/src/Attribute/Group.php
+++ b/src/Attribute/Group.php
@@ -13,14 +13,26 @@ final readonly class Group
     public string $name;
 
     /**
+     * @param non-empty-string $name
+     *
      * @throws \InvalidArgumentException
      */
     public function __construct(string $name)
+    {
+        $this->name = $this->validatedName($name);
+    }
+
+    /**
+     * @return non-empty-string
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function validatedName(string $name): string
     {
         if ($name === '') {
             throw new \InvalidArgumentException('Group names cannot be empty.');
         }
 
-        $this->name = $name;
+        return $name;
     }
 }

--- a/src/Attribute/Retry.php
+++ b/src/Attribute/Retry.php
@@ -46,10 +46,8 @@ final readonly class Retry
      */
     private function validatedOnlyOn(?string $onlyOn): ?string
     {
-        if ($onlyOn !== null
-            && (!\is_a($onlyOn, \Throwable::class, true) || !new \ReflectionClass($onlyOn)->isInstantiable())
-        ) {
-            throw new \InvalidArgumentException('Retry onlyOn MUST name an instantiable Throwable class.');
+        if ($onlyOn !== null && !\is_a($onlyOn, \Throwable::class, true)) {
+            throw new \InvalidArgumentException('Retry onlyOn MUST name a Throwable type.');
         }
 
         return $onlyOn;

--- a/src/Attribute/Retry.php
+++ b/src/Attribute/Retry.php
@@ -36,20 +36,19 @@ final readonly class Retry
         }
 
         $this->times = $times;
-        $this->onlyOn = $this->validatedOnlyOn($onlyOn);
+        $this->assertValidOnlyOn($onlyOn);
+        $this->onlyOn = $onlyOn;
     }
 
     /**
-     * @return class-string<\Throwable>|null
+     * @phpstan-assert class-string<\Throwable>|null $onlyOn
      *
      * @throws \InvalidArgumentException
      */
-    private function validatedOnlyOn(?string $onlyOn): ?string
+    private function assertValidOnlyOn(?string $onlyOn): void
     {
         if ($onlyOn !== null && !\is_a($onlyOn, \Throwable::class, true)) {
             throw new \InvalidArgumentException('Retry onlyOn MUST name a Throwable type.');
         }
-
-        return $onlyOn;
     }
 }

--- a/src/Attribute/Retry.php
+++ b/src/Attribute/Retry.php
@@ -36,19 +36,11 @@ final readonly class Retry
         }
 
         $this->times = $times;
-        $this->assertValidOnlyOn($onlyOn);
-        $this->onlyOn = $onlyOn;
-    }
 
-    /**
-     * @phpstan-assert class-string<\Throwable>|null $onlyOn
-     *
-     * @throws \InvalidArgumentException
-     */
-    private function assertValidOnlyOn(?string $onlyOn): void
-    {
         if ($onlyOn !== null && !\is_a($onlyOn, \Throwable::class, true)) {
             throw new \InvalidArgumentException('Retry onlyOn MUST name a Throwable type.');
         }
+
+        $this->onlyOn = $onlyOn;
     }
 }

--- a/src/Attribute/Retry.php
+++ b/src/Attribute/Retry.php
@@ -23,6 +23,8 @@ final readonly class Retry
     public ?string $onlyOn;
 
     /**
+     * @param class-string<\Throwable>|null $onlyOn
+     *
      * @throws \InvalidArgumentException
      */
     public function __construct(
@@ -33,11 +35,23 @@ final readonly class Retry
             throw new \InvalidArgumentException('Retry times must be at least 1.');
         }
 
-        if ($onlyOn !== null && !\is_a($onlyOn, \Throwable::class, true)) {
-            throw new \InvalidArgumentException('Retry onlyOn MUST name a Throwable type.');
+        $this->times = $times;
+        $this->onlyOn = $this->validatedOnlyOn($onlyOn);
+    }
+
+    /**
+     * @return class-string<\Throwable>|null
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function validatedOnlyOn(?string $onlyOn): ?string
+    {
+        if ($onlyOn !== null
+            && (!\is_a($onlyOn, \Throwable::class, true) || !new \ReflectionClass($onlyOn)->isInstantiable())
+        ) {
+            throw new \InvalidArgumentException('Retry onlyOn MUST name an instantiable Throwable class.');
         }
 
-        $this->times = $times;
-        $this->onlyOn = $onlyOn;
+        return $onlyOn;
     }
 }

--- a/src/Attribute/Skip.php
+++ b/src/Attribute/Skip.php
@@ -13,14 +13,26 @@ final readonly class Skip
     public string $reason;
 
     /**
+     * @param non-empty-string $reason
+     *
      * @throws \InvalidArgumentException If $reason is empty.
      */
     public function __construct(string $reason)
+    {
+        $this->reason = $this->validatedReason($reason);
+    }
+
+    /**
+     * @return non-empty-string
+     *
+     * @throws \InvalidArgumentException If $reason is empty.
+     */
+    private function validatedReason(string $reason): string
     {
         if ($reason === '') {
             throw new \InvalidArgumentException('Skip reasons cannot be empty.');
         }
 
-        $this->reason = $reason;
+        return $reason;
     }
 }

--- a/src/Attribute/Skip.php
+++ b/src/Attribute/Skip.php
@@ -19,20 +19,19 @@ final readonly class Skip
      */
     public function __construct(string $reason)
     {
-        $this->reason = $this->validatedReason($reason);
+        $this->assertValidReason($reason);
+        $this->reason = $reason;
     }
 
     /**
-     * @return non-empty-string
+     * @phpstan-assert non-empty-string $reason
      *
      * @throws \InvalidArgumentException If $reason is empty.
      */
-    private function validatedReason(string $reason): string
+    private function assertValidReason(string $reason): void
     {
         if ($reason === '') {
             throw new \InvalidArgumentException('Skip reasons cannot be empty.');
         }
-
-        return $reason;
     }
 }

--- a/src/Attribute/Skip.php
+++ b/src/Attribute/Skip.php
@@ -19,19 +19,10 @@ final readonly class Skip
      */
     public function __construct(string $reason)
     {
-        $this->assertValidReason($reason);
-        $this->reason = $reason;
-    }
-
-    /**
-     * @phpstan-assert non-empty-string $reason
-     *
-     * @throws \InvalidArgumentException If $reason is empty.
-     */
-    private function assertValidReason(string $reason): void
-    {
         if ($reason === '') {
             throw new \InvalidArgumentException('Skip reasons cannot be empty.');
         }
+
+        $this->reason = $reason;
     }
 }

--- a/src/Attribute/SkipUnless.php
+++ b/src/Attribute/SkipUnless.php
@@ -33,25 +33,6 @@ final readonly class SkipUnless
         string $condition,
         mixed ...$arguments,
     ) {
-        $this->assertValidCondition($condition);
-        $this->condition = $condition;
-
-        foreach ($arguments as $argument) {
-            if (\is_float($argument) && !\is_finite($argument)) {
-                throw new \InvalidArgumentException('SkipUnless arguments MUST use finite floats.');
-            }
-        }
-
-        $this->arguments = \array_values($arguments);
-    }
-
-    /**
-     * @phpstan-assert class-string<Condition> $condition
-     *
-     * @throws \InvalidArgumentException
-     */
-    private function assertValidCondition(string $condition): void
-    {
         if (!\is_a($condition, Condition::class, true)) {
             throw new \InvalidArgumentException(
                 'SkipUnless condition MUST name an instantiable Condition class.',
@@ -65,5 +46,15 @@ final readonly class SkipUnless
                 'SkipUnless condition MUST name an instantiable Condition class.',
             );
         }
+
+        $this->condition = $condition;
+
+        foreach ($arguments as $argument) {
+            if (\is_float($argument) && !\is_finite($argument)) {
+                throw new \InvalidArgumentException('SkipUnless arguments MUST use finite floats.');
+            }
+        }
+
+        $this->arguments = \array_values($arguments);
     }
 }

--- a/src/Attribute/SkipUnless.php
+++ b/src/Attribute/SkipUnless.php
@@ -25,12 +25,32 @@ final readonly class SkipUnless
     public array $arguments;
 
     /**
+     * @param class-string<Condition> $condition
+     *
      * @throws \InvalidArgumentException
      */
     public function __construct(
         string $condition,
         mixed ...$arguments,
     ) {
+        $this->condition = $this->validatedCondition($condition);
+
+        foreach ($arguments as $argument) {
+            if (\is_float($argument) && !\is_finite($argument)) {
+                throw new \InvalidArgumentException('SkipUnless arguments MUST use finite floats.');
+            }
+        }
+
+        $this->arguments = \array_values($arguments);
+    }
+
+    /**
+     * @return class-string<Condition>
+     *
+     * @throws \InvalidArgumentException
+     */
+    private function validatedCondition(string $condition): string
+    {
         if (!\is_a($condition, Condition::class, true)) {
             throw new \InvalidArgumentException(
                 'SkipUnless condition MUST name an instantiable Condition class.',
@@ -45,13 +65,6 @@ final readonly class SkipUnless
             );
         }
 
-        foreach ($arguments as $argument) {
-            if (\is_float($argument) && !\is_finite($argument)) {
-                throw new \InvalidArgumentException('SkipUnless arguments MUST use finite floats.');
-            }
-        }
-
-        $this->condition = $condition;
-        $this->arguments = \array_values($arguments);
+        return $condition;
     }
 }

--- a/src/Attribute/SkipUnless.php
+++ b/src/Attribute/SkipUnless.php
@@ -33,7 +33,8 @@ final readonly class SkipUnless
         string $condition,
         mixed ...$arguments,
     ) {
-        $this->condition = $this->validatedCondition($condition);
+        $this->assertValidCondition($condition);
+        $this->condition = $condition;
 
         foreach ($arguments as $argument) {
             if (\is_float($argument) && !\is_finite($argument)) {
@@ -45,11 +46,11 @@ final readonly class SkipUnless
     }
 
     /**
-     * @return class-string<Condition>
+     * @phpstan-assert class-string<Condition> $condition
      *
      * @throws \InvalidArgumentException
      */
-    private function validatedCondition(string $condition): string
+    private function assertValidCondition(string $condition): void
     {
         if (!\is_a($condition, Condition::class, true)) {
             throw new \InvalidArgumentException(
@@ -64,7 +65,5 @@ final readonly class SkipUnless
                 'SkipUnless condition MUST name an instantiable Condition class.',
             );
         }
-
-        return $condition;
     }
 }

--- a/src/PhpStan/AttributeArgumentRule.php
+++ b/src/PhpStan/AttributeArgumentRule.php
@@ -4,17 +4,23 @@ declare(strict_types=1);
 
 namespace Greenlight\PhpStan;
 
+use Greenlight\Attribute\DataRow;
+use Greenlight\Attribute\Group;
 use Greenlight\Attribute\RequiresResource;
 use Greenlight\Attribute\Retry;
+use Greenlight\Attribute\Skip;
 use Greenlight\Attribute\SkipUnless;
 use Greenlight\Attribute\Timeout;
+use Greenlight\Core\Condition;
 use Greenlight\Core\Test\ResourceName;
 use PhpParser\Node;
 use PhpParser\Node\Attribute;
 use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\ReflectionProvider;
 use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
 
 /**
  * Validates constant attribute values whose domains PHP types cannot express.
@@ -23,8 +29,10 @@ use PHPStan\Rules\RuleErrorBuilder;
  *
  * @implements Rule<Attribute>
  */
-final class AttributeArgumentRule implements Rule
+final readonly class AttributeArgumentRule implements Rule
 {
+    public function __construct(private ReflectionProvider $reflectionProvider) {}
+
     #[\Override]
     public function getNodeType(): string
     {
@@ -50,6 +58,18 @@ final class AttributeArgumentRule implements Rule
 
         if ($name === RequiresResource::class) {
             return $this->checkResource($node, $scope);
+        }
+
+        if ($name === Group::class) {
+            return $this->checkNonEmptyString($node, $scope, 0, 'name', 'Group', 'group');
+        }
+
+        if ($name === Skip::class) {
+            return $this->checkNonEmptyString($node, $scope, 0, 'reason', 'Skip', 'skip');
+        }
+
+        if ($name === DataRow::class) {
+            return $this->checkNonEmptyString($node, $scope, 1, 'label', 'DataRow', 'dataRow');
         }
 
         return [];
@@ -90,23 +110,35 @@ final class AttributeArgumentRule implements Rule
      */
     private function checkRetry(Attribute $attribute, Scope $scope): array
     {
-        $argument = $this->argument($attribute, 0, 'times');
+        $errors = [];
+        $times = $this->argument($attribute, 0, 'times');
 
-        if (!$argument instanceof Node\Expr) {
-            return [];
+        if ($times instanceof Node\Expr) {
+            $values = $scope->getType($times)->getConstantScalarValues();
+
+            if (\count($values) === 1 && \is_int($values[0]) && $values[0] < 1) {
+                $errors[] = $this->error(
+                    '#[Retry] times must be at least 1.',
+                    'retry',
+                    $attribute->getStartLine(),
+                );
+            }
         }
 
-        $values = $scope->getType($argument)->getConstantScalarValues();
+        $onlyOn = $this->argument($attribute, 1, 'onlyOn');
 
-        if (\count($values) !== 1 || !\is_int($values[0]) || $values[0] > 0) {
-            return [];
+        if ($onlyOn instanceof Node\Expr
+            && !$scope->getType($onlyOn)->isNull()->yes()
+            && !$this->isInstantiableClass($onlyOn, $scope, \Throwable::class)
+        ) {
+            $errors[] = $this->error(
+                '#[Retry] onlyOn must name an instantiable Throwable class.',
+                'retry',
+                $onlyOn->getStartLine(),
+            );
         }
 
-        return [$this->error(
-            '#[Retry] times must be at least 1.',
-            'retry',
-            $attribute->getStartLine(),
-        )];
+        return $errors;
     }
 
     /**
@@ -115,6 +147,18 @@ final class AttributeArgumentRule implements Rule
     private function checkSkipUnless(Attribute $attribute, Scope $scope): array
     {
         $errors = [];
+        $condition = $this->argument($attribute, 0, 'condition');
+
+        if ($condition instanceof Node\Expr
+            && !$this->isInstantiableClass($condition, $scope, Condition::class)
+        ) {
+            $errors[] = $this->error(
+                '#[SkipUnless] condition must name an instantiable Condition class.',
+                'skipUnless',
+                $condition->getStartLine(),
+            );
+        }
+
         $conditionArgumentNumber = 0;
 
         foreach ($attribute->args as $index => $argument) {
@@ -153,6 +197,57 @@ final class AttributeArgumentRule implements Rule
         }
 
         return $errors;
+    }
+
+    /**
+     * @param class-string $parent
+     */
+    private function isInstantiableClass(Node\Expr $argument, Scope $scope, string $parent): bool
+    {
+        $classes = $scope->getType($argument)->getConstantStrings();
+
+        if (\count($classes) !== 1) {
+            return true;
+        }
+
+        $class = $classes[0]->getValue();
+
+        if (!$this->reflectionProvider->hasClass($class)) {
+            return false;
+        }
+
+        return new ObjectType($parent)->isSuperTypeOf(new ObjectType($class))->yes()
+            && $this->reflectionProvider->getClass($class)->getNativeReflection()->isInstantiable();
+    }
+
+    /**
+     * @return list<IdentifierRuleError>
+     */
+    private function checkNonEmptyString(
+        Attribute $attribute,
+        Scope $scope,
+        int $position,
+        string $name,
+        string $displayName,
+        string $identifier,
+    ): array {
+        $argument = $this->argument($attribute, $position, $name);
+
+        if (!$argument instanceof Node\Expr) {
+            return [];
+        }
+
+        $strings = $scope->getType($argument)->getConstantStrings();
+
+        if (\count($strings) !== 1 || $strings[0]->getValue() !== '') {
+            return [];
+        }
+
+        return [$this->error(
+            \sprintf('#[%s] %s must not be empty.', $displayName, $name),
+            $identifier,
+            $argument->getStartLine(),
+        )];
     }
 
     /**

--- a/src/PhpStan/AttributeArgumentRule.php
+++ b/src/PhpStan/AttributeArgumentRule.php
@@ -129,10 +129,10 @@ final readonly class AttributeArgumentRule implements Rule
 
         if ($onlyOn instanceof Node\Expr
             && !$scope->getType($onlyOn)->isNull()->yes()
-            && !$this->isInstantiableClass($onlyOn, $scope, \Throwable::class)
+            && !$this->isClass($onlyOn, $scope, \Throwable::class)
         ) {
             $errors[] = $this->error(
-                '#[Retry] onlyOn must name an instantiable Throwable class.',
+                '#[Retry] onlyOn must name a Throwable type.',
                 'retry',
                 $onlyOn->getStartLine(),
             );
@@ -212,12 +212,28 @@ final readonly class AttributeArgumentRule implements Rule
 
         $class = $classes[0]->getValue();
 
-        if (!$this->reflectionProvider->hasClass($class)) {
+        if (!$this->isClass($argument, $scope, $parent)) {
             return false;
         }
 
-        return new ObjectType($parent)->isSuperTypeOf(new ObjectType($class))->yes()
-            && $this->reflectionProvider->getClass($class)->getNativeReflection()->isInstantiable();
+        return $this->reflectionProvider->getClass($class)->getNativeReflection()->isInstantiable();
+    }
+
+    /**
+     * @param class-string $parent
+     */
+    private function isClass(Node\Expr $argument, Scope $scope, string $parent): bool
+    {
+        $classes = $scope->getType($argument)->getConstantStrings();
+
+        if (\count($classes) !== 1) {
+            return true;
+        }
+
+        $class = $classes[0]->getValue();
+
+        return $this->reflectionProvider->hasClass($class)
+            && new ObjectType($parent)->isSuperTypeOf(new ObjectType($class))->yes();
     }
 
     /**

--- a/tests/Acceptance/PhpStanAttributeArgumentRuleTest.php
+++ b/tests/Acceptance/PhpStanAttributeArgumentRuleTest.php
@@ -27,17 +27,28 @@ final readonly class PhpStanAttributeArgumentRuleTest
 
             namespace GreenlightAttributeArgumentProbe;
 
+            use Greenlight\Attribute\DataRow;
+            use Greenlight\Attribute\Group;
             use Greenlight\Attribute\RequiresResource;
             use Greenlight\Attribute\Retry;
+            use Greenlight\Attribute\Skip;
             use Greenlight\Attribute\SkipUnless;
+            use Greenlight\Attribute\Test;
             use Greenlight\Attribute\Timeout;
             use Greenlight\Condition\EnvironmentVariableEquals;
 
+            #[Group('analysis')]
             #[RequiresResource('postgres.primary')]
-            #[Retry(1)]
+            #[Retry(1, \RuntimeException::class)]
+            #[Skip('not applicable in the probe')]
             #[SkipUnless(EnvironmentVariableEquals::class, 'APP_ENV', 'test')]
             #[Timeout(0.5)]
-            final class GoodAttributeArgumentProbe {}
+            final class GoodAttributeArgumentProbe
+            {
+                #[Test]
+                #[DataRow([], label: null)]
+                public function acceptsAnUnlabeledDataRow(): void {}
+            }
             PHP,
             <<<'PHP'
             <?php
@@ -46,12 +57,20 @@ final readonly class PhpStanAttributeArgumentRuleTest
 
             namespace GreenlightAttributeArgumentProbe;
 
+            use Greenlight\Attribute\DataRow;
+            use Greenlight\Attribute\Group;
             use Greenlight\Attribute\RequiresResource;
             use Greenlight\Attribute\Retry;
+            use Greenlight\Attribute\Skip;
             use Greenlight\Attribute\SkipUnless;
+            use Greenlight\Attribute\Test;
             use Greenlight\Attribute\Timeout;
             use Greenlight\Condition\EnvironmentVariableSet;
             use Greenlight\Core\Condition;
+
+            abstract class AbstractRetryFailure extends \RuntimeException {}
+
+            abstract class AbstractCondition implements Condition {}
 
             final readonly class FloatCondition implements Condition
             {
@@ -79,17 +98,45 @@ final readonly class PhpStanAttributeArgumentRuleTest
 
             #[SkipUnless(FloatCondition::class, 1.0e1000)]
             final class BadNonFiniteSkipUnlessArgumentProbe {}
+
+            #[Retry(1, \stdClass::class)]
+            final class BadRetryTypeProbe {}
+
+            #[Retry(1, AbstractRetryFailure::class)]
+            final class BadAbstractRetryTypeProbe {}
+
+            #[SkipUnless(\stdClass::class)]
+            final class BadConditionTypeProbe {}
+
+            #[SkipUnless(AbstractCondition::class)]
+            final class BadAbstractConditionProbe {}
+
+            #[Group('')]
+            #[Skip('')]
+            final class BadEmptyStringAttributeProbe {}
+
+            final class BadEmptyDataRowLabelProbe
+            {
+                #[Test]
+                #[DataRow([], '')]
+                public function hasAnEmptyLabel(): void {}
+            }
             PHP,
         );
 
         Expect::that($probe->exitCode)->because('attribute arguments must have valid values')->toBe(1);
         Expect::that($probe->goodPassed)->toBeTrue();
-        Expect::that(\count($probe->errors))->toBe(9);
+        Expect::that(\count($probe->errors))->toBeGreaterThan(9);
         Expect::that($probe->messages())->toContain('#[RequiresResource] name "Postgres primary" does not match')
             ->toContain('#[Retry] times must be at least 1')
+            ->toContain('#[Retry] onlyOn must name an instantiable Throwable class')
+            ->toContain('#[SkipUnless] condition must name an instantiable Condition class')
             ->toContain('#[SkipUnless] argument 1 must be a scalar or null')
             ->toContain('#[SkipUnless] argument 1 must be a finite float')
             ->not()->toContain('#[SkipUnless] argument 0')
+            ->toContain('#[Group] name must not be empty')
+            ->toContain('#[Skip] reason must not be empty')
+            ->toContain('#[DataRow] label must not be empty')
             ->toContain('#[Timeout] seconds must be finite and greater than zero');
     }
 }

--- a/tests/Acceptance/PhpStanAttributeArgumentRuleTest.php
+++ b/tests/Acceptance/PhpStanAttributeArgumentRuleTest.php
@@ -37,6 +37,8 @@ final readonly class PhpStanAttributeArgumentRuleTest
             use Greenlight\Attribute\Timeout;
             use Greenlight\Condition\EnvironmentVariableEquals;
 
+            abstract class GoodAbstractRetryFailure extends \RuntimeException {}
+
             #[Group('analysis')]
             #[RequiresResource('postgres.primary')]
             #[Retry(1, \RuntimeException::class)]
@@ -49,6 +51,12 @@ final readonly class PhpStanAttributeArgumentRuleTest
                 #[DataRow([], label: null)]
                 public function acceptsAnUnlabeledDataRow(): void {}
             }
+
+            #[Retry(1, \Throwable::class)]
+            final class GoodThrowableInterfaceRetryProbe {}
+
+            #[Retry(1, GoodAbstractRetryFailure::class)]
+            final class GoodAbstractRetryProbe {}
             PHP,
             <<<'PHP'
             <?php
@@ -67,8 +75,6 @@ final readonly class PhpStanAttributeArgumentRuleTest
             use Greenlight\Attribute\Timeout;
             use Greenlight\Condition\EnvironmentVariableSet;
             use Greenlight\Core\Condition;
-
-            abstract class AbstractRetryFailure extends \RuntimeException {}
 
             abstract class AbstractCondition implements Condition {}
 
@@ -102,9 +108,6 @@ final readonly class PhpStanAttributeArgumentRuleTest
             #[Retry(1, \stdClass::class)]
             final class BadRetryTypeProbe {}
 
-            #[Retry(1, AbstractRetryFailure::class)]
-            final class BadAbstractRetryTypeProbe {}
-
             #[SkipUnless(\stdClass::class)]
             final class BadConditionTypeProbe {}
 
@@ -126,10 +129,10 @@ final readonly class PhpStanAttributeArgumentRuleTest
 
         Expect::that($probe->exitCode)->because('attribute arguments must have valid values')->toBe(1);
         Expect::that($probe->goodPassed)->toBeTrue();
-        Expect::that(\count($probe->errors))->toBeGreaterThan(9);
+        Expect::that(\count($probe->errors))->toBe(20);
         Expect::that($probe->messages())->toContain('#[RequiresResource] name "Postgres primary" does not match')
             ->toContain('#[Retry] times must be at least 1')
-            ->toContain('#[Retry] onlyOn must name an instantiable Throwable class')
+            ->toContain('#[Retry] onlyOn must name a Throwable type')
             ->toContain('#[SkipUnless] condition must name an instantiable Condition class')
             ->toContain('#[SkipUnless] argument 1 must be a scalar or null')
             ->toContain('#[SkipUnless] argument 1 must be a finite float')

--- a/tests/Unit/Attribute/AttributeContractTest.php
+++ b/tests/Unit/Attribute/AttributeContractTest.php
@@ -25,7 +25,7 @@ final class AttributeContractTest
     #[Test]
     public function skipRejectsAnEmptyReason(): void
     {
-        Expect::that(static fn(): Skip => new Skip(''))
+        Expect::that(static fn(): object => new \ReflectionClass(Skip::class)->newInstance(''))
             ->because('skip reasons cannot be empty')
             ->toThrow(\InvalidArgumentException::class, message: 'Skip reasons cannot be empty.');
     }
@@ -98,7 +98,7 @@ final class AttributeContractTest
     #[Test]
     public function groupRejectsAnEmptyName(): void
     {
-        Expect::that(static fn(): Group => new Group(''))
+        Expect::that(static fn(): object => new \ReflectionClass(Group::class)->newInstance(''))
             ->because('group names cannot be empty')
             ->toThrow(\InvalidArgumentException::class, message: 'Group names cannot be empty.');
     }

--- a/tests/Unit/Attribute/RetryTest.php
+++ b/tests/Unit/Attribute/RetryTest.php
@@ -12,16 +12,14 @@ use Greenlight\Expect\Expect;
 final class RetryTest
 {
     #[Test]
-    public function abstractThrowableTypesAreRejected(): void
+    public function throwableFiltersDoNotNeedToBeInstantiable(): void
     {
-        Expect::that(
-            static fn(): object => new \ReflectionClass(Retry::class)->newInstance(1, AbstractRetryFailure::class),
-        )
-            ->because('a retry filter MUST name an instantiable Throwable class')
-            ->toThrow(
-                \InvalidArgumentException::class,
-                message: 'Retry onlyOn MUST name an instantiable Throwable class.',
-            );
+        Expect::that(new Retry(1, \Throwable::class)->onlyOn)
+            ->because('the Throwable interface is a valid retry type filter')
+            ->toBe(\Throwable::class);
+        Expect::that(new Retry(1, AbstractRetryFailure::class)->onlyOn)
+            ->because('an abstract throwable is a valid retry type filter')
+            ->toBe(AbstractRetryFailure::class);
     }
 
     #[Test]
@@ -31,10 +29,10 @@ final class RetryTest
         Expect::that(
             static fn(): object => new \ReflectionClass(Retry::class)->newInstance(1, $onlyOn),
         )
-            ->because('a retry filter MUST name an instantiable Throwable class')
+            ->because('a retry filter MUST name a Throwable type')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Retry onlyOn MUST name an instantiable Throwable class.',
+                message: 'Retry onlyOn MUST name a Throwable type.',
             );
     }
 

--- a/tests/Unit/Attribute/RetryTest.php
+++ b/tests/Unit/Attribute/RetryTest.php
@@ -12,16 +12,29 @@ use Greenlight\Expect\Expect;
 final class RetryTest
 {
     #[Test]
+    public function abstractThrowableTypesAreRejected(): void
+    {
+        Expect::that(
+            static fn(): object => new \ReflectionClass(Retry::class)->newInstance(1, AbstractRetryFailure::class),
+        )
+            ->because('a retry filter MUST name an instantiable Throwable class')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Retry onlyOn MUST name an instantiable Throwable class.',
+            );
+    }
+
+    #[Test]
     #[DataSet('invalidThrowableTypes')]
     public function invalidThrowableTypesAreRejected(string $onlyOn): void
     {
         Expect::that(
-            static fn(): Retry => new Retry(1, onlyOn: $onlyOn),
+            static fn(): object => new \ReflectionClass(Retry::class)->newInstance(1, $onlyOn),
         )
-            ->because('a retry filter MUST name a Throwable type')
+            ->because('a retry filter MUST name an instantiable Throwable class')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Retry onlyOn MUST name a Throwable type.',
+                message: 'Retry onlyOn MUST name an instantiable Throwable class.',
             );
     }
 
@@ -37,3 +50,5 @@ final class RetryTest
         yield 'unknown class' => ['Example\MissingThrowable'];
     }
 }
+
+abstract class AbstractRetryFailure extends \Exception {}

--- a/tests/Unit/Attribute/SkipUnlessTest.php
+++ b/tests/Unit/Attribute/SkipUnlessTest.php
@@ -18,7 +18,7 @@ final class SkipUnlessTest
     public function invalidConditionClassesAreRejected(string $condition): void
     {
         Expect::that(
-            static fn(): SkipUnless => new SkipUnless($condition),
+            static fn(): object => new \ReflectionClass(SkipUnless::class)->newInstance($condition),
         )
             ->because('a skip condition MUST name an instantiable Condition class')
             ->toThrow(


### PR DESCRIPTION
## Summary

- validate constant arguments for Retry, SkipUnless, Group, Skip, and DataRow attributes during PHPStan analysis
- align the runtime constructors with their refined PHPDoc contracts through inline validation
- accept any Throwable type for Retry filters and require an instantiable Condition for SkipUnless
- set treatPhpDocTypesAsCertain to false so library analysis checks defensive validation without weakening consumer call-site contracts