### PR TITLE
docs(data-set): explain provider purity contract

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -104,8 +104,10 @@ or:
 
 The provider must return an iterable of named data sets for the test method.
 
-Providers run at discovery time before tests execute. Do not use I/O or global
-state in a provider.
+Greenlight invokes each provider when it creates the execution plan and again
+when a worker resolves the planned data-set key. A provider MUST return the
+same data each time and MUST NOT change external state. Do not use I/O or
+global state in a provider.
 
 Each provider key names a data set and appears in test IDs and reports. Each
 provider value is the argument list for one test invocation.

--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -330,6 +330,11 @@ first, PHPStan reports a broken provider before a test can report the error:
 * Constant inline row labels must be unique. An explicit label must not
   duplicate a generated positional label such as `#0`.
 
+Provider purity is a Greenlight runtime contract. The Greenlight PHPStan
+extension validates provider signatures and row shapes, but it does not
+enforce this contract. Add `@phpstan-pure` to report operations that PHPStan
+knows are impure.
+
 <!-- php-example {"mode":"display","reason":"Uses an ellipsis to omit code that is not relevant to the example."} -->
 ```php
 #[Test]


### PR DESCRIPTION
## Summary

- explain that Greenlight invokes data providers during planning and again in workers
- require providers to return the same data and avoid changes to external state
- keep the existing DataSet public API purity contract unchanged
- document that the PHPStan extension checks provider signatures and row shapes, while @phpstan-pure can report known impure operations