### PR TITLE
fix(phpstan): enforce extension matcher contracts

### DIFF
--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -209,8 +209,8 @@ Expect::eventually(fn(): string => $hash)
     ->toHaveDigestLength(6);
 ```
 
-If configuration files register one matcher name with different signatures,
-analysis fails. PHPStan does not select one signature.
+If configuration files register one matcher name with different parameter or
+return types, analysis fails. PHPStan does not select one signature.
 
 Subject-type errors use the `greenlight.extensionMatcher.subjectType`
 identifier. Return-type errors use the

--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -163,6 +163,9 @@ signatures from `__call()`. The extension loads your configuration files in the
 same way as workers. It reflects each matcher closure and checks calls against
 the real signature.
 
+The declared closure return type must be compatible with `bool`. PHPStan leaves
+an absent or `mixed` return type unresolved.
+
 For example, use a plugin with these matchers:
 
 <!-- php-example {"example":"phpstan-example-05","file":"snippet.php","mode":"file","tools":["rector"]} -->
@@ -210,7 +213,9 @@ If configuration files register one matcher name with different signatures,
 analysis fails. PHPStan does not select one signature.
 
 Subject-type errors use the `greenlight.extensionMatcher.subjectType`
-identifier. Matcher argument errors keep the PHPStan error identifier.
+identifier. Return-type errors use the
+`greenlight.extensionMatcher.returnType` identifier. Matcher argument errors
+keep the PHPStan error identifier.
 
 To give an IDE the same signatures, generate the helper file:
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -436,6 +436,10 @@ Declare matcher parameters with normal native PHP types. PHP enforces these
 types at run time. Greenlight's PHPStan extension reads them for static
 analysis.
 
+Declare `bool` as the matcher return type. An absent or `mixed` return type
+remains unresolved. PHPStan reports other declared types when code calls the
+matcher.
+
 #### PHPStan support for extension matchers
 
 The expectation chain sends matcher calls through `__call`. PHPStan cannot
@@ -446,8 +450,8 @@ Greenlight configuration files in the same way as workers. It reflects each
 matcher closure and exposes each matcher as a real expectation-chain method.
 This support includes `eventually()` and `consistently()` chains.
 
-Typos, incorrect argument counts, and incorrect argument types then cause a
-normal `phpstan analyse` error.
+Typos, incorrect argument counts, incorrect argument types, and incompatible
+return types then cause a normal `phpstan analyse` error.
 
 ```neon
 includes:

--- a/extension.neon
+++ b/extension.neon
@@ -53,3 +53,9 @@ services:
             matcherMap: @greenlight.matcherMapProvider
         tags:
             - phpstan.rules.rule
+    greenlight.extensionMatcherReturnRule:
+        class: Greenlight\PhpStan\ExtensionMatcherReturnRule
+        arguments:
+            matcherMap: @greenlight.matcherMapProvider
+        tags:
+            - phpstan.rules.rule

--- a/src/PhpStan/ExtensionMatcherParameter.php
+++ b/src/PhpStan/ExtensionMatcherParameter.php
@@ -28,7 +28,7 @@ final readonly class ExtensionMatcherParameter implements ParameterReflection
     #[\Override]
     public function getType(): Type
     {
-        return NativeType::fromReflection($this->parameter->getType());
+        return NativeType::fromParameter($this->parameter);
     }
 
     #[\Override]

--- a/src/PhpStan/ExtensionMatcherReturnRule.php
+++ b/src/PhpStan/ExtensionMatcherReturnRule.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\PhpStan;
+
+use Greenlight\Config\ConfigFileError;
+use Greenlight\Config\InvalidConfiguration;
+use Greenlight\Expect\Expectation;
+use Greenlight\Expect\TemporalExpectation;
+use PhpParser\Node;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+use PHPStan\Analyser\Scope;
+use PHPStan\Rules\IdentifierRuleError;
+use PHPStan\Rules\Rule;
+use PHPStan\Rules\RuleErrorBuilder;
+use PHPStan\Type\ObjectType;
+
+/**
+ * Checks that an extension matcher has a boolean return type.
+ *
+ * @internal
+ *
+ * @implements Rule<MethodCall>
+ */
+final readonly class ExtensionMatcherReturnRule implements Rule
+{
+    public function __construct(private MatcherMapProvider $matcherMap) {}
+
+    #[\Override]
+    public function getNodeType(): string
+    {
+        return MethodCall::class;
+    }
+
+    /**
+     * @throws ConfigFileError
+     * @throws InvalidConfiguration
+     * @throws MatcherMapError
+     */
+    #[\Override]
+    public function processNode(Node $node, Scope $scope): array
+    {
+        if (!$node->name instanceof Identifier) {
+            return [];
+        }
+
+        $name = $node->name->toString();
+        $map = $this->matcherMap->get();
+
+        if (!$map->has($name) || !$this->isExpectation($scope, $node)) {
+            return [];
+        }
+
+        $returnType = $map->returnType($name);
+
+        if (!$returnType instanceof \ReflectionType || self::isCompatibleReturn($returnType)) {
+            return [];
+        }
+
+        return [$this->error($name, MatcherMap::typeName($returnType), $node->getStartLine())];
+    }
+
+    private static function isCompatibleReturn(\ReflectionType $type): bool
+    {
+        if ($type instanceof \ReflectionUnionType || $type instanceof \ReflectionIntersectionType) {
+            return \array_all($type->getTypes(), self::isCompatibleReturn(...));
+        }
+
+        return $type instanceof \ReflectionNamedType
+            && \in_array($type->getName(), ['bool', 'true', 'false', 'mixed', 'never'], true)
+            && (!$type->allowsNull() || $type->getName() === 'mixed');
+    }
+
+    private function isExpectation(Scope $scope, MethodCall $call): bool
+    {
+        $receiver = $scope->getType($call->var);
+
+        return new ObjectType(Expectation::class)->isSuperTypeOf($receiver)->yes()
+            || new ObjectType(TemporalExpectation::class)->isSuperTypeOf($receiver)->yes();
+    }
+
+    private function error(string $matcher, string $returnType, int $line): IdentifierRuleError
+    {
+        return RuleErrorBuilder::message(\sprintf(
+            'Extension matcher %s() must return bool, but its declared return type is %s.',
+            $matcher,
+            $returnType,
+        ))
+            ->identifier('greenlight.extensionMatcher.returnType')
+            ->line($line)
+            ->build();
+    }
+}

--- a/src/PhpStan/ExtensionMatcherSubjectRule.php
+++ b/src/PhpStan/ExtensionMatcherSubjectRule.php
@@ -65,7 +65,9 @@ final readonly class ExtensionMatcherSubjectRule implements Rule
         }
 
         $subjectParameter = $map->subjectParameter($name);
-        $accepted = NativeType::fromReflection($subjectParameter?->getType());
+        $accepted = $subjectParameter instanceof \ReflectionParameter
+            ? NativeType::fromParameter($subjectParameter)
+            : new MixedType();
 
         if ($accepted instanceof MixedType || !$accepted->accepts($subject, $scope->isDeclareStrictTypes())->no()) {
             return [];

--- a/src/PhpStan/MatcherMap.php
+++ b/src/PhpStan/MatcherMap.php
@@ -126,6 +126,14 @@ final readonly class MatcherMap
         return '(' . \implode(', ', $parts) . ')';
     }
 
+    /**
+     * Returns the declared matcher return type. An absent type remains unresolved.
+     */
+    public function returnType(string $name): ?\ReflectionType
+    {
+        return $this->matcher($name)->getReturnType();
+    }
+
     private function matcher(string $name): \ReflectionFunction
     {
         if (!isset($this->matchers[$name])) {
@@ -144,7 +152,7 @@ final readonly class MatcherMap
     {
         return \sprintf(
             '%s %s$%s%s',
-            self::typeName($parameter->getType()),
+            self::typeName($parameter->getType(), self::scopeClass($parameter->getDeclaringFunction())),
             $parameter->isVariadic() ? '...' : '',
             $parameter->getName(),
             !$parameter->isVariadic() && $parameter->isOptional() ? ' = ' . $defaultPlaceholder : '',
@@ -155,20 +163,25 @@ final readonly class MatcherMap
      * Renders a native reflection type in source-code form.
      *
      * Signature comparison and generated @method annotations use this form.
+     *
+     * @param ?\ReflectionClass<object> $scopeClass
      */
-    public static function typeName(?\ReflectionType $type): string
+    public static function typeName(?\ReflectionType $type, ?\ReflectionClass $scopeClass = null): string
     {
         if ($type instanceof \ReflectionUnionType) {
             return \implode('|', \array_map(
                 static fn(\ReflectionType $member): string => $member instanceof \ReflectionIntersectionType
-                    ? '(' . self::typeName($member) . ')'
-                    : self::typeName($member),
+                    ? '(' . self::typeName($member, $scopeClass) . ')'
+                    : self::typeName($member, $scopeClass),
                 $type->getTypes(),
             ));
         }
 
         if ($type instanceof \ReflectionIntersectionType) {
-            return \implode('&', \array_map(self::typeName(...), $type->getTypes()));
+            return \implode('&', \array_map(
+                static fn(\ReflectionType $member): string => self::typeName($member, $scopeClass),
+                $type->getTypes(),
+            ));
         }
 
         if (!$type instanceof \ReflectionNamedType) {
@@ -177,6 +190,31 @@ final readonly class MatcherMap
 
         $nullable = $type->allowsNull() && !\in_array($type->getName(), ['mixed', 'null'], true);
 
-        return ($nullable ? '?' : '') . $type->getName();
+        return ($nullable ? '?' : '') . self::resolvedTypeName($type->getName(), $scopeClass);
+    }
+
+    /** @param ?\ReflectionClass<object> $scopeClass */
+    private static function resolvedTypeName(string $name, ?\ReflectionClass $scopeClass): string
+    {
+        if (!\in_array($name, ['self', 'static', 'parent'], true) || !$scopeClass instanceof \ReflectionClass) {
+            return $name;
+        }
+
+        if ($name === 'parent') {
+            $parentClass = $scopeClass->getParentClass();
+            $scopeClass = $parentClass === false ? null : $parentClass;
+        }
+
+        return $scopeClass instanceof \ReflectionClass
+            ? '\\' . $scopeClass->getName()
+            : 'mixed';
+    }
+
+    /** @return ?\ReflectionClass<object> */
+    private static function scopeClass(\ReflectionFunctionAbstract $function): ?\ReflectionClass
+    {
+        return $function instanceof \ReflectionMethod
+            ? $function->getDeclaringClass()
+            : $function->getClosureScopeClass();
     }
 }

--- a/src/PhpStan/MatcherMap.php
+++ b/src/PhpStan/MatcherMap.php
@@ -123,7 +123,11 @@ final readonly class MatcherMap
             $matcher->getParameters(),
         );
 
-        return '(' . \implode(', ', $parts) . ')';
+        return \sprintf(
+            '(%s): %s',
+            \implode(', ', $parts),
+            self::typeName($matcher->getReturnType(), self::scopeClass($matcher)),
+        );
     }
 
     /**

--- a/src/PhpStan/NativeType.php
+++ b/src/PhpStan/NativeType.php
@@ -32,21 +32,28 @@ final class NativeType
     #[CoverageIgnore]
     private function __construct() {}
 
-    public static function fromReflection(?\ReflectionType $type): Type
+    /** @param ?\ReflectionClass<object> $scopeClass */
+    public static function fromReflection(?\ReflectionType $type, ?\ReflectionClass $scopeClass = null): Type
     {
         if ($type instanceof \ReflectionUnionType) {
-            return TypeCombinator::union(...\array_map(self::fromReflection(...), $type->getTypes()));
+            return TypeCombinator::union(...\array_map(
+                static fn(\ReflectionType $member): Type => self::fromReflection($member, $scopeClass),
+                $type->getTypes(),
+            ));
         }
 
         if ($type instanceof \ReflectionIntersectionType) {
-            return new IntersectionType(\array_values(\array_map(self::fromReflection(...), $type->getTypes())));
+            return new IntersectionType(\array_values(\array_map(
+                static fn(\ReflectionType $member): Type => self::fromReflection($member, $scopeClass),
+                $type->getTypes(),
+            )));
         }
 
         if (!$type instanceof \ReflectionNamedType) {
             return new MixedType();
         }
 
-        $mapped = self::fromName($type->getName());
+        $mapped = self::fromName($type->getName(), $scopeClass);
 
         if ($type->allowsNull() && !\in_array($type->getName(), ['mixed', 'null'], true)) {
             return TypeCombinator::addNull($mapped);
@@ -55,7 +62,16 @@ final class NativeType
         return $mapped;
     }
 
-    private static function fromName(string $name): Type
+    public static function fromParameter(\ReflectionParameter $parameter): Type
+    {
+        return self::fromReflection(
+            $parameter->getType(),
+            self::scopeClass($parameter->getDeclaringFunction()),
+        );
+    }
+
+    /** @param ?\ReflectionClass<object> $scopeClass */
+    private static function fromName(string $name, ?\ReflectionClass $scopeClass): Type
     {
         return match ($name) {
             'string' => new StringType(),
@@ -70,7 +86,31 @@ final class NativeType
             'object' => new ObjectWithoutClassType(),
             'null' => new NullType(),
             'mixed' => new MixedType(),
+            'self', 'static' => $scopeClass instanceof \ReflectionClass
+                ? new ObjectType($scopeClass->getName())
+                : new MixedType(),
+            'parent' => self::parentType($scopeClass),
             default => new ObjectType($name),
         };
+    }
+
+    /** @return ?\ReflectionClass<object> */
+    private static function scopeClass(\ReflectionFunctionAbstract $function): ?\ReflectionClass
+    {
+        if ($function instanceof \ReflectionMethod) {
+            return $function->getDeclaringClass();
+        }
+
+        return $function->getClosureScopeClass();
+    }
+
+    /** @param ?\ReflectionClass<object> $scopeClass */
+    private static function parentType(?\ReflectionClass $scopeClass): Type
+    {
+        $parent = $scopeClass?->getParentClass();
+
+        return $parent instanceof \ReflectionClass
+            ? new ObjectType($parent->getName())
+            : new MixedType();
     }
 }

--- a/tests/Acceptance/PhpStanMatcherSignatureTest.php
+++ b/tests/Acceptance/PhpStanMatcherSignatureTest.php
@@ -102,4 +102,57 @@ final readonly class PhpStanMatcherSignatureTest
         Expect::that($probe->messages())->toContain('toHaveDigestLength() expects int, string given')
             ->toContain('invoked with 1 parameter, 0 required');
     }
+
+    #[Test]
+    public function matcherReturnTypesMustBeBooleanWhenDeclared(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Expect\Expect;
+
+            final class GreenlightMatcherNameCollision
+            {
+                public function toReturnText(): string
+                {
+                    return 'value';
+                }
+            }
+
+            function greenlightGoodMatcherReturnProbe(): void
+            {
+                Expect::that('value')->toReturnBoolean();
+                Expect::that('value')->toReturnMixed();
+                Expect::that('value')->toReturnUntyped();
+                Expect::that((new GreenlightMatcherNameCollision())->toReturnText())->toBe('value');
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Expect\Expect;
+
+            function greenlightBadMatcherReturnProbe(): void
+            {
+                Expect::that('value')->toReturnText();
+                Expect::eventually(static fn(): string => 'value')
+                    ->within(1.0)
+                    ->toReturnText();
+            }
+            PHP,
+            \dirname(__DIR__) . '/Fixture/PhpStanMatcherReturn/probe.neon',
+        );
+
+        Expect::that($probe->exitCode)->because('declared matcher return types must be boolean')->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(2);
+        Expect::that($probe->messages())
+            ->toContain('toReturnText() must return bool, but its declared return type is string');
+    }
 }

--- a/tests/Acceptance/PhpStanMatcherSubjectTest.php
+++ b/tests/Acceptance/PhpStanMatcherSubjectTest.php
@@ -111,4 +111,54 @@ final readonly class PhpStanMatcherSubjectTest
         Expect::that(\count($probe->errors))->toBe(3);
         Expect::that($probe->messages())->toContain('requires subject type string, but the subject has type int');
     }
+
+    #[Test]
+    public function relativeMatcherTypesUseTheClosureScope(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Expect\Expect;
+            use Greenlight\Tests\Fixture\PhpStanScopedMatcher\MatcherSubject;
+            use Greenlight\Tests\Fixture\PhpStanScopedMatcher\ScopedMatcherExtension;
+
+            function greenlightGoodScopedMatcherProbe(): void
+            {
+                $extension = new ScopedMatcherExtension();
+                Expect::that($extension)->toAcceptSelf();
+                Expect::that($extension)->toAcceptParent();
+                Expect::that('value')->toAcceptSelfArgument($extension);
+                Expect::that('value')->toAcceptParentArgument(new MatcherSubject());
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Expect\Expect;
+            use Greenlight\Tests\Fixture\PhpStanScopedMatcher\MatcherSubject;
+
+            function greenlightBadScopedMatcherProbe(): void
+            {
+                Expect::that(new MatcherSubject())->toAcceptSelf();
+                Expect::that('value')->toAcceptParent();
+                Expect::that('value')->toAcceptSelfArgument(new MatcherSubject());
+                Expect::that('value')->toAcceptParentArgument(new \stdClass());
+            }
+            PHP,
+            \dirname(__DIR__) . '/Fixture/PhpStanScopedMatcher/probe.neon',
+        );
+
+        Expect::that($probe->exitCode)->because('relative matcher types use the closure scope')->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(4);
+        Expect::that($probe->messages())
+            ->toContain('requires subject type Greenlight\\Tests\\Fixture\\PhpStanScopedMatcher\\ScopedMatcherExtension')
+            ->toContain('expects Greenlight\\Tests\\Fixture\\PhpStanScopedMatcher\\MatcherSubject');
+    }
 }

--- a/tests/Fixture/PhpStanMatcherReturn/InvalidReturnExtension.php
+++ b/tests/Fixture/PhpStanMatcherReturn/InvalidReturnExtension.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\PhpStanMatcherReturn;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Expect\ExpectationExtension;
+
+final class InvalidReturnExtension implements ExpectationExtension, Fake
+{
+    #[\Override]
+    public function matchers(): array
+    {
+        return [
+            'toReturnText' => static fn(string $subject): string => $subject,
+            'toReturnBoolean' => static fn(string $subject): bool => $subject !== '',
+            'toReturnMixed' => static fn(string $subject): mixed => $subject !== '',
+            'toReturnUntyped' => static fn(string $subject) => $subject !== '',
+        ];
+    }
+}

--- a/tests/Fixture/PhpStanMatcherReturn/greenlight.php
+++ b/tests/Fixture/PhpStanMatcherReturn/greenlight.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Tests\Fixture\PhpStanMatcherReturn\InvalidReturnExtension;
+
+return GreenlightConfig::create()
+    ->paths([__DIR__ . '/../DiscoveryBasic'])
+    ->plugins(new InvalidReturnExtension());

--- a/tests/Fixture/PhpStanMatcherReturn/probe.neon
+++ b/tests/Fixture/PhpStanMatcherReturn/probe.neon
@@ -1,0 +1,8 @@
+includes:
+    - ../../../extension.neon
+
+parameters:
+    level: max
+    greenlight:
+        configFiles:
+            - tests/Fixture/PhpStanMatcherReturn/greenlight.php

--- a/tests/Fixture/PhpStanMatcherReturnConflict/BooleanReturnExtension.php
+++ b/tests/Fixture/PhpStanMatcherReturnConflict/BooleanReturnExtension.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\PhpStanMatcherReturnConflict;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Expect\ExpectationExtension;
+
+final class BooleanReturnExtension implements ExpectationExtension, Fake
+{
+    #[\Override]
+    public function matchers(): array
+    {
+        return [
+            'toBeAvailable' => static fn(string $subject): bool => $subject !== '',
+        ];
+    }
+}

--- a/tests/Fixture/PhpStanMatcherReturnConflict/EquivalentBooleanReturnExtension.php
+++ b/tests/Fixture/PhpStanMatcherReturnConflict/EquivalentBooleanReturnExtension.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\PhpStanMatcherReturnConflict;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Expect\ExpectationExtension;
+
+final class EquivalentBooleanReturnExtension implements ExpectationExtension, Fake
+{
+    #[\Override]
+    public function matchers(): array
+    {
+        return [
+            'toBeAvailable' => static fn(string $subject): bool => \strlen($subject) > 0,
+        ];
+    }
+}

--- a/tests/Fixture/PhpStanMatcherReturnConflict/LiteralReturnExtension.php
+++ b/tests/Fixture/PhpStanMatcherReturnConflict/LiteralReturnExtension.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\PhpStanMatcherReturnConflict;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Expect\ExpectationExtension;
+
+final class LiteralReturnExtension implements ExpectationExtension, Fake
+{
+    #[\Override]
+    public function matchers(): array
+    {
+        return [
+            'toBeAvailable' => static fn(string $subject): true => true,
+        ];
+    }
+}

--- a/tests/Fixture/PhpStanMatcherReturnConflict/boolean.php
+++ b/tests/Fixture/PhpStanMatcherReturnConflict/boolean.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Tests\Fixture\PhpStanMatcherReturnConflict\BooleanReturnExtension;
+
+return GreenlightConfig::create()
+    ->paths([__DIR__ . '/../DiscoveryBasic'])
+    ->plugins(new BooleanReturnExtension());

--- a/tests/Fixture/PhpStanMatcherReturnConflict/equivalent.php
+++ b/tests/Fixture/PhpStanMatcherReturnConflict/equivalent.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Tests\Fixture\PhpStanMatcherReturnConflict\EquivalentBooleanReturnExtension;
+
+return GreenlightConfig::create()
+    ->paths([__DIR__ . '/../DiscoveryBasic'])
+    ->plugins(new EquivalentBooleanReturnExtension());

--- a/tests/Fixture/PhpStanMatcherReturnConflict/literal.php
+++ b/tests/Fixture/PhpStanMatcherReturnConflict/literal.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Tests\Fixture\PhpStanMatcherReturnConflict\LiteralReturnExtension;
+
+return GreenlightConfig::create()
+    ->paths([__DIR__ . '/../DiscoveryBasic'])
+    ->plugins(new LiteralReturnExtension());

--- a/tests/Fixture/PhpStanScopedMatcher/MatcherSubject.php
+++ b/tests/Fixture/PhpStanScopedMatcher/MatcherSubject.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\PhpStanScopedMatcher;
+
+use Greenlight\Doubles\Fake;
+
+class MatcherSubject implements Fake {}

--- a/tests/Fixture/PhpStanScopedMatcher/ScopedMatcherExtension.php
+++ b/tests/Fixture/PhpStanScopedMatcher/ScopedMatcherExtension.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\PhpStanScopedMatcher;
+
+use Greenlight\Expect\ExpectationExtension;
+
+final class ScopedMatcherExtension extends MatcherSubject implements ExpectationExtension
+{
+    #[\Override]
+    public function matchers(): array
+    {
+        return [
+            'toAcceptSelf' => static fn(self $subject): bool => true,
+            'toAcceptParent' => static fn(parent $subject): bool => true,
+            'toAcceptSelfArgument' => static fn(mixed $subject, self $other): bool => true,
+            'toAcceptParentArgument' => static fn(mixed $subject, parent $other): bool => true,
+        ];
+    }
+}

--- a/tests/Fixture/PhpStanScopedMatcher/greenlight.php
+++ b/tests/Fixture/PhpStanScopedMatcher/greenlight.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Tests\Fixture\PhpStanScopedMatcher\ScopedMatcherExtension;
+
+return GreenlightConfig::create()
+    ->paths([__DIR__ . '/../DiscoveryBasic'])
+    ->plugins(new ScopedMatcherExtension());

--- a/tests/Fixture/PhpStanScopedMatcher/probe.neon
+++ b/tests/Fixture/PhpStanScopedMatcher/probe.neon
@@ -1,0 +1,8 @@
+includes:
+    - ../../../extension.neon
+
+parameters:
+    level: max
+    greenlight:
+        configFiles:
+            - tests/Fixture/PhpStanScopedMatcher/greenlight.php

--- a/tests/Unit/PhpStan/MatcherMapConflictDiagnosticTest.php
+++ b/tests/Unit/PhpStan/MatcherMapConflictDiagnosticTest.php
@@ -28,7 +28,8 @@ final class MatcherMapConflictDiagnosticTest
                 MatcherMapError::class,
                 message: \sprintf(
                     'Extension matcher "toHaveDigestLength" is declared with conflicting signatures: '
-                    . '(string $subject, int $length) in "%s" and (mixed $subject, string $length) in "%s". '
+                    . '(string $subject, int $length): bool in "%s" and '
+                    . '(mixed $subject, string $length): bool in "%s". '
                     . 'Static analysis needs one signature per matcher name across all configured files.',
                     self::CONFIG,
                     self::CONFLICTING_CONFIG,

--- a/tests/Unit/PhpStan/MatcherMapFirstDeclarationTest.php
+++ b/tests/Unit/PhpStan/MatcherMapFirstDeclarationTest.php
@@ -29,8 +29,8 @@ final class MatcherMapFirstDeclarationTest
                 MatcherMapError::class,
                 message: \sprintf(
                     'Extension matcher "toHaveDigestLength" is declared with conflicting signatures: '
-                    . '(string $subject, int $length) in "%s" and '
-                    . '(mixed $subject, string $length) in "%s". '
+                    . '(string $subject, int $length): bool in "%s" and '
+                    . '(mixed $subject, string $length): bool in "%s". '
                     . 'Static analysis needs one signature per matcher name across all configured files.',
                     self::CONFIG,
                     self::CONFLICTING_CONFIG,

--- a/tests/Unit/PhpStan/MatcherMapReturnConflictTest.php
+++ b/tests/Unit/PhpStan/MatcherMapReturnConflictTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\PhpStan;
+
+use Greenlight\Attribute\DataRow;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\PhpStan\MatcherMap;
+use Greenlight\PhpStan\MatcherMapError;
+
+final class MatcherMapReturnConflictTest
+{
+    private const string BOOLEAN_CONFIG = __DIR__ . '/../../Fixture/PhpStanMatcherReturnConflict/boolean.php';
+    private const string EQUIVALENT_CONFIG = __DIR__ . '/../../Fixture/PhpStanMatcherReturnConflict/equivalent.php';
+    private const string LITERAL_CONFIG = __DIR__ . '/../../Fixture/PhpStanMatcherReturnConflict/literal.php';
+
+    #[Test]
+    #[DataRow([self::BOOLEAN_CONFIG, self::LITERAL_CONFIG, 'bool', 'true'], label: 'bool then true')]
+    #[DataRow([self::LITERAL_CONFIG, self::BOOLEAN_CONFIG, 'true', 'bool'], label: 'true then bool')]
+    public function returnTypesConflictInEitherConfigurationOrder(
+        string $firstConfig,
+        string $secondConfig,
+        string $firstReturn,
+        string $secondReturn,
+    ): void {
+        Expect::that(
+            static fn(): MatcherMap => MatcherMap::fromConfigFiles([$firstConfig, $secondConfig]),
+        )
+            ->because('return types are part of the normalized matcher signature')
+            ->toThrow(
+                MatcherMapError::class,
+                message: \sprintf(
+                    'Extension matcher "toBeAvailable" is declared with conflicting signatures: '
+                    . '(string $subject): %s in "%s" and (string $subject): %s in "%s". '
+                    . 'Static analysis needs one signature per matcher name across all configured files.',
+                    $firstReturn,
+                    $firstConfig,
+                    $secondReturn,
+                    $secondConfig,
+                ),
+            );
+    }
+
+    #[Test]
+    #[DataRow([self::BOOLEAN_CONFIG, self::EQUIVALENT_CONFIG], label: 'first then equivalent')]
+    #[DataRow([self::EQUIVALENT_CONFIG, self::BOOLEAN_CONFIG], label: 'equivalent then first')]
+    public function equivalentReturnTypesMergeInEitherConfigurationOrder(
+        string $firstConfig,
+        string $secondConfig,
+    ): void {
+        $map = MatcherMap::fromConfigFiles([$firstConfig, $secondConfig]);
+
+        Expect::that($map->has('toBeAvailable'))
+            ->because('equivalent normalized matcher signatures do not conflict')
+            ->toBeTrue();
+    }
+}

--- a/tests/Unit/PhpStan/MatcherParameterSignatureTest.php
+++ b/tests/Unit/PhpStan/MatcherParameterSignatureTest.php
@@ -11,6 +11,8 @@ use Greenlight\PhpStan\MatcherMap;
 
 final class MatcherParameterSignatureTest
 {
+    private const string SCOPED_CONFIG = __DIR__ . '/../../Fixture/PhpStanScopedMatcher/greenlight.php';
+
     #[Test]
     #[DataSet('parameterSignatures')]
     public function rendersOptionalAndVariadicParameters(string $method, string $expected): void
@@ -20,6 +22,25 @@ final class MatcherParameterSignatureTest
         Expect::that(MatcherMap::parameterSignature($parameter, 'null'))
             ->because('generated matcher signatures MUST distinguish optional and variadic parameters')
             ->toBe($expected);
+    }
+
+    #[Test]
+    public function resolvesRelativeTypesAgainstTheClosureScope(): void
+    {
+        $map = MatcherMap::fromConfigFiles([self::SCOPED_CONFIG]);
+        $selfParameter = $map->parameters('toAcceptSelfArgument')[0];
+        $parentParameter = $map->parameters('toAcceptParentArgument')[0];
+
+        Expect::that(MatcherMap::parameterSignature($selfParameter, 'null'))
+            ->because('self uses the matcher closure scope')
+            ->toBe(
+                '\\Greenlight\\Tests\\Fixture\\PhpStanScopedMatcher\\ScopedMatcherExtension $other',
+            );
+        Expect::that(MatcherMap::parameterSignature($parentParameter, 'null'))
+            ->because('parent uses the matcher closure parent scope')
+            ->toBe(
+                '\\Greenlight\\Tests\\Fixture\\PhpStanScopedMatcher\\MatcherSubject $other',
+            );
     }
 
     /**

--- a/tests/Unit/PhpStan/NativeTypeTest.php
+++ b/tests/Unit/PhpStan/NativeTypeTest.php
@@ -8,10 +8,11 @@ use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\PhpStan\NativeType;
+use Greenlight\Tests\Fixture\PhpStanScopedMatcher\MatcherSubject;
 use PHPStan\Type\Constant\ConstantBooleanType;
 use PHPStan\Type\VerbosityLevel;
 
-final class NativeTypeTest
+final class NativeTypeTest extends MatcherSubject
 {
     #[Test]
     #[DataSet('nativeTypes')]
@@ -52,6 +53,31 @@ final class NativeTypeTest
             ->toBe(ConstantBooleanType::class);
         Expect::that($mapped->describe(VerbosityLevel::typeOnly()))
             ->toBe($expected ? 'true' : 'false');
+    }
+
+    #[Test]
+    public function relativeTypesUseTheClosureScopeClass(): void
+    {
+        $selfClosure = static fn(self $subject): bool => true;
+        $parentClosure = static fn(parent $subject): bool => true;
+        $staticClosure = static fn(): static => throw new \LogicException('Not called.');
+
+        $selfParameter = new \ReflectionFunction($selfClosure)->getParameters()[0];
+        $parentParameter = new \ReflectionFunction($parentClosure)->getParameters()[0];
+        $staticReflection = new \ReflectionFunction($staticClosure);
+
+        Expect::that(NativeType::fromParameter($selfParameter)->getObjectClassNames())
+            ->because('self uses the closure scope class')
+            ->toBe([self::class]);
+        Expect::that(NativeType::fromParameter($parentParameter)->getObjectClassNames())
+            ->because('parent uses the closure scope parent class')
+            ->toBe([MatcherSubject::class]);
+        Expect::that(NativeType::fromReflection(
+            $staticReflection->getReturnType(),
+            $staticReflection->getClosureScopeClass(),
+        )->getObjectClassNames())
+            ->because('static uses the closure scope class')
+            ->toBe([self::class]);
     }
 
     /**


### PR DESCRIPTION
## Summary

- report incompatible declared return types for configured extension matchers
- resolve self, parent, and static native types from the matcher closure scope
- cover synchronous, temporal, subject, argument, and IDE-signature behavior