### PR TITLE
refactor(phpstan): check benevolent union types

### DIFF
--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -6,6 +6,7 @@ includes:
 
 parameters:
     level: max
+    checkBenevolentUnionTypes: true
     checkMissingCallableSignature: true
     treatPhpDocTypesAsCertain: false
     tmpDir: build/cache/phpstan

--- a/src/Discovery/DataSetExpander.php
+++ b/src/Discovery/DataSetExpander.php
@@ -24,17 +24,17 @@ use Greenlight\Core\ErrorTrap;
 final readonly class DataSetExpander
 {
     /**
-     * @var \Closure(): int
+     * @var \Closure(): (int|float)
      */
     private \Closure $monotonicTime;
 
     /**
-     * @param (callable(): int)|null $monotonicTime
+     * @param (callable(): (int|float))|null $monotonicTime
      */
     public function __construct(?callable $monotonicTime = null)
     {
         $this->monotonicTime = $monotonicTime === null
-            ? static fn(): int => \hrtime(true)
+            ? static fn(): int|float => \hrtime(true)
             : $monotonicTime(...);
     }
 
@@ -106,7 +106,7 @@ final readonly class DataSetExpander
 
         foreach ($this->expand($class, $providerReflection, $testMethod, $provider, $budgetSeconds) as $key => $value) {
             if (\array_key_exists($key, $rows)) {
-                throw DiscoveryError::duplicateDataSetKey($className, $testMethod, $key);
+                throw DiscoveryError::duplicateDataSetKey($className, $testMethod, (string) $key);
             }
 
             $rows[$key] = $value;

--- a/src/PhpStan/DoublePlanRule.php
+++ b/src/PhpStan/DoublePlanRule.php
@@ -169,7 +169,7 @@ final readonly class DoublePlanRule implements Rule
         $errors = [];
         $matcher = new ObjectType(ArgumentMatcher::class);
 
-        foreach ($arguments as $index => $argument) {
+        foreach (\array_values($arguments) as $index => $argument) {
             $parameter = $parameters[\min($index, \count($parameters) - 1)];
             $argumentType = $scope->getType($argument->value);
 
@@ -298,7 +298,7 @@ final readonly class DoublePlanRule implements Rule
 
         $errors = [];
 
-        foreach ($arguments as $index => $argument) {
+        foreach (\array_values($arguments) as $index => $argument) {
             if ($argument->unpack) {
                 continue;
             }

--- a/tests/Support/JsonlEvents.php
+++ b/tests/Support/JsonlEvents.php
@@ -63,13 +63,15 @@ final class JsonlEvents
 
                 $events[] = $eventClass::fromWire(Wire::map($map, 'data'));
             } catch (\Throwable $failure) {
+                $code = $failure->getCode();
+
                 throw new \RuntimeException(
                     \sprintf(
                         'Invalid Greenlight JSONL on stdout line %d: %s',
                         $index + 1,
                         $failure->getMessage(),
                     ),
-                    $failure->getCode(),
+                    \is_int($code) ? $code : 0,
                     $failure,
                 );
             }

--- a/tests/Support/SimpleXml.php
+++ b/tests/Support/SimpleXml.php
@@ -12,8 +12,13 @@ final class SimpleXml
     public static function attributes(\SimpleXMLElement $element): array
     {
         $attributes = [];
+        $xmlAttributes = $element->attributes();
 
-        foreach ($element->attributes() as $name => $value) {
+        if ($xmlAttributes === null) {
+            return [];
+        }
+
+        foreach ($xmlAttributes as $name => $value) {
             $attributes[$name] = (string) $value;
         }
 

--- a/tests/Unit/Reporting/JUnitReporterTest.php
+++ b/tests/Unit/Reporting/JUnitReporterTest.php
@@ -196,8 +196,8 @@ final class JUnitReporterTest
             ->because('JUnit output MUST remain valid XML when diagnostics contain forbidden characters')
             ->toBeInstanceOf(\SimpleXMLElement::class);
 
-        $case = $document->testsuite->testcase;
-        $failure = $case->failure;
+        $case = SimpleXml::xpath($document, '/testsuites/testsuite/testcase')[0];
+        $failure = SimpleXml::xpath($case, 'failure')[0];
 
         Expect::that((string) $case['name'])
             ->because('forbidden characters in test names are replaced')

--- a/tests/Unit/Support/SimpleXmlTest.php
+++ b/tests/Unit/Support/SimpleXmlTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Support;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\SimpleXml;
+
+final class SimpleXmlTest
+{
+    #[Test]
+    public function attributesReturnsAnEmptyMapWhenTheElementHasNoAttributes(): void
+    {
+        $element = \simplexml_load_string('<element/>');
+
+        Expect::that($element)->toBeInstanceOf(\SimpleXMLElement::class);
+        Expect::that(SimpleXml::attributes($element))->toBe([]);
+    }
+}

--- a/tools/benchmark.php
+++ b/tools/benchmark.php
@@ -21,6 +21,11 @@ const PHPUNIT_VERSION = '13.2.3';
 const PARATEST_VERSION = '7.23.0';
 
 $options = \getopt('', ['shape:', 'scale:', 'workers:', 'runs:', 'with-phpunit']);
+
+if ($options === false) {
+    throw new RuntimeException('Cannot parse benchmark options.');
+}
+
 $shapes = isset($options['shape']) && \is_string($options['shape'])
     ? [$options['shape']]
     : ['many-fast', 'few-slow', 'giant-dataset', 'mixed'];


### PR DESCRIPTION
Enables PHPStan's benevolent-union check and resolves every diagnostic it exposes. Models platform and parser return types explicitly, preserves PHP array-key normalization, validates optional XML and CLI results, and adds coverage for attribute-free XML elements.