### PR TITLE
chore(phpstan): require explained suppressions

### DIFF
--- a/docs/api-expectations.md
+++ b/docs/api-expectations.md
@@ -780,7 +780,7 @@ PHPDoc:
 
 - `@return array<non-empty-string, \Closure>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/ExpectationExtension.php#L24)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/ExpectationExtension.php#L23)
 
 ## `ExpectationFailed`
 

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -8,6 +8,7 @@ parameters:
     level: max
     checkBenevolentUnionTypes: true
     checkMissingCallableSignature: true
+    reportIgnoresWithoutComments: true
     treatPhpDocTypesAsCertain: false
     tmpDir: build/cache/phpstan
     exceptions:

--- a/src/Doubles/MethodExpectation.php
+++ b/src/Doubles/MethodExpectation.php
@@ -47,8 +47,7 @@ final class MethodExpectation
 
     private int $sequenceIndex = 0;
 
-    // @phpstan-ignore-next-line missingType.callable (The doubled method determines the callback signature.)
-    private ?\Closure $callback = null;
+    private ?\Closure $callback = null; // @phpstan-ignore missingType.callable (The doubled method determines the callback signature.)
 
     private ?\Throwable $throwable = null;
 
@@ -181,8 +180,7 @@ final class MethodExpectation
      * from the closure.
      * @throws DoublesError
      */
-    // @phpstan-ignore-next-line missingType.callable (The doubled method determines the answer signature.)
-    public function andReturnsUsing(\Closure $answer): self
+    public function andReturnsUsing(\Closure $answer): self // @phpstan-ignore missingType.callable (The doubled method determines the answer signature.)
     {
         $this->assertNoAnswerConfigured();
 
@@ -340,8 +338,7 @@ final class MethodExpectation
     /**
      * @internal Only the call handler calls this method.
      */
-    // @phpstan-ignore-next-line missingType.callable (The doubled method determines the callback signature.)
-    public function configuredCallback(): ?\Closure
+    public function configuredCallback(): ?\Closure // @phpstan-ignore missingType.callable (The doubled method determines the callback signature.)
     {
         return $this->callback;
     }

--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -844,8 +844,7 @@ final class Expectation
             $matched = \preg_match($matching, $thrown->getMessage()) === 1;
         } elseif ($matched && $callback instanceof \Closure) {
             try {
-                // @phpstan-ignore-next-line argument.type (Reflection confirms that the callback accepts the matched throwable.)
-                $result = $this->invokeThrowableCallback($callback, $thrown);
+                $result = $this->invokeThrowableCallback($callback, $thrown); // @phpstan-ignore argument.type (Reflection confirms that the callback accepts the matched throwable.)
             } catch (ExpectationFailed $failure) {
                 if (!$this->negated) {
                     $this->negated = false;

--- a/src/Expect/ExpectationExtension.php
+++ b/src/Expect/ExpectationExtension.php
@@ -20,6 +20,5 @@ interface ExpectationExtension extends Plugin
      *
      * @return array<non-empty-string, \Closure>
      */
-    // @phpstan-ignore-next-line missingType.callable (Each matcher has its own parameter signature.)
-    public function matchers(): array;
+    public function matchers(): array; // @phpstan-ignore missingType.callable (Each matcher has its own parameter signature.)
 }

--- a/tests/Fixture/DiscoveryProviderNonPublic/NonPublicProviderTest.php
+++ b/tests/Fixture/DiscoveryProviderNonPublic/NonPublicProviderTest.php
@@ -10,9 +10,7 @@ use Greenlight\Attribute\Test;
 final class NonPublicProviderTest
 {
     #[Test]
-    // Deliberately broken to drive the runtime discovery-error path.
-    // @phpstan-ignore-next-line greenlight.dataProvider.provider
-    #[DataSet('privateProvider')]
+    #[DataSet('privateProvider')] // @phpstan-ignore greenlight.dataProvider.provider (deliberately broken: drives the runtime discovery-error path)
     public function needsData(int $value): void
     {
         self::privateProvider();

--- a/tests/Unit/Expect/ToThrowTest.php
+++ b/tests/Unit/Expect/ToThrowTest.php
@@ -378,8 +378,7 @@ final class ToThrowTest
     /**
      * @return iterable<string, array{\Closure, non-empty-string}>
      */
-    // @phpstan-ignore-next-line missingType.callable (Each invalid callback has a different deliberate signature.)
-    public static function invalidThrowableCallbacks(): iterable
+    public static function invalidThrowableCallbacks(): iterable // @phpstan-ignore missingType.callable (Each invalid callback has a different deliberate signature.)
     {
         yield 'no throwable parameter' => [
             static function (): void {},

--- a/tests/Unit/Psr/Psr11PluginTest.php
+++ b/tests/Unit/Psr/Psr11PluginTest.php
@@ -238,8 +238,7 @@ final readonly class Psr11PluginTest
     #[Test]
     public function aFactoryMustReturnAPsr11Container(): void
     {
-        // @phpstan-ignore-next-line argument.type (This test deliberately supplies an invalid factory result.)
-        $plugin = new Psr11Plugin($this->invalidContainerFactory());
+        $plugin = new Psr11Plugin($this->invalidContainerFactory()); // @phpstan-ignore argument.type (This test deliberately supplies an invalid factory result.)
 
         Expect::that(static fn(): ?object => $plugin->resolve(Greeter::class, []))->toThrow(
             Psr11BridgeError::class,


### PR DESCRIPTION
Enable PHPStan's explained-ignore check so new inline suppressions require a rationale.

Replace the remaining all-line next-line suppression with an identifier-scoped, explained suppression on the affected attribute.