### PR TITLE
chore(phpstan): require callable signatures

### DIFF
--- a/docs/api-doubles.md
+++ b/docs/api-doubles.md
@@ -50,7 +50,11 @@ The description identifies the constraint in failure messages.
 public static function predicate(\Closure $predicate, string $description = 'predicate'): ArgumentMatcher
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L34)
+PHPDoc:
+
+- `@param \Closure(mixed): mixed $predicate`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L36)
 
 ### `equals()`
 
@@ -61,7 +65,7 @@ This form states the comparison explicitly.
 public static function equals(mixed $value): ArgumentMatcher
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L43)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L45)
 
 ### `captor()`
 
@@ -72,7 +76,7 @@ selects the related expectation for the call.
 public static function captor(): ArgumentCaptor
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L52)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L54)
 
 ## `ArgumentCaptor`
 

--- a/docs/api-expectations.md
+++ b/docs/api-expectations.md
@@ -780,7 +780,7 @@ PHPDoc:
 
 - `@return array<non-empty-string, \Closure>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/ExpectationExtension.php#L23)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/ExpectationExtension.php#L24)
 
 ## `ExpectationFailed`
 

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -6,6 +6,7 @@ includes:
 
 parameters:
     level: max
+    checkMissingCallableSignature: true
     tmpDir: build/cache/phpstan
     exceptions:
         checkedExceptionClasses:

--- a/src/Cli/SignalOperations.php
+++ b/src/Cli/SignalOperations.php
@@ -15,5 +15,6 @@ interface SignalOperations
 
     public function enableAsync(): void;
 
+    /** @param (callable(int): void)|int $handler */
     public function register(int $signal, callable|int $handler): void;
 }

--- a/src/Cli/SystemSignalOperations.php
+++ b/src/Cli/SystemSignalOperations.php
@@ -19,6 +19,7 @@ final readonly class SystemSignalOperations implements SignalOperations
         \pcntl_async_signals(true);
     }
 
+    /** @param (callable(int): void)|int $handler */
     #[\Override]
     public function register(int $signal, callable|int $handler): void
     {

--- a/src/Core/ErrorHandlerStack.php
+++ b/src/Core/ErrorHandlerStack.php
@@ -8,12 +8,15 @@ namespace Greenlight\Core;
  * Removes a selected PHP error handler and reinstalls handlers that were above it.
  *
  * @internal
+ *
+ * @phpstan-type ErrorHandler callable(int, string, string, int): bool
  */
 final class ErrorHandlerStack
 {
     /** @codeCoverageIgnore */
     private function __construct() {}
 
+    /** @param ErrorHandler $handler */
     public static function remove(callable $handler): void
     {
         $laterHandlers = [];
@@ -33,6 +36,7 @@ final class ErrorHandlerStack
         self::restore($laterHandlers);
     }
 
+    /** @return ErrorHandler|null */
     private static function active(): ?callable
     {
         $probe = static fn(): bool => true;
@@ -42,7 +46,7 @@ final class ErrorHandlerStack
         return $active;
     }
 
-    /** @param list<callable> $handlers */
+    /** @param list<ErrorHandler> $handlers */
     private static function restore(array $handlers): void
     {
         foreach (\array_reverse($handlers) as $handler) {

--- a/src/Core/Test/Cleanup.php
+++ b/src/Core/Test/Cleanup.php
@@ -14,7 +14,7 @@ namespace Greenlight\Core\Test;
  */
 final class Cleanup
 {
-    /** @var list<\Closure> */
+    /** @var list<\Closure(): mixed> */
     private array $callbacks = [];
 
     private bool $closed = false;

--- a/src/Doubles/Argument.php
+++ b/src/Doubles/Argument.php
@@ -30,6 +30,8 @@ final class Argument
     /**
      * This matcher accepts the value when the closure returns true.
      * The description identifies the constraint in failure messages.
+     *
+     * @param \Closure(mixed): mixed $predicate
      */
     public static function predicate(\Closure $predicate, string $description = 'predicate'): ArgumentMatcher
     {

--- a/src/Doubles/MethodExpectation.php
+++ b/src/Doubles/MethodExpectation.php
@@ -47,6 +47,7 @@ final class MethodExpectation
 
     private int $sequenceIndex = 0;
 
+    // @phpstan-ignore-next-line missingType.callable (The doubled method determines the callback signature.)
     private ?\Closure $callback = null;
 
     private ?\Throwable $throwable = null;
@@ -180,6 +181,7 @@ final class MethodExpectation
      * from the closure.
      * @throws DoublesError
      */
+    // @phpstan-ignore-next-line missingType.callable (The doubled method determines the answer signature.)
     public function andReturnsUsing(\Closure $answer): self
     {
         $this->assertNoAnswerConfigured();
@@ -338,6 +340,7 @@ final class MethodExpectation
     /**
      * @internal Only the call handler calls this method.
      */
+    // @phpstan-ignore-next-line missingType.callable (The doubled method determines the callback signature.)
     public function configuredCallback(): ?\Closure
     {
         return $this->callback;

--- a/src/Doubles/PredicateMatcher.php
+++ b/src/Doubles/PredicateMatcher.php
@@ -7,6 +7,7 @@ namespace Greenlight\Doubles;
 /** @internal */
 final readonly class PredicateMatcher implements ArgumentMatcher
 {
+    /** @param \Closure(mixed): mixed $predicate */
     public function __construct(
         private \Closure $predicate,
         private string $description,

--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -844,6 +844,7 @@ final class Expectation
             $matched = \preg_match($matching, $thrown->getMessage()) === 1;
         } elseif ($matched && $callback instanceof \Closure) {
             try {
+                // @phpstan-ignore-next-line argument.type (Reflection confirms that the callback accepts the matched throwable.)
                 $result = $this->invokeThrowableCallback($callback, $thrown);
             } catch (ExpectationFailed $failure) {
                 if (!$this->negated) {
@@ -997,6 +998,10 @@ final class Expectation
      *
      * @return class-string<\Throwable>
      *
+     * @template TThrowable of \Throwable
+     *
+     * @param \Closure(TThrowable): mixed $callback
+     *
      * @throws ExpectationFailed
      */
     private function requireThrowableCallback(\Closure $callback): string
@@ -1055,6 +1060,12 @@ final class Expectation
         return $throwable;
     }
 
+    /**
+     * @template TThrowable of \Throwable
+     *
+     * @param \Closure(TThrowable): mixed $callback
+     * @param TThrowable $throwable
+     */
     private function invokeThrowableCallback(\Closure $callback, \Throwable $throwable): mixed
     {
         return $callback($throwable);

--- a/src/Expect/ExpectationExtension.php
+++ b/src/Expect/ExpectationExtension.php
@@ -20,5 +20,6 @@ interface ExpectationExtension extends Plugin
      *
      * @return array<non-empty-string, \Closure>
      */
+    // @phpstan-ignore-next-line missingType.callable (Each matcher has its own parameter signature.)
     public function matchers(): array;
 }

--- a/tests/Fixture/Cli/RecordingSignalOperations.php
+++ b/tests/Fixture/Cli/RecordingSignalOperations.php
@@ -12,7 +12,7 @@ final class RecordingSignalOperations implements SignalOperations, Fake
     public bool $asyncEnabled = false;
 
     /**
-     * @var list<array{signal: int, handler: callable|int}>
+     * @var list<array{signal: int, handler: (callable(int): void)|int}>
      */
     public array $registrations = [];
 
@@ -30,6 +30,7 @@ final class RecordingSignalOperations implements SignalOperations, Fake
         $this->asyncEnabled = true;
     }
 
+    /** @param (callable(int): void)|int $handler */
     #[\Override]
     public function register(int $signal, callable|int $handler): void
     {

--- a/tests/Fixture/Expect/EvenNumbersExtension.php
+++ b/tests/Fixture/Expect/EvenNumbersExtension.php
@@ -9,6 +9,7 @@ use Greenlight\Expect\ExpectationExtension;
 
 final class EvenNumbersExtension implements ExpectationExtension, Fake
 {
+    /** @return array{toBeEven: \Closure(mixed): bool} */
     #[\Override]
     public function matchers(): array
     {

--- a/tests/Fixture/Expect/PositiveNumbersExtension.php
+++ b/tests/Fixture/Expect/PositiveNumbersExtension.php
@@ -9,6 +9,7 @@ use Greenlight\Expect\ExpectationExtension;
 
 final class PositiveNumbersExtension implements ExpectationExtension, Fake
 {
+    /** @return array{toBePositive: \Closure(mixed): bool} */
     #[\Override]
     public function matchers(): array
     {

--- a/tests/Fixture/MutationPrototype/project/tests/TemperatureTest.php
+++ b/tests/Fixture/MutationPrototype/project/tests/TemperatureTest.php
@@ -6,16 +6,19 @@ namespace MutationPrototype\Tests;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
+use Greenlight\Expect\ExpectationFailed;
 use MutationPrototype\Temperature;
 
 final class TemperatureTest
 {
+    /** @throws ExpectationFailed */
     #[Test]
     public function zeroIsFreezing(): void
     {
         Expect::that(new Temperature()->isFreezing(0.0))->toBeTrue();
     }
 
+    /** @throws ExpectationFailed */
     #[Test]
     public function warmIsNotFreezing(): void
     {

--- a/tests/Fixture/PhpStanExtension/DigestExtension.php
+++ b/tests/Fixture/PhpStanExtension/DigestExtension.php
@@ -9,6 +9,13 @@ use Greenlight\Expect\ExpectationExtension;
 
 final class DigestExtension implements ExpectationExtension, Fake
 {
+    /**
+     * @return array{
+     *     toBeHexadecimal: \Closure(string): bool,
+     *     toHaveDigestLength: \Closure(string, int): bool,
+     *     toBePositive: \Closure(int): bool
+     * }
+     */
     #[\Override]
     public function matchers(): array
     {

--- a/tests/Fixture/PhpStanExtensionConflict/ConflictingDigestExtension.php
+++ b/tests/Fixture/PhpStanExtensionConflict/ConflictingDigestExtension.php
@@ -9,6 +9,7 @@ use Greenlight\Expect\ExpectationExtension;
 
 final class ConflictingDigestExtension implements ExpectationExtension, Fake
 {
+    /** @return array{toHaveDigestLength: \Closure(mixed, string): bool} */
     #[\Override]
     public function matchers(): array
     {

--- a/tests/Fixture/PhpStanIdeHelperDnf/DnfExtension.php
+++ b/tests/Fixture/PhpStanIdeHelperDnf/DnfExtension.php
@@ -9,6 +9,7 @@ use Greenlight\Expect\ExpectationExtension;
 
 final class DnfExtension implements ExpectationExtension, Fake
 {
+    /** @return array{toCompareWith: \Closure(mixed, (\Countable&\Iterator<mixed, mixed>)|string): bool} */
     #[\Override]
     public function matchers(): array
     {

--- a/tests/Fixture/PhpStanNativeType/NativeTypeExtension.php
+++ b/tests/Fixture/PhpStanNativeType/NativeTypeExtension.php
@@ -9,6 +9,13 @@ use Greenlight\Expect\ExpectationExtension;
 
 final class NativeTypeExtension implements ExpectationExtension, Fake
 {
+    /**
+     * @return array{
+     *     toAcceptNullableDateTime: \Closure(\DateTimeInterface|null): true,
+     *     toAcceptIntegerOrString: \Closure(int|string): true,
+     *     toAcceptSerializableString: \Closure(\JsonSerializable&\Stringable): true
+     * }
+     */
     #[\Override]
     public function matchers(): array
     {

--- a/tests/Fixture/Plugins/EvenNumbersExtension.php
+++ b/tests/Fixture/Plugins/EvenNumbersExtension.php
@@ -9,6 +9,7 @@ use Greenlight\Expect\ExpectationExtension;
 
 final readonly class EvenNumbersExtension implements ExpectationExtension, Fake
 {
+    /** @return array{toBeEven: \Closure(mixed): bool} */
     #[\Override]
     public function matchers(): array
     {

--- a/tests/Unit/Capture/OutputCaptureTest.php
+++ b/tests/Unit/Capture/OutputCaptureTest.php
@@ -421,6 +421,7 @@ final readonly class OutputCaptureTest
         yield 'negative diagnostics bound' => [1, -1, 'Diagnostics bound must be at least 1 entry, got -1.'];
     }
 
+    /** @return (callable(int, string, string, int): bool)|null */
     private function activeErrorHandler(): ?callable
     {
         $probe = static fn(): bool => false;
@@ -430,6 +431,7 @@ final readonly class OutputCaptureTest
         return $active;
     }
 
+    /** @param (callable(int, string, string, int): bool)|null $baseline */
     private function restoreErrorHandler(?callable $baseline): void
     {
         for ($attempt = 0; $attempt < 4; ++$attempt) {

--- a/tests/Unit/Core/ErrorTrapTest.php
+++ b/tests/Unit/Core/ErrorTrapTest.php
@@ -209,6 +209,7 @@ final class ErrorTrapTest
         }
     }
 
+    /** @return (callable(int, string, string, int): bool)|null */
     private function activeErrorHandler(): ?callable
     {
         $probe = static fn(): bool => true;
@@ -218,6 +219,7 @@ final class ErrorTrapTest
         return $active;
     }
 
+    /** @param callable(int, string, string, int): bool $last */
     private function restoreErrorHandlersThrough(callable $last): void
     {
         while (($active = $this->activeErrorHandler()) !== null) {

--- a/tests/Unit/Expect/BecauseTest.php
+++ b/tests/Unit/Expect/BecauseTest.php
@@ -109,6 +109,7 @@ final readonly class BecauseTest
     {
         $restoreExtensions = Expect::install([
             new class implements ExpectationExtension {
+                /** @return array{toBeOdd: \Closure(mixed): bool} */
                 #[\Override]
                 public function matchers(): array
                 {

--- a/tests/Unit/Expect/ToThrowTest.php
+++ b/tests/Unit/Expect/ToThrowTest.php
@@ -378,6 +378,7 @@ final class ToThrowTest
     /**
      * @return iterable<string, array{\Closure, non-empty-string}>
      */
+    // @phpstan-ignore-next-line missingType.callable (Each invalid callback has a different deliberate signature.)
     public static function invalidThrowableCallbacks(): iterable
     {
         yield 'no throwable parameter' => [
@@ -430,6 +431,7 @@ final class ToThrowTest
     public function toThrowAcceptsScopedThrowableCallbackParameterTypes(): void
     {
         $selfScopedError = new class ('self') extends \DomainException {
+            /** @return \Closure(self): void */
             public function throwableCallback(): \Closure
             {
                 return static function (self $error): void {
@@ -442,6 +444,7 @@ final class ToThrowTest
             ->toThrow($selfScopedError->throwableCallback());
 
         $parentScopedCallback = new class ('parent') extends \Exception {
+            /** @return \Closure(parent): void */
             public function throwableCallback(): \Closure
             {
                 return static function (parent $error): void {

--- a/tests/Unit/PhpStan/NativeTypeTest.php
+++ b/tests/Unit/PhpStan/NativeTypeTest.php
@@ -139,6 +139,11 @@ final class NativeTypeTest
         return $value;
     }
 
+    /**
+     * @param callable(): mixed $value
+     *
+     * @return callable(): mixed
+     */
     public function callable(callable $value): callable
     {
         return $value;

--- a/tests/Unit/Psr/Psr11PluginTest.php
+++ b/tests/Unit/Psr/Psr11PluginTest.php
@@ -238,6 +238,7 @@ final readonly class Psr11PluginTest
     #[Test]
     public function aFactoryMustReturnAPsr11Container(): void
     {
+        // @phpstan-ignore-next-line argument.type (This test deliberately supplies an invalid factory result.)
         $plugin = new Psr11Plugin($this->invalidContainerFactory());
 
         Expect::that(static fn(): ?object => $plugin->resolve(Greeter::class, []))->toThrow(
@@ -350,6 +351,7 @@ final readonly class Psr11PluginTest
         return $container;
     }
 
+    /** @return \Closure(): \stdClass */
     private function invalidContainerFactory(): \Closure
     {
         return static fn(): object => new \stdClass();


### PR DESCRIPTION
## Summary

- enable PHPStan callable-signature checking
- document exact callback contracts for signals, cleanup, predicates, throwable callbacks, and test fixtures
- keep narrowly explained exceptions for matcher maps and doubled-method callbacks whose signatures are intentionally heterogeneous