### PR TITLE
ci: analyse optional framework bridges

### DIFF
--- a/.github/fixtures/hyperf-bridge/app/GreetingAspect.php
+++ b/.github/fixtures/hyperf-bridge/app/GreetingAspect.php
@@ -9,12 +9,19 @@ use Hyperf\Di\Aop\ProceedingJoinPoint;
 
 final class GreetingAspect extends AbstractAspect
 {
-    public array $classes = [Greeter::class . '::greet'];
-
-    public array $annotations = [];
+    public function __construct()
+    {
+        $this->classes = [Greeter::class . '::greet'];
+    }
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint): string
     {
-        return $proceedingJoinPoint->process() . ' through AOP';
+        $result = $proceedingJoinPoint->process();
+
+        if (!\is_string($result)) {
+            throw new \RuntimeException('The Hyperf greeting aspect requires a string result.');
+        }
+
+        return $result . ' through AOP';
     }
 }

--- a/.github/fixtures/hyperf-bridge/app/GreetingAspect.php
+++ b/.github/fixtures/hyperf-bridge/app/GreetingAspect.php
@@ -9,10 +9,13 @@ use Hyperf\Di\Aop\ProceedingJoinPoint;
 
 final class GreetingAspect extends AbstractAspect
 {
-    public function __construct()
-    {
-        $this->classes = [Greeter::class . '::greet'];
-    }
+    /** @var list<string> */
+    // @phpstan-ignore-next-line property.phpDocType (Hyperf declares the overridden property as an untyped array.)
+    public array $classes = [Greeter::class . '::greet'];
+
+    /** @var list<class-string> */
+    // @phpstan-ignore-next-line property.phpDocType (Hyperf declares the overridden property as an untyped array.)
+    public array $annotations = [];
 
     public function process(ProceedingJoinPoint $proceedingJoinPoint): string
     {

--- a/.github/fixtures/hyperf-bridge/composer.json
+++ b/.github/fixtures/hyperf-bridge/composer.json
@@ -21,6 +21,11 @@
         "hyperf/di": "~3.2.0",
         "hyperf/framework": "~3.2.0"
     },
+    "require-dev": {
+        "phpstan/phpstan": "^2.2",
+        "phpstan/phpstan-deprecation-rules": "^2.0",
+        "phpstan/phpstan-strict-rules": "^2.0"
+    },
     "autoload": {
         "psr-4": {
             "App\\": "app/"

--- a/.github/fixtures/hyperf-bridge/greenlight.php
+++ b/.github/fixtures/hyperf-bridge/greenlight.php
@@ -8,7 +8,8 @@ use Greenlight\Hyperf\ContainerLifetime;
 use Greenlight\Hyperf\HyperfPlugin;
 use Psr\Container\ContainerInterface;
 
-$mode = \getenv('GREENLIGHT_HYPERF_CONTAINER_LIFETIME') ?: 'worker';
+$configuredLifetime = \getenv('GREENLIGHT_HYPERF_CONTAINER_LIFETIME');
+$mode = \is_string($configuredLifetime) && $configuredLifetime !== '' ? $configuredLifetime : 'worker';
 $lifetime = match ($mode) {
     'worker' => ContainerLifetime::Worker,
     'attempt' => ContainerLifetime::TestAttempt,
@@ -16,9 +17,17 @@ $lifetime = match ($mode) {
 };
 $marker = __DIR__ . '/runtime/lifecycle-' . $mode . '.json';
 @\unlink($marker);
-$record = static function (ContainerInterface $container) use ($marker): void {
-    $probe = $container->get(DisposalProbe::class);
-    $json = \json_encode($probe->snapshot(), \JSON_THROW_ON_ERROR);
+$probe = static function (ContainerInterface $container): DisposalProbe {
+    $service = $container->get(DisposalProbe::class);
+
+    if (!$service instanceof DisposalProbe) {
+        throw new \RuntimeException('The Hyperf container MUST return DisposalProbe.');
+    }
+
+    return $service;
+};
+$record = static function (ContainerInterface $container) use ($marker, $probe): void {
+    $json = \json_encode($probe($container)->snapshot(), \JSON_THROW_ON_ERROR);
 
     if (\file_put_contents($marker, $json) === false) {
         throw new \RuntimeException('The Hyperf acceptance fixture did not write its lifecycle marker.');
@@ -31,12 +40,12 @@ return GreenlightConfig::create()
     ->plugins(new HyperfPlugin(
         __DIR__,
         containerLifetime: $lifetime,
-        reset: static function (ContainerInterface $container) use ($record): void {
-            $container->get(DisposalProbe::class)->reset();
+        reset: static function (ContainerInterface $container) use ($probe, $record): void {
+            $probe($container)->reset();
             $record($container);
         },
-        dispose: static function (ContainerInterface $container) use ($record): void {
-            $container->get(DisposalProbe::class)->dispose();
+        dispose: static function (ContainerInterface $container) use ($probe, $record): void {
+            $probe($container)->dispose();
             $record($container);
         },
     ));

--- a/.github/fixtures/hyperf-bridge/phpstan.neon
+++ b/.github/fixtures/hyperf-bridge/phpstan.neon
@@ -1,0 +1,13 @@
+includes:
+    - vendor/phpstan/phpstan/conf/bleedingEdge.neon
+    - vendor/phpstan/phpstan-strict-rules/rules.neon
+    - vendor/phpstan/phpstan-deprecation-rules/rules.neon
+
+parameters:
+    level: max
+    tmpDir: ../../../build/cache/phpstan-hyperf
+    paths:
+        - vendor/greenlight/greenlight/src/Hyperf
+        - app
+        - tests
+        - greenlight.php

--- a/.github/fixtures/tempest-bridge/phpstan.neon
+++ b/.github/fixtures/tempest-bridge/phpstan.neon
@@ -2,6 +2,7 @@ includes:
     - ../../../vendor/phpstan/phpstan/conf/bleedingEdge.neon
     - ../../../vendor/phpstan/phpstan-strict-rules/rules.neon
     - ../../../vendor/phpstan/phpstan-deprecation-rules/rules.neon
+    - ../../../extension.neon
 
 parameters:
     level: max

--- a/.github/fixtures/tempest-bridge/phpstan.neon
+++ b/.github/fixtures/tempest-bridge/phpstan.neon
@@ -1,0 +1,12 @@
+includes:
+    - ../../../vendor/phpstan/phpstan/conf/bleedingEdge.neon
+    - ../../../vendor/phpstan/phpstan-strict-rules/rules.neon
+    - ../../../vendor/phpstan/phpstan-deprecation-rules/rules.neon
+
+parameters:
+    level: max
+    tmpDir: ../../../build/cache/phpstan-tempest
+    paths:
+        - ../../../src/Tempest
+        - ../../../tests/Unit/Tempest
+        - ../../../tests/Acceptance/TempestRunTest.php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,10 @@ jobs:
         working-directory: ".github/fixtures/hyperf-bridge"
         run: "php verify-path-diagnostics.php"
 
+      - name: "Analyze the Hyperf bridge"
+        working-directory: ".github/fixtures/hyperf-bridge"
+        run: "vendor/bin/phpstan analyse --ansi --no-progress --memory-limit=-1"
+
       - name: "Run Hyperf worker-container acceptance tests"
         working-directory: ".github/fixtures/hyperf-bridge"
         env:
@@ -467,6 +471,9 @@ jobs:
         run: |
           composer config platform.php 8.5.0
           composer require --dev --no-interaction --no-progress --with-all-dependencies "tempest/framework:^3.18"
+
+      - name: "Analyze the Tempest bridge"
+        run: "vendor/bin/phpstan analyse --ansi --no-progress --memory-limit=-1 --configuration=.github/fixtures/tempest-bridge/phpstan.neon"
 
       - name: "Run Tempest bridge tests with coverage"
         shell: "bash"

--- a/tests/Unit/Tempest/TempestPluginLifecycleTest.php
+++ b/tests/Unit/Tempest/TempestPluginLifecycleTest.php
@@ -191,9 +191,9 @@ final class TempestPluginLifecycleTest
         $factory = $plugin->services()[0]->factory;
         $kernel = $factory();
 
-        Expect::that($kernel)
-            ->because('the Tempest kernel factory MUST return FrameworkKernel')
-            ->toBeInstanceOf(FrameworkKernel::class);
+        if (!$kernel instanceof FrameworkKernel) {
+            Fail::because('The Tempest kernel factory MUST return FrameworkKernel.');
+        }
 
         return $kernel;
     }

--- a/tests/Unit/Tempest/TempestPluginLifecycleTest.php
+++ b/tests/Unit/Tempest/TempestPluginLifecycleTest.php
@@ -191,9 +191,9 @@ final class TempestPluginLifecycleTest
         $factory = $plugin->services()[0]->factory;
         $kernel = $factory();
 
-        if (!$kernel instanceof FrameworkKernel) {
-            Fail::because('The Tempest kernel factory MUST return FrameworkKernel.');
-        }
+        Expect::that($kernel)
+            ->because('the Tempest kernel factory MUST return FrameworkKernel')
+            ->toBeInstanceOf(FrameworkKernel::class);
 
         return $kernel;
     }


### PR DESCRIPTION
## Summary

- run PHPStan against the optional Hyperf and Tempest integrations with their real framework packages installed
- load the bundled Greenlight extension during Tempest bridge analysis so Greenlight expectations keep their type narrowing
- add bridge-specific analysis configuration and precise fixture types for the real dependencies