### PR TITLE
ci: expand PHPStan dependency coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,7 @@ jobs:
             dependencies: "highest"
             symfony-version: "6.4.*"
             analysis: "phpstan"
+            phpstan-configuration: "phpstan.no-laravel.neon"
           - php-version: "8.4"
             dependencies: "highest"
             symfony-version: "7.4.*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -234,24 +234,31 @@ jobs:
           - php-version: "8.4"
             dependencies: "locked"
             analytics: true
+            analysis: "full"
           - php-version: "8.4"
             dependencies: "lowest"
             symfony-version: "6.4.*"
+            analysis: "phpstan"
           - php-version: "8.5"
             dependencies: "lowest"
             symfony-version: "6.4.*"
+            analysis: "phpstan"
           - php-version: "8.4"
             dependencies: "highest"
             symfony-version: "6.4.*"
+            analysis: "phpstan"
           - php-version: "8.4"
             dependencies: "highest"
             symfony-version: "7.4.*"
+            analysis: "phpstan"
           - php-version: "8.4"
             dependencies: "highest"
             symfony-version: "8.1.*"
+            analysis: "phpstan"
           - php-version: "8.5"
             dependencies: "highest"
             symfony-version: "8.1.*"
+            analysis: "phpstan"
     steps:
       - name: "Checkout"
         uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7
@@ -294,15 +301,24 @@ jobs:
         env:
           SYMFONY_REQUIRE: "${{ matrix.symfony-version }}"
 
+      # The lowest compatible PHPStan version reports false errors for types
+      # that later PHPStan 2.2 releases can infer.
+      - name: "Update PHPStan for lowest-dependency analysis"
+        if: "matrix.dependencies == 'lowest' && matrix.analysis == 'phpstan'"
+        shell: "bash"
+        run: >-
+          composer update --no-interaction --no-progress --prefer-dist
+          phpstan/phpstan phpstan/phpstan-deprecation-rules phpstan/phpstan-strict-rules
+
       - name: "Calculate static analysis cache content hash"
         id: "analysis_cache"
-        if: "matrix.dependencies == 'locked' && matrix.php-version == '8.4'"
+        if: "matrix.analysis"
         env:
           CONTENT_HASH: "${{ hashFiles('composer.lock', '.php-cs-fixer.dist.php', 'deptrac.yaml', 'extension.neon', 'phpstan.dist.neon', 'phpstan.docs.neon', 'rector.php', 'rector.docs.php', 'tools/docs-php.php', 'tools/rector-config.php') }}"
         run: 'echo "content_hash=${CONTENT_HASH}" >> "${GITHUB_OUTPUT}"'
 
       - name: "Restore static analysis cache"
-        if: "matrix.dependencies == 'locked' && matrix.php-version == '8.4'"
+        if: "matrix.analysis"
         uses: "actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9" # v6.1.0
         with:
           path: |
@@ -312,15 +328,19 @@ jobs:
             build/cache/phpstan-docs
             build/cache/rector
             build/cache/rector-docs
-          key: "static-analysis-${{ runner.os }}-php-${{ matrix.php-version }}-${{ steps.analysis_cache.outputs.content_hash }}-${{ github.run_id }}"
-          restore-keys: "static-analysis-${{ runner.os }}-php-${{ matrix.php-version }}-${{ steps.analysis_cache.outputs.content_hash }}-"
+          key: "static-analysis-${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependencies }}-symfony-${{ matrix.symfony-version || 'default' }}-${{ steps.analysis_cache.outputs.content_hash }}-${{ github.run_id }}"
+          restore-keys: "static-analysis-${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependencies }}-symfony-${{ matrix.symfony-version || 'default' }}-${{ steps.analysis_cache.outputs.content_hash }}-"
 
       - name: "Static analysis"
-        if: "matrix.dependencies == 'locked' && matrix.php-version == '8.4'"
+        if: "matrix.analysis == 'full'"
         run: "composer static-analysis"
 
+      - name: "PHPStan"
+        if: "matrix.analysis == 'phpstan'"
+        run: "composer phpstan"
+
       - name: "Save static analysis cache"
-        if: "${{ !cancelled() && matrix.dependencies == 'locked' && matrix.php-version == '8.4' }}"
+        if: "${{ !cancelled() && matrix.analysis }}"
         uses: "actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9" # v6.1.0
         with:
           path: |
@@ -330,12 +350,8 @@ jobs:
             build/cache/phpstan-docs
             build/cache/rector
             build/cache/rector-docs
-          key: "static-analysis-${{ runner.os }}-php-${{ matrix.php-version }}-${{ steps.analysis_cache.outputs.content_hash }}-${{ github.run_id }}"
+          key: "static-analysis-${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependencies }}-symfony-${{ matrix.symfony-version || 'default' }}-${{ steps.analysis_cache.outputs.content_hash }}-${{ github.run_id }}"
 
-      # PHPStan does not run in the "lowest" jobs. The oldest permitted PHPStan
-      # cannot infer types that the code requires. Examples include the
-      # proc_open return type and ReflectionClass variance. Consequently, all PHPStan
-      # reports in these jobs are false.
       - name: "Tests"
         if: "matrix.analytics != true"
         run: "composer tests"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,10 +239,12 @@ jobs:
             dependencies: "lowest"
             symfony-version: "6.4.*"
             analysis: "phpstan"
+            phpstan-configuration: "phpstan.no-laravel.neon"
           - php-version: "8.5"
             dependencies: "lowest"
             symfony-version: "6.4.*"
             analysis: "phpstan"
+            phpstan-configuration: "phpstan.no-laravel.neon"
           - php-version: "8.4"
             dependencies: "highest"
             symfony-version: "6.4.*"
@@ -314,7 +316,7 @@ jobs:
         id: "analysis_cache"
         if: "matrix.analysis"
         env:
-          CONTENT_HASH: "${{ hashFiles('composer.lock', '.php-cs-fixer.dist.php', 'deptrac.yaml', 'extension.neon', 'phpstan.dist.neon', 'phpstan.docs.neon', 'rector.php', 'rector.docs.php', 'tools/docs-php.php', 'tools/rector-config.php') }}"
+          CONTENT_HASH: "${{ hashFiles('composer.lock', '.php-cs-fixer.dist.php', 'deptrac.yaml', 'extension.neon', 'phpstan.dist.neon', 'phpstan.docs.neon', 'phpstan.no-laravel.neon', 'rector.php', 'rector.docs.php', 'tools/docs-php.php', 'tools/rector-config.php') }}"
         run: 'echo "content_hash=${CONTENT_HASH}" >> "${GITHUB_OUTPUT}"'
 
       - name: "Restore static analysis cache"
@@ -337,7 +339,9 @@ jobs:
 
       - name: "PHPStan"
         if: "matrix.analysis == 'phpstan'"
-        run: "composer phpstan"
+        env:
+          PHPSTAN_CONFIGURATION: "${{ matrix.phpstan-configuration || 'phpstan.dist.neon' }}"
+        run: 'vendor/bin/phpstan analyse --ansi --no-progress --memory-limit=-1 --configuration="${PHPSTAN_CONFIGURATION}"'
 
       - name: "Save static analysis cache"
         if: "${{ !cancelled() && matrix.analysis }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -304,6 +304,12 @@ jobs:
         env:
           SYMFONY_REQUIRE: "${{ matrix.symfony-version }}"
 
+      # Lowest Rector uses the lowest PHPStan API in the test suite.
+      # Run the tests before the PHPStan update.
+      - name: "Tests"
+        if: "matrix.dependencies == 'lowest'"
+        run: "composer tests"
+
       # The lowest compatible PHPStan version reports false errors for types
       # that later PHPStan 2.2 releases can infer.
       - name: "Update PHPStan for lowest-dependency analysis"
@@ -358,7 +364,7 @@ jobs:
           key: "static-analysis-${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependencies }}-symfony-${{ matrix.symfony-version || 'default' }}-${{ steps.analysis_cache.outputs.content_hash }}-${{ github.run_id }}"
 
       - name: "Tests"
-        if: "matrix.analytics != true"
+        if: "matrix.analytics != true && matrix.dependencies != 'lowest'"
         run: "composer tests"
 
       - name: "Tests with JUnit output"

--- a/phpstan.no-laravel.neon
+++ b/phpstan.no-laravel.neon
@@ -1,0 +1,13 @@
+includes:
+    - phpstan.dist.neon
+
+parameters:
+    # Laravel 13 requires Symfony 7.4 or later. Lowest-dependency jobs use
+    # Symfony 6.4 and cannot install the Laravel bridge dependency.
+    excludePaths:
+        analyse:
+            - src/Laravel
+            - tests/Acceptance/LaravelRunTest.php
+            - tests/Fixture/Laravel
+            - tests/Unit/Doubles/FakeFixtureTest.php
+            - tests/Unit/Laravel

--- a/src/Runner/Artifact/ArtifactStore.php
+++ b/src/Runner/Artifact/ArtifactStore.php
@@ -662,13 +662,9 @@ final class ArtifactStore
             return 'application/octet-stream';
         }
 
-        try {
-            $type = \finfo_file($finfo, $path);
+        $type = \finfo_file($finfo, $path);
 
-            return \is_string($type) && $type !== '' ? $type : 'application/octet-stream';
-        } finally {
-            \finfo_close($finfo);
-        }
+        return \is_string($type) && $type !== '' ? $type : 'application/octet-stream';
     }
 
     /**

--- a/tests/Fixture/Symfony/BareKernel.php
+++ b/tests/Fixture/Symfony/BareKernel.php
@@ -118,7 +118,7 @@ final class BareKernel implements KernelInterface, Fake
 
     // No Override attribute: the parent declaration only exists on
     // Symfony >= 8, and the attribute is a compile error without one.
-    public function getShareDir(): ?string
+    public function getShareDir(): null
     {
         return null;
     }

--- a/tests/Fixture/Symfony/FixtureKernel.php
+++ b/tests/Fixture/Symfony/FixtureKernel.php
@@ -32,7 +32,7 @@ final class FixtureKernel extends Kernel
     #[\Override]
     public function getCacheDir(): string
     {
-        return $this->stateDir() . '/cache/' . $this->environment;
+        return $this->stateDir() . '/cache/' . $this->getEnvironment();
     }
 
     #[\Override]

--- a/tools/docs-php.php
+++ b/tools/docs-php.php
@@ -8,4 +8,7 @@ use Greenlight\Documentation\PhpExample\Command;
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
-exit(Command::run($argv));
+/** @var list<string> $arguments */
+$arguments = $_SERVER['argv'] ?? [];
+
+exit(Command::run($arguments));

--- a/tools/prose-check.php
+++ b/tools/prose-check.php
@@ -1722,7 +1722,9 @@ function prosePrintFinding(array $finding, string $suffix = ''): void
     ) . "\n";
 }
 
-$options = \proseArguments($argv);
+/** @var list<string> $arguments */
+$arguments = $_SERVER['argv'] ?? [];
+$options = \proseArguments($arguments);
 $findings = \proseFindings($options['root']);
 
 if ($options['command'] === 'review') {

--- a/tools/workflow-shell-check.php
+++ b/tools/workflow-shell-check.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 $root = \dirname(__DIR__);
 $workflowFiles = [];
+/** @var list<string> $arguments */
+$arguments = $_SERVER['argv'] ?? [];
 
-foreach (\array_slice($argv, 1) as $argument) {
+foreach (\array_slice($arguments, 1) as $argument) {
     if (\str_starts_with($argument, '-')) {
         \fwrite(\STDERR, \sprintf("Unknown workflow shell check option \"%s\".\n", $argument));
 


### PR DESCRIPTION
Run PHPStan against the lowest dependency set and each highest Symfony variant on supported PHP versions. Keep the complete static-analysis suite on the locked PHP 8.4 job, and isolate caches by dependency combination.