### PR TITLE
fix(core): wrap atomic file operation errors

### DIFF
--- a/src/Core/AtomicFile.php
+++ b/src/Core/AtomicFile.php
@@ -36,13 +36,23 @@ final class AtomicFile
 
         $temp = \sprintf('%s.tmp-%s-%s', $path, (int) \getmypid(), $suffix);
 
-        if (ErrorTrap::run(static fn() => \file_put_contents($temp, $contents), $warning) === false) {
+        if (ErrorTrap::run(
+            static fn() => \file_put_contents($temp, $contents),
+            $warning,
+            wrap: static fn(\Throwable $error): AtomicFileError =>
+                AtomicFileError::cannotWriteTemporary($temp, $error->getMessage(), $error),
+        ) === false) {
             ErrorTrap::run(static fn() => \unlink($temp));
 
             throw AtomicFileError::cannotWriteTemporary($temp, $warning);
         }
 
-        if (ErrorTrap::run(static fn() => \rename($temp, $path), $warning) === false) {
+        if (ErrorTrap::run(
+            static fn() => \rename($temp, $path),
+            $warning,
+            wrap: static fn(\Throwable $error): AtomicFileError =>
+                AtomicFileError::cannotRename($temp, $path, $error->getMessage(), $error),
+        ) === false) {
             ErrorTrap::run(static fn() => \unlink($temp));
 
             throw AtomicFileError::cannotRename($temp, $path, $warning);

--- a/src/Core/AtomicFile.php
+++ b/src/Core/AtomicFile.php
@@ -36,23 +36,27 @@ final class AtomicFile
 
         $temp = \sprintf('%s.tmp-%s-%s', $path, (int) \getmypid(), $suffix);
 
-        if (ErrorTrap::run(
+        $written = ErrorTrap::run(
             static fn() => \file_put_contents($temp, $contents),
             $warning,
             wrap: static fn(\Throwable $error): AtomicFileError =>
                 AtomicFileError::cannotWriteTemporary($temp, $error->getMessage(), $error),
-        ) === false) {
+        );
+
+        if ($written === false) {
             ErrorTrap::run(static fn() => \unlink($temp));
 
             throw AtomicFileError::cannotWriteTemporary($temp, $warning);
         }
 
-        if (ErrorTrap::run(
+        $renamed = ErrorTrap::run(
             static fn() => \rename($temp, $path),
             $warning,
             wrap: static fn(\Throwable $error): AtomicFileError =>
                 AtomicFileError::cannotRename($temp, $path, $error->getMessage(), $error),
-        ) === false) {
+        );
+
+        if ($renamed === false) {
             ErrorTrap::run(static fn() => \unlink($temp));
 
             throw AtomicFileError::cannotRename($temp, $path, $warning);

--- a/src/Core/AtomicFileError.php
+++ b/src/Core/AtomicFileError.php
@@ -25,22 +25,29 @@ final class AtomicFileError extends \RuntimeException
         ), $previous);
     }
 
-    public static function cannotWriteTemporary(string $temporary, ?string $reason): self
-    {
+    public static function cannotWriteTemporary(
+        string $temporary,
+        ?string $reason,
+        ?\Throwable $previous = null,
+    ): self {
         return new self(\sprintf(
             'Cannot write temporary file "%s"%s.',
             $temporary,
             $reason === null ? '' : ': ' . $reason,
-        ));
+        ), $previous);
     }
 
-    public static function cannotRename(string $temporary, string $path, ?string $reason): self
-    {
+    public static function cannotRename(
+        string $temporary,
+        string $path,
+        ?string $reason,
+        ?\Throwable $previous = null,
+    ): self {
         return new self(\sprintf(
             'Cannot rename "%s" to "%s"%s.',
             $temporary,
             $path,
             $reason === null ? '' : ': ' . $reason,
-        ));
+        ), $previous);
     }
 }

--- a/tests/Unit/Core/AtomicFileTest.php
+++ b/tests/Unit/Core/AtomicFileTest.php
@@ -53,6 +53,22 @@ final readonly class AtomicFileTest
     }
 
     #[Test]
+    public function temporaryWriteThrowableBecomesAnAtomicFileError(): void
+    {
+        $path = $this->tempDirectory->path() . "/invalid\0/state.json";
+
+        Expect::that(static fn() => AtomicFile::write($path, '{}'))
+            ->because('a native write throwable MUST not escape the atomic-file seam')
+            ->toThrow(
+                static function (AtomicFileError $error): void {
+                    Expect::that($error->getPrevious())
+                        ->because('the atomic-file error MUST preserve the native write error')
+                        ->toBeInstanceOf(\ValueError::class);
+                },
+            );
+    }
+
+    #[Test]
     public function randomNameFailurePreservesItsCauseWithoutWritingAFile(): void
     {
         $path = $this->tempDirectory->path() . '/state.json';


### PR DESCRIPTION
AtomicFile documents AtomicFileError as its failure seam, but native write and rename throwables could escape ErrorTrap unchanged. Wrap those throwables as AtomicFileError and preserve the original cause. Add a null-byte path regression that exercises the native ValueError path.

Static analysis currently reaches this diff cleanly but fails on five pre-existing missing callable signatures in PHPStan matcher fixtures on main. The full 3,005-test suite passes.