### PR TITLE
fix(phpstan): type matcher fixture callables

### DIFF
--- a/tests/Fixture/PhpStanMatcherReturn/InvalidReturnExtension.php
+++ b/tests/Fixture/PhpStanMatcherReturn/InvalidReturnExtension.php
@@ -9,6 +9,14 @@ use Greenlight\Expect\ExpectationExtension;
 
 final class InvalidReturnExtension implements ExpectationExtension, Fake
 {
+    /**
+     * @return array{
+     *     toReturnText: \Closure(string): string,
+     *     toReturnBoolean: \Closure(string): bool,
+     *     toReturnMixed: \Closure(string): mixed,
+     *     toReturnUntyped: \Closure(string): mixed
+     * }
+     */
     #[\Override]
     public function matchers(): array
     {

--- a/tests/Fixture/PhpStanMatcherReturnConflict/BooleanReturnExtension.php
+++ b/tests/Fixture/PhpStanMatcherReturnConflict/BooleanReturnExtension.php
@@ -9,6 +9,7 @@ use Greenlight\Expect\ExpectationExtension;
 
 final class BooleanReturnExtension implements ExpectationExtension, Fake
 {
+    /** @return array{toBeAvailable: \Closure(string): bool} */
     #[\Override]
     public function matchers(): array
     {

--- a/tests/Fixture/PhpStanMatcherReturnConflict/EquivalentBooleanReturnExtension.php
+++ b/tests/Fixture/PhpStanMatcherReturnConflict/EquivalentBooleanReturnExtension.php
@@ -9,6 +9,7 @@ use Greenlight\Expect\ExpectationExtension;
 
 final class EquivalentBooleanReturnExtension implements ExpectationExtension, Fake
 {
+    /** @return array{toBeAvailable: \Closure(string): bool} */
     #[\Override]
     public function matchers(): array
     {

--- a/tests/Fixture/PhpStanMatcherReturnConflict/LiteralReturnExtension.php
+++ b/tests/Fixture/PhpStanMatcherReturnConflict/LiteralReturnExtension.php
@@ -9,6 +9,7 @@ use Greenlight\Expect\ExpectationExtension;
 
 final class LiteralReturnExtension implements ExpectationExtension, Fake
 {
+    /** @return array{toBeAvailable: \Closure(string): true} */
     #[\Override]
     public function matchers(): array
     {

--- a/tests/Fixture/PhpStanScopedMatcher/ScopedMatcherExtension.php
+++ b/tests/Fixture/PhpStanScopedMatcher/ScopedMatcherExtension.php
@@ -8,6 +8,14 @@ use Greenlight\Expect\ExpectationExtension;
 
 final class ScopedMatcherExtension extends MatcherSubject implements ExpectationExtension
 {
+    /**
+     * @return array{
+     *     toAcceptSelf: \Closure(self): bool,
+     *     toAcceptParent: \Closure(parent): bool,
+     *     toAcceptSelfArgument: \Closure(mixed, self): bool,
+     *     toAcceptParentArgument: \Closure(mixed, parent): bool
+     * }
+     */
     #[\Override]
     public function matchers(): array
     {


### PR DESCRIPTION
## Summary

- Declare exact closure parameter and return types for five matcher fixtures.
- Keep return-conflict and relative-scope fixture contracts explicit without PHPStan suppressions.