### PR TITLE
fix(reporting): wrap stream output errors

### DIFF
--- a/src/Reporting/Output/StreamOutput.php
+++ b/src/Reporting/Output/StreamOutput.php
@@ -26,7 +26,10 @@ final class StreamOutput implements Output
     public function write(string $text): void
     {
         while ($text !== '') {
-            $written = ErrorTrap::run(fn() => \fwrite($this->stream, $text));
+            $written = ErrorTrap::run(
+                fn() => \fwrite($this->stream, $text),
+                wrap: static fn(\Throwable $error): ReportingError => ReportingError::writeFailed($error),
+            );
 
             if ($written === false || $written === 0) {
                 throw ReportingError::writeFailed();

--- a/src/Reporting/ReportingError.php
+++ b/src/Reporting/ReportingError.php
@@ -7,14 +7,14 @@ namespace Greenlight\Reporting;
 /** @internal */
 final class ReportingError extends \RuntimeException
 {
-    private function __construct(string $message)
+    private function __construct(string $message, ?\Throwable $previous = null)
     {
-        parent::__construct($message);
+        parent::__construct($message, previous: $previous);
     }
 
-    public static function writeFailed(): self
+    public static function writeFailed(?\Throwable $previous = null): self
     {
-        return new self('Greenlight did not write reporter output to the stream.');
+        return new self('Greenlight did not write reporter output to the stream.', $previous);
     }
 
     /**

--- a/tests/Unit/Reporting/StreamOutputTest.php
+++ b/tests/Unit/Reporting/StreamOutputTest.php
@@ -66,6 +66,30 @@ final readonly class StreamOutputTest
     }
 
     #[Test]
+    public function aClosedStreamThrowableBecomesAReportingError(): void
+    {
+        $stream = ErrorTrap::run(static fn() => \fopen('php://memory', 'r+'));
+
+        Expect::that($stream)
+            ->because('Greenlight MUST open the in-memory stream.')
+            ->not()
+            ->toBeFalse();
+        \fclose($stream);
+
+        $output = new StreamOutput($stream);
+
+        Expect::that(static fn() => $output->write('cannot be written'))
+            ->because('a native stream throwable MUST not escape the reporting seam')
+            ->toThrow(
+                static function (ReportingError $error): void {
+                    Expect::that($error->getPrevious())
+                        ->because('the reporting error MUST preserve the native stream error')
+                        ->toBeInstanceOf(\TypeError::class);
+                },
+            );
+    }
+
+    #[Test]
     public function partialWritesAreRetriedUntilTheReporterTextIsComplete(): void
     {
         $stream = $this->openPartialWriteStream('partial');


### PR DESCRIPTION
StreamOutput accepts a caller-owned resource, so the stream can become invalid before write(). ErrorTrap previously let the resulting native TypeError escape the Output contract. Wrap stream throwables as ReportingError and retain the original cause.

Static analysis reaches this diff cleanly but the repository-wide run fails on five pre-existing missing callable signatures in PHPStan matcher fixtures on main. The full 3,005-test suite passes.