### PR TITLE
fix(runner): wrap listener operation errors

### DIFF
--- a/src/Runner/Orchestrator/ServerSocket.php
+++ b/src/Runner/Orchestrator/ServerSocket.php
@@ -38,11 +38,14 @@ final class ServerSocket
         $socketPath = $socketDirectory . '/s';
         $errorMessage = null;
 
-        $server = ErrorTrap::run(static function () use ($runtime, $socketDirectory, $socketPath, &$errorMessage) {
-            \mkdir($socketDirectory, 0o700);
+        $server = ErrorTrap::run(
+            static function () use ($runtime, $socketDirectory, $socketPath, &$errorMessage) {
+                \mkdir($socketDirectory, 0o700);
 
-            return $runtime->listen('unix://' . $socketPath, $errorMessage);
-        });
+                return $runtime->listen('unix://' . $socketPath, $errorMessage);
+            },
+            wrap: static fn(\Throwable $error): ProtocolError => ProtocolError::listenerFailed($error),
+        );
 
         if (\is_resource($server)) {
             $boundPath = $runtime->name($server);
@@ -63,9 +66,12 @@ final class ServerSocket
 
         ErrorTrap::run(static fn() => \rmdir($socketDirectory));
 
-        $server = ErrorTrap::run(static function () use ($runtime, &$errorMessage) {
-            return $runtime->listen('tcp://127.0.0.1:0', $errorMessage);
-        });
+        $server = ErrorTrap::run(
+            static function () use ($runtime, &$errorMessage) {
+                return $runtime->listen('tcp://127.0.0.1:0', $errorMessage);
+            },
+            wrap: static fn(\Throwable $error): ProtocolError => ProtocolError::listenerFailed($error),
+        );
 
         if (!\is_resource($server)) {
             throw ProtocolError::malformedFrame(

--- a/src/Runner/Protocol/ProtocolError.php
+++ b/src/Runner/Protocol/ProtocolError.php
@@ -40,6 +40,11 @@ final class ProtocolError extends WireError
         return new self(\sprintf('Worker protocol stream %s failed.', $operation), $previous);
     }
 
+    public static function listenerFailed(\Throwable $previous): self
+    {
+        return new self('Greenlight could not open the orchestrator socket.', $previous);
+    }
+
     public static function unsupportedVersion(int $version): self
     {
         return new self(\sprintf('Unsupported protocol version %d.', $version));

--- a/tests/Unit/Runner/Orchestrator/ServerSocketFailureTest.php
+++ b/tests/Unit/Runner/Orchestrator/ServerSocketFailureTest.php
@@ -38,8 +38,8 @@ final readonly class ServerSocketFailureTest
     public function listenerThrowableBecomesAProtocolError(): void
     {
         $cause = new \RuntimeException('The fixture listener failed.');
-        $runtime = new class ($cause) implements ServerSocketRuntime {
-            public function __construct(private readonly \Throwable $cause) {}
+        $runtime = new readonly class ($cause) implements ServerSocketRuntime {
+            public function __construct(private \Throwable $cause) {}
 
             #[\Override]
             public function listen(string $address, ?string &$errorMessage): never

--- a/tests/Unit/Runner/Orchestrator/ServerSocketFailureTest.php
+++ b/tests/Unit/Runner/Orchestrator/ServerSocketFailureTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Unit\Runner\Orchestrator;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\Orchestrator\ServerSocket;
+use Greenlight\Runner\Orchestrator\ServerSocketRuntime;
 use Greenlight\Runner\Protocol\ProtocolError;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Fixture\Runner\Orchestrator\ControlledServerSocketRuntime;
@@ -31,6 +32,39 @@ final readonly class ServerSocketFailureTest
         Expect::that($runtime->unixDirectoryExists())
             ->because('a failed Unix listener MUST remove its generated directory')
             ->toBeFalse();
+    }
+
+    #[Test]
+    public function listenerThrowableBecomesAProtocolError(): void
+    {
+        $cause = new \RuntimeException('The fixture listener failed.');
+        $runtime = new class ($cause) implements ServerSocketRuntime {
+            public function __construct(private readonly \Throwable $cause) {}
+
+            #[\Override]
+            public function listen(string $address, ?string &$errorMessage): never
+            {
+                throw $this->cause;
+            }
+
+            #[\Override]
+            public function name($server): string|false
+            {
+                return false;
+            }
+        };
+
+        Expect::that(fn(): ServerSocket => ServerSocket::listen($this->tempDirectory->path(), $runtime))
+            ->because('a listener throwable MUST not escape the worker protocol seam')
+            ->toThrow(
+                static function (ProtocolError $error) use ($cause): void {
+                    Expect::that($error->getMessage())
+                        ->toBe('Greenlight could not open the orchestrator socket.');
+                    Expect::that($error->getPrevious())
+                        ->because('the protocol error MUST preserve the listener error')
+                        ->toBe($cause);
+                },
+            );
     }
 
     #[Test]


### PR DESCRIPTION
ServerSocket documents ProtocolError as its listener failure seam, but ErrorTrap let runtime listener throwables escape unchanged. Wrap both Unix and TCP listener operations as ProtocolError and preserve the original cause. Add a controlled runtime regression for the throwable path.

Static analysis reaches this diff cleanly but the repository-wide run fails on five pre-existing missing callable signatures in PHPStan matcher fixtures on main. The full 3,005-test suite passes.