### PR TITLE
fix(sandbox): wrap stream wrapper load errors

### DIFF
--- a/docs/api-sandboxes.md
+++ b/docs/api-sandboxes.md
@@ -100,7 +100,11 @@ final class StreamWrapperError extends \RuntimeException
 ### `registrationFailed()`
 
 ```php
-public static function registrationFailed(string $scheme, ?string $warning): self
+public static function registrationFailed(
+    string $scheme,
+    ?string $warning,
+    ?\Throwable $previous = null,
+): self
 ```
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/StreamWrapperError.php#L17)
@@ -115,7 +119,7 @@ PHPDoc:
 
 - `@param non-empty-list<array{non-empty-string, string|null}> $failures`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/StreamWrapperError.php#L29)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/StreamWrapperError.php#L32)
 
 ## `StreamWrappers`
 
@@ -153,7 +157,7 @@ PHPDoc:
 
 - `@throws StreamWrapperError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/StreamWrappers.php#L40)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/StreamWrappers.php#L44)
 
 ## `TemporaryDirectory`
 

--- a/src/Sandbox/StreamWrapperError.php
+++ b/src/Sandbox/StreamWrapperError.php
@@ -9,18 +9,21 @@ namespace Greenlight\Sandbox;
  */
 final class StreamWrapperError extends \RuntimeException
 {
-    private function __construct(string $message)
+    private function __construct(string $message, ?\Throwable $previous = null)
     {
-        parent::__construct($message);
+        parent::__construct($message, previous: $previous);
     }
 
-    public static function registrationFailed(string $scheme, ?string $warning): self
-    {
+    public static function registrationFailed(
+        string $scheme,
+        ?string $warning,
+        ?\Throwable $previous = null,
+    ): self {
         return new self(\sprintf(
             'Failed to register stream wrapper "%s"%s.',
             $scheme,
             $warning === null ? '' : ': ' . $warning,
-        ));
+        ), $previous);
     }
 
     /**

--- a/src/Sandbox/StreamWrappers.php
+++ b/src/Sandbox/StreamWrappers.php
@@ -26,10 +26,14 @@ final class StreamWrappers implements Disposable
             throw new \InvalidArgumentException('Stream wrapper scheme cannot be empty.');
         }
 
-        if (!ErrorTrap::run(
+        $registered = ErrorTrap::run(
             static fn() => \stream_wrapper_register($scheme, $wrapper),
             $warning,
-        )) {
+            wrap: static fn(\Throwable $error): StreamWrapperError =>
+                StreamWrapperError::registrationFailed($scheme, $error->getMessage(), $error),
+        );
+
+        if (!$registered) {
             throw StreamWrapperError::registrationFailed($scheme, $warning);
         }
 
@@ -43,7 +47,9 @@ final class StreamWrappers implements Disposable
         $failures = [];
 
         foreach (\array_reverse($this->schemes) as $scheme) {
-            if (!ErrorTrap::run(static fn() => \stream_wrapper_unregister($scheme), $warning)) {
+            $unregistered = ErrorTrap::run(static fn() => \stream_wrapper_unregister($scheme), $warning);
+
+            if (!$unregistered) {
                 $failures[] = [$scheme, $warning];
             }
         }

--- a/tests/Fixture/StreamWrapper/AutoloadableStream.php
+++ b/tests/Fixture/StreamWrapper/AutoloadableStream.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\StreamWrapper;
+
+use Greenlight\Doubles\Fake;
+
+final readonly class AutoloadableStream implements Fake {}

--- a/tests/Unit/Sandbox/StreamWrappersTest.php
+++ b/tests/Unit/Sandbox/StreamWrappersTest.php
@@ -9,6 +9,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\StreamWrapperError;
 use Greenlight\Sandbox\StreamWrappers;
 use Greenlight\Tests\Fixture\Runner\Protocol\UnselectableStream;
+use Greenlight\Tests\Fixture\StreamWrapper\AutoloadableStream;
 
 final readonly class StreamWrappersTest
 {
@@ -58,6 +59,37 @@ final readonly class StreamWrappersTest
             );
         } finally {
             $owner->dispose();
+        }
+    }
+
+    #[Test]
+    public function anAutoloadThrowableBecomesAStreamWrapperError(): void
+    {
+        $cause = new \RuntimeException('The fixture autoloader failed');
+        $loader = static function (string $class) use ($cause): void {
+            if ($class === AutoloadableStream::class) {
+                throw $cause;
+            }
+        };
+        \spl_autoload_register($loader, prepend: true);
+
+        try {
+            Expect::that(static function (): void {
+                new StreamWrappers()->register(
+                    'greenlight-sandbox-autoload',
+                    AutoloadableStream::class,
+                );
+            })
+                ->because('an autoload throwable MUST not escape the stream-wrapper seam')
+                ->toThrow(
+                    static function (StreamWrapperError $error) use ($cause): void {
+                        Expect::that($error->getPrevious())
+                            ->because('the stream-wrapper error MUST preserve the autoload error')
+                            ->toBe($cause);
+                    },
+                );
+        } finally {
+            \spl_autoload_unregister($loader);
         }
     }
 


### PR DESCRIPTION
Stream wrapper registration can invoke PHP autoload, and a throwing autoloader previously escaped the documented StreamWrapperError seam through ErrorTrap. Wrap registration throwables, retain the original cause, and add a dedicated autoload regression fixture. Name trapped registration and unregistration outcomes before their conditions to keep the control flow readable.