### PR TITLE
fix(discovery): wrap path operation errors

### DIFF
--- a/src/Discovery/ClassFileParser.php
+++ b/src/Discovery/ClassFileParser.php
@@ -26,7 +26,12 @@ final class ClassFileParser
      */
     public static function declarationsIn(string $file): array
     {
-        $code = ErrorTrap::run(static fn() => \file_get_contents($file), $warning);
+        $code = ErrorTrap::run(
+            static fn() => \file_get_contents($file),
+            $warning,
+            wrap: static fn(\Throwable $error): DiscoveryError =>
+                DiscoveryError::unreadableFile($file, $error->getMessage(), $error),
+        );
 
         if ($code === false) {
             throw DiscoveryError::unreadableFile($file, $warning);

--- a/src/Discovery/DiscoveryError.php
+++ b/src/Discovery/DiscoveryError.php
@@ -20,18 +20,24 @@ final class DiscoveryError extends \RuntimeException
         parent::__construct($message, previous: $previous);
     }
 
-    public static function directoryNotFound(string $directory): self
+    public static function directoryNotFound(string $directory, ?\Throwable $previous = null): self
     {
-        return new self(\sprintf('Discovery directory "%s" is missing or is not a directory.', $directory));
+        return new self(
+            \sprintf('Discovery directory "%s" is missing or is not a directory.', $directory),
+            $previous,
+        );
     }
 
-    public static function unreadableFile(string $file, ?string $reason = null): self
-    {
+    public static function unreadableFile(
+        string $file,
+        ?string $reason = null,
+        ?\Throwable $previous = null,
+    ): self {
         return new self(\sprintf(
             'Greenlight cannot read test file "%s"%s.',
             $file,
             $reason === null ? '' : ': ' . $reason,
-        ));
+        ), $previous);
     }
 
     public static function noClassInFile(string $file): self

--- a/src/Discovery/TestDiscoverer.php
+++ b/src/Discovery/TestDiscoverer.php
@@ -250,7 +250,11 @@ final readonly class TestDiscoverer
         $files = [];
 
         foreach ($directories as $directory) {
-            $real = ErrorTrap::run(static fn() => \realpath($directory));
+            $real = ErrorTrap::run(
+                static fn() => \realpath($directory),
+                wrap: static fn(\Throwable $error): DiscoveryError =>
+                    DiscoveryError::directoryNotFound($directory, $error),
+            );
 
             if ($real === false || !\is_dir($real)) {
                 throw DiscoveryError::directoryNotFound($directory);

--- a/tests/Unit/Discovery/ClassFileParserTest.php
+++ b/tests/Unit/Discovery/ClassFileParserTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Unit\Discovery;
 use Greenlight\Attribute\Test;
 use Greenlight\Discovery\ClassDeclaration;
 use Greenlight\Discovery\ClassFileParser;
+use Greenlight\Discovery\DiscoveryError;
 use Greenlight\Expect\Expect;
 use Greenlight\Fixture\TempDirectory;
 
@@ -79,5 +80,19 @@ final readonly class ClassFileParserTest
                 ['Example\Named\NamedTest', 'class'],
                 ['GlobalTest', 'class'],
             ]);
+    }
+
+    #[Test]
+    public function aNativeReadThrowableBecomesADiscoveryError(): void
+    {
+        Expect::that(static fn(): array => ClassFileParser::declarationsIn("invalid\0Test.php"))
+            ->because('a native file-read throwable MUST not escape the discovery seam')
+            ->toThrow(
+                static function (DiscoveryError $error): void {
+                    Expect::that($error->getPrevious())
+                        ->because('the discovery error MUST preserve the native file-read error')
+                        ->toBeInstanceOf(\ValueError::class);
+                },
+            );
     }
 }

--- a/tests/Unit/Discovery/TestDiscovererTest.php
+++ b/tests/Unit/Discovery/TestDiscovererTest.php
@@ -151,6 +151,22 @@ final class TestDiscovererTest
     }
 
     #[Test]
+    public function aNativeDirectoryThrowableBecomesADiscoveryError(): void
+    {
+        Expect::that(
+            static fn(): array => new TestDiscoverer()->testFiles(["invalid\0tests"]),
+        )
+            ->because('a native directory throwable MUST not escape the discovery seam')
+            ->toThrow(
+                static function (DiscoveryError $error): void {
+                    Expect::that($error->getPrevious())
+                        ->because('the discovery error MUST preserve the native directory error')
+                        ->toBeInstanceOf(\ValueError::class);
+                },
+            );
+    }
+
+    #[Test]
     #[Isolated]
     public function inaccessibleDirectoryFailsWithoutEngineDiagnostics(): void
     {


### PR DESCRIPTION
Discovery documents DiscoveryError for unreadable files and invalid directories, but trapped native path operations could throw ValueError directly for null-byte paths. Wrap file-read and directory-resolution throwables as DiscoveryError and preserve their causes. Add focused regressions for both paths. Trapped results remain named before their conditions.