### PR TITLE
fix(protocol): wrap stream operation errors

### DIFF
--- a/src/Runner/Protocol/ProtocolError.php
+++ b/src/Runner/Protocol/ProtocolError.php
@@ -35,6 +35,11 @@ final class ProtocolError extends WireError
         ));
     }
 
+    public static function streamOperationFailed(string $operation, \Throwable $previous): self
+    {
+        return new self(\sprintf('Worker protocol stream %s failed.', $operation), $previous);
+    }
+
     public static function unsupportedVersion(int $version): self
     {
         return new self(\sprintf('Unsupported protocol version %d.', $version));

--- a/src/Runner/Protocol/SocketChannel.php
+++ b/src/Runner/Protocol/SocketChannel.php
@@ -51,21 +51,26 @@ final class SocketChannel
 
         $bytes = $this->codec->encode(MessageRegistry::envelope($message));
 
-        $completed = ErrorTrap::run(function () use ($bytes) {
-            $remaining = \strlen($bytes);
+        $completed = ErrorTrap::run(
+            function () use ($bytes) {
+                $remaining = \strlen($bytes);
 
-            while ($remaining > 0) {
-                $written = \fwrite($this->stream, \substr($bytes, -$remaining));
+                while ($remaining > 0) {
+                    $written = \fwrite($this->stream, \substr($bytes, -$remaining));
 
-                if ($written === false || $written === 0) {
-                    return false;
+                    if ($written === false || $written === 0) {
+                        return false;
+                    }
+
+                    $remaining -= $written;
                 }
 
-                $remaining -= $written;
-            }
-
-            return \fflush($this->stream);
-        }, $warning);
+                return \fflush($this->stream);
+            },
+            $warning,
+            wrap: static fn(\Throwable $error): ProtocolError =>
+                ProtocolError::streamOperationFailed('write', $error),
+        );
 
         if (!$completed) {
             throw ProtocolError::malformedFrame('peer closed the connection during a write', $warning);
@@ -151,11 +156,16 @@ final class SocketChannel
 
         \stream_set_blocking($this->stream, false);
 
-        [$bytes, $reachedEof] = ErrorTrap::run(function () {
-            $bytes = \fread($this->stream, 65536);
+        [$bytes, $reachedEof] = ErrorTrap::run(
+            function () {
+                $bytes = \fread($this->stream, 65536);
 
-            return [$bytes, ($bytes === false || $bytes === '') && \feof($this->stream)];
-        }, $warning);
+                return [$bytes, ($bytes === false || $bytes === '') && \feof($this->stream)];
+            },
+            $warning,
+            wrap: static fn(\Throwable $error): ProtocolError =>
+                ProtocolError::streamOperationFailed('read', $error),
+        );
 
         if ($bytes === false && !$reachedEof) {
             throw ProtocolError::malformedFrame('peer connection failed during a read', $warning);

--- a/tests/Fixture/Runner/Protocol/ThrowingStream.php
+++ b/tests/Fixture/Runner/Protocol/ThrowingStream.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Runner\Protocol;
+
+use Greenlight\Doubles\Fake;
+
+final class ThrowingStream implements Fake
+{
+    public mixed $context;
+
+    public function stream_open(
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+    ): bool {
+        return true;
+    }
+
+    public function stream_read(int $count): never
+    {
+        throw new \RuntimeException('Fixture stream read failed.');
+    }
+
+    public function stream_write(string $data): never
+    {
+        throw new \RuntimeException('Fixture stream write failed.');
+    }
+
+    public function stream_eof(): bool
+    {
+        return false;
+    }
+
+    public function stream_set_option(
+        int $option,
+        int $argumentOne,
+        ?int $argumentTwo,
+    ): bool {
+        return true;
+    }
+}

--- a/tests/Unit/Runner/Protocol/SocketChannelThrowableTest.php
+++ b/tests/Unit/Runner/Protocol/SocketChannelThrowableTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Protocol;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Runner\Protocol\Messages\Drain;
+use Greenlight\Runner\Protocol\ProtocolError;
+use Greenlight\Runner\Protocol\SocketChannel;
+use Greenlight\Sandbox\StreamWrappers;
+use Greenlight\Test\Cleanup;
+use Greenlight\Tests\Fixture\Runner\Protocol\ThrowingStream;
+
+final readonly class SocketChannelThrowableTest
+{
+    private const string STREAM_SCHEME = 'greenlight-throwing-channel';
+
+    public function __construct(
+        private StreamWrappers $streamWrappers,
+        private Cleanup $cleanup,
+    ) {}
+
+    #[Test]
+    #[DataSet('operations')]
+    public function streamThrowablesBecomeProtocolErrors(string $operation): void
+    {
+        $this->streamWrappers->register(self::STREAM_SCHEME, ThrowingStream::class);
+
+        $stream = \fopen(self::STREAM_SCHEME . '://channel', 'r+');
+
+        if ($stream === false) {
+            Fail::because('The test could not open the throwing stream.');
+        }
+
+        $channel = new SocketChannel($stream);
+        $this->cleanup->defer($channel->close(...));
+        $invoke = $operation === 'read'
+            ? $channel->poll(...)
+            : static fn() => $channel->send(new Drain());
+
+        Expect::that($invoke)
+            ->because('a stream throwable MUST not escape the worker protocol seam')
+            ->toThrow(
+                static function (ProtocolError $error) use ($operation): void {
+                    Expect::that($error->getMessage())
+                        ->toBe(\sprintf('Worker protocol stream %s failed.', $operation));
+                    Expect::that($error->getPrevious())
+                        ->because('the protocol error MUST preserve the stream error')
+                        ->toBeInstanceOf(\RuntimeException::class);
+                },
+            );
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function operations(): iterable
+    {
+        yield 'read' => ['read'];
+        yield 'write' => ['write'];
+    }
+}


### PR DESCRIPTION
Wrap unexpected stream read and write throwables at the worker protocol boundary. Preserve the original throwable as the cause of a documented ProtocolError, and keep the trap results named before control-flow checks.