### PR TITLE
docs: tighten homepage narrative

### DIFF
--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -76,10 +76,12 @@ final class PriceTest
 
     <section class="execution-story section-shell">
       <div class="execution-heading">
-        <div class="execution-heading-copy">
-          <p class="eyebrow">Run the suite</p>
-          <h2>Greenlight manages the worker pool for you.</h2>
-        </div>
+        <p class="eyebrow">Run the suite</p>
+        <h2>Greenlight manages the worker pool for you.</h2>
+        <p>
+          The runner discovers the suite once, keeps the available workers busy,
+          and returns one ordered result.
+        </p>
       </div>
       <ol class="execution-steps">
         <li>
@@ -165,29 +167,19 @@ final class PriceTest
 
     <section class="closing-cta">
       <div class="closing-cta-intro">
-        <p class="eyebrow">Try one test class</p>
-        <h2>Go from installation to your first run.</h2>
+        <p class="eyebrow">Run Greenlight</p>
+        <h2>Put every available core to work.</h2>
+        <p>
+          Start with a complete configuration and one small test class, or move an
+          existing PHPUnit class when you are ready.
+        </p>
       </div>
-      <ol class="setup-steps">
-        <li>
-          <span>01</span>
-          <h3>Install Greenlight</h3>
-          <code>composer require --dev greenlight/greenlight</code>
-        </li>
-        <li>
-          <span>02</span>
-          <h3>Add <code>greenlight.php</code></h3>
-          <code>&lt;?php return GreenlightConfig::create();</code>
-        </li>
-        <li>
-          <span>03</span>
-          <h3>Run one class</h3>
-          <code>vendor/bin/greenlight run --filter=PriceTest</code>
-        </li>
-      </ol>
-      <div class="hero-actions">
+      <div class="closing-cta-actions">
         <a class="button primary" href={sitePath('docs/getting-started/')}>
-          Read the Start with Greenlight guide
+          Start with Greenlight
+        </a>
+        <a class="button secondary" href={sitePath('docs/migrating-from-phpunit/')}>
+          Move from PHPUnit
         </a>
       </div>
     </section>

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -790,7 +790,7 @@ code {
 .section-shell {
   width: min(100%, var(--max-width));
   margin-inline: auto;
-  padding: clamp(6rem, 11vw, 11rem) var(--page-padding);
+  padding: clamp(5rem, 8vw, 8rem) var(--page-padding);
 }
 
 .code-proof {
@@ -880,18 +880,26 @@ code {
 
 .execution-heading {
   display: grid;
-  grid-template-columns: 1fr 2fr;
-  gap: 3rem;
+  grid-template-columns: minmax(16rem, 0.75fr) minmax(0, 1.25fr);
+  align-items: end;
+  gap: clamp(2rem, 8vw, 9rem);
 }
 
-.execution-heading-copy {
-  grid-column: 2;
+.execution-heading .eyebrow {
+  grid-column: 1 / -1;
+  margin-bottom: 0;
+}
+
+.execution-heading > p:not(.eyebrow) {
+  max-width: 34rem;
+  color: var(--muted);
+  font-size: 1.15rem;
 }
 
 .execution-steps {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  margin: clamp(4rem, 8vw, 7.5rem) 0 0;
+  margin: clamp(3rem, 6vw, 5rem) 0 0;
   padding: 0;
   border-top: 1px solid var(--rule-strong);
   list-style: none;
@@ -1011,7 +1019,7 @@ code {
 }
 
 .closing-cta {
-  padding: clamp(6rem, 11vw, 11rem) var(--page-padding);
+  padding: clamp(5rem, 8vw, 8rem) var(--page-padding);
   background: var(--signal);
   color: var(--ink);
 }
@@ -1035,59 +1043,11 @@ code {
   font-size: 1.2rem;
 }
 
-.setup-steps {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  margin-top: clamp(3rem, 6vw, 5rem);
-  padding: 0;
-  border-top: 1px solid color-mix(in oklch, var(--ink) 40%, var(--signal));
-  list-style: none;
-}
-
-.setup-steps li {
-  min-width: 0;
-  padding: 1.5rem clamp(1rem, 2.4vw, 2rem) 0 0;
-}
-
-.setup-steps li + li {
-  padding-left: clamp(1rem, 2.4vw, 2rem);
-  border-left: 1px solid color-mix(in oklch, var(--ink) 24%, var(--signal));
-}
-
-.setup-steps li > span {
-  color: var(--action-dark);
-  font-family: var(--font-code);
-  font-size: 0.72rem;
-}
-
-.setup-steps h3 {
-  margin-top: 0.45rem;
-  font-size: 1.2rem;
-}
-
-.setup-steps h3 code {
-  padding: 0;
-  border: 0;
-  background: transparent;
-  font-family: inherit;
-  font-size: inherit;
-}
-
-.setup-steps li > code {
-  display: block;
-  margin-top: 1rem;
-  padding: 0.8rem 0.9rem;
-  border: 1px solid color-mix(in oklch, var(--ink) 22%, var(--signal));
-  border-radius: 0.35rem;
-  background: color-mix(in oklch, var(--ink) 9%, var(--signal));
-  color: var(--ink);
-  font-size: clamp(0.72rem, 0.9vw, 0.8rem);
-  line-height: 1.45;
-  overflow-wrap: anywhere;
-}
-
-.closing-cta .hero-actions {
-  justify-content: flex-start;
+.closing-cta-actions {
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: clamp(2.5rem, 5vw, 4rem);
+  gap: 0.75rem;
 }
 
 .closing-cta .text-link {
@@ -1522,10 +1482,13 @@ code {
 
   .execution-heading {
     grid-template-columns: 1fr;
+    align-items: start;
+    gap: 1.5rem;
   }
 
-  .execution-heading-copy {
+  .execution-heading .eyebrow {
     grid-column: 1;
+    margin-bottom: 0;
   }
 
   .execution-steps {
@@ -1535,21 +1498,6 @@ code {
   .execution-steps li + li {
     padding-left: 0;
     border-top: 1px solid var(--rule);
-    border-left: 0;
-  }
-
-  .setup-steps {
-    grid-template-columns: 1fr;
-  }
-
-  .setup-steps li {
-    padding-right: 0;
-    padding-bottom: 1.5rem;
-  }
-
-  .setup-steps li + li {
-    padding-left: 0;
-    border-top: 1px solid color-mix(in oklch, var(--ink) 24%, var(--signal));
     border-left: 0;
   }
 


### PR DESCRIPTION
Shortens the homepage journey and removes repeated setup instructions. Aligns the worker-pool explanation into a denser two-column composition and replaces the closing walkthrough with focused start and migration paths.