### PR TITLE
refactor(core): name error trap results

### DIFF
--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -228,7 +228,7 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L66)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L68)
 
 ### `resolve()`
 
@@ -243,7 +243,7 @@ PHPDoc:
 - `@param list<object> $attributes`
 - `@throws LaravelBridgeError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L83)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L85)
 
 ### `beforeTest()`
 
@@ -252,7 +252,7 @@ PHPDoc:
 public function beforeTest(TestContext $context): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L113)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L115)
 
 ### `afterTest()`
 
@@ -261,7 +261,7 @@ public function beforeTest(TestContext $context): void
 public function afterTest(TestContext $context, TestResult $result): TestResult
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L116)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L118)
 
 ## `Laravel\Service`
 

--- a/docs/api-sandboxes.md
+++ b/docs/api-sandboxes.md
@@ -210,7 +210,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException`
 - `@throws TemporaryDirectoryError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/TemporaryDirectory.php#L59)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/TemporaryDirectory.php#L60)
 
 ### `dispose()`
 
@@ -223,7 +223,7 @@ PHPDoc:
 
 - `@throws TemporaryDirectoryError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/TemporaryDirectory.php#L106)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/TemporaryDirectory.php#L107)
 
 ## `TemporaryDirectoryError`
 

--- a/src/Cli/RunState.php
+++ b/src/Cli/RunState.php
@@ -79,8 +79,9 @@ final class RunState
 
         $this->loaded = true;
         $file = $this->file;
+        $exists = ErrorTrap::run(static fn() => \is_file($file));
 
-        if (!ErrorTrap::run(static fn() => \is_file($file))) {
+        if (!$exists) {
             return null;
         }
 

--- a/src/Config/ConfigLoader.php
+++ b/src/Config/ConfigLoader.php
@@ -17,8 +17,9 @@ final class ConfigLoader
     public function loadFromDirectory(string $directory): GreenlightConfig
     {
         $file = \rtrim($directory, '/') . '/' . self::FILE_NAME;
+        $exists = ErrorTrap::run(static fn() => \is_file($file));
 
-        if (!ErrorTrap::run(static fn() => \is_file($file))) {
+        if (!$exists) {
             throw ConfigFileError::noneInDirectory($directory);
         }
 
@@ -30,7 +31,9 @@ final class ConfigLoader
      */
     public function loadFile(string $file): GreenlightConfig
     {
-        if (!ErrorTrap::run(static fn() => \is_file($file))) {
+        $exists = ErrorTrap::run(static fn() => \is_file($file));
+
+        if (!$exists) {
             throw ConfigFileError::notFound($file);
         }
 

--- a/src/Doubles/ProxyGenerator.php
+++ b/src/Doubles/ProxyGenerator.php
@@ -48,8 +48,9 @@ final readonly class ProxyGenerator
 
         if (!\class_exists($proxyClass, false)) {
             $file = $this->directory . '/' . $shortName . '.php';
+            $fileExists = ErrorTrap::run(static fn() => \is_file($file));
 
-            if (!ErrorTrap::run(static fn() => \is_file($file))) {
+            if (!$fileExists) {
                 $this->write($file, $this->renderFile($reflection, $shortName, $body));
             }
 

--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -1099,7 +1099,9 @@ final class Expectation
      */
     private function requireValidPattern(string $pattern, string $matcher): void
     {
-        if (ErrorTrap::run(static fn() => \preg_match($pattern, ''), $warning) === false) {
+        $matched = ErrorTrap::run(static fn() => \preg_match($pattern, ''), $warning);
+
+        if ($matched === false) {
             throw new \InvalidArgumentException(\sprintf(
                 'The pattern for %s() is an invalid regular expression: %s%s',
                 $matcher,

--- a/src/Hyperf/HyperfPlugin.php
+++ b/src/Hyperf/HyperfPlugin.php
@@ -248,7 +248,9 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemp
         }
 
         try {
-            if (!ErrorTrap::run(static fn() => \flock($lock, \LOCK_EX), $warning)) {
+            $locked = ErrorTrap::run(static fn() => \flock($lock, \LOCK_EX), $warning);
+
+            if (!$locked) {
                 throw HyperfBridgeError::scanLockFailed($lockPath);
             }
 

--- a/src/Laravel/LaravelPlugin.php
+++ b/src/Laravel/LaravelPlugin.php
@@ -52,7 +52,9 @@ final class LaravelPlugin implements HarnessProvider, ServiceResolver, TestLifec
         $this->factory = $application instanceof \Closure
             ? $application
             : static function () use ($application): mixed {
-                if (!ErrorTrap::run(static fn() => \is_file($application))) {
+                $applicationExists = ErrorTrap::run(static fn() => \is_file($application));
+
+                if (!$applicationExists) {
                     throw LaravelBridgeError::bootstrapFileMissing($application);
                 }
 

--- a/src/PhpStan/ExpectationArgumentRule.php
+++ b/src/PhpStan/ExpectationArgumentRule.php
@@ -147,7 +147,9 @@ final class ExpectationArgumentRule implements Rule
         }
 
         foreach ($scope->getType($argument->value)->getConstantStrings() as $pattern) {
-            if (ErrorTrap::run(static fn() => \preg_match($pattern->getValue(), ''), $warning) !== false) {
+            $matched = ErrorTrap::run(static fn() => \preg_match($pattern->getValue(), ''), $warning);
+
+            if ($matched !== false) {
                 continue;
             }
 

--- a/src/Runner/Artifact/ArtifactStore.php
+++ b/src/Runner/Artifact/ArtifactStore.php
@@ -828,8 +828,9 @@ final class ArtifactStore
             if (\file_exists($current)) {
                 throw AttachmentError::storage('Attachment output path contains a non-directory entry');
             }
+            $created = ErrorTrap::run(static fn() => \mkdir($current, 0o700), $warning);
 
-            if (!ErrorTrap::run(static fn() => \mkdir($current, 0o700), $warning)) {
+            if (!$created) {
                 throw AttachmentError::storage('Failed to create attachment output directory' . ($warning === null ? '' : ': ' . $warning));
             }
         }

--- a/src/Runner/CpuCores.php
+++ b/src/Runner/CpuCores.php
@@ -48,7 +48,9 @@ final class CpuCores
      */
     private static function probe(): int
     {
-        if (ErrorTrap::run(static fn() => \is_file('/proc/cpuinfo'))) {
+        $cpuInfoExists = ErrorTrap::run(static fn() => \is_file('/proc/cpuinfo'));
+
+        if ($cpuInfoExists) {
             $cpuinfo = ErrorTrap::run(static fn() => \file_get_contents('/proc/cpuinfo'));
 
             if (\is_string($cpuinfo)) {

--- a/src/Runner/SharedCoverageDirectory.php
+++ b/src/Runner/SharedCoverageDirectory.php
@@ -27,8 +27,9 @@ final readonly class SharedCoverageDirectory
     public static function open(CoverageSettings $settings): self
     {
         $directory = \rtrim(\sys_get_temp_dir(), '/') . '/greenlight-coverage-' . \bin2hex(\random_bytes(6));
+        $created = ErrorTrap::run(static fn() => \mkdir($directory, 0o700, true), $warning);
 
-        if (!ErrorTrap::run(static fn() => \mkdir($directory, 0o700, true), $warning)) {
+        if (!$created) {
             throw CoverageError::sharedDirectoryCreationFailed($directory, $warning);
         }
 

--- a/src/Sandbox/TemporaryDirectory.php
+++ b/src/Sandbox/TemporaryDirectory.php
@@ -36,8 +36,9 @@ final class TemporaryDirectory implements Disposable
             $resolvedTemporaryRoot = ErrorTrap::run(static fn() => \realpath($systemTemporaryRoot));
             $temporaryRoot = $resolvedTemporaryRoot === false ? $systemTemporaryRoot : $resolvedTemporaryRoot;
             $path = $temporaryRoot . '/greenlight-' . \bin2hex(\random_bytes(8));
+            $created = ErrorTrap::run(static fn() => \mkdir($path, 0700), $warning);
 
-            if (!ErrorTrap::run(static fn() => \mkdir($path, 0700), $warning)) {
+            if (!$created) {
                 throw TemporaryDirectoryError::rootCreationFailed($path, $warning);
             }
 
@@ -118,7 +119,9 @@ final class TemporaryDirectory implements Disposable
         }
 
         if ($isLink) {
-            if (!ErrorTrap::run(static fn() => \unlink($path), $warning)) {
+            $unlinked = ErrorTrap::run(static fn() => \unlink($path), $warning);
+
+            if (!$unlinked) {
                 throw TemporaryDirectoryError::rootLinkRemovalFailed($path, $warning);
             }
 
@@ -160,8 +163,9 @@ final class TemporaryDirectory implements Disposable
                 ? TemporaryDirectoryError::rootRemovalFailed($path, $error->getMessage())
                 : $error,
         );
+        $removed = ErrorTrap::run(static fn() => \rmdir($path), $warning);
 
-        if (!ErrorTrap::run(static fn() => \rmdir($path), $warning)) {
+        if (!$removed) {
             throw TemporaryDirectoryError::rootRemovalFailed($path, $warning);
         }
 


### PR DESCRIPTION
Assign ErrorTrap results to descriptive variables before branching. This removes nested trap calls from conditionals across core, sandbox, runner, bridge, and extension code without changing behavior.