### PR TITLE
feat(docs): add parallel lane visual system

### DIFF
--- a/website/src/components/WorkerFlow.astro
+++ b/website/src/components/WorkerFlow.astro
@@ -1,0 +1,41 @@
+<figure class="worker-flow" aria-labelledby="worker-flow-caption">
+  <figcaption id="worker-flow-caption" class="worker-flow__caption">
+    <span>Execution plan</span>
+    <strong>Classes move independently. Results return in order.</strong>
+  </figcaption>
+
+  <div class="worker-flow__stage" aria-hidden="true">
+    <div class="worker-flow__source">
+      <span>discovered once</span>
+      <strong>12 test classes</strong>
+    </div>
+
+    <ol class="worker-flow__lanes">
+      <li>
+        <code>CheckoutTest</code>
+        <span>worker 01</span>
+        <strong>passed</strong>
+      </li>
+      <li>
+        <code>OrderTest</code>
+        <span>worker 02</span>
+        <strong>running</strong>
+      </li>
+      <li>
+        <code>BillingTest</code>
+        <span>worker 03</span>
+        <strong>passed</strong>
+      </li>
+    </ol>
+
+    <div class="worker-flow__result">
+      <span>one ordered report</span>
+      <strong>802 tests</strong>
+    </div>
+  </div>
+
+  <p class="worker-flow__description">
+    Greenlight discovers the suite once, assigns test classes to available workers,
+    and combines their results into one ordered report.
+  </p>
+</figure>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -4,6 +4,7 @@ import { Code } from 'astro:components';
 import BaseLayout from '../layouts/BaseLayout.astro';
 import RunPreview from '../components/RunPreview.astro';
 import TerminalOutput from '../components/TerminalOutput.astro';
+import WorkerFlow from '../components/WorkerFlow.astro';
 import { githubUrl, sitePath } from '../lib/paths';
 
 const testExample = `<?php
@@ -76,12 +77,15 @@ final class PriceTest
 
     <section class="execution-story section-shell">
       <div class="execution-heading">
-        <p class="eyebrow">Run the suite</p>
-        <h2>Greenlight manages the worker pool for you.</h2>
-        <p>
-          The runner discovers the suite once, keeps the available workers busy,
-          and returns one ordered result.
-        </p>
+        <WorkerFlow />
+        <div class="execution-heading-copy">
+          <p class="eyebrow">Run the suite</p>
+          <h2>Greenlight manages the worker pool for you.</h2>
+          <p>
+            The runner discovers the suite once, keeps the available workers busy,
+            and returns one ordered result.
+          </p>
+        </div>
       </div>
       <ol class="execution-steps">
         <li>

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -503,6 +503,8 @@ code {
 }
 
 .eyebrow {
+  display: flex;
+  align-items: center;
   margin-bottom: 1.25rem;
   color: var(--action);
   font-family: var(--font-display);
@@ -510,6 +512,18 @@ code {
   font-weight: 700;
   letter-spacing: 0.105em;
   text-transform: uppercase;
+  gap: 0.7rem;
+}
+
+.eyebrow::before {
+  width: 1.3rem;
+  height: 0.7rem;
+  flex: 0 0 auto;
+  background:
+    linear-gradient(currentcolor 0 0) right top / 55% 2px no-repeat,
+    linear-gradient(currentcolor 0 0) right center / 78% 2px no-repeat,
+    linear-gradient(currentcolor 0 0) right bottom / 100% 2px no-repeat;
+  content: '';
 }
 
 .hero h1 {
@@ -884,9 +898,9 @@ code {
 
 .execution-heading {
   display: grid;
-  grid-template-columns: minmax(16rem, 0.75fr) minmax(0, 1.25fr);
-  align-items: end;
-  gap: clamp(2rem, 8vw, 9rem);
+  grid-template-columns: 1fr 2fr;
+  align-items: center;
+  gap: clamp(3rem, 7vw, 7rem);
 }
 
 .execution-heading .eyebrow {
@@ -894,10 +908,145 @@ code {
   margin-bottom: 0;
 }
 
-.execution-heading > p:not(.eyebrow) {
+.execution-heading-copy > p:not(.eyebrow) {
   max-width: 34rem;
+  margin-top: 1.5rem;
   color: var(--muted);
   font-size: 1.15rem;
+}
+
+.worker-flow {
+  min-width: 0;
+  margin: 0;
+  border: 1px solid var(--rule-strong);
+  border-radius: 0.55rem;
+  background: var(--canvas);
+  box-shadow: 0 1.5rem 4rem color-mix(in oklch, var(--ink) 8%, transparent);
+  overflow: hidden;
+}
+
+.worker-flow__caption {
+  display: grid;
+  padding: 1rem 1.15rem;
+  border-bottom: 1px solid var(--rule);
+  gap: 0.25rem;
+}
+
+.worker-flow__caption span,
+.worker-flow__source span,
+.worker-flow__result span {
+  color: var(--muted);
+  font-family: var(--font-code);
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.worker-flow__caption strong {
+  font-family: var(--font-display);
+  font-size: 0.95rem;
+  font-weight: 650;
+}
+
+.worker-flow__stage {
+  position: relative;
+  display: grid;
+  padding: 1.15rem;
+  gap: 1rem;
+}
+
+.worker-flow__stage::before {
+  position: absolute;
+  top: 3.5rem;
+  bottom: 3.5rem;
+  left: 50%;
+  width: 1px;
+  background: var(--rule-strong);
+  content: '';
+}
+
+.worker-flow__source,
+.worker-flow__result {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 0.75rem 0.85rem;
+  border: 1px solid var(--rule);
+  border-radius: 0.35rem;
+  background: var(--surface);
+  gap: 1rem;
+}
+
+.worker-flow__source strong,
+.worker-flow__result strong {
+  font-family: var(--font-display);
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+
+.worker-flow__result {
+  border-color: color-mix(in oklch, var(--action) 45%, var(--rule));
+  background: var(--signal-soft);
+}
+
+.worker-flow__lanes {
+  position: relative;
+  z-index: 1;
+  display: grid;
+  margin: 0;
+  padding: 0;
+  gap: 0.55rem;
+  list-style: none;
+}
+
+.worker-flow__lanes li {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  min-height: 3.25rem;
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--rule);
+  border-radius: 0.35rem;
+  background: var(--surface);
+  gap: 0.2rem 0.75rem;
+}
+
+.worker-flow__lanes code {
+  min-width: 0;
+  color: var(--ink);
+  font-size: 0.72rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.worker-flow__lanes span {
+  grid-column: 1;
+  color: var(--muted);
+  font-family: var(--font-code);
+  font-size: 0.65rem;
+}
+
+.worker-flow__lanes strong {
+  grid-row: 1 / 3;
+  grid-column: 2;
+  color: var(--action);
+  font-family: var(--font-code);
+  font-size: 0.65rem;
+  font-weight: 650;
+}
+
+.worker-flow__description {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .execution-steps {


### PR DESCRIPTION
Turns Greenlight parallel execution into a reusable visual motif. Adds an accessible worker-flow figure to the execution section and carries three converging lanes into homepage section labels without raster assets or runtime dependencies.