### PR TITLE
fix(docs): improve homepage accessibility

### DIFF
--- a/website/src/components/RunPreview.astro
+++ b/website/src/components/RunPreview.astro
@@ -1,15 +1,15 @@
-<figure class="run-preview" aria-label="A typical Greenlight test run">
+<figure class="run-preview" aria-label="Example Greenlight test run">
   <figcaption class="run-preview__bar">
     <code><span aria-hidden="true">›</span> vendor/bin/greenlight</code>
     <span class="run-preview__state">
       <span aria-hidden="true"></span>
-      Running
+      Example run
     </span>
   </figcaption>
 
   <div class="run-preview__body">
     <div class="run-preview__meta">
-      <strong>Greenlight <span>dev-main</span></strong>
+      <strong>Greenlight <span>1.0.0</span></strong>
       <code>PHP 8.4.14 · configuration: greenlight.php · workers: 11</code>
     </div>
 
@@ -18,28 +18,43 @@
       <div aria-hidden="true"><span></span></div>
     </div>
 
-    <ol class="run-preview__tests">
-      <li>
-        <code>Acceptance\WorkerProcessRunTest</code>
-        <span>4</span>
-        <strong>3.302s</strong>
-      </li>
-      <li>
-        <code>Acceptance\CliTest</code>
-        <span>5</span>
-        <strong>3.302s</strong>
-      </li>
-      <li>
-        <code>Acceptance\PhpStanMatcherSignatureTest</code>
-        <span>0</span>
-        <strong>3.297s</strong>
-      </li>
-      <li>
-        <code>Acceptance\SymfonyRunTest</code>
-        <span>0</span>
-        <strong>0.762s</strong>
-      </li>
-    </ol>
+    <table class="run-preview__tests">
+      <caption class="visually-hidden">Test classes in progress</caption>
+      <colgroup>
+        <col />
+        <col class="run-preview__test-count" />
+        <col class="run-preview__elapsed" />
+      </colgroup>
+      <thead class="visually-hidden">
+        <tr>
+          <th scope="col">Test class</th>
+          <th scope="col">Tests</th>
+          <th scope="col">Elapsed</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <th scope="row"><code>Acceptance\WorkerProcessRunTest</code></th>
+          <td>4</td>
+          <td><strong>3.302s</strong></td>
+        </tr>
+        <tr>
+          <th scope="row"><code>Acceptance\CliTest</code></th>
+          <td>5</td>
+          <td><strong>3.302s</strong></td>
+        </tr>
+        <tr>
+          <th scope="row"><code>Acceptance\PhpStanMatcherSignatureTest</code></th>
+          <td>0</td>
+          <td><strong>3.297s</strong></td>
+        </tr>
+        <tr>
+          <th scope="row"><code>Acceptance\SymfonyRunTest</code></th>
+          <td>0</td>
+          <td><strong>0.762s</strong></td>
+        </tr>
+      </tbody>
+    </table>
 
     <p class="run-preview__more">… and 3 more running</p>
   </div>

--- a/website/src/components/Search.astro
+++ b/website/src/components/Search.astro
@@ -8,11 +8,23 @@ const pagefindScript = sitePath('_pagefind/pagefind-ui.js');
 <link rel="stylesheet" href={pagefindCss} />
 
 <details class="site-search" data-search data-pagefind-ignore="all">
-  <summary>
-    <span>Search</span>
-    <kbd>/</kbd>
+  <summary
+    role="button"
+    aria-label="Search documentation"
+    aria-keyshortcuts="/"
+    aria-controls="documentation-search"
+    aria-expanded="false"
+  >
+    <span class="search-label-full">Search</span>
+    <span class="search-label-short" aria-hidden="true">Find</span>
+    <kbd aria-hidden="true">/</kbd>
   </summary>
-  <div class="search-surface" role="dialog" aria-label="Search documentation">
+  <div
+    id="documentation-search"
+    class="search-surface"
+    role="region"
+    aria-label="Documentation search results"
+  >
     <div id="pagefind-search">
       <p class="search-loading">Enter text to search the documentation.</p>
     </div>
@@ -58,6 +70,8 @@ const pagefindScript = sitePath('_pagefind/pagefind-ui.js');
   };
 
   search?.addEventListener('toggle', () => {
+    search.querySelector('summary')?.setAttribute('aria-expanded', String(search.open));
+
     if (search.open) {
       loadPagefind();
       focusSearchInput();

--- a/website/src/components/TerminalOutput.astro
+++ b/website/src/components/TerminalOutput.astro
@@ -14,7 +14,7 @@ const lines: Part[][] = [
   [],
   [
     { text: 'Greenlight', tone: 'success' },
-    { text: ' dev-main' },
+    { text: ' 1.0.0' },
   ],
   [
     { text: 'PHP 8.4.14 | configuration: greenlight.php | workers: 11 | ' },

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -134,6 +134,17 @@ code {
   transform: translateY(0);
 }
 
+.visually-hidden {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  overflow: hidden !important;
+  clip-path: inset(50%) !important;
+  border: 0 !important;
+  white-space: nowrap !important;
+}
+
 .site-header {
   position: sticky;
   z-index: 50;
@@ -240,6 +251,10 @@ code {
 }
 
 .site-search summary::-webkit-details-marker {
+  display: none;
+}
+
+.search-label-short {
   display: none;
 }
 
@@ -714,25 +729,38 @@ code {
 }
 
 .run-preview__tests {
-  display: grid;
+  width: 100%;
   margin: 1.8rem 0 0;
-  padding: 0;
-  list-style: none;
+  border-collapse: collapse;
+  table-layout: fixed;
 }
 
-.run-preview__tests li {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) 2rem 4.2rem;
-  align-items: baseline;
-  min-height: 2.6rem;
+.run-preview__test-count {
+  width: 2rem;
+}
+
+.run-preview__elapsed {
+  width: 4.2rem;
+}
+
+.run-preview__tests th,
+.run-preview__tests td {
+  height: 2.6rem;
   padding-block: 0.65rem;
   border-bottom: 1px solid var(--rule);
   font-family: var(--font-code);
   font-size: clamp(0.66rem, 1.1vw, 0.78rem);
-  gap: 0.7rem;
+  vertical-align: baseline;
 }
 
-.run-preview__tests code {
+.run-preview__tests tbody th {
+  padding-right: 0.7rem;
+  font-weight: 400;
+  text-align: left;
+}
+
+.run-preview__tests tbody th code {
+  display: block;
   min-width: 0;
   color: var(--ink);
   overflow: hidden;
@@ -740,15 +768,14 @@ code {
   white-space: nowrap;
 }
 
-.run-preview__tests li > span {
+.run-preview__tests td {
   color: var(--muted);
   text-align: right;
 }
 
-.run-preview__tests li > strong {
+.run-preview__tests td > strong {
   color: var(--action);
   font-weight: 650;
-  text-align: right;
 }
 
 .run-preview__more {
@@ -1860,10 +1887,21 @@ code {
     line-height: 1.5;
   }
 
-  .run-preview__tests li {
-    grid-template-columns: minmax(0, 1fr) 1.5rem 3.6rem;
+  .run-preview__test-count {
+    width: 1.5rem;
+  }
+
+  .run-preview__elapsed {
+    width: 3.6rem;
+  }
+
+  .run-preview__tests th,
+  .run-preview__tests td {
     font-size: 0.74rem;
-    gap: 0.45rem;
+  }
+
+  .run-preview__tests tbody th {
+    padding-right: 0.45rem;
   }
 
   .run-preview__more {
@@ -1875,13 +1913,12 @@ code {
     font-size: 0.8rem;
   }
 
-  .site-search summary span {
-    font-size: 0;
+  .search-label-full {
+    display: none;
   }
 
-  .site-search summary span::after {
-    font-size: 0.9rem;
-    content: 'Find';
+  .search-label-short {
+    display: inline;
   }
 
   .capability-list p {


### PR DESCRIPTION
Clarifies the static run preview, gives its result rows semantic column labels, stabilizes the responsive search control accessible name, and treats search as a nonmodal region. The illustrative output now uses the released 1.0.0 version.