### PR TITLE
ci: enable color output in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,7 +333,7 @@ jobs:
         if: "matrix.dependencies == 'lowest'"
         env:
           TMPDIR: "${{ runner.temp }}/greenlight-state"
-        run: "composer tests"
+        run: "composer tests -- --ansi"
 
       # The lowest compatible PHPStan version reports false errors for types
       # that later PHPStan 2.2 releases can infer.
@@ -393,7 +393,7 @@ jobs:
         if: "matrix.analytics != true && matrix.dependencies != 'lowest'"
         env:
           TMPDIR: "${{ runner.temp }}/greenlight-state"
-        run: "composer tests"
+        run: "composer tests -- --ansi"
 
       - name: "Tests with JUnit output"
         id: "tests_analytics"
@@ -455,6 +455,7 @@ jobs:
         shell: "bash"
         run: |
           php bin/greenlight run \
+            --ansi \
             --filter=CpuCoresTest \
             --filter=InterruptionTest \
             --filter=ReporterSmokeTest \
@@ -505,6 +506,7 @@ jobs:
         shell: "bash"
         run: |
           XDEBUG_MODE=coverage php bin/greenlight run --config=greenlight.tempest-coverage.php \
+            --ansi \
             --filter='*Tempest*Test::*'
 
       - name: "Upload Tempest coverage to Codecov"
@@ -552,7 +554,7 @@ jobs:
       - name: "Tests"
         id: "compatibility-tests"
         continue-on-error: true # Allow failures until PHP 8.6 is stable.
-        run: "composer tests"
+        run: "composer tests -- --ansi"
 
       - name: "Report compatibility failure"
         if: "steps.compatibility-tests.outcome == 'failure'"
@@ -620,7 +622,7 @@ jobs:
           dependency-versions: "locked"
 
       - name: "Run the suite with coverage"
-        run: "composer tests:coverage"
+        run: "composer tests:coverage -- --ansi"
 
       - name: "Upload coverage to Codecov"
         continue-on-error: true
@@ -663,7 +665,7 @@ jobs:
           dependency-versions: "locked"
 
       - name: "Collect and export coverage with PCOV"
-        run: "php bin/greenlight run --filter='Greenlight\\Tests\\Acceptance\\CoverageRunTest::collectsAndExportsCoverageThroughTheProcessPool'"
+        run: "php bin/greenlight run --ansi --filter='Greenlight\\Tests\\Acceptance\\CoverageRunTest::collectsAndExportsCoverageThroughTheProcessPool'"
 
   benchmark-harness:
     name: "Benchmark harness smoke (numbers not published)"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -731,6 +731,11 @@ execution.
 
 In interactive output, prints a permanent line for every completed class.
 
+### `--ansi`
+
+Enables colors in append-only reporter output. It does not enable the live
+progress window.
+
 ### `--no-ansi`
 
 Disables colors and the live progress window. Output becomes plain and
@@ -738,7 +743,8 @@ append-only.
 
 A truthy `CI` environment variable has the same effect.
 
-`NO_COLOR` disables colors only.
+`NO_COLOR` disables colors only. `NO_COLOR` and `--no-ansi` have priority over
+`--ansi`.
 
 ### -h, --help
 

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -156,6 +156,7 @@ final readonly class Application
           --detect-leaks     Verify collection of each test instance. Leaks fail the run.
           --verbose          Print a permanent line per completed class in
                              interactive output
+          --ansi             Enable colors in append-only reporter output.
           --no-ansi          Disable colors and the live progress window.
                              Use plain append-only output.
           --fail-on-deprecation  Fail passed tests that captured a deprecation
@@ -894,12 +895,13 @@ final readonly class Application
             Terminal::isTty($this->stdout),
             ['CI' => \getenv('CI'), 'NO_COLOR' => \getenv('NO_COLOR')],
             $arguments->has('no-ansi'),
+            $arguments->has('ansi'),
         );
 
         $names = $arguments->values('reporter');
 
         if ($names === []) {
-            $names = [$capabilities->interactive ? 'tty' : 'plain'];
+            $names = [$capabilities->interactive || $capabilities->color ? 'tty' : 'plain'];
         }
 
         $prefix = \rtrim($workingDirectory, '/') . '/';
@@ -1092,6 +1094,7 @@ final readonly class Application
             Terminal::isTty($this->stdout),
             ['CI' => \getenv('CI'), 'NO_COLOR' => \getenv('NO_COLOR')],
             $arguments->has('no-ansi'),
+            $arguments->has('ansi'),
         )->color));
 
         if ($report === '') {
@@ -1357,6 +1360,7 @@ final readonly class Application
             new OptionSpec('watch'),
             new OptionSpec('detect-leaks'),
             new OptionSpec('dry-run'),
+            new OptionSpec('ansi'),
             new OptionSpec('no-ansi'),
             new OptionSpec('verbose'),
             new OptionSpec('profile'),

--- a/src/Cli/TerminalCapabilities.php
+++ b/src/Cli/TerminalCapabilities.php
@@ -7,7 +7,8 @@ namespace Greenlight\Cli;
 /**
  * Interactive output requires a TTY, no --no-ansi flag, and no truthy CI
  * variable. Interactive output includes the live window and cursor control.
- * Color also requires an unset or empty NO_COLOR variable.
+ * --ansi can enable color without interactive output. NO_COLOR and --no-ansi
+ * have priority over --ansi.
  *
  * @internal
  */
@@ -21,13 +22,14 @@ final readonly class TerminalCapabilities
     /**
      * @param array<string, string|false> $env getenv() snapshot for CI and NO_COLOR
      */
-    public static function detect(bool $stdoutIsTty, array $env, bool $noAnsiFlag): self
+    public static function detect(bool $stdoutIsTty, array $env, bool $noAnsiFlag, bool $ansiFlag = false): self
     {
         $interactive = $stdoutIsTty && !$noAnsiFlag && !self::truthy($env['CI'] ?? false);
         $noColorValue = $env['NO_COLOR'] ?? false;
         $noColor = $noColorValue !== false && $noColorValue !== '';
+        $color = !$noAnsiFlag && !$noColor && ($interactive || $ansiFlag);
 
-        return new self($interactive, $interactive && !$noColor);
+        return new self($interactive, $color);
     }
 
     private static function truthy(string|false $value): bool

--- a/tests/Unit/Cli/ApplicationReporterStreamTest.php
+++ b/tests/Unit/Cli/ApplicationReporterStreamTest.php
@@ -53,4 +53,39 @@ final readonly class ApplicationReporterStreamTest
         Expect::that($errors)
             ->toBe('');
     }
+
+    #[Test]
+    public function ansiFlagSelectsColoredAppendOnlyOutputWithoutATerminal(): void
+    {
+        $this->environment->unset('GREENLIGHT_CHANNEL');
+        $this->environment->set('CI', 'true');
+        $this->environment->unset('NO_COLOR');
+        $project = AcceptanceProject::createWithDiscoveryBasicTests(
+            $this->tempDirectory,
+            'application-ansi-output',
+        );
+        $stdout = MemoryStream::open();
+        $this->cleanup->defer(static fn() => MemoryStream::close($stdout));
+        $stderr = MemoryStream::open();
+        $this->cleanup->defer(static fn() => MemoryStream::close($stderr));
+
+        $exit = Application::forStreams($stdout, $stderr)->run(
+            ['run', '--workers=1', '--ansi'],
+            $project->directory,
+        );
+        \rewind($stdout);
+        \rewind($stderr);
+        $output = \stream_get_contents($stdout);
+        $errors = \stream_get_contents($stderr);
+
+        Expect::that($exit)
+            ->toBe(0);
+        Expect::that($output)
+            ->because('the ANSI flag uses color without cursor control')
+            ->toContain("\x1b[32m")
+            ->not()
+            ->toContain("\x1b[0J");
+        Expect::that($errors)
+            ->toBe('');
+    }
 }

--- a/tests/Unit/Cli/TerminalCapabilitiesTest.php
+++ b/tests/Unit/Cli/TerminalCapabilitiesTest.php
@@ -30,9 +30,32 @@ final class TerminalCapabilitiesTest
     }
 
     #[Test]
+    public function ansiFlagEnablesColorWithoutInteractivity(): void
+    {
+        $capabilities = TerminalCapabilities::detect(
+            stdoutIsTty: false,
+            env: ['CI' => 'true'],
+            noAnsiFlag: false,
+            ansiFlag: true,
+        );
+
+        Expect::that($capabilities->interactive)
+            ->because('the ANSI flag MUST NOT enable cursor control')
+            ->toBeFalse();
+        Expect::that($capabilities->color)
+            ->because('the ANSI flag enables color output in CI')
+            ->toBeTrue();
+    }
+
+    #[Test]
     public function theNoAnsiFlagForcesNonInteractive(): void
     {
-        $capabilities = TerminalCapabilities::detect(stdoutIsTty: true, env: [], noAnsiFlag: true);
+        $capabilities = TerminalCapabilities::detect(
+            stdoutIsTty: true,
+            env: [],
+            noAnsiFlag: true,
+            ansiFlag: true,
+        );
 
         Expect::that($capabilities->interactive)->because('the no ANSI flag forces non interactive')->toBeFalse();
         Expect::that($capabilities->color)->toBeFalse();
@@ -65,7 +88,12 @@ final class TerminalCapabilitiesTest
     #[Test]
     public function noColorStripsColorButKeepsInteractivity(): void
     {
-        $capabilities = TerminalCapabilities::detect(stdoutIsTty: true, env: ['NO_COLOR' => '1'], noAnsiFlag: false);
+        $capabilities = TerminalCapabilities::detect(
+            stdoutIsTty: true,
+            env: ['NO_COLOR' => '1'],
+            noAnsiFlag: false,
+            ansiFlag: true,
+        );
 
         Expect::that($capabilities->interactive)->because('no color strips color but keeps interactivity')->toBeTrue();
         Expect::that($capabilities->color)->toBeFalse();


### PR DESCRIPTION
## Summary

- enable `FORCE_COLOR` for GitHub Actions jobs
- let Greenlight emit colored append-only output without terminal cursor controls
- preserve `NO_COLOR` and `--no-ansi` precedence
- document and test forced-color behavior