### PR TITLE
perf(runner): batch tiny class assignments

### DIFF
--- a/docs/architecture/worker-lifecycle.md
+++ b/docs/architecture/worker-lifecycle.md
@@ -31,7 +31,7 @@ Ten message types cross the socket:
 | `hello` | worker to orchestrator | worker ID, shared token, process ID |
 | `bootstrap` | orchestrator to worker | stable channel, config file path, that channel's integration resources |
 | `ready` | worker to orchestrator | bootstrap acknowledgement |
-| `assign` | orchestrator to worker | a plan slice (test classes to run), recycle budgets, coverage settings, leak detection flag, result policy, artifact session and limits |
+| `assign` | orchestrator to worker | a plan slice (test classes to run), recycle budgets, remaining failure allowance, coverage settings, leak detection flag, result policy, artifact session and limits |
 | `event` | worker to orchestrator | one test event: class started, test started, test finished, class finished |
 | `attempt-started` | worker to orchestrator | active test ID and attempt number for a crash report |
 | `done` | worker to orchestrator | result summary, peak memory, coverage, detected leaks, optional recycle request |
@@ -115,6 +115,14 @@ provider when it resolves arguments for a split entry.
 The provider MUST be pure and deterministic. The execution-plan keys detect a
 provider result that changes between discovery and execution.
 
+When a previous run supplies class durations, the orchestrator can put adjacent
+small classes in one assignment. Each batch has a maximum predicted duration of
+50 ms and a maximum of 16 classes. Each adjacent group with the same resource
+set keeps at least one pooled unit for each requested worker. Batching does not
+change the class order or seed. A run without duration data keeps one pooled
+unit for each class. Greenlight does not batch a class that contains an
+`#[AllowParallel]` entry.
+
 Each channel's integration resource catalog is capped at 1 MiB, below the
 general frame limit. Greenlight sends it through the authenticated local socket,
 not through environment variables or command arguments.
@@ -133,6 +141,10 @@ attachments if a worker crashes. See [artifact storage](artifacts.md).
 it with the events it counted and fails the run on a mismatch. A lost or
 duplicated frame cannot silently pass a suite.
 
+The assignment includes the remaining failure allowance. A worker stops its
+batch locally when it uses that allowance. The orchestrator also drains all
+workers when the run reaches the limit.
+
 A retried test still produces one `test-started` event and one `test-finished`
 event. Attempts are not separate public events. The internal `attempt-started`
 frame lets the orchestrator report the correct attempt count after a worker
@@ -145,6 +157,9 @@ groups non-isolated entries by class and combines their requirements.
 
 It treats each `#[AllowParallel]` entry as a separate pooled scheduling unit.
 It treats each isolated entry as a separate isolated scheduling unit.
+It can batch small classes only when their combined resource sets are
+identical. It does not batch a class that contains an isolated or
+`#[AllowParallel]` entry.
 
 Before it sends `assign`, the orchestrator claims one slot from each required
 resource in one atomic operation. A resource without a configured limit has one

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -459,6 +459,10 @@ For a class with `#[AllowParallel]`, each split assignment holds only its own
 class-level and method-level requirements. Each isolated test also has a
 separate assignment.
 
+Cached duration data can put small classes in one unit only when they have
+identical resource sets. Greenlight does not batch a class that contains an
+isolated or `#[AllowParallel]` test.
+
 Resources default to a limit of one. Use `resourceLimit()` in `greenlight.php`
 or `--resource-limit` to set a larger limit.
 

--- a/src/Runner/Orchestrator/Distributor.php
+++ b/src/Runner/Orchestrator/Distributor.php
@@ -7,28 +7,43 @@ namespace Greenlight\Runner\Orchestrator;
 use Greenlight\Discovery\ExecutionPlan;
 
 /**
- * Produces one pooled scheduling unit for each test class by default. It
- * produces one-entry units for opted-in classes and isolated tests.
+ * Produces bounded pooled scheduling units and one-entry isolated units.
+ *
+ * By default, classes in one pooled unit have the same resource set. A pooled
+ * unit has a maximum predicted duration and class count. The distributor also
+ * keeps enough pooled units to use all requested workers. Opted-in entries and
+ * isolated entries remain one-entry units.
  *
  * @internal
  */
 final readonly class Distributor
 {
+    private const float TARGET_BATCH_SECONDS = 0.05;
+
+    private const int MAX_BATCH_CLASSES = 16;
+
     /**
-     * @return array{list<SchedulingUnit>, list<SchedulingUnit>} pooled per-class units in plan order, then isolated single-entry units
+     * @param array<string, float> $classSeconds Recorded class durations.
+     * @param positive-int $workerCount
+     *
+     * @return array{list<SchedulingUnit>, list<SchedulingUnit>} pooled units in plan order, then isolated single-entry units
      */
-    public function units(ExecutionPlan $plan): array
+    public function units(ExecutionPlan $plan, array $classSeconds = [], int $workerCount = 1): array
     {
         $pooled = [];
         $isolated = [];
+        $batchable = [];
 
-        foreach ($plan->entriesByClass() as $entries) {
+        foreach ($plan->entriesByClass() as $class => $entries) {
             $pooledEntries = [];
+            $hasUnbatchableEntry = false;
 
             foreach ($entries as $entry) {
                 if ($entry->metadata->isolated) {
+                    $hasUnbatchableEntry = true;
                     $isolated[] = new SchedulingUnit(new ExecutionPlan([$entry], $plan->seed), true);
                 } elseif ($entry->metadata->allowParallel) {
+                    $hasUnbatchableEntry = true;
                     $pooled[] = new SchedulingUnit(new ExecutionPlan([$entry], $plan->seed), false);
                 } else {
                     $pooledEntries[] = $entry;
@@ -37,9 +52,128 @@ final readonly class Distributor
 
             if ($pooledEntries !== []) {
                 $pooled[] = new SchedulingUnit(new ExecutionPlan($pooledEntries, $plan->seed), false);
+                $batchable[$class] = !$hasUnbatchableEntry;
             }
         }
 
-        return [$pooled, $isolated];
+        if ($classSeconds === []) {
+            return [$pooled, $isolated];
+        }
+
+        return [$this->batch($pooled, $classSeconds, $batchable, $workerCount), $isolated];
+    }
+
+    /**
+     * @param list<SchedulingUnit> $units
+     * @param array<string, float> $classSeconds
+     * @param array<non-empty-string, bool> $batchable
+     * @param positive-int $workerCount
+     *
+     * @return list<SchedulingUnit>
+     */
+    private function batch(array $units, array $classSeconds, array $batchable, int $workerCount): array
+    {
+        $batched = [];
+        $compatible = [];
+
+        foreach ($units as $unit) {
+            $class = $unit->plan->entries[0]->id->class;
+            $seconds = $classSeconds[$class] ?? null;
+
+            if (($batchable[$class] ?? false) !== true
+                || !\is_float($seconds)
+                || !\is_finite($seconds)
+                || $seconds < 0.0
+                || $seconds > self::TARGET_BATCH_SECONDS
+            ) {
+                $this->flushCompatible($batched, $compatible, $workerCount);
+                $batched[] = $unit;
+
+                continue;
+            }
+
+            if ($compatible !== [] && !$this->hasSameResources($compatible[0][0], $unit)) {
+                $this->flushCompatible($batched, $compatible, $workerCount);
+            }
+
+            $compatible[] = [$unit, $seconds];
+        }
+
+        $this->flushCompatible($batched, $compatible, $workerCount);
+
+        return $batched;
+    }
+
+    /**
+     * @param list<SchedulingUnit> $batched
+     * @param list<array{SchedulingUnit, float}> $compatible
+     * @param positive-int $workerCount
+     */
+    private function flushCompatible(array &$batched, array &$compatible, int $workerCount): void
+    {
+        if ($compatible === []) {
+            return;
+        }
+
+        $pending = [];
+        $pendingSeconds = 0.0;
+        $remainingMerges = \max(0, \count($compatible) - $workerCount);
+
+        foreach ($compatible as [$unit, $seconds]) {
+            if ($pending !== [] && (
+                $remainingMerges === 0
+                || \count($pending) >= self::MAX_BATCH_CLASSES
+                || $pendingSeconds + $seconds > self::TARGET_BATCH_SECONDS
+            )) {
+                $this->flushBatch($batched, $pending);
+                $pendingSeconds = 0.0;
+            }
+
+            if ($pending !== [] && $remainingMerges > 0) {
+                --$remainingMerges;
+            }
+
+            $pending[] = $unit;
+            $pendingSeconds += $seconds;
+        }
+
+        $this->flushBatch($batched, $pending);
+        $compatible = [];
+    }
+
+    /**
+     * @param list<SchedulingUnit> $batched
+     * @param list<SchedulingUnit> $pending
+     */
+    private function flushBatch(array &$batched, array &$pending): void
+    {
+        if (\count($pending) === 1) {
+            $batched[] = $pending[0];
+            $pending = [];
+
+            return;
+        }
+
+        $entries = [];
+
+        foreach ($pending as $unit) {
+            $entries = [...$entries, ...$unit->plan->entries];
+        }
+
+        $batched[] = new SchedulingUnit(
+            new ExecutionPlan($entries, $pending[0]->plan->seed),
+            false,
+        );
+        $pending = [];
+    }
+
+    private function hasSameResources(SchedulingUnit $left, SchedulingUnit $right): bool
+    {
+        $leftResources = $left->resources;
+        $rightResources = $right->resources;
+        \sort($leftResources);
+        \sort($rightResources);
+
+        return $leftResources === $rightResources;
     }
 }

--- a/src/Runner/Orchestrator/Orchestrator.php
+++ b/src/Runner/Orchestrator/Orchestrator.php
@@ -172,6 +172,7 @@ final class Orchestrator
 
     /**
      * @param positive-int $workerCount
+     * @param array<string, float> $classSeconds Recorded class durations.
      *
      * @throws ProtocolError
      * @throws AttachmentError
@@ -179,13 +180,13 @@ final class Orchestrator
      * @throws ReportingError
      * @throws WireError
      */
-    public function run(ExecutionPlan $plan, EventSink $sink, int $workerCount): ResultSummary
+    public function run(ExecutionPlan $plan, EventSink $sink, int $workerCount, array $classSeconds = []): ResultSummary
     {
         foreach ($plan->entries as $entry) {
             $this->entriesById[(string) $entry->id] = $entry;
         }
 
-        [$pooled, $isolated] = new Distributor()->units($plan);
+        [$pooled, $isolated] = new Distributor()->units($plan, $classSeconds, $workerCount);
         $this->scheduler = new ResourceScheduler($pooled, $isolated, $this->resourceLimits);
 
         if ($this->scheduler->pendingCount() === 0) {
@@ -469,6 +470,7 @@ final class Orchestrator
                 $this->policy,
                 $this->artifactStore?->session(),
                 $this->artifactConfiguration,
+                $this->remainingFailureAllowance(),
             ));
             $handle->lastProgressAt = $this->monotonicTime();
         } catch (ProtocolError) {
@@ -668,6 +670,18 @@ final class Orchestrator
         }
 
         $handle->inFlightAttempt = $message->attempt;
+    }
+
+    /**
+     * @return positive-int|null
+     */
+    private function remainingFailureAllowance(): ?int
+    {
+        if ($this->stopAfterFailures === null) {
+            return null;
+        }
+
+        return \max(1, $this->stopAfterFailures - $this->summary->failed - $this->summary->errored);
     }
 
     private function drainAll(): void

--- a/src/Runner/Orchestrator/SchedulingUnit.php
+++ b/src/Runner/Orchestrator/SchedulingUnit.php
@@ -7,7 +7,7 @@ namespace Greenlight\Runner\Orchestrator;
 use Greenlight\Discovery\ExecutionPlan;
 
 /**
- * One test-class assignment and its required resources.
+ * One bounded assignment and its required resources.
  *
  * @internal
  */

--- a/src/Runner/ParallelRunner.php
+++ b/src/Runner/ParallelRunner.php
@@ -89,7 +89,7 @@ final readonly class ParallelRunner
             $fixtures = new ProvisionedIntegrationFixtures();
 
             if (\count($plan) > 0) {
-                [$pooled, $isolated] = new Distributor()->units($plan);
+                [$pooled, $isolated] = new Distributor()->units($plan, $classSeconds, $workerCount);
                 $channelCount = \min($workerCount, \count($pooled) + \count($isolated));
                 $fixtures = IntegrationFixtureManager::provision(
                     $orchestratorSide,
@@ -127,7 +127,7 @@ final readonly class ParallelRunner
                     resourceLimits: $configuration->resourceLimits,
                 );
 
-                $summary = $orchestrator->run($plan, $sink, $workerCount);
+                $summary = $orchestrator->run($plan, $sink, $workerCount, $classSeconds);
 
                 $durationSeconds = (\hrtime(true) - $startedAt) / 1_000_000_000;
                 $sink->emit(new RunFinished($runId, $summary, $durationSeconds, \microtime(true)));

--- a/src/Runner/Protocol/Messages/Assign.php
+++ b/src/Runner/Protocol/Messages/Assign.php
@@ -12,7 +12,7 @@ use Greenlight\Runner\Artifact\ArtifactSession;
 use Greenlight\Runner\Protocol\Message;
 
 /**
- * Sends an execution-plan part and worker replacement limits to a worker.
+ * Sends an execution-plan part, limits, and settings to a worker.
  *
  * @internal
  */
@@ -23,6 +23,7 @@ final readonly class Assign implements Message
      * @param positive-int|null $recycleAboveMemoryBytes
      * @param list<non-empty-string>|null $coverageInclude Null disables coverage.
      * @param non-empty-string|null $coverageDriver
+     * @param positive-int|null $stopAfterFailures Remaining assignment failure allowance.
      */
     public function __construct(
         public ExecutionPlan $slice,
@@ -34,6 +35,7 @@ final readonly class Assign implements Message
         public ?ResultPolicy $policy = null,
         public ?ArtifactSession $artifactSession = null,
         public ?ArtifactConfiguration $artifactConfiguration = null,
+        public ?int $stopAfterFailures = null,
     ) {}
 
     #[\Override]
@@ -55,6 +57,7 @@ final readonly class Assign implements Message
             'policy' => $this->policy?->toWire(),
             'artifactSession' => $this->artifactSession?->toWire(),
             'artifactConfiguration' => $this->artifactConfiguration?->toWire(),
+            'stopAfterFailures' => $this->stopAfterFailures,
         ];
     }
 
@@ -65,6 +68,9 @@ final readonly class Assign implements Message
         $recycleAboveMemory = Wire::nullableInt($payload, 'recycleAboveMemoryBytes');
         $coverageInclude = Wire::nullableListOfStrings($payload, 'coverageInclude');
         $coverageDriver = Wire::nullableString($payload, 'coverageDriver');
+        $stopAfterFailures = \array_key_exists('stopAfterFailures', $payload)
+            ? Wire::nullableInt($payload, 'stopAfterFailures')
+            : null;
 
         if ($coverageInclude !== null) {
             $coverageInclude = \array_values(\array_filter($coverageInclude, static fn(string $path): bool => $path !== ''));
@@ -84,6 +90,7 @@ final readonly class Assign implements Message
             ($artifactConfiguration = \array_key_exists('artifactConfiguration', $payload) ? Wire::nullableMap($payload, 'artifactConfiguration') : null) === null
                 ? null
                 : ArtifactConfiguration::fromWire($artifactConfiguration),
+            $stopAfterFailures === null ? null : \max(1, $stopAfterFailures),
         );
     }
 }

--- a/src/Runner/Worker/WorkerProcess.php
+++ b/src/Runner/Worker/WorkerProcess.php
@@ -257,7 +257,7 @@ final readonly class WorkerProcess
             )->run(
                 $message->slice,
                 new SocketEventSink($channel),
-                null,
+                $message->stopAfterFailures,
                 new WorkerBudget($message->recycleAfterTests, $message->recycleAboveMemoryBytes),
                 static fn(): bool => $channel->poll() instanceof Drain,
                 $scopes,

--- a/tests/Unit/Runner/Orchestrator/DistributorBatchingTest.php
+++ b/tests/Unit/Runner/Orchestrator/DistributorBatchingTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Orchestrator;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\ExecutionPlan;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\Orchestrator\Distributor;
+use Greenlight\Runner\Orchestrator\SchedulingUnit;
+use Greenlight\Tests\Support\PlanEntryFixture;
+
+final readonly class DistributorBatchingTest
+{
+    #[Test]
+    public function tinyClassesWithTheSameResourcesShareABoundedUnit(): void
+    {
+        $plan = new ExecutionPlan([
+            PlanEntryFixture::create('Acme\\AlphaTest', resources: ['redis', 'postgres']),
+            PlanEntryFixture::create('Acme\\BetaTest', resources: ['postgres', 'redis']),
+            PlanEntryFixture::create('Acme\\GammaTest', resources: ['redis', 'postgres']),
+        ]);
+
+        [$pooled, $isolated] = new Distributor()->units($plan, [
+            'Acme\\AlphaTest' => 0.02,
+            'Acme\\BetaTest' => 0.02,
+            'Acme\\GammaTest' => 0.02,
+        ]);
+
+        Expect::that($this->classShape($pooled))
+            ->because('a batch MUST preserve class order and stay below its predicted duration limit')
+            ->toBe([
+                ['Acme\\AlphaTest', 'Acme\\BetaTest'],
+                ['Acme\\GammaTest'],
+            ]);
+        Expect::that($pooled[0]->resources)
+            ->because('resource order MUST NOT change resource-set compatibility')
+            ->toBe(['redis', 'postgres']);
+        Expect::that($isolated)->toBe([]);
+    }
+
+    #[Test]
+    public function incompatibleAndUnknownClassesKeepOneClassUnits(): void
+    {
+        $plan = new ExecutionPlan([
+            PlanEntryFixture::create('Acme\\FreeTest'),
+            PlanEntryFixture::create('Acme\\PostgresTest', resources: ['postgres']),
+            PlanEntryFixture::create('Acme\\RedisTest', resources: ['redis']),
+            PlanEntryFixture::create('Acme\\UnknownTest'),
+            PlanEntryFixture::create('Acme\\LargeTest'),
+        ]);
+
+        [$pooled] = new Distributor()->units($plan, [
+            'Acme\\FreeTest' => 0.001,
+            'Acme\\PostgresTest' => 0.001,
+            'Acme\\RedisTest' => 0.001,
+            'Acme\\LargeTest' => 0.051,
+        ]);
+
+        Expect::that($this->classShape($pooled))
+            ->because('unsafe duration or resource combinations MUST keep one-class assignments')
+            ->toBe([
+                ['Acme\\FreeTest'],
+                ['Acme\\PostgresTest'],
+                ['Acme\\RedisTest'],
+                ['Acme\\UnknownTest'],
+                ['Acme\\LargeTest'],
+            ]);
+    }
+
+    #[Test]
+    public function classesWithIsolatedEntriesDoNotJoinBatches(): void
+    {
+        $plan = new ExecutionPlan([
+            PlanEntryFixture::create('Acme\\MixedTest', 'pooled'),
+            PlanEntryFixture::create('Acme\\MixedTest', 'isolated', isolated: true),
+            PlanEntryFixture::create('Acme\\NextTest'),
+        ]);
+
+        [$pooled, $isolated] = new Distributor()->units($plan, [
+            'Acme\\MixedTest' => 0.001,
+            'Acme\\NextTest' => 0.001,
+        ]);
+
+        Expect::that($this->classShape($pooled))
+            ->because('a mixed-isolation class has no safe pooled duration estimate')
+            ->toBe([
+                ['Acme\\MixedTest'],
+                ['Acme\\NextTest'],
+            ]);
+        Expect::that($this->classShape($isolated))
+            ->because('an isolated entry MUST remain a separate unit')
+            ->toBe([['Acme\\MixedTest']]);
+    }
+
+    #[Test]
+    public function allowParallelEntriesDoNotJoinBatches(): void
+    {
+        $plan = new ExecutionPlan([
+            PlanEntryFixture::create('Acme\\ParallelTest', 'first', allowParallel: true),
+            PlanEntryFixture::create('Acme\\ParallelTest', 'second', allowParallel: true),
+            PlanEntryFixture::create('Acme\\NextTest'),
+        ]);
+
+        [$pooled] = new Distributor()->units($plan, [
+            'Acme\\ParallelTest' => 0.001,
+            'Acme\\NextTest' => 0.001,
+        ]);
+
+        Expect::that($this->classShape($pooled))
+            ->because('opted-in entries MUST remain separate scheduling units')
+            ->toBe([
+                ['Acme\\ParallelTest'],
+                ['Acme\\ParallelTest'],
+                ['Acme\\NextTest'],
+            ]);
+    }
+
+    #[Test]
+    public function seededPlansPreserveTheirClassOrderAndSeed(): void
+    {
+        $plan = new ExecutionPlan([
+            PlanEntryFixture::create('Acme\\AlphaTest'),
+            PlanEntryFixture::create('Acme\\BetaTest'),
+        ], seed: 4242);
+
+        [$pooled] = new Distributor()->units($plan, [
+            'Acme\\AlphaTest' => 0.001,
+            'Acme\\BetaTest' => 0.001,
+        ]);
+
+        Expect::that($this->classShape($pooled))
+            ->because('batching a seeded plan MUST preserve its class order')
+            ->toBe([['Acme\\AlphaTest', 'Acme\\BetaTest']]);
+        Expect::that($pooled[0]->plan->seed)->toBe(4242);
+    }
+
+    #[Test]
+    public function manyZeroDurationClassesKeepWorkerCapacityAndLimitBatchSize(): void
+    {
+        $entries = [];
+        $durations = [];
+
+        for ($index = 0; $index < 64; ++$index) {
+            $class = \sprintf('Acme\\Fast%02dTest', $index);
+            $entries[] = PlanEntryFixture::create($class);
+            $durations[$class] = 0.0;
+        }
+
+        [$pooled] = new Distributor()->units(new ExecutionPlan($entries), $durations, workerCount: 4);
+
+        Expect::that($pooled)
+            ->because('many fast classes SHOULD need fewer assignments without reducing worker capacity')
+            ->toHaveCount(4);
+
+        foreach ($pooled as $unit) {
+            Expect::that($unit->plan->classes())
+                ->because('a stale zero-duration estimate MUST NOT create a large tail unit')
+                ->toHaveCount(16);
+        }
+
+        Expect::that(\array_merge(...$this->classShape($pooled)))
+            ->because('batching MUST preserve every class in plan order')
+            ->toBe(\array_keys($durations));
+    }
+
+    #[Test]
+    public function eachCompatibleResourceRunKeepsWorkerCapacity(): void
+    {
+        $entries = [];
+        $durations = [];
+
+        foreach (['FreeA', 'FreeB', 'FreeC', 'FreeD', 'FreeE', 'FreeF', 'FreeG', 'FreeH'] as $name) {
+            $class = 'Acme\\' . $name . 'Test';
+            $entries[] = PlanEntryFixture::create($class);
+            $durations[$class] = 0.001;
+        }
+
+        foreach (['DbA', 'DbB', 'DbC', 'DbD'] as $name) {
+            $class = 'Acme\\' . $name . 'Test';
+            $entries[] = PlanEntryFixture::create($class, resources: ['postgres']);
+            $durations[$class] = 0.001;
+        }
+
+        [$pooled] = new Distributor()->units(new ExecutionPlan($entries), $durations, workerCount: 4);
+
+        Expect::that($this->classShape($pooled))
+            ->because('batching MUST preserve worker capacity for each resource-compatible run')
+            ->toBe([
+                ['Acme\\FreeATest', 'Acme\\FreeBTest', 'Acme\\FreeCTest', 'Acme\\FreeDTest', 'Acme\\FreeETest'],
+                ['Acme\\FreeFTest'],
+                ['Acme\\FreeGTest'],
+                ['Acme\\FreeHTest'],
+                ['Acme\\DbATest'],
+                ['Acme\\DbBTest'],
+                ['Acme\\DbCTest'],
+                ['Acme\\DbDTest'],
+            ]);
+    }
+
+    /**
+     * @param list<SchedulingUnit> $units
+     *
+     * @return list<list<non-empty-string>>
+     */
+    private function classShape(array $units): array
+    {
+        return \array_map(
+            static fn(SchedulingUnit $unit): array => $unit->plan->classes(),
+            $units,
+        );
+    }
+}

--- a/tests/Unit/Runner/Orchestrator/OrchestratorTest.php
+++ b/tests/Unit/Runner/Orchestrator/OrchestratorTest.php
@@ -11,6 +11,7 @@ use Greenlight\Core\Event\RecycleReason;
 use Greenlight\Core\Event\TestClassStarted;
 use Greenlight\Core\Event\WorkerRecycled;
 use Greenlight\Core\Result\ResultSummary;
+use Greenlight\Core\Result\TestResult;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Discovery\ExecutionPlan;
@@ -486,7 +487,7 @@ final class OrchestratorTest
 
     #[Test]
     #[Timeout(30.0)]
-    public function failureLimitDrainsQueuedClassAssignments(): void
+    public function failureLimitDrainsRemainingBatchedClasses(): void
     {
         $root = \dirname(__DIR__, 4);
         $sink = new CollectingEventSink();
@@ -496,11 +497,19 @@ final class OrchestratorTest
             stopAfterFailures: 1,
         );
 
-        $summary = $orchestrator->run($this->failingThenPassingPlan(), $sink, 1);
+        $summary = $orchestrator->run(
+            $this->failingThenPassingPlan(),
+            $sink,
+            1,
+            [
+                AaTest::class => 0.001,
+                BbTest::class => 0.001,
+            ],
+        );
         $results = $sink->results();
 
         Expect::that($summary->total())
-            ->because('the failure limit MUST stop before the queued class assignment runs')
+            ->because('the failure limit MUST stop before the remaining batched class runs')
             ->toBe(1);
         Expect::that($summary->errored)
             ->toBe(1);
@@ -508,6 +517,42 @@ final class OrchestratorTest
             ->toHaveCount(1);
         Expect::that((string) $results[0]->id)
             ->toBe(AaTest::class . '::fails');
+    }
+
+    #[Test]
+    #[Timeout(30.0)]
+    public function workerRecyclingPreservesABatchedRemainder(): void
+    {
+        $root = \dirname(__DIR__, 4);
+        $sink = new CollectingEventSink();
+        $orchestrator = new Orchestrator(
+            workerCommand: [\PHP_BINARY, $root . '/bin/greenlight'],
+            workingDirectory: $root,
+            recycleAfterTests: 1,
+        );
+
+        $summary = $orchestrator->run(
+            $this->twoClassPassingPlan(),
+            $sink,
+            1,
+            [
+                CleanTest::class => 0.001,
+                WaitingResourceTest::class => 0.001,
+            ],
+        );
+
+        Expect::that($summary->passed)
+            ->because('a replacement worker MUST complete the remainder of a batched assignment')
+            ->toBe(2);
+        Expect::that(\array_map(
+            static fn(TestResult $result): string => (string) $result->id,
+            $sink->results(),
+        ))
+            ->because('worker recycling MUST preserve class and test order')
+            ->toBe([
+                CleanTest::class . '::passesAndIsCollectable',
+                WaitingResourceTest::class . '::runsAfterTheWait',
+            ]);
     }
 
     #[Test]
@@ -536,6 +581,42 @@ final class OrchestratorTest
                 . "Worker output:\nThe worker emitted crash diagnostics.",
             );
         Expect::that($results[0]->error?->class)->toBe(WorkerError::class);
+    }
+
+    #[Test]
+    #[Timeout(30.0)]
+    public function crashedWorkerRequeuesLaterClassesFromABatchedAssignment(): void
+    {
+        $root = \dirname(__DIR__, 4);
+        $sink = new CollectingEventSink();
+        $orchestrator = new Orchestrator(
+            workerCommand: [\PHP_BINARY, $root . '/bin/greenlight'],
+            workingDirectory: $root,
+        );
+
+        $summary = $orchestrator->run(
+            $this->crashThenPassingPlan(),
+            $sink,
+            1,
+            [
+                CrashDiagnosticsTest::class => 0.001,
+                CleanTest::class => 0.001,
+            ],
+        );
+        $results = $sink->results();
+
+        Expect::that($summary->errored)->toBe(1);
+        Expect::that($summary->passed)
+            ->because('crash containment MUST requeue later classes in a batched assignment')
+            ->toBe(1);
+        Expect::that(\array_map(
+            static fn(TestResult $result): string => (string) $result->id,
+            $results,
+        ))
+            ->toBe([
+                CrashDiagnosticsTest::class . '::writesDiagnosticsThenExits',
+                CleanTest::class . '::passesAndIsCollectable',
+            ]);
     }
 
     #[Test]
@@ -691,6 +772,17 @@ final class OrchestratorTest
 
         return new ExecutionPlan([
             new PlanEntry($id, new TestMetadata($id->class, $id->method)),
+        ]);
+    }
+
+    private function crashThenPassingPlan(): ExecutionPlan
+    {
+        $crash = new TestId(CrashDiagnosticsTest::class, 'writesDiagnosticsThenExits');
+        $passing = new TestId(CleanTest::class, 'passesAndIsCollectable');
+
+        return new ExecutionPlan([
+            new PlanEntry($crash, new TestMetadata($crash->class, $crash->method)),
+            new PlanEntry($passing, new TestMetadata($passing->class, $passing->method)),
         ]);
     }
 

--- a/tests/Unit/Runner/Protocol/ProtocolTest.php
+++ b/tests/Unit/Runner/Protocol/ProtocolTest.php
@@ -119,6 +119,7 @@ final class ProtocolTest
             10,
             artifactSession: new ArtifactSession('/tmp/staging', 'build/artifacts/run-1'),
             artifactConfiguration: new ArtifactConfiguration(maxRunAttachments: 123),
+            stopAfterFailures: 2,
         )->toWire());
 
         Expect::that($assign->slice->seed)->because('assign carries the plan intact')->toBe(42);
@@ -127,6 +128,7 @@ final class ProtocolTest
         Expect::that($assign->artifactSession?->stagingDirectory)->toBe('/tmp/staging');
         Expect::that($assign->artifactSession?->publicDirectory)->toBe('build/artifacts/run-1');
         Expect::that($assign->artifactConfiguration?->maxRunAttachments)->toBe(123);
+        Expect::that($assign->stopAfterFailures)->toBe(2);
         Expect::that($assign->slice->entries[0]->id->dataSetKey)->toBe('data set one');
         Expect::that($assign->slice->entries[0]->metadata->isolated)->toBeTrue();
         Expect::that($assign->slice->entries[0]->metadata->resources)->toBe(['postgres']);
@@ -151,7 +153,7 @@ final class ProtocolTest
     public function legacyAssignmentPayloadsDefaultArtifactFields(): void
     {
         $payload = new Assign(new ExecutionPlan([]))->toWire();
-        unset($payload['artifactSession'], $payload['artifactConfiguration']);
+        unset($payload['artifactSession'], $payload['artifactConfiguration'], $payload['stopAfterFailures']);
 
         $assign = Assign::fromWire($payload);
 
@@ -160,6 +162,9 @@ final class ProtocolTest
             ->toBeNull();
         Expect::that($assign->artifactConfiguration)
             ->because('legacy assignments have no artifact configuration')
+            ->toBeNull();
+        Expect::that($assign->stopAfterFailures)
+            ->because('legacy assignments have no local failure allowance')
             ->toBeNull();
     }
 


### PR DESCRIPTION
## Summary

- Batch adjacent tiny classes when cached durations predict a bounded assignment.
- Limit batches to 50 ms and 16 classes while preserving worker capacity, class order, isolation, and exact resource sets.
- Keep one-class assignments without duration data and enforce bail locally within batched assignments.

## Performance

On the 2,000-test many-fast benchmark with five runs, the four-worker median fell from 5.352 s to 1.208 s. The one-worker median fell from 2.161 s to 0.642 s.