### PR TITLE
feat: allow parallel scheduling within test classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,8 +115,11 @@ The orchestrator controls resource limits, worker replacement, event checks,
 and reports. It also stores test durations to improve the order of later runs.
 
 Greenlight normally schedules complete test classes. It schedules each
-`#[Isolated]` test separately. It preserves the method order in a class, but
-different workers can run different classes.
+`#[Isolated]` test separately. Add `#[AllowParallel]` to split an independent
+large class into one assignment for each selected test or data set.
+
+Greenlight preserves execution-plan order. Worker placement and completion
+order remain load-dependent.
 
 Use a channel to give each worker a separate external resource. Use
 `#[RequiresResource]` to limit concurrent access to a shared resource.

--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -22,6 +22,23 @@ final readonly class After
 
 This type does not declare public members.
 
+## `AllowParallel`
+
+Namespace: `Greenlight\Attribute`
+
+Allows Greenlight to assign tests from one class to different workers.
+
+The class MUST NOT use per-class harness services or `#[Isolated]`.
+
+```php
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final readonly class AllowParallel
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/AllowParallel.php#L13)
+
+This type does not declare public members.
+
 ## `Before`
 
 Namespace: `Greenlight\Attribute`
@@ -230,7 +247,7 @@ This type does not declare public members.
 
 Namespace: `Greenlight\Attribute`
 
-Declares a resource that the assignment for the test class requires.
+Declares a resource that the assignment for the test requires.
 
 ```php
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]

--- a/docs/api-test-contracts.md
+++ b/docs/api-test-contracts.md
@@ -302,7 +302,7 @@ PHPDoc:
 public ?string $skipReason
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L59)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L60)
 
 ### `$skipUnlessCondition`
 
@@ -310,7 +310,7 @@ public ?string $skipReason
 public ?string $skipUnlessCondition
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L60)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L61)
 
 ### `$retryTimes`
 
@@ -318,7 +318,7 @@ public ?string $skipUnlessCondition
 public ?int $retryTimes
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L61)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L62)
 
 ### `$retryOnlyOn`
 
@@ -326,7 +326,7 @@ public ?int $retryTimes
 public ?string $retryOnlyOn
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L62)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L63)
 
 ### `$timeoutSeconds`
 
@@ -334,7 +334,7 @@ public ?string $retryOnlyOn
 public ?float $timeoutSeconds
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L63)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L64)
 
 ### `$isolated`
 
@@ -342,7 +342,7 @@ public ?float $timeoutSeconds
 public bool $isolated
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L64)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L65)
 
 ### `$dataSetProvider`
 
@@ -350,7 +350,7 @@ public bool $isolated
 public ?string $dataSetProvider
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L65)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L66)
 
 ### `$capture`
 
@@ -358,7 +358,7 @@ public ?string $dataSetProvider
 public bool $capture
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L66)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L67)
 
 ### `$noExpectations`
 
@@ -366,7 +366,7 @@ public bool $capture
 public bool $noExpectations
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L67)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L68)
 
 ### `$dataSetProviderClass`
 
@@ -374,7 +374,15 @@ public bool $noExpectations
 public ?string $dataSetProviderClass
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L70)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L71)
+
+### `$allowParallel`
+
+```php
+public bool $allowParallel
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L72)
 
 ### `__construct()`
 
@@ -395,6 +403,7 @@ public function __construct(
     array $skipUnlessArguments = [],
     array $resources = [],
     public ?string $dataSetProviderClass = null,
+    public bool $allowParallel = false,
 )
 ```
 
@@ -409,9 +418,10 @@ PHPDoc:
 - `@param list<mixed> $skipUnlessArguments validated to scalars or null`
 - `@param list<string> $resources named resources required by this test entry`
 - `@param non-empty-string|null $dataSetProviderClass`
+- `@param bool $allowParallel Whether the class permits separate worker assignments.`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L55)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L56)
 
 ### `toWire()`
 
@@ -420,7 +430,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L128)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L130)
 
 ### `fromWire()`
 
@@ -434,7 +444,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the decoded metadata violates a domain invariant`
 - `@throws InvalidWirePayload when a required field is missing or has the wrong type`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L154)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Test/TestMetadata.php#L157)
 
 ## `InvalidWirePayload`
 

--- a/docs/architecture/worker-lifecycle.md
+++ b/docs/architecture/worker-lifecycle.md
@@ -90,6 +90,31 @@ them for later assignments. Per-run harness services therefore live for the
 physical worker's lifetime. Workers rebuild per-class reflection, hooks, and
 data sets for each class.
 
+The default scheduling unit contains the selected non-isolated tests from one
+class. `#[AllowParallel]` changes each selected test or data set into a pooled
+one-entry scheduling unit.
+
+The orchestrator keeps these units in execution-plan order. It assigns them to
+workers by capacity, so their completion events can have a different order.
+
+Each split unit opens and closes its own class context. It emits one
+`TestClassStarted` and `TestClassFinished` pair.
+
+These pairs can overlap for one class. Reporters MUST combine or separate them
+without loss of test results.
+
+Greenlight has no class hooks. `#[Before]` and `#[After]` are test hooks, so
+their lifecycle does not change for a split class.
+
+A split class cannot use a per-class harness service. A service request causes
+a contained test error with corrective guidance.
+
+Data providers run during discovery. A worker also runs the applicable
+provider when it resolves arguments for a split entry.
+
+The provider MUST be pure and deterministic. The execution-plan keys detect a
+provider result that changes between discovery and execution.
+
 Each channel's integration resource catalog is capped at 1 MiB, below the
 general frame limit. Greenlight sends it through the authenticated local socket,
 not through environment variables or command arguments.
@@ -116,8 +141,10 @@ crash. It uses this frame when a worker dies before `test-finished`.
 ## Resource assignment
 
 Discovery stores `#[RequiresResource]` names in test metadata. The orchestrator
-groups non-isolated entries by class and combines their requirements. It treats
-each isolated entry as a separate scheduling unit.
+groups non-isolated entries by class and combines their requirements.
+
+It treats each `#[AllowParallel]` entry as a separate pooled scheduling unit.
+It treats each isolated entry as a separate isolated scheduling unit.
 
 Before it sends `assign`, the orchestrator claims one slot from each required
 resource in one atomic operation. A resource without a configured limit has one
@@ -244,6 +271,21 @@ may take an isolated entry, and only after the pooled queue is empty. After
 `done`, the orchestrator sends `drain` and lets the process exit instead of
 returning it to the pool. Any global state changed by the test dies with the
 worker. An isolated entry still waits for its required resources.
+
+`#[AllowParallel]` and `#[Isolated]` express incompatible process ownership.
+Discovery rejects a class that combines them.
+
+## Split classes
+
+`#[AllowParallel]` changes scheduling granularity. It does not change plan
+creation, selection, seeds, retry rules, timeout rules, or result identities.
+
+The orchestrator applies resource limits and crash containment to each split
+unit. A worker crash affects only the active test because a split unit has one
+entry.
+
+With one worker, the attribute does not create concurrency. Parallel execution
+always uses worker processes. Greenlight does not use Fibers for this feature.
 
 ## Channel numbers
 

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -378,6 +378,55 @@ period.
 public function convergesQuickly(): void { ... }
 ```
 
+## AllowParallel
+
+Target: class.
+
+No parameters.
+
+Allows Greenlight to assign tests from one class to different worker
+processes. Each selected test or data set becomes one pooled assignment.
+
+Without this attribute, Greenlight assigns all non-isolated tests in a class
+as one unit. This default preserves method order and class-scope state.
+
+Use this attribute only when all tests and data sets in the class are
+independent:
+
+<!-- php-example {"mode":"display","reason":"Uses an ellipsis to omit code that is not relevant to the example."} -->
+```php
+#[AllowParallel]
+final class LargeImportTest
+{
+    #[Test]
+    #[DataSet('imports')]
+    public function importsOneFile(ImportCase $case): void { ... }
+}
+```
+
+Greenlight preserves execution-plan order when it makes assignments. Worker
+placement and completion-event order remain load-dependent.
+
+Each assignment emits one class-started and class-finished event pair. The
+`#[Before]` and `#[After]` hooks still run for each test attempt.
+
+A data provider can run again in each assigned worker. Providers MUST be pure,
+deterministic, and fast.
+
+`#[AllowParallel]` is incompatible with these features:
+
+* `#[Isolated]` on the class or one of its test methods
+* a harness service with `Scope::PerClass`
+
+Discovery rejects the combination with `#[Isolated]`. A worker reports a test
+error if the class requests a per-class harness service.
+
+Retries and timeouts remain local to one test. Resource limits apply to each
+split assignment.
+
+The attribute has no concurrency effect with one worker. Greenlight uses
+worker processes for concurrency and does not use Fibers.
+
 ## RequiresResource
 
 Target: method or class. Repeatable.
@@ -403,11 +452,12 @@ final class OrderRepositoryTest { ... }
 Class-level requirements apply to each method. Greenlight combines method-level
 requirements with them. Multiple occurrences of the same name have no effect.
 
-Greenlight combines requirements from all non-isolated tests in a class and
-holds them until the class assignment finishes. Thus, a method requirement can
-reduce concurrency for other non-isolated tests in the class. Each isolated
-test has a separate assignment with its class-level and method-level
-requirements.
+By default, Greenlight combines requirements from all non-isolated tests in a
+class. It holds them until the class assignment finishes.
+
+For a class with `#[AllowParallel]`, each split assignment holds only its own
+class-level and method-level requirements. Each isolated test also has a
+separate assignment.
 
 Resources default to a limit of one. Use `resourceLimit()` in `greenlight.php`
 or `--resource-limit` to set a larger limit.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -82,18 +82,23 @@ Default: `'auto'` workers, a `256M` memory recycle limit, and no test-count
 recycle limit.
 
 A worker requests one class at a time. When the worker finishes that class, it
-requests the next class. Thus, a long class does not make another worker idle.
+requests the next class.
+
+Greenlight keeps this class-level schedule by default. Add `#[AllowParallel]`
+to an independent large class to make each test or data set a separate
+assignment.
+
 The orchestrator gives first priority to classes that failed in the previous
 run. It orders the other classes by previous duration, longest first.
 
 Worker placement is load-dependent. The stable parts are:
 
 * queue order for a given plan
-* method order within each class under the selected seed
-* per-class results
+* method and data-set order in the execution plan
+* assignment queue order for entries from `#[AllowParallel]` classes
 
 The seed reproduces failures related to order. It does not reproduce exact
-worker placement.
+worker placement or completion-event order.
 
 `$count` accepts a positive integer or `'auto'`. With `'auto'`, Greenlight uses
 one worker per CPU core. Install the suggested `fidry/cpu-core-counter` package

--- a/docs/migrating-from-phpunit.md
+++ b/docs/migrating-from-phpunit.md
@@ -313,6 +313,24 @@ returns service definitions with their scopes.
 For shared suite fixtures, move the fixtures to a small plugin. Do not keep
 them in a static property on the test class.
 
+## Split a large class after migration
+
+Keep class-level scheduling during the initial migration. This schedule
+preserves method order and one per-class harness service instance.
+
+After the suite is stable, add `#[AllowParallel]` only to an independent large
+class. The attribute makes each selected test or data set a separate worker
+assignment.
+
+Do not add the attribute to a class that uses a per-class harness service.
+Greenlight rejects that service request.
+
+Do not combine `#[AllowParallel]` with `#[Isolated]`. Greenlight rejects this
+combination during discovery.
+
+Data providers can run again in each assigned worker. Keep each provider pure,
+deterministic, and fast.
+
 ## Understand the deliberate differences
 
 These differences are intentional:
@@ -328,6 +346,7 @@ These differences are intentional:
   parallel execution.
 * Put expensive shared state in a class-scoped or suite-scoped harness service.
 * Tests run in parallel worker processes by default.
+* Tests in one class stay together unless the class has `#[AllowParallel]`.
 * Use `#[Isolated]` for a test that must own its process.
 * External dependencies require an explicit parallel strategy.
 * Use a channel for one resource for each worker.

--- a/src/Attribute/AllowParallel.php
+++ b/src/Attribute/AllowParallel.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Attribute;
+
+/**
+ * Allows Greenlight to assign tests from one class to different workers.
+ *
+ * The class MUST NOT use per-class harness services or `#[Isolated]`.
+ */
+#[\Attribute(\Attribute::TARGET_CLASS)]
+final readonly class AllowParallel {}

--- a/src/Attribute/RequiresResource.php
+++ b/src/Attribute/RequiresResource.php
@@ -7,7 +7,7 @@ namespace Greenlight\Attribute;
 use Greenlight\Core\Test\ResourceName;
 
 /**
- * Declares a resource that the assignment for the test class requires.
+ * Declares a resource that the assignment for the test requires.
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE)]
 final readonly class RequiresResource

--- a/src/Core/Test/TestMetadata.php
+++ b/src/Core/Test/TestMetadata.php
@@ -49,6 +49,7 @@ final readonly class TestMetadata implements WireSerializable
      * @param list<mixed> $skipUnlessArguments validated to scalars or null
      * @param list<string> $resources named resources required by this test entry
      * @param non-empty-string|null $dataSetProviderClass
+     * @param bool $allowParallel Whether the class permits separate worker assignments.
      *
      * @throws \InvalidArgumentException
      */
@@ -68,6 +69,7 @@ final readonly class TestMetadata implements WireSerializable
         array $skipUnlessArguments = [],
         array $resources = [],
         public ?string $dataSetProviderClass = null,
+        public bool $allowParallel = false,
     ) {
         if ($class === '') {
             throw new \InvalidArgumentException('Test metadata class must not be empty.');
@@ -144,6 +146,7 @@ final readonly class TestMetadata implements WireSerializable
             'capture' => $this->capture,
             'noExpectations' => $this->noExpectations,
             'resources' => $this->resources,
+            'allowParallel' => $this->allowParallel,
         ];
     }
 
@@ -205,6 +208,7 @@ final readonly class TestMetadata implements WireSerializable
             $skipUnlessArguments,
             $resources,
             $dataSetProviderClass === '' ? null : $dataSetProviderClass,
+            \array_key_exists('allowParallel', $payload) && Wire::bool($payload, 'allowParallel'),
         );
     }
 

--- a/src/Discovery/DiscoveryError.php
+++ b/src/Discovery/DiscoveryError.php
@@ -81,6 +81,16 @@ final class DiscoveryError extends \RuntimeException
         );
     }
 
+    public static function incompatibleAttributes(string $class, string $first, string $second): self
+    {
+        return new self(\sprintf(
+            'Test class "%s" uses incompatible attributes #[%s] and #[%s]. Remove one of these attributes.',
+            $class,
+            $first,
+            $second,
+        ));
+    }
+
     public static function providerClassMissing(string $class, string $method, string $providerClass): self
     {
         return new self(\sprintf(

--- a/src/Discovery/MetadataFactory.php
+++ b/src/Discovery/MetadataFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Discovery;
 
+use Greenlight\Attribute\AllowParallel;
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Group;
 use Greenlight\Attribute\Isolated;
@@ -42,7 +43,12 @@ final class MetadataFactory
         $classRetry = $this->attributeInstance($class, Retry::class, $className);
         $classTimeout = $this->attributeInstance($class, Timeout::class, $className);
         $classIsolated = $class->getAttributes(Isolated::class) !== [];
+        $classAllowsParallel = $class->getAttributes(AllowParallel::class) !== [];
         $classResources = $this->resourceNames($class, $className);
+
+        if ($classAllowsParallel && $classIsolated) {
+            throw DiscoveryError::incompatibleAttributes($className, 'AllowParallel', 'Isolated');
+        }
 
         $metadata = [];
 
@@ -75,6 +81,10 @@ final class MetadataFactory
             $groups = \array_values(\array_unique([...$classGroups, ...$this->groupNames($method, $where)]));
             $resources = \array_values(\array_unique([...$classResources, ...$this->resourceNames($method, $where)]));
 
+            if ($classAllowsParallel && $method->getAttributes(Isolated::class) !== []) {
+                throw DiscoveryError::incompatibleAttributes($className, 'AllowParallel', 'Isolated');
+            }
+
             $metadata[] = new TestMetadata(
                 $className,
                 $methodName,
@@ -91,6 +101,7 @@ final class MetadataFactory
                 $this->skipUnlessArguments($skipUnless, $where),
                 $resources,
                 $dataSet?->providerClass,
+                $classAllowsParallel,
             );
         }
 

--- a/src/Harness/HarnessScopes.php
+++ b/src/Harness/HarnessScopes.php
@@ -23,6 +23,8 @@ final class HarnessScopes
 
     private ?ScopeContainer $test = null;
 
+    private bool $classServicesAllowed = true;
+
     /**
      * @param list<ServiceResolver> $resolvers
      */
@@ -51,6 +53,10 @@ final class HarnessScopes
         $definition = $this->registry->find($type);
 
         if ($definition instanceof ServiceDefinition) {
+            if ($definition->scope === Scope::PerClass && !$this->classServicesAllowed) {
+                throw UnresolvableService::perClassServiceInParallelClass($type, $consumer);
+            }
+
             $service = $this->containerFor($definition->scope)->get($definition);
 
             if (!$service instanceof $type) {
@@ -77,9 +83,10 @@ final class HarnessScopes
         throw UnresolvableService::unknownType($type, $consumer, \count($this->resolvers));
     }
 
-    public function openClass(): void
+    public function openClass(bool $allowPerClassServices = true): void
     {
         $this->class = new ScopeContainer();
+        $this->classServicesAllowed = $allowPerClassServices;
     }
 
     /**
@@ -89,6 +96,7 @@ final class HarnessScopes
     {
         $failures = $this->class?->dispose() ?? [];
         $this->class = null;
+        $this->classServicesAllowed = true;
 
         return $failures;
     }

--- a/src/Harness/UnresolvableService.php
+++ b/src/Harness/UnresolvableService.php
@@ -58,6 +58,16 @@ final class UnresolvableService extends ServiceResolutionError
         ));
     }
 
+    public static function perClassServiceInParallelClass(string $type, string $consumer): self
+    {
+        return new self(\sprintf(
+            'Per-class harness service "%s", required by "%s", cannot be used by a class with #[AllowParallel]. '
+            . 'Use a per-test service or remove #[AllowParallel].',
+            $type,
+            $consumer,
+        ));
+    }
+
     public static function unsupportedParameter(string $parameter, string $consumer): self
     {
         return new self(\sprintf(

--- a/src/Reporting/TeamCityReporter.php
+++ b/src/Reporting/TeamCityReporter.php
@@ -18,8 +18,8 @@ use Greenlight\Reporting\Output\Output;
 
 /**
  * Each message uses the test-class name as its flowId. Thus, consumers can
- * separate parallel output. A test class does not use multiple workers. The
- * test-class name is also available on test events and test-class events.
+ * separate parallel output. Concurrent assignments for one split class share
+ * one open suite. Test events and test-class events contain the class name.
  *
  * The reporter omits JetBrains navigation hints if the orchestrator cannot
  * load the class.
@@ -34,6 +34,11 @@ final class TeamCityReporter implements Reporter
      * @var array<string, ?string>
      */
     private array $classFiles = [];
+
+    /**
+     * @var array<non-empty-string, positive-int>
+     */
+    private array $activeClassAssignments = [];
 
     private ?string $artifactsDirectory = null;
     private bool $hasAttachments = false;
@@ -50,6 +55,13 @@ final class TeamCityReporter implements Reporter
         }
 
         if ($event instanceof TestClassStarted) {
+            $active = $this->activeClassAssignments[$event->class] ?? 0;
+            $this->activeClassAssignments[$event->class] = $active + 1;
+
+            if ($active > 0) {
+                return;
+            }
+
             $attributes = ['name' => $event->class];
 
             $hint = $this->locationHint($event->class);
@@ -66,6 +78,15 @@ final class TeamCityReporter implements Reporter
         }
 
         if ($event instanceof TestClassFinished) {
+            $active = $this->activeClassAssignments[$event->class] ?? 0;
+
+            if ($active > 1) {
+                $this->activeClassAssignments[$event->class] = $active - 1;
+
+                return;
+            }
+
+            unset($this->activeClassAssignments[$event->class]);
             $this->message('testSuiteFinished', [
                 'name' => $event->class,
                 'flowId' => $event->class,

--- a/src/Reporting/TtyReporter.php
+++ b/src/Reporting/TtyReporter.php
@@ -38,6 +38,11 @@ final class TtyReporter implements Reporter, Ticking
     private array $live = [];
 
     /**
+     * @var array<non-empty-string, positive-int>
+     */
+    private array $activeClassAssignments = [];
+
+    /**
      * @var list<TestResult>
      */
     private array $problems = [];
@@ -137,7 +142,13 @@ final class TtyReporter implements Reporter, Ticking
 
         if ($event instanceof TestClassStarted) {
             $this->lastEventAt = $event->occurredAt;
-            $this->live[$event->class] = ['done' => 0, 'failed' => 0, 'skipped' => 0, 'duration' => 0.0, 'startedAt' => $event->occurredAt];
+            $active = $this->activeClassAssignments[$event->class] ?? 0;
+            $this->activeClassAssignments[$event->class] = $active + 1;
+
+            if ($active === 0) {
+                $this->live[$event->class] = ['done' => 0, 'failed' => 0, 'skipped' => 0, 'duration' => 0.0, 'startedAt' => $event->occurredAt];
+            }
+
             $this->redraw();
 
             return;
@@ -192,6 +203,15 @@ final class TtyReporter implements Reporter, Ticking
 
         if ($event instanceof TestClassFinished) {
             $this->lastEventAt = $event->occurredAt;
+            $active = $this->activeClassAssignments[$event->class] ?? 0;
+
+            if ($active > 1) {
+                $this->activeClassAssignments[$event->class] = $active - 1;
+
+                return;
+            }
+
+            unset($this->activeClassAssignments[$event->class]);
             $this->finalizeClass($event->class);
 
             return;

--- a/src/Runner/Orchestrator/Distributor.php
+++ b/src/Runner/Orchestrator/Distributor.php
@@ -7,8 +7,8 @@ namespace Greenlight\Runner\Orchestrator;
 use Greenlight\Discovery\ExecutionPlan;
 
 /**
- * Produces one pooled scheduling unit for each test class. It produces a
- * one-entry scheduling unit for each isolated test.
+ * Produces one pooled scheduling unit for each test class by default. It
+ * produces one-entry units for opted-in classes and isolated tests.
  *
  * @internal
  */
@@ -28,6 +28,8 @@ final readonly class Distributor
             foreach ($entries as $entry) {
                 if ($entry->metadata->isolated) {
                     $isolated[] = new SchedulingUnit(new ExecutionPlan([$entry], $plan->seed), true);
+                } elseif ($entry->metadata->allowParallel) {
+                    $pooled[] = new SchedulingUnit(new ExecutionPlan([$entry], $plan->seed), false);
                 } else {
                     $pooledEntries[] = $entry;
                 }

--- a/src/Runner/Worker/ClassContext.php
+++ b/src/Runner/Worker/ClassContext.php
@@ -13,8 +13,8 @@ use Greenlight\Discovery\DiscoveryError;
  * Contains the execution state for one test class. This state includes
  * reflection, hook lists, and expanded data sets.
  *
- * Data providers run one time for each class. The class scope stores their
- * expanded data sets.
+ * Data providers run one time for each class assignment. The class context
+ * stores their expanded data sets.
  *
  * @internal
  */

--- a/src/Runner/Worker/Worker.php
+++ b/src/Runner/Worker/Worker.php
@@ -83,7 +83,7 @@ final readonly class Worker
 
             $isolated = \count($entries) === 1 && $entries[0]->metadata->isolated;
             $sink->emit(new TestClassStarted($class, \microtime(true), $this->workerId, $isolated));
-            $scopes->openClass();
+            $scopes->openClass(allowPerClassServices: !$entries[0]->metadata->allowParallel);
             $lastIndex = \count($entries) - 1;
 
             $context = null;

--- a/tests/Acceptance/AllowParallelRunTest.php
+++ b/tests/Acceptance/AllowParallelRunTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\TestClassStarted;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\GreenlightCli;
+use Greenlight\Tests\Support\JsonlEvents;
+
+final readonly class AllowParallelRunTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function giantDataSetRunsOnMoreThanOneWorker(): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'allow-parallel');
+        $project->writeFile('tests/GiantDataSetTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace AllowParallelProbe;
+
+            use Greenlight\Attribute\AllowParallel;
+            use Greenlight\Attribute\DataSet;
+            use Greenlight\Attribute\Test;
+            use Greenlight\Expect\Expect;
+
+            #[AllowParallel]
+            final readonly class GiantDataSetTest
+            {
+                #[Test]
+                #[DataSet('rows')]
+                public function handlesRow(int $row): void
+                {
+                    \usleep(20_000);
+                    Expect::that($row)->toBeGreaterThanOrEqual(0);
+                }
+
+                /** @return iterable<string, array{int}> */
+                public static function rows(): iterable
+                {
+                    for ($row = 0; $row < 64; ++$row) {
+                        yield 'row-' . $row => [$row];
+                    }
+                }
+            }
+            PHP);
+        $project->configureWithTestFiles(['tests/GiantDataSetTest.php'], workers: 4);
+
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=jsonl']);
+        $workerIds = [];
+        $classStarts = 0;
+
+        foreach (JsonlEvents::from($result) as $event) {
+            if (!$event instanceof TestClassStarted || $event->class !== 'AllowParallelProbe\GiantDataSetTest') {
+                continue;
+            }
+
+            ++$classStarts;
+            $workerIds[$event->workerId] = true;
+        }
+
+        Expect::that($result->exitCode)->because('the giant data-set run succeeds')->toBe(0);
+        Expect::that(JsonlEvents::finishedTestIds($result))
+            ->because('the split run MUST preserve every planned data set')
+            ->toHaveCount(64);
+        Expect::that($classStarts)
+            ->because('each split data set MUST have one class-event bracket')
+            ->toBe(64);
+        Expect::that(\count($workerIds))
+            ->because('the opt-in MUST execute one class on more than one worker process')
+            ->toBeGreaterThan(1);
+    }
+}

--- a/tests/Fixture/DiscoveryParallelConflict/ClassIsolatedTest.php
+++ b/tests/Fixture/DiscoveryParallelConflict/ClassIsolatedTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\DiscoveryParallelConflict;
+
+use Greenlight\Attribute\AllowParallel;
+use Greenlight\Attribute\Isolated;
+use Greenlight\Attribute\Test;
+
+#[AllowParallel]
+#[Isolated]
+final readonly class ClassIsolatedTest
+{
+    #[Test]
+    public function neverRuns(): void {}
+}

--- a/tests/Fixture/DiscoveryParallelConflict/MethodIsolatedTest.php
+++ b/tests/Fixture/DiscoveryParallelConflict/MethodIsolatedTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\DiscoveryParallelConflict;
+
+use Greenlight\Attribute\AllowParallel;
+use Greenlight\Attribute\Isolated;
+use Greenlight\Attribute\Test;
+
+#[AllowParallel]
+final readonly class MethodIsolatedTest
+{
+    #[Test]
+    #[Isolated]
+    public function neverRuns(): void {}
+}

--- a/tests/Support/PlanEntryFixture.php
+++ b/tests/Support/PlanEntryFixture.php
@@ -25,10 +25,17 @@ final class PlanEntryFixture
         ?string $dataSetKey = null,
         array $resources = [],
         bool $isolated = false,
+        bool $allowParallel = false,
     ): PlanEntry {
         return new PlanEntry(
             new TestId($class, $method, $dataSetKey),
-            new TestMetadata($class, $method, isolated: $isolated, resources: $resources),
+            new TestMetadata(
+                $class,
+                $method,
+                isolated: $isolated,
+                resources: $resources,
+                allowParallel: $allowParallel,
+            ),
         );
     }
 }

--- a/tests/Unit/Attribute/AttributeContractTest.php
+++ b/tests/Unit/Attribute/AttributeContractTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Attribute;
 
 use Greenlight\Attribute\After;
+use Greenlight\Attribute\AllowParallel;
 use Greenlight\Attribute\Before;
 use Greenlight\Attribute\CoverageIgnore;
 use Greenlight\Attribute\DataRow;
@@ -44,6 +45,12 @@ final class AttributeContractTest
         foreach ([Test::class, Before::class, After::class, DataSet::class, NoExpectations::class] as $attribute) {
             Expect::that($this->flags($attribute))->toBe(\Attribute::TARGET_METHOD);
         }
+    }
+
+    #[Test]
+    public function allowParallelTargetsClasses(): void
+    {
+        Expect::that($this->flags(AllowParallel::class))->toBe(\Attribute::TARGET_CLASS);
     }
 
     #[Test]

--- a/tests/Unit/Core/TestMetadataWireTest.php
+++ b/tests/Unit/Core/TestMetadataWireTest.php
@@ -120,6 +120,7 @@ final class TestMetadataWireTest
         yield 'data-set provider class' => ['dataSetProviderClass', null];
         yield 'skip-unless arguments' => ['skipUnlessArguments', []];
         yield 'no-expectations policy' => ['noExpectations', false];
+        yield 'parallel class opt-in' => ['allowParallel', false];
     }
 
     /**

--- a/tests/Unit/Discovery/MetadataFactoryTest.php
+++ b/tests/Unit/Discovery/MetadataFactoryTest.php
@@ -14,6 +14,8 @@ use Greenlight\Tests\Fixture\DiscoveryAttributeArgumentsInvalid\WrongGroupTypeTe
 use Greenlight\Tests\Fixture\DiscoveryInvalidMethods\AbstractMethodTest;
 use Greenlight\Tests\Fixture\DiscoveryInvalidMethods\NonPublicMethodTest;
 use Greenlight\Tests\Fixture\DiscoveryInvalidMethods\StaticMethodTest;
+use Greenlight\Tests\Fixture\DiscoveryParallelConflict\ClassIsolatedTest;
+use Greenlight\Tests\Fixture\DiscoveryParallelConflict\MethodIsolatedTest;
 
 final class MetadataFactoryTest
 {
@@ -90,6 +92,34 @@ final class MetadataFactoryTest
         yield 'static' => [StaticMethodTest::class, 'it is static'];
 
         yield 'abstract' => [AbstractMethodTest::class, 'it is abstract'];
+    }
+
+    /**
+     * @param class-string $class
+     */
+    #[Test]
+    #[DataSet('parallelIsolationConflicts')]
+    public function rejectsParallelClassesWithIsolation(string $class): void
+    {
+        Expect::that(static fn(): array => new MetadataFactory()->forClass(new \ReflectionClass($class)))
+            ->because('parallel class splitting and process isolation are incompatible')
+            ->toThrow(
+                DiscoveryError::class,
+                message: \sprintf(
+                    'Test class "%s" uses incompatible attributes #[AllowParallel] and #[Isolated]. '
+                    . 'Remove one of these attributes.',
+                    $class,
+                ),
+            );
+    }
+
+    /**
+     * @return iterable<string, array{class-string}>
+     */
+    public static function parallelIsolationConflicts(): iterable
+    {
+        yield 'class isolation' => [ClassIsolatedTest::class];
+        yield 'method isolation' => [MethodIsolatedTest::class];
     }
 
     /**

--- a/tests/Unit/Reporting/TeamCityReporterTest.php
+++ b/tests/Unit/Reporting/TeamCityReporterTest.php
@@ -246,4 +246,25 @@ final readonly class TeamCityReporterTest
             . "##teamcity[testSuiteFinished name='{$alpha}' flowId='{$alpha}']\n",
         );
     }
+
+    #[Test]
+    public function concurrentAssignmentsForOneClassShareOneSuite(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new TeamCityReporter($output);
+        $class = 'Acme\Flow\SplitTest';
+
+        $reporter->onEvent(new TestClassStarted($class, 1.0, 'w-1'));
+        $reporter->onEvent(new TestClassStarted($class, 1.01, 'w-2'));
+        $reporter->onEvent(new TestClassFinished($class, 1.02, 'w-1'));
+        $reporter->onEvent(new TestClassFinished($class, 1.03, 'w-2'));
+        $reporter->finish();
+
+        Expect::that($output->buffer())
+            ->because('concurrent split assignments MUST share one TeamCity suite flow')
+            ->toBe(
+                "##teamcity[testSuiteStarted name='{$class}' flowId='{$class}']\n"
+                . "##teamcity[testSuiteFinished name='{$class}' flowId='{$class}']\n",
+            );
+    }
 }

--- a/tests/Unit/Reporting/TtyReporterTest.php
+++ b/tests/Unit/Reporting/TtyReporterTest.php
@@ -76,6 +76,24 @@ final class TtyReporterTest
     }
 
     #[Test]
+    public function concurrentAssignmentsForOneClassShareOneLiveEntry(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new TtyReporter($output, color: false, cursor: false);
+
+        $reporter->onEvent(new TestClassStarted('App\SplitTest', 1.0, 'w-1'));
+        $reporter->onEvent(new TestClassStarted('App\SplitTest', 1.01, 'w-2'));
+        $reporter->onEvent(new TestFinished($this->result('App\SplitTest', 'one', Outcome::Passed), 1.1));
+        $reporter->onEvent(new TestClassFinished('App\SplitTest', 1.11, 'w-1'));
+        $reporter->onEvent(new TestFinished($this->result('App\SplitTest', 'two', Outcome::Passed), 1.2));
+        $reporter->onEvent(new TestClassFinished('App\SplitTest', 1.21, 'w-2'));
+
+        Expect::that($output->buffer())
+            ->because('concurrent split assignments MUST retain all results in one live class entry')
+            ->toBe("✓ App\\SplitTest (2 tests, 0.020s)\n");
+    }
+
+    #[Test]
     public function aClassFinishedEventWithoutAStartUsesAnEmptyState(): void
     {
         $output = new BufferOutput();

--- a/tests/Unit/Runner/Orchestrator/DistributorTest.php
+++ b/tests/Unit/Runner/Orchestrator/DistributorTest.php
@@ -6,8 +6,10 @@ namespace Greenlight\Tests\Unit\Runner\Orchestrator;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Discovery\ExecutionPlan;
+use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\Orchestrator\Distributor;
+use Greenlight\Runner\Orchestrator\SchedulingUnit;
 use Greenlight\Tests\Support\PlanEntryFixture;
 
 final class DistributorTest
@@ -67,5 +69,36 @@ final class DistributorTest
         Expect::that($isolated)->because('class units hold the union of every entry requirement')->toHaveCount(1);
         Expect::that($isolated[0]->resources)->because('class units hold the union of every entry requirement')->toBe(['sandbox']);
         Expect::that($isolated[0]->isolated)->because('class units hold the union of every entry requirement')->toBeTrue();
+    }
+
+    #[Test]
+    public function optedInClassEntriesBecomePooledSingletonUnitsInPlanOrder(): void
+    {
+        $plan = new ExecutionPlan([
+            PlanEntryFixture::create('LargeTest', 'rows', 'first', ['database'], allowParallel: true),
+            PlanEntryFixture::create('LargeTest', 'rows', 'second', ['queue'], allowParallel: true),
+            PlanEntryFixture::create('OtherTest', 'staysTogether'),
+            PlanEntryFixture::create('OtherTest', 'alsoStaysTogether'),
+        ], 42);
+
+        [$pooled, $isolated] = new Distributor()->units($plan);
+
+        Expect::that(\array_map(
+            static fn(SchedulingUnit $unit): array => \array_map(
+                static fn(PlanEntry $entry): string => (string) $entry->id,
+                $unit->plan->entries,
+            ),
+            $pooled,
+        ))
+            ->because('the opt-in MUST split entries without changing their plan order')
+            ->toBe([
+                ['LargeTest::rows[first]'],
+                ['LargeTest::rows[second]'],
+                ['OtherTest::staysTogether', 'OtherTest::alsoStaysTogether'],
+            ]);
+        Expect::that($pooled[0]->plan->seed)->toBe(42);
+        Expect::that($pooled[0]->resources)->toBe(['database']);
+        Expect::that($pooled[1]->resources)->toBe(['queue']);
+        Expect::that($isolated)->toBe([]);
     }
 }

--- a/tests/Unit/Runner/WorkerTest.php
+++ b/tests/Unit/Runner/WorkerTest.php
@@ -33,6 +33,7 @@ use Greenlight\Tests\Fixture\Lifecycle\PerTestDisposeFails\FailingPerTestDisposa
 use Greenlight\Tests\Fixture\Lifecycle\Retries\RetriesTest;
 use Greenlight\Tests\Fixture\Lifecycle\RetryFilter\RetryFilterTest;
 use Greenlight\Tests\Fixture\Lifecycle\Services\ServiceProbe;
+use Greenlight\Tests\Fixture\Lifecycle\Services\ServicesTest;
 use Greenlight\Tests\Fixture\Lifecycle\TemporalRetry\TemporalRetryTest;
 use Greenlight\Tests\Fixture\Lifecycle\TraceLog;
 use Greenlight\Tests\Fixture\Lifecycle\VerifyOnDispose\VerifyingProbe;
@@ -392,6 +393,35 @@ final class WorkerTest
             'probe1:touched',
             'probe1:disposed',
         ]);
+    }
+
+    #[Test]
+    public function parallelClassesRejectPerClassHarnessServices(): void
+    {
+        $id = new TestId(ServicesTest::class, 'firstTouch');
+        $plan = new ExecutionPlan([
+            new PlanEntry($id, new TestMetadata($id->class, $id->method, allowParallel: true)),
+        ]);
+        $registry = $this->registry();
+        $registry->register(new ServiceDefinition(
+            ServiceProbe::class,
+            Scope::PerClass,
+            static fn(): ServiceProbe => new ServiceProbe(),
+        ));
+        $sink = new CollectingEventSink();
+
+        new Worker($registry)->run($plan, $sink);
+
+        $result = $sink->results()[0];
+        Expect::that($result->outcome)
+            ->because('a parallel class MUST NOT silently receive one class scope for each split entry')
+            ->toBe(Outcome::Errored);
+        Expect::that($result->error?->message)->toBe(\sprintf(
+            'Per-class harness service "%s", required by "%s", cannot be used by a class with #[AllowParallel]. '
+            . 'Use a per-test service or remove #[AllowParallel].',
+            ServiceProbe::class,
+            $id->class,
+        ));
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

- add the class-only #[AllowParallel] opt-in for per-test and per-data-set worker assignments
- preserve default class scheduling, plan order, seeds, retries, timeouts, resources, isolation, result identities, and crash containment
- reject incompatible isolation and per-class harness scopes, and support overlapping class events in reporters
- document the public behavior and migration guidance