### PR TITLE
ci: cache Greenlight run state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,10 +316,23 @@ jobs:
         env:
           SYMFONY_REQUIRE: "${{ matrix.symfony-version }}"
 
+      - name: "Prepare Greenlight run-state directory"
+        run: 'mkdir -p "${RUNNER_TEMP}/greenlight-state"'
+
+      - name: "Restore Greenlight run state"
+        uses: "actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9" # v6.1.0
+        with:
+          path: "${{ runner.temp }}/greenlight-state/greenlight-state-*.json"
+          key: "greenlight-run-state-v1-${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependencies }}-symfony-${{ matrix.symfony-version || 'default' }}-${{ github.run_id }}-${{ github.run_attempt }}"
+          restore-keys: "greenlight-run-state-v1-${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependencies }}-symfony-${{ matrix.symfony-version || 'default' }}-"
+
       # Lowest Rector uses the lowest PHPStan API in the test suite.
       # Run the tests before the PHPStan update.
       - name: "Tests"
+        id: "tests_lowest"
         if: "matrix.dependencies == 'lowest'"
+        env:
+          TMPDIR: "${{ runner.temp }}/greenlight-state"
         run: "composer tests"
 
       # The lowest compatible PHPStan version reports false errors for types
@@ -376,15 +389,28 @@ jobs:
           key: "static-analysis-${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependencies }}-symfony-${{ matrix.symfony-version || 'default' }}-${{ steps.analysis_cache.outputs.content_hash }}-${{ github.run_id }}"
 
       - name: "Tests"
+        id: "tests_standard"
         if: "matrix.analytics != true && matrix.dependencies != 'lowest'"
+        env:
+          TMPDIR: "${{ runner.temp }}/greenlight-state"
         run: "composer tests"
 
       - name: "Tests with JUnit output"
+        id: "tests_analytics"
         if: "matrix.analytics == true"
         shell: "bash"
+        env:
+          TMPDIR: "${{ runner.temp }}/greenlight-state"
         run: |
           mkdir -p build/test-results
           php bin/greenlight run --reporter=junit > build/test-results/greenlight.junit.xml
+
+      - name: "Save Greenlight run state"
+        if: "${{ !cancelled() && (steps.tests_lowest.outcome != 'skipped' || steps.tests_standard.outcome != 'skipped' || steps.tests_analytics.outcome != 'skipped') }}"
+        uses: "actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9" # v6.1.0
+        with:
+          path: "${{ runner.temp }}/greenlight-state/greenlight-state-*.json"
+          key: "greenlight-run-state-v1-${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependencies }}-symfony-${{ matrix.symfony-version || 'default' }}-${{ github.run_id }}-${{ github.run_attempt }}"
 
       - name: "Upload test results to Codecov"
         if: "${{ !cancelled() && matrix.analytics == true }}"

--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ for the complete model.
 
 * [Start with Greenlight](docs/getting-started.md)
 * [Configuration reference](docs/configuration.md)
+* [Use Greenlight in GitHub Actions](docs/github-actions.md)
 * [Attribute reference](docs/attributes.md)
 * [Expectations](docs/expectations.md)
 * [Test doubles](docs/test-doubles.md)

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,0 +1,85 @@
+# GitHub Actions
+
+Greenlight stores run state in the system temporary directory. Run state
+contains failed test IDs and class durations from the previous run.
+
+The next run uses this data to put failed classes first. It then puts the
+remaining classes in longest-first order. This order reduces idle worker time
+near the end of a run.
+
+## Cache run state
+
+Use a known temporary directory for the Greenlight test step. Restore the run
+state before the step and save it after the step.
+
+This example keeps separate state for each operating system and PHP version:
+
+```yaml
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ['8.4', '8.5']
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Prepare Greenlight run-state directory
+        run: mkdir -p "${RUNNER_TEMP}/greenlight-state"
+
+      - name: Restore Greenlight run state
+        uses: actions/cache/restore@v6
+        with:
+          path: ${{ runner.temp }}/greenlight-state/greenlight-state-*.json
+          key: greenlight-run-state-v1-${{ runner.os }}-php-${{ matrix.php }}-${{ github.run_id }}-${{ github.run_attempt }}
+          restore-keys: greenlight-run-state-v1-${{ runner.os }}-php-${{ matrix.php }}-
+
+      - name: Run tests
+        id: tests
+        env:
+          TMPDIR: ${{ runner.temp }}/greenlight-state
+        run: vendor/bin/greenlight run
+
+      - name: Save Greenlight run state
+        if: ${{ !cancelled() && steps.tests.outcome != 'skipped' }}
+        uses: actions/cache/save@v6
+        with:
+          path: ${{ runner.temp }}/greenlight-state/greenlight-state-*.json
+          key: greenlight-run-state-v1-${{ runner.os }}-php-${{ matrix.php }}-${{ github.run_id }}-${{ github.run_attempt }}
+```
+
+GitHub cache entries are immutable. The run ID and run attempt make each save
+key unique. The restore prefix selects the most recent applicable entry.
+
+Save state after a failed test run. A normal failed run contains useful
+failure and duration data. Do not save state from a canceled job.
+
+Add all settings that can materially change durations to the key. Examples
+include the operating system, PHP version, dependency profile, suite, and
+shard number.
+
+Do not use one state file for multiple concurrent shards. Each shard records
+only its selected tests and replaces the file contents.
+
+The state is advisory. A missing or invalid file does not fail a normal run.
+Do not put secrets in the cache path. Pull request workflows can read caches
+from their base branch.
+
+For cache matching and security rules, see the
+[GitHub dependency caching reference](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching).
+
+## Other Greenlight caches
+
+Greenlight also stores discovery data and generated double proxies in the
+system temporary directory.
+
+Do not cache discovery data across fresh GitHub Actions checkouts. Discovery
+entries include file modification times, which usually change at checkout.
+Greenlight rejects these stale entries.
+
+Generated double proxies are executable PHP files. Their regeneration cost is
+small, and restored executable caches need more trust. Do not cache them by
+default.
+
+Cache package downloads and static analysis data separately. Their invalidation
+rules differ from the Greenlight run-state rules.

--- a/website/src/lib/docs.ts
+++ b/website/src/lib/docs.ts
@@ -27,6 +27,11 @@ export const docSections = [
         description: 'This reference explains configuration for suites, workers, resource limits, coverage, and the CLI.',
       },
       {
+        id: 'github-actions',
+        title: 'GitHub Actions',
+        description: 'This guide explains how to reuse Greenlight run state between GitHub Actions runs.',
+      },
+      {
         id: 'attributes',
         title: 'Attributes',
         description: 'This reference explains attributes for tests, hooks, data sets, and execution.',


### PR DESCRIPTION
## Summary

- restore prior failures and class durations for each CI matrix profile
- save useful run state after successful and failed test runs
- document secure cache keys, invalidation, and cache exclusions