### PR TITLE
fix(runner): cache complete class durations

### DIFF
--- a/src/Cli/FailedTestsTap.php
+++ b/src/Cli/FailedTestsTap.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Greenlight\Cli;
 
 use Greenlight\Core\Event\Event;
+use Greenlight\Core\Event\TestClassFinished;
+use Greenlight\Core\Event\TestClassStarted;
 use Greenlight\Core\Event\TestFinished;
 use Greenlight\Runner\Worker\EventSink;
 
@@ -31,19 +33,24 @@ final class FailedTestsTap implements EventSink
      */
     private array $classSeconds = [];
 
+    /**
+     * @var array<string, array{class: non-empty-string, occurredAt: float}>
+     */
+    private array $startedClasses = [];
+
     public function __construct(private readonly EventSink $inner) {}
 
     #[\Override]
     public function emit(Event $event): void
     {
-        if ($event instanceof TestFinished) {
-            $class = $event->result->id->class;
-            $recorded = $this->classSeconds[$class] ?? 0.0;
-            $duration = $event->result->durationSeconds;
-            $this->classSeconds[$class] = $recorded > \PHP_FLOAT_MAX - $duration
-                ? \PHP_FLOAT_MAX
-                : $recorded + $duration;
-
+        if ($event instanceof TestClassStarted) {
+            $this->startedClasses[$event->workerId] = [
+                'class' => $event->class,
+                'occurredAt' => $event->occurredAt,
+            ];
+        } elseif ($event instanceof TestClassFinished) {
+            $this->recordClassDuration($event);
+        } elseif ($event instanceof TestFinished) {
             if (!$event->result->outcome->isSuccessful()) {
                 $id = (string) $event->result->id;
 
@@ -54,6 +61,32 @@ final class FailedTestsTap implements EventSink
         }
 
         $this->inner->emit($event);
+    }
+
+    private function recordClassDuration(TestClassFinished $event): void
+    {
+        $started = $this->startedClasses[$event->workerId] ?? null;
+
+        if ($started === null || $started['class'] !== $event->class) {
+            return;
+        }
+
+        unset($this->startedClasses[$event->workerId]);
+
+        if ($event->occurredAt < $started['occurredAt']) {
+            return;
+        }
+
+        $duration = $event->occurredAt - $started['occurredAt'];
+
+        if (!\is_finite($duration)) {
+            $duration = \PHP_FLOAT_MAX;
+        }
+
+        $recorded = $this->classSeconds[$event->class] ?? 0.0;
+        $this->classSeconds[$event->class] = $recorded > \PHP_FLOAT_MAX - $duration
+            ? \PHP_FLOAT_MAX
+            : $recorded + $duration;
     }
 
     /**

--- a/tests/Acceptance/SchedulingTest.php
+++ b/tests/Acceptance/SchedulingTest.php
@@ -48,9 +48,45 @@ final readonly class SchedulingTest
             ->toContain('SchedulingProbe\SlowTest');
     }
 
-    private function run(AcceptanceProject $project): ProcessResult
+    #[Test]
+    public function classWallDurationMakesOverheadHeavyClassLeadTheNextRun(): void
     {
-        return GreenlightCli::run($project->directory, ['run', '--workers=2', '--reporter=jsonl']);
+        $project = $this->writeOverheadProject();
+
+        $first = $this->run($project, workers: 1);
+        $firstClasses = $this->startedClasses(JsonlEvents::from($first));
+        $cached = RunState::forWorkingDirectory($project->directory)->classSeconds();
+        $second = $this->run($project, workers: 1);
+        $secondClasses = $this->startedClasses(JsonlEvents::from($second));
+        $firstOutput = $first->output();
+        $secondOutput = $second->output();
+
+        Expect::that($first->exitCode)
+            ->because($firstOutput === '' ? 'The first scheduling run returned no output.' : $firstOutput)
+            ->toBe(0);
+        Expect::that($firstClasses)
+            ->because('the first run MUST use discovery order without timing data')
+            ->toBe([
+                'SchedulingOverheadProbe\AlphaTest',
+                'SchedulingOverheadProbe\SlowTest',
+            ]);
+        Expect::that($cached['SchedulingOverheadProbe\SlowTest'] ?? 0.0)
+            ->because('the timing cache MUST include plugin overhead after the test result duration')
+            ->toBeGreaterThan($cached['SchedulingOverheadProbe\AlphaTest'] ?? \PHP_FLOAT_MAX);
+        Expect::that($second->exitCode)
+            ->because($secondOutput === '' ? 'The second scheduling run returned no output.' : $secondOutput)
+            ->toBe(0);
+        Expect::that($secondClasses)
+            ->because('the next run MUST schedule the overhead-heavy class first')
+            ->toBe([
+                'SchedulingOverheadProbe\SlowTest',
+                'SchedulingOverheadProbe\AlphaTest',
+            ]);
+    }
+
+    private function run(AcceptanceProject $project, int $workers = 2): ProcessResult
+    {
+        return GreenlightCli::run($project->directory, ['run', '--workers=' . $workers, '--reporter=jsonl']);
     }
 
     /**
@@ -141,6 +177,89 @@ final readonly class SchedulingTest
             }
 
             return GreenlightConfig::create()->paths([__DIR__ . '/tests']);
+            PHP);
+
+        return $project;
+    }
+
+    private function writeOverheadProject(): AcceptanceProject
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'scheduling-overhead');
+        $project->writeFile('OverheadPlugin.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace SchedulingOverheadProbe;
+
+            use Greenlight\Core\Result\TestResult;
+            use Greenlight\Plugin\TestContext;
+            use Greenlight\Plugin\TestLifecycleSubscriber;
+
+            final class OverheadPlugin implements TestLifecycleSubscriber
+            {
+                public function beforeTest(TestContext $context): void {}
+
+                public function afterTest(TestContext $context, TestResult $result): TestResult
+                {
+                    if ($context->id->class === SlowTest::class) {
+                        \usleep(300_000);
+                    }
+
+                    return $result;
+                }
+            }
+            PHP);
+        $project->writeFile('tests/AlphaTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace SchedulingOverheadProbe;
+
+            use Greenlight\Attribute\Test;
+
+            final class AlphaTest
+            {
+                #[Test]
+                public function slowerTestBody(): void
+                {
+                    \usleep(20_000);
+                }
+            }
+            PHP);
+        $project->writeFile('tests/SlowTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace SchedulingOverheadProbe;
+
+            use Greenlight\Attribute\Test;
+
+            final class SlowTest
+            {
+                #[Test]
+                public function quickTestBody(): void {}
+            }
+            PHP);
+        $project->writeFile('greenlight.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Config\GreenlightConfig;
+            use SchedulingOverheadProbe\OverheadPlugin;
+
+            require_once __DIR__ . '/OverheadPlugin.php';
+
+            foreach (\glob(__DIR__ . '/tests/*Test.php') ?: [] as $file) {
+                require_once $file;
+            }
+
+            return GreenlightConfig::create()
+                ->paths([__DIR__ . '/tests'])
+                ->plugins(new OverheadPlugin());
             PHP);
 
         return $project;

--- a/tests/Unit/Cli/FailedTestsTapTest.php
+++ b/tests/Unit/Cli/FailedTestsTapTest.php
@@ -8,6 +8,8 @@ use Greenlight\Attribute\Test;
 use Greenlight\Cli\FailedTestsTap;
 use Greenlight\Cli\RunState;
 use Greenlight\Core\Event\RunStarted;
+use Greenlight\Core\Event\TestClassFinished;
+use Greenlight\Core\Event\TestClassStarted;
 use Greenlight\Core\Event\TestFinished;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\TestResult;
@@ -39,15 +41,21 @@ final readonly class FailedTestsTapTest
     }
 
     #[Test]
-    public function recordsFailuresAndClassDurationsWhileForwardingEveryEvent(): void
+    public function recordsFailuresAndCompleteClassSpansWhileForwardingEveryEvent(): void
     {
         $inner = new CollectingEventSink();
         $tap = new FailedTestsTap($inner);
         $events = [
+            new TestClassStarted('App\AlphaTest', 10.0, 'worker-1'),
             $this->finished('App\AlphaTest', 'passes', Outcome::Passed, 1.0),
+            new TestClassStarted('App\BetaTest', 20.0, 'worker-2'),
             $this->finished('App\AlphaTest', 'fails', Outcome::Failed, 2.0),
+            new TestClassFinished('App\AlphaTest', 14.0, 'worker-1'),
             $this->finished('App\BetaTest', 'errors', Outcome::Errored, 4.0),
+            new TestClassFinished('App\BetaTest', 26.0, 'worker-2'),
+            new TestClassStarted('App\AlphaTest', 30.0, 'worker-1', isolated: true),
             $this->finished('App\AlphaTest', 'fails', Outcome::Failed, 8.0),
+            new TestClassFinished('App\AlphaTest', 33.5, 'worker-1'),
             $this->finished('App\BetaTest', 'skips', Outcome::Skipped, 16.0),
         ];
 
@@ -62,10 +70,10 @@ final readonly class FailedTestsTapTest
                 'App\BetaTest::errors',
             ]);
         Expect::that($tap->classSeconds())
-            ->because('scheduling history MUST accumulate every result duration by class')
+            ->because('scheduling history MUST include each complete class span')
             ->toBe([
-                'App\AlphaTest' => 11.0,
-                'App\BetaTest' => 20.0,
+                'App\AlphaTest' => 7.5,
+                'App\BetaTest' => 6.0,
             ]);
         Expect::that($inner->events)
             ->because('the tap MUST forward every event unchanged')
@@ -73,11 +81,48 @@ final readonly class FailedTestsTapTest
     }
 
     #[Test]
+    public function incompleteAndMalformedClassLifecyclesDoNotInventDurations(): void
+    {
+        $tap = new FailedTestsTap(new CollectingEventSink());
+        $events = [
+            new TestClassStarted('App\CrashTest', 1.0, 'worker-1'),
+            $this->finished('App\CrashTest', 'crashes', Outcome::Errored, 100.0),
+            new TestClassFinished('App\MissingStartTest', 4.0, 'worker-2'),
+            new TestClassStarted('App\ReversedTest', 10.0, 'worker-3'),
+            new TestClassFinished('App\ReversedTest', 9.0, 'worker-3'),
+            new TestClassStarted('App\CrashTest', 20.0, 'worker-4'),
+            new TestClassFinished('App\CrashTest', 24.0, 'worker-4'),
+            new TestClassFinished('App\CrashTest', 30.0, 'worker-4'),
+            new TestClassStarted('App\RestartedTest', 40.0, 'worker-5'),
+            new TestClassStarted('App\RestartedTest', 42.0, 'worker-5'),
+            new TestClassFinished('App\RestartedTest', 45.0, 'worker-5'),
+        ];
+
+        foreach ($events as $event) {
+            $tap->emit($event);
+        }
+
+        Expect::that($tap->classSeconds())
+            ->because('only valid start and finish pairs MUST supply advisory durations')
+            ->toBe([
+                'App\CrashTest' => 4.0,
+                'App\RestartedTest' => 3.0,
+            ]);
+        Expect::that($tap->failedTests())
+            ->because('an incomplete class MUST still supply its failed test ID')
+            ->toBe(['App\CrashTest::crashes']);
+    }
+
+    #[Test]
     public function accumulatedDurationsRemainPersistableAtTheFloatLimit(): void
     {
         $tap = new FailedTestsTap(new CollectingEventSink());
-        $tap->emit($this->finished('App\ExtremeTest', 'first', Outcome::Failed, \PHP_FLOAT_MAX));
-        $tap->emit($this->finished('App\ExtremeTest', 'second', Outcome::Failed, \PHP_FLOAT_MAX));
+        $tap->emit(new TestClassStarted('App\ExtremeTest', 0.0, 'worker-1'));
+        $tap->emit($this->finished('App\ExtremeTest', 'first', Outcome::Failed, 0.0));
+        $tap->emit(new TestClassFinished('App\ExtremeTest', \PHP_FLOAT_MAX, 'worker-1'));
+        $tap->emit(new TestClassStarted('App\ExtremeTest', 0.0, 'worker-2'));
+        $tap->emit($this->finished('App\ExtremeTest', 'second', Outcome::Failed, 0.0));
+        $tap->emit(new TestClassFinished('App\ExtremeTest', \PHP_FLOAT_MAX, 'worker-2'));
 
         Expect::that($tap->classSeconds())
             ->because('accepted durations MUST remain finite when their sum exceeds the float range')


### PR DESCRIPTION
Measure cached class timings from complete class lifecycle spans instead of summed test results.

This includes class-level overhead, safely ignores incomplete or malformed pairs, and preserves repeated and isolated span accumulation. The existing `classSeconds` state key remains unchanged for compatibility.

Adds unit coverage for lifecycle edge cases and an acceptance regression that shows overhead-heavy classes move first on the next run.