### PR TITLE
perf(runner): reap retired workers asynchronously

### DIFF
--- a/src/Runner/Orchestrator/Orchestrator.php
+++ b/src/Runner/Orchestrator/Orchestrator.php
@@ -75,6 +75,7 @@ final class Orchestrator
     private const float PROGRESS_DEADLINE_SECONDS = 60.0;
     private const float TIMEOUT_GRACE_FACTOR = 2.0;
     private const float TIMEOUT_GRACE_FLAT_SECONDS = 2.0;
+    private const float WORKER_EXIT_GRACE_SECONDS = 2.0;
 
     private ?ResourceScheduler $scheduler = null;
 
@@ -205,6 +206,7 @@ final class Orchestrator
                     $this->drainAll();
                 }
 
+                $this->reapRetiringHandles();
                 $this->spawnUpTo($workerCount, $server->address, $token, $sink, $spawnBudget);
 
                 if ($this->finished()) {
@@ -243,7 +245,10 @@ final class Orchestrator
         // allocator has a channel for each possible live worker.
         $channels = $this->channels ??= new ChannelAllocator($workerCount);
 
-        while (!$this->draining && $this->pendingUnits() > $this->unassignedActiveCount() && $this->activeCount() < $workerCount) {
+        while (!$this->draining
+            && $this->pendingUnits() > $this->unassignedActiveCount()
+            && \count($this->handles) < $workerCount
+        ) {
             $workerId = $spawnBudget->nextWorkerId();
 
             $command = [...$this->workerCommand, '__worker', $address, $workerId, $token];
@@ -281,25 +286,12 @@ final class Orchestrator
         }
     }
 
-    private function activeCount(): int
-    {
-        $active = 0;
-
-        foreach ($this->handles as $handle) {
-            if (!$handle->done) {
-                ++$active;
-            }
-        }
-
-        return $active;
-    }
-
     private function finished(): bool
     {
         if ($this->pendingUnits() > 0 && !$this->draining) {
             return false;
         }
-        return \array_all($this->handles, fn($handle) => $handle->done);
+        return $this->handles === [];
     }
 
     private function pendingUnits(): int
@@ -318,7 +310,7 @@ final class Orchestrator
         $count = 0;
 
         foreach ($this->handles as $handle) {
-            if (!$handle->done && $handle->assigned === null) {
+            if ($handle->isActive() && $handle->assigned === null) {
                 ++$count;
             }
         }
@@ -337,21 +329,22 @@ final class Orchestrator
     private function tick(mixed $server, string $token, EventSink $sink): void
     {
         $read = [$server];
+        $waitMicroseconds = $this->hasRetiringHandles() ? 10_000 : 200_000;
 
         foreach ($this->awaitingHello as [$channel]) {
             $read[] = $channel->stream();
         }
 
         foreach ($this->handles as $handle) {
-            if (!$handle->done && $handle->channel !== null) {
+            if ($handle->isActive() && $handle->channel !== null) {
                 $read[] = $handle->channel->stream();
             }
         }
 
-        $connection = ErrorTrap::run(static function () use ($server, $read) {
+        $connection = ErrorTrap::run(static function () use ($server, $read, $waitMicroseconds) {
             $write = null;
             $except = null;
-            \stream_select($read, $write, $except, 0, 200_000);
+            \stream_select($read, $write, $except, 0, $waitMicroseconds);
 
             return \stream_socket_accept($server, 0);
         });
@@ -365,6 +358,7 @@ final class Orchestrator
         $this->detectCrashes($sink);
         $this->enforceTimeouts($sink);
         $this->assignWaiting($sink);
+        $this->reapRetiringHandles();
     }
 
     /**
@@ -490,7 +484,7 @@ final class Orchestrator
         foreach ($this->handles as $handle) {
             $channel = $handle->channel;
 
-            if ($handle->done || $channel === null) {
+            if (!$handle->isActive() || $channel === null) {
                 continue;
             }
 
@@ -562,7 +556,7 @@ final class Orchestrator
 
                     $this->assignNext($handle, $sink);
 
-                    if ($handle->done) {
+                    if (!$handle->isActive()) {
                         break;
                     }
                 } elseif ($message instanceof Fatal) {
@@ -586,7 +580,7 @@ final class Orchestrator
         $ready = 0;
 
         foreach ($this->handles as $handle) {
-            if (!$handle->done && $handle->ready) {
+            if ($handle->isActive() && $handle->ready) {
                 ++$ready;
             }
         }
@@ -598,7 +592,7 @@ final class Orchestrator
         $this->initialBarrierPassed = true;
 
         foreach ($this->handles as $handle) {
-            if (!$handle->done && $handle->ready && $handle->assigned === null) {
+            if ($handle->isActive() && $handle->ready && $handle->assigned === null) {
                 // Every initial worker is fresh, so once pooled work is gone
                 // it may take an isolated unit.
                 $this->assignNext($handle, $sink);
@@ -676,7 +670,7 @@ final class Orchestrator
         $this->resourceScheduler()->clearPending();
 
         foreach ($this->handles as $handle) {
-            if (!$handle->done && $handle->channel !== null) {
+            if ($handle->isActive() && $handle->channel !== null) {
                 try {
                     $handle->channel->send(new Drain());
                 } catch (ProtocolError) {
@@ -697,7 +691,7 @@ final class Orchestrator
     private function detectCrashes(EventSink $sink): void
     {
         foreach ($this->handles as $handle) {
-            if ($handle->done) {
+            if (!$handle->isActive()) {
                 continue;
             }
 
@@ -749,7 +743,7 @@ final class Orchestrator
     private function enforceTimeouts(EventSink $sink): void
     {
         foreach ($this->handles as $handle) {
-            if ($handle->done) {
+            if (!$handle->isActive()) {
                 continue;
             }
 
@@ -790,7 +784,6 @@ final class Orchestrator
             $deadline = $handle->inFlightSince + $budget * self::TIMEOUT_GRACE_FACTOR + self::TIMEOUT_GRACE_FLAT_SECONDS;
 
             if ($this->monotonicTime() > $deadline) {
-                $handle->terminate();
                 $this->containTimeout($handle, $sink, $budget);
             }
         }
@@ -826,7 +819,7 @@ final class Orchestrator
             ));
         }
 
-        $this->retireFailedWorker($handle, $sink);
+        $this->retireFailedWorker($handle, $sink, true);
     }
 
     /**
@@ -874,12 +867,16 @@ final class Orchestrator
         $sink->emit(new TestFinished($result, \microtime(true)));
     }
 
-    private function retireFailedWorker(WorkerHandle $handle, EventSink $sink): void
+    private function retireFailedWorker(WorkerHandle $handle, EventSink $sink, bool $kill = false): void
     {
         $remainder = $handle->unfinished();
         $sink->emit(new WorkerRecycled($handle->workerId, RecycleReason::Crash, \microtime(true)));
         $this->releaseAssignment($handle);
-        $this->finishHandle($handle);
+        if ($kill) {
+            $handle->kill($this->monotonicTime());
+        } else {
+            $this->finishHandle($handle);
+        }
         $this->enqueueRemainder($remainder);
     }
 
@@ -968,7 +965,7 @@ final class Orchestrator
         $this->retryWaitingWorkers = false;
 
         foreach ($this->handles as $handle) {
-            if ($handle->done || $handle->channel === null || $handle->assigned !== null) {
+            if (!$handle->isActive() || $handle->channel === null || $handle->assigned !== null) {
                 continue;
             }
 
@@ -1001,30 +998,26 @@ final class Orchestrator
 
     private function finishHandle(WorkerHandle $handle): void
     {
-        if (!$handle->done) {
-            $this->channels?->release($handle->channelNumber);
-        }
+        $handle->retire($this->monotonicTime(), self::WORKER_EXIT_GRACE_SECONDS);
+    }
 
-        $handle->done = true;
-        $handle->drainPipes();
-        $handle->channel?->close();
+    private function reapRetiringHandles(): void
+    {
+        $now = $this->monotonicTime();
 
-        if (\is_resource($handle->process)) {
-            // Permit the worker to exit, and then collect it.
-            $deadline = $this->monotonicTime() + 2.0;
-
-            while ($this->monotonicTime() < $deadline && $handle->isRunning()) {
-                \usleep(10_000);
+        foreach ($this->handles as $workerId => $handle) {
+            if (!$handle->reap($now)) {
+                continue;
             }
 
-            ErrorTrap::run(static function () use ($handle) {
-                if ($handle->isRunning()) {
-                    \proc_terminate($handle->process, 9);
-                }
-
-                \proc_close($handle->process);
-            });
+            $this->channels?->release($handle->channelNumber);
+            unset($this->handles[$workerId]);
         }
+    }
+
+    private function hasRetiringHandles(): bool
+    {
+        return \array_any($this->handles, static fn(WorkerHandle $handle): bool => $handle->isRetiring());
     }
 
     private function monotonicTime(): float

--- a/src/Runner/Orchestrator/WorkerHandle.php
+++ b/src/Runner/Orchestrator/WorkerHandle.php
@@ -49,7 +49,9 @@ final class WorkerHandle
      */
     public int $inFlightAttempt = 0;
 
-    public bool $done = false;
+    public WorkerLifecycle $lifecycle = WorkerLifecycle::Active;
+
+    private float $retirementDeadline = 0.0;
 
     public string $diagnostics = '';
 
@@ -114,6 +116,95 @@ final class WorkerHandle
         $status = \proc_get_status($this->process);
 
         return $status['running'];
+    }
+
+    public function isActive(): bool
+    {
+        return $this->lifecycle === WorkerLifecycle::Active;
+    }
+
+    public function isRetiring(): bool
+    {
+        return $this->lifecycle === WorkerLifecycle::Retiring
+            || $this->lifecycle === WorkerLifecycle::Killing;
+    }
+
+    public function retire(float $now, float $graceSeconds): void
+    {
+        if (!$this->isActive()) {
+            return;
+        }
+
+        $this->lifecycle = WorkerLifecycle::Retiring;
+        $this->retirementDeadline = $now + $graceSeconds;
+        $this->drainPipes();
+        $this->channel?->close();
+    }
+
+    public function kill(float $now): void
+    {
+        $this->retire($now, 0.0);
+
+        if ($this->lifecycle !== WorkerLifecycle::Retiring) {
+            return;
+        }
+
+        $this->sendKillSignal();
+    }
+
+    /**
+     * Advances process retirement without waiting for the process.
+     *
+     * @return bool True when the process handle is fully reaped.
+     */
+    public function reap(float $now): bool
+    {
+        if ($this->lifecycle === WorkerLifecycle::Reaped) {
+            return true;
+        }
+
+        if (!$this->isRetiring()) {
+            return false;
+        }
+
+        $this->drainPipes();
+
+        if ($this->isRunning()) {
+            if ($this->lifecycle === WorkerLifecycle::Retiring && $now >= $this->retirementDeadline) {
+                $this->sendKillSignal();
+            }
+
+            return false;
+        }
+
+        $this->drainPipes();
+        $this->closeDiagnosticPipes();
+
+        if (\is_resource($this->process)) {
+            ErrorTrap::run(fn() => \proc_close($this->process));
+        }
+
+        $this->lifecycle = WorkerLifecycle::Reaped;
+
+        return true;
+    }
+
+    private function sendKillSignal(): void
+    {
+        if (\is_resource($this->process)) {
+            ErrorTrap::run(fn() => \proc_terminate($this->process, 9));
+        }
+
+        $this->lifecycle = WorkerLifecycle::Killing;
+    }
+
+    private function closeDiagnosticPipes(): void
+    {
+        foreach ([$this->stdout, $this->stderr] as $pipe) {
+            if (\is_resource($pipe)) {
+                ErrorTrap::run(static fn() => \fclose($pipe));
+            }
+        }
     }
 
     /**
@@ -224,6 +315,8 @@ final class WorkerHandle
                 \proc_close($this->process);
             });
         }
+
+        $this->lifecycle = WorkerLifecycle::Reaped;
     }
 
     /**

--- a/src/Runner/Orchestrator/WorkerLifecycle.php
+++ b/src/Runner/Orchestrator/WorkerLifecycle.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Runner\Orchestrator;
+
+/**
+ * Identifies the process retirement stage for one worker handle.
+ *
+ * @internal
+ */
+enum WorkerLifecycle
+{
+    case Active;
+    case Retiring;
+    case Killing;
+    case Reaped;
+}

--- a/tests/Fixture/Runner/Orchestrator/LoggedWorkerProcess.php
+++ b/tests/Fixture/Runner/Orchestrator/LoggedWorkerProcess.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Runner\Orchestrator;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Runner\Worker\WorkerProcess;
+
+final readonly class LoggedWorkerProcess implements Fake
+{
+    /**
+     * @param non-empty-string $address
+     * @param non-empty-string $workerId
+     * @param non-empty-string $token
+     */
+    public static function run(string $address, string $workerId, string $token): int
+    {
+        self::record('start', $workerId);
+
+        \register_shutdown_function(static function () use ($workerId): void {
+            self::record('exit-start', $workerId);
+            $delay = \getenv('GREENLIGHT_RETIREMENT_DELAY_MICROSECONDS');
+
+            if (\is_string($delay) && \ctype_digit($delay)) {
+                \usleep((int) $delay);
+            }
+
+            self::record('exit-end', $workerId);
+        });
+
+        return new WorkerProcess()->run($address, $workerId, $token);
+    }
+
+    private static function record(string $phase, string $workerId): void
+    {
+        $path = \getenv('GREENLIGHT_RETIREMENT_LOG');
+
+        if (!\is_string($path) || $path === '') {
+            return;
+        }
+
+        \file_put_contents($path, \json_encode([
+            'phase' => $phase,
+            'worker' => $workerId,
+            'channel' => \getenv('GREENLIGHT_CHANNEL'),
+            'at' => \microtime(true),
+        ], \JSON_THROW_ON_ERROR) . "\n", \FILE_APPEND | \LOCK_EX);
+    }
+}

--- a/tests/Fixture/Runner/Orchestrator/RecycleUntilProgressWorker.php
+++ b/tests/Fixture/Runner/Orchestrator/RecycleUntilProgressWorker.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Runner\Orchestrator;
+
+use Greenlight\Core\Event\RecycleReason;
+use Greenlight\Core\Result\ResultSummary;
+use Greenlight\Discovery\PlanEntry;
+use Greenlight\Doubles\Fake;
+use Greenlight\Runner\Protocol\Messages\Assign;
+use Greenlight\Runner\Protocol\Messages\Hello;
+use Greenlight\Runner\Protocol\Messages\Ready;
+use Greenlight\Runner\Protocol\Messages\Recycling;
+use Greenlight\Runner\Protocol\SocketChannel;
+use Greenlight\Runner\Worker\WorkerProcess;
+
+final readonly class RecycleUntilProgressWorker implements Fake
+{
+    /**
+     * @param non-empty-string $address
+     * @param non-empty-string $workerId
+     * @param non-empty-string $token
+     */
+    public static function run(string $address, string $workerId, string $token): int
+    {
+        if ($workerId !== 'w-1') {
+            return new WorkerProcess()->run($address, $workerId, $token);
+        }
+
+        $stream = \stream_socket_client($address);
+
+        if (!\is_resource($stream)) {
+            return 2;
+        }
+
+        $channel = new SocketChannel($stream);
+        $pid = \getmypid();
+        $channel->send(new Hello($workerId, $token, $pid === false ? 1 : \max(1, $pid)));
+        $channel->receive(5.0);
+        $channel->send(new Ready());
+        $assignment = $channel->receive(5.0);
+
+        if (!$assignment instanceof Assign) {
+            $channel->close();
+
+            return 3;
+        }
+
+        $channel->send(new Recycling(
+            RecycleReason::TestCount,
+            \array_map(static fn(PlanEntry $entry) => $entry->id, $assignment->slice->entries),
+            new ResultSummary(),
+        ));
+        $channel->close();
+
+        $marker = \getenv('GREENLIGHT_RETIREMENT_PROGRESS_MARKER');
+        $deadline = \microtime(true) + 1.5;
+
+        while (\is_string($marker) && !\is_file($marker) && \microtime(true) < $deadline) {
+            \usleep(10_000);
+        }
+
+        $log = \getenv('GREENLIGHT_RETIREMENT_LOG');
+
+        if (\is_string($log) && $log !== '') {
+            $result = \is_string($marker) && \is_file($marker) ? 'progress-observed' : 'progress-timeout';
+            \file_put_contents($log, $result . "\n", \FILE_APPEND | \LOCK_EX);
+        }
+
+        return 0;
+    }
+}

--- a/tests/Fixture/Runner/Orchestrator/RetirementProgressTest.php
+++ b/tests/Fixture/Runner/Orchestrator/RetirementProgressTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Runner\Orchestrator;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+
+final readonly class RetirementProgressTest
+{
+    #[Test]
+    public function recordsProgress(): void
+    {
+        $marker = \getenv('GREENLIGHT_RETIREMENT_PROGRESS_MARKER');
+
+        Expect::that(\is_string($marker) && $marker !== '')
+            ->because('the retirement progress fixture MUST have a marker path')
+            ->toBeTrue();
+
+        if (!\is_string($marker) || $marker === '') {
+            Fail::because('The retirement progress fixture requires a marker path.');
+        }
+
+        \file_put_contents($marker, 'progress');
+    }
+}

--- a/tests/Unit/Runner/Orchestrator/OrchestratorRetirementTest.php
+++ b/tests/Unit/Runner/Orchestrator/OrchestratorRetirementTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Orchestrator;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Attribute\Timeout;
+use Greenlight\Core\Event\TestClassStarted;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Discovery\ExecutionPlan;
+use Greenlight\Discovery\PlanEntry;
+use Greenlight\Doubles\Fake;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Reporting\Ticking;
+use Greenlight\Runner\Orchestrator\Orchestrator;
+use Greenlight\Sandbox\EnvironmentVariables;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Fixture\LeakSuite\CleanTest;
+use Greenlight\Tests\Fixture\ResourceScheduling\SlowResourceTest;
+use Greenlight\Tests\Fixture\ResourceScheduling\WaitingResourceTest;
+use Greenlight\Tests\Fixture\Runner\Orchestrator\LoggedWorkerProcess;
+use Greenlight\Tests\Fixture\Runner\Orchestrator\RecycleUntilProgressWorker;
+use Greenlight\Tests\Fixture\Runner\Orchestrator\RetirementProgressTest;
+use Greenlight\Tests\Support\CollectingEventSink;
+use Greenlight\Tests\Support\PlanEntryFixture;
+
+final readonly class OrchestratorRetirementTest
+{
+    public function __construct(
+        private TemporaryDirectory $tempDirectory,
+        private EnvironmentVariables $environment,
+    ) {}
+
+    #[Test]
+    #[Timeout(10.0)]
+    public function simultaneousRetirementsContinueReporterTicks(): void
+    {
+        $log = $this->tempDirectory->path() . '/simultaneous.jsonl';
+        $this->environment->set('GREENLIGHT_RETIREMENT_LOG', $log);
+        $this->environment->set('GREENLIGHT_RETIREMENT_DELAY_MICROSECONDS', '1000000');
+        $ticker = new class implements Fake, Ticking {
+            /** @var list<float> */
+            public array $ticks = [];
+
+            #[\Override]
+            public function tick(float $now): void
+            {
+                $this->ticks[] = $now;
+            }
+        };
+        $sink = new CollectingEventSink();
+        $orchestrator = new Orchestrator(
+            workerCommand: $this->workerCommand(LoggedWorkerProcess::class),
+            workingDirectory: $this->repositoryRoot(),
+            ticker: $ticker,
+        );
+        $plan = new ExecutionPlan([
+            PlanEntryFixture::create(CleanTest::class, 'passesAndIsCollectable'),
+            PlanEntryFixture::create(WaitingResourceTest::class, 'runsAfterTheWait'),
+        ]);
+
+        $summary = $orchestrator->run($plan, $sink, 2);
+        $records = $this->records($log);
+        $starts = $this->phaseTimes($records, 'exit-start');
+        $ends = $this->phaseTimes($records, 'exit-end');
+
+        if (\count($starts) !== 2 || \count($ends) !== 2) {
+            Fail::because('Expected two complete worker retirement records.');
+        }
+
+        $ticksDuringExit = \array_filter(
+            $ticker->ticks,
+            static fn(float $tick): bool => $tick > \max($starts) && $tick < \min($ends),
+        );
+
+        Expect::that($summary->passed)
+            ->because('both workers MUST complete their assignments before simultaneous retirement')
+            ->toBe(2);
+        Expect::that(\max($starts))
+            ->because('both workers MUST be in retirement at the same time')
+            ->toBeLessThan(\min($ends));
+        Expect::that($ticksDuringExit)
+            ->because('reporter ticks MUST continue while workers exit')
+            ->not()->toBe([]);
+    }
+
+    #[Test]
+    #[Timeout(10.0)]
+    public function delayedRetirementDoesNotBlockAssignmentsToAnotherWorker(): void
+    {
+        $log = $this->tempDirectory->path() . '/progress.log';
+        $marker = $this->tempDirectory->path() . '/progress.marker';
+        $this->environment->set('GREENLIGHT_RETIREMENT_LOG', $log);
+        $this->environment->set('GREENLIGHT_RETIREMENT_PROGRESS_MARKER', $marker);
+        $sink = new CollectingEventSink();
+        $orchestrator = new Orchestrator(
+            workerCommand: $this->workerCommand(RecycleUntilProgressWorker::class),
+            workingDirectory: $this->repositoryRoot(),
+        );
+        $plan = new ExecutionPlan([
+            PlanEntryFixture::create(CleanTest::class, 'passesAndIsCollectable'),
+            PlanEntryFixture::create(SlowResourceTest::class, 'holdsTheResource'),
+            PlanEntryFixture::create(RetirementProgressTest::class, 'recordsProgress'),
+        ]);
+
+        $summary = $orchestrator->run($plan, $sink, 2);
+        $workers = [];
+
+        foreach ($sink->events as $event) {
+            if ($event instanceof TestClassStarted) {
+                $workers[] = $event->workerId;
+            }
+        }
+
+        Expect::that($summary->passed)
+            ->because('the active worker MUST complete all assignments while the first worker exits')
+            ->toBe(3);
+        Expect::that(\trim((string) \file_get_contents($log)))
+            ->because('the delayed worker MUST observe progress before it exits')
+            ->toBe('progress-observed');
+        Expect::that($workers)
+            ->because('the active worker MUST receive the queued and requeued assignments')
+            ->toBe(['w-2', 'w-2', 'w-2']);
+    }
+
+    #[Test]
+    #[Timeout(30.0)]
+    public function highIsolatedChurnReusesChannelsAfterExitAndPrunesHandles(): void
+    {
+        $log = $this->tempDirectory->path() . '/isolated.jsonl';
+        $this->environment->set('GREENLIGHT_RETIREMENT_LOG', $log);
+        $this->environment->set('GREENLIGHT_RETIREMENT_DELAY_MICROSECONDS', '10000');
+        $orchestrator = new Orchestrator(
+            workerCommand: $this->workerCommand(LoggedWorkerProcess::class),
+            workingDirectory: $this->repositoryRoot(),
+        );
+        $entries = [];
+
+        for ($index = 1; $index <= 12; ++$index) {
+            $class = 'Greenlight\\Tests\\Fixture\\MissingIsolated' . $index;
+            $id = new TestId($class, 'doesNotExist');
+            $entries[] = new PlanEntry($id, new TestMetadata($class, $id->method, isolated: true));
+        }
+
+        $summary = $orchestrator->run(new ExecutionPlan($entries), new CollectingEventSink(), 1);
+        $records = $this->records($log);
+        $starts = \array_values(\array_filter($records, static fn(array $record): bool => $record['phase'] === 'start'));
+        $ends = \array_values(\array_filter($records, static fn(array $record): bool => $record['phase'] === 'exit-end'));
+
+        Expect::that($summary->errored)
+            ->because('each isolated fixture MUST complete through a fresh worker')
+            ->toBe(12);
+        Expect::that($starts)
+            ->because('isolated churn MUST start one worker for each scheduling unit')
+            ->toHaveCount(12);
+        Expect::that(\array_column($starts, 'channel'))
+            ->because('a single-worker run MUST reuse its only channel')
+            ->toBe(\array_fill(0, 12, '1'));
+        $startCount = \count($starts);
+
+        for ($index = 1; $index < $startCount; ++$index) {
+            Expect::that($starts[$index]['at'])
+                ->because('a channel MUST stay unavailable until its old process exits')
+                ->toBeGreaterThanOrEqual($ends[$index - 1]['at']);
+        }
+
+        Expect::that(new \ReflectionProperty($orchestrator, 'handles')->getValue($orchestrator))
+            ->because('the orchestrator MUST remove each reaped worker handle')
+            ->toBe([]);
+    }
+
+    /**
+     * @param class-string $worker
+     * @return non-empty-list<non-empty-string>
+     */
+    private function workerCommand(string $worker): array
+    {
+        $bootstrap = \sprintf(
+            'require %s; exit(%s::run($argv[2], $argv[3], $argv[4]));',
+            \var_export($this->repositoryRoot() . '/vendor/autoload.php', true),
+            $worker,
+        );
+
+        return [\PHP_BINARY, '-r', $bootstrap];
+    }
+
+    /**
+     * @return list<array{phase: string, worker: string, channel: string, at: float}>
+     */
+    private function records(string $path): array
+    {
+        $records = [];
+        $lines = \file($path, \FILE_IGNORE_NEW_LINES | \FILE_SKIP_EMPTY_LINES);
+
+        if ($lines === false) {
+            Fail::because('Expected the worker retirement log to be readable.');
+        }
+
+        foreach ($lines as $line) {
+            /** @var array{phase: string, worker: string, channel: string, at: float} $record */
+            $record = \json_decode($line, true, flags: \JSON_THROW_ON_ERROR);
+            $records[] = $record;
+        }
+
+        return $records;
+    }
+
+    /**
+     * @param list<array{phase: string, worker: string, channel: string, at: float}> $records
+     * @return list<float>
+     */
+    private function phaseTimes(array $records, string $phase): array
+    {
+        return \array_values(\array_map(
+            static fn(array $record): float => $record['at'],
+            \array_filter($records, static fn(array $record): bool => $record['phase'] === $phase),
+        ));
+    }
+
+    private function repositoryRoot(): string
+    {
+        return \dirname(__DIR__, 4);
+    }
+}

--- a/tests/Unit/Runner/Orchestrator/WorkerHandleRetirementTest.php
+++ b/tests/Unit/Runner/Orchestrator/WorkerHandleRetirementTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Orchestrator;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Attribute\Timeout;
+use Greenlight\Core\ErrorTrap;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Runner\Orchestrator\WorkerHandle;
+use Greenlight\Runner\Orchestrator\WorkerLifecycle;
+use Greenlight\Runner\Protocol\SocketChannel;
+use Greenlight\Tests\Support\ConnectedStreamPair;
+
+final readonly class WorkerHandleRetirementTest
+{
+    #[Test]
+    #[Timeout(5.0)]
+    public function retirementReturnsBeforeTheWorkerExitsAndKeepsDiagnosticsSafe(): void
+    {
+        [$handle, $process, $pipes, $sockets] = $this->handle(
+            'fwrite(STDOUT, "before\\n"); fflush(STDOUT); usleep(100000); '
+            . 'fwrite(STDERR, "after\\n"); fflush(STDERR); usleep(1000000);',
+        );
+
+        try {
+            \stream_set_timeout($pipes[1], 2);
+            Expect::that(\fgets($pipes[1]))
+                ->because('the process fixture MUST start before retirement')
+                ->toBe("before\n");
+            $before = \hrtime(true) / 1_000_000_000;
+            $handle->retire($before, 0.3);
+            $after = \hrtime(true) / 1_000_000_000;
+
+            Expect::that($after - $before)
+                ->because('retirement MUST return without waiting for worker exit')
+                ->toBeLessThan(0.1);
+            Expect::that($handle->lifecycle)
+                ->toBe(WorkerLifecycle::Retiring);
+            Expect::that($handle->channel?->isEof())
+                ->because('retirement MUST close the protocol channel immediately')
+                ->toBeTrue();
+
+            $deadline = \microtime(true) + 2.0;
+
+            while (!$handle->reap(\hrtime(true) / 1_000_000_000) && \microtime(true) < $deadline) {
+                \usleep(10_000);
+            }
+
+            Expect::that($handle->lifecycle)
+                ->because('the reaper MUST kill and collect a worker after its graceful deadline')
+                ->toBe(WorkerLifecycle::Reaped);
+            Expect::that($handle->diagnostics)
+                ->because('retirement MUST continue to drain standard output and standard error')
+                ->toBe("after\n");
+            Expect::that(\is_resource($process))
+                ->because('a reaped worker MUST not retain its process handle')
+                ->toBeFalse();
+        } finally {
+            $this->cleanup($process, [...$pipes, ...$sockets]);
+        }
+    }
+
+    /**
+     * @return array{WorkerHandle, resource, array<int, resource>, array{resource, resource}}
+     */
+    private function handle(string $script): array
+    {
+        $process = \proc_open(
+            [\PHP_BINARY, '-r', $script],
+            [
+                0 => ['pipe', 'r'],
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ],
+            $pipes,
+            options: ['bypass_shell' => true],
+        );
+
+        if (!\is_resource($process)) {
+            Fail::because('Expected the worker process fixture to start.');
+        }
+
+        \fclose($pipes[0]);
+        unset($pipes[0]);
+        $sockets = ConnectedStreamPair::open();
+        $handle = new WorkerHandle('worker-1', 1, $process, $pipes[1], $pipes[2]);
+        $handle->channel = new SocketChannel($sockets[0]);
+
+        return [$handle, $process, $pipes, $sockets];
+    }
+
+    /**
+     * @param resource $process
+     * @param list<resource> $resources
+     */
+    private function cleanup(mixed $process, array $resources): void
+    {
+        foreach ($resources as $resource) {
+            if (\is_resource($resource)) {
+                ErrorTrap::run(static fn() => \fclose($resource));
+            }
+        }
+
+        if (\is_resource($process)) {
+            ErrorTrap::run(static fn() => \proc_terminate($process, 9));
+            ErrorTrap::run(static fn() => \proc_close($process));
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- move worker retirement into an explicit non-blocking lifecycle state machine
- reap processes in the orchestrator loop before releasing channels and pruning handles
- preserve diagnostics and graceful deadlines while active workers continue to receive work