### PR TITLE
test(benchmark): make runner samples reproducible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -663,7 +663,7 @@ jobs:
           dependency-versions: "locked"
 
       - name: "Run the harness on a small parameter set"
-        run: "php tools/benchmark.php --shape=many-fast --scale=1 --runs=1"
+        run: "php tools/benchmark.php --shape=many-fast --scale=1 --workers=2 --warmups=1 --runs=1 --seed=20260821"
 
   deploy-documentation:
     name: "Deploy documentation"

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -7,7 +7,48 @@ php tools/benchmark.php --with-phpunit
 ```
 
 The script generates the test suites and installs the comparison tools in a
-temporary project. It reports the median wall-clock time for three runs.
+temporary project. The `coverage-heavy` shape requires PCOV or Xdebug.
+
+The default parameters use one warm-up round and three sample rounds. The
+script discards warm-up times. Each round runs each selected configuration once.
+
+The seed creates the first configuration order. The script reverses that order
+in the next round. It rotates the first order after each pair of rounds.
+Thus, one configuration does not always run before another configuration.
+
+The report gives these values for each configuration:
+
+* Minimum wall time
+* Median wall time
+* Maximum wall time
+* Observed spread, as `(maximum - minimum) / median`
+
+Use `--seed` to reproduce the order. Use `--warmups` to change the warm-up count.
+Record both values with results. A large spread identifies results that require
+more samples or a quieter machine.
+
+PHPUnit and ParaTest run only the four common comparison shapes. The
+runner-specific shapes do not have equivalent scheduler configuration in those
+tools.
+
+## Benchmark shapes
+
+The common comparison shapes are:
+
+* `many-fast`: many test classes with short test bodies
+* `few-slow`: a small number of test classes with 25 ms test bodies
+* `giant-dataset`: one test class with one large data set
+* `mixed`: fast tests, slow tests, and one large data set
+
+The runner-specific shapes are:
+
+* `many-isolated`: many isolated tests that each require a new worker
+* `recycle-one`: workers that Greenlight replaces after one test
+* `resource-constrained`: work that one resource slot serializes
+* `skewed-bootstrap`: worker bootstrap delays that increase with the channel
+  number
+* `chatty-diagnostics`: many notices that workers capture and send
+* `coverage-heavy`: assignments with large coverage maps
 
 ## Setup
 
@@ -18,11 +59,15 @@ temporary project. It reports the median wall-clock time for three runs.
   (2026-07-12)
 * PHPUnit: 13.2.3
 * ParaTest: 7.23.0
-* Parameters: `--scale=10 --workers=4 --runs=3`, which are the defaults
+* Parameters: `--scale=10 --workers=4 --runs=3`, which were the defaults
 
 Wall-clock time includes process start, autoload, discovery, and execution.
 Greenlight uses plain output, PHPUnit disables output, and ParaTest uses its
 default output. The measurements include these output-mode differences.
+
+These published results predate warm-up rounds, alternate configuration order,
+and distribution output. This change does not replace them because it did not
+run the full benchmark on an idle machine.
 
 ## Results
 
@@ -93,7 +138,8 @@ large I/O waits can have a much larger benefit from parallel execution.
 CI runs a small benchmark to check the harness:
 
 ```sh
-php tools/benchmark.php --shape=many-fast --scale=1 --runs=1
+php tools/benchmark.php --shape=many-fast --scale=1 --workers=2 \
+  --warmups=1 --runs=1 --seed=20260821
 ```
 
 The project does not publish CI numbers because shared runners do not give

--- a/tests/Unit/Tools/BenchmarkTest.php
+++ b/tests/Unit/Tools/BenchmarkTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Tools;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+
+require_once __DIR__ . '/../../../tools/benchmark.php';
+
+final readonly class BenchmarkTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function parsesExplicitBenchmarkOptions(): void
+    {
+        $options = \benchmarkParseOptions([
+            'shape' => 'many-isolated',
+            'scale' => '2',
+            'workers' => '3',
+            'warmups' => '2',
+            'runs' => '5',
+            'seed' => '-17',
+            'with-phpunit' => false,
+        ]);
+
+        Expect::that($options)->toBe([
+            'shapes' => ['many-isolated'],
+            'scale' => 2,
+            'workers' => 3,
+            'warmups' => 2,
+            'runs' => 5,
+            'seed' => -17,
+            'withPhpunit' => true,
+        ]);
+    }
+
+    #[Test]
+    public function scheduleIsReproducibleAndAlternatesEachPairOfRounds(): void
+    {
+        $configurationIds = ['parallel', 'one', 'phpunit', 'paratest'];
+        $schedule = \benchmarkSchedule($configurationIds, 4, 731, 'many-fast:sample');
+
+        Expect::that($schedule)->because('the same seed MUST reproduce the configuration order')
+            ->toBe(\benchmarkSchedule($configurationIds, 4, 731, 'many-fast:sample'));
+        Expect::that($schedule[1])->because('the second round MUST reverse the first round')
+            ->toBe(\array_reverse($schedule[0]));
+        Expect::that($schedule[3])->because('the fourth round MUST reverse the third round')
+            ->toBe(\array_reverse($schedule[2]));
+
+        foreach ($schedule as $order) {
+            \sort($order);
+            $expected = $configurationIds;
+            \sort($expected);
+
+            Expect::that($order)->because('each round MUST contain each configuration once')->toBe($expected);
+        }
+    }
+
+    #[Test]
+    public function distributionUsesTheConventionalMedianAndReportsTheObservedRange(): void
+    {
+        Expect::that(\benchmarkDistribution([9.0, 1.0, 5.0, 3.0]))->toBe([
+            'minimum' => 1.0,
+            'median' => 4.0,
+            'maximum' => 9.0,
+            'spreadPercent' => 200.0,
+        ]);
+    }
+
+    /** @param array<string, string|array<mixed>|false> $options */
+    #[Test]
+    #[DataSet('invalidOptions')]
+    public function rejectsInvalidBenchmarkOptions(array $options, string $message): void
+    {
+        Expect::that(static fn() => \benchmarkParseOptions($options))
+            ->toThrow(\InvalidArgumentException::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{array<string, string|array<mixed>|false>, string}>
+     */
+    public static function invalidOptions(): iterable
+    {
+        yield 'unknown shape' => [
+            ['shape' => 'unknown'],
+            'Unknown benchmark shape "unknown". Use one of: many-fast, few-slow, giant-dataset, mixed, many-isolated, recycle-one, resource-constrained, skewed-bootstrap, chatty-diagnostics, coverage-heavy.',
+        ];
+        yield 'invalid run count' => [
+            ['runs' => '0'],
+            'Option --runs must be at least 1, got 0.',
+        ];
+        yield 'invalid warm-up count' => [
+            ['warmups' => '-1'],
+            'Option --warmups must be at least 0, got -1.',
+        ];
+        yield 'non-integer worker count' => [
+            ['workers' => 'many'],
+            'Option --workers must be an integer, got "many".',
+        ];
+        yield 'repeated shape' => [
+            ['shape' => ['many-fast', 'mixed']],
+            'Specify option --shape exactly once with a value.',
+        ];
+    }
+
+    #[Test]
+    #[DataSet('specializedShapes')]
+    public function generatesSpecializedRunnerShapes(string $shape, string $relativeFile, string $expectedText): void
+    {
+        $project = $this->tempDirectory->path() . '/benchmark-' . $shape;
+
+        Expect::that(\benchmarkGenerateShape($shape, 1, $project))
+            ->because('each specialized benchmark shape MUST contain tests')
+            ->toBeGreaterThan(0);
+        Expect::that((string) \file_get_contents($project . '/' . $relativeFile))
+            ->toContain($expectedText);
+    }
+
+    /** @return iterable<string, array{string, string, string}> */
+    public static function specializedShapes(): iterable
+    {
+        yield 'many isolated tests' => ['many-isolated', 'tests/gl/ManyIsolated0000Test.php', '#[Isolated]'];
+        yield 'recycle after one test' => ['recycle-one', 'greenlight.php', 'recycleAfterTests: 1'];
+        yield 'resource constrained work' => ['resource-constrained', 'greenlight.php', "resourceLimit('database')"];
+        yield 'skewed worker bootstrap' => ['skewed-bootstrap', 'greenlight.php', 'BenchmarkBootstrapPlugin'];
+        yield 'chatty worker diagnostics' => ['chatty-diagnostics', 'tests/gl/ChattyDiagnostics0000Test.php', 'Benchmark diagnostic.'];
+        yield 'coverage-heavy assignments' => ['coverage-heavy', 'greenlight.php', 'CoverageBuilder'];
+        yield 'single giant data set' => ['giant-dataset', 'tests/gl/GiantTest.php', 'final class GiantTest'];
+    }
+}

--- a/tools/benchmark.php
+++ b/tools/benchmark.php
@@ -3,181 +3,437 @@
 declare(strict_types=1);
 
 /**
- * Generates synthetic suites and reports median wall times for each benchmark
- * shape. Greenlight runs all shapes. With --with-phpunit, PHPUnit and ParaTest
- * also run after Composer installs them in the generated project.
+ * Generates synthetic suites and reports wall-time distributions for each
+ * benchmark shape. The schedule uses an explicit warm-up and a reproducible
+ * configuration order.
  *
  * Run the benchmark on an idle machine. Record the parameters with the
- * results in docs/benchmarks.md so others can reproduce them.
+ * results in docs/benchmarks.md so that other users can reproduce them.
  *
  * Usage:
  *   php tools/benchmark.php [--shape=<name>] [--scale=<n>] [--workers=<k>]
- *                           [--runs=<r>] [--with-phpunit]
+ *                           [--warmups=<w>] [--runs=<r>] [--seed=<s>]
+ *                           [--with-phpunit]
  *
- * Shapes: many-fast, few-slow, giant-dataset, mixed (default: all).
+ * Omit --shape to run all shapes.
  */
 
 const PHPUNIT_VERSION = '13.2.3';
 const PARATEST_VERSION = '7.23.0';
+const BENCHMARK_DEFAULT_SEED = 2_026_082_1;
 
-$options = \getopt('', ['shape:', 'scale:', 'workers:', 'runs:', 'with-phpunit']);
+const BENCHMARK_SHAPES = [
+    'many-fast',
+    'few-slow',
+    'giant-dataset',
+    'mixed',
+    'many-isolated',
+    'recycle-one',
+    'resource-constrained',
+    'skewed-bootstrap',
+    'chatty-diagnostics',
+    'coverage-heavy',
+];
 
-if ($options === false) {
-    throw new RuntimeException('Cannot parse benchmark options.');
+$scriptFilename = $_SERVER['SCRIPT_FILENAME'] ?? null;
+
+if (\is_string($scriptFilename) && \realpath($scriptFilename) === __FILE__) {
+    exit(\benchmarkMain());
 }
 
-$shapes = isset($options['shape']) && \is_string($options['shape'])
-    ? [$options['shape']]
-    : ['many-fast', 'few-slow', 'giant-dataset', 'mixed'];
-$scale = isset($options['scale']) && \is_string($options['scale']) ? \max(1, (int) $options['scale']) : 10;
-$workers = isset($options['workers']) && \is_string($options['workers']) ? \max(1, (int) $options['workers']) : 4;
-$runs = isset($options['runs']) && \is_string($options['runs']) ? \max(1, (int) $options['runs']) : 3;
-$withPhpunit = \array_key_exists('with-phpunit', $options);
-
-$root = \dirname(__DIR__);
-$results = [];
-
-foreach ($shapes as $shape) {
-    $project = \sys_get_temp_dir() . '/greenlight-bench-' . $shape . '-' . \bin2hex(\random_bytes(4));
-    $tests = \generateShape($shape, $scale, $project);
-    \fwrite(\STDERR, \sprintf("[%s] %d tests generated in %s\n", $shape, $tests, $project));
-
-    $results[] = [
-        'shape' => $shape,
-        'tests' => $tests,
-        'tool' => \sprintf('greenlight (workers=%d)', $workers),
-        'seconds' => \median(\times($runs, \sprintf(
-            'cd %s && %s %s run --workers=%d --reporter=plain',
-            \escapeshellarg($project),
-            \escapeshellarg(\PHP_BINARY),
-            \escapeshellarg($root . '/bin/greenlight'),
-            $workers,
-        ))),
-    ];
-
-    $results[] = [
-        'shape' => $shape,
-        'tests' => $tests,
-        'tool' => 'greenlight (workers=1)',
-        'seconds' => \median(\times($runs, \sprintf(
-            'cd %s && %s %s run --workers=1 --reporter=plain',
-            \escapeshellarg($project),
-            \escapeshellarg(\PHP_BINARY),
-            \escapeshellarg($root . '/bin/greenlight'),
-        ))),
-    ];
-
-    if ($withPhpunit) {
-        \install($project);
-
-        $results[] = [
-            'shape' => $shape,
-            'tests' => $tests,
-            'tool' => 'phpunit',
-            'seconds' => \median(\times($runs, \sprintf(
-                'cd %s && %s vendor/bin/phpunit --no-progress --no-output',
-                \escapeshellarg($project),
-                \escapeshellarg(\PHP_BINARY),
-            ))),
-        ];
-
-        $results[] = [
-            'shape' => $shape,
-            'tests' => $tests,
-            'tool' => \sprintf('paratest (p=%d)', $workers),
-            'seconds' => \median(\times($runs, \sprintf(
-                'cd %s && %s vendor/bin/paratest -p%d 2>&1',
-                \escapeshellarg($project),
-                \escapeshellarg(\PHP_BINARY),
-                $workers,
-            ))),
-        ];
-    }
-
-    \removeTree($project);
-}
-
-echo \sprintf("%-14s %6s  %-24s %8s\n", 'shape', 'tests', 'tool', 'median');
-
-foreach ($results as $row) {
-    echo \sprintf("%-14s %6d  %-24s %7.3fs\n", $row['shape'], $row['tests'], $row['tool'], $row['seconds']);
-}
-
-exit(0);
-
-/**
- * @return list<float>
- */
-function times(int $runs, string $command): array
+function benchmarkMain(): int
 {
-    $samples = [];
+    try {
+        $parsed = \getopt('', [
+            'shape:',
+            'scale:',
+            'workers:',
+            'warmups:',
+            'runs:',
+            'seed:',
+            'with-phpunit',
+        ]);
 
-    for ($i = 0; $i < $runs; ++$i) {
-        $started = \hrtime(true);
-        \exec($command . ' >/dev/null 2>&1', $ignored, $exit);
-        $seconds = (\hrtime(true) - $started) / 1_000_000_000;
-
-        if ($exit !== 0) {
-            \fwrite(\STDERR, \sprintf("Command failed (exit %d): %s\n", $exit, $command));
-            exit(1);
+        if ($parsed === false) {
+            throw new InvalidArgumentException('Greenlight cannot parse the benchmark options.');
         }
 
-        $samples[] = $seconds;
+        $options = \benchmarkParseOptions($parsed);
+        $root = \dirname(__DIR__);
+        $results = [];
+
+        \fwrite(\STDERR, \sprintf(
+            "Benchmark schedule: warm-up rounds %d, sample rounds %d, seed %d.\n",
+            $options['warmups'],
+            $options['runs'],
+            $options['seed'],
+        ));
+
+        foreach ($options['shapes'] as $shape) {
+            $project = \sys_get_temp_dir() . '/greenlight-bench-' . $shape . '-' . \bin2hex(\random_bytes(4));
+
+            try {
+                $tests = \benchmarkGenerateShape($shape, $options['scale'], $project);
+                \fwrite(\STDERR, \sprintf("[%s] %d tests generated in %s.\n", $shape, $tests, $project));
+
+                $configurations = \benchmarkConfigurations(
+                    $shape,
+                    $project,
+                    $root,
+                    $options['workers'],
+                    $options['withPhpunit'],
+                );
+
+                if ($options['withPhpunit'] && \benchmarkHasComparisonFixture($shape)) {
+                    \benchmarkInstall($project);
+                }
+
+                $samples = [];
+
+                foreach ($configurations as $id => $_configuration) {
+                    $samples[$id] = [];
+                }
+
+                foreach (\benchmarkSchedule(\array_keys($configurations), $options['warmups'], $options['seed'], $shape . ':warmup') as $round => $order) {
+                    foreach ($order as $id) {
+                        \fwrite(\STDERR, \sprintf(
+                            "[%s] warm-up %d/%d: %s.\n",
+                            $shape,
+                            $round + 1,
+                            $options['warmups'],
+                            $configurations[$id]['tool'],
+                        ));
+                        \benchmarkTime($configurations[$id]['command']);
+                    }
+                }
+
+                foreach (\benchmarkSchedule(\array_keys($configurations), $options['runs'], $options['seed'], $shape . ':sample') as $round => $order) {
+                    foreach ($order as $id) {
+                        \fwrite(\STDERR, \sprintf(
+                            "[%s] sample %d/%d: %s.\n",
+                            $shape,
+                            $round + 1,
+                            $options['runs'],
+                            $configurations[$id]['tool'],
+                        ));
+                        $samples[$id][] = \benchmarkTime($configurations[$id]['command']);
+                    }
+                }
+
+                foreach ($configurations as $id => $configuration) {
+                    $results[] = [
+                        'shape' => $shape,
+                        'tests' => $tests,
+                        'tool' => $configuration['tool'],
+                        ...\benchmarkDistribution($samples[$id]),
+                    ];
+                }
+            } finally {
+                \benchmarkRemoveTree($project);
+            }
+        }
+
+        echo \sprintf(
+            "%-20s %6s  %-24s %8s %8s %8s %8s\n",
+            'shape',
+            'tests',
+            'tool',
+            'minimum',
+            'median',
+            'maximum',
+            'spread',
+        );
+
+        foreach ($results as $row) {
+            echo \sprintf(
+                "%-20s %6d  %-24s %7.3fs %7.3fs %7.3fs %7.1f%%\n",
+                $row['shape'],
+                $row['tests'],
+                $row['tool'],
+                $row['minimum'],
+                $row['median'],
+                $row['maximum'],
+                $row['spreadPercent'],
+            );
+        }
+
+        return 0;
+    } catch (InvalidArgumentException|RuntimeException $error) {
+        \fwrite(\STDERR, $error->getMessage() . "\n");
+
+        return 1;
+    }
+}
+
+/**
+ * @param array<string, string|array<mixed>|false> $options
+ *
+ * @return array{
+ *   shapes: list<string>,
+ *   scale: positive-int,
+ *   workers: positive-int,
+ *   warmups: non-negative-int,
+ *   runs: positive-int,
+ *   seed: int,
+ *   withPhpunit: bool
+ * }
+ */
+function benchmarkParseOptions(array $options): array
+{
+    $shape = \benchmarkOptionValue($options, 'shape');
+    $shapes = $shape === null ? BENCHMARK_SHAPES : [$shape];
+
+    foreach ($shapes as $selected) {
+        if (!\in_array($selected, BENCHMARK_SHAPES, true)) {
+            throw new InvalidArgumentException(\sprintf(
+                'Unknown benchmark shape "%s". Use one of: %s.',
+                $selected,
+                \implode(', ', BENCHMARK_SHAPES),
+            ));
+        }
     }
 
-    return $samples;
+    return [
+        'shapes' => $shapes,
+        'scale' => \benchmarkPositiveIntegerOption($options, 'scale', 10),
+        'workers' => \benchmarkPositiveIntegerOption($options, 'workers', 4),
+        'warmups' => \benchmarkNonNegativeIntegerOption($options, 'warmups', 1),
+        'runs' => \benchmarkPositiveIntegerOption($options, 'runs', 3),
+        'seed' => \benchmarkIntegerOption($options, 'seed', BENCHMARK_DEFAULT_SEED),
+        'withPhpunit' => \array_key_exists('with-phpunit', $options),
+    ];
+}
+
+/** @param array<string, string|array<mixed>|false> $options */
+function benchmarkOptionValue(array $options, string $name): ?string
+{
+    if (!\array_key_exists($name, $options)) {
+        return null;
+    }
+
+    $value = $options[$name];
+
+    if (!\is_string($value)) {
+        throw new InvalidArgumentException(\sprintf('Specify option --%s exactly once with a value.', $name));
+    }
+
+    return $value;
+}
+
+/** @param array<string, string|array<mixed>|false> $options */
+function benchmarkIntegerOption(array $options, string $name, int $default): int
+{
+    $value = \benchmarkOptionValue($options, $name);
+
+    if ($value === null) {
+        return $default;
+    }
+
+    if (\preg_match('/^-?\d+$/D', $value) !== 1) {
+        throw new InvalidArgumentException(\sprintf('Option --%s must be an integer, got "%s".', $name, $value));
+    }
+
+    return (int) $value;
+}
+
+/**
+ * @param array<string, string|array<mixed>|false> $options
+ *
+ * @return positive-int
+ */
+function benchmarkPositiveIntegerOption(array $options, string $name, int $default): int
+{
+    $parsed = \benchmarkIntegerOption($options, $name, $default);
+
+    if ($parsed < 1) {
+        throw new InvalidArgumentException(\sprintf('Option --%s must be at least 1, got %d.', $name, $parsed));
+    }
+
+    return $parsed;
+}
+
+/**
+ * @param array<string, string|array<mixed>|false> $options
+ *
+ * @return non-negative-int
+ */
+function benchmarkNonNegativeIntegerOption(array $options, string $name, int $default): int
+{
+    $parsed = \benchmarkIntegerOption($options, $name, $default);
+
+    if ($parsed < 0) {
+        throw new InvalidArgumentException(\sprintf('Option --%s must be at least 0, got %d.', $name, $parsed));
+    }
+
+    return $parsed;
+}
+
+/**
+ * @param list<string> $configurationIds
+ *
+ * @return list<list<string>>
+ */
+function benchmarkSchedule(array $configurationIds, int $rounds, int $seed, string $context): array
+{
+    if ($configurationIds === [] || $rounds < 1) {
+        return [];
+    }
+
+    $base = $configurationIds;
+    \usort($base, static function (string $left, string $right) use ($seed, $context): int {
+        $leftHash = \hash('sha256', $seed . "\0" . $context . "\0" . $left);
+        $rightHash = \hash('sha256', $seed . "\0" . $context . "\0" . $right);
+
+        return [$leftHash, $left] <=> [$rightHash, $right];
+    });
+
+    $schedule = [];
+    $count = \count($base);
+
+    for ($round = 0; $round < $rounds; ++$round) {
+        $rotation = \intdiv($round, 2) % $count;
+        $order = [...\array_slice($base, $rotation), ...\array_slice($base, 0, $rotation)];
+        $schedule[] = $round % 2 === 0 ? $order : \array_reverse($order);
+    }
+
+    return $schedule;
+}
+
+/** @return array<string, array{tool: string, command: string}> */
+function benchmarkConfigurations(string $shape, string $project, string $root, int $workers, bool $withPhpunit): array
+{
+    $environment = $shape === 'coverage-heavy' ? 'XDEBUG_MODE=coverage ' : '';
+    $greenlight = \sprintf(
+        'cd %s && %s%s %s run --workers=%%d --reporter=plain',
+        \escapeshellarg($project),
+        $environment,
+        \escapeshellarg(\PHP_BINARY),
+        \escapeshellarg($root . '/bin/greenlight'),
+    );
+    $configurations = [
+        'greenlight-parallel' => [
+            'tool' => \sprintf('greenlight (workers=%d)', $workers),
+            'command' => \sprintf($greenlight, $workers),
+        ],
+        'greenlight-one' => [
+            'tool' => 'greenlight (workers=1)',
+            'command' => \sprintf($greenlight, 1),
+        ],
+    ];
+
+    if (!$withPhpunit || !\benchmarkHasComparisonFixture($shape)) {
+        return $configurations;
+    }
+
+    $configurations['phpunit'] = [
+        'tool' => 'phpunit',
+        'command' => \sprintf(
+            'cd %s && %s vendor/bin/phpunit --no-progress --no-output',
+            \escapeshellarg($project),
+            \escapeshellarg(\PHP_BINARY),
+        ),
+    ];
+    $configurations['paratest'] = [
+        'tool' => \sprintf('paratest (p=%d)', $workers),
+        'command' => \sprintf(
+            'cd %s && %s vendor/bin/paratest -p%d 2>&1',
+            \escapeshellarg($project),
+            \escapeshellarg(\PHP_BINARY),
+            $workers,
+        ),
+    ];
+
+    return $configurations;
+}
+
+function benchmarkHasComparisonFixture(string $shape): bool
+{
+    return \in_array($shape, ['many-fast', 'few-slow', 'giant-dataset', 'mixed'], true);
+}
+
+function benchmarkTime(string $command): float
+{
+    $started = \hrtime(true);
+    $ignored = [];
+    \exec($command . ' >/dev/null 2>&1', $ignored, $exit);
+    $seconds = (\hrtime(true) - $started) / 1_000_000_000;
+
+    if ($exit !== 0) {
+        throw new RuntimeException(\sprintf('Command failed with exit %d: %s.', $exit, $command));
+    }
+
+    return $seconds;
 }
 
 /**
  * @param list<float> $samples
+ *
+ * @return array{minimum: float, median: float, maximum: float, spreadPercent: float}
  */
-function median(array $samples): float
+function benchmarkDistribution(array $samples): array
 {
-    \sort($samples);
+    if ($samples === []) {
+        throw new RuntimeException('The benchmark distribution needs at least one sample.');
+    }
 
-    return $samples[\intdiv(\count($samples), 2)] ?? 0.0;
+    \sort($samples);
+    $count = \count($samples);
+    $middle = \intdiv($count, 2);
+    $median = $count % 2 === 0
+        ? ($samples[$middle - 1] + $samples[$middle]) / 2
+        : $samples[$middle];
+    $minimum = $samples[0];
+    $maximum = $samples[$count - 1];
+
+    return [
+        'minimum' => $minimum,
+        'median' => $median,
+        'maximum' => $maximum,
+        'spreadPercent' => $median > 0.0 ? (($maximum - $minimum) / $median) * 100 : 0.0,
+    ];
 }
 
-function generateShape(string $shape, int $scale, string $project): int
+function benchmarkGenerateShape(string $shape, int $scale, string $project): int
 {
     if (!\mkdir($project . '/tests/gl', 0o777, true) || !\mkdir($project . '/tests/pu', 0o777, true)) {
-        \fwrite(\STDERR, "Greenlight did not create the benchmark project directory.\n");
-        exit(1);
+        throw new RuntimeException('Greenlight did not create the benchmark project directory.');
     }
 
     $tests = match ($shape) {
         // Measures discovery and event costs with many classes and trivial bodies.
-        'many-fast' => \writeClasses($project, 'ManyFast', 40 * $scale, 5, 0),
+        'many-fast' => \benchmarkWriteClasses($project, 'ManyFast', 40 * $scale, 5),
         // Measures scheduler costs with a small number of classes that sleep.
-        'few-slow' => \writeClasses($project, 'FewSlow', 8, 4, 25_000),
+        'few-slow' => \benchmarkWriteClasses($project, 'FewSlow', 8, 4, sleepMicros: 25_000),
         // Measures the indivisible-class limit with one class and many data rows.
-        'giant-dataset' => \writeGiantDataSet($project, 100 * $scale),
-        'mixed' => \writeClasses($project, 'MixedFast', 20 * $scale, 5, 0)
-            + \writeClasses($project, 'MixedSlow', 4, 4, 25_000)
-            + \writeGiantDataSet($project, 40 * $scale),
-        default => -1,
+        'giant-dataset' => \benchmarkWriteGiantDataSet($project, 100 * $scale),
+        'mixed' => \benchmarkWriteClasses($project, 'MixedFast', 20 * $scale, 5)
+            + \benchmarkWriteClasses($project, 'MixedSlow', 4, 4, sleepMicros: 25_000)
+            + \benchmarkWriteGiantDataSet($project, 40 * $scale),
+        // Measures fresh-worker creation for isolated scheduling units.
+        'many-isolated' => \benchmarkWriteClasses($project, 'ManyIsolated', 4 * $scale, 1, attribute: "#[Isolated]\n"),
+        // Measures worker replacement after each test.
+        'recycle-one' => \benchmarkWriteClasses($project, 'RecycleOne', 4 * $scale, 2),
+        // Measures work that a resource limit serializes.
+        'resource-constrained' => \benchmarkWriteClasses(
+            $project,
+            'ResourceConstrained',
+            4 * $scale,
+            1,
+            sleepMicros: 10_000,
+            attribute: "#[RequiresResource('database')]\n",
+        ),
+        // Measures scheduling while workers finish bootstrap at different times.
+        'skewed-bootstrap' => \benchmarkWriteClasses($project, 'SkewedBootstrap', 20 * $scale, 2),
+        // Measures capture and protocol costs for worker diagnostics.
+        'chatty-diagnostics' => \benchmarkWriteClasses($project, 'ChattyDiagnostics', 10 * $scale, 2, diagnostics: 25),
+        // Measures large per-assignment coverage maps.
+        'coverage-heavy' => \benchmarkWriteClasses($project, 'CoverageHeavy', 4 * $scale, 2, statements: 100),
+        default => throw new InvalidArgumentException(\sprintf('Unknown benchmark shape "%s".', $shape)),
     };
 
-    if ($tests < 0) {
-        \fwrite(\STDERR, \sprintf("Unknown shape \"%s\".\n", $shape));
-        exit(1);
-    }
+    \benchmarkWriteConfiguration($project, $shape);
 
-    \file_put_contents($project . '/greenlight.php', <<<PHP
-        <?php
-
-        declare(strict_types=1);
-
-        use Greenlight\\Config\\GreenlightConfig;
-
-        foreach (glob(__DIR__ . '/tests/gl/*Test.php') ?: [] as \$file) {
-            require_once \$file;
-        }
-
-        return GreenlightConfig::create()->paths([__DIR__ . '/tests/gl']);
-        PHP);
-
-    \file_put_contents($project . '/phpunit.xml', <<<XML
+    \file_put_contents($project . '/phpunit.xml', <<<'XML'
         <?xml version="1.0" encoding="UTF-8"?>
         <phpunit bootstrap="vendor/autoload.php" colors="false">
             <testsuites>
@@ -188,11 +444,11 @@ function generateShape(string $shape, int $scale, string $project): int
         </phpunit>
         XML);
 
-    \file_put_contents($project . '/composer.json', <<<JSON
+    \file_put_contents($project . '/composer.json', <<<'JSON'
         {
             "autoload-dev": {
                 "psr-4": {
-                    "Bench\\\\": "tests/pu/"
+                    "Bench\\": "tests/pu/"
                 }
             }
         }
@@ -201,32 +457,112 @@ function generateShape(string $shape, int $scale, string $project): int
     return $tests;
 }
 
-function writeClasses(string $project, string $prefix, int $classes, int $methods, int $sleepMicros): int
+function benchmarkWriteConfiguration(string $project, string $shape): void
 {
+    $definitions = '';
+    $chain = '';
+
+    if ($shape === 'recycle-one') {
+        $chain = "\n    ->workers(recycleAfterTests: 1)";
+    } elseif ($shape === 'resource-constrained') {
+        $chain = "\n    ->resourceLimit('database')";
+    } elseif ($shape === 'coverage-heavy') {
+        $chain = "\n    ->coverage(fn(CoverageBuilder \$coverage) => \$coverage->include(__DIR__ . '/tests/gl'))";
+    } elseif ($shape === 'skewed-bootstrap') {
+        $definitions = <<<'PHP'
+
+        final class BenchmarkBootstrapPlugin implements WorkerBootstrapSubscriber
+        {
+            public function onWorkerBootstrap(WorkerBootstrapContext $context): void
+            {
+                \usleep($context->channel->number * 15_000);
+            }
+        }
+
+        PHP;
+        $chain = "\n    ->plugins(new BenchmarkBootstrapPlugin())";
+    }
+
+    \file_put_contents($project . '/greenlight.php', \sprintf(<<<'PHP'
+        <?php
+
+        declare(strict_types=1);
+
+        use Greenlight\Config\CoverageBuilder;
+        use Greenlight\Config\GreenlightConfig;
+        use Greenlight\Plugin\WorkerBootstrapContext;
+        use Greenlight\Plugin\WorkerBootstrapSubscriber;
+        %s
+        foreach (glob(__DIR__ . '/tests/gl/*Test.php') ?: [] as $file) {
+            require_once $file;
+        }
+
+        return GreenlightConfig::create()
+            ->paths([__DIR__ . '/tests/gl'])%s;
+        PHP, $definitions, $chain));
+}
+
+function benchmarkWriteClasses(
+    string $project,
+    string $prefix,
+    int $classes,
+    int $methods,
+    int $sleepMicros = 0,
+    string $attribute = '',
+    int $diagnostics = 0,
+    int $statements = 0,
+): int {
     for ($i = 0; $i < $classes; ++$i) {
         $name = \sprintf('%s%04dTest', $prefix, $i);
         $glBody = '';
         $puBody = '';
 
         for ($m = 0; $m < $methods; ++$m) {
-            $work = $sleepMicros > 0 ? \sprintf("\\usleep(%d);\n        ", $sleepMicros) : '';
+            $glWork = $sleepMicros > 0 ? \sprintf("\\usleep(%d);\n        ", $sleepMicros) : '';
+            $puWork = $glWork;
+
+            if ($diagnostics > 0) {
+                $diagnosticWork = \sprintf(
+                    "for (\$diagnostic = 0; \$diagnostic < %d; ++\$diagnostic) {\n            \\trigger_error('Benchmark diagnostic.', \\E_USER_NOTICE);\n        }\n        ",
+                    $diagnostics,
+                );
+                $glWork .= $diagnosticWork;
+                $puWork .= $diagnosticWork;
+            }
+
+            if ($statements > 0) {
+                $glWork .= \sprintf("\$value = %d;\n        ", $m);
+                $puWork .= \sprintf("\$value = %d;\n        ", $m);
+
+                for ($statement = 0; $statement < $statements; ++$statement) {
+                    $glWork .= "\$value += 1;\n        ";
+                    $puWork .= "\$value += 1;\n        ";
+                }
+
+                $glExpectation = \sprintf('Expect::that($value)->toBe(%d);', $m + $statements);
+                $puExpectation = \sprintf('$this->assertSame(%d, $value);', $m + $statements);
+            } else {
+                $glExpectation = \sprintf('Expect::that(%d + 1)->toBe(%d);', $m, $m + 1);
+                $puExpectation = \sprintf('$this->assertSame(%d, %d + 1);', $m + 1, $m);
+            }
+
             $glBody .= \sprintf(<<<'PHP'
 
                     #[Test]
                     public function case%d(): void
                     {
-                        %sExpect::that(%d + 1)->toBe(%d);
+                        %s%s
                     }
 
-                PHP, $m, $work, $m, $m + 1);
+                PHP, $m, $glWork, $glExpectation);
             $puBody .= \sprintf(<<<'PHP'
 
                     public function testCase%d(): void
                     {
-                        %s$this->assertSame(%d, %d + 1);
+                        %s%s
                     }
 
-                PHP, $m, $work, $m + 1, $m);
+                PHP, $m, $puWork, $puExpectation);
         }
 
         \file_put_contents($project . '/tests/gl/' . $name . '.php', \sprintf(<<<'PHP'
@@ -236,13 +572,15 @@ function writeClasses(string $project, string $prefix, int $classes, int $method
 
             namespace Bench;
 
+            use Greenlight\Attribute\Isolated;
+            use Greenlight\Attribute\RequiresResource;
             use Greenlight\Attribute\Test;
             use Greenlight\Expect\Expect;
 
-            final class %s
+            %sfinal class %s
             {%s}
 
-            PHP, $name, $glBody));
+            PHP, $attribute, $name, $glBody));
 
         \file_put_contents($project . '/tests/pu/' . $name . '.php', \sprintf(<<<'PHP_WRAP'
         <?php
@@ -263,7 +601,7 @@ function writeClasses(string $project, string $prefix, int $classes, int $method
     return $classes * $methods;
 }
 
-function writeGiantDataSet(string $project, int $rows): int
+function benchmarkWriteGiantDataSet(string $project, int $rows): int
 {
     \file_put_contents($project . '/tests/gl/GiantTest.php', \sprintf(<<<'PHP'
         <?php
@@ -328,8 +666,9 @@ function writeGiantDataSet(string $project, int $rows): int
     return $rows;
 }
 
-function install(string $project): void
+function benchmarkInstall(string $project): void
 {
+    $output = [];
     \exec(\sprintf(
         'cd %s && composer require --dev --quiet --no-interaction %s %s 2>&1',
         \escapeshellarg($project),
@@ -338,12 +677,32 @@ function install(string $project): void
     ), $output, $exit);
 
     if ($exit !== 0) {
-        \fwrite(\STDERR, "Composer did not install PHPUnit and ParaTest:\n" . \implode("\n", $output) . "\n");
-        exit(1);
+        throw new RuntimeException("Composer did not install PHPUnit and ParaTest:\n" . \implode("\n", $output));
     }
 }
 
-function removeTree(string $directory): void
+function benchmarkRemoveTree(string $directory): void
 {
-    \exec(\sprintf('rm -rf %s', \escapeshellarg($directory)));
+    if (!\is_dir($directory)) {
+        return;
+    }
+
+    $iterator = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST,
+    );
+
+    foreach ($iterator as $entry) {
+        if (!$entry instanceof SplFileInfo) {
+            throw new RuntimeException('Greenlight cannot read a benchmark temporary-directory entry.');
+        }
+
+        if ($entry->isDir() && !$entry->isLink()) {
+            \rmdir($entry->getPathname());
+        } else {
+            \unlink($entry->getPathname());
+        }
+    }
+
+    \rmdir($directory);
 }


### PR DESCRIPTION
## Summary

- warm benchmark configurations and interleave seeded sample rounds
- report minimum, median, maximum, and spread across runner-focused shapes
- document the method and keep the CI benchmark bounded

The published benchmark numbers remain unchanged because this change did not run the full benchmark on an idle machine.