### PR TITLE
feat(reporting): detail worker lifecycle profile

### DIFF
--- a/docs/api-events.md
+++ b/docs/api-events.md
@@ -90,7 +90,7 @@ PHPDoc:
 public ResultSummary $summary
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L22)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L24)
 
 ### `$durationSeconds`
 
@@ -98,7 +98,7 @@ public ResultSummary $summary
 public float $durationSeconds
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L23)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L25)
 
 ### `$occurredAt`
 
@@ -106,7 +106,15 @@ public float $durationSeconds
 public float $occurredAt
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L24)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L26)
+
+### `$workerTimings`
+
+```php
+public array $workerTimings
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L27)
 
 ### `__construct()`
 
@@ -116,14 +124,16 @@ public function __construct(
     public ResultSummary $summary,
     public float $durationSeconds,
     public float $occurredAt,
+    public array $workerTimings = [],
 )
 ```
 
 PHPDoc:
 
+- `@param list<WorkerTiming> $workerTimings Orchestrator-observed worker timing data.`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L20)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L22)
 
 ### `toWire()`
 
@@ -132,7 +142,7 @@ PHPDoc:
 public function toWire(): array
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L45)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L48)
 
 ### `fromWire()`
 
@@ -141,7 +151,7 @@ public function toWire(): array
 public static function fromWire(array $payload): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L56)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/RunFinished.php#L62)
 
 ## `RunStarted`
 
@@ -767,3 +777,148 @@ public static function fromWire(array $payload): static
 ```
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerSpawned.php#L55)
+
+## `WorkerTiming`
+
+Namespace: `Greenlight\Core\Event`
+
+Contains orchestrator-observed timing data for one worker process.
+
+A null phase duration means that the worker did not reach both phase
+endpoints. Idle durations contain only states that the orchestrator can
+distinguish.
+
+```php
+final readonly class WorkerTiming implements WireSerializable
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerTiming.php#L17)
+
+### `$workerId`
+
+```php
+public string $workerId;
+```
+
+PHPDoc:
+
+- `@var non-empty-string`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerTiming.php#L20)
+
+### `$assignmentGaps`
+
+```php
+public int $assignmentGaps;
+```
+
+PHPDoc:
+
+- `@var non-negative-int`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerTiming.php#L23)
+
+### `$spawnToHelloSeconds`
+
+```php
+public ?float $spawnToHelloSeconds
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerTiming.php#L30)
+
+### `$helloToReadySeconds`
+
+```php
+public ?float $helloToReadySeconds
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerTiming.php#L31)
+
+### `$readyToFirstAssignmentSeconds`
+
+```php
+public ?float $readyToFirstAssignmentSeconds
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerTiming.php#L32)
+
+### `$assignmentGapSeconds`
+
+```php
+public float $assignmentGapSeconds
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerTiming.php#L34)
+
+### `$bootstrapBarrierSeconds`
+
+```php
+public float $bootstrapBarrierSeconds
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerTiming.php#L35)
+
+### `$resourceCapacitySeconds`
+
+```php
+public float $resourceCapacitySeconds
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerTiming.php#L36)
+
+### `$noQueuedWorkSeconds`
+
+```php
+public float $noQueuedWorkSeconds
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerTiming.php#L37)
+
+### `$retirementToExitSeconds`
+
+```php
+public ?float $retirementToExitSeconds
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerTiming.php#L38)
+
+### `__construct()`
+
+```php
+public function __construct(
+    string $workerId,
+    public ?float $spawnToHelloSeconds,
+    public ?float $helloToReadySeconds,
+    public ?float $readyToFirstAssignmentSeconds,
+    int $assignmentGaps,
+    public float $assignmentGapSeconds,
+    public float $bootstrapBarrierSeconds,
+    public float $resourceCapacitySeconds,
+    public float $noQueuedWorkSeconds,
+    public ?float $retirementToExitSeconds,
+)
+```
+
+PHPDoc:
+
+- `@throws \InvalidArgumentException`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerTiming.php#L28)
+
+### `toWire()`
+
+```php
+[\Override]
+public function toWire(): array
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerTiming.php#L67)
+
+### `fromWire()`
+
+```php
+[\Override]
+public static function fromWire(array $payload): static
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Core/Event/WorkerTiming.php#L84)

--- a/docs/architecture/jsonl.md
+++ b/docs/architecture/jsonl.md
@@ -58,7 +58,7 @@ guarantees, and incomplete-output behavior.
 | Tag               | Event                                | Payload keys                                                           |
 | ----------------- | ------------------------------------ | ---------------------------------------------------------------------- |
 | `run-started`     | Run begins                           | `runId`, `plannedTests`, `workers`, `occurredAt`, `artifactsDirectory` |
-| `run-finished`    | Run ends                             | `runId`, `summary`, `durationSeconds`, `occurredAt`                    |
+| `run-finished`    | Run ends                             | `runId`, `summary`, `durationSeconds`, `occurredAt`, `workerTimings`   |
 | `suite-started`   | Suite begins                         | `suite`, `occurredAt`                                                  |
 | `suite-finished`  | Suite ends                           | `suite`, `occurredAt`                                                  |
 | `class-started`   | Test class begins                    | `class`, `occurredAt`, `workerId`, `isolated`                          |
@@ -69,6 +69,28 @@ guarantees, and incomplete-output behavior.
 | `worker-recycled` | Greenlight replaces a worker process | `workerId`, `reason`, `occurredAt`                                     |
 
 `run-finished.summary` contains the passed, failed, errored, and skipped totals.
+
+`run-finished.workerTimings` is an optional list. Each item contains timing
+data for one worker process. Greenlight omits the key when timing data is not
+available.
+
+Each item contains these durations in seconds:
+
+* `spawnToHelloSeconds`
+* `helloToReadySeconds`
+* `readyToFirstAssignmentSeconds`
+* `assignmentGapSeconds`
+* `bootstrapBarrierSeconds`
+* `resourceCapacitySeconds`
+* `noQueuedWorkSeconds`
+* `retirementToExitSeconds`
+
+The item also contains `workerId` and `assignmentGaps`. A nullable duration is
+`null` when the worker did not reach both phase endpoints.
+
+The orchestrator calculates these values from protocol and scheduler state.
+Thus, worker test loops do not contain profile instrumentation. The idle values
+contain only states that the orchestrator can distinguish.
 
 `run-started.artifactsDirectory` is the absolute target directory for retained
 evidence from this run. Its value is `null` when an artifact directory is not

--- a/docs/architecture/worker-lifecycle.md
+++ b/docs/architecture/worker-lifecycle.md
@@ -81,6 +81,19 @@ sequenceDiagram
 `ready` and `done` act as work requests. The orchestrator assigns work when a
 worker becomes ready and whenever it finishes an assignment.
 
+The orchestrator records worker timing only at protocol and scheduler
+transitions. It records these lifecycle phases:
+
+* process spawn to observed `hello`
+* observed `hello` to observed `ready`, which includes worker bootstrap
+* observed `ready` to the first sent `assign`
+* observed `done` to the next sent `assign`
+* a retirement request to observed process exit
+
+The orchestrator also attributes idle time to the initial ready barrier,
+resource capacity, or no queued work. It does not add instrumentation to a
+worker test loop or a scheduler polling loop.
+
 The initial ready barrier prevents tests from starting while another initial
 worker is still bootstrapping. A replacement worker created after a crash or
 recycle needs to complete only its own bootstrap.

--- a/docs/architecture/worker-lifecycle.md
+++ b/docs/architecture/worker-lifecycle.md
@@ -184,8 +184,8 @@ the slots.
 If the oldest unit waits, the orchestrator reserves one slot from each required
 resource. A later unit can pass it only in one of these conditions:
 
-- The later unit uses other resources.
-- Capacity exists beyond the reservation.
+* The later unit uses other resources.
+* Capacity exists beyond the reservation.
 
 Unrelated work can continue. It cannot delay the oldest unit indefinitely.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -699,7 +699,12 @@ The profile includes:
 * workers requested
 * workers spawned
 * workers recycled
-* average boot latency, measured from spawn to first class
+* average spawn-to-hello time
+* average hello-to-ready bootstrap time
+* average ready-to-first-assignment time
+* total time between assignments
+* idle time from the bootstrap barrier, resource capacity, and no queued work
+* average time from a retirement request to observed process exit
 * per-worker class count, busy time, and utilization for non-isolated workers
 * workers that run isolated tests
 * makespan spread between the first and last worker to finish

--- a/resources/schema/jsonl-v2.schema.json
+++ b/resources/schema/jsonl-v2.schema.json
@@ -102,7 +102,11 @@
                 "runId": {"type": "string", "minLength": 1},
                 "summary": {"$ref": "#/definitions/summary"},
                 "durationSeconds": {"type": "number", "minimum": 0},
-                "occurredAt": {"$ref": "#/definitions/occurredAt"}
+                "occurredAt": {"$ref": "#/definitions/occurredAt"},
+                "workerTimings": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/workerTiming"}
+                }
             }
         },
         "summary": {
@@ -165,6 +169,33 @@
                 "workerId": {"type": "string", "minLength": 1},
                 "reason": {"enum": ["test-count", "memory", "crash"]},
                 "occurredAt": {"$ref": "#/definitions/occurredAt"}
+            }
+        },
+        "workerTiming": {
+            "type": "object",
+            "required": [
+                "workerId",
+                "spawnToHelloSeconds",
+                "helloToReadySeconds",
+                "readyToFirstAssignmentSeconds",
+                "assignmentGaps",
+                "assignmentGapSeconds",
+                "bootstrapBarrierSeconds",
+                "resourceCapacitySeconds",
+                "noQueuedWorkSeconds",
+                "retirementToExitSeconds"
+            ],
+            "properties": {
+                "workerId": {"type": "string", "minLength": 1},
+                "spawnToHelloSeconds": {"type": ["number", "null"], "minimum": 0},
+                "helloToReadySeconds": {"type": ["number", "null"], "minimum": 0},
+                "readyToFirstAssignmentSeconds": {"type": ["number", "null"], "minimum": 0},
+                "assignmentGaps": {"type": "integer", "minimum": 0},
+                "assignmentGapSeconds": {"type": "number", "minimum": 0},
+                "bootstrapBarrierSeconds": {"type": "number", "minimum": 0},
+                "resourceCapacitySeconds": {"type": "number", "minimum": 0},
+                "noQueuedWorkSeconds": {"type": "number", "minimum": 0},
+                "retirementToExitSeconds": {"type": ["number", "null"], "minimum": 0}
             }
         },
         "testId": {

--- a/src/Core/Event/RunFinished.php
+++ b/src/Core/Event/RunFinished.php
@@ -15,6 +15,8 @@ final readonly class RunFinished implements Event
     public string $runId;
 
     /**
+     * @param list<WorkerTiming> $workerTimings Orchestrator-observed worker timing data.
+     *
      * @throws \InvalidArgumentException
      */
     public function __construct(
@@ -22,6 +24,7 @@ final readonly class RunFinished implements Event
         public ResultSummary $summary,
         public float $durationSeconds,
         public float $occurredAt,
+        public array $workerTimings = [],
     ) {
         if ($runId === '') {
             throw new \InvalidArgumentException('RunFinished requires a non-empty run ID.');
@@ -50,6 +53,9 @@ final readonly class RunFinished implements Event
             'summary' => $this->summary->toWire(),
             'durationSeconds' => $this->durationSeconds,
             'occurredAt' => $this->occurredAt,
+            ...($this->workerTimings === [] ? [] : [
+                'workerTimings' => \array_map(static fn(WorkerTiming $timing): array => $timing->toWire(), $this->workerTimings),
+            ]),
         ];
     }
 
@@ -61,6 +67,10 @@ final readonly class RunFinished implements Event
             ResultSummary::fromWire(Wire::map($payload, 'summary')),
             \max(0.0, Wire::float($payload, 'durationSeconds')),
             Wire::float($payload, 'occurredAt'),
+            \array_map(
+                WorkerTiming::fromWire(...),
+                \array_key_exists('workerTimings', $payload) ? Wire::listOfMaps($payload, 'workerTimings') : [],
+            ),
         );
     }
 }

--- a/src/Core/Event/WorkerTiming.php
+++ b/src/Core/Event/WorkerTiming.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Core\Event;
+
+use Greenlight\Core\Wire\Wire;
+use Greenlight\Core\Wire\WireSerializable;
+
+/**
+ * Contains orchestrator-observed timing data for one worker process.
+ *
+ * A null phase duration means that the worker did not reach both phase
+ * endpoints. Idle durations contain only states that the orchestrator can
+ * distinguish.
+ */
+final readonly class WorkerTiming implements WireSerializable
+{
+    /** @var non-empty-string */
+    public string $workerId;
+
+    /** @var non-negative-int */
+    public int $assignmentGaps;
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    public function __construct(
+        string $workerId,
+        public ?float $spawnToHelloSeconds,
+        public ?float $helloToReadySeconds,
+        public ?float $readyToFirstAssignmentSeconds,
+        int $assignmentGaps,
+        public float $assignmentGapSeconds,
+        public float $bootstrapBarrierSeconds,
+        public float $resourceCapacitySeconds,
+        public float $noQueuedWorkSeconds,
+        public ?float $retirementToExitSeconds,
+    ) {
+        if ($workerId === '') {
+            throw new \InvalidArgumentException('Worker ID MUST NOT be empty.');
+        }
+
+        foreach ([
+            $spawnToHelloSeconds,
+            $helloToReadySeconds,
+            $readyToFirstAssignmentSeconds,
+            $assignmentGapSeconds,
+            $bootstrapBarrierSeconds,
+            $resourceCapacitySeconds,
+            $noQueuedWorkSeconds,
+            $retirementToExitSeconds,
+        ] as $duration) {
+            if ($duration !== null && (!\is_finite($duration) || $duration < 0.0)) {
+                throw new \InvalidArgumentException('Worker timing durations MUST be finite and nonnegative.');
+            }
+        }
+
+        if ($assignmentGaps < 0) {
+            throw new \InvalidArgumentException('Worker assignment gap count MUST NOT be negative.');
+        }
+
+        $this->workerId = $workerId;
+        $this->assignmentGaps = $assignmentGaps;
+    }
+
+    #[\Override]
+    public function toWire(): array
+    {
+        return [
+            'workerId' => $this->workerId,
+            'spawnToHelloSeconds' => $this->spawnToHelloSeconds,
+            'helloToReadySeconds' => $this->helloToReadySeconds,
+            'readyToFirstAssignmentSeconds' => $this->readyToFirstAssignmentSeconds,
+            'assignmentGaps' => $this->assignmentGaps,
+            'assignmentGapSeconds' => $this->assignmentGapSeconds,
+            'bootstrapBarrierSeconds' => $this->bootstrapBarrierSeconds,
+            'resourceCapacitySeconds' => $this->resourceCapacitySeconds,
+            'noQueuedWorkSeconds' => $this->noQueuedWorkSeconds,
+            'retirementToExitSeconds' => $this->retirementToExitSeconds,
+        ];
+    }
+
+    #[\Override]
+    public static function fromWire(array $payload): static
+    {
+        return new self(
+            Wire::nonEmptyString($payload, 'workerId'),
+            Wire::nullableFloat($payload, 'spawnToHelloSeconds'),
+            Wire::nullableFloat($payload, 'helloToReadySeconds'),
+            Wire::nullableFloat($payload, 'readyToFirstAssignmentSeconds'),
+            Wire::int($payload, 'assignmentGaps'),
+            Wire::float($payload, 'assignmentGapSeconds'),
+            Wire::float($payload, 'bootstrapBarrierSeconds'),
+            Wire::float($payload, 'resourceCapacitySeconds'),
+            Wire::float($payload, 'noQueuedWorkSeconds'),
+            Wire::nullableFloat($payload, 'retirementToExitSeconds'),
+        );
+    }
+}

--- a/src/Reporting/ProfileAggregator.php
+++ b/src/Reporting/ProfileAggregator.php
@@ -11,6 +11,7 @@ use Greenlight\Core\Event\TestClassFinished;
 use Greenlight\Core\Event\TestClassStarted;
 use Greenlight\Core\Event\WorkerRecycled;
 use Greenlight\Core\Event\WorkerSpawned;
+use Greenlight\Core\Event\WorkerTiming;
 
 /**
  * Makes a run profile only from the event stream.
@@ -18,13 +19,12 @@ use Greenlight\Core\Event\WorkerSpawned;
  * Thus, a live run and a saved JSONL artifact produce the same values.
  *
  * Class events use worker clocks. Worker and run events use orchestrator
- * clocks. These clocks use host wall time. Thus, boot latency can
- * include a scheduler delay.
+ * clocks. Detailed worker timings use the orchestrator monotonic clock.
  *
  * Worker busy time is the sum of its test-class periods. Utilization is busy
  * time divided by the worker period for a non-isolated worker. Boot latency is
- * the time from process start to the first test class. It includes the hello
- * exchange and the wait for the first assignment.
+ * the time from process start to the first test class. Legacy streams use this
+ * broad latency when they have no detailed worker timing data.
  *
  * @internal
  */
@@ -116,6 +116,12 @@ final class ProfileAggregator
 
         $lines[] = $workerSummary . \sprintf(', %d recycled', $recycled);
 
+        if ($this->runFinished->workerTimings !== []) {
+            foreach ($this->timingLines($this->runFinished->workerTimings) as $line) {
+                $lines[] = $line;
+            }
+        }
+
         $bootLatencies = [];
         $finishTimes = [];
 
@@ -131,7 +137,7 @@ final class ProfileAggregator
             }
         }
 
-        if ($bootLatencies !== []) {
+        if ($this->runFinished->workerTimings === [] && $bootLatencies !== []) {
             $lines[] = \sprintf(
                 '  Boot latency: %.3fs average (spawn to first class, %s)',
                 ProfileDuration::average($bootLatencies),
@@ -187,6 +193,89 @@ final class ProfileAggregator
         }
 
         return \implode("\n", $lines) . "\n";
+    }
+
+    /**
+     * Returns detailed worker lifecycle and idle timing lines.
+     *
+     * @param list<WorkerTiming> $timings
+     *
+     * @return list<string>
+     */
+    private function timingLines(array $timings): array
+    {
+        $spawnToHello = [];
+        $helloToReady = [];
+        $readyToAssignment = [];
+        $retirementToExit = [];
+        $assignmentGaps = 0;
+        $assignmentGapSeconds = 0.0;
+        $bootstrapBarrierSeconds = 0.0;
+        $resourceCapacitySeconds = 0.0;
+        $noQueuedWorkSeconds = 0.0;
+
+        foreach ($timings as $timing) {
+            if ($timing->spawnToHelloSeconds !== null) {
+                $spawnToHello[] = $timing->spawnToHelloSeconds;
+            }
+
+            if ($timing->helloToReadySeconds !== null) {
+                $helloToReady[] = $timing->helloToReadySeconds;
+            }
+
+            if ($timing->readyToFirstAssignmentSeconds !== null) {
+                $readyToAssignment[] = $timing->readyToFirstAssignmentSeconds;
+            }
+
+            if ($timing->retirementToExitSeconds !== null) {
+                $retirementToExit[] = $timing->retirementToExitSeconds;
+            }
+
+            $assignmentGaps += $timing->assignmentGaps;
+            $assignmentGapSeconds = ProfileDuration::add($assignmentGapSeconds, $timing->assignmentGapSeconds);
+            $bootstrapBarrierSeconds = ProfileDuration::add($bootstrapBarrierSeconds, $timing->bootstrapBarrierSeconds);
+            $resourceCapacitySeconds = ProfileDuration::add($resourceCapacitySeconds, $timing->resourceCapacitySeconds);
+            $noQueuedWorkSeconds = ProfileDuration::add($noQueuedWorkSeconds, $timing->noQueuedWorkSeconds);
+        }
+
+        $lines = ['  Startup phases:'];
+
+        foreach ([
+            ['Spawn to hello', $spawnToHello],
+            ['Hello to ready (bootstrap)', $helloToReady],
+            ['Ready to first assignment', $readyToAssignment],
+        ] as [$label, $durations]) {
+            if ($durations === []) {
+                continue;
+            }
+
+            $lines[] = \sprintf(
+                '    %s: %.3fs average (%s)',
+                $label,
+                ProfileDuration::average($durations),
+                Plural::count(\count($durations), 'worker'),
+            );
+        }
+
+        $lines[] = \sprintf(
+            '  Assignment gaps: %.3fs total (%s)',
+            $assignmentGapSeconds,
+            Plural::count($assignmentGaps, 'gap'),
+        );
+        $lines[] = '  Idle attribution:';
+        $lines[] = \sprintf('    Bootstrap barrier: %.3fs total', $bootstrapBarrierSeconds);
+        $lines[] = \sprintf('    Resource capacity: %.3fs total', $resourceCapacitySeconds);
+        $lines[] = \sprintf('    No queued work: %.3fs total', $noQueuedWorkSeconds);
+
+        if ($retirementToExit !== []) {
+            $lines[] = \sprintf(
+                '  Retirement request to exit observed: %.3fs average (%s)',
+                ProfileDuration::average($retirementToExit),
+                Plural::count(\count($retirementToExit), 'worker'),
+            );
+        }
+
+        return $lines;
     }
 
     /**

--- a/src/Runner/Orchestrator/Orchestrator.php
+++ b/src/Runner/Orchestrator/Orchestrator.php
@@ -86,6 +86,11 @@ final class Orchestrator
     private array $handles = [];
 
     /**
+     * @var array<string, WorkerTiming>
+     */
+    private array $reapedWorkerTimings = [];
+
+    /**
      * @var list<array{SocketChannel, float}> connected but not yet authenticated
      */
     private array $awaitingHello = [];
@@ -170,10 +175,13 @@ final class Orchestrator
      */
     public function workerTimings(): array
     {
-        return \array_values(\array_map(
-            static fn(WorkerHandle $handle): WorkerTiming => $handle->timing->snapshot($handle->workerId),
-            $this->handles,
-        ));
+        $timings = $this->reapedWorkerTimings;
+
+        foreach ($this->handles as $handle) {
+            $timings[$handle->workerId] = $handle->timing->snapshot($handle->workerId);
+        }
+
+        return \array_values($timings);
     }
 
     private function mergeCoverage(?CoverageMap $coverage): void
@@ -1058,6 +1066,7 @@ final class Orchestrator
             }
 
             $handle->timing->exitObserved($this->monotonicTime());
+            $this->reapedWorkerTimings[$handle->workerId] = $handle->timing->snapshot($handle->workerId);
             $this->channels?->release($handle->channelNumber);
             unset($this->handles[$workerId]);
         }

--- a/src/Runner/Orchestrator/Orchestrator.php
+++ b/src/Runner/Orchestrator/Orchestrator.php
@@ -13,6 +13,7 @@ use Greenlight\Core\Event\TestFinished;
 use Greenlight\Core\Event\TestStarted;
 use Greenlight\Core\Event\WorkerRecycled;
 use Greenlight\Core\Event\WorkerSpawned;
+use Greenlight\Core\Event\WorkerTiming;
 use Greenlight\Core\GracefulShutdown;
 use Greenlight\Core\Result\FailureDetail;
 use Greenlight\Core\Result\Outcome;
@@ -160,6 +161,19 @@ final class Orchestrator
     public function detectedLeaks(): array
     {
         return $this->leaks;
+    }
+
+    /**
+     * Returns orchestrator-observed timing data for each spawned worker.
+     *
+     * @return list<WorkerTiming>
+     */
+    public function workerTimings(): array
+    {
+        return \array_values(\array_map(
+            static fn(WorkerHandle $handle): WorkerTiming => $handle->timing->snapshot($handle->workerId),
+            $this->handles,
+        ));
     }
 
     private function mergeCoverage(?CoverageMap $coverage): void
@@ -382,6 +396,7 @@ final class Orchestrator
                 if ($handle !== null && $handle->channel === null) {
                     $handle->channel = $channel;
                     $handle->lastProgressAt = $this->monotonicTime();
+                    $handle->timing->hello($handle->lastProgressAt);
                     try {
                         $channel->send(new Bootstrap(
                             $handle->channelNumber,
@@ -430,10 +445,16 @@ final class Orchestrator
             : $this->resourceScheduler()->dispatch($handle->isFresh());
 
         if ($decision->kind === DispatchKind::Wait) {
+            $handle->timing->wait(WorkerIdleReason::ResourceCapacity, $this->monotonicTime());
+
             return;
         }
 
         if ($decision->kind === DispatchKind::Drain) {
+            $at = $this->monotonicTime();
+            $handle->timing->wait(WorkerIdleReason::NoQueuedWork, $at);
+            $handle->timing->retirementRequested($at);
+
             try {
                 $channel->send(new Drain());
             } catch (ProtocolError) {
@@ -467,6 +488,7 @@ final class Orchestrator
                 $this->remainingFailureAllowance(),
             ));
             $handle->lastProgressAt = $this->monotonicTime();
+            $handle->timing->assigned($handle->lastProgressAt);
         } catch (ProtocolError) {
             // The worker stopped before it received the assignment. Crash
             // containment puts the complete scheduling unit in the queue for
@@ -508,8 +530,11 @@ final class Orchestrator
                     }
 
                     $handle->ready = true;
+                    $readyAt = $this->monotonicTime();
+                    $handle->timing->ready($readyAt);
 
                     if (!$this->initialBarrierPassed) {
+                        $handle->timing->wait(WorkerIdleReason::BootstrapBarrier, $readyAt);
                         $this->openInitialBarrier($sink);
                     } else {
                         // A replacement worker can start as soon as its own
@@ -518,6 +543,9 @@ final class Orchestrator
                         $this->assignNext($handle, $sink);
                     }
                 } elseif ($message instanceof Recycling) {
+                    $at = $this->monotonicTime();
+                    $handle->timing->assignmentFinished($at);
+                    $handle->timing->retirementRequested($at);
                     $this->crossCheck($handle, $message->summary);
                     $this->assertRemainder($handle, $message->remaining);
                     $this->mergeCoverage($message->coverage);
@@ -528,6 +556,8 @@ final class Orchestrator
 
                     break;
                 } elseif ($message instanceof Done) {
+                    $at = $this->monotonicTime();
+                    $handle->timing->assignmentFinished($at);
                     $this->crossCheck($handle, $message->summary);
                     $this->mergeCoverage($message->coverage);
                     $this->leaks = [...$this->leaks, ...$message->leaks];
@@ -539,12 +569,14 @@ final class Orchestrator
                         // after Done, and a replacement worker processes the
                         // queue.
                         $sink->emit(new WorkerRecycled($handle->workerId, $message->wantsRecycle, \microtime(true)));
+                        $handle->timing->retirementRequested($at);
                         $this->finishHandle($handle);
 
                         break;
                     }
 
                     if ($this->draining || $isolatedAssignment) {
+                        $handle->timing->retirementRequested($this->monotonicTime());
                         try {
                             $channel->send(new Drain());
                         } catch (ProtocolError) {
@@ -685,6 +717,7 @@ final class Orchestrator
 
         foreach ($this->handles as $handle) {
             if ($handle->isActive() && $handle->channel !== null) {
+                $handle->timing->retirementRequested($this->monotonicTime());
                 try {
                     $handle->channel->send(new Drain());
                 } catch (ProtocolError) {
@@ -1024,6 +1057,7 @@ final class Orchestrator
                 continue;
             }
 
+            $handle->timing->exitObserved($this->monotonicTime());
             $this->channels?->release($handle->channelNumber);
             unset($this->handles[$workerId]);
         }

--- a/src/Runner/Orchestrator/WorkerHandle.php
+++ b/src/Runner/Orchestrator/WorkerHandle.php
@@ -60,6 +60,8 @@ final class WorkerHandle
 
     public readonly float $spawnedAt;
 
+    public readonly WorkerTimingRecorder $timing;
+
     public float $lastProgressAt;
 
     /**
@@ -79,6 +81,7 @@ final class WorkerHandle
         $this->tally = new ResultSummary();
         $this->spawnedAt = \hrtime(true) / 1_000_000_000;
         $this->lastProgressAt = $this->spawnedAt;
+        $this->timing = new WorkerTimingRecorder($this->spawnedAt);
     }
 
     public function beginAssignment(ResourceLease $lease): void

--- a/src/Runner/Orchestrator/WorkerIdleReason.php
+++ b/src/Runner/Orchestrator/WorkerIdleReason.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Runner\Orchestrator;
+
+/**
+ * Identifies an orchestrator-visible cause for worker idle time.
+ *
+ * @internal
+ */
+enum WorkerIdleReason
+{
+    case BootstrapBarrier;
+    case ResourceCapacity;
+    case NoQueuedWork;
+}

--- a/src/Runner/Orchestrator/WorkerTimingRecorder.php
+++ b/src/Runner/Orchestrator/WorkerTimingRecorder.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Runner\Orchestrator;
+
+use Greenlight\Core\Event\WorkerTiming;
+
+/**
+ * Records orchestrator protocol transitions for one worker process.
+ *
+ * Each transition has constant cost. The recorder does not run in test or
+ * scheduler polling loops.
+ *
+ * @internal
+ */
+final class WorkerTimingRecorder
+{
+    private ?float $helloAt = null;
+
+    private ?float $readyAt = null;
+
+    private ?float $firstAssignmentAt = null;
+
+    private ?float $lastAssignmentFinishedAt = null;
+
+    private int $assignmentGaps = 0;
+
+    private float $assignmentGapSeconds = 0.0;
+
+    private ?WorkerIdleReason $idleReason = null;
+
+    private ?float $idleSince = null;
+
+    private float $bootstrapBarrierSeconds = 0.0;
+
+    private float $resourceCapacitySeconds = 0.0;
+
+    private float $noQueuedWorkSeconds = 0.0;
+
+    private ?float $retirementRequestedAt = null;
+
+    private ?float $exitObservedAt = null;
+
+    public function __construct(private readonly float $spawnedAt) {}
+
+    public function hello(float $at): void
+    {
+        $this->helloAt ??= $at;
+    }
+
+    public function ready(float $at): void
+    {
+        $this->readyAt ??= $at;
+    }
+
+    public function wait(WorkerIdleReason $reason, float $at): void
+    {
+        if ($this->idleReason === $reason) {
+            return;
+        }
+
+        $wasIdle = $this->idleReason instanceof WorkerIdleReason;
+        $this->finishIdle($at);
+        $this->idleReason = $reason;
+        $this->idleSince = $wasIdle ? $at : ($this->lastAssignmentFinishedAt ?? $at);
+    }
+
+    public function assigned(float $at): void
+    {
+        $this->finishIdle($at);
+        $this->firstAssignmentAt ??= $at;
+
+        if ($this->lastAssignmentFinishedAt !== null) {
+            ++$this->assignmentGaps;
+            $this->assignmentGapSeconds = $this->add(
+                $this->assignmentGapSeconds,
+                $this->between($this->lastAssignmentFinishedAt, $at),
+            );
+            $this->lastAssignmentFinishedAt = null;
+        }
+    }
+
+    public function assignmentFinished(float $at): void
+    {
+        $this->lastAssignmentFinishedAt = $at;
+    }
+
+    public function retirementRequested(float $at): void
+    {
+        $this->finishIdle($at);
+        $this->retirementRequestedAt ??= $at;
+    }
+
+    public function exitObserved(float $at): void
+    {
+        $this->finishIdle($at);
+        $this->exitObservedAt ??= $at;
+    }
+
+    /**
+     * @param non-empty-string $workerId
+     */
+    public function snapshot(string $workerId): WorkerTiming
+    {
+        return new WorkerTiming(
+            $workerId,
+            $this->helloAt === null ? null : $this->between($this->spawnedAt, $this->helloAt),
+            $this->helloAt === null || $this->readyAt === null ? null : $this->between($this->helloAt, $this->readyAt),
+            $this->readyAt === null || $this->firstAssignmentAt === null ? null : $this->between($this->readyAt, $this->firstAssignmentAt),
+            $this->assignmentGaps,
+            $this->assignmentGapSeconds,
+            $this->bootstrapBarrierSeconds,
+            $this->resourceCapacitySeconds,
+            $this->noQueuedWorkSeconds,
+            $this->retirementRequestedAt === null || $this->exitObservedAt === null
+                ? null
+                : $this->between($this->retirementRequestedAt, $this->exitObservedAt),
+        );
+    }
+
+    private function finishIdle(float $at): void
+    {
+        if (!$this->idleReason instanceof WorkerIdleReason || $this->idleSince === null) {
+            return;
+        }
+
+        $duration = $this->between($this->idleSince, $at);
+
+        match ($this->idleReason) {
+            WorkerIdleReason::BootstrapBarrier => $this->bootstrapBarrierSeconds = $this->add($this->bootstrapBarrierSeconds, $duration),
+            WorkerIdleReason::ResourceCapacity => $this->resourceCapacitySeconds = $this->add($this->resourceCapacitySeconds, $duration),
+            WorkerIdleReason::NoQueuedWork => $this->noQueuedWorkSeconds = $this->add($this->noQueuedWorkSeconds, $duration),
+        };
+
+        $this->idleReason = null;
+        $this->idleSince = null;
+    }
+
+    private function between(float $start, float $finish): float
+    {
+        $duration = $finish - $start;
+
+        if (!\is_finite($duration) || $duration <= 0.0) {
+            return $duration > 0.0 ? \PHP_FLOAT_MAX : 0.0;
+        }
+
+        return $duration;
+    }
+
+    private function add(float $left, float $right): float
+    {
+        if ($left > \PHP_FLOAT_MAX - $right) {
+            return \PHP_FLOAT_MAX;
+        }
+
+        return $left + $right;
+    }
+}

--- a/src/Runner/ParallelRunner.php
+++ b/src/Runner/ParallelRunner.php
@@ -130,7 +130,13 @@ final readonly class ParallelRunner
                 $summary = $orchestrator->run($plan, $sink, $workerCount, $classSeconds);
 
                 $durationSeconds = (\hrtime(true) - $startedAt) / 1_000_000_000;
-                $sink->emit(new RunFinished($runId, $summary, $durationSeconds, \microtime(true)));
+                $sink->emit(new RunFinished(
+                    $runId,
+                    $summary,
+                    $durationSeconds,
+                    \microtime(true),
+                    $orchestrator->workerTimings(),
+                ));
 
                 $result = new RunResult($summary, \count($plan), $durationSeconds, $seed, $orchestrator->collectedCoverage(), $orchestrator->detectedLeaks());
             } catch (\Throwable $failure) {

--- a/tests/Acceptance/ProfileRunTest.php
+++ b/tests/Acceptance/ProfileRunTest.php
@@ -33,7 +33,12 @@ final readonly class ProfileRunTest
         Expect::that($result->exitCode)->because('live profile and offline report agree')->toBe(0);
         Expect::that($live)->toContain('Profile:')
             ->toContain('spawned, 0 recycled')
-            ->toContain('Boot latency:')
+            ->toContain('Startup phases:')
+            ->toContain('Spawn to hello:')
+            ->toContain('Hello to ready (bootstrap):')
+            ->toContain('Ready to first assignment:')
+            ->toContain('Idle attribution:')
+            ->toContain('Retirement request to exit observed:')
             ->toContain('Slowest classes:');
 
         // The plain report and JSONL lines share standard output. Extract the

--- a/tests/Unit/Core/EventsTest.php
+++ b/tests/Unit/Core/EventsTest.php
@@ -18,6 +18,7 @@ use Greenlight\Core\Event\TestFinished;
 use Greenlight\Core\Event\TestStarted;
 use Greenlight\Core\Event\WorkerRecycled;
 use Greenlight\Core\Event\WorkerSpawned;
+use Greenlight\Core\Event\WorkerTiming;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\ResultSummary;
 use Greenlight\Core\Result\TestResult;
@@ -152,6 +153,12 @@ final class EventsTest
             'workers' => 1,
             'occurredAt' => 1_780_000_000.0,
         ]);
+        $finishedRun = RunFinished::fromWire([
+            'runId' => 'run-1',
+            'summary' => new ResultSummary()->toWire(),
+            'durationSeconds' => 1.0,
+            'occurredAt' => 1_780_000_001.0,
+        ]);
 
         Expect::that($started->workerId)
             ->because('legacy class-started events have no worker attribution')
@@ -165,6 +172,23 @@ final class EventsTest
         Expect::that($run->artifactsDirectory)
             ->because('legacy run-started events have no artifacts directory')
             ->toBeNull();
+        Expect::that($finishedRun->workerTimings)
+            ->because('legacy run-finished events have no worker timing data')
+            ->toBe([]);
+    }
+
+    #[Test]
+    public function runFinishedAddsWorkerTimingsAsAnOptionalWireField(): void
+    {
+        $timing = new WorkerTiming('w-1', 0.1, 0.2, 0.3, 1, 0.4, 0.5, 0.6, 0.7, 0.8);
+        $event = new RunFinished('run-1', new ResultSummary(passed: 1), 2.0, 3.0, [$timing]);
+
+        Expect::that($event->toWire())
+            ->because('run-finished adds timing data without changing its existing fields')
+            ->toHaveKey('workerTimings');
+        Expect::that(RunFinished::fromWire(JsonWire::roundTrip($event->toWire()))->workerTimings[0]->toWire())
+            ->because('run-finished worker timing MUST survive the event wire')
+            ->toBe($timing->toWire());
     }
 
     #[Test]

--- a/tests/Unit/Core/WorkerTimingTest.php
+++ b/tests/Unit/Core/WorkerTimingTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Core;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Core\Event\WorkerTiming;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\JsonWire;
+
+final readonly class WorkerTimingTest
+{
+    #[Test]
+    public function workerTimingSurvivesTheWire(): void
+    {
+        $timing = new WorkerTiming('worker-2', 0.1, 0.2, 0.3, 2, 0.4, 0.5, 0.6, 0.7, 0.8);
+
+        Expect::that(WorkerTiming::fromWire(JsonWire::roundTrip($timing->toWire()))->toWire())
+            ->because('worker timing MUST preserve each lifecycle and idle duration')
+            ->toBe($timing->toWire());
+    }
+
+    #[Test]
+    public function workerTimingRejectsNegativeDurations(): void
+    {
+        Expect::that(static fn(): WorkerTiming => new WorkerTiming(
+            'worker-2',
+            -0.1,
+            null,
+            null,
+            0,
+            0.0,
+            0.0,
+            0.0,
+            0.0,
+            null,
+        ))
+            ->because('worker timing durations MUST be nonnegative')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Worker timing durations MUST be finite and nonnegative.',
+            );
+    }
+}

--- a/tests/Unit/Reporting/CannedStream.php
+++ b/tests/Unit/Reporting/CannedStream.php
@@ -16,6 +16,7 @@ use Greenlight\Core\Event\TestFinished;
 use Greenlight\Core\Event\TestStarted;
 use Greenlight\Core\Event\WorkerRecycled;
 use Greenlight\Core\Event\WorkerSpawned;
+use Greenlight\Core\Event\WorkerTiming;
 use Greenlight\Core\Result\FailureDetail;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\ResultSummary;
@@ -125,6 +126,7 @@ final class CannedStream
                 new ResultSummary(passed: 3, failed: 1, errored: 1, skipped: 1),
                 1.234,
                 $at + 0.22,
+                [new WorkerTiming('w-1', 0.01, 0.02, 0.01, 1, 0.01, 0.01, 0.0, 0.01, 0.02)],
             ),
         ];
     }

--- a/tests/Unit/Reporting/ProfileAggregatorTest.php
+++ b/tests/Unit/Reporting/ProfileAggregatorTest.php
@@ -14,6 +14,7 @@ use Greenlight\Core\Event\TestClassFinished;
 use Greenlight\Core\Event\TestClassStarted;
 use Greenlight\Core\Event\WorkerRecycled;
 use Greenlight\Core\Event\WorkerSpawned;
+use Greenlight\Core\Event\WorkerTiming;
 use Greenlight\Core\Result\ResultSummary;
 use Greenlight\Expect\Expect;
 use Greenlight\Reporting\ProfileAggregator;
@@ -74,6 +75,43 @@ final class ProfileAggregatorTest
 
         Expect::that($rendered)->because('slowest durations right align across widths')->toContain("    12.000s  Acme\\SlowTest\n")
             ->toContain("     1.000s  Acme\\QuickTest\n");
+    }
+
+    #[Test]
+    public function detailedWorkerTimingsReplaceBroadBootLatency(): void
+    {
+        $aggregator = new ProfileAggregator();
+        $events = [
+            new RunStarted('run-1', 2, 2, 100.0),
+            new WorkerSpawned('w-1', 11, 100.0),
+            new WorkerSpawned('w-2', 12, 100.0),
+            new TestClassStarted('Acme\\AlphaTest', 101.0, 'w-1'),
+            new TestClassFinished('Acme\\AlphaTest', 102.0, 'w-1'),
+            new RunFinished('run-1', new ResultSummary(passed: 1), 2.0, 102.0, [
+                new WorkerTiming('w-1', 0.1, 0.4, 0.5, 2, 0.3, 0.2, 0.25, 0.05, 0.1),
+                new WorkerTiming('w-2', 0.3, 0.6, null, 0, 0.0, 0.4, 0.75, 0.15, 0.3),
+            ]),
+        ];
+
+        foreach ($events as $event) {
+            $aggregator->onEvent($event);
+        }
+
+        $rendered = $aggregator->render(new Style(ansi: false));
+
+        Expect::that($rendered)
+            ->because('detailed timing MUST split worker startup and attribute orchestrator-visible idle time')
+            ->toContain("  Startup phases:\n")
+            ->toContain("    Spawn to hello: 0.200s average (2 workers)\n")
+            ->toContain("    Hello to ready (bootstrap): 0.500s average (2 workers)\n")
+            ->toContain("    Ready to first assignment: 0.500s average (1 worker)\n")
+            ->toContain("  Assignment gaps: 0.300s total (2 gaps)\n")
+            ->toContain("    Bootstrap barrier: 0.600s total\n")
+            ->toContain("    Resource capacity: 1.000s total\n")
+            ->toContain("    No queued work: 0.200s total\n")
+            ->toContain("  Retirement request to exit observed: 0.200s average (2 workers)\n")
+            ->not()
+            ->toContain('Boot latency:');
     }
 
     #[Test]

--- a/tests/Unit/Runner/Orchestrator/WorkerTimingRecorderTest.php
+++ b/tests/Unit/Runner/Orchestrator/WorkerTimingRecorderTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Orchestrator;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Runner\Orchestrator\WorkerIdleReason;
+use Greenlight\Runner\Orchestrator\WorkerTimingRecorder;
+
+final readonly class WorkerTimingRecorderTest
+{
+    #[Test]
+    public function protocolTransitionsProduceLifecyclePhasesAndIdleAttribution(): void
+    {
+        $recorder = new WorkerTimingRecorder(10.0);
+        $recorder->hello(10.1);
+        $recorder->ready(10.4);
+        $recorder->wait(WorkerIdleReason::BootstrapBarrier, 10.4);
+        $recorder->wait(WorkerIdleReason::ResourceCapacity, 10.6);
+        $recorder->assigned(10.9);
+        $recorder->assignmentFinished(11.4);
+        $recorder->wait(WorkerIdleReason::ResourceCapacity, 11.5);
+        $recorder->assigned(11.7);
+        $recorder->assignmentFinished(12.0);
+        $recorder->wait(WorkerIdleReason::NoQueuedWork, 12.05);
+        $recorder->retirementRequested(12.1);
+        $recorder->exitObserved(12.25);
+
+        $timing = $recorder->snapshot('worker-1');
+
+        Expect::that($timing->spawnToHelloSeconds)->toBeWithin(0.000_001, 0.1);
+        Expect::that($timing->helloToReadySeconds)->toBeWithin(0.000_001, 0.3);
+        Expect::that($timing->readyToFirstAssignmentSeconds)->toBeWithin(0.000_001, 0.5);
+        Expect::that($timing->assignmentGaps)->toBe(1);
+        Expect::that($timing->assignmentGapSeconds)->toBeWithin(0.000_001, 0.3);
+        Expect::that($timing->bootstrapBarrierSeconds)->toBeWithin(0.000_001, 0.2);
+        Expect::that($timing->resourceCapacitySeconds)->toBeWithin(0.000_001, 0.6);
+        Expect::that($timing->noQueuedWorkSeconds)->toBeWithin(0.000_001, 0.1);
+        Expect::that($timing->retirementToExitSeconds)->toBeWithin(0.000_001, 0.15);
+    }
+}


### PR DESCRIPTION
Records protocol- and scheduler-derived worker startup, assignment-gap, idle-reason, and retirement timings. Persists the measurements through an optional compatible JSONL v2 run-finished field so live and saved profiles agree. Documents the profile contract and adds focused wire, lifecycle, reporting, and acceptance coverage.