### PR TITLE
feat(protocol): add worker message schema

### DIFF
--- a/docs/architecture/worker-lifecycle.md
+++ b/docs/architecture/worker-lifecycle.md
@@ -17,6 +17,9 @@ oversized or malformed frames as protocol errors. The JSON envelope contains a
 protocol version (`v`, currently `2`), a type tag, and the payload. Greenlight
 also rejects unknown versions and tags.
 
+The [version 2 schema](../../resources/schema/worker-protocol-v2.schema.json)
+specifies each envelope and payload that Greenlight sends.
+
 The socket carries all protocol data. Greenlight closes the worker's stdin after
 spawn and drains stdout and stderr into a small bounded buffer. The orchestrator
 attaches the buffered output to a crash report when something goes wrong. Test

--- a/resources/schema/worker-protocol-v2.schema.json
+++ b/resources/schema/worker-protocol-v2.schema.json
@@ -1,0 +1,741 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://raw.githubusercontent.com/ben-challis/greenlight/main/resources/schema/worker-protocol-v2.schema.json",
+    "title": "Greenlight worker protocol envelope (version 2)",
+    "description": "The JSON body of one length-prefixed worker protocol frame.",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["v", "t", "p"],
+    "properties": {
+        "v": {"enum": [2]},
+        "t": {"type": "string", "minLength": 1},
+        "p": {"type": ["object", "array"]}
+    },
+    "oneOf": [
+        {
+            "properties": {
+                "t": {"enum": ["hello"]},
+                "p": {"$ref": "#/definitions/hello"}
+            }
+        },
+        {
+            "properties": {
+                "t": {"enum": ["bootstrap"]},
+                "p": {"$ref": "#/definitions/bootstrap"}
+            }
+        },
+        {
+            "properties": {
+                "t": {"enum": ["ready"]},
+                "p": {"$ref": "#/definitions/emptyPayload"}
+            }
+        },
+        {
+            "properties": {
+                "t": {"enum": ["assign"]},
+                "p": {"$ref": "#/definitions/assign"}
+            }
+        },
+        {
+            "properties": {
+                "t": {"enum": ["drain"]},
+                "p": {"$ref": "#/definitions/emptyPayload"}
+            }
+        },
+        {
+            "properties": {
+                "t": {"enum": ["event"]},
+                "p": {"$ref": "#/definitions/eventEnvelope"}
+            }
+        },
+        {
+            "properties": {
+                "t": {"enum": ["attempt-started"]},
+                "p": {"$ref": "#/definitions/attemptStarted"}
+            }
+        },
+        {
+            "properties": {
+                "t": {"enum": ["recycling"]},
+                "p": {"$ref": "#/definitions/recycling"}
+            }
+        },
+        {
+            "properties": {
+                "t": {"enum": ["done"]},
+                "p": {"$ref": "#/definitions/done"}
+            }
+        },
+        {
+            "properties": {
+                "t": {"enum": ["fatal"]},
+                "p": {"$ref": "#/definitions/fatal"}
+            }
+        }
+    ],
+    "definitions": {
+        "emptyPayload": {
+            "type": "array",
+            "maxItems": 0
+        },
+        "hello": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["workerId", "token", "pid"],
+            "properties": {
+                "workerId": {"type": "string", "minLength": 1},
+                "token": {"type": "string", "minLength": 1},
+                "pid": {"type": "integer", "minimum": 1}
+            }
+        },
+        "bootstrap": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["channel", "configFile", "resources"],
+            "properties": {
+                "channel": {"type": "integer", "minimum": 1},
+                "configFile": {"type": ["string", "null"]},
+                "resources": {"$ref": "#/definitions/integrationResources"}
+            }
+        },
+        "integrationResources": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["fixtures"],
+            "properties": {
+                "fixtures": {"$ref": "#/definitions/fixtureMap"}
+            }
+        },
+        "fixtureMap": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "additionalProperties": {"$ref": "#/definitions/fixtureResource"}
+                },
+                {"$ref": "#/definitions/emptyMap"}
+            ]
+        },
+        "fixtureResource": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["values", "secrets"],
+            "properties": {
+                "values": {"$ref": "#/definitions/jsonMap"},
+                "secrets": {"$ref": "#/definitions/stringMap"}
+            }
+        },
+        "jsonMap": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "additionalProperties": {"$ref": "#/definitions/jsonValue"}
+                },
+                {"$ref": "#/definitions/emptyMap"}
+            ]
+        },
+        "jsonValue": {
+            "oneOf": [
+                {"type": "null"},
+                {"type": "boolean"},
+                {"type": "number"},
+                {"type": "string"},
+                {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/jsonValue"}
+                },
+                {
+                    "type": "object",
+                    "additionalProperties": {"$ref": "#/definitions/jsonValue"}
+                }
+            ]
+        },
+        "stringMap": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "additionalProperties": {"type": "string"}
+                },
+                {"$ref": "#/definitions/emptyMap"}
+            ]
+        },
+        "emptyMap": {
+            "type": "array",
+            "maxItems": 0
+        },
+        "assign": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "slice",
+                "recycleAfterTests",
+                "recycleAboveMemoryBytes",
+                "coverageInclude",
+                "coverageDriver",
+                "detectLeaks",
+                "policy"
+            ],
+            "properties": {
+                "slice": {"$ref": "#/definitions/executionPlan"},
+                "recycleAfterTests": {"type": ["integer", "null"], "minimum": 1},
+                "recycleAboveMemoryBytes": {"type": ["integer", "null"], "minimum": 1},
+                "coverageInclude": {
+                    "oneOf": [
+                        {"type": "null"},
+                        {
+                            "type": "array",
+                            "items": {"type": "string", "minLength": 1}
+                        }
+                    ]
+                },
+                "coverageDriver": {"type": ["string", "null"], "minLength": 1},
+                "detectLeaks": {"type": "boolean"},
+                "policy": {
+                    "oneOf": [
+                        {"type": "null"},
+                        {"$ref": "#/definitions/resultPolicy"}
+                    ]
+                },
+                "artifactSession": {
+                    "oneOf": [
+                        {"type": "null"},
+                        {"$ref": "#/definitions/artifactSession"}
+                    ]
+                },
+                "artifactConfiguration": {
+                    "oneOf": [
+                        {"type": "null"},
+                        {"$ref": "#/definitions/artifactConfiguration"}
+                    ]
+                },
+                "stopAfterFailures": {
+                    "type": ["integer", "null"],
+                    "minimum": 1
+                }
+            }
+        },
+        "executionPlan": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["seed", "entries"],
+            "properties": {
+                "seed": {"type": ["integer", "null"]},
+                "entries": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/planEntry"}
+                }
+            }
+        },
+        "planEntry": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "metadata"],
+            "properties": {
+                "id": {"$ref": "#/definitions/testId"},
+                "metadata": {"$ref": "#/definitions/testMetadata"}
+            }
+        },
+        "testMetadata": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "class",
+                "method",
+                "groups",
+                "skipReason",
+                "skipUnlessCondition",
+                "retryTimes",
+                "retryOnlyOn",
+                "timeoutSeconds",
+                "isolated",
+                "dataSetProvider",
+                "capture"
+            ],
+            "properties": {
+                "class": {"type": "string", "minLength": 1},
+                "method": {"type": "string", "minLength": 1},
+                "groups": {
+                    "type": "array",
+                    "items": {"type": "string", "minLength": 1}
+                },
+                "skipReason": {"type": ["string", "null"], "minLength": 1},
+                "skipUnlessCondition": {"type": ["string", "null"], "minLength": 1},
+                "skipUnlessArguments": {
+                    "type": "array",
+                    "items": {"type": ["string", "number", "boolean", "null"]}
+                },
+                "retryTimes": {"type": ["integer", "null"], "minimum": 1},
+                "retryOnlyOn": {"type": ["string", "null"], "minLength": 1},
+                "timeoutSeconds": {"type": ["number", "null"], "minimum": 0, "exclusiveMinimum": true},
+                "isolated": {"type": "boolean"},
+                "dataSetProvider": {"type": ["string", "null"], "minLength": 1},
+                "dataSetProviderClass": {"type": ["string", "null"], "minLength": 1},
+                "capture": {"type": "boolean"},
+                "noExpectations": {"type": "boolean"},
+                "resources": {
+                    "type": "array",
+                    "items": {"type": "string", "pattern": "^[a-z0-9][a-z0-9._-]*$"}
+                },
+                "allowParallel": {"type": "boolean"}
+            }
+        },
+        "resultPolicy": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["failOnDeprecation", "failOnNotice", "ignoreDeprecations", "failOnRisky"],
+            "properties": {
+                "failOnDeprecation": {"type": "boolean"},
+                "failOnNotice": {"type": "boolean"},
+                "ignoreDeprecations": {
+                    "type": "array",
+                    "items": {"type": "string", "minLength": 1}
+                },
+                "failOnRisky": {"type": "boolean"}
+            }
+        },
+        "artifactSession": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["stagingDirectory", "publicDirectory"],
+            "properties": {
+                "stagingDirectory": {"type": "string", "minLength": 1},
+                "publicDirectory": {"type": "string", "minLength": 1}
+            }
+        },
+        "artifactConfiguration": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "directory",
+                "maxAttachmentsPerTest",
+                "maxAttachmentBytes",
+                "maxTestBytes",
+                "maxRunAttachments",
+                "maxRunBytes"
+            ],
+            "properties": {
+                "directory": {"type": "string", "minLength": 1},
+                "maxAttachmentsPerTest": {"type": "integer", "minimum": 1},
+                "maxAttachmentBytes": {"type": "integer", "minimum": 1},
+                "maxTestBytes": {"type": "integer", "minimum": 1},
+                "maxRunAttachments": {"type": "integer", "minimum": 1},
+                "maxRunBytes": {"type": "integer", "minimum": 1}
+            }
+        },
+        "attemptStarted": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "attempt"],
+            "properties": {
+                "id": {"$ref": "#/definitions/testId"},
+                "attempt": {"type": "integer", "minimum": 1}
+            }
+        },
+        "recycling": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["reason", "remaining", "summary", "coverage"],
+            "properties": {
+                "reason": {"$ref": "#/definitions/recycleReason"},
+                "remaining": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/testId"}
+                },
+                "summary": {"$ref": "#/definitions/resultSummary"},
+                "coverage": {
+                    "oneOf": [
+                        {"type": "null"},
+                        {"$ref": "#/definitions/coverageMap"}
+                    ]
+                }
+            }
+        },
+        "done": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["summary", "peakMemoryBytes", "coverage", "leaks", "wantsRecycle"],
+            "properties": {
+                "summary": {"$ref": "#/definitions/resultSummary"},
+                "peakMemoryBytes": {"type": "integer", "minimum": 0},
+                "coverage": {
+                    "oneOf": [
+                        {"type": "null"},
+                        {"$ref": "#/definitions/coverageMap"}
+                    ]
+                },
+                "leaks": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/testId"}
+                },
+                "wantsRecycle": {
+                    "oneOf": [
+                        {"type": "null"},
+                        {"$ref": "#/definitions/recycleReason"}
+                    ]
+                }
+            }
+        },
+        "recycleReason": {
+            "enum": ["test-count", "memory", "crash"]
+        },
+        "coverageMap": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["files"],
+            "properties": {
+                "files": {
+                    "oneOf": [
+                        {
+                            "type": "object",
+                            "additionalProperties": {"$ref": "#/definitions/coverageLineSets"}
+                        },
+                        {"$ref": "#/definitions/emptyMap"}
+                    ]
+                }
+            }
+        },
+        "coverageLineSets": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "items": {
+                "type": "array",
+                "items": {"type": "integer", "minimum": 1}
+            }
+        },
+        "fatal": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["detail"],
+            "properties": {
+                "detail": {"$ref": "#/definitions/throwableDetail"}
+            }
+        },
+        "eventEnvelope": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["event", "data"],
+            "properties": {
+                "event": {"type": "string", "minLength": 1},
+                "data": {"type": "object"}
+            },
+            "oneOf": [
+                {
+                    "properties": {
+                        "event": {"enum": ["run-started"]},
+                        "data": {"$ref": "#/definitions/runStarted"}
+                    }
+                },
+                {
+                    "properties": {
+                        "event": {"enum": ["run-finished"]},
+                        "data": {"$ref": "#/definitions/runFinished"}
+                    }
+                },
+                {
+                    "properties": {
+                        "event": {"enum": ["suite-started"]},
+                        "data": {"$ref": "#/definitions/suiteEvent"}
+                    }
+                },
+                {
+                    "properties": {
+                        "event": {"enum": ["suite-finished"]},
+                        "data": {"$ref": "#/definitions/suiteEvent"}
+                    }
+                },
+                {
+                    "properties": {
+                        "event": {"enum": ["class-started"]},
+                        "data": {"$ref": "#/definitions/testClassStarted"}
+                    }
+                },
+                {
+                    "properties": {
+                        "event": {"enum": ["class-finished"]},
+                        "data": {"$ref": "#/definitions/testClassFinished"}
+                    }
+                },
+                {
+                    "properties": {
+                        "event": {"enum": ["test-started"]},
+                        "data": {"$ref": "#/definitions/testStarted"}
+                    }
+                },
+                {
+                    "properties": {
+                        "event": {"enum": ["test-finished"]},
+                        "data": {"$ref": "#/definitions/testFinished"}
+                    }
+                },
+                {
+                    "properties": {
+                        "event": {"enum": ["worker-spawned"]},
+                        "data": {"$ref": "#/definitions/workerSpawned"}
+                    }
+                },
+                {
+                    "properties": {
+                        "event": {"enum": ["worker-recycled"]},
+                        "data": {"$ref": "#/definitions/workerRecycled"}
+                    }
+                }
+            ]
+        },
+        "runStarted": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["runId", "plannedTests", "workers", "occurredAt"],
+            "properties": {
+                "runId": {"type": "string", "minLength": 1},
+                "plannedTests": {"type": "integer", "minimum": 0},
+                "workers": {"type": "integer", "minimum": 1},
+                "occurredAt": {"type": "number"},
+                "artifactsDirectory": {"type": ["string", "null"]}
+            }
+        },
+        "runFinished": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["runId", "summary", "durationSeconds", "occurredAt"],
+            "properties": {
+                "runId": {"type": "string", "minLength": 1},
+                "summary": {"$ref": "#/definitions/resultSummary"},
+                "durationSeconds": {"type": "number", "minimum": 0},
+                "occurredAt": {"type": "number"}
+            }
+        },
+        "suiteEvent": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["suite", "occurredAt"],
+            "properties": {
+                "suite": {"type": "string", "minLength": 1},
+                "occurredAt": {"type": "number"}
+            }
+        },
+        "testClassStarted": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["class", "occurredAt"],
+            "properties": {
+                "class": {"type": "string", "minLength": 1},
+                "occurredAt": {"type": "number"},
+                "workerId": {"type": "string"},
+                "isolated": {"type": "boolean"}
+            }
+        },
+        "testClassFinished": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["class", "occurredAt"],
+            "properties": {
+                "class": {"type": "string", "minLength": 1},
+                "occurredAt": {"type": "number"},
+                "workerId": {"type": "string"}
+            }
+        },
+        "testStarted": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["id", "occurredAt"],
+            "properties": {
+                "id": {"$ref": "#/definitions/testId"},
+                "occurredAt": {"type": "number"}
+            }
+        },
+        "testFinished": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["result", "occurredAt"],
+            "properties": {
+                "result": {"$ref": "#/definitions/testResult"},
+                "occurredAt": {"type": "number"}
+            }
+        },
+        "workerSpawned": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["workerId", "pid", "occurredAt"],
+            "properties": {
+                "workerId": {"type": "string", "minLength": 1},
+                "pid": {"type": "integer", "minimum": 1},
+                "occurredAt": {"type": "number"}
+            }
+        },
+        "workerRecycled": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["workerId", "reason", "occurredAt"],
+            "properties": {
+                "workerId": {"type": "string", "minLength": 1},
+                "reason": {"$ref": "#/definitions/recycleReason"},
+                "occurredAt": {"type": "number"}
+            }
+        },
+        "testId": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["class", "method", "dataSetKey"],
+            "properties": {
+                "class": {"type": "string", "minLength": 1},
+                "method": {"type": "string", "minLength": 1},
+                "dataSetKey": {"type": ["string", "null"]}
+            }
+        },
+        "resultSummary": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["passed", "failed", "errored", "skipped"],
+            "properties": {
+                "passed": {"type": "integer", "minimum": 0},
+                "failed": {"type": "integer", "minimum": 0},
+                "errored": {"type": "integer", "minimum": 0},
+                "skipped": {"type": "integer", "minimum": 0}
+            }
+        },
+        "testResult": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "id",
+                "outcome",
+                "durationSeconds",
+                "memoryDeltaBytes",
+                "attempts",
+                "failures",
+                "error",
+                "skipReason",
+                "transformations",
+                "output"
+            ],
+            "properties": {
+                "id": {"$ref": "#/definitions/testId"},
+                "outcome": {"$ref": "#/definitions/outcome"},
+                "durationSeconds": {"type": "number", "minimum": 0},
+                "memoryDeltaBytes": {"type": "integer"},
+                "attempts": {"type": "integer", "minimum": 1},
+                "failures": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/failureDetail"}
+                },
+                "error": {
+                    "oneOf": [
+                        {"type": "null"},
+                        {"$ref": "#/definitions/throwableDetail"}
+                    ]
+                },
+                "skipReason": {"type": ["string", "null"]},
+                "transformations": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/outcomeTransformation"}
+                },
+                "output": {
+                    "oneOf": [
+                        {"type": "null"},
+                        {"$ref": "#/definitions/capturedOutput"}
+                    ]
+                },
+                "risky": {"type": "boolean"},
+                "expectations": {"type": "integer", "minimum": 0},
+                "attachments": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/attachment"}
+                }
+            }
+        },
+        "outcome": {
+            "enum": ["passed", "failed", "errored", "skipped"]
+        },
+        "failureDetail": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["message", "expected", "actual", "location"],
+            "properties": {
+                "message": {"type": "string", "minLength": 1},
+                "expected": {"type": ["string", "null"]},
+                "actual": {"type": ["string", "null"]},
+                "location": {
+                    "oneOf": [
+                        {"type": "null"},
+                        {"$ref": "#/definitions/sourceLocation"}
+                    ]
+                }
+            }
+        },
+        "sourceLocation": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["file", "line"],
+            "properties": {
+                "file": {"type": "string", "minLength": 1},
+                "line": {"type": "integer", "minimum": 1}
+            }
+        },
+        "throwableDetail": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["class", "message", "file", "line", "stackFrames"],
+            "properties": {
+                "class": {"type": "string", "minLength": 1},
+                "message": {"type": "string"},
+                "file": {"type": "string", "minLength": 1},
+                "line": {"type": "integer", "minimum": 1},
+                "stackFrames": {
+                    "type": "array",
+                    "items": {"type": "string"}
+                }
+            }
+        },
+        "outcomeTransformation": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["transformedBy", "from", "to"],
+            "properties": {
+                "transformedBy": {"type": "string", "minLength": 1},
+                "from": {"$ref": "#/definitions/outcome"},
+                "to": {"$ref": "#/definitions/outcome"}
+            }
+        },
+        "capturedOutput": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["stdout", "diagnostics", "stdoutTruncated", "diagnosticsTruncated"],
+            "properties": {
+                "stdout": {"type": "string"},
+                "diagnostics": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/diagnostic"}
+                },
+                "stdoutTruncated": {"type": "boolean"},
+                "diagnosticsTruncated": {"type": "boolean"}
+            }
+        },
+        "diagnostic": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["severity", "message", "file", "line"],
+            "properties": {
+                "severity": {"enum": ["notice", "warning", "deprecation"]},
+                "message": {"type": "string"},
+                "file": {"type": "string"},
+                "line": {"type": "integer", "minimum": 1}
+            }
+        },
+        "attachment": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["name", "kind", "mediaType", "sizeBytes", "sha256", "attempt", "path"],
+            "properties": {
+                "name": {"type": "string", "minLength": 1},
+                "kind": {"enum": ["value", "text", "binary", "file"]},
+                "mediaType": {"type": "string", "minLength": 1},
+                "sizeBytes": {"type": "integer", "minimum": 0},
+                "sha256": {"type": "string", "pattern": "^[0-9a-f]{64}$"},
+                "attempt": {"type": "integer", "minimum": 1},
+                "path": {"type": "string", "minLength": 1},
+                "retention": {"enum": ["on-failure", "always"]},
+                "storageKey": {"type": "string", "minLength": 1}
+            }
+        }
+    }
+}

--- a/src/Runner/Protocol/MessageRegistry.php
+++ b/src/Runner/Protocol/MessageRegistry.php
@@ -63,6 +63,14 @@ final class MessageRegistry
     }
 
     /**
+     * @return array<non-empty-string, class-string<Message>>
+     */
+    public static function all(): array
+    {
+        return self::TAGS;
+    }
+
+    /**
      * @param array<string, mixed> $envelope
      *
      * @throws ProtocolError

--- a/tests/Unit/Runner/Protocol/WorkerProtocolSchemaTest.php
+++ b/tests/Unit/Runner/Protocol/WorkerProtocolSchemaTest.php
@@ -1,0 +1,448 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Runner\Protocol;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Core\Artifact\AttachmentKind;
+use Greenlight\Core\Artifact\AttachmentRetention;
+use Greenlight\Core\Artifact\StagedAttachment;
+use Greenlight\Core\Event\EventTags;
+use Greenlight\Core\Event\RecycleReason;
+use Greenlight\Core\Event\TestFinished;
+use Greenlight\Core\Result\CapturedOutput;
+use Greenlight\Core\Result\Diagnostic;
+use Greenlight\Core\Result\DiagnosticSeverity;
+use Greenlight\Core\Result\FailureDetail;
+use Greenlight\Core\Result\Outcome;
+use Greenlight\Core\Result\OutcomeTransformation;
+use Greenlight\Core\Result\ResultPolicy;
+use Greenlight\Core\Result\ResultSummary;
+use Greenlight\Core\Result\SourceLocation;
+use Greenlight\Core\Result\TestResult;
+use Greenlight\Core\Result\ThrowableDetail;
+use Greenlight\Core\Test\TestId;
+use Greenlight\Core\Test\TestMetadata;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Coverage\FileCoverage;
+use Greenlight\Discovery\ExecutionPlan;
+use Greenlight\Discovery\PlanEntry;
+use Greenlight\Expect\Expect;
+use Greenlight\Harness\FixtureResource;
+use Greenlight\Harness\IntegrationResources;
+use Greenlight\Runner\Artifact\ArtifactSession;
+use Greenlight\Runner\Protocol\JsonFrameCodec;
+use Greenlight\Runner\Protocol\Message;
+use Greenlight\Runner\Protocol\MessageRegistry;
+use Greenlight\Runner\Protocol\Messages\Assign;
+use Greenlight\Runner\Protocol\Messages\AttemptStarted;
+use Greenlight\Runner\Protocol\Messages\Bootstrap;
+use Greenlight\Runner\Protocol\Messages\Done;
+use Greenlight\Runner\Protocol\Messages\Drain;
+use Greenlight\Runner\Protocol\Messages\EventEnvelope;
+use Greenlight\Runner\Protocol\Messages\Fatal;
+use Greenlight\Runner\Protocol\Messages\Hello;
+use Greenlight\Runner\Protocol\Messages\Ready;
+use Greenlight\Runner\Protocol\Messages\Recycling;
+use Greenlight\Tests\Unit\Reporting\CannedStream;
+use JsonSchema\Validator;
+
+final class WorkerProtocolSchemaTest
+{
+    #[Test]
+    public function everyRegisteredMessageValidatesAgainstTheSchema(): void
+    {
+        $messages = $this->messages();
+        $classes = \array_map(static fn(Message $message): string => $message::class, $messages);
+
+        Expect::that($classes)
+            ->because('each registered message MUST have a schema test value')
+            ->toBe(MessageRegistry::all());
+        Expect::that($this->messageSchemaTags())
+            ->because('each registered message MUST have an explicit schema')
+            ->toBe(\array_keys(MessageRegistry::all()));
+
+        foreach ($messages as $tag => $message) {
+            Expect::that($this->validationErrors($this->encodedEnvelope($message)))
+                ->because(\sprintf('the "%s" message validates against the worker protocol schema', $tag))
+                ->toBe([]);
+        }
+    }
+
+    #[Test]
+    public function everyRegisteredEventPayloadValidatesAgainstTheSchema(): void
+    {
+        $events = [];
+
+        foreach (CannedStream::events() as $event) {
+            $tag = EventTags::tagFor($event);
+
+            if ($tag !== null) {
+                $events[$tag] = $event;
+            }
+        }
+
+        Expect::that(\array_keys($events))
+            ->because('each registered event MUST have a schema test value')
+            ->toEqualCanonicalizing(\array_keys(EventTags::all()));
+        Expect::that($this->eventSchemaTags())
+            ->because('each registered event MUST have an explicit worker protocol schema')
+            ->toBe(\array_keys(EventTags::all()));
+
+        foreach ($events as $tag => $event) {
+            Expect::that($this->validationErrors($this->encodedEnvelope(new EventEnvelope($event))))
+                ->because(\sprintf('the "%s" event payload validates against the worker protocol schema', $tag))
+                ->toBe([]);
+        }
+    }
+
+    #[Test]
+    public function compatiblePayloadsWithoutNewOptionalFieldsValidateAgainstTheSchema(): void
+    {
+        $assignPayload = $this->withoutPaths($this->messages()['assign']->toWire(), [
+            ['artifactSession'],
+            ['artifactConfiguration'],
+            ['stopAfterFailures'],
+            ['slice', 'entries', 0, 'metadata', 'skipUnlessArguments'],
+            ['slice', 'entries', 0, 'metadata', 'dataSetProviderClass'],
+            ['slice', 'entries', 0, 'metadata', 'noExpectations'],
+            ['slice', 'entries', 0, 'metadata', 'resources'],
+            ['slice', 'entries', 0, 'metadata', 'allowParallel'],
+        ]);
+        $eventPayload = $this->withoutPaths($this->messages()['event']->toWire(), [
+            ['data', 'result', 'risky'],
+            ['data', 'result', 'expectations'],
+            ['data', 'result', 'attachments'],
+        ]);
+
+        Expect::that($this->validationErrors($this->asJsonObject(['v' => 2, 't' => 'assign', 'p' => $assignPayload])))
+            ->because('the schema MUST accept compatible assignment payloads')
+            ->toBe([]);
+        Expect::that($this->validationErrors($this->asJsonObject(['v' => 2, 't' => 'event', 'p' => $eventPayload])))
+            ->because('the schema MUST accept compatible test result payloads')
+            ->toBe([]);
+    }
+
+    #[Test]
+    public function anUnspecifiedMessageFieldIsRejected(): void
+    {
+        $payload = $this->messages()['assign']->toWire();
+        $payload['futureProtocolField'] = true;
+
+        Expect::that($this->validationErrors($this->asJsonObject(['v' => 2, 't' => 'assign', 'p' => $payload])))
+            ->because('a protocol change MUST update the schema')
+            ->not()
+            ->toBe([]);
+    }
+
+    /**
+     * @return array<non-empty-string, Message>
+     */
+    private function messages(): array
+    {
+        $id = new TestId('App\ExampleTest', 'checksValue', 'example');
+        $entry = new PlanEntry(
+            $id,
+            new TestMetadata(
+                'App\ExampleTest',
+                'checksValue',
+                ['unit'],
+                skipUnlessCondition: 'App\Conditions::available',
+                retryTimes: 2,
+                retryOnlyOn: \RuntimeException::class,
+                timeoutSeconds: 1.5,
+                isolated: true,
+                dataSetProvider: 'examples',
+                capture: true,
+                noExpectations: false,
+                skipUnlessArguments: ['primary', 1, 2.5, true, null],
+                resources: ['database.primary'],
+                dataSetProviderClass: 'App\Examples',
+                allowParallel: true,
+            ),
+        );
+        $coverage = new CoverageMap([
+            new FileCoverage('/project/src/Example.php', [2, 3], [5]),
+        ]);
+        $detail = new ThrowableDetail(
+            \RuntimeException::class,
+            'Example error.',
+            '/project/tests/ExampleTest.php',
+            12,
+            ['App\ExampleTest::checksValue at /project/tests/ExampleTest.php:12'],
+        );
+        $result = new TestResult(
+            $id,
+            Outcome::Failed,
+            0.125,
+            -128,
+            2,
+            [new FailureDetail(
+                'The values are not equal.',
+                '1',
+                '2',
+                new SourceLocation('/project/tests/ExampleTest.php', 12),
+            )],
+            $detail,
+            null,
+            [new OutcomeTransformation('example policy', Outcome::Passed, Outcome::Failed)],
+            new CapturedOutput(
+                "example output\n",
+                [new Diagnostic(DiagnosticSeverity::Warning, 'Example warning.', '/project/tests/ExampleTest.php', 12)],
+                stdoutTruncated: true,
+            ),
+            risky: true,
+            expectations: 3,
+            attachments: [new StagedAttachment(
+                'response',
+                AttachmentKind::Text,
+                'text/plain',
+                7,
+                \str_repeat('a', 64),
+                2,
+                'response.txt',
+                AttachmentRetention::Always,
+                'worker-1/response',
+            )],
+        );
+
+        return [
+            'hello' => new Hello('worker-1', 'run-token', 4242),
+            'bootstrap' => new Bootstrap(
+                2,
+                '/project/greenlight.php',
+                new IntegrationResources([
+                    'postgres' => FixtureResource::from(
+                        [
+                            'database' => 'greenlight',
+                            'port' => 5432,
+                            'tls' => true,
+                            'replicas' => ['primary', 'secondary'],
+                            'options' => ['timeout' => 2.5],
+                        ],
+                        ['password' => 'test-secret'],
+                    ),
+                ]),
+            ),
+            'ready' => new Ready(),
+            'assign' => new Assign(
+                new ExecutionPlan([$entry], 17),
+                10,
+                256 * 1024 * 1024,
+                ['/project/src'],
+                'pcov',
+                true,
+                new ResultPolicy(true, true, ['known deprecation*'], true),
+                new ArtifactSession('/tmp/greenlight-staging', 'build/greenlight-artifacts/run-1'),
+                new ArtifactConfiguration(maxRunAttachments: 100),
+                stopAfterFailures: 3,
+            ),
+            'drain' => new Drain(),
+            'event' => new EventEnvelope(new TestFinished($result, 1_780_000_000.5)),
+            'attempt-started' => new AttemptStarted($id, 2),
+            'recycling' => new Recycling(
+                RecycleReason::Memory,
+                [$id],
+                new ResultSummary(passed: 2),
+                $coverage,
+            ),
+            'done' => new Done(
+                new ResultSummary(passed: 2, failed: 1),
+                123_456,
+                $coverage,
+                [$id],
+                RecycleReason::TestCount,
+            ),
+            'fatal' => new Fatal($detail),
+        ];
+    }
+
+    private function encodedEnvelope(Message $message): object
+    {
+        $frame = new JsonFrameCodec()->encode(MessageRegistry::envelope($message));
+        $envelope = \json_decode(\substr($frame, 4), flags: \JSON_THROW_ON_ERROR);
+
+        if (!\is_object($envelope)) {
+            throw new \LogicException('A worker protocol envelope MUST be a JSON object.');
+        }
+
+        return $envelope;
+    }
+
+    /**
+     * @param array<string, mixed> $envelope
+     */
+    private function asJsonObject(array $envelope): object
+    {
+        $decoded = \json_decode(\json_encode($envelope, \JSON_THROW_ON_ERROR), flags: \JSON_THROW_ON_ERROR);
+
+        if (!\is_object($decoded)) {
+            throw new \LogicException('A worker protocol envelope MUST be a JSON object.');
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function validationErrors(object $envelope): array
+    {
+        $validator = new Validator();
+        $validator->validate($envelope, $this->schema());
+        $errors = [];
+
+        foreach ($validator->getErrors() as $error) {
+            if (!\is_array($error)) {
+                continue;
+            }
+
+            $property = $error['property'] ?? null;
+            $message = $error['message'] ?? null;
+
+            $errors[] = \sprintf(
+                '[%s] %s',
+                \is_string($property) ? $property : '',
+                \is_string($message) ? $message : '',
+            );
+        }
+
+        return $errors;
+    }
+
+    private function schema(): object
+    {
+        return (object) ['$ref' => 'file://' . $this->schemaPath()];
+    }
+
+    /**
+     * @return list<non-empty-string>
+     */
+    private function messageSchemaTags(): array
+    {
+        $schema = $this->schemaDocument();
+
+        return $this->tagsFromVariants($schema['oneOf']);
+    }
+
+    /**
+     * @return list<non-empty-string>
+     */
+    private function eventSchemaTags(): array
+    {
+        $schema = $this->schemaDocument();
+        $definitions = $schema['definitions'] ?? null;
+
+        if (!\is_array($definitions)) {
+            throw new \LogicException('The worker protocol schema MUST contain definitions.');
+        }
+
+        $eventEnvelope = $definitions['eventEnvelope'] ?? null;
+
+        if (!\is_array($eventEnvelope)) {
+            throw new \LogicException('The worker protocol schema MUST define the event envelope.');
+        }
+
+        return $this->tagsFromVariants($eventEnvelope['oneOf'] ?? null, 'event');
+    }
+
+    /**
+     * @return list<non-empty-string>
+     */
+    private function tagsFromVariants(mixed $variants, string $property = 't'): array
+    {
+        if (!\is_array($variants) || !\array_is_list($variants)) {
+            throw new \LogicException('Protocol schema variants MUST be a list.');
+        }
+
+        $tags = [];
+
+        foreach ($variants as $variant) {
+            if (!\is_array($variant)) {
+                throw new \LogicException('Each protocol schema variant MUST be an object.');
+            }
+
+            $properties = $variant['properties'] ?? null;
+            $tagSchema = \is_array($properties) ? ($properties[$property] ?? null) : null;
+            $values = \is_array($tagSchema) ? ($tagSchema['enum'] ?? null) : null;
+            $tag = \is_array($values) ? ($values[0] ?? null) : null;
+
+            if (!\is_string($tag) || $tag === '') {
+                throw new \LogicException('Protocol schema tags MUST be nonempty strings.');
+            }
+
+            $tags[] = $tag;
+        }
+
+        return $tags;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function schemaDocument(): array
+    {
+        $contents = \file_get_contents($this->schemaPath());
+
+        if ($contents === false) {
+            throw new \LogicException('Greenlight cannot read the worker protocol schema.');
+        }
+
+        $schema = \json_decode($contents, true, flags: \JSON_THROW_ON_ERROR);
+
+        if (!\is_array($schema) || \array_is_list($schema)) {
+            throw new \LogicException('The worker protocol schema MUST be a JSON object.');
+        }
+
+        return $schema;
+    }
+
+    private function schemaPath(): string
+    {
+        return \dirname(__DIR__, 4) . '/resources/schema/worker-protocol-v2.schema.json';
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @param list<non-empty-list<array-key>> $paths
+     *
+     * @return array<string, mixed>
+     */
+    private function withoutPaths(array $payload, array $paths): array
+    {
+        foreach ($paths as $path) {
+            $payload = $this->withoutPath($payload, $path);
+        }
+
+        return $payload;
+    }
+
+    /**
+     * @template TKey of array-key
+     *
+     * @param array<TKey, mixed> $payload
+     * @param non-empty-list<array-key> $path
+     *
+     * @return array<TKey, mixed>
+     */
+    private function withoutPath(array $payload, array $path): array
+    {
+        $key = \array_shift($path);
+
+        if ($path === []) {
+            unset($payload[$key]);
+
+            return $payload;
+        }
+
+        $child = $payload[$key] ?? null;
+
+        if (\is_array($child)) {
+            $payload[$key] = $this->withoutPath($child, $path);
+        }
+
+        return $payload;
+    }
+}


### PR DESCRIPTION
## Summary

- add a versioned JSON Schema for protocol version 2 envelopes, message payloads, and registered event payloads
- require explicit schema and representative test coverage for every registered message and event
- retain optional legacy wire fields while rejecting unspecified protocol additions
- document the schema from the worker protocol architecture guide