### PR TITLE
fix(reporting): clean up skipped reason headings

### DIFF
--- a/src/Runner/Worker/TestExecutor.php
+++ b/src/Runner/Worker/TestExecutor.php
@@ -97,7 +97,7 @@ final readonly class TestExecutor
 
             if (!$satisfied) {
                 return $this->skipped($entry, \sprintf(
-                    'Condition %s is not satisfied.',
+                    'Condition %s is not satisfied',
                     $this->describeCondition($metadata->skipUnlessCondition, $metadata->skipUnlessArguments),
                 ));
             }

--- a/tests/Unit/Runner/ConditionEvaluationTest.php
+++ b/tests/Unit/Runner/ConditionEvaluationTest.php
@@ -47,7 +47,7 @@ final readonly class ConditionEvaluationTest
         Expect::that($summary->passed)->toBe(1);
         Expect::that($byMethod['skipsWhenTheVariableDiffers']->outcome)->toBe(Outcome::Skipped);
         Expect::that($byMethod['skipsWhenTheVariableDiffers']->skipReason)
-            ->toBe('Condition EnvironmentVariableEquals("GREENLIGHT_STDLIB_NOPE", "yes") is not satisfied.');
+            ->toBe('Condition EnvironmentVariableEquals("GREENLIGHT_STDLIB_NOPE", "yes") is not satisfied');
         Expect::that($byMethod['runsWhenTheVersionIsSatisfied']->outcome)->toBe(Outcome::Passed);
     }
 


### PR DESCRIPTION
Remove the terminal period from condition-generated skip reasons. Grouped summaries now add only their heading colon.

Update the existing condition evaluation test for the exact reason.