### PR TITLE
fix(protocol): add worker timing schema

### DIFF
--- a/resources/schema/worker-protocol-v2.schema.json
+++ b/resources/schema/worker-protocol-v2.schema.json
@@ -501,7 +501,11 @@
                 "runId": {"type": "string", "minLength": 1},
                 "summary": {"$ref": "#/definitions/resultSummary"},
                 "durationSeconds": {"type": "number", "minimum": 0},
-                "occurredAt": {"type": "number"}
+                "occurredAt": {"type": "number"},
+                "workerTimings": {
+                    "type": "array",
+                    "items": {"$ref": "#/definitions/workerTiming"}
+                }
             }
         },
         "suiteEvent": {
@@ -570,6 +574,34 @@
                 "workerId": {"type": "string", "minLength": 1},
                 "reason": {"$ref": "#/definitions/recycleReason"},
                 "occurredAt": {"type": "number"}
+            }
+        },
+        "workerTiming": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+                "workerId",
+                "spawnToHelloSeconds",
+                "helloToReadySeconds",
+                "readyToFirstAssignmentSeconds",
+                "assignmentGaps",
+                "assignmentGapSeconds",
+                "bootstrapBarrierSeconds",
+                "resourceCapacitySeconds",
+                "noQueuedWorkSeconds",
+                "retirementToExitSeconds"
+            ],
+            "properties": {
+                "workerId": {"type": "string", "minLength": 1},
+                "spawnToHelloSeconds": {"type": ["number", "null"], "minimum": 0},
+                "helloToReadySeconds": {"type": ["number", "null"], "minimum": 0},
+                "readyToFirstAssignmentSeconds": {"type": ["number", "null"], "minimum": 0},
+                "assignmentGaps": {"type": "integer", "minimum": 0},
+                "assignmentGapSeconds": {"type": "number", "minimum": 0},
+                "bootstrapBarrierSeconds": {"type": "number", "minimum": 0},
+                "resourceCapacitySeconds": {"type": "number", "minimum": 0},
+                "noQueuedWorkSeconds": {"type": "number", "minimum": 0},
+                "retirementToExitSeconds": {"type": ["number", "null"], "minimum": 0}
             }
         },
         "testId": {


### PR DESCRIPTION
Add the optional worker timing payload to the internal worker-protocol schema. This keeps the closed schema aligned with RunFinished and restores the main CI matrix after #1522 and #1523 merged in the opposite order.