### PR TITLE
perf(tests): parallelize analysis acceptance tests

### DIFF
--- a/tests/Acceptance/PhpStanCheckedExceptionTest.php
+++ b/tests/Acceptance/PhpStanCheckedExceptionTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Acceptance;
 
+use Greenlight\Attribute\AllowParallel;
 use Greenlight\Attribute\RequiresResource;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\PhpStanProbe;
 
+#[AllowParallel]
 #[RequiresResource('analysis-process')]
 final readonly class PhpStanCheckedExceptionTest
 {

--- a/tests/Acceptance/PhpStanExpectationArgumentRuleTest.php
+++ b/tests/Acceptance/PhpStanExpectationArgumentRuleTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Acceptance;
 
+use Greenlight\Attribute\AllowParallel;
 use Greenlight\Attribute\RequiresResource;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\PhpStanProbe;
 
+#[AllowParallel]
 #[RequiresResource('analysis-process')]
 final readonly class PhpStanExpectationArgumentRuleTest
 {

--- a/tests/Acceptance/PhpStanMatcherSignatureTest.php
+++ b/tests/Acceptance/PhpStanMatcherSignatureTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Acceptance;
 
+use Greenlight\Attribute\AllowParallel;
 use Greenlight\Attribute\RequiresResource;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\PhpStanProbe;
 
+#[AllowParallel]
 #[RequiresResource('analysis-process')]
 final readonly class PhpStanMatcherSignatureTest
 {

--- a/tests/Acceptance/PhpStanMatcherSubjectTest.php
+++ b/tests/Acceptance/PhpStanMatcherSubjectTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Acceptance;
 
+use Greenlight\Attribute\AllowParallel;
 use Greenlight\Attribute\RequiresResource;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\PhpStanProbe;
 
+#[AllowParallel]
 #[RequiresResource('analysis-process')]
 final readonly class PhpStanMatcherSubjectTest
 {

--- a/tests/Acceptance/PhpStanTestConstructorRuleTest.php
+++ b/tests/Acceptance/PhpStanTestConstructorRuleTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Acceptance;
 
+use Greenlight\Attribute\AllowParallel;
 use Greenlight\Attribute\RequiresResource;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\PhpStanProbe;
 
+#[AllowParallel]
 #[RequiresResource('analysis-process')]
 final readonly class PhpStanTestConstructorRuleTest
 {

--- a/tests/Acceptance/PhpStanToThrowRuleTest.php
+++ b/tests/Acceptance/PhpStanToThrowRuleTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Acceptance;
 
+use Greenlight\Attribute\AllowParallel;
 use Greenlight\Attribute\RequiresResource;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\PhpStanProbe;
 
+#[AllowParallel]
 #[RequiresResource('analysis-process')]
 final readonly class PhpStanToThrowRuleTest
 {

--- a/tests/Acceptance/RectorMigrationRunTest.php
+++ b/tests/Acceptance/RectorMigrationRunTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Acceptance;
 
+use Greenlight\Attribute\AllowParallel;
 use Greenlight\Attribute\RequiresResource;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
@@ -11,6 +12,7 @@ use Greenlight\Rector\PhpUnitToGreenlightRector;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\RectorProbe;
 
+#[AllowParallel]
 #[RequiresResource('analysis-process')]
 final readonly class RectorMigrationRunTest
 {

--- a/tests/Acceptance/RectorSizeAttributeTest.php
+++ b/tests/Acceptance/RectorSizeAttributeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Acceptance;
 
+use Greenlight\Attribute\AllowParallel;
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\RequiresResource;
 use Greenlight\Attribute\Test;
@@ -11,6 +12,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\RectorProbe;
 
+#[AllowParallel]
 #[RequiresResource('analysis-process')]
 final readonly class RectorSizeAttributeTest
 {

--- a/tests/Acceptance/RectorUnsupportedAssertionTest.php
+++ b/tests/Acceptance/RectorUnsupportedAssertionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Acceptance;
 
+use Greenlight\Attribute\AllowParallel;
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\RequiresResource;
 use Greenlight\Attribute\Test;
@@ -11,6 +12,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\RectorProbe;
 
+#[AllowParallel]
 #[RequiresResource('analysis-process')]
 final readonly class RectorUnsupportedAssertionTest
 {

--- a/tests/Acceptance/RectorUnsupportedClassShapeTest.php
+++ b/tests/Acceptance/RectorUnsupportedClassShapeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Acceptance;
 
+use Greenlight\Attribute\AllowParallel;
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\RequiresResource;
 use Greenlight\Attribute\Test;
@@ -11,6 +12,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\RectorProbe;
 
+#[AllowParallel]
 #[RequiresResource('analysis-process')]
 final readonly class RectorUnsupportedClassShapeTest
 {

--- a/tests/Acceptance/RectorUnsupportedFrameworkApiTest.php
+++ b/tests/Acceptance/RectorUnsupportedFrameworkApiTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Acceptance;
 
+use Greenlight\Attribute\AllowParallel;
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\RequiresResource;
 use Greenlight\Attribute\Test;
@@ -11,6 +12,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\RectorProbe;
 
+#[AllowParallel]
 #[RequiresResource('analysis-process')]
 final readonly class RectorUnsupportedFrameworkApiTest
 {

--- a/tests/Acceptance/RectorUnsupportedProcessControlTest.php
+++ b/tests/Acceptance/RectorUnsupportedProcessControlTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Acceptance;
 
+use Greenlight\Attribute\AllowParallel;
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\RequiresResource;
 use Greenlight\Attribute\Test;
@@ -11,6 +12,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\RectorProbe;
 
+#[AllowParallel]
 #[RequiresResource('analysis-process')]
 final readonly class RectorUnsupportedProcessControlTest
 {


### PR DESCRIPTION
## Summary

- split independent PHPStan and Rector acceptance tests across workers
- preserve the analysis-process resource limit for bounded concurrency
- reduce long-class tail latency without changing test logic