### PR TITLE
feat(config): add configurable storage directories

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,13 +316,10 @@ jobs:
         env:
           SYMFONY_REQUIRE: "${{ matrix.symfony-version }}"
 
-      - name: "Prepare Greenlight run-state directory"
-        run: 'mkdir -p "${RUNNER_TEMP}/greenlight-state"'
-
       - name: "Restore Greenlight run state"
         uses: "actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9" # v6.1.0
         with:
-          path: "${{ runner.temp }}/greenlight-state/greenlight-state-*.json"
+          path: "build/greenlight-state/run-state.json"
           key: "greenlight-run-state-v1-${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependencies }}-symfony-${{ matrix.symfony-version || 'default' }}-${{ github.run_id }}-${{ github.run_attempt }}"
           restore-keys: "greenlight-run-state-v1-${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependencies }}-symfony-${{ matrix.symfony-version || 'default' }}-"
 
@@ -331,8 +328,6 @@ jobs:
       - name: "Tests"
         id: "tests_lowest"
         if: "matrix.dependencies == 'lowest'"
-        env:
-          TMPDIR: "${{ runner.temp }}/greenlight-state"
         run: "composer tests -- --ansi"
 
       # The lowest compatible PHPStan version reports false errors for types
@@ -391,16 +386,12 @@ jobs:
       - name: "Tests"
         id: "tests_standard"
         if: "matrix.analytics != true && matrix.dependencies != 'lowest'"
-        env:
-          TMPDIR: "${{ runner.temp }}/greenlight-state"
         run: "composer tests -- --ansi"
 
       - name: "Tests with JUnit output"
         id: "tests_analytics"
         if: "matrix.analytics == true"
         shell: "bash"
-        env:
-          TMPDIR: "${{ runner.temp }}/greenlight-state"
         run: |
           mkdir -p build/test-results
           php bin/greenlight run --reporter=junit > build/test-results/greenlight.junit.xml
@@ -409,7 +400,7 @@ jobs:
         if: "${{ !cancelled() && (steps.tests_lowest.outcome != 'skipped' || steps.tests_standard.outcome != 'skipped' || steps.tests_analytics.outcome != 'skipped') }}"
         uses: "actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9" # v6.1.0
         with:
-          path: "${{ runner.temp }}/greenlight-state/greenlight-state-*.json"
+          path: "build/greenlight-state/run-state.json"
           key: "greenlight-run-state-v1-${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependencies }}-symfony-${{ matrix.symfony-version || 'default' }}-${{ github.run_id }}-${{ github.run_attempt }}"
 
       - name: "Upload test results to Codecov"

--- a/docs/api-configuration.md
+++ b/docs/api-configuration.md
@@ -156,7 +156,7 @@ final class GreenlightConfig
 public static function create(): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L78)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L80)
 
 ### `paths()`
 
@@ -172,7 +172,7 @@ PHPDoc:
 - `@param list<string> $tests`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L91)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L93)
 
 ### `suite()`
 
@@ -191,7 +191,7 @@ PHPDoc:
 - `@param callable(SuiteBuilder): mixed $configurator`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L147)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L149)
 
 ### `workers()`
 
@@ -213,7 +213,7 @@ PHPDoc:
 - `@param int|null $recycleAfterTests A null value disables test-count worker replacement.`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L175)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L177)
 
 ### `resourceLimit()`
 
@@ -230,7 +230,7 @@ PHPDoc:
 
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L203)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L205)
 
 ### `coverage()`
 
@@ -242,7 +242,7 @@ PHPDoc:
 
 - `@param callable(CoverageBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L231)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L233)
 
 ### `watch()`
 
@@ -254,7 +254,7 @@ PHPDoc:
 
 - `@param callable(WatchBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L243)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L245)
 
 ### `artifacts()`
 
@@ -266,7 +266,22 @@ PHPDoc:
 
 - `@param callable(ArtifactBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L255)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L257)
+
+### `storage()`
+
+Sets directories for persistent state, caches, generated code, and
+temporary run data. Multiple calls use the same builder.
+
+```php
+public function storage(callable $configurator): self
+```
+
+PHPDoc:
+
+- `@param callable(StorageBuilder): mixed $configurator`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L272)
 
 ### `failOnDeprecation()`
 
@@ -282,7 +297,7 @@ PHPDoc:
 
 - `@see self::ignoreDeprecationsMatching()`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L271)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L288)
 
 ### `failOnNotice()`
 
@@ -290,7 +305,7 @@ PHPDoc:
 public function failOnNotice(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L278)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L295)
 
 ### `failOnRisky()`
 
@@ -302,7 +317,7 @@ expectations.
 public function failOnRisky(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L290)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L307)
 
 ### `ignoreDeprecationsMatching()`
 
@@ -318,7 +333,7 @@ PHPDoc:
 
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L303)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L320)
 
 ### `plugins()`
 
@@ -326,7 +341,7 @@ PHPDoc:
 public function plugins(Plugin ...$plugins): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L320)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L337)
 
 ### `failFast()`
 
@@ -334,7 +349,7 @@ public function plugins(Plugin ...$plugins): self
 public function failFast(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L329)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L346)
 
 ### `randomizeOrder()`
 
@@ -344,7 +359,7 @@ If the seed is null, Greenlight generates and prints a seed at run time.
 public function randomizeOrder(?int $seed = null): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L337)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L354)
 
 ### `build()`
 
@@ -356,7 +371,79 @@ PHPDoc:
 
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L369)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L386)
+
+## `StorageBuilder`
+
+Namespace: `Greenlight\Config`
+
+Collects directory configuration for Greenlight-owned storage.
+
+```php
+final class StorageBuilder
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/StorageBuilder.php#L8)
+
+### `rootDirectory()`
+
+```php
+public function rootDirectory(string $directory): self
+```
+
+PHPDoc:
+
+- `@throws InvalidConfiguration`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/StorageBuilder.php#L17)
+
+### `stateDirectory()`
+
+```php
+public function stateDirectory(string $directory): self
+```
+
+PHPDoc:
+
+- `@throws InvalidConfiguration`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/StorageBuilder.php#L25)
+
+### `cacheDirectory()`
+
+```php
+public function cacheDirectory(string $directory): self
+```
+
+PHPDoc:
+
+- `@throws InvalidConfiguration`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/StorageBuilder.php#L33)
+
+### `generatedCodeDirectory()`
+
+```php
+public function generatedCodeDirectory(string $directory): self
+```
+
+PHPDoc:
+
+- `@throws InvalidConfiguration`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/StorageBuilder.php#L41)
+
+### `temporaryDirectory()`
+
+```php
+public function temporaryDirectory(string $directory): self
+```
+
+PHPDoc:
+
+- `@throws InvalidConfiguration`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/StorageBuilder.php#L49)
 
 ## `SuiteBuilder`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -305,6 +305,54 @@ later. Greenlight releases run quota when it discards an attachment.
 
 See [test attachments](attachments.md) for the runtime API and security model.
 
+### `storage(callable $configurator): self`
+
+Default: all storage uses the system temporary directory.
+
+The configurator receives a `StorageBuilder`. Repeated calls use the same
+builder.
+
+Use `rootDirectory()` to put all Greenlight storage below one directory. An
+area-specific directory replaces its directory below the root.
+
+`StorageBuilder` has these methods:
+
+* `rootDirectory(string $directory): self` sets the common storage root.
+* `stateDirectory(string $directory): self` stores prior failures and the
+  timing cache.
+* `cacheDirectory(string $directory): self` stores discovery metadata.
+* `generatedCodeDirectory(string $directory): self` stores generated double
+  proxy PHP.
+* `temporaryDirectory(string $directory): self` stores run-owned temporary
+  data.
+
+Relative directories resolve against the initial project working directory.
+Greenlight creates missing directories when a storage product first writes
+data.
+
+Use separate areas when their retention or trust requirements differ:
+
+<!-- php-example {"example":"configuration-example-08","file":"snippet.php","mode":"statements","tools":["rector"]} -->
+```php
+->storage(fn ($storage) => $storage
+    ->stateDirectory('build/greenlight-state')
+    ->cacheDirectory('build/greenlight-cache')
+    ->generatedCodeDirectory('/var/tmp/greenlight-code')
+    ->temporaryDirectory('/var/tmp/greenlight'))
+```
+
+The state directory contains `run-state.json`. This file has the failed test
+IDs and class durations from the previous run.
+
+Do not share one state directory between concurrent shards. Each shard writes
+one complete snapshot and can replace data from another shard.
+
+Generated proxy files contain executable PHP. Use only a private, trusted
+directory. Do not restore this directory from an untrusted cache.
+
+Greenlight does not remove configured roots. It removes only temporary child
+directories that it creates and owns.
+
 ### `failFast(bool $enabled = true): self`
 
 Default: off.

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -1,7 +1,7 @@
 # GitHub Actions
 
-Greenlight stores run state in the system temporary directory. Run state
-contains failed test IDs and class durations from the previous run.
+Greenlight stores run state in the system temporary directory by default. Run
+state contains failed test IDs and class durations from the previous run.
 
 The next run uses this data to put failed classes first. It then puts the
 remaining classes in longest-first order. This order reduces idle worker time
@@ -9,8 +9,16 @@ near the end of a run.
 
 ## Cache run state
 
-Use a known temporary directory for the Greenlight test step. Restore the run
-state before the step and save it after the step.
+Configure a project state directory. Restore the state before the test step and
+save it after the step.
+
+For example, add this configuration to `greenlight.php`:
+
+<!-- php-example {"mode":"display","reason":"Shows one method in an existing Greenlight configuration chain."} -->
+```php
+->storage(fn ($storage) => $storage
+    ->stateDirectory('build/greenlight-state'))
+```
 
 This example keeps separate state for each operating system and PHP version:
 
@@ -24,27 +32,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Prepare Greenlight run-state directory
-        run: mkdir -p "${RUNNER_TEMP}/greenlight-state"
-
       - name: Restore Greenlight run state
         uses: actions/cache/restore@v6
         with:
-          path: ${{ runner.temp }}/greenlight-state/greenlight-state-*.json
+          path: build/greenlight-state/run-state.json
           key: greenlight-run-state-v1-${{ runner.os }}-php-${{ matrix.php }}-${{ github.run_id }}-${{ github.run_attempt }}
           restore-keys: greenlight-run-state-v1-${{ runner.os }}-php-${{ matrix.php }}-
 
       - name: Run tests
         id: tests
-        env:
-          TMPDIR: ${{ runner.temp }}/greenlight-state
         run: vendor/bin/greenlight run
 
       - name: Save Greenlight run state
         if: ${{ !cancelled() && steps.tests.outcome != 'skipped' }}
         uses: actions/cache/save@v6
         with:
-          path: ${{ runner.temp }}/greenlight-state/greenlight-state-*.json
+          path: build/greenlight-state/run-state.json
           key: greenlight-run-state-v1-${{ runner.os }}-php-${{ matrix.php }}-${{ github.run_id }}-${{ github.run_attempt }}
 ```
 
@@ -71,7 +74,8 @@ For cache matching and security rules, see the
 ## Other Greenlight caches
 
 Greenlight also stores discovery data and generated double proxies in the
-system temporary directory.
+system temporary directory by default. Configure these areas separately from
+run state.
 
 Do not cache discovery data across fresh GitHub Actions checkouts. Discovery
 entries include file modification times, which usually change at checkout.

--- a/greenlight.php
+++ b/greenlight.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use Greenlight\Config\GreenlightConfig;
+use Greenlight\Config\StorageBuilder;
 
 return GreenlightConfig::create()
     // tests/Fixture MUST NOT be part of this suite.
@@ -11,4 +12,6 @@ return GreenlightConfig::create()
     ->paths(['tests/Unit', 'tests/Acceptance'])
     ->workers(count: 'auto')
     ->resourceLimit('analysis-process', 5)
+    ->storage(static fn(StorageBuilder $storage) => $storage
+        ->stateDirectory('build/greenlight-state'))
     ->randomizeOrder();

--- a/resources/schema/worker-protocol-v2.schema.json
+++ b/resources/schema/worker-protocol-v2.schema.json
@@ -95,7 +95,9 @@
             "properties": {
                 "channel": {"type": "integer", "minimum": 1},
                 "configFile": {"type": ["string", "null"]},
-                "resources": {"$ref": "#/definitions/integrationResources"}
+                "resources": {"$ref": "#/definitions/integrationResources"},
+                "generatedCodeDirectory": {"type": ["string", "null"]},
+                "temporaryDirectory": {"type": ["string", "null"]}
             }
         },
         "integrationResources": {

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -15,6 +15,7 @@ use Greenlight\Config\ConfigLoader;
 use Greenlight\Config\Configuration;
 use Greenlight\Config\CoverageConfiguration;
 use Greenlight\Config\InvalidConfiguration;
+use Greenlight\Config\StorageLayout;
 use Greenlight\Config\SuiteConfiguration;
 use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Core\AtomicFile;
@@ -334,7 +335,7 @@ final readonly class Application
         }
 
         if ($arguments->has('dry-run')) {
-            ($this->out)(PlanFormatter::format($resolved, $configFile));
+            ($this->out)(PlanFormatter::format($resolved, $configFile, $workingDirectory));
 
             return self::EXIT_OK;
         }
@@ -375,7 +376,8 @@ final readonly class Application
             return $this->watchCommand($arguments, $workingDirectory, $workerBin, $resolved, $configFile, $shutdown);
         }
 
-        $state = RunState::forWorkingDirectory($workingDirectory);
+        $storage = StorageLayout::resolve($resolved->storage, $workingDirectory);
+        $state = RunState::forFile($storage->runStateFile);
         $previousFailures = $state->failedTests();
 
         if ($arguments->has('failed')) {
@@ -517,6 +519,7 @@ final readonly class Application
         $coverageSession = CoverageSession::open(
             $coverageSettings,
             $workers !== 1 && $workerBin !== false && !SubprocessCoverage::requested(),
+            StorageLayout::resolve($resolved->storage, $workingDirectory)->temporaryDirectory,
         );
 
         try {
@@ -692,10 +695,11 @@ final readonly class Application
         $workers = $resolved->workers->fixed ?? CpuCores::count();
         $coverageSettings = CoverageSettingsResolver::resolve($resolved->coverage, $workingDirectory);
         $detectLeaks = $arguments->has('detect-leaks');
+        $storage = StorageLayout::resolve($resolved->storage, $workingDirectory);
         $this->warnWhenLeakDetectionIsUnreliable($detectLeaks, $arguments->has('no-ansi'));
 
         $runOnce =
-            function (array $priorityClasses) use ($arguments, $resolved, $directories, $workers, $workerBin, $workingDirectory, $coverageSettings, $configFile, $detectLeaks, $shutdown): array {
+            function (array $priorityClasses) use ($arguments, $resolved, $directories, $workers, $workerBin, $workingDirectory, $coverageSettings, $configFile, $detectLeaks, $shutdown, $storage): array {
                 $priorityClasses = \array_values(\array_filter(
                     $priorityClasses,
                     static fn(mixed $class): bool => \is_string($class) && $class !== '',
@@ -711,7 +715,8 @@ final readonly class Application
 
                 $tap = new ClassFailureTap($failedTap = new FailedTestsTap(new ReporterSink($reporter)));
 
-                $classSeconds = $resolved->randomizeOrder ? [] : RunState::forWorkingDirectory($workingDirectory)->classSeconds();
+                $state = RunState::forFile($storage->runStateFile);
+                $classSeconds = $resolved->randomizeOrder ? [] : $state->classSeconds();
 
                 try {
                     if ($workers === 1 || $workerBin === false) {
@@ -729,7 +734,7 @@ final readonly class Application
                 }
 
                 $reporter->finish();
-                $this->persistRunState(RunState::forWorkingDirectory($workingDirectory), $failedTap->failedTests(), $failedTap->classSeconds());
+                $this->persistRunState($state, $failedTap->failedTests(), $failedTap->classSeconds());
 
                 return $tap->failedClasses();
             };
@@ -1146,7 +1151,13 @@ final readonly class Application
         $filter = SelectionFilter::fromConfiguration($resolved);
 
         $directories = $this->directories($resolved, $workingDirectory);
-        $plan = new TestDiscoverer()->discover($directories, $filter, $resolved->randomSeed, DiscoveryCache::forDirectories($directories));
+        $storage = StorageLayout::resolve($resolved->storage, $workingDirectory);
+        $plan = new TestDiscoverer()->discover(
+            $directories,
+            $filter,
+            $resolved->randomSeed,
+            DiscoveryCache::forDirectories($directories, $storage->cacheDirectory),
+        );
 
         if ($resolved->shard !== null) {
             return PlanShard::select($plan, \max(1, $resolved->shard[0]), \max(1, $resolved->shard[1]));

--- a/src/Cli/ConfigurationResolver.php
+++ b/src/Cli/ConfigurationResolver.php
@@ -69,6 +69,7 @@ final class ConfigurationResolver
             excludePaths: $overrides->excludePaths,
             artifacts: $artifacts,
             resourceLimits: \array_replace($configuration->resourceLimits, $overrides->resourceLimits),
+            storage: $configuration->storage,
         );
     }
 }

--- a/src/Cli/CoverageSession.php
+++ b/src/Cli/CoverageSession.php
@@ -28,8 +28,11 @@ final class CoverageSession
     /**
      * @throws CoverageError
      */
-    public static function open(?CoverageSettings $settings, bool $collectProcess): self
-    {
+    public static function open(
+        ?CoverageSettings $settings,
+        bool $collectProcess,
+        ?string $temporaryDirectory = null,
+    ): self {
         $session = new self();
 
         if (!$settings instanceof CoverageSettings) {
@@ -46,7 +49,7 @@ final class CoverageSession
                 }
             }
 
-            $session->shared = SharedCoverageDirectory::open($settings);
+            $session->shared = SharedCoverageDirectory::open($settings, $temporaryDirectory);
         } catch (\Throwable $failure) {
             $session->close();
 

--- a/src/Cli/PlanFormatter.php
+++ b/src/Cli/PlanFormatter.php
@@ -7,6 +7,7 @@ namespace Greenlight\Cli;
 use Greenlight\Config\Configuration;
 use Greenlight\Config\CoverageConfiguration;
 use Greenlight\Config\MemorySize;
+use Greenlight\Config\StorageLayout;
 
 /** @internal */
 final class PlanFormatter
@@ -14,8 +15,11 @@ final class PlanFormatter
     /** @codeCoverageIgnore */
     private function __construct() {}
 
-    public static function format(Configuration $configuration, string $configFile): string
-    {
+    public static function format(
+        Configuration $configuration,
+        string $configFile,
+        string $workingDirectory,
+    ): string {
         $lines = [];
         $lines[] = 'Run plan';
         $lines[] = '  configuration file: ' . $configFile;
@@ -70,6 +74,11 @@ final class PlanFormatter
 
         $lines[] = '  plugins: ' . ($plugins === [] ? '(none)' : \implode(', ', $plugins));
         $lines[] = '  artifacts: ' . $configuration->artifacts->directory;
+        $storage = StorageLayout::resolve($configuration->storage, $workingDirectory);
+        $lines[] = '  storage state: ' . $storage->runStateFile;
+        $lines[] = '  storage cache: ' . $storage->cacheDirectory;
+        $lines[] = '  storage generated code: ' . $storage->generatedCodeDirectory;
+        $lines[] = '  storage temporary: ' . $storage->temporaryDirectory;
 
         if (!$configuration->coverage instanceof CoverageConfiguration) {
             $lines[] = '  coverage: (off)';

--- a/src/Cli/RunState.php
+++ b/src/Cli/RunState.php
@@ -151,6 +151,17 @@ final class RunState
             return false;
         }
 
+        $directory = \dirname($this->file);
+        $directoryExists = ErrorTrap::run(static fn() => \is_dir($directory));
+
+        if (!$directoryExists && !ErrorTrap::run(static fn() => \mkdir($directory, 0o700, true))) {
+            $directoryExists = ErrorTrap::run(static fn() => \is_dir($directory));
+
+            if (!$directoryExists) {
+                return false;
+            }
+        }
+
         try {
             AtomicFile::write($this->file, $encoded);
         } catch (AtomicFileError) {

--- a/src/Config/Configuration.php
+++ b/src/Config/Configuration.php
@@ -60,6 +60,7 @@ final readonly class Configuration
         public array $excludePaths = [],
         public ArtifactConfiguration $artifacts = new ArtifactConfiguration(),
         public array $resourceLimits = [],
+        public StorageConfiguration $storage = new StorageConfiguration(),
     ) {}
 
     /**
@@ -90,6 +91,7 @@ final readonly class Configuration
             excludePaths: $this->excludePaths,
             artifacts: $this->artifacts,
             resourceLimits: $this->resourceLimits,
+            storage: $this->storage,
         );
     }
 
@@ -121,6 +123,7 @@ final readonly class Configuration
             excludePaths: $paths,
             artifacts: $this->artifacts,
             resourceLimits: $this->resourceLimits,
+            storage: $this->storage,
         );
     }
 }

--- a/src/Config/GreenlightConfig.php
+++ b/src/Config/GreenlightConfig.php
@@ -43,6 +43,8 @@ final class GreenlightConfig
 
     private ?ArtifactBuilder $artifacts = null;
 
+    private ?StorageBuilder $storage = null;
+
     /**
      * @var list<Plugin>
      */
@@ -262,6 +264,21 @@ final class GreenlightConfig
     }
 
     /**
+     * Sets directories for persistent state, caches, generated code, and
+     * temporary run data. Multiple calls use the same builder.
+     *
+     * @param callable(StorageBuilder): mixed $configurator
+     */
+    public function storage(callable $configurator): self
+    {
+        $builder = $this->storage instanceof StorageBuilder ? clone $this->storage : new StorageBuilder();
+        $configurator($builder);
+        $this->storage = clone $builder;
+
+        return $this;
+    }
+
+    /**
      * Fails an otherwise passed test if captured output contains a
      * deprecation. The diagnostic becomes the failure detail. Use a regular
      * expression to exempt known dependency messages.
@@ -388,6 +405,7 @@ final class GreenlightConfig
             randomSeed: $this->randomSeed,
             artifacts: $this->artifacts?->toConfiguration() ?? new ArtifactConfiguration(),
             resourceLimits: $this->resourceLimits,
+            storage: $this->storage?->toConfiguration() ?? new StorageConfiguration(),
         );
     }
 }

--- a/src/Config/StorageBuilder.php
+++ b/src/Config/StorageBuilder.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Config;
+
+/** Collects directory configuration for Greenlight-owned storage. */
+final class StorageBuilder
+{
+    private ?string $rootDirectory = null;
+    private ?string $stateDirectory = null;
+    private ?string $cacheDirectory = null;
+    private ?string $generatedCodeDirectory = null;
+    private ?string $temporaryDirectory = null;
+
+    /** @throws InvalidConfiguration */
+    public function rootDirectory(string $directory): self
+    {
+        $this->rootDirectory = $this->validate($directory, 'Storage root directory');
+
+        return $this;
+    }
+
+    /** @throws InvalidConfiguration */
+    public function stateDirectory(string $directory): self
+    {
+        $this->stateDirectory = $this->validate($directory, 'State directory');
+
+        return $this;
+    }
+
+    /** @throws InvalidConfiguration */
+    public function cacheDirectory(string $directory): self
+    {
+        $this->cacheDirectory = $this->validate($directory, 'Cache directory');
+
+        return $this;
+    }
+
+    /** @throws InvalidConfiguration */
+    public function generatedCodeDirectory(string $directory): self
+    {
+        $this->generatedCodeDirectory = $this->validate($directory, 'Generated-code directory');
+
+        return $this;
+    }
+
+    /** @throws InvalidConfiguration */
+    public function temporaryDirectory(string $directory): self
+    {
+        $this->temporaryDirectory = $this->validate($directory, 'Temporary directory');
+
+        return $this;
+    }
+
+    /** @internal */
+    public function toConfiguration(): StorageConfiguration
+    {
+        return new StorageConfiguration(
+            $this->rootDirectory,
+            $this->stateDirectory,
+            $this->cacheDirectory,
+            $this->generatedCodeDirectory,
+            $this->temporaryDirectory,
+        );
+    }
+
+    /** @throws InvalidConfiguration */
+    private function validate(string $directory, string $name): string
+    {
+        if ($directory === '') {
+            throw new InvalidConfiguration($name . ' cannot be empty.');
+        }
+
+        if (\str_contains($directory, "\0")) {
+            throw new InvalidConfiguration($name . ' cannot contain a null byte.');
+        }
+
+        return $directory;
+    }
+}

--- a/src/Config/StorageConfiguration.php
+++ b/src/Config/StorageConfiguration.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Config;
+
+/**
+ * Contains unresolved storage directories from the project configuration.
+ * A null value uses the storage root or the system temporary directory.
+ *
+ * @internal
+ */
+final readonly class StorageConfiguration
+{
+    public function __construct(
+        public ?string $rootDirectory = null,
+        public ?string $stateDirectory = null,
+        public ?string $cacheDirectory = null,
+        public ?string $generatedCodeDirectory = null,
+        public ?string $temporaryDirectory = null,
+    ) {}
+}

--- a/src/Config/StorageLayout.php
+++ b/src/Config/StorageLayout.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Config;
+
+/**
+ * Resolves Greenlight storage once against the project working directory.
+ * Explicit area directories replace the applicable directory below the root.
+ *
+ * @internal
+ */
+final readonly class StorageLayout
+{
+    private function __construct(
+        public string $runStateFile,
+        public string $cacheDirectory,
+        public string $generatedCodeDirectory,
+        public string $temporaryDirectory,
+    ) {}
+
+    public static function resolve(StorageConfiguration $configuration, string $workingDirectory): self
+    {
+        $temporary = \rtrim(\sys_get_temp_dir(), '/');
+        $root = self::configured($configuration->rootDirectory, $workingDirectory);
+        $state = self::area($configuration->stateDirectory, $root, 'state', $workingDirectory);
+        $cache = self::area($configuration->cacheDirectory, $root, 'cache', $workingDirectory);
+        $generatedCode = self::area(
+            $configuration->generatedCodeDirectory,
+            $root,
+            'generated-code',
+            $workingDirectory,
+        );
+        $runtime = self::area($configuration->temporaryDirectory, $root, 'temporary', $workingDirectory);
+        $projectKey = \substr(\sha1($workingDirectory), 0, 12);
+
+        return new self(
+            $state === null
+                ? \sprintf('%s/greenlight-state-%s.json', $temporary, $projectKey)
+                : $state . '/run-state.json',
+            $cache ?? $temporary,
+            $generatedCode ?? \sprintf('%s/greenlight-proxies-%s', $temporary, $projectKey),
+            $runtime ?? $temporary,
+        );
+    }
+
+    private static function area(
+        ?string $configured,
+        ?string $root,
+        string $name,
+        string $workingDirectory,
+    ): ?string {
+        if ($configured !== null) {
+            return self::absolute($configured, $workingDirectory);
+        }
+
+        return $root === null ? null : \rtrim($root, '/') . '/' . $name;
+    }
+
+    private static function configured(?string $directory, string $workingDirectory): ?string
+    {
+        return $directory === null ? null : self::absolute($directory, $workingDirectory);
+    }
+
+    private static function absolute(string $directory, string $workingDirectory): string
+    {
+        $path = \str_starts_with($directory, '/')
+            ? $directory
+            : \rtrim($workingDirectory, '/') . '/' . $directory;
+
+        $trimmed = \rtrim($path, '/');
+
+        return $trimmed === '' ? '/' : $trimmed;
+    }
+}

--- a/src/Discovery/DiscoveryCache.php
+++ b/src/Discovery/DiscoveryCache.php
@@ -41,14 +41,16 @@ final class DiscoveryCache
     /**
      * @param list<non-empty-string> $directories
      */
-    public static function forDirectories(array $directories): self
+    public static function forDirectories(array $directories, ?string $cacheDirectory = null): self
     {
         $sorted = $directories;
         \sort($sorted);
 
+        $cacheDirectory ??= \sys_get_temp_dir();
+
         return new self(\sprintf(
             '%s/greenlight-discovery-%s.json',
-            \rtrim(\sys_get_temp_dir(), '/'),
+            \rtrim($cacheDirectory, '/'),
             \substr(\sha1(\implode("\n", $sorted)), 0, 12),
         ));
     }
@@ -207,6 +209,17 @@ final class DiscoveryCache
             );
         } catch (\JsonException) {
             return false;
+        }
+
+        $directory = \dirname($this->file);
+        $directoryExists = ErrorTrap::run(static fn() => \is_dir($directory));
+
+        if (!$directoryExists && !ErrorTrap::run(static fn() => \mkdir($directory, 0o700, true))) {
+            $directoryExists = ErrorTrap::run(static fn() => \is_dir($directory));
+
+            if (!$directoryExists) {
+                return false;
+            }
         }
 
         try {

--- a/src/Runner/Artifact/ArtifactStore.php
+++ b/src/Runner/Artifact/ArtifactStore.php
@@ -41,6 +41,7 @@ final class ArtifactStore
         string $workingDirectory,
         string $runId,
         ?FileCopier $fileCopier = null,
+        ?string $temporaryDirectory = null,
     ): self {
         $configured = \rtrim($configuration->directory, '/');
 
@@ -66,7 +67,8 @@ final class ArtifactStore
         $output = \str_starts_with($configured, '/')
             ? $public
             : \rtrim($workingDirectory, '/') . '/' . $public;
-        $staging = \rtrim(\sys_get_temp_dir(), '/') . '/greenlight-artifacts-'
+        $temporaryDirectory ??= \sys_get_temp_dir();
+        $staging = \rtrim($temporaryDirectory, '/') . '/greenlight-artifacts-'
             . \substr(\hash('sha256', $runId), 0, 16)
             . '-' . \bin2hex(\random_bytes(6));
         return new self(

--- a/src/Runner/DefaultServices.php
+++ b/src/Runner/DefaultServices.php
@@ -33,12 +33,14 @@ final class DefaultServices
     public static function registry(
         PluginRegistry $plugins = new PluginRegistry(),
         IntegrationResources $integrationResources = new IntegrationResources(),
+        ?string $generatedCodeDirectory = null,
+        ?string $temporaryDirectory = null,
     ): HarnessRegistry {
         Expect::install($plugins->ofType(ExpectationExtension::class));
 
         $registry = new HarnessRegistry([
-            new ServiceDefinition(Doubles::class, Scope::PerTest, static fn(): Doubles => new Doubles()),
-            new ServiceDefinition(TemporaryDirectory::class, Scope::PerTest, static fn(): TemporaryDirectory => new TemporaryDirectory()),
+            new ServiceDefinition(Doubles::class, Scope::PerTest, static fn(): Doubles => new Doubles($generatedCodeDirectory)),
+            new ServiceDefinition(TemporaryDirectory::class, Scope::PerTest, static fn(): TemporaryDirectory => new TemporaryDirectory($temporaryDirectory)),
             new ServiceDefinition(Autoloaders::class, Scope::PerTest, static fn(): Autoloaders => new Autoloaders()),
             new ServiceDefinition(EnvironmentVariables::class, Scope::PerTest, static fn(): EnvironmentVariables => new EnvironmentVariables()),
             new ServiceDefinition(StreamWrappers::class, Scope::PerTest, static fn(): StreamWrappers => new StreamWrappers()),

--- a/src/Runner/InProcessRunner.php
+++ b/src/Runner/InProcessRunner.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Runner;
 
 use Greenlight\Config\Configuration;
+use Greenlight\Config\StorageLayout;
 use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Core\EnvironmentBackup;
 use Greenlight\Core\Event\RunFinished;
@@ -58,6 +59,7 @@ final readonly class InProcessRunner
         array $classSeconds = [],
         ?GracefulShutdown $shutdown = null,
     ): RunResult {
+        $storage = StorageLayout::resolve($configuration->storage, $this->workingDirectory);
         $seed = null;
 
         if ($configuration->randomizeOrder) {
@@ -77,6 +79,7 @@ final readonly class InProcessRunner
             $artifactConfiguration,
             $this->workingDirectory,
             $runId,
+            temporaryDirectory: $storage->temporaryDirectory,
         );
         $channelEnvironment = null;
 
@@ -143,7 +146,12 @@ final readonly class InProcessRunner
                 $collector?->start();
 
                 $outcome = $plugins->runWorker(static fn() => new Worker(
-                    DefaultServices::registry($plugins, $resources),
+                    DefaultServices::registry(
+                        $plugins,
+                        $resources,
+                        $storage->generatedCodeDirectory,
+                        $storage->temporaryDirectory,
+                    ),
                     $plugins,
                     $detectLeaks ? new LeakDetector() : null,
                     'in-process',
@@ -204,7 +212,14 @@ final readonly class InProcessRunner
     {
         $filter = SelectionFilter::fromConfiguration($configuration);
 
-        return new TestDiscoverer()->discover($directories, $filter, $seed, DiscoveryCache::forDirectories($directories));
+        $storage = StorageLayout::resolve($configuration->storage, $this->workingDirectory);
+
+        return new TestDiscoverer()->discover(
+            $directories,
+            $filter,
+            $seed,
+            DiscoveryCache::forDirectories($directories, $storage->cacheDirectory),
+        );
     }
 
     private function sharded(ExecutionPlan $plan, Configuration $configuration): ExecutionPlan

--- a/src/Runner/Orchestrator/Orchestrator.php
+++ b/src/Runner/Orchestrator/Orchestrator.php
@@ -152,6 +152,8 @@ final class Orchestrator
         private readonly float $progressDeadlineSeconds = self::PROGRESS_DEADLINE_SECONDS,
         private readonly array $resourceLimits = [],
         private readonly InitialWorkerAssignment $initialWorkerAssignment = InitialWorkerAssignment::Progressive,
+        private readonly ?string $generatedCodeDirectory = null,
+        private readonly ?string $temporaryDirectory = null,
     ) {
         $this->summary = new ResultSummary();
     }
@@ -229,7 +231,7 @@ final class Orchestrator
         $spawnBudget = new WorkerSpawnBudget(\count($plan->entries), $workerCount);
 
         $token = \bin2hex(\random_bytes(16));
-        $server = ServerSocket::listen();
+        $server = ServerSocket::listen($this->temporaryDirectory);
 
         try {
             while (true) {
@@ -422,6 +424,8 @@ final class Orchestrator
                             $handle->channelNumber,
                             $this->configFile === '' ? null : $this->configFile,
                             $this->integrationFixtures->forChannel($handle->channelNumber),
+                            $this->generatedCodeDirectory,
+                            $this->temporaryDirectory,
                         ));
                     } catch (ProtocolError) {
                         $this->containCrash($handle, $sink, 'the worker exited before receiving bootstrap data');

--- a/src/Runner/ParallelRunner.php
+++ b/src/Runner/ParallelRunner.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Runner;
 
 use Greenlight\Config\Configuration;
+use Greenlight\Config\StorageLayout;
 use Greenlight\Core\Artifact\AttachmentError;
 use Greenlight\Core\Event\RunFinished;
 use Greenlight\Core\Event\RunStarted;
@@ -63,6 +64,7 @@ final readonly class ParallelRunner
         ?GracefulShutdown $shutdown = null,
         ?Ticking $ticker = null,
     ): RunResult {
+        $storage = StorageLayout::resolve($configuration->storage, $this->workingDirectory);
         $seed = null;
 
         if ($configuration->randomizeOrder) {
@@ -71,7 +73,12 @@ final readonly class ParallelRunner
 
         $filter = SelectionFilter::fromConfiguration($configuration);
         $plan = PlanOrder::schedule(
-            $this->sharded(new TestDiscoverer()->discover($directories, $filter, $seed, DiscoveryCache::forDirectories($directories)), $configuration),
+            $this->sharded(new TestDiscoverer()->discover(
+                $directories,
+                $filter,
+                $seed,
+                DiscoveryCache::forDirectories($directories, $storage->cacheDirectory),
+            ), $configuration),
             $priorityClasses,
             $configuration->randomizeOrder ? [] : $classSeconds,
         );
@@ -79,7 +86,12 @@ final readonly class ParallelRunner
         $runId = \bin2hex(\random_bytes(8));
         $startedAt = \hrtime(true);
         $artifactConfiguration = $configuration->artifacts;
-        $artifactStore = ArtifactStore::open($artifactConfiguration, $this->workingDirectory, $runId);
+        $artifactStore = ArtifactStore::open(
+            $artifactConfiguration,
+            $this->workingDirectory,
+            $runId,
+            temporaryDirectory: $storage->temporaryDirectory,
+        );
 
         try {
             $orchestratorSide = PluginRegistry::orchestratorSide($configuration->plugins);
@@ -135,6 +147,8 @@ final readonly class ParallelRunner
                     $fixtures,
                     resourceLimits: $configuration->resourceLimits,
                     initialWorkerAssignment: $initialWorkerAssignment,
+                    generatedCodeDirectory: $storage->generatedCodeDirectory,
+                    temporaryDirectory: $storage->temporaryDirectory,
                 );
 
                 $summary = $orchestrator->run($plan, $sink, $workerCount, $classSeconds);

--- a/src/Runner/Protocol/Messages/Bootstrap.php
+++ b/src/Runner/Protocol/Messages/Bootstrap.php
@@ -23,6 +23,8 @@ final readonly class Bootstrap implements Message
         public int $channel,
         public ?string $configFile,
         public IntegrationResources $resources,
+        public ?string $generatedCodeDirectory = null,
+        public ?string $temporaryDirectory = null,
     ) {}
 
     #[\Override]
@@ -38,6 +40,8 @@ final readonly class Bootstrap implements Message
             'channel' => $this->channel,
             'configFile' => $this->configFile,
             'resources' => $this->resources->toWire(),
+            'generatedCodeDirectory' => $this->generatedCodeDirectory,
+            'temporaryDirectory' => $this->temporaryDirectory,
         ];
     }
 
@@ -50,6 +54,12 @@ final readonly class Bootstrap implements Message
             \max(1, Wire::int($payload, 'channel')),
             $configFile === '' ? null : $configFile,
             IntegrationResources::fromWire(Wire::map($payload, 'resources')),
+            ($generatedCode = \array_key_exists('generatedCodeDirectory', $payload)
+                ? Wire::nullableString($payload, 'generatedCodeDirectory')
+                : null) === '' ? null : $generatedCode,
+            ($temporary = \array_key_exists('temporaryDirectory', $payload)
+                ? Wire::nullableString($payload, 'temporaryDirectory')
+                : null) === '' ? null : $temporary,
         );
     }
 }

--- a/src/Runner/SharedCoverageDirectory.php
+++ b/src/Runner/SharedCoverageDirectory.php
@@ -24,9 +24,10 @@ final readonly class SharedCoverageDirectory
     ) {}
 
     /** @throws CoverageError */
-    public static function open(CoverageSettings $settings): self
+    public static function open(CoverageSettings $settings, ?string $temporaryDirectory = null): self
     {
-        $directory = \rtrim(\sys_get_temp_dir(), '/') . '/greenlight-coverage-' . \bin2hex(\random_bytes(6));
+        $temporaryDirectory ??= \sys_get_temp_dir();
+        $directory = \rtrim($temporaryDirectory, '/') . '/greenlight-coverage-' . \bin2hex(\random_bytes(6));
         $created = ErrorTrap::run(static fn() => \mkdir($directory, 0o700, true), $warning);
 
         if (!$created) {

--- a/src/Runner/Worker/WorkerProcess.php
+++ b/src/Runner/Worker/WorkerProcess.php
@@ -141,7 +141,12 @@ final readonly class WorkerProcess
                     new TestChannel($message->channel),
                     $message->resources,
                 ));
-                $registry = DefaultServices::registry($plugins, $message->resources);
+                $registry = DefaultServices::registry(
+                    $plugins,
+                    $message->resources,
+                    $message->generatedCodeDirectory,
+                    $message->temporaryDirectory,
+                );
                 $scopes = new HarnessScopes($registry, $plugins->serviceResolvers());
 
                 $finalMessage = $plugins->runWorker(function () use (

--- a/src/Sandbox/TemporaryDirectory.php
+++ b/src/Sandbox/TemporaryDirectory.php
@@ -36,7 +36,7 @@ final class TemporaryDirectory implements Disposable
             $resolvedTemporaryRoot = ErrorTrap::run(static fn() => \realpath($systemTemporaryRoot));
             $temporaryRoot = $resolvedTemporaryRoot === false ? $systemTemporaryRoot : $resolvedTemporaryRoot;
             $path = $temporaryRoot . '/greenlight-' . \bin2hex(\random_bytes(8));
-            $created = ErrorTrap::run(static fn() => \mkdir($path, 0700), $warning);
+            $created = ErrorTrap::run(static fn() => \mkdir($path, 0700, true), $warning);
 
             if (!$created) {
                 throw TemporaryDirectoryError::rootCreationFailed($path, $warning);

--- a/tests/Acceptance/StorageDirectoriesRunTest.php
+++ b/tests/Acceptance/StorageDirectoriesRunTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\GreenlightCli;
+
+final readonly class StorageDirectoriesRunTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function configuredAreasReceiveTheirOwnedDataAcrossAWorkerProcess(): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'storage-directories');
+        $project->writeFile('greenlight.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Config\GreenlightConfig;
+            use Greenlight\Config\StorageBuilder;
+
+            require_once __DIR__ . '/tests/StorageProbeTest.php';
+
+            return GreenlightConfig::create()
+                ->paths([__DIR__ . '/tests'])
+                ->workers(2)
+                ->storage(static fn(StorageBuilder $storage) => $storage
+                    ->stateDirectory(__DIR__ . '/storage/state')
+                    ->cacheDirectory(__DIR__ . '/storage/cache')
+                    ->generatedCodeDirectory(__DIR__ . '/storage/generated-code')
+                    ->temporaryDirectory(__DIR__ . '/storage/temporary'));
+
+            PHP);
+        $project->writeFile('tests/StorageProbeTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace StorageProbe;
+
+            use Greenlight\Attribute\Test;
+            use Greenlight\Doubles\Doubles;
+            use Greenlight\Expect\Expect;
+            use Greenlight\Sandbox\TemporaryDirectory;
+
+            interface Collaborator {}
+
+            final readonly class StorageProbeTest
+            {
+                public function __construct(
+                    private Doubles $doubles,
+                    private TemporaryDirectory $temporaryDirectory,
+                ) {}
+
+                #[Test]
+                public function usesWorkerStorage(): void
+                {
+                    $double = $this->doubles->spy(Collaborator::class);
+                    file_put_contents(dirname(__DIR__) . '/observed-temporary-path.txt', $this->temporaryDirectory->path());
+
+                    Expect::that($double)->toBeInstanceOf(Collaborator::class);
+                }
+            }
+
+            PHP);
+
+        $result = GreenlightCli::run($project->directory, ['run', '--no-ansi']);
+        $discoveryFiles = \glob($project->path('storage/cache/greenlight-discovery-*.json'));
+        $proxyFiles = \glob($project->path('storage/generated-code/*.php'));
+        $temporaryPath = (string) \file_get_contents($project->path('observed-temporary-path.txt'));
+
+        Expect::that($result->exitCode)
+            ->because($result->output() === '' ? 'The configured storage run returned no output.' : $result->output())
+            ->toBe(0);
+        Expect::that(\is_file($project->path('storage/state/run-state.json')))
+            ->because('run state MUST use its configured persistent directory')
+            ->toBeTrue();
+        Expect::that($discoveryFiles === false ? [] : $discoveryFiles)
+            ->because('discovery metadata MUST use its configured data-cache directory')
+            ->toHaveCount(1);
+        Expect::that($proxyFiles === false ? [] : $proxyFiles)
+            ->because('worker proxy PHP MUST use its configured generated-code directory')
+            ->toHaveCount(1);
+        Expect::that($temporaryPath)
+            ->because('the worker temporary directory MUST use the configured runtime root')
+            ->toStartWith($project->path('storage/temporary/greenlight-'));
+        Expect::that(\is_dir($temporaryPath))
+            ->because('test disposal MUST remove the owned temporary child')
+            ->toBeFalse();
+    }
+}

--- a/tests/Unit/Cli/PlanFormatterTest.php
+++ b/tests/Unit/Cli/PlanFormatterTest.php
@@ -42,8 +42,11 @@ final class PlanFormatterTest
             randomSeed: null,
         );
 
-        Expect::that(PlanFormatter::format($configuration, '/project/greenlight.php'))->toBe(
-            <<<'PLAN'
+        $temporary = \rtrim(\sys_get_temp_dir(), '/');
+        $projectKey = \substr(\sha1('/project'), 0, 12);
+
+        Expect::that(PlanFormatter::format($configuration, '/project/greenlight.php', '/project'))->toBe(
+            <<<PLAN
                 Run plan
                   configuration file: /project/greenlight.php
                   test paths: tests
@@ -56,6 +59,10 @@ final class PlanFormatterTest
                   groups: (all)
                   plugins: (none)
                   artifacts: build/greenlight-artifacts
+                  storage state: {$temporary}/greenlight-state-{$projectKey}.json
+                  storage cache: {$temporary}
+                  storage generated code: {$temporary}/greenlight-proxies-{$projectKey}
+                  storage temporary: {$temporary}
                   coverage include paths: src
                   coverage driver: xdebug
                   coverage exports: json -> build/coverage.json
@@ -72,7 +79,7 @@ final class PlanFormatterTest
             ->plugins(new NamedFakePlugin())
             ->build();
 
-        $formatted = PlanFormatter::format($configuration, '/project/greenlight.php');
+        $formatted = PlanFormatter::format($configuration, '/project/greenlight.php', '/project');
 
         Expect::that($formatted)
             ->because('the plan names runtime seed selection and configured plugins')
@@ -108,7 +115,10 @@ final class PlanFormatterTest
             resourceLimits: ['database' => 2, 'redis' => 1],
         );
 
-        Expect::that(PlanFormatter::format($configuration, '/project/greenlight.php'))
+        $temporary = \rtrim(\sys_get_temp_dir(), '/');
+        $projectKey = \substr(\sha1('/project'), 0, 12);
+
+        Expect::that(PlanFormatter::format($configuration, '/project/greenlight.php', '/project'))
             ->because('the run plan MUST show each configured execution detail')
             ->toBe(
                 <<<PLAN
@@ -125,6 +135,10 @@ final class PlanFormatterTest
                       groups: smoke, unit
                       plugins: Greenlight\Tests\Fixture\Plugins\NamedFakePlugin
                       artifacts: build/greenlight-artifacts
+                      storage state: {$temporary}/greenlight-state-{$projectKey}.json
+                      storage cache: {$temporary}
+                      storage generated code: {$temporary}/greenlight-proxies-{$projectKey}
+                      storage temporary: {$temporary}
                       coverage: (off)
 
                     PLAN,

--- a/tests/Unit/Config/GreenlightConfigApiTest.php
+++ b/tests/Unit/Config/GreenlightConfigApiTest.php
@@ -40,6 +40,7 @@ final class GreenlightConfigApiTest
             'plugins',
             'randomizeOrder',
             'resourceLimit',
+            'storage',
             'suite',
             'watch',
             'workers',

--- a/tests/Unit/Config/StorageBuilderTest.php
+++ b/tests/Unit/Config/StorageBuilderTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Config;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Config\InvalidConfiguration;
+use Greenlight\Config\StorageBuilder;
+use Greenlight\Expect\Expect;
+
+final readonly class StorageBuilderTest
+{
+    #[Test]
+    public function repeatedConfigurationKeepsAllAreaDirectories(): void
+    {
+        $configuration = GreenlightConfig::create()
+            ->storage(static fn(StorageBuilder $storage) => $storage
+                ->rootDirectory('build/greenlight')
+                ->stateDirectory('/shared/state'))
+            ->storage(static fn(StorageBuilder $storage) => $storage
+                ->cacheDirectory('/local/cache')
+                ->generatedCodeDirectory('/local/code')
+                ->temporaryDirectory('/local/tmp'))
+            ->build()
+            ->storage;
+
+        Expect::that($configuration->rootDirectory)->toBe('build/greenlight');
+        Expect::that($configuration->stateDirectory)->toBe('/shared/state');
+        Expect::that($configuration->cacheDirectory)->toBe('/local/cache');
+        Expect::that($configuration->generatedCodeDirectory)->toBe('/local/code');
+        Expect::that($configuration->temporaryDirectory)->toBe('/local/tmp');
+    }
+
+    /** @param \Closure(StorageBuilder): mixed $configure */
+    #[Test]
+    #[DataSet('invalidDirectories')]
+    public function invalidDirectoriesGiveExactGuidance(
+        \Closure $configure,
+        string $message,
+    ): void {
+        Expect::that(static fn(): mixed => $configure(new StorageBuilder()))
+            ->toThrow(InvalidConfiguration::class, message: $message);
+    }
+
+    /**
+     * @return iterable<string, array{\Closure(StorageBuilder): mixed, non-empty-string}>
+     */
+    public static function invalidDirectories(): iterable
+    {
+        yield 'empty root' => [
+            static fn(StorageBuilder $storage): StorageBuilder => $storage->rootDirectory(''),
+            'Storage root directory cannot be empty.',
+        ];
+        yield 'state null byte' => [
+            static fn(StorageBuilder $storage): StorageBuilder => $storage->stateDirectory("state\0dir"),
+            'State directory cannot contain a null byte.',
+        ];
+        yield 'empty cache' => [
+            static fn(StorageBuilder $storage): StorageBuilder => $storage->cacheDirectory(''),
+            'Cache directory cannot be empty.',
+        ];
+        yield 'generated code null byte' => [
+            static fn(StorageBuilder $storage): StorageBuilder => $storage->generatedCodeDirectory("code\0dir"),
+            'Generated-code directory cannot contain a null byte.',
+        ];
+        yield 'empty temporary' => [
+            static fn(StorageBuilder $storage): StorageBuilder => $storage->temporaryDirectory(''),
+            'Temporary directory cannot be empty.',
+        ];
+    }
+}

--- a/tests/Unit/Config/StorageLayoutTest.php
+++ b/tests/Unit/Config/StorageLayoutTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Config;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\StorageConfiguration;
+use Greenlight\Config\StorageLayout;
+use Greenlight\Expect\Expect;
+
+final readonly class StorageLayoutTest
+{
+    #[Test]
+    public function defaultsPreserveTheCurrentSystemTemporaryPaths(): void
+    {
+        $workingDirectory = '/project';
+        $key = \substr(\sha1($workingDirectory), 0, 12);
+        $temporary = \rtrim(\sys_get_temp_dir(), '/');
+        $layout = StorageLayout::resolve(new StorageConfiguration(), $workingDirectory);
+
+        Expect::that($layout->runStateFile)
+            ->because('default run state MUST retain its project-specific system temporary path')
+            ->toBe($temporary . '/greenlight-state-' . $key . '.json');
+        Expect::that($layout->cacheDirectory)
+            ->because('the default data cache MUST use the system temporary directory')
+            ->toBe($temporary);
+        Expect::that($layout->generatedCodeDirectory)
+            ->because('default generated code MUST retain its project-specific directory')
+            ->toBe($temporary . '/greenlight-proxies-' . $key);
+        Expect::that($layout->temporaryDirectory)
+            ->because('default runtime data MUST use the system temporary directory')
+            ->toBe($temporary);
+    }
+
+    #[Test]
+    public function areaDirectoriesOverrideTheConfiguredRoot(): void
+    {
+        $layout = StorageLayout::resolve(new StorageConfiguration(
+            rootDirectory: '.greenlight',
+            stateDirectory: '/shared/state',
+            temporaryDirectory: 'build/runtime',
+        ), '/project');
+
+        Expect::that($layout->runStateFile)
+            ->because('an explicit state directory MUST not depend on the checkout path')
+            ->toBe('/shared/state/run-state.json');
+        Expect::that($layout->cacheDirectory)
+            ->because('an area without an override MUST use its directory below the root')
+            ->toBe('/project/.greenlight/cache');
+        Expect::that($layout->generatedCodeDirectory)
+            ->because('generated code without an override MUST use its directory below the root')
+            ->toBe('/project/.greenlight/generated-code');
+        Expect::that($layout->temporaryDirectory)
+            ->because('relative area overrides MUST resolve against the initial working directory')
+            ->toBe('/project/build/runtime');
+    }
+}


### PR DESCRIPTION
Adds a nested storage configuration with common-root and per-area overrides for persistent run state, discovery cache, generated double proxies, and run-owned temporary data. Resolves relative directories from the project working directory, propagates worker paths through bootstrap, and reports the layout during dry runs. Updates CI and documentation to persist run state without repurposing TMPDIR.