### PR TITLE
docs(integrations): link framework introductions

### DIFF
--- a/docs/hyperf.md
+++ b/docs/hyperf.md
@@ -1,6 +1,7 @@
 # Hyperf applications
 
-The Hyperf bridge runs each Greenlight test attempt in a Hyperf coroutine.
+The [Hyperf](https://hyperf.io/) bridge runs each Greenlight test attempt in a
+Hyperf coroutine.
 
 The bridge supports Hyperf 3.2 with Swoole 5 or later. It does not support the
 Swow engine.

--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -1,7 +1,7 @@
 # Laravel applications
 
-The Laravel bridge supplies Laravel container services and built-in Greenlight
-harness services to test constructors.
+The [Laravel](https://laravel.com/) bridge supplies Laravel container services
+and built-in Greenlight harness services to test constructors.
 
 The bridge boots a fresh application for each test that uses it. Register the
 plugin to activate the bridge. The bridge uses the Laravel package that the

--- a/docs/symfony.md
+++ b/docs/symfony.md
@@ -1,7 +1,7 @@
 # Symfony applications
 
-The Symfony bridge supplies Symfony services and built-in Greenlight harness
-services to test constructors.
+The [Symfony](https://symfony.com/) bridge supplies Symfony services and
+built-in Greenlight harness services to test constructors.
 
 The bridge boots the application kernel once for each worker. Register the
 plugin to activate the bridge. The bridge uses the Symfony packages that the

--- a/docs/tempest.md
+++ b/docs/tempest.md
@@ -1,6 +1,7 @@
 # Tempest applications
 
-The Tempest bridge supplies Tempest container services to test constructors.
+The [Tempest](https://tempestphp.com/) bridge supplies Tempest container
+services to test constructors.
 
 The bridge boots a Tempest kernel when a test first requests a Tempest service.
 The kernel stays active for the worker lifetime. Tempest controls discovery,


### PR DESCRIPTION
## Summary

- Link each framework name to its canonical website at the start of the Hyperf, Tempest, Symfony, and Laravel integration guides.