### PR TITLE
refactor(coverage): centralize executable line hits

### DIFF
--- a/src/Coverage/Export/CloverExporter.php
+++ b/src/Coverage/Export/CloverExporter.php
@@ -30,19 +30,7 @@ final readonly class CloverExporter implements CoverageExporter
         foreach ($map->files() as $path => $file) {
             $out .= \sprintf('    <file name="%s">', XmlEscaper::attribute($path)) . "\n";
 
-            $counts = [];
-
-            foreach ($file->coveredLines as $line) {
-                $counts[$line] = 1;
-            }
-
-            foreach ($file->uncoveredLines as $line) {
-                $counts[$line] = 0;
-            }
-
-            \ksort($counts);
-
-            foreach ($counts as $line => $count) {
+            foreach ($file->lineHits() as $line => $count) {
                 $out .= \sprintf('      <line num="%d" type="stmt" count="%d"/>', $line, $count) . "\n";
             }
 

--- a/src/Coverage/Export/CoberturaExporter.php
+++ b/src/Coverage/Export/CoberturaExporter.php
@@ -53,19 +53,7 @@ final readonly class CoberturaExporter implements CoverageExporter
             $out .= '          <methods/>' . "\n";
             $out .= '          <lines>' . "\n";
 
-            $hits = [];
-
-            foreach ($file->coveredLines as $line) {
-                $hits[$line] = 1;
-            }
-
-            foreach ($file->uncoveredLines as $line) {
-                $hits[$line] = 0;
-            }
-
-            \ksort($hits);
-
-            foreach ($hits as $line => $hit) {
+            foreach ($file->lineHits() as $line => $hit) {
                 $out .= \sprintf('            <line number="%d" hits="%d"/>', $line, $hit) . "\n";
             }
 

--- a/src/Coverage/Export/HtmlExporter.php
+++ b/src/Coverage/Export/HtmlExporter.php
@@ -156,17 +156,16 @@ final readonly class HtmlExporter implements CoverageExporter
             $file->executableLineCount(),
         );
 
-        $covered = \array_fill_keys($file->coveredLines, true);
-        $uncovered = \array_fill_keys($file->uncoveredLines, true);
+        $lineHits = $file->lineHits();
         $source = $this->highlightedLines($file->file);
         $lastLine = $source === null
-            ? \max([0, ...$file->coveredLines, ...$file->uncoveredLines])
+            ? (\array_key_last($lineHits) ?? 0)
             : \count($source);
 
         $body .= '<pre>' . "\n";
 
         for ($line = 1; $line <= $lastLine; ++$line) {
-            $lineClass = isset($covered[$line]) ? 'cov' : (isset($uncovered[$line]) ? 'unc' : '');
+            $lineClass = ($lineHits[$line] ?? null) === 1 ? 'cov' : (isset($lineHits[$line]) ? 'unc' : '');
             $content = \sprintf('<span class="num">%d</span>%s', $line, $source[$line - 1] ?? '');
             // Lines with a class appear as blocks. A final newline adds an
             // empty line box inside the <pre>.

--- a/src/Coverage/Export/LcovExporter.php
+++ b/src/Coverage/Export/LcovExporter.php
@@ -34,19 +34,7 @@ final readonly class LcovExporter implements CoverageExporter
 
             $out .= 'SF:' . $path . "\n";
 
-            $hits = [];
-
-            foreach ($file->coveredLines as $line) {
-                $hits[$line] = 1;
-            }
-
-            foreach ($file->uncoveredLines as $line) {
-                $hits[$line] = 0;
-            }
-
-            \ksort($hits);
-
-            foreach ($hits as $line => $hit) {
+            foreach ($file->lineHits() as $line => $hit) {
                 $out .= 'DA:' . $line . ',' . $hit . "\n";
             }
 

--- a/src/Coverage/FileCoverage.php
+++ b/src/Coverage/FileCoverage.php
@@ -67,6 +67,24 @@ final readonly class FileCoverage
     }
 
     /**
+     * Returns executable line hit counts in ascending line order.
+     *
+     * @return array<positive-int, 0|1>
+     */
+    public function lineHits(): array
+    {
+        $hits = \array_fill_keys($this->uncoveredLines, 0);
+
+        foreach ($this->coveredLines as $line) {
+            $hits[$line] = 1;
+        }
+
+        \ksort($hits);
+
+        return $hits;
+    }
+
+    /**
      * Returns covered lines as a percentage of executable lines.
      *
      * A file with no executable lines has full coverage.

--- a/tests/Unit/Coverage/FileCoverageTest.php
+++ b/tests/Unit/Coverage/FileCoverageTest.php
@@ -57,6 +57,22 @@ final class FileCoverageTest
     }
 
     #[Test]
+    public function lineHitsAreOrderedWithCoveredLinesSetToOne(): void
+    {
+        $file = new FileCoverage('/src/A.php', [9, 3, 5], [12, 3, 7]);
+
+        Expect::that($file->lineHits())
+            ->because('line hits are canonical and covered wins')
+            ->toBe([
+                3 => 1,
+                5 => 1,
+                7 => 0,
+                9 => 1,
+                12 => 0,
+            ]);
+    }
+
+    #[Test]
     public function percentageIsCoveredOverExecutable(): void
     {
         $file = new FileCoverage('/src/A.php', [1, 2, 3], [4]);


### PR DESCRIPTION
## Summary

- add one canonical ordered line-to-hit representation to `FileCoverage`
- use it in Clover, Cobertura, LCOV, and HTML coverage exporters
- preserve covered-wins behavior and existing export formats