### PR TITLE
perf(benchmark): make comparisons reproducible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -691,7 +691,7 @@ jobs:
           dependency-versions: "locked"
 
       - name: "Run the harness on a small parameter set"
-        run: "php tools/benchmark.php --shape=many-fast --scale=1 --workers=2 --warmups=1 --runs=1 --seed=20260821"
+        run: "php tools/benchmark.php --shape=many-fast --scale=1 --workers=2 --warmups=1 --runs=1 --pause-ms=0 --seed=20260821 --format=json"
 
   deploy-documentation:
     name: "Deploy documentation"

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,137 +1,135 @@
 # Benchmarks
 
-Run the full benchmark with:
+The benchmark compares complete command run times for generated test suites.
+It does not measure test-body time in isolation.
+
+Save all samples from the full comparison:
 
 ```sh
-php tools/benchmark.php --with-phpunit
+php tools/benchmark.php --with-comparisons --format=json > benchmark.json
 ```
 
-The script generates the test suites and installs the comparison tools in a
-temporary project. The `coverage-heavy` shape requires PCOV or Xdebug.
+Run a Greenlight-only benchmark with the default table report:
 
-The default parameters use one warm-up round and three sample rounds. The
-script discards warm-up times. Each round runs each selected configuration once.
+```sh
+php tools/benchmark.php
+```
 
-The seed creates the first configuration order. The script reverses that order
-in the next round. It rotates the first order after each pair of rounds.
-Thus, one configuration does not always run before another configuration.
+The `coverage-heavy` benchmark shape requires PCOV or Xdebug.
 
-The report gives these values for each configuration:
+## Measurement controls
 
-* Minimum wall time
-* Median wall time
-* Maximum wall time
-* Observed spread, as `(maximum - minimum) / median`
+The harness applies these controls before and during each measurement:
 
-Use `--seed` to reproduce the order. Use `--warmups` to change the warm-up count.
-Record both values with results. A large spread identifies results that require
-more samples or a quieter machine.
+* It generates equivalent Greenlight, PHPUnit, and Pest fixtures.
+* A verification run creates one unique proof file for each test.
+* The harness stops if a configuration does not execute all generated tests.
+* Two warmups run before the measured samples.
+* The harness discards all warmup times.
+* Twelve sample rounds put each comparison configuration in each position twice.
+* A seed makes the configuration order reproducible.
+* A 100 ms pause separates command executions.
+* One temporary project supplies all configurations for a benchmark shape.
 
-PHPUnit and ParaTest run only the four common comparison shapes. The
-runner-specific shapes do not have equivalent scheduler configuration in those
-tools.
+The timer includes process start, autoload, discovery, report creation, and execution.
+It measures the complete command that a user runs.
 
-## Benchmark shapes
+Output modes are not identical because the tools have different reporter
+interfaces. Each tool creates its default noninteractive output.
+Greenlight selects its plain reporter explicitly. The harness discards all output.
 
-The common comparison shapes are:
+Each comparison configuration has a separate cache directory.
+One tool cannot warm or change the cache of another tool.
 
-* `many-fast`: many test classes with short test bodies
-* `few-slow`: a small number of test classes with 25 ms test bodies
-* `giant-dataset`: one test class with one large data set
-* `mixed`: fast tests, slow tests, and one large data set
+Use the JSON report to inspect each exact command.
 
-The runner-specific shapes are:
+## Comparison tools
 
-* `many-isolated`: many isolated tests that each require a new worker
-* `recycle-one`: workers that Greenlight replaces after one test
-* `resource-constrained`: work that one resource slot serializes
-* `skewed-bootstrap`: worker bootstrap delays that increase with the channel
-  number
-* `chatty-diagnostics`: many notices that workers capture and send
-* `coverage-heavy`: assignments with large coverage maps
+Use `--with-comparisons` to add these pinned tools:
 
-## Setup
+* PHPUnit 13.3.0
+* ParaTest 7.24.0
+* Pest 5.1.1
 
-* Machine: Apple Silicon, 11 logical cores, macOS, local SSD
-* PHP: 8.4.14 NTS, with default CLI opcache settings
-* Greenlight:
-  [`305f833ab5d3`](https://github.com/ben-challis/greenlight/commit/305f833ab5d3fc8c046b04182a9d0989e6b072aa)
-  (2026-07-12)
-* PHPUnit: 13.2.3
-* ParaTest: 7.23.0
-* Parameters: `--scale=10 --workers=4 --runs=3`, which were the defaults
+The harness installs the tools in each temporary project.
+Pest uses its closure-style test syntax.
+The Pest comparison includes serial and parallel configurations.
 
-Wall-clock time includes process start, autoload, discovery, and execution.
-Greenlight uses plain output, PHPUnit disables output, and ParaTest uses its
-default output. The measurements include these output-mode differences.
+The comparison tools run only the four common benchmark shapes.
+The other shapes use Greenlight features that do not have equivalent configurations.
 
-These published results predate warm-up rounds, alternate configuration order,
-and distribution output. This change does not replace them because it did not
-run the full benchmark on an idle machine.
+The common benchmark shapes are:
 
-## Results
+* `many-fast`: Many test files with short test bodies
+* `few-slow`: A small number of test files with 25 ms test bodies
+* `giant-dataset`: One test file with one large data set
+* `mixed`: Fast tests, slow tests, and one large data set
 
-### `many-fast`
+The Greenlight-specific benchmark shapes are:
 
-This shape has 400 classes with trivial bodies and 2,000 tests:
+* `many-isolated`: Many isolated tests that each require a new worker
+* `recycle-one`: Workers that Greenlight replaces after one test
+* `resource-constrained`: Work that one resource slot serializes
+* `skewed-bootstrap`: Worker bootstrap delays that increase with the channel number
+* `chatty-diagnostics`: Many notices that workers capture and send
+* `coverage-heavy`: Assignments with large coverage maps
 
-* Greenlight, 4 workers: 0.490s
-* Greenlight, 1 worker: 0.257s
-* PHPUnit: 1.910s
-* ParaTest, 4 processes: 4.810s
+## Reports
 
-### `few-slow`
+The table report gives these robust statistics:
 
-This shape has 8 classes, 25ms for each test, and 32 tests:
+* First quartile (`q1`)
+* Median
+* Third quartile (`q3`)
+* Relative median absolute deviation (`rMAD`)
 
-* Greenlight, 4 workers: 0.529s
-* Greenlight, 1 worker: 1.064s
-* PHPUnit: 1.326s
-* ParaTest, 4 processes: 0.840s
+The harness does not report the fastest sample as the result.
+A low `rMAD` shows that samples stay close to the median.
+A wide quartile interval or high `rMAD` identifies unstable measurements.
 
-### `giant-dataset`
+The JSON report also contains these items:
 
-This shape has 1 class and 1,000 provider rows:
+* Every raw sample in sample-round order for each configuration
+* The exact command for each configuration
+* All benchmark parameters
+* The source revision
+* The source-tree status
+* The PHP version and binary path
+* The platform description
+* Loaded measurement extensions, such as Xdebug or `ddtrace`
+* All resolved comparison package versions
 
-* Greenlight, 4 workers: 0.442s
-* Greenlight, 1 worker: 0.165s
-* PHPUnit: 1.016s
-* ParaTest, 4 processes: 1.190s
+Use `--seed` to reproduce the order.
+Use `--warmups` and `--runs` to change the sample plan.
+Use `--pause-ms` to change the pause between commands.
 
-### `mixed`
+## Publication procedure
 
-This shape combines fast tests, slow tests, and a data set. It has 1,416 tests:
+Use an idle machine with a stable power source and power mode.
+Stop scheduled work and other variable workloads before the benchmark.
+Record the processor model and power mode with the JSON report.
 
-* Greenlight, 4 workers: 0.617s
-* Greenlight, 1 worker: 0.708s
-* PHPUnit: 1.855s
-* ParaTest, 4 processes: 2.920s
+Choose the benchmark parameters before you inspect the results.
+Commit all source changes before a publication run.
+Publish all raw samples from the chosen run.
+Do not select the fastest sample or the fastest run.
 
-## Results analysis
+Do not publish results when `sourceTreeDirty` is `true`.
 
-In this run, Greenlight's fastest configuration is faster on each generated
-shape than PHPUnit's fastest configuration. Runner overhead for each test and
-class causes most of the difference. Parallelism is not the only cause.
+If the distribution is unstable, do not publish a performance claim.
+Find the cause and execute the complete benchmark again.
 
-Parallelism is not always faster. On trivial suites such as `many-fast` and
-`giant-dataset`, four Greenlight workers are slower than one worker. Worker
-startup and socket communication cost more time than the trivial test bodies
-save.
+Do not compare results from different benchmark shapes, parameters, machines,
+PHP versions, source revisions, or comparison-tool versions.
 
-Parallel execution helps once tests do enough work. In `few-slow`, four workers
-reduce the run from 1.064s to 0.529s.
+Synthetic benchmark results do not predict all real test suites.
+Use representative application suites before you make a general performance claim.
 
-The `giant-dataset` shape is one class. Thus, the Greenlight class-level
-schedule cannot split it across workers. Extra workers add overhead but do not
-add parallelism.
+## Published results
 
-A similar overhead pattern has a larger effect on small ParaTest work units. In the
-`many-fast` shape, ParaTest is slower than plain PHPUnit. Process-level
-parallelism adds overhead for each process.
-
-These synthetic benchmarks are from one machine. They help compare runner
-overhead for known shapes, but they do not predict every real suite. Suites with
-large I/O waits can have a much larger benefit from parallel execution.
+The project does not currently publish benchmark numbers.
+The previous numbers used three unbalanced samples and different output modes.
+They do not meet the current publication procedure.
 
 ## Maintenance
 
@@ -139,13 +137,11 @@ CI runs a small benchmark to check the harness:
 
 ```sh
 php tools/benchmark.php --shape=many-fast --scale=1 --workers=2 \
-  --warmups=1 --runs=1 --seed=20260821
+  --warmups=1 --runs=1 --pause-ms=0 --seed=20260821
 ```
 
-The project does not publish CI numbers because shared runners do not give
-stable comparisons.
+The project does not publish CI numbers.
+Shared runners do not give stable performance comparisons.
 
-When the runner changes materially, run the full benchmark on an idle machine.
-Record the Greenlight commit and run date with the results. The
-`tools/benchmark.php` file pins comparison-tool versions. Update the constants
-and this page in the same change.
+When the runner changes materially, execute the full benchmark on an idle machine.
+Update the pinned comparison-tool constants and this page in the same change.

--- a/tests/Unit/Tools/BenchmarkTest.php
+++ b/tests/Unit/Tools/BenchmarkTest.php
@@ -25,7 +25,9 @@ final readonly class BenchmarkTest
             'warmups' => '2',
             'runs' => '5',
             'seed' => '-17',
-            'with-phpunit' => false,
+            'pause-ms' => '250',
+            'format' => 'json',
+            'with-comparisons' => false,
         ]);
 
         Expect::that($options)->toBe([
@@ -35,18 +37,20 @@ final readonly class BenchmarkTest
             'warmups' => 2,
             'runs' => 5,
             'seed' => -17,
-            'withPhpunit' => true,
+            'pauseMs' => 250,
+            'format' => 'json',
+            'withComparisons' => true,
         ]);
     }
 
     #[Test]
     public function scheduleIsReproducibleAndAlternatesEachPairOfRounds(): void
     {
-        $configurationIds = ['parallel', 'one', 'phpunit', 'paratest'];
-        $schedule = \benchmarkSchedule($configurationIds, 4, 731, 'many-fast:sample');
+        $configurationIds = ['parallel', 'one', 'phpunit', 'paratest', 'pest', 'pest-parallel'];
+        $schedule = \benchmarkSchedule($configurationIds, 12, 731, 'many-fast:sample');
 
         Expect::that($schedule)->because('the same seed MUST reproduce the configuration order')
-            ->toBe(\benchmarkSchedule($configurationIds, 4, 731, 'many-fast:sample'));
+            ->toBe(\benchmarkSchedule($configurationIds, 12, 731, 'many-fast:sample'));
         Expect::that($schedule[1])->because('the second round MUST reverse the first round')
             ->toBe(\array_reverse($schedule[0]));
         Expect::that($schedule[3])->because('the fourth round MUST reverse the third round')
@@ -59,16 +63,30 @@ final readonly class BenchmarkTest
 
             Expect::that($order)->because('each round MUST contain each configuration once')->toBe($expected);
         }
+
+        foreach ($configurationIds as $configurationId) {
+            $configurationCount = \count($configurationIds);
+
+            for ($position = 0; $position < $configurationCount; ++$position) {
+                $positionCount = \count(\array_filter(
+                    $schedule,
+                    static fn(array $order): bool => $order[$position] === $configurationId,
+                ));
+                Expect::that($positionCount)
+                    ->because('the default sample count MUST put each configuration in each position twice')
+                    ->toBe(2);
+            }
+        }
     }
 
     #[Test]
-    public function distributionUsesTheConventionalMedianAndReportsTheObservedRange(): void
+    public function distributionReportsRobustLocationAndVariationStatistics(): void
     {
         Expect::that(\benchmarkDistribution([9.0, 1.0, 5.0, 3.0]))->toBe([
-            'minimum' => 1.0,
+            'firstQuartile' => 2.0,
             'median' => 4.0,
-            'maximum' => 9.0,
-            'spreadPercent' => 200.0,
+            'thirdQuartile' => 7.0,
+            'relativeMadPercent' => 50.0,
         ]);
     }
 
@@ -106,6 +124,14 @@ final readonly class BenchmarkTest
             ['shape' => ['many-fast', 'mixed']],
             'Specify option --shape exactly once with a value.',
         ];
+        yield 'unknown format' => [
+            ['format' => 'csv'],
+            'Option --format must be "table" or "json", got "csv".',
+        ];
+        yield 'excessive pause' => [
+            ['pause-ms' => '60001'],
+            'Option --pause-ms must be at most 60000, got 60001.',
+        ];
     }
 
     #[Test]
@@ -131,5 +157,44 @@ final readonly class BenchmarkTest
         yield 'chatty worker diagnostics' => ['chatty-diagnostics', 'tests/gl/ChattyDiagnostics0000Test.php', 'Benchmark diagnostic.'];
         yield 'coverage-heavy assignments' => ['coverage-heavy', 'greenlight.php', 'CoverageBuilder'];
         yield 'single giant data set' => ['giant-dataset', 'tests/gl/GiantTest.php', 'final class GiantTest'];
+        yield 'Pest giant data set' => ['giant-dataset', 'tests/pest/GiantTest.php', "test('handles'"];
+    }
+
+    #[Test]
+    public function comparisonConfigurationsIncludeNativePestRuns(): void
+    {
+        $configurations = \benchmarkConfigurations('many-fast', '/tmp/project', '/tmp/root', 4, true);
+
+        Expect::that($configurations)->toHaveKey('pest');
+        Expect::that($configurations)->toHaveKey('pest-parallel');
+        Expect::that($configurations['phpunit']['command'])->toContain('--cache-directory=.benchmark-cache/phpunit');
+        Expect::that($configurations['paratest']['command'])->toContain('--cache-directory=.benchmark-cache/paratest');
+        Expect::that($configurations['pest']['command'])->toContain('--configuration=pest.xml');
+        Expect::that($configurations['pest']['command'])->toContain('--cache-directory=.benchmark-cache/pest');
+        Expect::that($configurations['pest-parallel']['command'])->toContain('--parallel --processes=4');
+        Expect::that($configurations['pest-parallel']['command'])->toContain('--cache-directory=.benchmark-cache/pest-parallel');
+    }
+
+    #[Test]
+    public function installedComparisonPackageVersionsAreCompleteAndSorted(): void
+    {
+        $project = $this->tempDirectory->subdirectory('installed-packages');
+        $composer = $this->tempDirectory->subdirectory('installed-packages/vendor/composer');
+        \file_put_contents($composer . '/installed.php', <<<'PHP'
+            <?php
+
+            return [
+                'versions' => [
+                    '__root__' => ['pretty_version' => 'dev-main'],
+                    'vendor/zeta' => ['pretty_version' => '2.0.0'],
+                    'vendor/alpha' => ['pretty_version' => '1.0.0'],
+                ],
+            ];
+            PHP);
+
+        Expect::that(\benchmarkInstalledPackages($project))->toBe([
+            'vendor/alpha' => '1.0.0',
+            'vendor/zeta' => '2.0.0',
+        ]);
     }
 }

--- a/tests/Unit/Tools/RuntimeMessageTest.php
+++ b/tests/Unit/Tools/RuntimeMessageTest.php
@@ -232,14 +232,14 @@ final readonly class RuntimeMessageTest
                 '--scale=1',
                 '--workers=1',
                 '--runs=1',
-                '--with-phpunit',
+                '--with-comparisons',
             ],
             ['PATH' => $fakeBin . \PATH_SEPARATOR . (\is_string($path) ? $path : '')],
         );
 
         Expect::that($composerFailure->exitCode)->toBe(1);
         Expect::that($composerFailure->stderr)->toContain(
-            "Composer did not install PHPUnit and ParaTest:\nfixture composer failure",
+            "Composer did not install the comparison tools:\nfixture composer failure",
         );
     }
 

--- a/tools/benchmark.php
+++ b/tools/benchmark.php
@@ -4,8 +4,9 @@ declare(strict_types=1);
 
 /**
  * Generates synthetic suites and reports wall-time distributions for each
- * benchmark shape. The schedule uses an explicit warm-up and a reproducible
- * configuration order.
+ * benchmark shape. The schedule uses explicit warmups and a reproducible,
+ * position-balanced configuration order. A verification run confirms that
+ * each configuration executes all generated tests before measurement.
  *
  * Run the benchmark on an idle machine. Record the parameters with the
  * results in docs/benchmarks.md so that other users can reproduce them.
@@ -13,13 +14,15 @@ declare(strict_types=1);
  * Usage:
  *   php tools/benchmark.php [--shape=<name>] [--scale=<n>] [--workers=<k>]
  *                           [--warmups=<w>] [--runs=<r>] [--seed=<s>]
- *                           [--with-phpunit]
+ *                           [--pause-ms=<n>] [--format=<table|json>]
+ *                           [--with-comparisons]
  *
  * Omit --shape to run all shapes.
  */
 
-const PHPUNIT_VERSION = '13.2.3';
-const PARATEST_VERSION = '7.23.0';
+const PHPUNIT_VERSION = '13.3.0';
+const PARATEST_VERSION = '7.24.0';
+const PEST_VERSION = '5.1.1';
 const BENCHMARK_DEFAULT_SEED = 2_026_082_1;
 
 const BENCHMARK_SHAPES = [
@@ -51,6 +54,9 @@ function benchmarkMain(): int
             'warmups:',
             'runs:',
             'seed:',
+            'pause-ms:',
+            'format:',
+            'with-comparisons',
             'with-phpunit',
         ]);
 
@@ -61,12 +67,14 @@ function benchmarkMain(): int
         $options = \benchmarkParseOptions($parsed);
         $root = \dirname(__DIR__);
         $results = [];
+        $comparisonPackages = [];
 
         \fwrite(\STDERR, \sprintf(
-            "Benchmark schedule: warm-up rounds %d, sample rounds %d, seed %d.\n",
+            "Benchmark schedule: warm-up rounds %d, sample rounds %d, seed %d, pause %d ms.\n",
             $options['warmups'],
             $options['runs'],
             $options['seed'],
+            $options['pauseMs'],
         ));
 
         foreach ($options['shapes'] as $shape) {
@@ -81,11 +89,27 @@ function benchmarkMain(): int
                     $project,
                     $root,
                     $options['workers'],
-                    $options['withPhpunit'],
+                    $options['withComparisons'],
                 );
 
-                if ($options['withPhpunit'] && \benchmarkHasComparisonFixture($shape)) {
+                if ($options['withComparisons'] && \benchmarkHasComparisonFixture($shape)) {
                     \benchmarkInstall($project);
+                    $installedPackages = \benchmarkInstalledPackages($project);
+
+                    if ($comparisonPackages !== [] && $comparisonPackages !== $installedPackages) {
+                        throw new RuntimeException('Composer resolved different comparison package versions between benchmark shapes.');
+                    }
+
+                    $comparisonPackages = $installedPackages;
+                }
+
+                foreach ($configurations as $id => $configuration) {
+                    \fwrite(\STDERR, \sprintf(
+                        "[%s] verify: %s.\n",
+                        $shape,
+                        $configuration['tool'],
+                    ));
+                    \benchmarkVerifyConfiguration($configuration['command'], $tests, $project, $id);
                 }
 
                 $samples = [];
@@ -104,6 +128,7 @@ function benchmarkMain(): int
                             $configurations[$id]['tool'],
                         ));
                         \benchmarkTime($configurations[$id]['command']);
+                        \benchmarkPause($options['pauseMs']);
                     }
                 }
 
@@ -117,6 +142,7 @@ function benchmarkMain(): int
                             $configurations[$id]['tool'],
                         ));
                         $samples[$id][] = \benchmarkTime($configurations[$id]['command']);
+                        \benchmarkPause($options['pauseMs']);
                     }
                 }
 
@@ -125,6 +151,8 @@ function benchmarkMain(): int
                         'shape' => $shape,
                         'tests' => $tests,
                         'tool' => $configuration['tool'],
+                        'command' => $configuration['command'],
+                        'samplesSeconds' => $samples[$id],
                         ...\benchmarkDistribution($samples[$id]),
                     ];
                 }
@@ -133,29 +161,7 @@ function benchmarkMain(): int
             }
         }
 
-        echo \sprintf(
-            "%-20s %6s  %-24s %8s %8s %8s %8s\n",
-            'shape',
-            'tests',
-            'tool',
-            'minimum',
-            'median',
-            'maximum',
-            'spread',
-        );
-
-        foreach ($results as $row) {
-            echo \sprintf(
-                "%-20s %6d  %-24s %7.3fs %7.3fs %7.3fs %7.1f%%\n",
-                $row['shape'],
-                $row['tests'],
-                $row['tool'],
-                $row['minimum'],
-                $row['median'],
-                $row['maximum'],
-                $row['spreadPercent'],
-            );
-        }
+        \benchmarkReport($options, $results, $root, $comparisonPackages);
 
         return 0;
     } catch (InvalidArgumentException|RuntimeException $error) {
@@ -175,7 +181,9 @@ function benchmarkMain(): int
  *   warmups: non-negative-int,
  *   runs: positive-int,
  *   seed: int,
- *   withPhpunit: bool
+ *   pauseMs: int<0, 60000>,
+ *   format: 'table'|'json',
+ *   withComparisons: bool
  * }
  */
 function benchmarkParseOptions(array $options): array
@@ -193,14 +201,29 @@ function benchmarkParseOptions(array $options): array
         }
     }
 
+    $format = \benchmarkOptionValue($options, 'format') ?? 'table';
+
+    if (!\in_array($format, ['table', 'json'], true)) {
+        throw new InvalidArgumentException(\sprintf('Option --format must be "table" or "json", got "%s".', $format));
+    }
+
+    $pauseMs = \benchmarkNonNegativeIntegerOption($options, 'pause-ms', 100);
+
+    if ($pauseMs > 60_000) {
+        throw new InvalidArgumentException(\sprintf('Option --pause-ms must be at most 60000, got %d.', $pauseMs));
+    }
+
     return [
         'shapes' => $shapes,
         'scale' => \benchmarkPositiveIntegerOption($options, 'scale', 10),
         'workers' => \benchmarkPositiveIntegerOption($options, 'workers', 4),
-        'warmups' => \benchmarkNonNegativeIntegerOption($options, 'warmups', 1),
-        'runs' => \benchmarkPositiveIntegerOption($options, 'runs', 3),
+        'warmups' => \benchmarkNonNegativeIntegerOption($options, 'warmups', 2),
+        'runs' => \benchmarkPositiveIntegerOption($options, 'runs', 12),
         'seed' => \benchmarkIntegerOption($options, 'seed', BENCHMARK_DEFAULT_SEED),
-        'withPhpunit' => \array_key_exists('with-phpunit', $options),
+        'pauseMs' => $pauseMs,
+        'format' => $format,
+        'withComparisons' => \array_key_exists('with-comparisons', $options)
+            || \array_key_exists('with-phpunit', $options),
     ];
 }
 
@@ -300,7 +323,7 @@ function benchmarkSchedule(array $configurationIds, int $rounds, int $seed, stri
 }
 
 /** @return array<string, array{tool: string, command: string}> */
-function benchmarkConfigurations(string $shape, string $project, string $root, int $workers, bool $withPhpunit): array
+function benchmarkConfigurations(string $shape, string $project, string $root, int $workers, bool $withComparisons): array
 {
     $environment = $shape === 'coverage-heavy' ? 'XDEBUG_MODE=coverage ' : '';
     $greenlight = \sprintf(
@@ -321,14 +344,14 @@ function benchmarkConfigurations(string $shape, string $project, string $root, i
         ],
     ];
 
-    if (!$withPhpunit || !\benchmarkHasComparisonFixture($shape)) {
+    if (!$withComparisons || !\benchmarkHasComparisonFixture($shape)) {
         return $configurations;
     }
 
     $configurations['phpunit'] = [
         'tool' => 'phpunit',
         'command' => \sprintf(
-            'cd %s && %s vendor/bin/phpunit --no-progress --no-output',
+            'cd %s && %s vendor/bin/phpunit --cache-directory=.benchmark-cache/phpunit',
             \escapeshellarg($project),
             \escapeshellarg(\PHP_BINARY),
         ),
@@ -336,7 +359,24 @@ function benchmarkConfigurations(string $shape, string $project, string $root, i
     $configurations['paratest'] = [
         'tool' => \sprintf('paratest (p=%d)', $workers),
         'command' => \sprintf(
-            'cd %s && %s vendor/bin/paratest -p%d 2>&1',
+            'cd %s && %s vendor/bin/paratest -p%d --cache-directory=.benchmark-cache/paratest',
+            \escapeshellarg($project),
+            \escapeshellarg(\PHP_BINARY),
+            $workers,
+        ),
+    ];
+    $configurations['pest'] = [
+        'tool' => 'pest',
+        'command' => \sprintf(
+            'cd %s && %s vendor/bin/pest --configuration=pest.xml --cache-directory=.benchmark-cache/pest',
+            \escapeshellarg($project),
+            \escapeshellarg(\PHP_BINARY),
+        ),
+    ];
+    $configurations['pest-parallel'] = [
+        'tool' => \sprintf('pest (p=%d)', $workers),
+        'command' => \sprintf(
+            'cd %s && %s vendor/bin/pest --configuration=pest.xml --parallel --processes=%d --cache-directory=.benchmark-cache/pest-parallel',
             \escapeshellarg($project),
             \escapeshellarg(\PHP_BINARY),
             $workers,
@@ -365,10 +405,61 @@ function benchmarkTime(string $command): float
     return $seconds;
 }
 
+function benchmarkPause(int $milliseconds): void
+{
+    if ($milliseconds > 0) {
+        \usleep($milliseconds * 1_000);
+    }
+}
+
+function benchmarkVerifyConfiguration(string $command, int $expectedTests, string $project, string $id): void
+{
+    $proof = $project . '/proof-' . $id;
+
+    if (!\mkdir($proof)) {
+        throw new RuntimeException('Greenlight cannot create the benchmark proof directory.');
+    }
+
+    try {
+        $output = [];
+        \exec(\sprintf(
+            'BENCHMARK_PROOF_DIRECTORY=%s /bin/sh -c %s 2>&1',
+            \escapeshellarg($proof),
+            \escapeshellarg($command),
+        ), $output, $exit);
+
+        if ($exit !== 0) {
+            throw new RuntimeException(\sprintf(
+                "Verification command failed with exit %d: %s.\n%s",
+                $exit,
+                $command,
+                \implode("\n", $output),
+            ));
+        }
+
+        $entries = \glob($proof . '/*');
+
+        if ($entries === false) {
+            throw new RuntimeException('Greenlight cannot read the benchmark proof directory.');
+        }
+
+        if (\count($entries) !== $expectedTests) {
+            throw new RuntimeException(\sprintf(
+                'Configuration "%s" executed %d of %d generated tests.',
+                $id,
+                \count($entries),
+                $expectedTests,
+            ));
+        }
+    } finally {
+        \benchmarkRemoveTree($proof);
+    }
+}
+
 /**
  * @param list<float> $samples
  *
- * @return array{minimum: float, median: float, maximum: float, spreadPercent: float}
+ * @return array{firstQuartile: float, median: float, thirdQuartile: float, relativeMadPercent: float}
  */
 function benchmarkDistribution(array $samples): array
 {
@@ -379,23 +470,169 @@ function benchmarkDistribution(array $samples): array
     \sort($samples);
     $count = \count($samples);
     $middle = \intdiv($count, 2);
-    $median = $count % 2 === 0
-        ? ($samples[$middle - 1] + $samples[$middle]) / 2
-        : $samples[$middle];
-    $minimum = $samples[0];
-    $maximum = $samples[$count - 1];
+    $median = \benchmarkMedian($samples);
+    $lower = \array_slice($samples, 0, $middle);
+    $upper = \array_slice($samples, $count % 2 === 0 ? $middle : $middle + 1);
+    $deviations = \array_map(static fn(float $sample): float => \abs($sample - $median), $samples);
 
     return [
-        'minimum' => $minimum,
+        'firstQuartile' => $lower === [] ? $median : \benchmarkMedian($lower),
         'median' => $median,
-        'maximum' => $maximum,
-        'spreadPercent' => $median > 0.0 ? (($maximum - $minimum) / $median) * 100 : 0.0,
+        'thirdQuartile' => $upper === [] ? $median : \benchmarkMedian($upper),
+        'relativeMadPercent' => $median > 0.0 ? (\benchmarkMedian($deviations) / $median) * 100 : 0.0,
+    ];
+}
+
+/** @param non-empty-list<float> $samples */
+function benchmarkMedian(array $samples): float
+{
+    \sort($samples);
+    $count = \count($samples);
+    $middle = \intdiv($count, 2);
+
+    return $count % 2 === 0
+        ? ($samples[$middle - 1] + $samples[$middle]) / 2
+        : $samples[$middle];
+}
+
+/**
+ * @param array{
+ *   shapes: list<string>,
+ *   scale: positive-int,
+ *   workers: positive-int,
+ *   warmups: non-negative-int,
+ *   runs: positive-int,
+ *   seed: int,
+ *   pauseMs: int<0, 60000>,
+ *   format: 'table'|'json',
+ *   withComparisons: bool
+ * } $options
+ * @param list<array{
+ *   shape: string,
+ *   tests: int,
+ *   tool: string,
+ *   command: string,
+ *   samplesSeconds: list<float>,
+ *   firstQuartile: float,
+ *   median: float,
+ *   thirdQuartile: float,
+ *   relativeMadPercent: float
+ * }> $results
+ * @param array<string, non-empty-string> $comparisonPackages
+ */
+function benchmarkReport(array $options, array $results, string $root, array $comparisonPackages): void
+{
+    $environment = \benchmarkEnvironment($root);
+
+    if ($options['format'] === 'json') {
+        try {
+            echo \json_encode([
+                'schemaVersion' => 1,
+                'environment' => $environment,
+                'parameters' => $options,
+                'comparisonVersions' => $options['withComparisons'] ? [
+                    'phpunit' => PHPUNIT_VERSION,
+                    'paratest' => PARATEST_VERSION,
+                    'pest' => PEST_VERSION,
+                ] : new stdClass(),
+                'comparisonPackages' => $comparisonPackages === [] ? new stdClass() : $comparisonPackages,
+                'results' => $results,
+            ], \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_THROW_ON_ERROR) . "\n";
+        } catch (JsonException $error) {
+            throw new RuntimeException('Greenlight cannot encode the benchmark report.', $error->getCode(), previous: $error);
+        }
+
+        return;
+    }
+
+    echo \sprintf(
+        "Environment: PHP %s | %s | extensions: %s.\n",
+        $environment['phpVersion'],
+        $environment['platform'],
+        $environment['measurementExtensions'] === [] ? 'none' : \implode(', ', $environment['measurementExtensions']),
+    );
+    echo \sprintf(
+        "Source revision: %s%s.\n",
+        $environment['sourceRevision'] ?? 'unknown',
+        $environment['sourceTreeDirty'] === true ? ' (dirty)' : '',
+    );
+
+    if ($options['withComparisons']) {
+        echo \sprintf(
+            "Comparison tools: PHPUnit %s, ParaTest %s, Pest %s.\n",
+            PHPUNIT_VERSION,
+            PARATEST_VERSION,
+            PEST_VERSION,
+        );
+    }
+    echo \sprintf(
+        "%-20s %6s  %-24s %7s %8s %8s %8s %8s\n",
+        'shape',
+        'tests',
+        'tool',
+        'samples',
+        'q1',
+        'median',
+        'q3',
+        'rMAD',
+    );
+
+    foreach ($results as $row) {
+        echo \sprintf(
+            "%-20s %6d  %-24s %7d %7.3fs %7.3fs %7.3fs %7.1f%%\n",
+            $row['shape'],
+            $row['tests'],
+            $row['tool'],
+            \count($row['samplesSeconds']),
+            $row['firstQuartile'],
+            $row['median'],
+            $row['thirdQuartile'],
+            $row['relativeMadPercent'],
+        );
+    }
+}
+
+/**
+ * @return array{
+ *   measuredAtUtc: string,
+ *   phpVersion: string,
+ *   phpBinary: string,
+ *   platform: string,
+ *   sourceRevision: non-empty-string|null,
+ *   sourceTreeDirty: bool|null,
+ *   measurementExtensions: list<string>
+ * }
+ */
+function benchmarkEnvironment(string $root): array
+{
+    $extensions = \array_values(\array_filter(
+        ['blackfire', 'ddtrace', 'pcov', 'xdebug', 'Zend OPcache'],
+        \extension_loaded(...),
+    ));
+    $revisionOutput = [];
+    \exec(\sprintf('git -C %s rev-parse HEAD 2>/dev/null', \escapeshellarg($root)), $revisionOutput, $revisionExit);
+    $revision = $revisionExit === 0 && isset($revisionOutput[0]) && $revisionOutput[0] !== ''
+        ? $revisionOutput[0]
+        : null;
+    $statusOutput = [];
+    \exec(\sprintf('git -C %s status --porcelain --untracked-files=no 2>/dev/null', \escapeshellarg($root)), $statusOutput, $statusExit);
+
+    return [
+        'measuredAtUtc' => \gmdate('c'),
+        'phpVersion' => \PHP_VERSION,
+        'phpBinary' => \PHP_BINARY,
+        'platform' => \php_uname(),
+        'sourceRevision' => $revision,
+        'sourceTreeDirty' => $statusExit === 0 ? $statusOutput !== [] : null,
+        'measurementExtensions' => $extensions,
     ];
 }
 
 function benchmarkGenerateShape(string $shape, int $scale, string $project): int
 {
-    if (!\mkdir($project . '/tests/gl', 0o777, true) || !\mkdir($project . '/tests/pu', 0o777, true)) {
+    if (!\mkdir($project . '/tests/gl', 0o777, true)
+        || !\mkdir($project . '/tests/pu', 0o777, true)
+        || !\mkdir($project . '/tests/pest', 0o777, true)) {
         throw new RuntimeException('Greenlight did not create the benchmark project directory.');
     }
 
@@ -444,11 +681,27 @@ function benchmarkGenerateShape(string $shape, int $scale, string $project): int
         </phpunit>
         XML);
 
+    \file_put_contents($project . '/pest.xml', <<<'XML'
+        <?xml version="1.0" encoding="UTF-8"?>
+        <phpunit bootstrap="vendor/autoload.php" colors="false">
+            <testsuites>
+                <testsuite name="bench">
+                    <directory>tests/pest</directory>
+                </testsuite>
+            </testsuites>
+        </phpunit>
+        XML);
+
     \file_put_contents($project . '/composer.json', <<<'JSON'
         {
             "autoload-dev": {
                 "psr-4": {
                     "Bench\\": "tests/pu/"
+                }
+            },
+            "config": {
+                "allow-plugins": {
+                    "pestphp/pest-plugin": true
                 }
             }
         }
@@ -516,10 +769,19 @@ function benchmarkWriteClasses(
         $name = \sprintf('%s%04dTest', $prefix, $i);
         $glBody = '';
         $puBody = '';
+        $pestBody = '';
 
         for ($m = 0; $m < $methods; ++$m) {
-            $glWork = $sleepMicros > 0 ? \sprintf("\\usleep(%d);\n        ", $sleepMicros) : '';
+            $proofWork = \sprintf(<<<'PHP'
+                if (($proof = \getenv('BENCHMARK_PROOF_DIRECTORY')) !== false) {
+                    \touch($proof . '/%s-%04d-%04d');
+                }
+
+                PHP, \strtolower($prefix), $i, $m);
+            $sleepWork = $sleepMicros > 0 ? \sprintf("\\usleep(%d);\n        ", $sleepMicros) : '';
+            $glWork = $proofWork . $sleepWork;
             $puWork = $glWork;
+            $pestWork = $glWork;
 
             if ($diagnostics > 0) {
                 $diagnosticWork = \sprintf(
@@ -528,22 +790,27 @@ function benchmarkWriteClasses(
                 );
                 $glWork .= $diagnosticWork;
                 $puWork .= $diagnosticWork;
+                $pestWork .= $diagnosticWork;
             }
 
             if ($statements > 0) {
                 $glWork .= \sprintf("\$value = %d;\n        ", $m);
                 $puWork .= \sprintf("\$value = %d;\n        ", $m);
+                $pestWork .= \sprintf("\$value = %d;\n        ", $m);
 
                 for ($statement = 0; $statement < $statements; ++$statement) {
                     $glWork .= "\$value += 1;\n        ";
                     $puWork .= "\$value += 1;\n        ";
+                    $pestWork .= "\$value += 1;\n        ";
                 }
 
                 $glExpectation = \sprintf('Expect::that($value)->toBe(%d);', $m + $statements);
                 $puExpectation = \sprintf('$this->assertSame(%d, $value);', $m + $statements);
+                $pestExpectation = \sprintf('expect($value)->toBe(%d);', $m + $statements);
             } else {
                 $glExpectation = \sprintf('Expect::that(%d + 1)->toBe(%d);', $m, $m + 1);
                 $puExpectation = \sprintf('$this->assertSame(%d, %d + 1);', $m + 1, $m);
+                $pestExpectation = \sprintf('expect(%d + 1)->toBe(%d);', $m, $m + 1);
             }
 
             $glBody .= \sprintf(<<<'PHP'
@@ -563,6 +830,13 @@ function benchmarkWriteClasses(
                     }
 
                 PHP, $m, $puWork, $puExpectation);
+            $pestBody .= \sprintf(<<<'PHP'
+
+                test('case %d', function (): void {
+                    %s%s
+                })%s
+
+                PHP, $m, $pestWork, $pestExpectation, ';');
         }
 
         \file_put_contents($project . '/tests/gl/' . $name . '.php', \sprintf(<<<'PHP'
@@ -596,6 +870,13 @@ function benchmarkWriteClasses(
         %s}
 
         PHP_WRAP, $name, $puBody));
+
+        \file_put_contents($project . '/tests/pest/' . $name . '.php', \sprintf(<<<'PHP_WRAP'
+        <?php
+
+        declare(strict_types=1);
+        %s
+        PHP_WRAP, $pestBody));
     }
 
     return $classes * $methods;
@@ -620,6 +901,10 @@ function benchmarkWriteGiantDataSet(string $project, int $rows): int
             #[DataSet('rows')]
             public function handles(int $value): void
             {
+                if (($proof = \getenv('BENCHMARK_PROOF_DIRECTORY')) !== false) {
+                    \touch($proof . '/giant-' . $value);
+                }
+
                 Expect::that($value)->toBeGreaterThan(-1);
             }
 
@@ -649,6 +934,10 @@ function benchmarkWriteGiantDataSet(string $project, int $rows): int
         #[DataProvider('rows')]
         public function testHandles(int $value): void
         {
+            if (($proof = \getenv('BENCHMARK_PROOF_DIRECTORY')) !== false) {
+                \touch($proof . '/giant-' . $value);
+            }
+
             $this->assertGreaterThan(-1, $value);
         }
 
@@ -663,6 +952,25 @@ function benchmarkWriteGiantDataSet(string $project, int $rows): int
 
     PHP_WRAP, $rows));
 
+    \file_put_contents($project . '/tests/pest/GiantTest.php', \sprintf(<<<'PHP'
+        <?php
+
+        declare(strict_types=1);
+
+        test('handles', function (int $value): void {
+            if (($proof = \getenv('BENCHMARK_PROOF_DIRECTORY')) !== false) {
+                \touch($proof . '/giant-' . $value);
+            }
+
+            expect($value)->toBeGreaterThan(-1);
+        })->with((static function (): iterable {
+            for ($i = 0; $i < %d; ++$i) {
+                yield 'row ' . $i => [$i];
+            }
+        })());
+
+        PHP, $rows));
+
     return $rows;
 }
 
@@ -670,15 +978,50 @@ function benchmarkInstall(string $project): void
 {
     $output = [];
     \exec(\sprintf(
-        'cd %s && composer require --dev --quiet --no-interaction %s %s 2>&1',
+        'cd %s && composer require --dev --quiet --no-interaction %s %s %s 2>&1',
         \escapeshellarg($project),
         \escapeshellarg('phpunit/phpunit:' . PHPUNIT_VERSION),
         \escapeshellarg('brianium/paratest:' . PARATEST_VERSION),
+        \escapeshellarg('pestphp/pest:' . PEST_VERSION),
     ), $output, $exit);
 
     if ($exit !== 0) {
-        throw new RuntimeException("Composer did not install PHPUnit and ParaTest:\n" . \implode("\n", $output));
+        throw new RuntimeException("Composer did not install the comparison tools:\n" . \implode("\n", $output));
     }
+}
+
+/** @return array<string, non-empty-string> */
+function benchmarkInstalledPackages(string $project): array
+{
+    $installedFile = $project . '/vendor/composer/installed.php';
+
+    if (!\is_file($installedFile)) {
+        throw new RuntimeException('Composer did not create the comparison package metadata.');
+    }
+
+    $installed = require $installedFile;
+
+    if (!\is_array($installed) || !isset($installed['versions']) || !\is_array($installed['versions'])) {
+        throw new RuntimeException('Composer created invalid comparison package metadata.');
+    }
+
+    $versions = [];
+
+    foreach ($installed['versions'] as $package => $metadata) {
+        if (!\is_string($package) || $package === '__root__' || !\is_array($metadata)) {
+            continue;
+        }
+
+        $version = $metadata['pretty_version'] ?? null;
+
+        if (\is_string($version) && $version !== '') {
+            $versions[$package] = $version;
+        }
+    }
+
+    \ksort($versions);
+
+    return $versions;
 }
 
 function benchmarkRemoveTree(string $directory): void


### PR DESCRIPTION
Makes benchmark comparisons self-verifying and reproducible. It adds balanced samples, robust distribution statistics, raw JSON provenance, isolated tool caches, and native serial and parallel Pest fixtures. It also removes the outdated published numbers and documents a strict publication procedure.