### PR TITLE
refactor(expect): simplify temporal expectation interface

### DIFF
--- a/docs/api-expectations.md
+++ b/docs/api-expectations.md
@@ -11,78 +11,1142 @@ These signatures are the public API.
 Namespace: `Greenlight\Expect`
 
 Checks each probe value for a fixed period and fails on the first mismatch.
+Use `Expect::consistently()` and `for()` to create this object.
 
 ```php
-final class ConsistentlyExpectation extends TemporalExpectation
+final class ConsistentlyExpectation
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/ConsistentlyExpectation.php#L17)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/ConsistentlyExpectation.php#L18)
 
 PHPDoc:
 
 - `@template T`
-- `@extends TemporalExpectation<T>`
 
-### `__construct()`
+### `__call()`
+
+Runs a native or configured extension matcher against each probe value.
 
 ```php
-public function __construct(
-    \Closure $probe,
-    PollingClock $clock,
-    ?float $attemptDeadline,
-    float $intervalSeconds,
-    private readonly float $forSeconds,
-    ValueRenderer $renderer,
-    array $extensions,
-)
+final public function __call(string $name, array $arguments): Expectation
 ```
 
 PHPDoc:
 
-- `@param \Closure(): T $probe`
-- `@param list<ExpectationExtension> $extensions`
+- `@param array<array-key, mixed> $arguments`
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/ConsistentlyExpectation.php#L23)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L85)
+
+### `not()`
+
+Negates the next matcher for every value returned by the probe.
+
+```php
+final public function not(): static
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L42)
+
+### `because()`
+
+Sets a reason for the next matcher. The next matcher consumes the
+reason.
+
+If the matcher fails, the failure message ends with "because" and the
+reason. An empty reason causes a usage failure.
+
+```php
+final public function because(string $reason): static
+```
+
+PHPDoc:
+
+- `@param non-empty-string $reason`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L60)
+
+### `toBe()`
+
+Passes when the subject and expected value are identical (===).
+
+```php
+public function toBe(mixed $expected): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L175)
+
+### `toEqual()`
+
+Passes when the subject and expected value satisfy the rules for deep
+equality on this class.
+
+```php
+public function toEqual(mixed $expected): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L192)
+
+### `toEqualCanonicalizing()`
+
+Uses the `toEqual()` rules but ignores list-element order at all levels.
+Associative arrays keep their keys.
+
+```php
+public function toEqualCanonicalizing(mixed $expected): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L209)
+
+### `toBeOneOf()`
+
+Passes when the subject is identical (===) to one of the options.
+
+```php
+public function toBeOneOf(mixed ...$options): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L225)
+
+### `toBeIn()`
+
+Passes when the haystack contains the subject by identity (===). This
+matcher is the reverse of `toContain()`. The check consumes a `Traversable`
+haystack.
+
+```php
+public function toBeIn(iterable $haystack): Expectation
+```
+
+PHPDoc:
+
+- `@param iterable<mixed> $haystack`
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L245)
+
+### `toBeInstanceOf()`
+
+```php
+public function toBeInstanceOf(string $class): Expectation
+```
+
+PHPDoc:
+
+- `@param class-string $class`
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L263)
+
+### `toBeTrue()`
+
+```php
+public function toBeTrue(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L277)
+
+### `toBeFalse()`
+
+```php
+public function toBeFalse(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L287)
+
+### `toBeNull()`
+
+```php
+public function toBeNull(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L297)
+
+### `toBeArray()`
+
+```php
+public function toBeArray(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L307)
+
+### `toBeString()`
+
+```php
+public function toBeString(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L322)
+
+### `toBeInt()`
+
+```php
+public function toBeInt(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L337)
+
+### `toBeFloat()`
+
+```php
+public function toBeFloat(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L352)
+
+### `toBeBool()`
+
+```php
+public function toBeBool(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L367)
+
+### `toBeCallable()`
+
+```php
+public function toBeCallable(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L382)
+
+### `toBeIterable()`
+
+```php
+public function toBeIterable(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L397)
+
+### `toContain()`
+
+For a string subject, checks for a string needle. For an iterable
+subject, checks for the value by identity (===). The check consumes a
+`Traversable` subject.
+
+```php
+public function toContain(mixed $needle): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L416)
+
+### `toHaveCount()`
+
+The subject must be `Countable` or `Traversable`. The count consumes a
+`Traversable` subject.
+
+```php
+public function toHaveCount(int $count): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L465)
+
+### `toBeEmpty()`
+
+Passes when the subject is an empty string or contains no elements.
+The subject must be a string, array, `Countable`, or iterable. The check
+consumes a `Traversable` subject.
+
+```php
+public function toBeEmpty(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L495)
+
+### `toHaveLength()`
+
+For a valid UTF-8 string, measures the number of code points. For other
+strings, measures the number of bytes. Array and `Countable` subjects use
+`count()`.
+
+```php
+public function toHaveLength(int $length): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L522)
+
+### `toHaveKey()`
+
+The subject must be an array or an `ArrayAccess` implementation. The
+matcher uses `array_key_exists()` for arrays and `offsetExists()` for
+`ArrayAccess`.
+
+```php
+public function toHaveKey(int|string $key): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L553)
+
+### `toContainSubset()`
+
+Each subset key must exist in the subject with an equal value. Equality
+uses the `toEqual()` rules. A nested array is also a subset. The
+related nested subject array can contain extra keys. The failure
+identifies the first different key by its dot-separated path.
+
+```php
+public function toContainSubset(array $subset): Expectation
+```
+
+PHPDoc:
+
+- `@param array<array-key, mixed> $subset`
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L585)
+
+### `toBeGreaterThan()`
+
+```php
+public function toBeGreaterThan(int|float $bound): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L615)
+
+### `toBeGreaterThanOrEqual()`
+
+```php
+public function toBeGreaterThanOrEqual(int|float $bound): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L629)
+
+### `toBeLessThan()`
+
+```php
+public function toBeLessThan(int|float $bound): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L643)
+
+### `toBeLessThanOrEqual()`
+
+```php
+public function toBeLessThanOrEqual(int|float $bound): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L657)
+
+### `toBeWithin()`
+
+Passes when the absolute difference between the numeric subject and
+`$of` is not more than `$delta`. The tolerance MUST be finite and zero
+or more.
+
+```php
+public function toBeWithin(float $delta, float $of): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L675)
+
+### `toMatch()`
+
+```php
+public function toMatch(string $pattern): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L702)
+
+### `toStartWith()`
+
+```php
+public function toStartWith(string $prefix): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L718)
+
+### `toEndWith()`
+
+```php
+public function toEndWith(string $suffix): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L732)
+
+### `toBeJson()`
+
+The subject must be a string. The matcher passes when the string
+contains valid JSON.
+
+```php
+public function toBeJson(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L749)
+
+### `toMatchJson()`
+
+The subject must be a string that contains valid JSON. The matcher
+decodes the subject and expected JSON. It then applies deep equality to
+the results. Object-key order has no effect. Invalid subject JSON causes
+an expectation failure. Invalid expected JSON causes a usage error.
+
+```php
+public function toMatchJson(string $expected): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L768)
+
+### `toThrow()`
+
+The subject must be callable. The matcher calls it with no arguments.
+It passes when the subject throws an instance of the specified class.
+A Throwable instance instead requires the subject to throw that exact
+object.
+
+The throwable can instead be a callback with one typed Throwable
+parameter. Its parameter type specifies the expected throwable class.
+Greenlight gives the caught throwable to the callback after its type
+matches. The callback matches when it returns without an expectation
+failure.
+
+The optional `matching:` argument checks the message with a regular
+expression. The `message:` argument checks the exact message. Do not use
+these arguments with a throwable callback or instance.
+
+With `not()`, a throwable that does not satisfy all applicable
+constraints makes the matcher pass. A different object does not satisfy
+an instance constraint.
+
+```php
+public function toThrow(
+    string|\Closure|\Throwable $throwable,
+    ?string $matching = null,
+    ?string $message = null,
+): Expectation
+```
+
+PHPDoc:
+
+- `@template TThrowable of \Throwable`
+- `@param class-string<TThrowable>|TThrowable|\Closure(TThrowable): void $throwable`
+- `@return Expectation<T>`
+- `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L827)
 
 ## `EventuallyExpectation`
 
 Namespace: `Greenlight\Expect`
 
 Polls the probe until its matcher passes or the deadline expires.
+Use `Expect::eventually()` and `within()` to create this object.
 
 ```php
-final class EventuallyExpectation extends TemporalExpectation
+final class EventuallyExpectation
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/EventuallyExpectation.php#L18)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/EventuallyExpectation.php#L19)
 
 PHPDoc:
 
 - `@template T`
-- `@extends TemporalExpectation<T>`
 
-### `__construct()`
+### `__call()`
+
+Runs a native or configured extension matcher against each probe value.
 
 ```php
-public function __construct(
-    \Closure $probe,
-    PollingClock $clock,
-    ?float $attemptDeadline,
-    float $intervalSeconds,
-    private readonly float $withinSeconds,
-    private readonly array $retryOnExceptions,
-    ValueRenderer $renderer,
-    array $extensions,
-)
+final public function __call(string $name, array $arguments): Expectation
 ```
 
 PHPDoc:
 
-- `@param \Closure(): T $probe`
-- `@param list<class-string<\Exception>> $retryOnExceptions`
-- `@param list<ExpectationExtension> $extensions`
+- `@param array<array-key, mixed> $arguments`
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/EventuallyExpectation.php#L25)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L85)
+
+### `not()`
+
+Negates the next matcher for every value returned by the probe.
+
+```php
+final public function not(): static
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L42)
+
+### `because()`
+
+Sets a reason for the next matcher. The next matcher consumes the
+reason.
+
+If the matcher fails, the failure message ends with "because" and the
+reason. An empty reason causes a usage failure.
+
+```php
+final public function because(string $reason): static
+```
+
+PHPDoc:
+
+- `@param non-empty-string $reason`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L60)
+
+### `toBe()`
+
+Passes when the subject and expected value are identical (===).
+
+```php
+public function toBe(mixed $expected): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L175)
+
+### `toEqual()`
+
+Passes when the subject and expected value satisfy the rules for deep
+equality on this class.
+
+```php
+public function toEqual(mixed $expected): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L192)
+
+### `toEqualCanonicalizing()`
+
+Uses the `toEqual()` rules but ignores list-element order at all levels.
+Associative arrays keep their keys.
+
+```php
+public function toEqualCanonicalizing(mixed $expected): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L209)
+
+### `toBeOneOf()`
+
+Passes when the subject is identical (===) to one of the options.
+
+```php
+public function toBeOneOf(mixed ...$options): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L225)
+
+### `toBeIn()`
+
+Passes when the haystack contains the subject by identity (===). This
+matcher is the reverse of `toContain()`. The check consumes a `Traversable`
+haystack.
+
+```php
+public function toBeIn(iterable $haystack): Expectation
+```
+
+PHPDoc:
+
+- `@param iterable<mixed> $haystack`
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L245)
+
+### `toBeInstanceOf()`
+
+```php
+public function toBeInstanceOf(string $class): Expectation
+```
+
+PHPDoc:
+
+- `@param class-string $class`
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L263)
+
+### `toBeTrue()`
+
+```php
+public function toBeTrue(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L277)
+
+### `toBeFalse()`
+
+```php
+public function toBeFalse(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L287)
+
+### `toBeNull()`
+
+```php
+public function toBeNull(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L297)
+
+### `toBeArray()`
+
+```php
+public function toBeArray(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L307)
+
+### `toBeString()`
+
+```php
+public function toBeString(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L322)
+
+### `toBeInt()`
+
+```php
+public function toBeInt(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L337)
+
+### `toBeFloat()`
+
+```php
+public function toBeFloat(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L352)
+
+### `toBeBool()`
+
+```php
+public function toBeBool(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L367)
+
+### `toBeCallable()`
+
+```php
+public function toBeCallable(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L382)
+
+### `toBeIterable()`
+
+```php
+public function toBeIterable(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L397)
+
+### `toContain()`
+
+For a string subject, checks for a string needle. For an iterable
+subject, checks for the value by identity (===). The check consumes a
+`Traversable` subject.
+
+```php
+public function toContain(mixed $needle): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L416)
+
+### `toHaveCount()`
+
+The subject must be `Countable` or `Traversable`. The count consumes a
+`Traversable` subject.
+
+```php
+public function toHaveCount(int $count): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L465)
+
+### `toBeEmpty()`
+
+Passes when the subject is an empty string or contains no elements.
+The subject must be a string, array, `Countable`, or iterable. The check
+consumes a `Traversable` subject.
+
+```php
+public function toBeEmpty(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L495)
+
+### `toHaveLength()`
+
+For a valid UTF-8 string, measures the number of code points. For other
+strings, measures the number of bytes. Array and `Countable` subjects use
+`count()`.
+
+```php
+public function toHaveLength(int $length): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L522)
+
+### `toHaveKey()`
+
+The subject must be an array or an `ArrayAccess` implementation. The
+matcher uses `array_key_exists()` for arrays and `offsetExists()` for
+`ArrayAccess`.
+
+```php
+public function toHaveKey(int|string $key): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L553)
+
+### `toContainSubset()`
+
+Each subset key must exist in the subject with an equal value. Equality
+uses the `toEqual()` rules. A nested array is also a subset. The
+related nested subject array can contain extra keys. The failure
+identifies the first different key by its dot-separated path.
+
+```php
+public function toContainSubset(array $subset): Expectation
+```
+
+PHPDoc:
+
+- `@param array<array-key, mixed> $subset`
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L585)
+
+### `toBeGreaterThan()`
+
+```php
+public function toBeGreaterThan(int|float $bound): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L615)
+
+### `toBeGreaterThanOrEqual()`
+
+```php
+public function toBeGreaterThanOrEqual(int|float $bound): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L629)
+
+### `toBeLessThan()`
+
+```php
+public function toBeLessThan(int|float $bound): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L643)
+
+### `toBeLessThanOrEqual()`
+
+```php
+public function toBeLessThanOrEqual(int|float $bound): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L657)
+
+### `toBeWithin()`
+
+Passes when the absolute difference between the numeric subject and
+`$of` is not more than `$delta`. The tolerance MUST be finite and zero
+or more.
+
+```php
+public function toBeWithin(float $delta, float $of): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L675)
+
+### `toMatch()`
+
+```php
+public function toMatch(string $pattern): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L702)
+
+### `toStartWith()`
+
+```php
+public function toStartWith(string $prefix): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L718)
+
+### `toEndWith()`
+
+```php
+public function toEndWith(string $suffix): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L732)
+
+### `toBeJson()`
+
+The subject must be a string. The matcher passes when the string
+contains valid JSON.
+
+```php
+public function toBeJson(): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L749)
+
+### `toMatchJson()`
+
+The subject must be a string that contains valid JSON. The matcher
+decodes the subject and expected JSON. It then applies deep equality to
+the results. Object-key order has no effect. Invalid subject JSON causes
+an expectation failure. Invalid expected JSON causes a usage error.
+
+```php
+public function toMatchJson(string $expected): Expectation
+```
+
+PHPDoc:
+
+- `@return Expectation<T>`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L768)
+
+### `toThrow()`
+
+The subject must be callable. The matcher calls it with no arguments.
+It passes when the subject throws an instance of the specified class.
+A Throwable instance instead requires the subject to throw that exact
+object.
+
+The throwable can instead be a callback with one typed Throwable
+parameter. Its parameter type specifies the expected throwable class.
+Greenlight gives the caught throwable to the callback after its type
+matches. The callback matches when it returns without an expectation
+failure.
+
+The optional `matching:` argument checks the message with a regular
+expression. The `message:` argument checks the exact message. Do not use
+these arguments with a throwable callback or instance.
+
+With `not()`, a throwable that does not satisfy all applicable
+constraints makes the matcher pass. A different object does not satisfy
+an instance constraint.
+
+```php
+public function toThrow(
+    string|\Closure|\Throwable $throwable,
+    ?string $matching = null,
+    ?string $message = null,
+): Expectation
+```
+
+PHPDoc:
+
+- `@template TThrowable of \Throwable`
+- `@param class-string<TThrowable>|TThrowable|\Closure(TThrowable): void $throwable`
+- `@return Expectation<T>`
+- `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
+- `@throws ExpectationFailed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L827)
 
 ## `Expect`
 
@@ -199,7 +1263,7 @@ public function __call(string $name, array $arguments): self
 
 PHPDoc:
 
-- `@param array<int, mixed> $arguments`
+- `@param array<array-key, mixed> $arguments`
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
@@ -219,7 +1283,7 @@ PHPDoc:
 
 - `@return self<T>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L100)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L135)
 
 ### `because()`
 
@@ -239,7 +1303,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L120)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L155)
 
 ### `toBe()`
 
@@ -254,7 +1318,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L140)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L175)
 
 ### `toEqual()`
 
@@ -270,7 +1334,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L157)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L192)
 
 ### `toEqualCanonicalizing()`
 
@@ -286,7 +1350,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L174)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L209)
 
 ### `toBeOneOf()`
 
@@ -301,7 +1365,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L190)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L225)
 
 ### `toBeIn()`
 
@@ -319,7 +1383,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L210)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L245)
 
 ### `toBeInstanceOf()`
 
@@ -333,7 +1397,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L228)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L263)
 
 ### `toBeTrue()`
 
@@ -346,7 +1410,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L242)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L277)
 
 ### `toBeFalse()`
 
@@ -359,7 +1423,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L252)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L287)
 
 ### `toBeNull()`
 
@@ -372,7 +1436,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L262)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L297)
 
 ### `toBeArray()`
 
@@ -385,7 +1449,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L272)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L307)
 
 ### `toBeString()`
 
@@ -398,7 +1462,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L287)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L322)
 
 ### `toBeInt()`
 
@@ -411,7 +1475,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L302)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L337)
 
 ### `toBeFloat()`
 
@@ -424,7 +1488,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L317)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L352)
 
 ### `toBeBool()`
 
@@ -437,7 +1501,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L332)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L367)
 
 ### `toBeCallable()`
 
@@ -450,7 +1514,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L347)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L382)
 
 ### `toBeIterable()`
 
@@ -463,7 +1527,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L362)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L397)
 
 ### `toContain()`
 
@@ -480,7 +1544,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L381)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L416)
 
 ### `toHaveCount()`
 
@@ -496,7 +1560,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L430)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L465)
 
 ### `toBeEmpty()`
 
@@ -513,7 +1577,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L460)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L495)
 
 ### `toHaveLength()`
 
@@ -530,7 +1594,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L487)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L522)
 
 ### `toHaveKey()`
 
@@ -547,7 +1611,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L518)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L553)
 
 ### `toContainSubset()`
 
@@ -566,7 +1630,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L550)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L585)
 
 ### `toBeGreaterThan()`
 
@@ -579,7 +1643,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L580)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L615)
 
 ### `toBeGreaterThanOrEqual()`
 
@@ -592,7 +1656,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L594)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L629)
 
 ### `toBeLessThan()`
 
@@ -605,7 +1669,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L608)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L643)
 
 ### `toBeLessThanOrEqual()`
 
@@ -618,7 +1682,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L622)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L657)
 
 ### `toBeWithin()`
 
@@ -635,7 +1699,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L640)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L675)
 
 ### `toMatch()`
 
@@ -649,7 +1713,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L667)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L702)
 
 ### `toStartWith()`
 
@@ -662,7 +1726,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L683)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L718)
 
 ### `toEndWith()`
 
@@ -675,7 +1739,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L697)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L732)
 
 ### `toBeJson()`
 
@@ -691,7 +1755,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L714)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L749)
 
 ### `toMatchJson()`
 
@@ -709,7 +1773,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L733)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L768)
 
 ### `toThrow()`
 
@@ -748,7 +1812,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L792)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L827)
 
 ## `ExpectationExtension`
 
@@ -864,35 +1928,17 @@ PHPDoc:
 Namespace: `Greenlight\Expect`
 
 Collects poll options until `for()` sets the duration.
+Use `Expect::consistently()` to create this object.
 
 ```php
 final class PendingConsistently
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingConsistently.php#L12)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingConsistently.php#L13)
 
 PHPDoc:
 
 - `@template T`
-
-### `__construct()`
-
-```php
-public function __construct(
-    private readonly \Closure $probe,
-    private readonly PollingClock $clock,
-    private readonly ?float $attemptDeadline,
-    private readonly ValueRenderer $renderer,
-    private readonly array $extensions,
-)
-```
-
-PHPDoc:
-
-- `@param \Closure(): T $probe`
-- `@param list<ExpectationExtension> $extensions`
-
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingConsistently.php#L22)
 
 ### `pollEvery()`
 
@@ -904,7 +1950,7 @@ PHPDoc:
 
 - `@return self<T>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingConsistently.php#L33)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingConsistently.php#L54)
 
 ### `for()`
 
@@ -916,42 +1962,24 @@ PHPDoc:
 
 - `@return ConsistentlyExpectation<T>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingConsistently.php#L49)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingConsistently.php#L70)
 
 ## `PendingEventually`
 
 Namespace: `Greenlight\Expect`
 
 Collects poll options until `within()` sets the deadline.
+Use `Expect::eventually()` to create this object.
 
 ```php
 final class PendingEventually
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingEventually.php#L12)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingEventually.php#L13)
 
 PHPDoc:
 
 - `@template T`
-
-### `__construct()`
-
-```php
-public function __construct(
-    private readonly \Closure $probe,
-    private readonly PollingClock $clock,
-    private readonly ?float $attemptDeadline,
-    private readonly ValueRenderer $renderer,
-    private readonly array $extensions,
-)
-```
-
-PHPDoc:
-
-- `@param \Closure(): T $probe`
-- `@param list<ExpectationExtension> $extensions`
-
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingEventually.php#L27)
 
 ### `pollEvery()`
 
@@ -963,7 +1991,7 @@ PHPDoc:
 
 - `@return self<T>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingEventually.php#L38)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingEventually.php#L59)
 
 ### `retryOnException()`
 
@@ -976,7 +2004,7 @@ PHPDoc:
 - `@param class-string<\Exception> ...$types`
 - `@return self<T>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingEventually.php#L51)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingEventually.php#L72)
 
 ### `within()`
 
@@ -988,4 +2016,4 @@ PHPDoc:
 
 - `@return EventuallyExpectation<T>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingEventually.php#L66)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingEventually.php#L87)

--- a/docs/architecture/temporal-expectations.md
+++ b/docs/architecture/temporal-expectations.md
@@ -4,10 +4,17 @@
 values that a probe returns. Only the fluent API is public. Its poll support is
 internal.
 
+These `Expect` methods are the public construction interface. The constructors
+and dependency-based creation methods are internal.
+
 ## Matcher operation
 
-`TemporalExpectation` has the same native matcher methods as `Expectation`.
-Each poll creates an ordinary expectation for the probe value. It then runs the
+`TemporalExpectation::__call()` sends native and extension matcher calls to an
+ordinary `Expectation`. The `@mixin Expectation<T>` declaration supplies the
+native matcher types to PHPStan. The API-reference generator uses this
+declaration to document the same methods on each public temporal return type.
+
+Each poll creates an ordinary expectation for the probe value. It runs the
 selected matcher without an increment to the expectation counter. The temporal
 matcher increments the counter one time.
 

--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -209,6 +209,9 @@ Expect::eventually(fn(): string => $hash)
     ->toHaveDigestLength(6);
 ```
 
+Temporal return types mix in the native `Expectation<T>` matcher declarations.
+Thus, native and extension matchers keep the probe subject type.
+
 If configuration files register one matcher name with different parameter or
 return types, analysis fails. PHPStan does not select one signature.
 

--- a/src/Expect/ConsistentlyExpectation.php
+++ b/src/Expect/ConsistentlyExpectation.php
@@ -9,6 +9,7 @@ use Greenlight\Core\Test\ExpectationCounter;
 
 /**
  * Checks each probe value for a fixed period and fails on the first mismatch.
+ * Use `Expect::consistently()` and `for()` to create this object.
  *
  * @template T
  *
@@ -20,7 +21,7 @@ final class ConsistentlyExpectation extends TemporalExpectation
      * @param \Closure(): T $probe
      * @param list<ExpectationExtension> $extensions
      */
-    public function __construct(
+    private function __construct(
         \Closure $probe,
         PollingClock $clock,
         ?float $attemptDeadline,
@@ -34,6 +35,36 @@ final class ConsistentlyExpectation extends TemporalExpectation
             $clock,
             $attemptDeadline,
             $intervalSeconds,
+            $renderer,
+            $extensions,
+        );
+    }
+
+    /**
+     * @internal Use Expect::consistently() and for() instead.
+     *
+     * @template TProbe
+     *
+     * @param \Closure(): TProbe $probe
+     * @param list<ExpectationExtension> $extensions
+     *
+     * @return self<TProbe>
+     */
+    public static function create(
+        \Closure $probe,
+        PollingClock $clock,
+        ?float $attemptDeadline,
+        float $intervalSeconds,
+        float $forSeconds,
+        ValueRenderer $renderer,
+        array $extensions,
+    ): self {
+        return new self(
+            $probe,
+            $clock,
+            $attemptDeadline,
+            $intervalSeconds,
+            $forSeconds,
             $renderer,
             $extensions,
         );

--- a/src/Expect/EventuallyExpectation.php
+++ b/src/Expect/EventuallyExpectation.php
@@ -10,6 +10,7 @@ use Greenlight\Core\Test\ExpectationCounter;
 
 /**
  * Polls the probe until its matcher passes or the deadline expires.
+ * Use `Expect::eventually()` and `within()` to create this object.
  *
  * @template T
  *
@@ -22,7 +23,7 @@ final class EventuallyExpectation extends TemporalExpectation
      * @param list<class-string<\Exception>> $retryOnExceptions
      * @param list<ExpectationExtension> $extensions
      */
-    public function __construct(
+    private function __construct(
         \Closure $probe,
         PollingClock $clock,
         ?float $attemptDeadline,
@@ -37,6 +38,39 @@ final class EventuallyExpectation extends TemporalExpectation
             $clock,
             $attemptDeadline,
             $intervalSeconds,
+            $renderer,
+            $extensions,
+        );
+    }
+
+    /**
+     * @internal Use Expect::eventually() and within() instead.
+     *
+     * @template TProbe
+     *
+     * @param \Closure(): TProbe $probe
+     * @param list<class-string<\Exception>> $retryOnExceptions
+     * @param list<ExpectationExtension> $extensions
+     *
+     * @return self<TProbe>
+     */
+    public static function create(
+        \Closure $probe,
+        PollingClock $clock,
+        ?float $attemptDeadline,
+        float $intervalSeconds,
+        float $withinSeconds,
+        array $retryOnExceptions,
+        ValueRenderer $renderer,
+        array $extensions,
+    ): self {
+        return new self(
+            $probe,
+            $clock,
+            $attemptDeadline,
+            $intervalSeconds,
+            $withinSeconds,
+            $retryOnExceptions,
             $renderer,
             $extensions,
         );

--- a/src/Expect/Expect.php
+++ b/src/Expect/Expect.php
@@ -43,7 +43,7 @@ final class Expect
      */
     public static function eventually(callable $probe): PendingEventually
     {
-        return new PendingEventually(
+        return PendingEventually::create(
             \Closure::fromCallable($probe),
             ExpectationRuntime::clock(),
             ExpectationRuntime::deadline(),
@@ -63,7 +63,7 @@ final class Expect
      */
     public static function consistently(callable $probe): PendingConsistently
     {
-        return new PendingConsistently(
+        return PendingConsistently::create(
             \Closure::fromCallable($probe),
             ExpectationRuntime::clock(),
             ExpectationRuntime::deadline(),

--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -63,7 +63,7 @@ final class Expectation
      * An extension cannot replace a native matcher. PHP calls the native
      * method directly.
      *
-     * @param array<int, mixed> $arguments
+     * @param array<array-key, mixed> $arguments
      *
      * @return self<T>
      *
@@ -88,6 +88,41 @@ final class Expectation
             'Greenlight has no native or registered extension matcher named %s.',
             $name,
         ));
+    }
+
+    /**
+     * Runs one native or extension matcher by name.
+     *
+     * @internal Temporal expectations use this method for matcher dispatch.
+     *
+     * @param array<array-key, mixed> $arguments
+     *
+     * @return self<T>
+     *
+     * @throws ExpectationFailed
+     */
+    public function dispatchMatcher(string $name, array $arguments): self
+    {
+        try {
+            $method = new \ReflectionMethod($this, $name);
+        } catch (\ReflectionException) {
+            return $this->__call($name, $arguments);
+        }
+
+        if (!$method->isPublic() || $method->isStatic() || $name === '__call') {
+            return $this->__call($name, $arguments);
+        }
+
+        $result = $method->invokeArgs($this, $arguments);
+
+        if (!$result instanceof self) {
+            throw new \LogicException(\sprintf(
+                'Matcher "%s" did not return an Expectation.',
+                $name,
+            ));
+        }
+
+        return $result;
     }
 
     /**

--- a/src/Expect/PendingConsistently.php
+++ b/src/Expect/PendingConsistently.php
@@ -6,6 +6,7 @@ namespace Greenlight\Expect;
 
 /**
  * Collects poll options until `for()` sets the duration.
+ * Use `Expect::consistently()` to create this object.
  *
  * @template T
  */
@@ -19,13 +20,33 @@ final class PendingConsistently
      * @param \Closure(): T $probe
      * @param list<ExpectationExtension> $extensions
      */
-    public function __construct(
+    private function __construct(
         private readonly \Closure $probe,
         private readonly PollingClock $clock,
         private readonly ?float $attemptDeadline,
         private readonly ValueRenderer $renderer,
         private readonly array $extensions,
     ) {}
+
+    /**
+     * @internal Use Expect::consistently() instead.
+     *
+     * @template TProbe
+     *
+     * @param \Closure(): TProbe $probe
+     * @param list<ExpectationExtension> $extensions
+     *
+     * @return self<TProbe>
+     */
+    public static function create(
+        \Closure $probe,
+        PollingClock $clock,
+        ?float $attemptDeadline,
+        ValueRenderer $renderer,
+        array $extensions,
+    ): self {
+        return new self($probe, $clock, $attemptDeadline, $renderer, $extensions);
+    }
 
     /**
      * @return self<T>
@@ -54,7 +75,7 @@ final class PendingConsistently
             );
         }
 
-        return new ConsistentlyExpectation(
+        return ConsistentlyExpectation::create(
             $this->probe,
             $this->clock,
             $this->attemptDeadline,

--- a/src/Expect/PendingEventually.php
+++ b/src/Expect/PendingEventually.php
@@ -6,6 +6,7 @@ namespace Greenlight\Expect;
 
 /**
  * Collects poll options until `within()` sets the deadline.
+ * Use `Expect::eventually()` to create this object.
  *
  * @template T
  */
@@ -24,13 +25,33 @@ final class PendingEventually
      * @param \Closure(): T $probe
      * @param list<ExpectationExtension> $extensions
      */
-    public function __construct(
+    private function __construct(
         private readonly \Closure $probe,
         private readonly PollingClock $clock,
         private readonly ?float $attemptDeadline,
         private readonly ValueRenderer $renderer,
         private readonly array $extensions,
     ) {}
+
+    /**
+     * @internal Use Expect::eventually() instead.
+     *
+     * @template TProbe
+     *
+     * @param \Closure(): TProbe $probe
+     * @param list<ExpectationExtension> $extensions
+     *
+     * @return self<TProbe>
+     */
+    public static function create(
+        \Closure $probe,
+        PollingClock $clock,
+        ?float $attemptDeadline,
+        ValueRenderer $renderer,
+        array $extensions,
+    ): self {
+        return new self($probe, $clock, $attemptDeadline, $renderer, $extensions);
+    }
 
     /**
      * @return self<T>
@@ -67,7 +88,7 @@ final class PendingEventually
     {
         $this->requireDuration($seconds, 'Eventually duration');
 
-        return new EventuallyExpectation(
+        return EventuallyExpectation::create(
             $this->probe,
             $this->clock,
             $this->attemptDeadline,

--- a/src/Expect/TemporalExpectation.php
+++ b/src/Expect/TemporalExpectation.php
@@ -15,6 +15,7 @@ use Greenlight\Core\Test\ExpectationCounter;
  * @internal
  *
  * @template T
+ * @mixin Expectation<T>
  */
 abstract class TemporalExpectation
 {
@@ -37,9 +38,7 @@ abstract class TemporalExpectation
         protected readonly array $extensions,
     ) {}
 
-    /**
-     * Negates the next matcher for every value returned by the probe.
-     */
+    /** Negates the next matcher for every value returned by the probe. */
     final public function not(): static
     {
         $this->negated = true;
@@ -75,9 +74,9 @@ abstract class TemporalExpectation
     }
 
     /**
-     * Runs a configured extension matcher against each value from the probe.
+     * Runs a native or configured extension matcher against each probe value.
      *
-     * @param array<int, mixed> $arguments
+     * @param array<array-key, mixed> $arguments
      *
      * @return Expectation<T>
      *
@@ -85,391 +84,57 @@ abstract class TemporalExpectation
      */
     final public function __call(string $name, array $arguments): Expectation
     {
+        if ($name === 'toThrow') {
+            $this->validateToThrowArguments($arguments);
+        }
+
+        if ($name === 'toBeIn') {
+            $key = \array_key_exists('haystack', $arguments) ? 'haystack' : 0;
+            $haystack = $arguments[$key] ?? null;
+
+            if ($haystack instanceof \Traversable) {
+                $arguments[$key] = \iterator_to_array($haystack, false);
+            }
+        }
+
         return $this->apply(
-            static fn(Expectation $expectation): Expectation => $expectation->__call($name, \array_values($arguments)),
+            static fn(Expectation $expectation): Expectation => $expectation->dispatchMatcher($name, $arguments),
         );
     }
 
     /**
-     * @return Expectation<T>
+     * @param array<array-key, mixed> $arguments
      *
      * @throws ExpectationFailed
      */
-    final public function toBe(mixed $expected): Expectation
+    private function validateToThrowArguments(array $arguments): void
     {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toBe($expected));
-    }
+        $throwable = $arguments['throwable'] ?? $arguments[0] ?? null;
+        $matching = $arguments['matching'] ?? $arguments[1] ?? null;
+        $message = $arguments['message'] ?? $arguments[2] ?? null;
 
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toEqual(mixed $expected): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toEqual($expected));
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toEqualCanonicalizing(mixed $expected): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toEqualCanonicalizing($expected));
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toBeOneOf(mixed ...$options): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toBeOneOf(...$options));
-    }
-
-    /**
-     * @param iterable<mixed> $haystack
-     *
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toBeIn(iterable $haystack): Expectation
-    {
-        $stableHaystack = \is_array($haystack) ? $haystack : \iterator_to_array($haystack, false);
-
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toBeIn($stableHaystack));
-    }
-
-    /**
-     * @param class-string $class
-     *
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toBeInstanceOf(string $class): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toBeInstanceOf($class));
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toBeTrue(): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toBeTrue());
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toBeFalse(): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toBeFalse());
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toBeNull(): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toBeNull());
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toBeArray(): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toBeArray());
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toBeString(): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toBeString());
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toBeInt(): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toBeInt());
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toBeFloat(): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toBeFloat());
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toBeBool(): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toBeBool());
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toBeCallable(): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toBeCallable());
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toBeIterable(): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toBeIterable());
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toContain(mixed $needle): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toContain($needle));
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toHaveCount(int $count): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toHaveCount($count));
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toBeEmpty(): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toBeEmpty());
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toHaveLength(int $length): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toHaveLength($length));
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toHaveKey(int|string $key): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toHaveKey($key));
-    }
-
-    /**
-     * @param array<array-key, mixed> $subset
-     *
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toContainSubset(array $subset): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toContainSubset($subset));
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toBeGreaterThan(int|float $bound): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toBeGreaterThan($bound));
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toBeGreaterThanOrEqual(int|float $bound): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toBeGreaterThanOrEqual($bound));
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toBeLessThan(int|float $bound): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toBeLessThan($bound));
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toBeLessThanOrEqual(int|float $bound): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toBeLessThanOrEqual($bound));
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toBeWithin(float $delta, float $of): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toBeWithin($delta, $of));
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toMatch(string $pattern): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toMatch($pattern));
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toStartWith(string $prefix): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toStartWith($prefix));
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toEndWith(string $suffix): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toEndWith($suffix));
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toBeJson(): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toBeJson());
-    }
-
-    /**
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toMatchJson(string $expected): Expectation
-    {
-        return $this->apply(static fn(Expectation $expectation): Expectation => $expectation->toMatchJson($expected));
-    }
-
-    /**
-     * @template TThrowable of \Throwable
-     *
-     * @param class-string<TThrowable>|TThrowable|\Closure(TThrowable): void $throwable
-     *
-     * @return Expectation<T>
-     *
-     * @throws ExpectationFailed
-     */
-    final public function toThrow(
-        string|\Closure|\Throwable $throwable,
-        ?string $matching = null,
-        ?string $message = null,
-    ): Expectation {
         if ($throwable instanceof \Closure && ($matching !== null || $message !== null)) {
-            throw ExpectationFailed::fromDetail(new FailureDetail(
-                'Do not specify matching: or message: when the throwable is a callback.',
-                location: CallSite::capture(),
-            ));
+            $this->usageFailure('Do not specify matching: or message: when the throwable is a callback.');
         }
 
         if ($throwable instanceof \Throwable && ($matching !== null || $message !== null)) {
-            throw ExpectationFailed::fromDetail(new FailureDetail(
+            $this->usageFailure(
                 'Do not specify matching: or message: when the throwable argument is a Throwable instance.',
-                location: CallSite::capture(),
-            ));
+            );
         }
 
         if ($matching !== null && $message !== null) {
-            throw ExpectationFailed::fromDetail(new FailureDetail(
-                'Specify matching: or message: for toThrow(). Do not specify both.',
-                location: CallSite::capture(),
-            ));
+            $this->usageFailure('Specify matching: or message: for toThrow(). Do not specify both.');
         }
+    }
 
-        return $this->apply(
-            static function (Expectation $expectation) use ($throwable, $matching, $message): Expectation {
-                if ($throwable instanceof \Closure) {
-                    return $expectation->toThrow($throwable);
-                }
-
-                if ($matching !== null) {
-                    return $expectation->toThrow($throwable, matching: $matching);
-                }
-
-                if ($message !== null) {
-                    return $expectation->toThrow($throwable, message: $message);
-                }
-
-                return $expectation->toThrow($throwable);
-            },
-        );
+    /** @throws ExpectationFailed */
+    private function usageFailure(string $message): never
+    {
+        throw ExpectationFailed::fromDetail(new FailureDetail(
+            $message,
+            location: CallSite::capture(),
+        ));
     }
 
     /**

--- a/src/PhpStan/IdeHelper.php
+++ b/src/PhpStan/IdeHelper.php
@@ -59,6 +59,7 @@ final readonly class IdeHelper
                 final class %s {}
 
                 /**
+                 * @mixin Expectation
                 %s
                  */
                 abstract class %s {}

--- a/tests/Acceptance/IdeHelperTest.php
+++ b/tests/Acceptance/IdeHelperTest.php
@@ -26,6 +26,7 @@ final readonly class IdeHelperTest
 
         $helper = (string) \file_get_contents($target);
         Expect::that($helper)->because('writes a lintable helper and skips when nothing is configured')->toContain('@method self toHaveDigestLength(int $length)')
+            ->toContain('@mixin Expectation')
             ->toContain('abstract class TemporalExpectation');
 
         $lint = Subprocess::run($root, [\PHP_BINARY, '-l', $target]);

--- a/tests/Unit/Expect/TemporalExpectationTest.php
+++ b/tests/Unit/Expect/TemporalExpectationTest.php
@@ -6,13 +6,10 @@ namespace Greenlight\Tests\Unit\Expect;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Test\ExpectationCounter;
-use Greenlight\Expect\EventuallyExpectation;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Expectation;
 use Greenlight\Expect\ExpectationFailed;
 use Greenlight\Expect\ExpectationRuntime;
 use Greenlight\Expect\PendingEventually;
-use Greenlight\Expect\TemporalExpectation;
 use Greenlight\Test\Cleanup;
 use Greenlight\Tests\Fixture\Expect\FakePollingClock;
 use Greenlight\Tests\Fixture\Expect\PositiveNumbersExtension;
@@ -21,13 +18,6 @@ use Greenlight\Tests\Fixture\Expect\TransientProbeFailure;
 final readonly class TemporalExpectationTest
 {
     public function __construct(private Cleanup $cleanup) {}
-
-    #[Test]
-    public function temporalAndImmediateExpectationsExposeTheSameNativeMatchers(): void
-    {
-        Expect::that($this->matcherSignatures(Expectation::class))->because('temporal and immediate expectations expose the same native matchers')
-            ->toEqual($this->matcherSignatures(TemporalExpectation::class));
-    }
 
     #[Test]
     public function eventuallyStopsAtTheFirstMatchingObservation(): void
@@ -468,8 +458,7 @@ final readonly class TemporalExpectationTest
                 return static function (): void {};
             })
                 ->within(0.100);
-            new \ReflectionMethod(EventuallyExpectation::class, 'toThrow')
-                ->invoke($eventually, \RuntimeException::class, '/x/', 'x');
+            $eventually->__call('toThrow', [\RuntimeException::class, '/x/', 'x']);
         })->because('polling durations and exception types are validated')->toThrow(
             ExpectationFailed::class,
             matching: '/^Specify matching: or message: for toThrow\(\)\. Do not specify both\./',
@@ -566,34 +555,4 @@ final readonly class TemporalExpectationTest
             ->toContain('earlier changes omitted');
     }
 
-    /**
-     * @param class-string $class
-     *
-     * @return array<string, list<string>>
-     */
-    private function matcherSignatures(string $class): array
-    {
-        $signatures = [];
-
-        foreach (new \ReflectionClass($class)->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
-            if (!\str_starts_with($method->getName(), 'to')) {
-                continue;
-            }
-
-            $signatures[$method->getName()] = \array_map(
-                static fn(\ReflectionParameter $parameter): string => \sprintf(
-                    '%s %s%s%s',
-                    (string) $parameter->getType(),
-                    $parameter->isVariadic() ? '...' : '',
-                    $parameter->getName(),
-                    $parameter->isOptional() && !$parameter->isVariadic() ? '?' : '',
-                ),
-                $method->getParameters(),
-            );
-        }
-
-        \ksort($signatures);
-
-        return $signatures;
-    }
 }

--- a/tests/Unit/Expect/TemporalMatcherForwardingTest.php
+++ b/tests/Unit/Expect/TemporalMatcherForwardingTest.php
@@ -7,8 +7,8 @@ namespace Greenlight\Tests\Unit\Expect;
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
+use Greenlight\Expect\Expectation;
 use Greenlight\Expect\ExpectationRuntime;
-use Greenlight\Expect\TemporalExpectation;
 use Greenlight\Tests\Fixture\Expect\FakePollingClock;
 
 final class TemporalMatcherForwardingTest
@@ -28,7 +28,7 @@ final class TemporalMatcherForwardingTest
 
         ExpectationRuntime::withClock($clock, static function () use ($subject, $matcher, $arguments): void {
             $expectation = Expect::eventually(static fn(): mixed => $subject)->within(1.0);
-            new \ReflectionMethod($expectation, $matcher)->invokeArgs($expectation, $arguments);
+            $expectation->__call($matcher, $arguments);
         });
 
         Expect::that($clock->sleeps)
@@ -47,7 +47,7 @@ final class TemporalMatcherForwardingTest
 
         $native = [];
 
-        foreach (new \ReflectionClass(TemporalExpectation::class)->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
+        foreach (new \ReflectionClass(Expectation::class)->getMethods(\ReflectionMethod::IS_PUBLIC) as $method) {
             if (\str_starts_with($method->getName(), 'to')) {
                 $native[] = $method->getName();
             }

--- a/tests/Unit/Expect/TemporalToThrowTest.php
+++ b/tests/Unit/Expect/TemporalToThrowTest.php
@@ -93,13 +93,10 @@ final class TemporalToThrowTest
 
         $detail = FailureProbe::detailOf(
             static function () use ($eventually): void {
-                new \ReflectionMethod($eventually, 'toThrow')->invokeArgs(
-                    $eventually,
-                    [
-                        'throwable' => static function (\RuntimeException $error): void {},
-                        'message' => 'boom',
-                    ],
-                );
+                $eventually->__call('toThrow', [
+                    'throwable' => static function (\RuntimeException $error): void {},
+                    'message' => 'boom',
+                ]);
             },
         );
 
@@ -122,13 +119,10 @@ final class TemporalToThrowTest
 
         $detail = FailureProbe::detailOf(
             static function () use ($eventually, $failure): void {
-                new \ReflectionMethod($eventually, 'toThrow')->invokeArgs(
-                    $eventually,
-                    [
-                        'throwable' => $failure,
-                        'matching' => '/boom/',
-                    ],
-                );
+                $eventually->__call('toThrow', [
+                    'throwable' => $failure,
+                    'matching' => '/boom/',
+                ]);
             },
         );
 

--- a/tests/Unit/Tools/ApiReferenceGenerationTest.php
+++ b/tests/Unit/Tools/ApiReferenceGenerationTest.php
@@ -37,6 +37,28 @@ final readonly class ApiReferenceGenerationTest
             ->not()->toContain('### `$scopes`');
     }
 
+    #[Test]
+    public function temporalTypesShowTheirFluentInterfaceWithoutConstructionDetails(): void
+    {
+        $reference = $this->reference('api-expectations.md');
+
+        Expect::that($reference)
+            ->because('temporal types MUST document their fluent interface')
+            ->toContain('## `EventuallyExpectation`')
+            ->toContain('## `ConsistentlyExpectation`')
+            ->toContain('### `not()`')
+            ->toContain('### `because()`')
+            ->toContain('### `toBe()`')
+            ->toContain('Runs a native or configured extension matcher against each probe value.');
+        Expect::that($reference)
+            ->because('temporal construction details MUST stay internal')
+            ->not()->toContain('PollingClock')
+            ->not()->toContain('### `__construct()`')
+            ->not()->toContain('class EventuallyExpectation extends TemporalExpectation')
+            ->not()->toContain('class ConsistentlyExpectation extends TemporalExpectation')
+            ->not()->toContain('@extends TemporalExpectation');
+    }
+
     private function reference(string $file): string
     {
         return (string) \file_get_contents(\dirname(__DIR__, 3) . '/docs/' . $file);

--- a/website/scripts/generate-api-reference.mjs
+++ b/website/scripts/generate-api-reference.mjs
@@ -101,7 +101,7 @@ const sections = [
 const check = process.argv.includes('--check');
 
 const sourceFiles = await filesBelow(sourceRoot);
-const publicTypes = [];
+const parsedTypes = [];
 
 for (const file of sourceFiles.filter((path) => path.endsWith('.php'))) {
   const source = await readFile(file, 'utf8');
@@ -114,9 +114,16 @@ for (const file of sourceFiles.filter((path) => path.endsWith('.php'))) {
     throw new Error(`${sourceFile}: ${error.message}`, { cause: error });
   }
 
-  if (type !== undefined && !type.internal) {
-    publicTypes.push(type);
+  if (type !== undefined) {
+    parsedTypes.push(type);
   }
+}
+
+const typesByName = new Map(parsedTypes.map((type) => [type.name, type]));
+const publicTypes = parsedTypes.filter((type) => !type.internal);
+
+for (const type of publicTypes) {
+  type.members = effectiveMembers(type, typesByName);
 }
 
 publicTypes.sort((left, right) => left.name.localeCompare(right.name));
@@ -281,7 +288,8 @@ function parseType(source, file) {
   const typeDoc = [...declarationTokens].reverse().find((token) => token.kind === 'doc');
   const signatureStart = firstSignatureToken(declarationTokens);
   const signature = source.slice(signatureStart.start, tokens[openIndex].start).trim();
-  const members = parseMembers(source, tokens, openIndex, closeIndex, kind);
+  const members = parseMembers(source, tokens, openIndex, closeIndex, kind)
+    .map((member) => ({ ...member, file }));
   const shortName = nameToken.value;
 
   return {
@@ -294,6 +302,70 @@ function parseType(source, file) {
     internal: typeDoc?.value.includes('@internal') ?? false,
     signature,
     members,
+  };
+}
+
+function effectiveMembers(type, typesByName, active = new Set()) {
+  if (active.has(type.name)) {
+    throw new Error(`Public API type inheritance contains a cycle at "${type.name}".`);
+  }
+
+  const nextActive = new Set(active).add(type.name);
+  const members = [];
+  const parentName = type.signature.match(/\bextends\s+([A-Za-z_\\][A-Za-z0-9_\\]*)/u)?.[1];
+  const parent = referencedType(type, parentName, typesByName);
+
+  if (parent !== undefined) {
+    members.push(...effectiveMembers(parent, typesByName, nextActive)
+      .filter((member) => member.name !== '__construct()'));
+  }
+
+  for (const tag of type.doc.tags) {
+    const mixinName = tag.match(/^@mixin\s+([A-Za-z_\\][A-Za-z0-9_\\]*)/u)?.[1];
+    const mixin = referencedType(type, mixinName, typesByName);
+
+    if (mixin !== undefined) {
+      members.push(...effectiveMembers(mixin, typesByName, nextActive)
+        .filter((member) => member.name !== '__construct()')
+        .map((member) => projectMixinMember(member, mixin)));
+    }
+  }
+
+  for (const member of type.members) {
+    const inheritedIndex = members.findIndex((candidate) => candidate.name === member.name);
+
+    if (inheritedIndex === -1) {
+      members.push(member);
+    } else {
+      members[inheritedIndex] = member;
+    }
+  }
+
+  return members;
+}
+
+function referencedType(owner, reference, typesByName) {
+  if (reference === undefined) {
+    return undefined;
+  }
+
+  const normalized = reference.replace(/^\\/u, '');
+  const namespace = owner.name.slice(0, owner.name.lastIndexOf('\\'));
+  const name = normalized.includes('\\') ? normalized : `${namespace}\\${normalized}`;
+
+  return typesByName.get(name);
+}
+
+function projectMixinMember(member, mixin) {
+  const replaceSelf = (value) => value.replace(/\bself\b/gu, mixin.shortName);
+
+  return {
+    ...member,
+    signature: replaceSelf(member.signature),
+    doc: {
+      ...member.doc,
+      tags: member.doc.tags.map(replaceSelf),
+    },
   };
 }
 
@@ -852,15 +924,17 @@ function renderSection(section, types) {
 
     lines.push(
       '```php',
-      type.signature,
+      publicTypeSignature(type),
       '```',
       '',
       `[View source](https://github.com/ben-challis/greenlight/blob/main/${type.file}#L${type.line})`,
       '',
     );
 
-    if (type.doc.tags.length > 0) {
-      lines.push('PHPDoc:', '', ...type.doc.tags.map((tag) => `- \`${escapeBackticks(tag)}\``), '');
+    const typeTags = publicTypeTags(type);
+
+    if (typeTags.length > 0) {
+      lines.push('PHPDoc:', '', ...typeTags.map((tag) => `- \`${escapeBackticks(tag)}\``), '');
     }
 
     if (type.members.length === 0) {
@@ -882,13 +956,31 @@ function renderSection(section, types) {
       }
 
       lines.push(
-        `[View source](https://github.com/ben-challis/greenlight/blob/main/${type.file}#L${member.line})`,
+        `[View source](https://github.com/ben-challis/greenlight/blob/main/${member.file}#L${member.line})`,
         '',
       );
     }
   }
 
   return `${lines.join('\n').trimEnd()}\n`;
+}
+
+function publicTypeSignature(type) {
+  const parentName = type.signature.match(/\bextends\s+([A-Za-z_\\][A-Za-z0-9_\\]*)/u)?.[1];
+  const parent = referencedType(type, parentName, typesByName);
+
+  return parent?.internal === true
+    ? type.signature.replace(/\s+extends\s+[A-Za-z_\\][A-Za-z0-9_\\]*/u, '')
+    : type.signature;
+}
+
+function publicTypeTags(type) {
+  return type.doc.tags.filter((tag) => {
+    const parentName = tag.match(/^@extends\s+([A-Za-z_\\][A-Za-z0-9_\\]*)/u)?.[1];
+    const parent = referencedType(type, parentName, typesByName);
+
+    return parent?.internal !== true;
+  });
 }
 
 function escapeBackticks(value) {


### PR DESCRIPTION
Restricts temporal expectation construction to the Expect factories and keeps polling dependencies internal. Derives temporal matcher dispatch, static-analysis types, and generated API members from Expectation so native and extension matchers stay aligned.