### PR TITLE
feat(harness)!: make service resolution explicit

### DIFF
--- a/docs/api-harness.md
+++ b/docs/api-harness.md
@@ -405,6 +405,95 @@ PHPDoc:
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceDefinition.php#L26)
 
+## `ServiceResolution`
+
+Namespace: `Greenlight\Harness`
+
+Reports whether a service resolver handled, resolved, or failed one request.
+Each state contains only the data that applies to that state.
+
+```php
+final readonly class ServiceResolution
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolution.php#L11)
+
+### `unhandled()`
+
+```php
+public static function unhandled(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolution.php#L19)
+
+### `resolved()`
+
+```php
+public static function resolved(object $service): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolution.php#L24)
+
+### `failed()`
+
+```php
+public static function failed(ServiceResolutionFailed $error): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolution.php#L29)
+
+### `isUnhandled()`
+
+```php
+public function isUnhandled(): bool
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolution.php#L34)
+
+### `isResolved()`
+
+```php
+public function isResolved(): bool
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolution.php#L39)
+
+### `isFailed()`
+
+```php
+public function isFailed(): bool
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolution.php#L44)
+
+### `service()`
+
+```php
+public function service(): object
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolution.php#L49)
+
+### `error()`
+
+```php
+public function error(): ServiceResolutionFailed
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolution.php#L55)
+
+### `value()`
+
+```php
+public function value(): ?object
+```
+
+PHPDoc:
+
+- `@throws ServiceResolutionFailed if the resolver failed`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolution.php#L64)
+
 ## `ServiceResolutionFailed`
 
 Namespace: `Greenlight\Harness`
@@ -423,9 +512,9 @@ This type does not declare public members.
 
 Namespace: `Greenlight\Harness`
 
-Greenlight calls service resolvers in registration order. If a resolver
-returns null, Greenlight calls the next resolver. A nonnull result must have
-the requested type.
+Greenlight calls service resolvers in registration order. An unhandled
+result asks Greenlight to call the next resolver. A resolved result must
+contain the requested type. A failed result stops resolution.
 
 Objects from a service resolver do not belong to a harness service scope.
 Greenlight does not dispose them. The source of an object controls its
@@ -440,13 +529,40 @@ interface ServiceResolver
 ### `resolve()`
 
 ```php
-public function resolve(string $type, array $attributes): ?object;
+public function resolve(string $type, array $attributes): ServiceResolution;
 ```
 
 PHPDoc:
 
 - `@param class-string $type`
 - `@param list<object> $attributes`
-- `@throws ServiceResolutionFailed when the resolver cannot supply a valid service`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolver.php#L24)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolver.php#L22)
+
+## `TerminalServiceResolver`
+
+Namespace: `Greenlight\Harness`
+
+Identifies a resolver that handles every request. Greenlight places one
+terminal resolver after all fallback-capable resolvers.
+
+A terminal resolver MUST return a resolved or failed result.
+
+```php
+interface TerminalServiceResolver extends ServiceResolver
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/TerminalServiceResolver.php#L13)
+
+### `resolve()`
+
+```php
+public function resolve(string $type, array $attributes): ServiceResolution;
+```
+
+PHPDoc:
+
+- `@param class-string $type`
+- `@param list<object> $attributes`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolver.php#L22)

--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -53,7 +53,7 @@ resources by `GREENLIGHT_CHANNEL`.
 final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemptRunner, WorkerBootstrapSubscriber, WorkerRuntimeRunner
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L39)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L40)
 
 ### `__construct()`
 
@@ -72,7 +72,7 @@ PHPDoc:
 - `@param null|\Closure(ContainerInterface): void $reset Resets project-owned request state after each test attempt. The callback runs inside the test coroutine.`
 - `@param null|\Closure(ContainerInterface): void $dispose Releases project-owned resources when the selected container lifetime ends. The callback runs inside a coroutine.`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L62)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L63)
 
 ### `services()`
 
@@ -85,20 +85,19 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L74)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L75)
 
 ### `resolve()`
 
 ```php
 [\Override]
-public function resolve(string $type, array $attributes): ?object
+public function resolve(string $type, array $attributes): ServiceResolution
 ```
 
 PHPDoc:
 
 - `@param class-string $type`
 - `@param list<object> $attributes`
-- `@throws ServiceResolutionFailed`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L87)
 
@@ -113,7 +112,7 @@ PHPDoc:
 
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L118)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L124)
 
 ### `runWorker()`
 
@@ -129,7 +128,7 @@ PHPDoc:
 - `@return T`
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L175)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L181)
 
 ### `runTestAttempt()`
 
@@ -145,7 +144,7 @@ PHPDoc:
 - `@return T`
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L219)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L225)
 
 ## `Hyperf\Service`
 
@@ -197,7 +196,7 @@ resources by `GREENLIGHT_CHANNEL`.
 final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, ServiceResolver
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L26)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L27)
 
 ### `__construct()`
 
@@ -215,7 +214,7 @@ PHPDoc:
 - `@param non-empty-string $env`
 - `@param bool $refreshBetweenTests Set to false only when no service carries state; tests on one worker then share one unreset application for the worker lifetime.`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L48)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L49)
 
 ### `services()`
 
@@ -228,20 +227,19 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L69)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L70)
 
 ### `resolve()`
 
 ```php
 [\Override]
-public function resolve(string $type, array $attributes): ?object
+public function resolve(string $type, array $attributes): ServiceResolution
 ```
 
 PHPDoc:
 
 - `@param class-string $type`
 - `@param list<object> $attributes`
-- `@throws ServiceResolutionFailed`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L86)
 
@@ -252,7 +250,7 @@ PHPDoc:
 public function afterTest(TestContext $context, TestResult $result): TestResult
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L116)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L122)
 
 ## `Laravel\Service`
 
@@ -306,7 +304,7 @@ by `GREENLIGHT_CHANNEL`.
 final class Psr11Plugin implements AfterTestSubscriber, HarnessProvider, ServiceResolver
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr/Psr11Plugin.php#L24)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr/Psr11Plugin.php#L25)
 
 ### `__construct()`
 
@@ -324,7 +322,7 @@ PHPDoc:
 - `@param bool $refreshBetweenTests Set to false only when the reset callback removes all container state, or when services do not keep state.`
 - `@param (\Closure(ContainerInterface): void)|null $reset An optional callback that resets the active container after each test.`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr/Psr11Plugin.php#L37)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr/Psr11Plugin.php#L38)
 
 ### `services()`
 
@@ -337,22 +335,21 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr/Psr11Plugin.php#L46)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr/Psr11Plugin.php#L47)
 
 ### `resolve()`
 
 ```php
 [\Override]
-public function resolve(string $type, array $attributes): ?object
+public function resolve(string $type, array $attributes): ServiceResolution
 ```
 
 PHPDoc:
 
 - `@param class-string $type`
 - `@param list<object> $attributes`
-- `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr/Psr11Plugin.php#L93)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr/Psr11Plugin.php#L92)
 
 ### `afterTest()`
 
@@ -365,7 +362,7 @@ PHPDoc:
 
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr/Psr11Plugin.php#L138)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr/Psr11Plugin.php#L139)
 
 ## `Psr\Service`
 
@@ -682,7 +679,7 @@ external resources with `GREENLIGHT_CHANNEL`.
 final class SymfonyPlugin implements AfterTestSubscriber, HarnessProvider, ServiceResolver
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L30)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L31)
 
 ### `__construct()`
 
@@ -701,7 +698,7 @@ PHPDoc:
 - `@param non-empty-string $env`
 - `@param bool $resetBetweenTests For a container without stateful services, use false to disable resets. Tests on one worker then share all service instances.`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L53)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L54)
 
 ### `services()`
 
@@ -714,20 +711,19 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L73)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L74)
 
 ### `resolve()`
 
 ```php
 [\Override]
-public function resolve(string $type, array $attributes): ?object
+public function resolve(string $type, array $attributes): ServiceResolution
 ```
 
 PHPDoc:
 
 - `@param class-string $type`
 - `@param list<object> $attributes`
-- `@throws ServiceResolutionFailed`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L86)
 
@@ -738,7 +734,7 @@ PHPDoc:
 public function afterTest(TestContext $context, TestResult $result): TestResult
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L116)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L122)
 
 ## `TempestPlugin`
 
@@ -753,10 +749,10 @@ attributes select tagged Tempest bindings. Tests MUST isolate external
 resources by `GREENLIGHT_CHANNEL`.
 
 ```php
-final class TempestPlugin implements AfterTestSubscriber, BeforeTestSubscriber, HarnessProvider, ServiceResolver, WorkerBootstrapSubscriber
+final class TempestPlugin implements AfterTestSubscriber, BeforeTestSubscriber, HarnessProvider, TerminalServiceResolver, WorkerBootstrapSubscriber
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L37)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L38)
 
 ### `__construct()`
 
@@ -774,7 +770,7 @@ PHPDoc:
 - `@param list<DiscoveryLocation> $discoveryLocations Additional locations for Tempest discovery.`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L50)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L51)
 
 ### `onWorkerBootstrap()`
 
@@ -783,7 +779,7 @@ PHPDoc:
 public function onWorkerBootstrap(WorkerBootstrapContext $context): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L64)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L65)
 
 ### `services()`
 
@@ -796,20 +792,19 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L73)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L74)
 
 ### `resolve()`
 
 ```php
 [\Override]
-public function resolve(string $type, array $attributes): object
+public function resolve(string $type, array $attributes): ServiceResolution
 ```
 
 PHPDoc:
 
 - `@param class-string $type`
 - `@param list<object> $attributes`
-- `@throws ServiceResolutionFailed`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L87)
 
@@ -820,7 +815,7 @@ PHPDoc:
 public function beforeTest(TestContext $context): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L113)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L115)
 
 ### `afterTest()`
 
@@ -833,4 +828,4 @@ PHPDoc:
 
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L126)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L128)

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -449,23 +449,39 @@ In `Greenlight\Harness`.
 
 <!-- php-example {"mode":"display","reason":"Shows one method signature without its interface declaration."} -->
 ```php
-public function resolve(string $type, array $attributes): ?object;
+public function resolve(string $type, array $attributes): ServiceResolution;
 ```
 
 A service resolver is a fallback source for a constructor parameter type.
 
 Registered harness services always take precedence. If no service matches,
 Greenlight calls resolvers in registration order. Each call receives the
-declared parameter type and the attribute instances. Greenlight injects the
-first non-null object.
+declared parameter type and the attribute instances.
 
-If the resolver cannot supply the requested type, return `null`. If it returns
-an object of a different type, the test has an error and names the resolver.
+Return `ServiceResolution::unhandled()` when the resolver does not support the
+type. Greenlight then calls the next resolver.
+
+Return `ServiceResolution::resolved($service)` when the resolver supplies the
+service. The service MUST have the requested type.
+
+Return `ServiceResolution::failed($error)` when the resolver handles the
+request but cannot supply a valid service. The error MUST be a
+`ServiceResolutionFailed`. Greenlight stops the resolver chain and exposes the
+public `ServiceResolutionFailed` contract.
+
+An explicit service ID or tag means that the applicable resolver handles the
+request. A missing explicit service is a failed result, not an unhandled
+result. A container operation failure is also a failed result.
+
+Implement `TerminalServiceResolver` when a resolver handles every request.
+Greenlight places one terminal resolver after all fallback-capable resolvers.
+A terminal resolver MUST NOT return an unhandled result. Greenlight rejects a
+resolver chain that has an item after a terminal resolver.
 
 The resolver owns each object that it returns. Harness scopes do not track or
 call disposal methods on these objects.
 
-The framework bridges use this interface to inject container services. See
+The framework bridges use these interfaces to inject container services. See
 [Symfony applications](symfony.md), [Laravel applications](laravel.md), and
 [Tempest applications](tempest.md).
 

--- a/docs/tempest.md
+++ b/docs/tempest.md
@@ -83,8 +83,9 @@ final class RegistrationTest
 ```
 
 Greenlight first resolves constructor parameters from its harness. It then asks
-the Tempest container to resolve the type. Greenlight harness services take
-precedence over Tempest services.
+fallback-capable service resolvers. Finally, it asks the Tempest container to
+resolve the type. Greenlight always places the terminal Tempest resolver last.
+Registration order and plugin priority do not change this rule.
 
 Tempest can use discovered initializers and automatic constructor injection. If
 Tempest cannot resolve the type, Greenlight throws `ServiceResolutionFailed`.

--- a/src/Harness/HarnessScopes.php
+++ b/src/Harness/HarnessScopes.php
@@ -27,6 +27,16 @@ final class HarnessScopes
         private readonly HarnessRegistry $registry,
         private readonly array $resolvers = [],
     ) {
+        $terminalSeen = false;
+
+        foreach ($resolvers as $resolver) {
+            if ($terminalSeen) {
+                throw new \InvalidArgumentException('A terminal service resolver MUST be the final resolver.');
+            }
+
+            $terminalSeen = $resolver instanceof TerminalServiceResolver;
+        }
+
         $this->worker = new ScopeContainer();
     }
 
@@ -61,11 +71,24 @@ final class HarnessScopes
         }
 
         foreach ($this->resolvers as $resolver) {
-            $service = $resolver->resolve($type, $attributes);
+            $resolution = $resolver->resolve($type, $attributes);
 
-            if ($service === null) {
+            if ($resolution->isUnhandled()) {
+                if ($resolver instanceof TerminalServiceResolver) {
+                    throw new \LogicException(\sprintf(
+                        'Terminal service resolver "%s" returned an unhandled result.',
+                        $resolver::class,
+                    ));
+                }
+
                 continue;
             }
+
+            if ($resolution->isFailed()) {
+                throw $resolution->error();
+            }
+
+            $service = $resolution->service();
 
             if (!$service instanceof $type) {
                 throw UnresolvableService::resolverTypeMismatch($type, $consumer, $resolver::class, $service::class);

--- a/src/Harness/ServiceResolution.php
+++ b/src/Harness/ServiceResolution.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Harness;
+
+/**
+ * Reports whether a service resolver handled, resolved, or failed one request.
+ * Each state contains only the data that applies to that state.
+ */
+final readonly class ServiceResolution
+{
+    private function __construct(
+        private ServiceResolutionStatus $status,
+        private ?object $service = null,
+        private ?ServiceResolutionFailed $error = null,
+    ) {}
+
+    public static function unhandled(): self
+    {
+        return new self(ServiceResolutionStatus::Unhandled);
+    }
+
+    public static function resolved(object $service): self
+    {
+        return new self(ServiceResolutionStatus::Resolved, service: $service);
+    }
+
+    public static function failed(ServiceResolutionFailed $error): self
+    {
+        return new self(ServiceResolutionStatus::Failed, error: $error);
+    }
+
+    public function isUnhandled(): bool
+    {
+        return $this->status === ServiceResolutionStatus::Unhandled;
+    }
+
+    public function isResolved(): bool
+    {
+        return $this->status === ServiceResolutionStatus::Resolved;
+    }
+
+    public function isFailed(): bool
+    {
+        return $this->status === ServiceResolutionStatus::Failed;
+    }
+
+    public function service(): object
+    {
+        return $this->service
+            ?? throw new \LogicException('A service is not available for this resolution state.');
+    }
+
+    public function error(): ServiceResolutionFailed
+    {
+        return $this->error
+            ?? throw new \LogicException('An error is not available for this resolution state.');
+    }
+
+    /**
+     * @throws ServiceResolutionFailed if the resolver failed
+     */
+    public function value(): ?object
+    {
+        if ($this->isFailed()) {
+            throw $this->error();
+        }
+
+        return $this->service;
+    }
+}
+
+/** @internal */
+enum ServiceResolutionStatus
+{
+    case Unhandled;
+    case Resolved;
+    case Failed;
+}

--- a/src/Harness/ServiceResolver.php
+++ b/src/Harness/ServiceResolver.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace Greenlight\Harness;
 
 /**
- * Greenlight calls service resolvers in registration order. If a resolver
- * returns null, Greenlight calls the next resolver. A nonnull result must have
- * the requested type.
+ * Greenlight calls service resolvers in registration order. An unhandled
+ * result asks Greenlight to call the next resolver. A resolved result must
+ * contain the requested type. A failed result stops resolution.
  *
  * Objects from a service resolver do not belong to a harness service scope.
  * Greenlight does not dispose them. The source of an object controls its
@@ -18,8 +18,6 @@ interface ServiceResolver
     /**
      * @param class-string $type
      * @param list<object> $attributes
-     *
-     * @throws ServiceResolutionFailed when the resolver cannot supply a valid service
      */
-    public function resolve(string $type, array $attributes): ?object;
+    public function resolve(string $type, array $attributes): ServiceResolution;
 }

--- a/src/Harness/TerminalServiceResolver.php
+++ b/src/Harness/TerminalServiceResolver.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Harness;
+
+/**
+ * Identifies a resolver that handles every request. Greenlight places one
+ * terminal resolver after all fallback-capable resolvers.
+ *
+ * A terminal resolver MUST return a resolved or failed result.
+ */
+interface TerminalServiceResolver extends ServiceResolver {}

--- a/src/Hyperf/HyperfBridgeError.php
+++ b/src/Hyperf/HyperfBridgeError.php
@@ -13,9 +13,9 @@ use Greenlight\Harness\ServiceResolutionFailed;
  */
 final class HyperfBridgeError extends ServiceResolutionFailed
 {
-    private function __construct(string $message)
+    private function __construct(string $message, ?\Throwable $previous = null)
     {
-        parent::__construct($message);
+        parent::__construct($message, previous: $previous);
     }
 
     public static function basePathMissing(string $path): self
@@ -163,5 +163,17 @@ final class HyperfBridgeError extends ServiceResolutionFailed
             $actual,
             $type,
         ));
+    }
+
+    public static function serviceResolutionFailed(string $id, string $type, \Throwable $previous): self
+    {
+        return new self(
+            \sprintf(
+                'The Hyperf container failed when it resolved service "%s" for parameter type "%s".',
+                $id,
+                $type,
+            ),
+            previous: $previous,
+        );
     }
 }

--- a/src/Hyperf/HyperfPlugin.php
+++ b/src/Hyperf/HyperfPlugin.php
@@ -7,6 +7,7 @@ namespace Greenlight\Hyperf;
 use Greenlight\Core\ErrorTrap;
 use Greenlight\Harness\Scope;
 use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Harness\ServiceResolution;
 use Greenlight\Harness\ServiceResolutionFailed;
 use Greenlight\Harness\ServiceResolver;
 use Greenlight\Plugin\HarnessProvider;
@@ -82,10 +83,9 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemp
     /**
      * @param class-string $type
      * @param list<object> $attributes
-     * @throws ServiceResolutionFailed
      */
     #[\Override]
-    public function resolve(string $type, array $attributes): ?object
+    public function resolve(string $type, array $attributes): ServiceResolution
     {
         $id = $type;
 
@@ -95,23 +95,29 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemp
             }
         }
 
-        $container = $this->container();
+        try {
+            $container = $this->container();
 
-        if (!$container->has($id)) {
-            if ($id !== $type) {
-                throw HyperfBridgeError::unknownServiceId($id, $type);
+            if (!$container->has($id)) {
+                return $id !== $type
+                    ? ServiceResolution::failed(HyperfBridgeError::unknownServiceId($id, $type))
+                    : ServiceResolution::unhandled();
             }
 
-            return null;
+            $service = $container->get($id);
+
+            if (!$service instanceof $type) {
+                return ServiceResolution::failed(
+                    HyperfBridgeError::serviceTypeMismatch($id, $type, \get_debug_type($service)),
+                );
+            }
+
+            return ServiceResolution::resolved($service);
+        } catch (ServiceResolutionFailed $error) {
+            return ServiceResolution::failed($error);
+        } catch (\Throwable $cause) {
+            return ServiceResolution::failed(HyperfBridgeError::serviceResolutionFailed($id, $type, $cause));
         }
-
-        $service = $container->get($id);
-
-        if (!$service instanceof $type) {
-            throw HyperfBridgeError::serviceTypeMismatch($id, $type, \get_debug_type($service));
-        }
-
-        return $service;
     }
 
     /** @throws ServiceResolutionFailed */

--- a/src/Laravel/LaravelBridgeError.php
+++ b/src/Laravel/LaravelBridgeError.php
@@ -13,9 +13,9 @@ use Greenlight\Harness\ServiceResolutionFailed;
  */
 final class LaravelBridgeError extends ServiceResolutionFailed
 {
-    private function __construct(string $message)
+    private function __construct(string $message, ?\Throwable $previous = null)
     {
-        parent::__construct($message);
+        parent::__construct($message, previous: $previous);
     }
 
     public static function bootstrapFileMissing(string $path): self
@@ -93,5 +93,17 @@ final class LaravelBridgeError extends ServiceResolutionFailed
             $actual,
             $type,
         ));
+    }
+
+    public static function serviceResolutionFailed(string $id, string $type, \Throwable $previous): self
+    {
+        return new self(
+            \sprintf(
+                'The Laravel container failed when it resolved service "%s" for parameter type "%s".',
+                $id,
+                $type,
+            ),
+            previous: $previous,
+        );
     }
 }

--- a/src/Laravel/LaravelPlugin.php
+++ b/src/Laravel/LaravelPlugin.php
@@ -8,6 +8,7 @@ use Greenlight\Core\ErrorTrap;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Harness\Scope;
 use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Harness\ServiceResolution;
 use Greenlight\Harness\ServiceResolutionFailed;
 use Greenlight\Harness\ServiceResolver;
 use Greenlight\Plugin\AfterTestSubscriber;
@@ -81,10 +82,9 @@ final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, Servi
     /**
      * @param class-string $type
      * @param list<object> $attributes
-     * @throws ServiceResolutionFailed
      */
     #[\Override]
-    public function resolve(string $type, array $attributes): ?object
+    public function resolve(string $type, array $attributes): ServiceResolution
     {
         $id = $type;
 
@@ -94,23 +94,29 @@ final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, Servi
             }
         }
 
-        $app = $this->application();
+        try {
+            $app = $this->application();
 
-        if (!$app->bound($id)) {
-            if ($id !== $type) {
-                throw LaravelBridgeError::unknownServiceId($id, $type);
+            if (!$app->bound($id)) {
+                return $id !== $type
+                    ? ServiceResolution::failed(LaravelBridgeError::unknownServiceId($id, $type))
+                    : ServiceResolution::unhandled();
             }
 
-            return null;
+            $service = $app->make($id);
+
+            if (!$service instanceof $type) {
+                return ServiceResolution::failed(
+                    LaravelBridgeError::serviceTypeMismatch($id, $type, \get_debug_type($service)),
+                );
+            }
+
+            return ServiceResolution::resolved($service);
+        } catch (ServiceResolutionFailed $error) {
+            return ServiceResolution::failed($error);
+        } catch (\Throwable $cause) {
+            return ServiceResolution::failed(LaravelBridgeError::serviceResolutionFailed($id, $type, $cause));
         }
-
-        $service = $app->make($id);
-
-        if (!$service instanceof $type) {
-            throw LaravelBridgeError::serviceTypeMismatch($id, $type, \get_debug_type($service));
-        }
-
-        return $service;
     }
 
     #[\Override]

--- a/src/Plugin/PluginRegistry.php
+++ b/src/Plugin/PluginRegistry.php
@@ -6,6 +6,7 @@ namespace Greenlight\Plugin;
 
 use Greenlight\Harness\ServiceDefinition;
 use Greenlight\Harness\ServiceResolver;
+use Greenlight\Harness\TerminalServiceResolver;
 
 /**
  * Stores the plugins for one run and groups them by capability.
@@ -141,7 +142,18 @@ final readonly class PluginRegistry
      */
     public function serviceResolvers(): array
     {
-        return $this->sorted($this->ofType(ServiceResolver::class));
+        $resolvers = $this->sorted($this->ofType(ServiceResolver::class));
+
+        return [
+            ...\array_values(\array_filter(
+                $resolvers,
+                static fn(ServiceResolver $resolver): bool => !$resolver instanceof TerminalServiceResolver,
+            )),
+            ...\array_values(\array_filter(
+                $resolvers,
+                static fn(ServiceResolver $resolver): bool => $resolver instanceof TerminalServiceResolver,
+            )),
+        ];
     }
 
     /**

--- a/src/Psr/Psr11Plugin.php
+++ b/src/Psr/Psr11Plugin.php
@@ -7,6 +7,7 @@ namespace Greenlight\Psr;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Harness\Scope;
 use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Harness\ServiceResolution;
 use Greenlight\Harness\ServiceResolutionFailed;
 use Greenlight\Harness\ServiceResolver;
 use Greenlight\Plugin\AfterTestSubscriber;
@@ -87,11 +88,9 @@ final class Psr11Plugin implements AfterTestSubscriber, HarnessProvider, Service
     /**
      * @param class-string $type
      * @param list<object> $attributes
-     *
-     * @throws ServiceResolutionFailed
      */
     #[\Override]
-    public function resolve(string $type, array $attributes): ?object
+    public function resolve(string $type, array $attributes): ServiceResolution
     {
         $id = $type;
         $explicit = false;
@@ -103,33 +102,35 @@ final class Psr11Plugin implements AfterTestSubscriber, HarnessProvider, Service
             }
         }
 
-        $container = $this->container();
-
         try {
+            $container = $this->container();
+
             $hasService = $container->has($id);
+        } catch (ServiceResolutionFailed $error) {
+            return ServiceResolution::failed($error);
         } catch (\Throwable $threw) {
-            throw Psr11BridgeError::serviceCheckFailed($id, $threw);
+            return ServiceResolution::failed(Psr11BridgeError::serviceCheckFailed($id, $threw));
         }
 
         if (!$hasService) {
-            if ($explicit) {
-                throw Psr11BridgeError::unknownServiceId($id, $type);
-            }
-
-            return null;
+            return $explicit
+                ? ServiceResolution::failed(Psr11BridgeError::unknownServiceId($id, $type))
+                : ServiceResolution::unhandled();
         }
 
         try {
             $service = $container->get($id);
         } catch (\Throwable $threw) {
-            throw Psr11BridgeError::serviceReadFailed($id, $threw);
+            return ServiceResolution::failed(Psr11BridgeError::serviceReadFailed($id, $threw));
         }
 
         if (!$service instanceof $type) {
-            throw Psr11BridgeError::serviceTypeMismatch($id, $type, \get_debug_type($service));
+            return ServiceResolution::failed(
+                Psr11BridgeError::serviceTypeMismatch($id, $type, \get_debug_type($service)),
+            );
         }
 
-        return $service;
+        return ServiceResolution::resolved($service);
     }
 
     /**

--- a/src/Symfony/SymfonyBridgeError.php
+++ b/src/Symfony/SymfonyBridgeError.php
@@ -6,12 +6,16 @@ namespace Greenlight\Symfony;
 
 use Greenlight\Harness\ServiceResolutionFailed;
 
-/** @internal */
+/**
+ * Reports a Symfony bridge configuration or runtime failure.
+ *
+ * @internal
+ */
 final class SymfonyBridgeError extends ServiceResolutionFailed
 {
-    private function __construct(string $message)
+    private function __construct(string $message, ?\Throwable $previous = null)
     {
-        parent::__construct($message);
+        parent::__construct($message, previous: $previous);
     }
 
     public static function testContainerUnavailable(string $environment): self
@@ -64,5 +68,17 @@ final class SymfonyBridgeError extends ServiceResolutionFailed
             . 'SymfonyPlugin cannot use this class as a kernel.',
             $class,
         ));
+    }
+
+    public static function serviceResolutionFailed(string $id, string $type, \Throwable $previous): self
+    {
+        return new self(
+            \sprintf(
+                'The Symfony container failed when it resolved service "%s" for parameter type "%s".',
+                $id,
+                $type,
+            ),
+            previous: $previous,
+        );
     }
 }

--- a/src/Symfony/SymfonyPlugin.php
+++ b/src/Symfony/SymfonyPlugin.php
@@ -7,6 +7,7 @@ namespace Greenlight\Symfony;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Harness\Scope;
 use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Harness\ServiceResolution;
 use Greenlight\Harness\ServiceResolutionFailed;
 use Greenlight\Harness\ServiceResolver;
 use Greenlight\Plugin\AfterTestSubscriber;
@@ -81,10 +82,9 @@ final class SymfonyPlugin implements AfterTestSubscriber, HarnessProvider, Servi
     /**
      * @param class-string $type
      * @param list<object> $attributes
-     * @throws ServiceResolutionFailed
      */
     #[\Override]
-    public function resolve(string $type, array $attributes): ?object
+    public function resolve(string $type, array $attributes): ServiceResolution
     {
         $id = $type;
 
@@ -94,23 +94,29 @@ final class SymfonyPlugin implements AfterTestSubscriber, HarnessProvider, Servi
             }
         }
 
-        $container = $this->container();
+        try {
+            $container = $this->container();
 
-        if (!$container->has($id)) {
-            if ($id !== $type) {
-                throw SymfonyBridgeError::unknownServiceId($id, $type);
+            if (!$container->has($id)) {
+                return $id !== $type
+                    ? ServiceResolution::failed(SymfonyBridgeError::unknownServiceId($id, $type))
+                    : ServiceResolution::unhandled();
             }
 
-            return null;
+            $service = $container->get($id);
+
+            if (!$service instanceof $type) {
+                return ServiceResolution::failed(
+                    SymfonyBridgeError::serviceTypeMismatch($id, $type, \get_debug_type($service)),
+                );
+            }
+
+            return ServiceResolution::resolved($service);
+        } catch (ServiceResolutionFailed $error) {
+            return ServiceResolution::failed($error);
+        } catch (\Throwable $cause) {
+            return ServiceResolution::failed(SymfonyBridgeError::serviceResolutionFailed($id, $type, $cause));
         }
-
-        $service = $container->get($id);
-
-        if (!$service instanceof $type) {
-            throw SymfonyBridgeError::serviceTypeMismatch($id, $type, \get_debug_type($service));
-        }
-
-        return $service;
     }
 
     #[\Override]

--- a/src/Tempest/TempestPlugin.php
+++ b/src/Tempest/TempestPlugin.php
@@ -7,8 +7,9 @@ namespace Greenlight\Tempest;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Harness\Scope;
 use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Harness\ServiceResolution;
 use Greenlight\Harness\ServiceResolutionFailed;
-use Greenlight\Harness\ServiceResolver;
+use Greenlight\Harness\TerminalServiceResolver;
 use Greenlight\Plugin\AfterTestSubscriber;
 use Greenlight\Plugin\BeforeTestSubscriber;
 use Greenlight\Plugin\HarnessProvider;
@@ -34,7 +35,7 @@ use Tempest\Http\Request;
  * attributes select tagged Tempest bindings. Tests MUST isolate external
  * resources by `GREENLIGHT_CHANNEL`.
  */
-final class TempestPlugin implements AfterTestSubscriber, BeforeTestSubscriber, HarnessProvider, ServiceResolver, WorkerBootstrapSubscriber
+final class TempestPlugin implements AfterTestSubscriber, BeforeTestSubscriber, HarnessProvider, TerminalServiceResolver, WorkerBootstrapSubscriber
 {
     private ?FrameworkKernel $kernel = null;
 
@@ -82,10 +83,9 @@ final class TempestPlugin implements AfterTestSubscriber, BeforeTestSubscriber, 
     /**
      * @param class-string $type
      * @param list<object> $attributes
-     * @throws ServiceResolutionFailed
      */
     #[\Override]
-    public function resolve(string $type, array $attributes): object
+    public function resolve(string $type, array $attributes): ServiceResolution
     {
         $tag = null;
 
@@ -97,17 +97,19 @@ final class TempestPlugin implements AfterTestSubscriber, BeforeTestSubscriber, 
 
         try {
             $service = $this->container()->get($type, $tag);
-        } catch (TempestBridgeError $error) {
-            throw $error;
+        } catch (ServiceResolutionFailed $error) {
+            return ServiceResolution::failed($error);
         } catch (\Throwable $cause) {
-            throw TempestBridgeError::serviceResolutionFailed($type, $cause);
+            return ServiceResolution::failed(TempestBridgeError::serviceResolutionFailed($type, $cause));
         }
 
         if (!$service instanceof $type) {
-            throw TempestBridgeError::serviceTypeMismatch($type, \get_debug_type($service));
+            return ServiceResolution::failed(
+                TempestBridgeError::serviceTypeMismatch($type, \get_debug_type($service)),
+            );
         }
 
-        return $service;
+        return ServiceResolution::resolved($service);
     }
 
     #[\Override]

--- a/tests/Fixture/Plugins/FakeCapabilityPlugin.php
+++ b/tests/Fixture/Plugins/FakeCapabilityPlugin.php
@@ -8,6 +8,7 @@ use Greenlight\Core\Event\Event;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Core\Test\TestMetadata;
 use Greenlight\Doubles\Fake;
+use Greenlight\Harness\ServiceResolution;
 use Greenlight\Harness\ServiceResolver;
 use Greenlight\Plugin\AfterTestSubscriber;
 use Greenlight\Plugin\BeforeTestSubscriber;
@@ -27,9 +28,9 @@ class FakeCapabilityPlugin implements AfterTestSubscriber, BeforeTestSubscriber,
     public function onRunEvent(Event $event): void {}
 
     #[\Override]
-    public function resolve(string $type, array $attributes): ?object
+    public function resolve(string $type, array $attributes): ServiceResolution
     {
-        return null;
+        return ServiceResolution::unhandled();
     }
 
     #[\Override]

--- a/tests/Support/ServiceResolverProbe.php
+++ b/tests/Support/ServiceResolverProbe.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Support;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Harness\ServiceResolution;
+use Greenlight\Harness\ServiceResolver;
+use Greenlight\Plugin\Plugin;
+
+/** Stores calls and returns one configured service resolution. */
+final class ServiceResolverProbe implements Fake, Plugin, ServiceResolver
+{
+    public int $calls = 0;
+
+    public function __construct(private readonly ServiceResolution $resolution) {}
+
+    #[\Override]
+    public function resolve(string $type, array $attributes): ServiceResolution
+    {
+        ++$this->calls;
+
+        return $this->resolution;
+    }
+}

--- a/tests/Unit/Harness/FallbackResolverCountTest.php
+++ b/tests/Unit/Harness/FallbackResolverCountTest.php
@@ -9,6 +9,7 @@ use Greenlight\Doubles\Fake;
 use Greenlight\Expect\Expect;
 use Greenlight\Harness\HarnessRegistry;
 use Greenlight\Harness\HarnessScopes;
+use Greenlight\Harness\ServiceResolution;
 use Greenlight\Harness\ServiceResolver;
 use Greenlight\Harness\UnresolvableService;
 
@@ -21,22 +22,22 @@ final class FallbackResolverCountTest
             public int $calls = 0;
 
             #[\Override]
-            public function resolve(string $type, array $attributes): ?object
+            public function resolve(string $type, array $attributes): ServiceResolution
             {
                 ++$this->calls;
 
-                return null;
+                return ServiceResolution::unhandled();
             }
         };
         $second = new class implements Fake, ServiceResolver {
             public int $calls = 0;
 
             #[\Override]
-            public function resolve(string $type, array $attributes): ?object
+            public function resolve(string $type, array $attributes): ServiceResolution
             {
                 ++$this->calls;
 
-                return null;
+                return ServiceResolution::unhandled();
             }
         };
         $scopes = new HarnessScopes(new HarnessRegistry(), [$first, $second]);

--- a/tests/Unit/Harness/HarnessScopesTest.php
+++ b/tests/Unit/Harness/HarnessScopesTest.php
@@ -13,7 +13,10 @@ use Greenlight\Harness\HarnessRegistry;
 use Greenlight\Harness\HarnessScopes;
 use Greenlight\Harness\Scope;
 use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Harness\ServiceResolution;
+use Greenlight\Harness\ServiceResolutionFailed;
 use Greenlight\Harness\ServiceResolver;
+use Greenlight\Harness\TerminalServiceResolver;
 use Greenlight\Harness\UnresolvableService;
 
 final class HarnessScopesTest
@@ -47,11 +50,11 @@ final class HarnessScopesTest
             public bool $consulted = false;
 
             #[\Override]
-            public function resolve(string $type, array $attributes): object
+            public function resolve(string $type, array $attributes): ServiceResolution
             {
                 $this->consulted = true;
 
-                return new \ArrayObject(['fallback']);
+                return ServiceResolution::resolved(new \ArrayObject(['fallback']));
             }
         };
 
@@ -78,12 +81,12 @@ final class HarnessScopesTest
             public array $attributes = [];
 
             #[\Override]
-            public function resolve(string $type, array $attributes): object
+            public function resolve(string $type, array $attributes): ServiceResolution
             {
                 $this->type = $type;
                 $this->attributes = $attributes;
 
-                return new \ArrayObject();
+                return ServiceResolution::resolved(new \ArrayObject());
             }
         };
         $marker = new \stdClass();
@@ -101,9 +104,9 @@ final class HarnessScopesTest
     {
         $passing = new class implements ServiceResolver {
             #[\Override]
-            public function resolve(string $type, array $attributes): ?object
+            public function resolve(string $type, array $attributes): ServiceResolution
             {
-                return null;
+                return ServiceResolution::unhandled();
             }
         };
         $answer = new \ArrayObject(['answered']);
@@ -114,9 +117,9 @@ final class HarnessScopesTest
             public function __construct(private \ArrayObject $answer) {}
 
             #[\Override]
-            public function resolve(string $type, array $attributes): object
+            public function resolve(string $type, array $attributes): ServiceResolution
             {
-                return $this->answer;
+                return ServiceResolution::resolved($this->answer);
             }
         };
 
@@ -141,9 +144,9 @@ final class HarnessScopesTest
             public function __construct(private Disposable $service) {}
 
             #[\Override]
-            public function resolve(string $type, array $attributes): object
+            public function resolve(string $type, array $attributes): ServiceResolution
             {
-                return $this->service;
+                return ServiceResolution::resolved($this->service);
             }
         };
         $scopes = new HarnessScopes(new HarnessRegistry(), [$resolver]);
@@ -165,9 +168,9 @@ final class HarnessScopesTest
     {
         $resolver = new class implements ServiceResolver {
             #[\Override]
-            public function resolve(string $type, array $attributes): object
+            public function resolve(string $type, array $attributes): ServiceResolution
             {
-                return new \stdClass();
+                return ServiceResolution::resolved(new \stdClass());
             }
         };
         $scopes = new HarnessScopes(new HarnessRegistry(), [$resolver]);
@@ -182,9 +185,9 @@ final class HarnessScopesTest
     {
         $resolver = new class implements ServiceResolver {
             #[\Override]
-            public function resolve(string $type, array $attributes): ?object
+            public function resolve(string $type, array $attributes): ServiceResolution
             {
-                return null;
+                return ServiceResolution::unhandled();
             }
         };
         $scopes = new HarnessScopes(new HarnessRegistry(), [$resolver]);
@@ -202,6 +205,89 @@ final class HarnessScopesTest
         Expect::that(static function () use ($scopes): void {
             $scopes->resolve(\ArrayObject::class, 'test');
         })->because('without resolvers the original message stands')->toThrow(UnresolvableService::class, matching: '/exact types only\.$/');
+    }
+
+    #[Test]
+    public function aFailedResolutionStopsTheResolverChain(): void
+    {
+        $failure = new class ('The resolver failed.') extends ServiceResolutionFailed {};
+        $failing = new readonly class ($failure) implements ServiceResolver {
+            public function __construct(private ServiceResolutionFailed $failure) {}
+
+            #[\Override]
+            public function resolve(string $type, array $attributes): ServiceResolution
+            {
+                return ServiceResolution::failed($this->failure);
+            }
+        };
+        $later = new class implements ServiceResolver {
+            public bool $consulted = false;
+
+            #[\Override]
+            public function resolve(string $type, array $attributes): ServiceResolution
+            {
+                $this->consulted = true;
+
+                return ServiceResolution::resolved(new \ArrayObject());
+            }
+        };
+        $scopes = new HarnessScopes(new HarnessRegistry(), [$failing, $later]);
+
+        $error = null;
+
+        try {
+            $scopes->resolve(\ArrayObject::class, 'test');
+        } catch (ServiceResolutionFailed $caught) {
+            $error = $caught;
+        }
+
+        Expect::that($error)
+            ->because('a failed result MUST expose the public service resolution failure contract')
+            ->toBeInstanceOf(ServiceResolutionFailed::class);
+        Expect::that($error)->toBe($failure);
+        Expect::that($later->consulted)
+            ->because('Greenlight MUST NOT call a resolver after a failed result')
+            ->toBeFalse();
+    }
+
+    #[Test]
+    public function aTerminalResolverMustBeFinal(): void
+    {
+        $terminal = new class implements TerminalServiceResolver {
+            #[\Override]
+            public function resolve(string $type, array $attributes): ServiceResolution
+            {
+                return ServiceResolution::failed(new class ('Terminal failure.') extends ServiceResolutionFailed {});
+            }
+        };
+        $fallback = new class implements ServiceResolver {
+            #[\Override]
+            public function resolve(string $type, array $attributes): ServiceResolution
+            {
+                return ServiceResolution::unhandled();
+            }
+        };
+
+        Expect::that(static fn(): HarnessScopes => new HarnessScopes(new HarnessRegistry(), [$terminal, $fallback]))
+            ->because('a terminal resolver MUST be the final resolver')
+            ->toThrow(\InvalidArgumentException::class, message: 'A terminal service resolver MUST be the final resolver.');
+    }
+
+    #[Test]
+    public function aTerminalResolverCannotReturnUnhandled(): void
+    {
+        $terminal = new class implements TerminalServiceResolver {
+            #[\Override]
+            public function resolve(string $type, array $attributes): ServiceResolution
+            {
+                return ServiceResolution::unhandled();
+            }
+        };
+        $scopes = new HarnessScopes(new HarnessRegistry(), [$terminal]);
+
+        Expect::that(static fn(): object => $scopes->resolve(\ArrayObject::class, 'test'))
+            ->because('a terminal resolver MUST handle every request')
+            ->toThrow(\LogicException::class, matching: '/Terminal service resolver .* returned an unhandled result/');
     }
 
     #[Test]

--- a/tests/Unit/Harness/ServiceResolutionTest.php
+++ b/tests/Unit/Harness/ServiceResolutionTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Harness;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Harness\ServiceResolution;
+use Greenlight\Harness\ServiceResolutionFailed;
+
+final readonly class ServiceResolutionTest
+{
+    #[Test]
+    public function unhandledResultContainsNoServiceOrError(): void
+    {
+        $resolution = ServiceResolution::unhandled();
+
+        Expect::that($resolution->isUnhandled())->toBeTrue();
+        Expect::that($resolution->isResolved())->toBeFalse();
+        Expect::that($resolution->isFailed())->toBeFalse();
+        Expect::that($resolution->value())->toBeNull();
+        Expect::that($resolution->service(...))->toThrow(\LogicException::class);
+        Expect::that($resolution->error(...))->toThrow(\LogicException::class);
+    }
+
+    #[Test]
+    public function resolvedResultContainsOnlyTheService(): void
+    {
+        $service = new \stdClass();
+        $resolution = ServiceResolution::resolved($service);
+
+        Expect::that($resolution->isUnhandled())->toBeFalse();
+        Expect::that($resolution->isResolved())->toBeTrue();
+        Expect::that($resolution->isFailed())->toBeFalse();
+        Expect::that($resolution->service())->toBe($service);
+        Expect::that($resolution->value())->toBe($service);
+        Expect::that($resolution->error(...))->toThrow(\LogicException::class);
+    }
+
+    #[Test]
+    public function failedResultContainsOnlyTheError(): void
+    {
+        $error = new class ('Resolution failed.') extends ServiceResolutionFailed {};
+        $resolution = ServiceResolution::failed($error);
+
+        Expect::that($resolution->isUnhandled())->toBeFalse();
+        Expect::that($resolution->isResolved())->toBeFalse();
+        Expect::that($resolution->isFailed())->toBeTrue();
+        Expect::that($resolution->error())->toBe($error);
+        Expect::that($resolution->service(...))->toThrow(\LogicException::class);
+        Expect::that($resolution->value(...))->toThrow($error);
+    }
+}

--- a/tests/Unit/Laravel/LaravelPluginTest.php
+++ b/tests/Unit/Laravel/LaravelPluginTest.php
@@ -14,7 +14,11 @@ use Greenlight\Core\Result\TestResult;
 use Greenlight\Doubles\Doubles;
 use Greenlight\Doubles\MockPlan;
 use Greenlight\Expect\Expect;
+use Greenlight\Harness\HarnessRegistry;
+use Greenlight\Harness\HarnessScopes;
 use Greenlight\Harness\Scope;
+use Greenlight\Harness\ServiceResolution;
+use Greenlight\Harness\ServiceResolutionFailed;
 use Greenlight\Laravel\LaravelBridgeError;
 use Greenlight\Laravel\LaravelFrameworkRequirement;
 use Greenlight\Laravel\LaravelPlugin;
@@ -27,6 +31,7 @@ use Greenlight\Tests\Fixture\Laravel\NamedGreeter;
 use Greenlight\Tests\Fixture\Laravel\VisitCounter;
 use Greenlight\Tests\Support\FilesystemRestriction;
 use Greenlight\Tests\Support\PluginLifecycle;
+use Greenlight\Tests\Support\ServiceResolverProbe;
 use Illuminate\Container\Container;
 use Illuminate\Contracts\Console\Kernel;
 use Illuminate\Contracts\Foundation\Application;
@@ -63,7 +68,7 @@ final class LaravelPluginTest
     #[Test]
     public function resolvesContainerServicesByType(): void
     {
-        $greeter = $this->plugin()->resolve(Greeter::class, []);
+        $greeter = $this->plugin()->resolve(Greeter::class, [])->value();
 
         Expect::that($greeter)
             ->because('LaravelPlugin::resolve() MUST return Greeter.')
@@ -77,14 +82,14 @@ final class LaravelPluginTest
     {
         $plugin = $this->plugin();
 
-        Expect::that($plugin->resolve(VisitCounter::class, []))
-            ->toBe($plugin->resolve(VisitCounter::class, []));
+        Expect::that($plugin->resolve(VisitCounter::class, [])->value())
+            ->toBe($plugin->resolve(VisitCounter::class, [])->value());
     }
 
     #[Test]
     public function theServiceAttributeResolvesByExplicitId(): void
     {
-        $named = $this->plugin()->resolve(NamedGreeter::class, [new Service('fixture.named_greeter')]);
+        $named = $this->plugin()->resolve(NamedGreeter::class, [new Service('fixture.named_greeter')])->value();
 
         Expect::that($named)->toBeInstanceOf(NamedGreeter::class);
     }
@@ -92,7 +97,7 @@ final class LaravelPluginTest
     #[Test]
     public function aTypeWithoutTheAttributeMissesIdOnlyServices(): void
     {
-        Expect::that($this->plugin()->resolve(NamedGreeter::class, []))->toBeNull();
+        Expect::that($this->plugin()->resolve(NamedGreeter::class, [])->value())->toBeNull();
     }
 
     #[Test]
@@ -100,7 +105,36 @@ final class LaravelPluginTest
     {
         // Laravel could construct ArrayObject through implicit resolution.
         // The bridge only serves explicit bindings.
-        Expect::that($this->plugin()->resolve(\ArrayObject::class, []))->toBeNull();
+        Expect::that($this->plugin()->resolve(\ArrayObject::class, [])->value())->toBeNull();
+    }
+
+    #[Test]
+    public function anUnboundTypeFallsThroughToTheNextResolver(): void
+    {
+        $answer = new \ArrayObject();
+        $later = new ServiceResolverProbe(ServiceResolution::resolved($answer));
+        $scopes = new HarnessScopes(new HarnessRegistry(), [$this->plugin(), $later]);
+
+        Expect::that($scopes->resolve(\ArrayObject::class, 'test'))
+            ->because('an unbound Laravel type MUST fall through to the next resolver')
+            ->toBe($answer);
+        Expect::that($later->calls)->toBe(1);
+    }
+
+    #[Test]
+    public function anUnknownExplicitBindingStopsTheResolverChain(): void
+    {
+        $later = new ServiceResolverProbe(ServiceResolution::resolved(new Greeter()));
+        $scopes = new HarnessScopes(new HarnessRegistry(), [$this->plugin(), $later]);
+
+        Expect::that(static fn(): object => $scopes->resolve(
+            Greeter::class,
+            'test',
+            [new Service('fixture.missing')],
+        ))
+            ->because('an explicit Laravel binding failure MUST stop the resolver chain')
+            ->toThrow(ServiceResolutionFailed::class, matching: '/no binding "fixture\.missing"/');
+        Expect::that($later->calls)->toBe(0);
     }
 
     #[Test]
@@ -109,7 +143,7 @@ final class LaravelPluginTest
         $plugin = $this->plugin();
 
         Expect::that(static function () use ($plugin): void {
-            $plugin->resolve(Greeter::class, [new Service('fixture.missing')]);
+            $plugin->resolve(Greeter::class, [new Service('fixture.missing')])->value();
         })->toThrow(LaravelBridgeError::class, matching: '/no binding "fixture\.missing".*Check the id for typos/s');
     }
 
@@ -119,7 +153,7 @@ final class LaravelPluginTest
         $plugin = $this->plugin();
 
         Expect::that(static function () use ($plugin): void {
-            $plugin->resolve(VisitCounter::class, [new Service('fixture.named_greeter')]);
+            $plugin->resolve(VisitCounter::class, [new Service('fixture.named_greeter')])->value();
         })->toThrow(LaravelBridgeError::class, matching: '/is an instance of .* but the parameter declares/');
     }
 
@@ -130,7 +164,7 @@ final class LaravelPluginTest
         $plugin = $this->track(new LaravelPlugin($this->fixtureDir() . '/missing-bootstrap.php'));
 
         Expect::that(static function () use ($plugin): void {
-            $plugin->resolve(Greeter::class, []);
+            $plugin->resolve(Greeter::class, [])->value();
         })->toThrow(LaravelBridgeError::class, matching: '/does not exist.*bootstrap\/app\.php/s');
         Expect::that(\getenv('APP_ENV'))->toBe('before-laravel');
         Expect::that($_ENV['APP_ENV'] ?? null)->toBe('before-laravel');
@@ -149,7 +183,7 @@ final class LaravelPluginTest
         Expect::that(
             static function () use ($plugin, &$warning): void {
                 ErrorTrap::run(
-                    static fn() => $plugin->resolve(Greeter::class, []),
+                    static fn() => $plugin->resolve(Greeter::class, [])->value(),
                     $warning,
                 );
             },
@@ -188,7 +222,7 @@ final class LaravelPluginTest
         $plugin = $this->track(new LaravelPlugin($this->fixtureDir() . '/bootstrap-invalid.php'));
 
         Expect::that(static function () use ($plugin): void {
-            $plugin->resolve(Greeter::class, []);
+            $plugin->resolve(Greeter::class, [])->value();
         })->toThrow(LaravelBridgeError::class, matching: '/returned "stdClass".*Application::configure/s');
     }
 
@@ -200,7 +234,7 @@ final class LaravelPluginTest
         ));
 
         Expect::that(static function () use ($plugin): void {
-            $plugin->resolve(Greeter::class, []);
+            $plugin->resolve(Greeter::class, [])->value();
         })->toThrow(LaravelBridgeError::class, matching: '/no console kernel binding/');
     }
 
@@ -215,7 +249,7 @@ final class LaravelPluginTest
         }));
 
         Expect::that(static function () use ($plugin): void {
-            $plugin->resolve(Greeter::class, []);
+            $plugin->resolve(Greeter::class, [])->value();
         })->toThrow(LaravelBridgeError::class, matching: '/contains "stdClass" instead of/');
     }
 
@@ -235,9 +269,19 @@ final class LaravelPluginTest
             return $app;
         }));
 
-        Expect::that(static function () use ($plugin): void {
-            $plugin->resolve(Greeter::class, []);
-        })->toThrow($failure);
+        $error = null;
+
+        try {
+            $plugin->resolve(Greeter::class, [])->value();
+        } catch (LaravelBridgeError $caught) {
+            $error = $caught;
+        }
+        Expect::that($error)
+            ->because('the failed kernel bootstrap MUST cause a Laravel bridge error')
+            ->toBeInstanceOf(LaravelBridgeError::class);
+        Expect::that($error->getPrevious())
+            ->because('the resolution failure MUST keep the container cause')
+            ->toBe($failure);
         Expect::that(Container::getInstance())->toBe($container);
         Expect::that(\getenv('APP_ENV'))->toBe('before-laravel');
         Expect::that($_ENV['APP_ENV'] ?? null)->toBe('before-laravel');
@@ -281,13 +325,13 @@ final class LaravelPluginTest
             static fn(): Application => FixtureApplication::create(),
         ));
 
-        Expect::that($plugin->resolve(Greeter::class, []))->toBeInstanceOf(Greeter::class);
+        Expect::that($plugin->resolve(Greeter::class, [])->value())->toBeInstanceOf(Greeter::class);
     }
 
     #[Test]
     public function theApplicationEnvironmentComesFromTheEnvParameter(): void
     {
-        $app = $this->plugin()->resolve(Application::class, []);
+        $app = $this->plugin()->resolve(Application::class, [])->value();
 
         Expect::that($app)
             ->because('LaravelPlugin::resolve() MUST return the application.')
@@ -302,14 +346,14 @@ final class LaravelPluginTest
         $plugin = $this->plugin();
         $app = ($plugin->services()[0]->factory)();
 
-        Expect::that($plugin->resolve(LaravelApplication::class, []))->toBe($app);
+        Expect::that($plugin->resolve(LaravelApplication::class, [])->value())->toBe($app);
     }
 
     #[Test]
     public function afterTestBootsAFreshApplicationForTheNextTest(): void
     {
         $plugin = $this->plugin();
-        $counter = $plugin->resolve(VisitCounter::class, []);
+        $counter = $plugin->resolve(VisitCounter::class, [])->value();
 
         Expect::that($counter)
             ->because('LaravelPlugin::resolve() MUST return VisitCounter.')
@@ -318,7 +362,7 @@ final class LaravelPluginTest
         $counter->record();
         $result = $this->result();
         $returned = $plugin->afterTest($this->context(), $result);
-        $second = $plugin->resolve(VisitCounter::class, []);
+        $second = $plugin->resolve(VisitCounter::class, [])->value();
 
         Expect::that($second)
             ->because('LaravelPlugin::resolve() MUST return VisitCounter.')
@@ -337,7 +381,7 @@ final class LaravelPluginTest
             $this->fixtureDir() . '/bootstrap.php',
             refreshBetweenTests: false,
         ));
-        $counter = $plugin->resolve(VisitCounter::class, []);
+        $counter = $plugin->resolve(VisitCounter::class, [])->value();
 
         Expect::that($counter)
             ->because('LaravelPlugin::resolve() MUST return VisitCounter.')
@@ -347,7 +391,7 @@ final class LaravelPluginTest
         $plugin->afterTest($this->context(), $this->result());
 
         Expect::that($counter->count())->toBe(1);
-        Expect::that($plugin->resolve(VisitCounter::class, []))->toBe($counter);
+        Expect::that($plugin->resolve(VisitCounter::class, [])->value())->toBe($counter);
     }
 
     #[Test]
@@ -393,7 +437,7 @@ final class LaravelPluginTest
         $this->environment->unset('APP_ENV');
         $plugin = $this->plugin();
 
-        $plugin->resolve(Greeter::class, []);
+        $plugin->resolve(Greeter::class, [])->value();
 
         Expect::that(\getenv('APP_ENV'))
             ->because('Laravel boot MUST set the configured application environment')
@@ -423,7 +467,7 @@ final class LaravelPluginTest
         \restore_exception_handler();
         $reportingBefore = \error_reporting();
 
-        $this->plugin()->resolve(Greeter::class, []);
+        $this->plugin()->resolve(Greeter::class, [])->value();
 
         $errorAfter = \set_error_handler(null);
         \restore_error_handler();
@@ -475,7 +519,7 @@ final class LaravelPluginTest
 
     private function refreshApplication(LaravelPlugin $plugin): void
     {
-        $plugin->resolve(Greeter::class, []);
+        $plugin->resolve(Greeter::class, [])->value();
         $plugin->afterTest($this->context(), $this->result());
     }
 

--- a/tests/Unit/Plugin/PluginRegistryHarnessPriorityTest.php
+++ b/tests/Unit/Plugin/PluginRegistryHarnessPriorityTest.php
@@ -9,7 +9,12 @@ use Greenlight\Doubles\Fake;
 use Greenlight\Expect\Expect;
 use Greenlight\Harness\Scope;
 use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Harness\ServiceResolution;
+use Greenlight\Harness\ServiceResolutionFailed;
+use Greenlight\Harness\ServiceResolver;
+use Greenlight\Harness\TerminalServiceResolver;
 use Greenlight\Plugin\HarnessProvider;
+use Greenlight\Plugin\Plugin;
 use Greenlight\Plugin\PluginRegistry;
 use Greenlight\Plugin\Prioritized;
 
@@ -50,6 +55,41 @@ final class PluginRegistryHarnessPriorityTest
                 \stdClass::class,
                 \DateTimeImmutable::class,
             ]);
+    }
+
+    #[Test]
+    public function terminalServiceResolverAlwaysFollowsFallbackResolvers(): void
+    {
+        $terminal = new class implements Fake, Plugin, Prioritized, TerminalServiceResolver {
+            #[\Override]
+            public function priority(): int
+            {
+                return -100;
+            }
+
+            #[\Override]
+            public function resolve(string $type, array $attributes): ServiceResolution
+            {
+                return ServiceResolution::failed(new class ('Terminal failure.') extends ServiceResolutionFailed {});
+            }
+        };
+        $fallback = new class implements Fake, Plugin, Prioritized, ServiceResolver {
+            #[\Override]
+            public function priority(): int
+            {
+                return 100;
+            }
+
+            #[\Override]
+            public function resolve(string $type, array $attributes): ServiceResolution
+            {
+                return ServiceResolution::unhandled();
+            }
+        };
+
+        Expect::that(new PluginRegistry([$terminal, $fallback])->serviceResolvers())
+            ->because('a terminal resolver MUST follow all fallback-capable resolvers')
+            ->toBe([$fallback, $terminal]);
     }
 
     /**

--- a/tests/Unit/Psr/Psr11PluginTest.php
+++ b/tests/Unit/Psr/Psr11PluginTest.php
@@ -7,7 +7,11 @@ namespace Greenlight\Tests\Unit\Psr;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Expect\Expect;
+use Greenlight\Harness\HarnessRegistry;
+use Greenlight\Harness\HarnessScopes;
 use Greenlight\Harness\Scope;
+use Greenlight\Harness\ServiceResolution;
+use Greenlight\Harness\ServiceResolutionFailed;
 use Greenlight\Plugin\TestContext;
 use Greenlight\Psr\Psr11BridgeError;
 use Greenlight\Psr\Psr11Plugin;
@@ -15,6 +19,7 @@ use Greenlight\Psr\Service;
 use Greenlight\Tests\Support\PluginLifecycle;
 use Greenlight\Tests\Support\Psr\ArrayContainer;
 use Greenlight\Tests\Support\Psr\Greeter;
+use Greenlight\Tests\Support\ServiceResolverProbe;
 use Psr\Container\ContainerInterface;
 
 final readonly class Psr11PluginTest
@@ -25,7 +30,7 @@ final readonly class Psr11PluginTest
         $greeter = new Greeter();
         $plugin = $this->plugin([Greeter::class => $greeter]);
 
-        Expect::that($plugin->resolve(Greeter::class, []))->toBe($greeter);
+        Expect::that($plugin->resolve(Greeter::class, [])->value())->toBe($greeter);
     }
 
     #[Test]
@@ -33,7 +38,7 @@ final readonly class Psr11PluginTest
     {
         $greeter = new Greeter();
         $plugin = $this->plugin(['application.greeter' => $greeter]);
-        $resolved = $plugin->resolve(Greeter::class, [new Service('application.greeter')]);
+        $resolved = $plugin->resolve(Greeter::class, [new Service('application.greeter')])->value();
 
         Expect::that($resolved)->toBe($greeter);
     }
@@ -41,7 +46,36 @@ final readonly class Psr11PluginTest
     #[Test]
     public function anUnknownTypeReturnsNull(): void
     {
-        Expect::that($this->plugin([])->resolve(Greeter::class, []))->toBeNull();
+        Expect::that($this->plugin([])->resolve(Greeter::class, [])->value())->toBeNull();
+    }
+
+    #[Test]
+    public function anUnknownTypeFallsThroughToTheNextResolver(): void
+    {
+        $answer = new Greeter();
+        $later = new ServiceResolverProbe(ServiceResolution::resolved($answer));
+        $scopes = new HarnessScopes(new HarnessRegistry(), [$this->plugin([]), $later]);
+
+        Expect::that($scopes->resolve(Greeter::class, 'test'))
+            ->because('an unknown PSR-11 type MUST fall through to the next resolver')
+            ->toBe($answer);
+        Expect::that($later->calls)->toBe(1);
+    }
+
+    #[Test]
+    public function anUnknownExplicitServiceStopsTheResolverChain(): void
+    {
+        $later = new ServiceResolverProbe(ServiceResolution::resolved(new Greeter()));
+        $scopes = new HarnessScopes(new HarnessRegistry(), [$this->plugin([]), $later]);
+
+        Expect::that(static fn(): object => $scopes->resolve(
+            Greeter::class,
+            'test',
+            [new Service('missing')],
+        ))
+            ->because('an explicit PSR-11 service failure MUST stop the resolver chain')
+            ->toThrow(ServiceResolutionFailed::class, matching: '/no service "missing"/');
+        Expect::that($later->calls)->toBe(0);
     }
 
     #[Test]
@@ -50,7 +84,7 @@ final readonly class Psr11PluginTest
         $plugin = $this->plugin([]);
 
         Expect::that(static function () use ($plugin): void {
-            $plugin->resolve(Greeter::class, [new Service('missing')]);
+            $plugin->resolve(Greeter::class, [new Service('missing')])->value();
         })->toThrow(
             Psr11BridgeError::class,
             matching: '/no service "missing".*Check the service ID/s',
@@ -63,7 +97,7 @@ final readonly class Psr11PluginTest
         $plugin = $this->plugin(['application' => new \stdClass()]);
 
         Expect::that(static function () use ($plugin): void {
-            $plugin->resolve(Greeter::class, [new Service('application')]);
+            $plugin->resolve(Greeter::class, [new Service('application')])->value();
         })->toThrow(
             Psr11BridgeError::class,
             matching: '/service "application" has type "stdClass".*requires type/s',
@@ -105,11 +139,11 @@ final readonly class Psr11PluginTest
 
             return new ArrayContainer([Greeter::class => new Greeter()]);
         });
-        $first = $plugin->resolve(Greeter::class, []);
+        $first = $plugin->resolve(Greeter::class, [])->value();
 
         $plugin->afterTest($this->context(), $this->result());
 
-        Expect::that($plugin->resolve(Greeter::class, []))->not()->toBe($first);
+        Expect::that($plugin->resolve(Greeter::class, [])->value())->not()->toBe($first);
         Expect::that($created)->toBe(2);
     }
 
@@ -125,11 +159,11 @@ final readonly class Psr11PluginTest
             },
             refreshBetweenTests: false,
         );
-        $first = $plugin->resolve(Greeter::class, []);
+        $first = $plugin->resolve(Greeter::class, [])->value();
 
         $plugin->afterTest($this->context(), $this->result());
 
-        Expect::that($plugin->resolve(Greeter::class, []))->toBe($first);
+        Expect::that($plugin->resolve(Greeter::class, [])->value())->toBe($first);
         Expect::that($created)->toBe(1);
     }
 
@@ -201,7 +235,7 @@ final readonly class Psr11PluginTest
                 throw $failure;
             },
         );
-        $plugin->resolve(Greeter::class, []);
+        $plugin->resolve(Greeter::class, [])->value();
 
         try {
             $plugin->afterTest($this->context(), $this->result());
@@ -209,7 +243,7 @@ final readonly class Psr11PluginTest
             Expect::that($error->getPrevious())->toBe($failure);
         }
 
-        $plugin->resolve(Greeter::class, []);
+        $plugin->resolve(Greeter::class, [])->value();
         Expect::that($created)->toBe(2);
     }
 
@@ -224,7 +258,7 @@ final readonly class Psr11PluginTest
         $error = null;
 
         try {
-            $plugin->resolve(Greeter::class, []);
+            $plugin->resolve(Greeter::class, [])->value();
         } catch (Psr11BridgeError $caught) {
             $error = $caught;
         }
@@ -241,7 +275,7 @@ final readonly class Psr11PluginTest
     {
         $plugin = new Psr11Plugin($this->invalidContainerFactory()); // @phpstan-ignore argument.type (This test deliberately supplies an invalid factory result.)
 
-        Expect::that(static fn(): ?object => $plugin->resolve(Greeter::class, []))->toThrow(
+        Expect::that(static fn(): ?object => $plugin->resolve(Greeter::class, [])->value())->toThrow(
             Psr11BridgeError::class,
             matching: '/returned "stdClass".*ContainerInterface/',
         );
@@ -269,7 +303,7 @@ final readonly class Psr11PluginTest
         $plugin = new Psr11Plugin(static fn(): ContainerInterface => $container);
 
         $this->expectCause(
-            static fn(): ?object => $plugin->resolve(Greeter::class, []),
+            static fn(): ?object => $plugin->resolve(Greeter::class, [])->value(),
             $failure,
             '/failed when it checked service/',
         );
@@ -297,7 +331,7 @@ final readonly class Psr11PluginTest
         $plugin = new Psr11Plugin(static fn(): ContainerInterface => $container);
 
         $this->expectCause(
-            static fn(): ?object => $plugin->resolve(Greeter::class, []),
+            static fn(): ?object => $plugin->resolve(Greeter::class, [])->value(),
             $failure,
             '/failed when it read service/',
         );

--- a/tests/Unit/Symfony/SymfonyPluginInvalidKernelCacheTest.php
+++ b/tests/Unit/Symfony/SymfonyPluginInvalidKernelCacheTest.php
@@ -23,7 +23,7 @@ final class SymfonyPluginInvalidKernelCacheTest
 
             return BareKernel::withoutTestContainer();
         });
-        $resolve = static fn(): ?object => $plugin->resolve(Greeter::class, []);
+        $resolve = static fn(): ?object => $plugin->resolve(Greeter::class, [])->value();
 
         Expect::that($resolve)
             ->because('the first invalid kernel fails validation')

--- a/tests/Unit/Symfony/SymfonyPluginTest.php
+++ b/tests/Unit/Symfony/SymfonyPluginTest.php
@@ -7,7 +7,11 @@ namespace Greenlight\Tests\Unit\Symfony;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Expect\Expect;
+use Greenlight\Harness\HarnessRegistry;
+use Greenlight\Harness\HarnessScopes;
 use Greenlight\Harness\Scope;
+use Greenlight\Harness\ServiceResolution;
+use Greenlight\Harness\ServiceResolutionFailed;
 use Greenlight\Plugin\TestContext;
 use Greenlight\Symfony\Service;
 use Greenlight\Symfony\SymfonyBridgeError;
@@ -18,6 +22,7 @@ use Greenlight\Tests\Fixture\Symfony\Greeter;
 use Greenlight\Tests\Fixture\Symfony\NamedGreeter;
 use Greenlight\Tests\Fixture\Symfony\VisitCounter;
 use Greenlight\Tests\Support\PluginLifecycle;
+use Greenlight\Tests\Support\ServiceResolverProbe;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 final class SymfonyPluginTest
@@ -25,7 +30,7 @@ final class SymfonyPluginTest
     #[Test]
     public function resolvesContainerServicesByType(): void
     {
-        $greeter = $this->plugin()->resolve(Greeter::class, []);
+        $greeter = $this->plugin()->resolve(Greeter::class, [])->value();
 
         Expect::that($greeter)
             ->because('SymfonyPlugin::resolve() MUST return Greeter.')
@@ -39,14 +44,14 @@ final class SymfonyPluginTest
     {
         // VisitCounter is private and has no reference. Only the test container
         // keeps it available.
-        Expect::that($this->plugin()->resolve(VisitCounter::class, []))->because('resolves private services through the test container')
+        Expect::that($this->plugin()->resolve(VisitCounter::class, [])->value())->because('resolves private services through the test container')
             ->toBeInstanceOf(VisitCounter::class);
     }
 
     #[Test]
     public function theServiceAttributeResolvesByExplicitId(): void
     {
-        $named = $this->plugin()->resolve(NamedGreeter::class, [new Service('fixture.named_greeter')]);
+        $named = $this->plugin()->resolve(NamedGreeter::class, [new Service('fixture.named_greeter')])->value();
 
         Expect::that($named)->because('the service attribute resolves by explicit ID')->toBeInstanceOf(NamedGreeter::class);
     }
@@ -54,13 +59,42 @@ final class SymfonyPluginTest
     #[Test]
     public function aTypeWithoutTheAttributeMissesIdOnlyServices(): void
     {
-        Expect::that($this->plugin()->resolve(NamedGreeter::class, []))->because('a type without the attribute misses ID only services')->toBeNull();
+        Expect::that($this->plugin()->resolve(NamedGreeter::class, [])->value())->because('a type without the attribute misses ID only services')->toBeNull();
     }
 
     #[Test]
     public function aTypeTheContainerDoesNotKnowReturnsNull(): void
     {
-        Expect::that($this->plugin()->resolve(\ArrayObject::class, []))->because('a type the container does not know returns null')->toBeNull();
+        Expect::that($this->plugin()->resolve(\ArrayObject::class, [])->value())->because('a type the container does not know returns null')->toBeNull();
+    }
+
+    #[Test]
+    public function anUnknownTypeFallsThroughToTheNextResolver(): void
+    {
+        $answer = new \ArrayObject();
+        $later = new ServiceResolverProbe(ServiceResolution::resolved($answer));
+        $scopes = new HarnessScopes(new HarnessRegistry(), [$this->plugin(), $later]);
+
+        Expect::that($scopes->resolve(\ArrayObject::class, 'test'))
+            ->because('an unknown Symfony type MUST fall through to the next resolver')
+            ->toBe($answer);
+        Expect::that($later->calls)->toBe(1);
+    }
+
+    #[Test]
+    public function anUnknownExplicitServiceStopsTheResolverChain(): void
+    {
+        $later = new ServiceResolverProbe(ServiceResolution::resolved(new Greeter()));
+        $scopes = new HarnessScopes(new HarnessRegistry(), [$this->plugin(), $later]);
+
+        Expect::that(static fn(): object => $scopes->resolve(
+            Greeter::class,
+            'test',
+            [new Service('fixture.missing')],
+        ))
+            ->because('an explicit Symfony service failure MUST stop the resolver chain')
+            ->toThrow(ServiceResolutionFailed::class, matching: '/no service "fixture\.missing"/');
+        Expect::that($later->calls)->toBe(0);
     }
 
     #[Test]
@@ -69,7 +103,7 @@ final class SymfonyPluginTest
         $plugin = $this->plugin();
 
         Expect::that(static function () use ($plugin): void {
-            $plugin->resolve(Greeter::class, [new Service('fixture.missing')]);
+            $plugin->resolve(Greeter::class, [new Service('fixture.missing')])->value();
         })->because('an unknown explicit ID causes an error')->toThrow(SymfonyBridgeError::class, matching: '/no service "fixture\.missing".*Check the service ID/s');
     }
 
@@ -79,7 +113,7 @@ final class SymfonyPluginTest
         $plugin = $this->plugin();
 
         Expect::that(static function () use ($plugin): void {
-            $plugin->resolve(VisitCounter::class, [new Service('fixture.named_greeter')]);
+            $plugin->resolve(VisitCounter::class, [new Service('fixture.named_greeter')])->value();
         })->because('an explicit ID of the wrong type causes an error')->toThrow(SymfonyBridgeError::class, matching: '/has type .* The parameter requires type/');
     }
 
@@ -92,7 +126,7 @@ final class SymfonyPluginTest
         $plugin = new SymfonyPlugin(FixtureKernel::class, env: 'prod', debug: true);
 
         Expect::that(static function () use ($plugin): void {
-            $plugin->resolve(Greeter::class, []);
+            $plugin->resolve(Greeter::class, [])->value();
         })->because('a kernel without the test container fails at boot')->toThrow(SymfonyBridgeError::class, matching: '/framework\.test/');
     }
 
@@ -102,7 +136,7 @@ final class SymfonyPluginTest
         $plugin = new SymfonyPlugin(static fn(): KernelInterface => BareKernel::withTestContainer());
 
         Expect::that(static function () use ($plugin): void {
-            $plugin->resolve(Greeter::class, []);
+            $plugin->resolve(Greeter::class, [])->value();
         })->because('a kernel without services resetter fails at boot')->toThrow(SymfonyBridgeError::class, matching: '/services_resetter.*resetBetweenTests: false/s');
     }
 
@@ -114,14 +148,14 @@ final class SymfonyPluginTest
             resetBetweenTests: false,
         );
 
-        Expect::that($plugin->resolve(Greeter::class, []))->because('waiving resets accepts a kernel without the resetter')->toBeNull();
+        Expect::that($plugin->resolve(Greeter::class, [])->value())->because('waiving resets accepts a kernel without the resetter')->toBeNull();
     }
 
     #[Test]
     public function waivedResetsLeaveStateInPlace(): void
     {
         $plugin = new SymfonyPlugin(FixtureKernel::class, env: 'test', debug: true, resetBetweenTests: false);
-        $counter = $plugin->resolve(VisitCounter::class, []);
+        $counter = $plugin->resolve(VisitCounter::class, [])->value();
 
         Expect::that($counter)
             ->because('SymfonyPlugin::resolve() MUST return VisitCounter.')
@@ -158,7 +192,7 @@ final class SymfonyPluginTest
     {
         $plugin = new SymfonyPlugin(static fn(): KernelInterface => new FixtureKernel('test', true));
 
-        Expect::that($plugin->resolve(Greeter::class, []))->because('a closure factory boots the kernel it produces')->toBeInstanceOf(Greeter::class);
+        Expect::that($plugin->resolve(Greeter::class, [])->value())->because('a closure factory boots the kernel it produces')->toBeInstanceOf(Greeter::class);
     }
 
     #[Test]
@@ -167,7 +201,7 @@ final class SymfonyPluginTest
         $plugin = new SymfonyPlugin(\ArrayObject::class);
 
         Expect::that(static function () use ($plugin): void {
-            $plugin->resolve(Greeter::class, []);
+            $plugin->resolve(Greeter::class, [])->value();
         })->because('a class that is not a kernel causes an error')->toThrow(SymfonyBridgeError::class, matching: '/does not implement/');
     }
 
@@ -175,7 +209,7 @@ final class SymfonyPluginTest
     public function afterTestResetsStatefulContainerServices(): void
     {
         $plugin = $this->plugin();
-        $counter = $plugin->resolve(VisitCounter::class, []);
+        $counter = $plugin->resolve(VisitCounter::class, [])->value();
 
         Expect::that($counter)
             ->because('SymfonyPlugin::resolve() MUST return VisitCounter.')

--- a/tests/Unit/Tempest/TempestPluginLifecycleTest.php
+++ b/tests/Unit/Tempest/TempestPluginLifecycleTest.php
@@ -11,12 +11,17 @@ use Greenlight\Condition\ClassAvailable;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
+use Greenlight\Harness\HarnessRegistry;
+use Greenlight\Harness\HarnessScopes;
+use Greenlight\Harness\ServiceResolution;
+use Greenlight\Plugin\PluginRegistry;
 use Greenlight\Plugin\TestContext;
 use Greenlight\Sandbox\EnvironmentVariables;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tempest\TempestBridgeError;
 use Greenlight\Tempest\TempestPlugin;
 use Greenlight\Tests\Support\PluginLifecycle;
+use Greenlight\Tests\Support\ServiceResolverProbe;
 use Tempest\Container\GenericContainer;
 use Tempest\Container\Tag;
 use Tempest\Core\FrameworkKernel;
@@ -55,9 +60,23 @@ final class TempestPluginLifecycleTest
         $expected = new TaggedProbeImplementation();
         $kernel->container->singleton(TaggedProbe::class, $expected, 'preferred');
 
-        Expect::that($plugin->resolve(TaggedProbe::class, [new Tag('preferred')]))
+        Expect::that($plugin->resolve(TaggedProbe::class, [new Tag('preferred')])->value())
             ->because('the Tempest Tag attribute MUST select the tagged container binding')
             ->toBe($expected);
+    }
+
+    #[Test]
+    public function fallbackResolverRunsBeforeTerminalTempestResolver(): void
+    {
+        $answer = new TaggedProbeImplementation();
+        $fallback = new ServiceResolverProbe(ServiceResolution::resolved($answer));
+        $resolvers = new PluginRegistry([$this->plugin(), $fallback])->serviceResolvers();
+        $scopes = new HarnessScopes(new HarnessRegistry(), $resolvers);
+
+        Expect::that($scopes->resolve(TaggedProbe::class, 'test'))
+            ->because('a fallback resolver MUST run before the terminal Tempest resolver')
+            ->toBe($answer);
+        Expect::that($fallback->calls)->toBe(1);
     }
 
     #[Test]
@@ -66,7 +85,7 @@ final class TempestPluginLifecycleTest
         $plugin = $this->plugin();
         $this->kernel($plugin);
 
-        Expect::that(static fn(): object => $plugin->resolve(MissingProbe::class, []))
+        Expect::that(static fn(): ?object => $plugin->resolve(MissingProbe::class, [])->value())
             ->toThrow(
                 TempestBridgeError::class,
                 matching: '/^The Tempest container could not resolve the parameter type "'
@@ -81,7 +100,7 @@ final class TempestPluginLifecycleTest
         $missingRoot = $this->tempDirectory->path() . '/missing-resolution-root';
         $plugin = new TempestPlugin($missingRoot);
 
-        Expect::that(static fn(): object => $plugin->resolve(MissingProbe::class, []))
+        Expect::that(static fn(): ?object => $plugin->resolve(MissingProbe::class, [])->value())
             ->toThrow(
                 TempestBridgeError::class,
                 matching: '/^TempestPlugin could not boot the application at "'
@@ -111,7 +130,7 @@ final class TempestPluginLifecycleTest
         $kernel = $this->kernel($plugin);
         $kernel->container->singleton(MissingProbe::class, new \stdClass());
 
-        Expect::that(static fn(): object => $plugin->resolve(MissingProbe::class, []))
+        Expect::that(static fn(): ?object => $plugin->resolve(MissingProbe::class, [])->value())
             ->toThrow(
                 TempestBridgeError::class,
                 message: 'The Tempest container returned "stdClass" for the parameter type "'


### PR DESCRIPTION
## Summary

- replace nullable resolver responses with explicit unhandled, resolved, and failed results
- normalize first-party bridge fallback and failure behavior, and enforce Tempest as terminal
- document the resolver contract and cover multi-resolver ordering