### PR TITLE
docs: make published guidance user-facing

### DIFF
--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -28,7 +28,7 @@ Namespace: `Greenlight\Attribute`
 
 Allows Greenlight to assign tests from one class to different workers.
 
-The class MUST NOT use per-class harness services or `#[Isolated]`.
+Do not use this attribute with per-class harness services or `#[Isolated]`.
 
 ```php
 #[\Attribute(\Attribute::TARGET_CLASS)]

--- a/docs/api-expectations.md
+++ b/docs/api-expectations.md
@@ -451,8 +451,7 @@ PHPDoc:
 ### `toBeWithin()`
 
 Passes when the absolute difference between the numeric subject and
-`$of` is not more than `$delta`. The tolerance MUST be finite and zero
-or more.
+`$of` is not more than `$delta`. Use a finite tolerance of zero or more.
 
 ```php
 public function toBeWithin(float $delta, float $of): Expectation
@@ -463,7 +462,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L675)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L674)
 
 ### `toMatch()`
 
@@ -477,7 +476,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L702)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L701)
 
 ### `toStartWith()`
 
@@ -490,7 +489,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L718)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L717)
 
 ### `toEndWith()`
 
@@ -503,7 +502,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L732)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L731)
 
 ### `toBeJson()`
 
@@ -519,7 +518,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L749)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L748)
 
 ### `toMatchJson()`
 
@@ -537,7 +536,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L768)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L767)
 
 ### `toThrow()`
 
@@ -576,7 +575,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L827)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L826)
 
 ## `EventuallyExpectation`
 
@@ -1023,8 +1022,7 @@ PHPDoc:
 ### `toBeWithin()`
 
 Passes when the absolute difference between the numeric subject and
-`$of` is not more than `$delta`. The tolerance MUST be finite and zero
-or more.
+`$of` is not more than `$delta`. Use a finite tolerance of zero or more.
 
 ```php
 public function toBeWithin(float $delta, float $of): Expectation
@@ -1035,7 +1033,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L675)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L674)
 
 ### `toMatch()`
 
@@ -1049,7 +1047,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L702)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L701)
 
 ### `toStartWith()`
 
@@ -1062,7 +1060,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L718)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L717)
 
 ### `toEndWith()`
 
@@ -1075,7 +1073,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L732)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L731)
 
 ### `toBeJson()`
 
@@ -1091,7 +1089,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L749)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L748)
 
 ### `toMatchJson()`
 
@@ -1109,7 +1107,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L768)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L767)
 
 ### `toThrow()`
 
@@ -1148,7 +1146,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L827)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L826)
 
 ## `Expect`
 
@@ -1689,8 +1687,7 @@ PHPDoc:
 ### `toBeWithin()`
 
 Passes when the absolute difference between the numeric subject and
-`$of` is not more than `$delta`. The tolerance MUST be finite and zero
-or more.
+`$of` is not more than `$delta`. Use a finite tolerance of zero or more.
 
 ```php
 public function toBeWithin(float $delta, float $of): self
@@ -1701,7 +1698,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L675)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L674)
 
 ### `toMatch()`
 
@@ -1715,7 +1712,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L702)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L701)
 
 ### `toStartWith()`
 
@@ -1728,7 +1725,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L718)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L717)
 
 ### `toEndWith()`
 
@@ -1741,7 +1738,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L732)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L731)
 
 ### `toBeJson()`
 
@@ -1757,7 +1754,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L749)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L748)
 
 ### `toMatchJson()`
 
@@ -1775,7 +1772,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L768)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L767)
 
 ### `toThrow()`
 
@@ -1814,7 +1811,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L827)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L826)
 
 ## `ExpectationExtension`
 
@@ -2465,8 +2462,7 @@ PHPDoc:
 ### `toBeWithin()`
 
 Passes when the absolute difference between the numeric subject and
-`$of` is not more than `$delta`. The tolerance MUST be finite and zero
-or more.
+`$of` is not more than `$delta`. Use a finite tolerance of zero or more.
 
 ```php
 public function toBeWithin(float $delta, float $of): Expectation
@@ -2477,7 +2473,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L675)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L674)
 
 ### `toMatch()`
 
@@ -2491,7 +2487,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L702)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L701)
 
 ### `toStartWith()`
 
@@ -2504,7 +2500,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L718)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L717)
 
 ### `toEndWith()`
 
@@ -2517,7 +2513,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L732)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L731)
 
 ### `toBeJson()`
 
@@ -2533,7 +2529,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L749)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L748)
 
 ### `toMatchJson()`
 
@@ -2551,7 +2547,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L768)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L767)
 
 ### `toThrow()`
 
@@ -2590,4 +2586,4 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L827)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L826)

--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -46,7 +46,7 @@ Initializes the Hyperf class loader once in each worker. It creates a
 coroutine context for each test attempt.
 
 The default worker container lifetime matches a long-running Hyperf worker.
-`#[Service]` selects an explicit container ID. Tests MUST isolate external
+`#[Service]` selects an explicit container ID. Isolate external test
 resources by `GREENLIGHT_CHANNEL`.
 
 ```php
@@ -190,8 +190,8 @@ PHPDoc:
 Namespace: `Greenlight\Laravel`
 
 Boots one Laravel application lazily for a test and resolves bound services.
-`#[Service]` selects an explicit binding ID. Tests MUST isolate external
-resources by `GREENLIGHT_CHANNEL`.
+`#[Service]` selects an explicit binding ID. Isolate external test resources
+by `GREENLIGHT_CHANNEL`.
 
 ```php
 final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, ServiceResolver
@@ -299,8 +299,8 @@ Namespace: `Greenlight\Psr`
 Creates a PSR-11 container lazily and resolves its services. By default, the
 plugin discards the container after each test that uses it.
 
-`#[Service]` selects an explicit ID. Tests MUST isolate external resources
-by `GREENLIGHT_CHANNEL`.
+`#[Service]` selects an explicit ID. Isolate external test resources by
+`GREENLIGHT_CHANNEL`.
 
 ```php
 final class Psr11Plugin implements AfterTestSubscriber, HarnessProvider, ServiceResolver
@@ -749,8 +749,8 @@ configuration, container reset, deferred tasks, and shutdown events stay
 under kernel control.
 
 The bridge uses the `testing` environment by default. Native `#[Tag]`
-attributes select tagged Tempest bindings. Tests MUST isolate external
-resources by `GREENLIGHT_CHANNEL`.
+attributes select tagged Tempest bindings. Isolate external test resources
+by `GREENLIGHT_CHANNEL`.
 
 ```php
 final class TempestPlugin implements AfterTestSubscriber, BeforeTestSubscriber, HarnessProvider, ServiceResolver, WorkerBootstrapSubscriber

--- a/docs/api-plugins.md
+++ b/docs/api-plugins.md
@@ -338,8 +338,8 @@ interface ReporterProvider extends Plugin
 
 ### `reporters()`
 
-A factory MUST return a new reporter for each call. It MUST NOT close the
-supplied output because Greenlight owns that output.
+Return a new reporter for each factory call. Do not close the supplied
+output because Greenlight owns it.
 
 ```php
 public function reporters(): array;

--- a/docs/api-reporting.md
+++ b/docs/api-reporting.md
@@ -119,7 +119,7 @@ public function __construct(
 PHPDoc:
 
 - `@param non-empty-string $name`
-- `@param \Closure(Output): Reporter $factory The factory MUST return a new reporter for each call. Greenlight owns the supplied output.`
+- `@param \Closure(Output): Reporter $factory Return a new reporter for each call. Greenlight owns the supplied output.`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Reporting/ReporterDefinition.php#L22)
 

--- a/docs/api-results.md
+++ b/docs/api-results.md
@@ -99,7 +99,7 @@ Namespace: `Greenlight\Core\Result`
 
 Greenlight converts the message and file to valid UTF-8 before the
 diagnostic crosses the wire. These values originate in user code.
-The line number MUST be greater than zero.
+The line number is greater than zero.
 
 ```php
 final readonly class Diagnostic implements WireSerializable

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -88,7 +88,7 @@ With one argument, references a public static provider method on the test
 class. With two arguments, the first argument is a provider class. The second
 argument is its public static method:
 
-Provider class and method names MUST NOT be empty.
+Use nonempty provider class and method names.
 
 <!-- php-example {"example":"attributes-example-04","file":"snippet.php","mode":"class-members","tools":["rector"]} -->
 ```php
@@ -253,16 +253,16 @@ string $condition
 mixed ...$arguments
 ```
 
-`$condition` MUST name an instantiable class that implements
+Use `$condition` to name an instantiable class that implements
 `Greenlight\Core\Condition`.
 
 Skips the test if the condition is false.
 
 Greenlight passes the remaining attribute arguments to the condition
-constructor. Arguments MUST be scalars or null because Greenlight sends them to
-parallel workers. Another argument type causes a discovery error. The
-constructor MUST only store the arguments. The `isSatisfied()` method MUST
-evaluate the condition without side effects:
+constructor. Use only scalar values or null because Greenlight sends them to
+parallel workers. Another argument type causes a discovery error. Only store
+the arguments in the constructor. Evaluate the condition without side effects
+in `isSatisfied()`:
 
 <!-- php-example {"example":"attributes-example-14","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
@@ -325,11 +325,10 @@ int $times
 
 Retries a failed test up to `$times` additional attempts.
 
-`$times` MUST be at least 1.
+Use a `$times` value of 1 or more.
 
-When you supply `$onlyOn`, it MUST be a throwable class-string. Greenlight
-retries only failures with that throwable type. It does not retry other
-failures.
+When you supply `$onlyOn`, use a throwable class-string. Greenlight retries
+only failures with that throwable type. It does not retry other failures.
 
 Greenlight gives each attempt a new test instance and a new per-test scope.
 Thus, state does not pass between attempts.
@@ -410,7 +409,7 @@ placement and completion-event order remain load-dependent.
 Each assignment emits one class-started and class-finished event pair. The
 `#[Before]` and `#[After]` hooks still run for each test attempt.
 
-A data provider can run again in each assigned worker. Providers MUST be pure,
+A data provider can run again in each assigned worker. Keep providers pure,
 deterministic, and fast.
 
 `#[AllowParallel]` is incompatible with these features:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -276,9 +276,9 @@ Also available as `--fail-on-risky`.
 
 Default: none.
 
-Registers plugin factories. Each factory MUST declare one non-null concrete
-plugin class return type. The factory MUST return a new plugin instance on each
-call.
+Registers plugin factories. Give each factory one non-null concrete plugin
+class return type. Return a new plugin instance each time Greenlight calls the
+factory.
 
 The method is repeatable and factories accumulate.
 
@@ -691,9 +691,9 @@ Repeatable. Multiple reporters write concurrently.
 order. A repeated name creates a separate reporter for each occurrence.
 
 All selected reporters use the same Greenlight-owned standard output. A custom
-reporter MUST NOT close this output.
+reporter does not close this output.
 
-Reporter names MUST be unique across built-ins and plugins. A duplicate name
+Choose unique reporter names across built-ins and plugins. A duplicate name
 stops the command before test execution.
 
 Shell completions suggest built-in names. Configured names remain valid.

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -127,8 +127,7 @@ Numeric matchers accept integer or float subjects:
 * `toBeWithin(float $delta, float $of)`
 
 `toBeWithin()` passes when the absolute difference between the subject and
-`$of` is no greater than `$delta`. The tolerance MUST be finite and zero or
-more.
+`$of` is no greater than `$delta`. Use a finite tolerance of zero or more.
 
 ### JSON
 
@@ -190,9 +189,8 @@ Expect::that(fn() => $fixtureManager->start())
     );
 ```
 
-The callback MUST declare one named, non-null Throwable parameter type by
-value. It MUST return `void`. The parameter type specifies the expected
-throwable class.
+Declare one named, non-null Throwable parameter type by value. Return `void`
+from the callback. The parameter type specifies the expected throwable class.
 
 The callback can contain ordinary expectations. A failed callback expectation
 keeps its diagnostic. An `eventually()` expectation retries this failure.

--- a/docs/hyperf.md
+++ b/docs/hyperf.md
@@ -29,12 +29,12 @@ return GreenlightConfig::create()
     ->plugins(static fn(): HyperfPlugin => new HyperfPlugin(dirname(__DIR__)));
 ```
 
-Pass the application root directory to the plugin. The directory MUST contain
-the standard `config/container.php` file.
+Pass the application root directory to the plugin. Include the standard
+`config/container.php` file in this directory.
 
-The container file MUST return a `Psr\Container\ContainerInterface` instance.
-For the test-attempt container lifetime, the file MUST create a new instance.
-The standard Hyperf container file creates a new instance.
+Return a `Psr\Container\ContainerInterface` instance from the container file.
+For the test-attempt container lifetime, create a new instance in this file.
+The standard Hyperf container file does this.
 
 ## Container lifetime
 
@@ -166,8 +166,8 @@ available only during the current test attempt.
 ## Reset and disposal
 
 Hyperf does not supply one reset operation for all application services. The
-application MUST keep request state in coroutine context or reset that state
-after each attempt. See Hyperf's
+application keeps request state in coroutine context or resets that state after
+each attempt. See Hyperf's
 [coroutine guidance](https://hyperf.wiki/3.1/#/en/coroutine).
 
 Use `reset:` to reset project state after each attempt. Use

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,9 +1,9 @@
 # Plugins
 
 Plugins implement one or more capability interfaces. Pass one factory for each
-plugin to `GreenlightConfig::plugins()` in `greenlight.php`. Each factory MUST
-declare its concrete plugin class as its return type. The factory MUST return a
-new instance on each call.
+plugin to `GreenlightConfig::plugins()` in `greenlight.php`. Give each factory
+its concrete plugin class as the return type. Return a new instance each time
+Greenlight calls the factory.
 
 Plugin capabilities run either in the orchestrator or in workers. Each
 capability section below names its side.
@@ -39,8 +39,8 @@ Greenlight calls the configured factory for each instance. It does not clone a
 plugin object.
 
 Plugin properties do not cross the orchestrator and worker seam. Do not use a
-property to transfer fixture data. An `IntegrationFixtureProvider` MUST expose
-data through integration resources. Tests can inject `IntegrationResources`.
+property to transfer fixture data. Expose data from an
+`IntegrationFixtureProvider` through integration resources. Tests can inject `IntegrationResources`.
 A `WorkerBootstrapSubscriber` can also read the resources and configure other
 worker capabilities on its worker-local instance.
 
@@ -87,15 +87,15 @@ vendor/bin/greenlight run --reporter=company-json
 A reporter name starts with a lowercase ASCII letter. It contains only
 lowercase ASCII letters, digits, and hyphens.
 
-Built-in and custom names share one registry. Each name MUST be unique. A
-duplicate name stops the command before the test run starts.
+Built-in and custom names share one registry. Choose a unique name. A duplicate
+name stops the command before the test run starts.
 
 Greenlight calls `reporters()` one time for each command. It calls a selected
 factory for each standard, repeat, or watch run. A repeated selection calls the
 factory one time for each occurrence.
 
-Each factory MUST return a new `Reporter`. Greenlight supplies the `Output` and
-owns it. A reporter MUST NOT close the output.
+Return a new `Reporter` each time Greenlight calls the factory. Greenlight
+supplies and owns the `Output`. Do not close this output from a reporter.
 
 Multiple selected reporters receive events in `--reporter` order. Greenlight
 also calls `finish()` in that order. It calls `finish()` one time after the

--- a/docs/psr.md
+++ b/docs/psr.md
@@ -57,9 +57,9 @@ services.
 Container creation, reset, and service-resolution failures throw
 `ServiceResolutionFailed`. Concrete PSR-11 bridge exceptions are internal.
 
-For an available service ID, the container MUST return `true` from `has()`.
-The value from `get()` MUST have the declared parameter type. Greenlight
-reports a type mismatch before the test runs.
+For an available service ID, the container returns `true` from `has()`. The
+value from `get()` has the declared parameter type. Greenlight reports a type
+mismatch before the test runs.
 
 ### Services with a different ID
 

--- a/docs/tempest.md
+++ b/docs/tempest.md
@@ -34,7 +34,7 @@ return GreenlightConfig::create()
     ->plugins(static fn(): TempestPlugin => new TempestPlugin(__DIR__));
 ```
 
-The root directory MUST contain the application `composer.json` file and the
+Use the directory that contains the application `composer.json` file and the
 `vendor` directory. Tempest reads the Composer metadata during discovery.
 
 The bridge sets `ENVIRONMENT` to `testing` while Tempest is active for a test.
@@ -103,8 +103,8 @@ public function __construct(
 ) {}
 ```
 
-The bridge passes the tag to the Tempest container. The resolved service MUST
-have the declared parameter type.
+The bridge passes the tag to the Tempest container. The resolved service has
+the declared parameter type.
 
 ### Kernel and container services
 

--- a/src/Attribute/AllowParallel.php
+++ b/src/Attribute/AllowParallel.php
@@ -7,7 +7,7 @@ namespace Greenlight\Attribute;
 /**
  * Allows Greenlight to assign tests from one class to different workers.
  *
- * The class MUST NOT use per-class harness services or `#[Isolated]`.
+ * Do not use this attribute with per-class harness services or `#[Isolated]`.
  */
 #[\Attribute(\Attribute::TARGET_CLASS)]
 final readonly class AllowParallel {}

--- a/src/Core/Result/Diagnostic.php
+++ b/src/Core/Result/Diagnostic.php
@@ -11,7 +11,7 @@ use Greenlight\Core\Wire\WireSerializable;
 /**
  * Greenlight converts the message and file to valid UTF-8 before the
  * diagnostic crosses the wire. These values originate in user code.
- * The line number MUST be greater than zero.
+ * The line number is greater than zero.
  */
 final readonly class Diagnostic implements WireSerializable
 {

--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -665,8 +665,7 @@ final class Expectation
 
     /**
      * Passes when the absolute difference between the numeric subject and
-     * `$of` is not more than `$delta`. The tolerance MUST be finite and zero
-     * or more.
+     * `$of` is not more than `$delta`. Use a finite tolerance of zero or more.
      *
      * @return self<T>
      *

--- a/src/Hyperf/HyperfPlugin.php
+++ b/src/Hyperf/HyperfPlugin.php
@@ -33,7 +33,7 @@ use function Hyperf\Coroutine\run;
  * coroutine context for each test attempt.
  *
  * The default worker container lifetime matches a long-running Hyperf worker.
- * `#[Service]` selects an explicit container ID. Tests MUST isolate external
+ * `#[Service]` selects an explicit container ID. Isolate external test
  * resources by `GREENLIGHT_CHANNEL`.
  */
 final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemptRunner, WorkerBootstrapSubscriber, WorkerRuntimeRunner

--- a/src/Laravel/LaravelPlugin.php
+++ b/src/Laravel/LaravelPlugin.php
@@ -20,8 +20,8 @@ use Illuminate\Foundation\Bootstrap\RegisterProviders;
 
 /**
  * Boots one Laravel application lazily for a test and resolves bound services.
- * `#[Service]` selects an explicit binding ID. Tests MUST isolate external
- * resources by `GREENLIGHT_CHANNEL`.
+ * `#[Service]` selects an explicit binding ID. Isolate external test resources
+ * by `GREENLIGHT_CHANNEL`.
  */
 final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, ServiceResolver
 {

--- a/src/Plugin/ReporterProvider.php
+++ b/src/Plugin/ReporterProvider.php
@@ -15,8 +15,8 @@ use Greenlight\Reporting\ReporterDefinition;
 interface ReporterProvider extends Plugin
 {
     /**
-     * A factory MUST return a new reporter for each call. It MUST NOT close the
-     * supplied output because Greenlight owns that output.
+     * Return a new reporter for each factory call. Do not close the supplied
+     * output because Greenlight owns it.
      *
      * @return list<ReporterDefinition>
      */

--- a/src/Psr/Psr11Plugin.php
+++ b/src/Psr/Psr11Plugin.php
@@ -18,8 +18,8 @@ use Psr\Container\ContainerInterface;
  * Creates a PSR-11 container lazily and resolves its services. By default, the
  * plugin discards the container after each test that uses it.
  *
- * `#[Service]` selects an explicit ID. Tests MUST isolate external resources
- * by `GREENLIGHT_CHANNEL`.
+ * `#[Service]` selects an explicit ID. Isolate external test resources by
+ * `GREENLIGHT_CHANNEL`.
  */
 final class Psr11Plugin implements AfterTestSubscriber, HarnessProvider, ServiceResolver
 {

--- a/src/Reporting/ReporterDefinition.php
+++ b/src/Reporting/ReporterDefinition.php
@@ -16,8 +16,8 @@ final readonly class ReporterDefinition
 {
     /**
      * @param non-empty-string $name
-     * @param \Closure(Output): Reporter $factory The factory MUST return a new
-     *   reporter for each call. Greenlight owns the supplied output.
+     * @param \Closure(Output): Reporter $factory Return a new reporter for each
+     *   call. Greenlight owns the supplied output.
      */
     public function __construct(
         public string $name,

--- a/src/Tempest/TempestPlugin.php
+++ b/src/Tempest/TempestPlugin.php
@@ -31,8 +31,8 @@ use Tempest\Http\Request;
  * under kernel control.
  *
  * The bridge uses the `testing` environment by default. Native `#[Tag]`
- * attributes select tagged Tempest bindings. Tests MUST isolate external
- * resources by `GREENLIGHT_CHANNEL`.
+ * attributes select tagged Tempest bindings. Isolate external test resources
+ * by `GREENLIGHT_CHANNEL`.
  */
 final class TempestPlugin implements AfterTestSubscriber, BeforeTestSubscriber, HarnessProvider, ServiceResolver, WorkerBootstrapSubscriber
 {


### PR DESCRIPTION
## Summary

- replace specification-style normative language in published guides with direct user guidance
- update public PHPDoc sources and regenerate the API reference
- retain normative terms in architecture and contributor material