### PR TITLE
fix(doubles): match bare arguments strictly

### DIFF
--- a/docs/api-doubles.md
+++ b/docs/api-doubles.md
@@ -58,8 +58,8 @@ PHPDoc:
 
 ### `equals()`
 
-This matcher uses the same deep equality as a value in `with()`.
-This form states the comparison explicitly.
+This matcher uses the same deep equality as `Expect::toEqual()`.
+Use it when `with()` must compare by value instead of identity.
 
 ```php
 public static function equals(mixed $value): ArgumentMatcher
@@ -687,7 +687,8 @@ specifies the accepted arguments, cardinality, and result.
 public interface. The call handler and verifier use members that have the
 `@internal` tag.
 
-Argument values compare with the same deep equality as `Expect::toEqual()`.
+Bare argument values use strict comparison (`===`). Use
+`Argument::equals()` to apply deep equality.
 
 ```php
 final class MethodExpectation

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -106,12 +106,14 @@ reports an error if a call occurs after the sequence is empty.
 
 ## Argument matches
 
-Bare values passed to `with()` use the same deep equality as `toEqual()`:
+Bare values passed to `with()` use strict comparison (`===`):
 
 <!-- php-example {"example":"test-doubles-example-04","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 $plan->expects('save')->with($expectedOrder);
 ```
+
+Use `Argument::equals($expectedOrder)` to apply deep equality to a value object.
 
 Use `withNoArguments()` to require a call that supplies no arguments:
 

--- a/src/Doubles/Argument.php
+++ b/src/Doubles/Argument.php
@@ -39,8 +39,8 @@ final class Argument
     }
 
     /**
-     * This matcher uses the same deep equality as a value in `with()`.
-     * This form states the comparison explicitly.
+     * This matcher uses the same deep equality as `Expect::toEqual()`.
+     * Use it when `with()` must compare by value instead of identity.
      */
     public static function equals(mixed $value): ArgumentMatcher
     {

--- a/src/Doubles/MethodExpectation.php
+++ b/src/Doubles/MethodExpectation.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Greenlight\Doubles;
 
-use Greenlight\Expect\Equality;
 use Greenlight\Expect\ValueRenderer;
 
 /**
@@ -15,7 +14,8 @@ use Greenlight\Expect\ValueRenderer;
  * public interface. The call handler and verifier use members that have the
  * `@internal` tag.
  *
- * Argument values compare with the same deep equality as `Expect::toEqual()`.
+ * Bare argument values use strict comparison (`===`). Use
+ * `Argument::equals()` to apply deep equality.
  *
  * @template TTarget of object = object
  * @template TMethod of non-empty-string = non-empty-string
@@ -246,7 +246,7 @@ final class MethodExpectation
                 continue;
             }
 
-            if (!Equality::equals($expected, $arguments[$position])) {
+            if ($expected !== $arguments[$position]) {
                 return false;
             }
         }

--- a/tests/Unit/Doubles/ArgumentMatchingTest.php
+++ b/tests/Unit/Doubles/ArgumentMatchingTest.php
@@ -157,6 +157,34 @@ final readonly class ArgumentMatchingTest
     }
 
     #[Test]
+    public function bareObjectValuesMatchByIdentity(): void
+    {
+        $expected = (object) ['values' => [1, 2]];
+        $recorder = $this->doubles->mock(Recorder::class, static function (MockPlan $plan) use ($expected): void {
+            $plan->expects('record')->with($expected)->once();
+        });
+
+        $recorder->record($expected);
+    }
+
+    #[Test]
+    public function bareObjectValuesRejectEqualCopies(): void
+    {
+        $expected = (object) ['values' => [1, 2]];
+        $actual = (object) ['values' => [1, 2]];
+        $doubles = new Doubles();
+        $recorder = $doubles->mock(Recorder::class, static function (MockPlan $plan) use ($expected): void {
+            $plan->expects('record')->with($expected)->once();
+        });
+
+        Expect::that(static function () use ($recorder, $actual): void {
+            $recorder->record($actual);
+        })
+            ->because('a bare object value in with() MUST match by identity')
+            ->toThrow(ExpectationFailed::class, '/unexpected call/');
+    }
+
+    #[Test]
     public function equalsDiagnosticsRenderTheExpectedValue(): void
     {
         Expect::that(Argument::equals(['a' => [1, 2]])->describe())

--- a/tests/Unit/Doubles/MockTest.php
+++ b/tests/Unit/Doubles/MockTest.php
@@ -207,14 +207,14 @@ final class MockTest
     }
 
     #[Test]
-    public function exactArgumentsUseDeepEquality(): void
+    public function exactArgumentsUseStrictComparison(): void
     {
         $doubles = new Doubles();
         $calculator = $doubles->mock(Calculator::class, static function (MockPlan $plan): void {
             $plan->expects('describe')->with('label')->once()->andReturns('matched');
         });
 
-        Expect::that($calculator->describe('label'))->because('exact arguments use deep equality')->toBe('matched');
+        Expect::that($calculator->describe('label'))->because('exact arguments use strict comparison')->toBe('matched');
 
         $doubles->dispose();
     }


### PR DESCRIPTION
Bare values passed to with() now use strict identity comparison. Deep equality remains available through Argument::equals() for value objects. Adds regression coverage and updates the doubles documentation.