### PR TITLE
feat(doubles): compose argument matchers

### DIFF
--- a/docs/api-doubles.md
+++ b/docs/api-doubles.md
@@ -37,9 +37,12 @@ public static function type(string $type): ArgumentMatcher
 
 PHPDoc:
 
+- `@template T of object`
+- `@param class-string<T>|string $type`
+- `@return ($type is class-string<T> ? ArgumentMatcher<T> : ArgumentMatcher<mixed>)`
 - `@throws InvalidDoubleUsage`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L25)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L31)
 
 ### `predicate()`
 
@@ -52,9 +55,11 @@ public static function predicate(\Closure $predicate, string $description = 'pre
 
 PHPDoc:
 
-- `@param \Closure(mixed): mixed $predicate`
+- `@template T`
+- `@param \Closure(T): mixed $predicate`
+- `@return ArgumentMatcher<T>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L36)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L46)
 
 ### `equals()`
 
@@ -65,7 +70,37 @@ Use it when `with()` must compare by value instead of identity.
 public static function equals(mixed $value): ArgumentMatcher
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L45)
+PHPDoc:
+
+- `@template T`
+- `@param T $value`
+- `@return ArgumentMatcher<T>`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L61)
+
+### `allOf()`
+
+This matcher accepts a value when all its matchers accept the value.
+Greenlight checks the matchers in argument order and stops after a failure.
+
+```php
+public static function allOf(
+    ArgumentMatcher $first,
+    ArgumentMatcher $second,
+    ArgumentMatcher ...$rest,
+): ArgumentMatcher
+```
+
+PHPDoc:
+
+- `@template T`
+- `@param ArgumentMatcher<T> $first`
+- `@param ArgumentMatcher<T> $second`
+- `@param ArgumentMatcher<T> ...$rest`
+- `@return ArgumentMatcher<T>`
+- `@throws InvalidDoubleUsage`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L79)
 
 ### `captor()`
 
@@ -76,7 +111,7 @@ selects the related expectation for the call.
 public static function captor(): ArgumentCaptor
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L54)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L97)
 
 ## `ArgumentCaptor`
 
@@ -157,7 +192,11 @@ Use the `Argument` factories to get matchers.
 interface ArgumentMatcher
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/ArgumentMatcher.php#L17)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/ArgumentMatcher.php#L19)
+
+PHPDoc:
+
+- `@template-covariant TValue = mixed`
 
 ### `matches()`
 
@@ -165,7 +204,7 @@ interface ArgumentMatcher
 public function matches(mixed $value): bool;
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/ArgumentMatcher.php#L19)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/ArgumentMatcher.php#L21)
 
 ### `describe()`
 
@@ -173,7 +212,7 @@ public function matches(mixed $value): bool;
 public function describe(): string;
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/ArgumentMatcher.php#L21)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/ArgumentMatcher.php#L23)
 
 ## `Doubles`
 
@@ -675,6 +714,14 @@ public static function invalidArgumentType(): self
 ```
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L298)
+
+### `compositeArgumentCaptor()`
+
+```php
+public static function compositeArgumentCaptor(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L303)
 
 ## `MethodExpectation`
 

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -147,13 +147,32 @@ Available matchers are:
 * `Argument::type(string $type)`
 * `Argument::predicate(Closure $predicate, string $description = 'predicate')`
 * `Argument::equals(mixed $value)`
+* `Argument::allOf(ArgumentMatcher $first, ArgumentMatcher $second, ArgumentMatcher ...$rest)`
 * `Argument::captor()`
+
+Use `Argument::allOf()` to apply two or more constraints to one argument:
+
+<!-- php-example {"example":"test-doubles-example-07","file":"snippet.php","mode":"file","tools":["rector"]} -->
+```php
+use Greenlight\Doubles\Argument;
+
+$plan->expects('save')->with(Argument::allOf(
+    Argument::type(Order::class),
+    Argument::predicate(
+        fn (Order $order): bool => $order->isReady(),
+        'a ready order',
+    ),
+));
+```
+
+Greenlight checks the matchers from left to right. Put a type matcher before a
+predicate that has a parameter of that type. `allOf()` does not accept a captor.
 
 ## Argument capture
 
 Capture one argument from every matched call:
 
-<!-- php-example {"example":"test-doubles-example-07","file":"snippet.php","mode":"statements","tools":["rector"]} -->
+<!-- php-example {"example":"test-doubles-example-08","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 $captor = $plan->expects('save')
     ->times(2)
@@ -176,7 +195,7 @@ If a plan must capture more than one argument, put an explicit
 
 `callsTo()` returns argument lists in call order:
 
-<!-- php-example {"example":"test-doubles-example-08","file":"snippet.php","mode":"statements","tools":["rector"]} -->
+<!-- php-example {"example":"test-doubles-example-09","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 $events = $this->doubles->spy(EventPublisher::class);
 

--- a/src/Doubles/AllOf.php
+++ b/src/Doubles/AllOf.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Doubles;
+
+/**
+ * Applies a sequence of argument matchers as one constraint.
+ *
+ * @template-covariant TValue
+ *
+ * @implements ArgumentMatcher<TValue>
+ *
+ * @internal
+ */
+final readonly class AllOf implements ArgumentMatcher
+{
+    /**
+     * @param non-empty-list<ArgumentMatcher<TValue>> $matchers
+     */
+    public function __construct(private array $matchers) {}
+
+    public function matches(mixed $value): bool
+    {
+        return \array_all($this->matchers, static fn(ArgumentMatcher $matcher): bool => $matcher->matches($value));
+    }
+
+    public function describe(): string
+    {
+        return 'allOf(' . \implode(', ', \array_map(
+            static fn(ArgumentMatcher $matcher): string => $matcher->describe(),
+            $this->matchers,
+        )) . ')';
+    }
+}

--- a/src/Doubles/Argument.php
+++ b/src/Doubles/Argument.php
@@ -20,6 +20,12 @@ final class Argument
     /**
      * This matcher accepts instances of the specified class or interface.
      * It also accepts values when `get_debug_type()` returns `$type`.
+     *
+     * @template T of object
+     *
+     * @param class-string<T>|string $type
+     *
+     * @return ($type is class-string<T> ? ArgumentMatcher<T> : ArgumentMatcher<mixed>)
      * @throws InvalidDoubleUsage
      */
     public static function type(string $type): ArgumentMatcher
@@ -31,7 +37,11 @@ final class Argument
      * This matcher accepts the value when the closure returns true.
      * The description identifies the constraint in failure messages.
      *
-     * @param \Closure(mixed): mixed $predicate
+     * @template T
+     *
+     * @param \Closure(T): mixed $predicate
+     *
+     * @return ArgumentMatcher<T>
      */
     public static function predicate(\Closure $predicate, string $description = 'predicate'): ArgumentMatcher
     {
@@ -41,10 +51,43 @@ final class Argument
     /**
      * This matcher uses the same deep equality as `Expect::toEqual()`.
      * Use it when `with()` must compare by value instead of identity.
+     *
+     * @template T
+     *
+     * @param T $value
+     *
+     * @return ArgumentMatcher<T>
      */
     public static function equals(mixed $value): ArgumentMatcher
     {
         return new EqualsMatcher($value);
+    }
+
+    /**
+     * This matcher accepts a value when all its matchers accept the value.
+     * Greenlight checks the matchers in argument order and stops after a failure.
+     *
+     * @template T
+     *
+     * @param ArgumentMatcher<T> $first
+     * @param ArgumentMatcher<T> $second
+     * @param ArgumentMatcher<T> ...$rest
+     *
+     * @return ArgumentMatcher<T>
+     * @throws InvalidDoubleUsage
+     */
+    public static function allOf(
+        ArgumentMatcher $first,
+        ArgumentMatcher $second,
+        ArgumentMatcher ...$rest,
+    ): ArgumentMatcher {
+        $matchers = [$first, $second, ...\array_values($rest)];
+
+        if (\array_any($matchers, static fn(ArgumentMatcher $matcher): bool => $matcher instanceof ArgumentCaptor)) {
+            throw InvalidDoubleUsage::compositeArgumentCaptor();
+        }
+
+        return new AllOf($matchers);
     }
 
     /**

--- a/src/Doubles/ArgumentMatcher.php
+++ b/src/Doubles/ArgumentMatcher.php
@@ -13,6 +13,8 @@ namespace Greenlight\Doubles;
  * the constraint in failure messages.
  *
  * Use the `Argument` factories to get matchers.
+ *
+ * @template-covariant TValue = mixed
  */
 interface ArgumentMatcher
 {

--- a/src/Doubles/InvalidDoubleUsage.php
+++ b/src/Doubles/InvalidDoubleUsage.php
@@ -300,6 +300,11 @@ final class InvalidDoubleUsage extends \LogicException
         return new self('Argument::type() requires a type name that contains a non-space character.');
     }
 
+    public static function compositeArgumentCaptor(): self
+    {
+        return new self('Argument::allOf() does not accept a captor. Put the captor directly in with().');
+    }
+
     private static function argumentCount(int $count): string
     {
         return \sprintf('%d argument%s', $count, $count === 1 ? '' : 's');

--- a/tests/Acceptance/PhpStanArgumentMatcherTypeTest.php
+++ b/tests/Acceptance/PhpStanArgumentMatcherTypeTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\PhpStanProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class PhpStanArgumentMatcherTypeTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function allOfPreservesTheTypesOfItsMatchers(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Doubles\Argument;
+            use Greenlight\Doubles\ArgumentMatcher;
+            use Greenlight\Doubles\InvalidDoubleUsage;
+
+            /**
+             * @return ArgumentMatcher<DateTimeInterface>
+             * @throws InvalidDoubleUsage
+             */
+            function greenlightGoodArgumentMatcherType(): ArgumentMatcher
+            {
+                return Argument::allOf(
+                    Argument::type(DateTimeInterface::class),
+                    Argument::predicate(
+                        static fn(DateTimeInterface $value): bool => $value->getTimestamp() > 0,
+                        'positive timestamp',
+                    ),
+                );
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Doubles\Argument;
+            use Greenlight\Doubles\ArgumentMatcher;
+            use Greenlight\Doubles\InvalidDoubleUsage;
+
+            /**
+             * @return ArgumentMatcher<DateTimeInterface>
+             * @throws InvalidDoubleUsage
+             */
+            function greenlightBadArgumentMatcherType(): ArgumentMatcher
+            {
+                return Argument::allOf(
+                    Argument::type(DateTimeInterface::class),
+                    Argument::predicate(
+                        static fn(DateTimeZone $value): bool => $value->getName() !== '',
+                        'named timezone',
+                    ),
+                );
+            }
+            PHP,
+        );
+
+        Expect::that($probe->exitCode)->because('PHPStan MUST preserve allOf() matcher types')->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(1);
+        Expect::that($probe->messages())
+            ->toContain('ArgumentMatcher<DateTimeInterface|DateTimeZone>');
+    }
+}

--- a/tests/Unit/Doubles/ArgumentMatchingTest.php
+++ b/tests/Unit/Doubles/ArgumentMatchingTest.php
@@ -185,6 +185,65 @@ final readonly class ArgumentMatchingTest
     }
 
     #[Test]
+    public function allOfMatchesWhenEveryMatcherMatches(): void
+    {
+        $recorder = $this->doubles->mock(Recorder::class, static function (MockPlan $plan): void {
+            $plan->expects('record')->with(Argument::allOf(
+                Argument::type(\DateTimeInterface::class),
+                Argument::predicate(
+                    static fn(\DateTimeInterface $value): bool => $value->getTimestamp() > 0,
+                    'positive timestamp',
+                ),
+            ))->once();
+        });
+
+        $recorder->record(new \DateTimeImmutable('2026-01-01'));
+    }
+
+    #[Test]
+    public function allOfStopsAfterTheFirstMatcherRejectsTheValue(): void
+    {
+        $predicateCalled = false;
+        $matcher = Argument::allOf(
+            Argument::type(\DateTimeInterface::class),
+            Argument::predicate(static function (\DateTimeInterface $value) use (&$predicateCalled): bool {
+                $predicateCalled = true;
+
+                return $value->getTimestamp() > 0;
+            }),
+        );
+
+        Expect::that($matcher->matches('not a date'))
+            ->because('allOf() MUST stop after the type matcher rejects the value')
+            ->toBeFalse();
+        Expect::that($predicateCalled)->toBeFalse();
+    }
+
+    #[Test]
+    public function allOfDiagnosticsDescribeEachMatcherInOrder(): void
+    {
+        $matcher = Argument::allOf(
+            Argument::type(\DateTimeInterface::class),
+            Argument::predicate(static fn(mixed $value): bool => $value !== null, 'not null'),
+        );
+
+        Expect::that($matcher->describe())
+            ->because('allOf() diagnostics MUST preserve matcher order')
+            ->toBe('allOf(type(DateTimeInterface), predicate(not null))');
+    }
+
+    #[Test]
+    public function allOfRejectsCaptors(): void
+    {
+        Expect::that(static fn(): ArgumentMatcher => Argument::allOf(Argument::any(), Argument::captor()))
+            ->because('a captor in allOf() cannot record the selected call')
+            ->toThrow(
+                InvalidDoubleUsage::class,
+                message: 'Argument::allOf() does not accept a captor. Put the captor directly in with().',
+            );
+    }
+
+    #[Test]
     public function equalsDiagnosticsRenderTheExpectedValue(): void
     {
         Expect::that(Argument::equals(['a' => [1, 2]])->describe())


### PR DESCRIPTION
Adds Argument::allOf() for two or more ordered constraints, with short-circuit evaluation and an explicit captor guard. Makes argument matchers generic so type(), predicate(), equals(), and allOf() preserve their PHPStan value types. Documents the API and composition behavior.