### PR TITLE
fix(config): refine builder PHPStan types

### DIFF
--- a/docs/api-configuration.md
+++ b/docs/api-configuration.md
@@ -26,9 +26,10 @@ public function directory(string $directory): self
 
 PHPDoc:
 
+- `@param non-empty-string $directory`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L22)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L35)
 
 ### `maxAttachmentsPerTest()`
 
@@ -38,9 +39,10 @@ public function maxAttachmentsPerTest(int $count): self
 
 PHPDoc:
 
+- `@param positive-int $count`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L40)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L55)
 
 ### `maxAttachmentSize()`
 
@@ -50,9 +52,10 @@ public function maxAttachmentSize(string $size): self
 
 PHPDoc:
 
+- `@param non-empty-string $size`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L54)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L71)
 
 ### `maxTestSize()`
 
@@ -62,9 +65,10 @@ public function maxTestSize(string $size): self
 
 PHPDoc:
 
+- `@param non-empty-string $size`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L64)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L83)
 
 ### `maxRunAttachments()`
 
@@ -74,9 +78,10 @@ public function maxRunAttachments(int $count): self
 
 PHPDoc:
 
+- `@param positive-int $count`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L74)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L95)
 
 ### `maxRunSize()`
 
@@ -86,9 +91,10 @@ public function maxRunSize(string $size): self
 
 PHPDoc:
 
+- `@param non-empty-string $size`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L88)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L111)
 
 ## `CoverageBuilder`
 
@@ -110,9 +116,10 @@ public function include(string ...$paths): self
 
 PHPDoc:
 
+- `@param non-empty-string ...$paths`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/CoverageBuilder.php#L28)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/CoverageBuilder.php#L30)
 
 ### `driver()`
 
@@ -122,9 +129,10 @@ public function driver(string $driver): self
 
 PHPDoc:
 
+- `@param non-empty-string $driver`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/CoverageBuilder.php#L52)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/CoverageBuilder.php#L56)
 
 ### `export()`
 
@@ -134,9 +142,11 @@ public function export(string $format, string $target): self
 
 PHPDoc:
 
+- `@param 'json'|'lcov'|'clover'|'cobertura'|'html' $format`
+- `@param non-empty-string $target`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/CoverageBuilder.php#L66)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/CoverageBuilder.php#L73)
 
 ## `GreenlightConfig`
 
@@ -169,7 +179,7 @@ public function paths(array $tests): self
 
 PHPDoc:
 
-- `@param list<string> $tests`
+- `@param non-empty-list<non-empty-string> $tests`
 - `@throws InvalidConfiguration`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L94)
@@ -188,10 +198,11 @@ public function suite(string $name, callable $configurator): self
 
 PHPDoc:
 
+- `@param non-empty-string $name`
 - `@param callable(SuiteBuilder): mixed $configurator`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L150)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L151)
 
 ### `workers()`
 
@@ -209,11 +220,12 @@ public function workers(
 
 PHPDoc:
 
-- `@param int|'auto' $count`
-- `@param int|null $recycleAfterTests A null value disables test-count worker replacement.`
+- `@param positive-int|'auto' $count`
+- `@param positive-int|null $recycleAfterTests A null value disables test-count worker replacement.`
+- `@param non-empty-string $recycleAboveMemory`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L178)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L180)
 
 ### `resourceLimit()`
 
@@ -228,9 +240,11 @@ public function resourceLimit(string $name, int $limit = 1): self
 
 PHPDoc:
 
+- `@param non-empty-string $name`
+- `@param positive-int $limit`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L206)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L211)
 
 ### `coverage()`
 
@@ -242,7 +256,7 @@ PHPDoc:
 
 - `@param callable(CoverageBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L234)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L239)
 
 ### `watch()`
 
@@ -254,7 +268,7 @@ PHPDoc:
 
 - `@param callable(WatchBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L246)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L251)
 
 ### `artifacts()`
 
@@ -266,7 +280,7 @@ PHPDoc:
 
 - `@param callable(ArtifactBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L258)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L263)
 
 ### `storage()`
 
@@ -281,7 +295,7 @@ PHPDoc:
 
 - `@param callable(StorageBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L273)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L278)
 
 ### `failOnDeprecation()`
 
@@ -297,7 +311,7 @@ PHPDoc:
 
 - `@see self::ignoreDeprecationsMatching()`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L289)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L294)
 
 ### `failOnNotice()`
 
@@ -305,7 +319,7 @@ PHPDoc:
 public function failOnNotice(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L296)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L301)
 
 ### `failOnRisky()`
 
@@ -317,7 +331,7 @@ expectations.
 public function failOnRisky(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L308)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L313)
 
 ### `ignoreDeprecationsMatching()`
 
@@ -331,9 +345,10 @@ public function ignoreDeprecationsMatching(string ...$patterns): self
 
 PHPDoc:
 
+- `@param non-empty-string ...$patterns`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L321)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L329)
 
 ### `plugins()`
 
@@ -346,7 +361,7 @@ PHPDoc:
 - `@param \Closure(): Plugin ...$plugins`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L342)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L350)
 
 ### `failFast()`
 
@@ -354,7 +369,7 @@ PHPDoc:
 public function failFast(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L359)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L367)
 
 ### `randomizeOrder()`
 
@@ -364,7 +379,7 @@ If the seed is null, Greenlight selects and prints a seed when it resolves the c
 public function randomizeOrder(?int $seed = null): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L367)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L375)
 
 ## `InvalidConfiguration`
 
@@ -400,9 +415,10 @@ public function rootDirectory(string $directory): self
 
 PHPDoc:
 
+- `@param non-empty-string $directory`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/StorageBuilder.php#L17)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/StorageBuilder.php#L29)
 
 ### `stateDirectory()`
 
@@ -412,9 +428,10 @@ public function stateDirectory(string $directory): self
 
 PHPDoc:
 
+- `@param non-empty-string $directory`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/StorageBuilder.php#L25)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/StorageBuilder.php#L40)
 
 ### `cacheDirectory()`
 
@@ -424,9 +441,10 @@ public function cacheDirectory(string $directory): self
 
 PHPDoc:
 
+- `@param non-empty-string $directory`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/StorageBuilder.php#L33)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/StorageBuilder.php#L51)
 
 ### `generatedCodeDirectory()`
 
@@ -436,9 +454,10 @@ public function generatedCodeDirectory(string $directory): self
 
 PHPDoc:
 
+- `@param non-empty-string $directory`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/StorageBuilder.php#L41)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/StorageBuilder.php#L62)
 
 ### `temporaryDirectory()`
 
@@ -448,9 +467,10 @@ public function temporaryDirectory(string $directory): self
 
 PHPDoc:
 
+- `@param non-empty-string $directory`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/StorageBuilder.php#L49)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/StorageBuilder.php#L73)
 
 ## `SuiteBuilder`
 
@@ -484,9 +504,10 @@ public function in(string ...$paths): self
 
 PHPDoc:
 
+- `@param non-empty-string ...$paths`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/SuiteBuilder.php#L28)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/SuiteBuilder.php#L30)
 
 ### `tag()`
 
@@ -496,9 +517,10 @@ public function tag(string ...$tags): self
 
 PHPDoc:
 
+- `@param non-empty-string ...$tags`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/SuiteBuilder.php#L52)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/SuiteBuilder.php#L56)
 
 ## `WatchBuilder`
 
@@ -521,6 +543,7 @@ public function debounceMilliseconds(int $milliseconds): self
 
 PHPDoc:
 
+- `@param positive-int $milliseconds`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/WatchBuilder.php#L20)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/WatchBuilder.php#L22)

--- a/src/Config/ArtifactBuilder.php
+++ b/src/Config/ArtifactBuilder.php
@@ -9,14 +9,27 @@ namespace Greenlight\Config;
  */
 final class ArtifactBuilder
 {
+    /** @var non-empty-string */
     private string $directory = ArtifactConfiguration::DEFAULT_DIRECTORY;
+
+    /** @var positive-int */
     private int $maxAttachmentsPerTest = ArtifactConfiguration::DEFAULT_MAX_ATTACHMENTS_PER_TEST;
+
+    /** @var positive-int */
     private int $maxAttachmentBytes = ArtifactConfiguration::DEFAULT_MAX_ATTACHMENT_BYTES;
+
+    /** @var positive-int */
     private int $maxTestBytes = ArtifactConfiguration::DEFAULT_MAX_TEST_BYTES;
+
+    /** @var positive-int */
     private int $maxRunAttachments = ArtifactConfiguration::DEFAULT_MAX_RUN_ATTACHMENTS;
+
+    /** @var positive-int */
     private int $maxRunBytes = ArtifactConfiguration::DEFAULT_MAX_RUN_BYTES;
 
     /**
+     * @param non-empty-string $directory
+     *
      * @throws InvalidConfiguration
      */
     public function directory(string $directory): self
@@ -35,6 +48,8 @@ final class ArtifactBuilder
     }
 
     /**
+     * @param positive-int $count
+     *
      * @throws InvalidConfiguration
      */
     public function maxAttachmentsPerTest(int $count): self
@@ -49,6 +64,8 @@ final class ArtifactBuilder
     }
 
     /**
+     * @param non-empty-string $size
+     *
      * @throws InvalidConfiguration
      */
     public function maxAttachmentSize(string $size): self
@@ -59,6 +76,8 @@ final class ArtifactBuilder
     }
 
     /**
+     * @param non-empty-string $size
+     *
      * @throws InvalidConfiguration
      */
     public function maxTestSize(string $size): self
@@ -69,6 +88,8 @@ final class ArtifactBuilder
     }
 
     /**
+     * @param positive-int $count
+     *
      * @throws InvalidConfiguration
      */
     public function maxRunAttachments(int $count): self
@@ -83,6 +104,8 @@ final class ArtifactBuilder
     }
 
     /**
+     * @param non-empty-string $size
+     *
      * @throws InvalidConfiguration
      */
     public function maxRunSize(string $size): self

--- a/src/Config/CoverageBuilder.php
+++ b/src/Config/CoverageBuilder.php
@@ -23,6 +23,8 @@ final class CoverageBuilder
     private array $exports = [];
 
     /**
+     * @param non-empty-string ...$paths
+     *
      * @throws InvalidConfiguration
      */
     public function include(string ...$paths): self
@@ -47,6 +49,8 @@ final class CoverageBuilder
     }
 
     /**
+     * @param non-empty-string $driver
+     *
      * @throws InvalidConfiguration
      */
     public function driver(string $driver): self
@@ -61,11 +65,18 @@ final class CoverageBuilder
     }
 
     /**
+     * @param 'json'|'lcov'|'clover'|'cobertura'|'html' $format
+     * @param non-empty-string $target
+     *
      * @throws InvalidConfiguration
      */
     public function export(string $format, string $target): self
     {
-        if ($format === '' || $target === '') {
+        if ($format === '') {
+            throw new InvalidConfiguration('Coverage exports need a non-empty format and target.');
+        }
+
+        if ($target === '') {
             throw new InvalidConfiguration('Coverage exports need a non-empty format and target.');
         }
 

--- a/src/Config/GreenlightConfig.php
+++ b/src/Config/GreenlightConfig.php
@@ -87,7 +87,7 @@ final class GreenlightConfig
      * Sets the top-level test-discovery directories. Greenlight combines these
      * paths with the paths from all named suites.
      *
-     * @param list<string> $tests
+     * @param non-empty-list<non-empty-string> $tests
      *
      * @throws InvalidConfiguration
      */
@@ -143,6 +143,7 @@ final class GreenlightConfig
      * with `in()`. Greenlight ignores its return value, which permits short
      * arrow functions.
      *
+     * @param non-empty-string $name
      * @param callable(SuiteBuilder): mixed $configurator
      *
      * @throws InvalidConfiguration
@@ -169,9 +170,10 @@ final class GreenlightConfig
      * when `$recycleAfterTests` has a value. Use this option for state that the
      * memory limit cannot control.
      *
-     * @param int|'auto' $count
-     * @param int|null $recycleAfterTests A null value disables test-count
+     * @param positive-int|'auto' $count
+     * @param positive-int|null $recycleAfterTests A null value disables test-count
      *   worker replacement.
+     * @param non-empty-string $recycleAboveMemory
      *
      * @throws InvalidConfiguration
      */
@@ -200,6 +202,9 @@ final class GreenlightConfig
      * named resource.
      *
      * A resource without an explicit resource limit has a limit of one.
+     *
+     * @param non-empty-string $name
+     * @param positive-int $limit
      *
      * @throws InvalidConfiguration
      */
@@ -316,6 +321,9 @@ final class GreenlightConfig
      * Exempts deprecation messages from `failOnDeprecation()`. A pattern matches
      * part of a message without case sensitivity. A pattern that contains "*"
      * or "?" matches the complete message. Multiple calls add patterns.
+     *
+     * @param non-empty-string ...$patterns
+     *
      * @throws InvalidConfiguration
      */
     public function ignoreDeprecationsMatching(string ...$patterns): self

--- a/src/Config/StorageBuilder.php
+++ b/src/Config/StorageBuilder.php
@@ -7,13 +7,25 @@ namespace Greenlight\Config;
 /** Collects directory configuration for Greenlight-owned storage. */
 final class StorageBuilder
 {
+    /** @var non-empty-string|null */
     private ?string $rootDirectory = null;
+
+    /** @var non-empty-string|null */
     private ?string $stateDirectory = null;
+
+    /** @var non-empty-string|null */
     private ?string $cacheDirectory = null;
+
+    /** @var non-empty-string|null */
     private ?string $generatedCodeDirectory = null;
+
+    /** @var non-empty-string|null */
     private ?string $temporaryDirectory = null;
 
-    /** @throws InvalidConfiguration */
+    /**
+     * @param non-empty-string $directory
+     * @throws InvalidConfiguration
+     */
     public function rootDirectory(string $directory): self
     {
         $this->rootDirectory = $this->validate($directory, 'Storage root directory');
@@ -21,7 +33,10 @@ final class StorageBuilder
         return $this;
     }
 
-    /** @throws InvalidConfiguration */
+    /**
+     * @param non-empty-string $directory
+     * @throws InvalidConfiguration
+     */
     public function stateDirectory(string $directory): self
     {
         $this->stateDirectory = $this->validate($directory, 'State directory');
@@ -29,7 +44,10 @@ final class StorageBuilder
         return $this;
     }
 
-    /** @throws InvalidConfiguration */
+    /**
+     * @param non-empty-string $directory
+     * @throws InvalidConfiguration
+     */
     public function cacheDirectory(string $directory): self
     {
         $this->cacheDirectory = $this->validate($directory, 'Cache directory');
@@ -37,7 +55,10 @@ final class StorageBuilder
         return $this;
     }
 
-    /** @throws InvalidConfiguration */
+    /**
+     * @param non-empty-string $directory
+     * @throws InvalidConfiguration
+     */
     public function generatedCodeDirectory(string $directory): self
     {
         $this->generatedCodeDirectory = $this->validate($directory, 'Generated-code directory');
@@ -45,7 +66,10 @@ final class StorageBuilder
         return $this;
     }
 
-    /** @throws InvalidConfiguration */
+    /**
+     * @param non-empty-string $directory
+     * @throws InvalidConfiguration
+     */
     public function temporaryDirectory(string $directory): self
     {
         $this->temporaryDirectory = $this->validate($directory, 'Temporary directory');
@@ -65,7 +89,10 @@ final class StorageBuilder
         );
     }
 
-    /** @throws InvalidConfiguration */
+    /**
+     * @return non-empty-string
+     * @throws InvalidConfiguration
+     */
     private function validate(string $directory, string $name): string
     {
         if ($directory === '') {

--- a/src/Config/SuiteBuilder.php
+++ b/src/Config/SuiteBuilder.php
@@ -23,6 +23,8 @@ final class SuiteBuilder
     public function __construct(private readonly string $name) {}
 
     /**
+     * @param non-empty-string ...$paths
+     *
      * @throws InvalidConfiguration
      */
     public function in(string ...$paths): self
@@ -47,6 +49,8 @@ final class SuiteBuilder
     }
 
     /**
+     * @param non-empty-string ...$tags
+     *
      * @throws InvalidConfiguration
      */
     public function tag(string ...$tags): self

--- a/src/Config/WatchBuilder.php
+++ b/src/Config/WatchBuilder.php
@@ -15,6 +15,8 @@ final class WatchBuilder
      * Sets the quiet period before a new run. The period restarts after each
      * change. Thus, multiple consecutive saves cause one run.
      *
+     * @param positive-int $milliseconds
+     *
      * @throws InvalidConfiguration
      */
     public function debounceMilliseconds(int $milliseconds): self

--- a/tests/Acceptance/PhpStanConfigurationBuilderTypeTest.php
+++ b/tests/Acceptance/PhpStanConfigurationBuilderTypeTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\PhpStanProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class PhpStanConfigurationBuilderTypeTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function builderArgumentsExposeTheirRuntimeConstraints(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Config\ArtifactBuilder;
+            use Greenlight\Config\CoverageBuilder;
+            use Greenlight\Config\GreenlightConfig;
+            use Greenlight\Config\StorageBuilder;
+            use Greenlight\Config\SuiteBuilder;
+            use Greenlight\Config\WatchBuilder;
+
+            function greenlightGoodConfigurationBuilderTypeProbe(): void
+            {
+                GreenlightConfig::create()
+                    ->paths(['tests'])
+                    ->suite('unit', static fn(SuiteBuilder $suite) => $suite->in('tests')->tag('fast'))
+                    ->workers(count: 2, recycleAfterTests: 100, recycleAboveMemory: '256M')
+                    ->resourceLimit('database', 1)
+                    ->ignoreDeprecationsMatching('vendor *')
+                    ->coverage(static fn(CoverageBuilder $coverage) => $coverage
+                        ->include('src')
+                        ->driver('pcov')
+                        ->export('lcov', 'build/coverage.lcov'))
+                    ->watch(static fn(WatchBuilder $watch) => $watch->debounceMilliseconds(200))
+                    ->artifacts(static fn(ArtifactBuilder $artifacts) => $artifacts
+                        ->directory('build/artifacts')
+                        ->maxAttachmentsPerTest(10)
+                        ->maxAttachmentSize('1M')
+                        ->maxTestSize('10M')
+                        ->maxRunAttachments(100)
+                        ->maxRunSize('100M'))
+                    ->storage(static fn(StorageBuilder $storage) => $storage
+                        ->rootDirectory('build/greenlight')
+                        ->stateDirectory('state')
+                        ->cacheDirectory('cache')
+                        ->generatedCodeDirectory('code')
+                        ->temporaryDirectory('tmp'));
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Config\ArtifactBuilder;
+            use Greenlight\Config\CoverageBuilder;
+            use Greenlight\Config\GreenlightConfig;
+            use Greenlight\Config\StorageBuilder;
+            use Greenlight\Config\SuiteBuilder;
+            use Greenlight\Config\WatchBuilder;
+
+            function greenlightBadConfigurationBuilderTypeProbe(): void
+            {
+                GreenlightConfig::create()->paths([]);
+                GreenlightConfig::create()->suite('', static fn(SuiteBuilder $suite) => $suite->in('tests'));
+                GreenlightConfig::create()->workers(count: 0);
+                GreenlightConfig::create()->workers(recycleAfterTests: 0);
+                GreenlightConfig::create()->workers(recycleAboveMemory: '');
+                GreenlightConfig::create()->resourceLimit('', 1);
+                GreenlightConfig::create()->resourceLimit('database', 0);
+                GreenlightConfig::create()->ignoreDeprecationsMatching('');
+
+                new SuiteBuilder('unit')->in('')->tag('');
+                new CoverageBuilder()->include('')->driver('')->export('', 'report');
+                new CoverageBuilder()->export('xml', 'report.xml');
+                new WatchBuilder()->debounceMilliseconds(0);
+                new ArtifactBuilder()
+                    ->directory('')
+                    ->maxAttachmentsPerTest(0)
+                    ->maxAttachmentSize('')
+                    ->maxTestSize('')
+                    ->maxRunAttachments(0)
+                    ->maxRunSize('');
+                new StorageBuilder()
+                    ->rootDirectory('')
+                    ->stateDirectory('')
+                    ->cacheDirectory('')
+                    ->generatedCodeDirectory('')
+                    ->temporaryDirectory('');
+            }
+            PHP,
+        );
+
+        Expect::that($probe->exitCode)
+            ->because('PHPStan rejects configuration values that cannot pass runtime validation')
+            ->toBe(1);
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(26);
+        Expect::that($probe->messages())->toContain('Greenlight\Config\GreenlightConfig::workers() expects');
+        Expect::that($probe->messages())->toContain('Greenlight\Config\ArtifactBuilder::maxRunAttachments() expects');
+        Expect::that($probe->messages())->toContain('Greenlight\Config\StorageBuilder::temporaryDirectory() expects');
+    }
+}

--- a/tests/Unit/Config/ArtifactBuilderTest.php
+++ b/tests/Unit/Config/ArtifactBuilderTest.php
@@ -45,28 +45,28 @@ final class ArtifactBuilderTest
     {
         yield 'zero per test' => [
             static function (ArtifactBuilder $builder): void {
-                $builder->maxAttachmentsPerTest(0);
+                $builder->maxAttachmentsPerTest(0); // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
             },
             'Artifact count per test must be at least 1.',
         ];
 
         yield 'negative per test' => [
             static function (ArtifactBuilder $builder): void {
-                $builder->maxAttachmentsPerTest(-1);
+                $builder->maxAttachmentsPerTest(-1); // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
             },
             'Artifact count per test must be at least 1.',
         ];
 
         yield 'zero per run' => [
             static function (ArtifactBuilder $builder): void {
-                $builder->maxRunAttachments(0);
+                $builder->maxRunAttachments(0); // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
             },
             'Artifact count per run must be at least 1.',
         ];
 
         yield 'negative per run' => [
             static function (ArtifactBuilder $builder): void {
-                $builder->maxRunAttachments(-1);
+                $builder->maxRunAttachments(-1); // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
             },
             'Artifact count per run must be at least 1.',
         ];

--- a/tests/Unit/Config/CoverageBuilderTest.php
+++ b/tests/Unit/Config/CoverageBuilderTest.php
@@ -16,7 +16,7 @@ final class CoverageBuilderTest
     public function anEmptyIncludePathIsRejected(): void
     {
         Expect::that(static function (): void {
-            new CoverageBuilder()->include('');
+            new CoverageBuilder()->include(''); // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
         })
             ->because('a coverage include path identifies source to instrument')
             ->toThrow(
@@ -30,7 +30,7 @@ final class CoverageBuilderTest
     {
         $builder = new CoverageBuilder()->include('src');
 
-        Expect::that(static fn(): CoverageBuilder => $builder->include('app', ''))
+        Expect::that(static fn(): CoverageBuilder => $builder->include('app', '')) // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
             ->because('a rejected include call does not partially change the builder')
             ->toThrow(InvalidConfiguration::class);
 
@@ -54,7 +54,7 @@ final class CoverageBuilderTest
     public function anEmptyDriverNameIsRejected(): void
     {
         Expect::that(static function (): void {
-            new CoverageBuilder()->driver('');
+            new CoverageBuilder()->driver(''); // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
         })
             ->because('a coverage driver needs a selectable name')
             ->toThrow(
@@ -68,7 +68,10 @@ final class CoverageBuilderTest
     public function aCoverageExportNeedsAFormatAndTarget(string $format, string $target): void
     {
         Expect::that(static function () use ($format, $target): void {
-            new CoverageBuilder()->export($format, $target);
+            // Reflection bypasses the static non-empty-string types and
+            // exercises the runtime guard.
+            new \ReflectionMethod(CoverageBuilder::class, 'export')
+                ->invoke(new CoverageBuilder(), $format, $target);
         })
             ->because('a coverage export needs a format and target')
             ->toThrow(

--- a/tests/Unit/Config/GreenlightConfigTest.php
+++ b/tests/Unit/Config/GreenlightConfigTest.php
@@ -143,7 +143,7 @@ final class GreenlightConfigTest
 
         Expect::that(static fn(): GreenlightConfig => $builder->workers(
             count: 8,
-            recycleAfterTests: 0,
+            recycleAfterTests: 0, // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
             recycleAboveMemory: '128M',
         ))
             ->because('a rejected worker configuration does not partially change the builder')
@@ -189,7 +189,7 @@ final class GreenlightConfigTest
         Expect::that(static fn(): GreenlightConfig => $builder->coverage(
             static fn(CoverageBuilder $coverage) => $coverage
                 ->driver('xdebug')
-                ->include(''),
+                ->include(''), // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
         ))
             ->because('a rejected coverage configuration does not partially change the builder')
             ->toThrow(InvalidConfiguration::class);
@@ -197,7 +197,7 @@ final class GreenlightConfigTest
         Expect::that(static fn(): GreenlightConfig => $builder->watch(
             static fn(WatchBuilder $watch) => $watch
                 ->debounceMilliseconds(750)
-                ->debounceMilliseconds(0),
+                ->debounceMilliseconds(0), // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
         ))
             ->because('a rejected watch configuration does not partially change the builder')
             ->toThrow(InvalidConfiguration::class);
@@ -205,7 +205,7 @@ final class GreenlightConfigTest
         Expect::that(static fn(): GreenlightConfig => $builder->artifacts(
             static fn(ArtifactBuilder $artifacts) => $artifacts
                 ->directory('build/changed')
-                ->maxRunAttachments(0),
+                ->maxRunAttachments(0), // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
         ))
             ->because('a rejected artifact configuration does not partially change the builder')
             ->toThrow(InvalidConfiguration::class);
@@ -231,7 +231,7 @@ final class GreenlightConfigTest
     {
         $builder = GreenlightConfig::create()->ignoreDeprecationsMatching('existing');
 
-        Expect::that(static fn(): GreenlightConfig => $builder->ignoreDeprecationsMatching('added', ''))
+        Expect::that(static fn(): GreenlightConfig => $builder->ignoreDeprecationsMatching('added', '')) // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
             ->because('a rejected deprecation pattern does not partially change the builder')
             ->toThrow(InvalidConfiguration::class);
 
@@ -314,7 +314,7 @@ final class GreenlightConfigTest
         yield 'empty name' => [
             static function (): void {
                 GreenlightConfig::create()->suite(
-                    '',
+                    '', // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
                     static fn(SuiteBuilder $suite) => $suite->in('tests'),
                 );
             },
@@ -342,7 +342,7 @@ final class GreenlightConfigTest
             static function (): void {
                 GreenlightConfig::create()->suite(
                     'unit',
-                    static fn(SuiteBuilder $suite) => $suite->in(''),
+                    static fn(SuiteBuilder $suite) => $suite->in(''), // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
                 );
             },
             'Suite "unit" was given an empty path.',
@@ -352,7 +352,7 @@ final class GreenlightConfigTest
             static function (): void {
                 GreenlightConfig::create()->suite(
                     'unit',
-                    static fn(SuiteBuilder $suite) => $suite->in('tests')->tag(''),
+                    static fn(SuiteBuilder $suite) => $suite->in('tests')->tag(''), // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
                 );
             },
             'Suite "unit" was given an empty tag.',
@@ -378,7 +378,7 @@ final class GreenlightConfigTest
     {
         yield 'negative limit' => [
             static function (): void {
-                GreenlightConfig::create()->resourceLimit('redis', -2);
+                GreenlightConfig::create()->resourceLimit('redis', -2); // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
             },
             'Resource "redis" must have a limit of at least 1, got -2.',
         ];
@@ -399,7 +399,7 @@ final class GreenlightConfigTest
     public static function invalidInputs(): iterable
     {
         yield 'zero workers' => [static function (): void {
-            GreenlightConfig::create()->workers(count: 0);
+            GreenlightConfig::create()->workers(count: 0); // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
         }];
 
         yield 'bad worker string' => [static function (): void {
@@ -410,7 +410,7 @@ final class GreenlightConfigTest
         }];
 
         yield 'zero recycleAfterTests' => [static function (): void {
-            GreenlightConfig::create()->workers(recycleAfterTests: 0);
+            GreenlightConfig::create()->workers(recycleAfterTests: 0); // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
         }];
 
         yield 'bad memory string' => [static function (): void {
@@ -418,7 +418,7 @@ final class GreenlightConfigTest
         }];
 
         yield 'empty artifact directory' => [static function (): void {
-            GreenlightConfig::create()->artifacts(static fn(ArtifactBuilder $artifacts) => $artifacts->directory(''));
+            GreenlightConfig::create()->artifacts(static fn(ArtifactBuilder $artifacts) => $artifacts->directory('')); // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
         }];
 
         yield 'invalid resource name' => [static function (): void {
@@ -426,7 +426,7 @@ final class GreenlightConfigTest
         }];
 
         yield 'zero resource limit' => [static function (): void {
-            GreenlightConfig::create()->resourceLimit('postgres', 0);
+            GreenlightConfig::create()->resourceLimit('postgres', 0); // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
         }];
 
         yield 'duplicate resource limit' => [static function (): void {
@@ -454,7 +454,7 @@ final class GreenlightConfigTest
         yield 'zero per-test count' => [
             static function (): void {
                 GreenlightConfig::create()->artifacts(
-                    static fn(ArtifactBuilder $artifacts) => $artifacts->maxAttachmentsPerTest(0),
+                    static fn(ArtifactBuilder $artifacts) => $artifacts->maxAttachmentsPerTest(0), // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
                 );
             },
             'Artifact count per test must be at least 1.',
@@ -462,7 +462,7 @@ final class GreenlightConfigTest
         yield 'negative per-test count' => [
             static function (): void {
                 GreenlightConfig::create()->artifacts(
-                    static fn(ArtifactBuilder $artifacts) => $artifacts->maxAttachmentsPerTest(-1),
+                    static fn(ArtifactBuilder $artifacts) => $artifacts->maxAttachmentsPerTest(-1), // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
                 );
             },
             'Artifact count per test must be at least 1.',
@@ -470,7 +470,7 @@ final class GreenlightConfigTest
         yield 'zero per-run count' => [
             static function (): void {
                 GreenlightConfig::create()->artifacts(
-                    static fn(ArtifactBuilder $artifacts) => $artifacts->maxRunAttachments(0),
+                    static fn(ArtifactBuilder $artifacts) => $artifacts->maxRunAttachments(0), // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
                 );
             },
             'Artifact count per run must be at least 1.',
@@ -478,7 +478,7 @@ final class GreenlightConfigTest
         yield 'negative per-run count' => [
             static function (): void {
                 GreenlightConfig::create()->artifacts(
-                    static fn(ArtifactBuilder $artifacts) => $artifacts->maxRunAttachments(-1),
+                    static fn(ArtifactBuilder $artifacts) => $artifacts->maxRunAttachments(-1), // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
                 );
             },
             'Artifact count per run must be at least 1.',

--- a/tests/Unit/Config/GreenlightConfigWorkerValidationTest.php
+++ b/tests/Unit/Config/GreenlightConfigWorkerValidationTest.php
@@ -31,7 +31,7 @@ final class GreenlightConfigWorkerValidationTest
     {
         yield 'negative worker count' => [
             static function (): void {
-                GreenlightConfig::create()->workers(count: -3);
+                GreenlightConfig::create()->workers(count: -3); // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
             },
             'Worker count must be at least 1, got -3.',
         ];
@@ -46,7 +46,7 @@ final class GreenlightConfigWorkerValidationTest
 
         yield 'negative recycle limit' => [
             static function (): void {
-                GreenlightConfig::create()->workers(recycleAfterTests: -4);
+                GreenlightConfig::create()->workers(recycleAfterTests: -4); // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
             },
             'recycleAfterTests must be at least 1, got -4.',
         ];

--- a/tests/Unit/Config/ResultPolicyConfigurationTest.php
+++ b/tests/Unit/Config/ResultPolicyConfigurationTest.php
@@ -118,7 +118,7 @@ final class ResultPolicyConfigurationTest
     {
         Expect::that(
             static fn(): GreenlightConfig => GreenlightConfig::create()
-                ->ignoreDeprecationsMatching(...$patterns),
+                ->ignoreDeprecationsMatching(...$patterns), // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
         )
             ->because('empty deprecation ignore patterns are invalid')
             ->toThrow(

--- a/tests/Unit/Config/StorageBuilderTest.php
+++ b/tests/Unit/Config/StorageBuilderTest.php
@@ -51,7 +51,7 @@ final readonly class StorageBuilderTest
     public static function invalidDirectories(): iterable
     {
         yield 'empty root' => [
-            static fn(StorageBuilder $storage): StorageBuilder => $storage->rootDirectory(''),
+            static fn(StorageBuilder $storage): StorageBuilder => $storage->rootDirectory(''), // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
             'Storage root directory cannot be empty.',
         ];
         yield 'state null byte' => [
@@ -59,7 +59,7 @@ final readonly class StorageBuilderTest
             'State directory cannot contain a null byte.',
         ];
         yield 'empty cache' => [
-            static fn(StorageBuilder $storage): StorageBuilder => $storage->cacheDirectory(''),
+            static fn(StorageBuilder $storage): StorageBuilder => $storage->cacheDirectory(''), // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
             'Cache directory cannot be empty.',
         ];
         yield 'generated code null byte' => [
@@ -67,7 +67,7 @@ final readonly class StorageBuilderTest
             'Generated-code directory cannot contain a null byte.',
         ];
         yield 'empty temporary' => [
-            static fn(StorageBuilder $storage): StorageBuilder => $storage->temporaryDirectory(''),
+            static fn(StorageBuilder $storage): StorageBuilder => $storage->temporaryDirectory(''), // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
             'Temporary directory cannot be empty.',
         ];
     }

--- a/tests/Unit/Config/SuiteBuilderTest.php
+++ b/tests/Unit/Config/SuiteBuilderTest.php
@@ -37,11 +37,11 @@ final class SuiteBuilderTest
             ->in('tests/Existing')
             ->tag('existing');
 
-        Expect::that(static fn(): SuiteBuilder => $builder->in('tests/Added', ''))
+        Expect::that(static fn(): SuiteBuilder => $builder->in('tests/Added', '')) // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
             ->because('a rejected path call does not partially change the builder')
             ->toThrow(InvalidConfiguration::class);
 
-        Expect::that(static fn(): SuiteBuilder => $builder->tag('added', ''))
+        Expect::that(static fn(): SuiteBuilder => $builder->tag('added', '')) // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
             ->because('a rejected tag call does not partially change the builder')
             ->toThrow(InvalidConfiguration::class);
 
@@ -69,8 +69,8 @@ final class SuiteBuilderTest
     }
 
     /**
-     * @param list<string> $paths
-     * @param list<string> $tags
+     * @param list<non-empty-string> $paths
+     * @param list<non-empty-string> $tags
      */
     #[Test]
     #[DataSet('zeroStringValues')]

--- a/tests/Unit/Config/WatchBuilderTest.php
+++ b/tests/Unit/Config/WatchBuilderTest.php
@@ -32,7 +32,7 @@ final class WatchBuilderTest
     public function theDebounceMustBePositive(int $milliseconds): void
     {
         Expect::that(static function () use ($milliseconds): void {
-            new WatchBuilder()->debounceMilliseconds($milliseconds);
+            new WatchBuilder()->debounceMilliseconds($milliseconds); // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
         })
             ->because('the watch debounce must be positive')
             ->toThrow(


### PR DESCRIPTION
## Summary

- Express validated configuration-builder inputs with PHPStan types such as positive-int, non-empty-string, and non-empty-list.
- Restrict coverage export formats to the supported literal union.
- Retain runtime validation and add consumer-style PHPStan coverage for the builder contracts.