### PR TITLE
refactor(config): construct nested builders eagerly

### DIFF
--- a/docs/api-configuration.md
+++ b/docs/api-configuration.md
@@ -166,7 +166,7 @@ final class GreenlightConfig
 public static function create(): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L67)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L73)
 
 ### `paths()`
 
@@ -182,7 +182,7 @@ PHPDoc:
 - `@param non-empty-list<non-empty-string> $tests`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L80)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L86)
 
 ### `suite()`
 
@@ -202,7 +202,7 @@ PHPDoc:
 - `@param callable(SuiteBuilder): mixed $configurator`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L137)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L143)
 
 ### `workers()`
 
@@ -217,7 +217,7 @@ PHPDoc:
 - `@param positive-int|'auto' $count`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L161)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L167)
 
 ### `resourceLimit()`
 
@@ -236,7 +236,7 @@ PHPDoc:
 - `@param positive-int $limit`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L179)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L185)
 
 ### `coverage()`
 
@@ -248,7 +248,7 @@ PHPDoc:
 
 - `@param callable(CoverageBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L207)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L213)
 
 ### `watch()`
 
@@ -260,7 +260,7 @@ PHPDoc:
 
 - `@param callable(WatchBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L219)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L226)
 
 ### `artifacts()`
 
@@ -272,7 +272,7 @@ PHPDoc:
 
 - `@param callable(ArtifactBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L231)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L238)
 
 ### `storage()`
 
@@ -287,7 +287,7 @@ PHPDoc:
 
 - `@param callable(StorageBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L246)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L253)
 
 ### `failOnDeprecation()`
 
@@ -303,7 +303,7 @@ PHPDoc:
 
 - `@see self::ignoreDeprecationsMatching()`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L262)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L269)
 
 ### `failOnNotice()`
 
@@ -311,7 +311,7 @@ PHPDoc:
 public function failOnNotice(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L269)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L276)
 
 ### `failOnRisky()`
 
@@ -323,7 +323,7 @@ expectations.
 public function failOnRisky(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L281)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L288)
 
 ### `ignoreDeprecationsMatching()`
 
@@ -340,7 +340,7 @@ PHPDoc:
 - `@param non-empty-string ...$patterns`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L297)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L304)
 
 ### `plugins()`
 
@@ -353,7 +353,7 @@ PHPDoc:
 - `@param \Closure(): Plugin ...$plugins`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L318)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L325)
 
 ### `failFast()`
 
@@ -361,7 +361,7 @@ PHPDoc:
 public function failFast(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L335)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L342)
 
 ### `randomizeOrder()`
 
@@ -371,7 +371,7 @@ If the seed is null, Greenlight selects and prints a seed when it resolves the c
 public function randomizeOrder(?int $seed = null): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L343)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L350)
 
 ## `InvalidConfiguration`
 

--- a/src/Config/GreenlightConfig.php
+++ b/src/Config/GreenlightConfig.php
@@ -24,13 +24,15 @@ final class GreenlightConfig
 
     private WorkerCount $workers;
 
-    private ?CoverageBuilder $coverage = null;
+    private CoverageBuilder $coverage;
 
-    private ?WatchBuilder $watch = null;
+    private bool $coverageEnabled = false;
 
-    private ?ArtifactBuilder $artifacts = null;
+    private WatchBuilder $watch;
 
-    private ?StorageBuilder $storage = null;
+    private ArtifactBuilder $artifacts;
+
+    private StorageBuilder $storage;
 
     /**
      * @var list<PluginDefinition>
@@ -62,6 +64,10 @@ final class GreenlightConfig
     private function __construct()
     {
         $this->workers = WorkerCount::auto();
+        $this->coverage = new CoverageBuilder();
+        $this->watch = new WatchBuilder();
+        $this->artifacts = new ArtifactBuilder();
+        $this->storage = new StorageBuilder();
     }
 
     public static function create(): self
@@ -206,9 +212,10 @@ final class GreenlightConfig
      */
     public function coverage(callable $configurator): self
     {
-        $builder = $this->coverage instanceof CoverageBuilder ? clone $this->coverage : new CoverageBuilder();
+        $builder = clone $this->coverage;
         $configurator($builder);
         $this->coverage = clone $builder;
+        $this->coverageEnabled = true;
 
         return $this;
     }
@@ -218,7 +225,7 @@ final class GreenlightConfig
      */
     public function watch(callable $configurator): self
     {
-        $builder = $this->watch instanceof WatchBuilder ? clone $this->watch : new WatchBuilder();
+        $builder = clone $this->watch;
         $configurator($builder);
         $this->watch = clone $builder;
 
@@ -230,7 +237,7 @@ final class GreenlightConfig
      */
     public function artifacts(callable $configurator): self
     {
-        $builder = $this->artifacts instanceof ArtifactBuilder ? clone $this->artifacts : new ArtifactBuilder();
+        $builder = clone $this->artifacts;
         $configurator($builder);
         $this->artifacts = clone $builder;
 
@@ -245,7 +252,7 @@ final class GreenlightConfig
      */
     public function storage(callable $configurator): self
     {
-        $builder = $this->storage instanceof StorageBuilder ? clone $this->storage : new StorageBuilder();
+        $builder = clone $this->storage;
         $configurator($builder);
         $this->storage = clone $builder;
 
@@ -393,12 +400,12 @@ final class GreenlightConfig
                     $this->failOnRisky,
                 ),
                 stopAfterFailures: $this->failFast ? 1 : null,
-                artifacts: $this->artifacts?->toConfiguration() ?? new ArtifactConfiguration(),
+                artifacts: $this->artifacts->toConfiguration(),
             ),
             order: new OrderConfiguration($this->randomizeOrder, $this->randomSeed),
-            coverage: $this->coverage?->toConfiguration(),
-            watch: $this->watch?->toConfiguration() ?? new WatchConfiguration(),
-            storage: $this->storage?->toConfiguration() ?? new StorageConfiguration(),
+            coverage: $this->coverageEnabled ? $this->coverage->toConfiguration() : null,
+            watch: $this->watch->toConfiguration(),
+            storage: $this->storage->toConfiguration(),
         );
     }
 }

--- a/tests/Unit/Config/GreenlightConfigTest.php
+++ b/tests/Unit/Config/GreenlightConfigTest.php
@@ -11,6 +11,7 @@ use Greenlight\Config\CoverageBuilder;
 use Greenlight\Config\CoverageConfiguration;
 use Greenlight\Config\GreenlightConfig;
 use Greenlight\Config\InvalidConfiguration;
+use Greenlight\Config\StorageBuilder;
 use Greenlight\Config\SuiteBuilder;
 use Greenlight\Config\WatchBuilder;
 use Greenlight\Core\Event\Event;
@@ -148,6 +149,22 @@ final class GreenlightConfigTest
     }
 
     #[Test]
+    public function rejectedCoverageConfigurationDoesNotEnableCoverage(): void
+    {
+        $builder = GreenlightConfig::create();
+
+        Expect::that(static fn(): GreenlightConfig => $builder->coverage(
+            static fn(CoverageBuilder $coverage) => $coverage->include(''), // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
+        ))
+            ->because('a rejected coverage configuration does not enable coverage')
+            ->toThrow(InvalidConfiguration::class);
+
+        Expect::that($builder->build()->coverage)
+            ->because('coverage stays off when its configurator fails')
+            ->toBe(null);
+    }
+
+    #[Test]
     public function rejectedNestedConfigurationsDoNotPartiallyChangeTheBuilder(): void
     {
         $builder = GreenlightConfig::create()
@@ -155,7 +172,8 @@ final class GreenlightConfigTest
                 ->include('src')
                 ->driver('pcov'))
             ->watch(static fn(WatchBuilder $watch) => $watch->debounceMilliseconds(500))
-            ->artifacts(static fn(ArtifactBuilder $artifacts) => $artifacts->directory('build/original'));
+            ->artifacts(static fn(ArtifactBuilder $artifacts) => $artifacts->directory('build/original'))
+            ->storage(static fn(StorageBuilder $storage) => $storage->cacheDirectory('build/original-cache'));
 
         Expect::that(static fn(): GreenlightConfig => $builder->coverage(
             static fn(CoverageBuilder $coverage) => $coverage
@@ -181,6 +199,14 @@ final class GreenlightConfigTest
             ->because('a rejected artifact configuration does not partially change the builder')
             ->toThrow(InvalidConfiguration::class);
 
+        Expect::that(static fn(): GreenlightConfig => $builder->storage(
+            static fn(StorageBuilder $storage) => $storage
+                ->cacheDirectory('build/changed-cache')
+                ->temporaryDirectory(''), // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
+        ))
+            ->because('a rejected storage configuration does not partially change the builder')
+            ->toThrow(InvalidConfiguration::class);
+
         $configuration = $builder->build();
 
         Expect::that($configuration->coverage?->includePaths)
@@ -195,6 +221,9 @@ final class GreenlightConfigTest
         Expect::that($configuration->execution->artifacts->directory)
             ->because('a rejected artifact configuration retains the prior directory')
             ->toBe('build/original');
+        Expect::that($configuration->storage->cacheDirectory)
+            ->because('a rejected storage configuration retains the prior cache directory')
+            ->toBe('build/original-cache');
     }
 
     #[Test]


### PR DESCRIPTION
## What

Construct the coverage, watch, artifact, and storage builders when GreenlightConfig is created. Keep coverage disabled until its configurator succeeds.

Preserve clone-on-write isolation and add regression coverage for failed coverage and storage configurators.

## Why

The builder allocations are negligible. Eager construction removes repeated nullable state checks and default fallbacks while retaining failure-atomic configuration.