### PR TITLE
fix(phpstan): preserve argument matcher native types

### DIFF
--- a/docs/api-doubles.md
+++ b/docs/api-doubles.md
@@ -37,12 +37,12 @@ public static function type(string $type): ArgumentMatcher
 
 PHPDoc:
 
-- `@template T of object`
-- `@param class-string<T>|string $type`
-- `@return ($type is class-string<T> ? ArgumentMatcher<T> : ArgumentMatcher<mixed>)`
+- `@template TType of string`
+- `@param TType $type`
+- `@return ( $type is 'array' ? ArgumentMatcher<array<array-key, mixed>> : ( $type is 'bool' ? ArgumentMatcher<bool> : ( $type is 'float' ? ArgumentMatcher<float> : ( $type is 'int' ? ArgumentMatcher<int> : ( $type is 'null' ? ArgumentMatcher<null> : ( $type is 'string' ? ArgumentMatcher<string> : ( $type is class-string ? ArgumentMatcher<new<TType>> : ArgumentMatcher<mixed> ) ) ) ) ) ) )`
 - `@throws InvalidDoubleUsage`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L31)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L59)
 
 ### `predicate()`
 
@@ -59,7 +59,7 @@ PHPDoc:
 - `@param \Closure(T): mixed $predicate`
 - `@return ArgumentMatcher<T>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L46)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L74)
 
 ### `equals()`
 
@@ -76,7 +76,7 @@ PHPDoc:
 - `@param T $value`
 - `@return ArgumentMatcher<T>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L61)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L89)
 
 ### `allOf()`
 
@@ -100,7 +100,7 @@ PHPDoc:
 - `@return ArgumentMatcher<T>`
 - `@throws InvalidDoubleUsage`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L79)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L107)
 
 ### `captor()`
 
@@ -111,7 +111,7 @@ selects the related expectation for the call.
 public static function captor(): ArgumentCaptor
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L97)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L125)
 
 ## `ArgumentCaptor`
 

--- a/src/Doubles/Argument.php
+++ b/src/Doubles/Argument.php
@@ -21,11 +21,39 @@ final class Argument
      * This matcher accepts instances of the specified class or interface.
      * It also accepts values when `get_debug_type()` returns `$type`.
      *
-     * @template T of object
+     * @template TType of string
      *
-     * @param class-string<T>|string $type
+     * @param TType $type
      *
-     * @return ($type is class-string<T> ? ArgumentMatcher<T> : ArgumentMatcher<mixed>)
+     * @return (
+     *     $type is 'array'
+     *         ? ArgumentMatcher<array<array-key, mixed>>
+     *         : (
+     *             $type is 'bool'
+     *                 ? ArgumentMatcher<bool>
+     *                 : (
+     *                     $type is 'float'
+     *                         ? ArgumentMatcher<float>
+     *                         : (
+     *                             $type is 'int'
+     *                                 ? ArgumentMatcher<int>
+     *                                 : (
+     *                                     $type is 'null'
+     *                                         ? ArgumentMatcher<null>
+     *                                         : (
+     *                                             $type is 'string'
+     *                                                 ? ArgumentMatcher<string>
+     *                                                 : (
+     *                                                     $type is class-string
+     *                                                         ? ArgumentMatcher<new<TType>>
+     *                                                         : ArgumentMatcher<mixed>
+     *                                                 )
+     *                                         )
+     *                                 )
+     *                         )
+     *                 )
+     *         )
+     * )
      * @throws InvalidDoubleUsage
      */
     public static function type(string $type): ArgumentMatcher

--- a/tests/Acceptance/PhpStanArgumentMatcherTypeTest.php
+++ b/tests/Acceptance/PhpStanArgumentMatcherTypeTest.php
@@ -16,6 +16,74 @@ final readonly class PhpStanArgumentMatcherTypeTest
     public function __construct(private TemporaryDirectory $tempDirectory) {}
 
     #[Test]
+    public function typePreservesKnownNativeTypesAndFallsBackForOtherNames(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Doubles\Argument;
+            use Greenlight\Doubles\ArgumentMatcher;
+
+            /**
+             * @return array{
+             *     ArgumentMatcher<array<array-key, mixed>>,
+             *     ArgumentMatcher<bool>,
+             *     ArgumentMatcher<float>,
+             *     ArgumentMatcher<int>,
+             *     ArgumentMatcher<null>,
+             *     ArgumentMatcher<string>,
+             *     ArgumentMatcher<DateTimeInterface>,
+             *     ArgumentMatcher<mixed>,
+             * }
+             */
+            function greenlightKnownArgumentMatcherTypes(): array
+            {
+                return [
+                    Argument::type('array'),
+                    Argument::type('bool'),
+                    Argument::type('float'),
+                    Argument::type('int'),
+                    Argument::type('null'),
+                    Argument::type('string'),
+                    Argument::type(DateTimeInterface::class),
+                    Argument::type('resource (stream)'),
+                ];
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Doubles\Argument;
+            use Greenlight\Doubles\ArgumentMatcher;
+
+            /** @return ArgumentMatcher<string> */
+            function greenlightWrongKnownArgumentMatcherType(): ArgumentMatcher
+            {
+                return Argument::type('int');
+            }
+
+            /** @return ArgumentMatcher<int> */
+            function greenlightWrongFallbackArgumentMatcherType(): ArgumentMatcher
+            {
+                return Argument::type('resource (stream)');
+            }
+            PHP,
+        );
+
+        Expect::that($probe->exitCode)->because('PHPStan MUST preserve known argument matcher types')->toBe(1);
+        Expect::that($probe->goodPassed)->because('PHPStan messages: ' . $probe->messages())->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(2);
+        Expect::that($probe->messages())->toContain('ArgumentMatcher<int>');
+        Expect::that($probe->messages())->toContain('ArgumentMatcher<mixed>');
+    }
+
+    #[Test]
     public function allOfPreservesTheTypesOfItsMatchers(): void
     {
         $probe = PhpStanProbe::analyze(


### PR DESCRIPTION
Refine Argument::type() so PHPStan preserves array, bool, float, int, null, and string matcher types. Keep class-string inference through new<TType> and retain ArgumentMatcher<mixed> for other get_debug_type() names, including resource-specific names. Add acceptance coverage for each precise branch and the mixed fallback, and regenerate the public API reference.