### PR TITLE
docs: remove redundant fixture path comment

### DIFF
--- a/greenlight.php
+++ b/greenlight.php
@@ -6,9 +6,6 @@ use Greenlight\Config\GreenlightConfig;
 use Greenlight\Config\StorageBuilder;
 
 return GreenlightConfig::create()
-    // Do not add tests/Fixture to these paths.
-    // Some fixture tests intentionally call sleep(60) or exit(9), or retain memory.
-    // Acceptance tests run these fixture suites in separate processes.
     ->paths(['tests/Unit', 'tests/Acceptance'])
     ->workers(count: 'auto')
     ->resourceLimit('analysis-process', 5)

--- a/greenlight.php
+++ b/greenlight.php
@@ -6,9 +6,9 @@ use Greenlight\Config\GreenlightConfig;
 use Greenlight\Config\StorageBuilder;
 
 return GreenlightConfig::create()
-    // tests/Fixture MUST NOT be part of this suite.
-    // Its Hang, Crash, and Leak suites call sleep(60) or exit(9).
-    // Only acceptance tests can safely run these suites as subprocesses.
+    // Do not add tests/Fixture to these paths.
+    // Some fixture tests intentionally call sleep(60) or exit(9), or retain memory.
+    // Acceptance tests run these fixture suites in separate processes.
     ->paths(['tests/Unit', 'tests/Acceptance'])
     ->workers(count: 'auto')
     ->resourceLimit('analysis-process', 5)


### PR DESCRIPTION
The root configuration already lists the only discovery paths. Remove the redundant tests/Fixture warning, which repeats the configuration and incorrectly describes LeakSuite.