### PR TITLE
feat(doubles): add argument type combinators

### DIFF
--- a/docs/api-doubles.md
+++ b/docs/api-doubles.md
@@ -44,6 +44,36 @@ PHPDoc:
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L59)
 
+### `intersection()`
+
+This matcher accepts values that have every specified type.
+
+```php
+public static function intersection(string $first, string $second, string ...$rest): ArgumentMatcher
+```
+
+PHPDoc:
+
+- `@return ArgumentMatcher<mixed>`
+- `@throws InvalidDoubleUsage`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L70)
+
+### `union()`
+
+This matcher accepts values that have one or more specified types.
+
+```php
+public static function union(string $first, string $second, string ...$rest): ArgumentMatcher
+```
+
+PHPDoc:
+
+- `@return ArgumentMatcher<mixed>`
+- `@throws InvalidDoubleUsage`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L81)
+
 ### `predicate()`
 
 This matcher accepts the value when the closure returns true.
@@ -59,7 +89,7 @@ PHPDoc:
 - `@param \Closure(T): mixed $predicate`
 - `@return ArgumentMatcher<T>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L74)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L96)
 
 ### `equals()`
 
@@ -76,7 +106,7 @@ PHPDoc:
 - `@param T $value`
 - `@return ArgumentMatcher<T>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L89)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L111)
 
 ### `allOf()`
 
@@ -100,7 +130,7 @@ PHPDoc:
 - `@return ArgumentMatcher<T>`
 - `@throws InvalidDoubleUsage`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L107)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L129)
 
 ### `captor()`
 
@@ -111,7 +141,7 @@ selects the related expectation for the call.
 public static function captor(): ArgumentCaptor
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L125)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L147)
 
 ## `ArgumentCaptor`
 
@@ -715,13 +745,21 @@ public static function invalidArgumentType(): self
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L298)
 
+### `invalidArgumentTypeCombination()`
+
+```php
+public static function invalidArgumentTypeCombination(string $factory): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L303)
+
 ### `compositeArgumentCaptor()`
 
 ```php
 public static function compositeArgumentCaptor(): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L303)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L311)
 
 ## `MethodExpectation`
 

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -145,10 +145,29 @@ Available matchers are:
 
 * `Argument::any()`
 * `Argument::type(string $type)`
+* `Argument::intersection(string $first, string $second, string ...$rest)`
+* `Argument::union(string $first, string $second, string ...$rest)`
 * `Argument::predicate(Closure $predicate, string $description = 'predicate')`
 * `Argument::equals(mixed $value)`
 * `Argument::allOf(ArgumentMatcher $first, ArgumentMatcher $second, ArgumentMatcher ...$rest)`
 * `Argument::captor()`
+
+Use `Argument::intersection()` when a value must have every specified type.
+Use `Argument::union()` when a value can have one or more specified types:
+
+<!-- php-example {"example":"test-doubles-type-combinations","file":"snippet.php","mode":"file","tools":["rector"]} -->
+```php
+use Greenlight\Doubles\Argument;
+
+$plan->expects('save')->with(
+    Argument::intersection(Entity::class, Persistable::class),
+    Argument::union('string', Stringable::class),
+);
+```
+
+The bundled PHPStan extension preserves the combined value type in each
+`ArgumentMatcher` generic type. Other type names use `mixed`, as they do for
+`Argument::type()`.
 
 Use `Argument::allOf()` to apply two or more constraints to one argument:
 

--- a/extension.neon
+++ b/extension.neon
@@ -25,6 +25,10 @@ rules:
     - Greenlight\PhpStan\ToThrowSubjectRule
 
 services:
+    greenlight.argumentTypeCombinationReturnTypeExtension:
+        class: Greenlight\PhpStan\ArgumentTypeCombinationReturnTypeExtension
+        tags:
+            - phpstan.broker.dynamicStaticMethodReturnTypeExtension
     greenlight.captureArgumentReturnTypeExtension:
         class: Greenlight\PhpStan\CaptureArgumentReturnTypeExtension
         tags:

--- a/src/Doubles/Argument.php
+++ b/src/Doubles/Argument.php
@@ -62,6 +62,28 @@ final class Argument
     }
 
     /**
+     * This matcher accepts values that have every specified type.
+     *
+     * @return ArgumentMatcher<mixed>
+     * @throws InvalidDoubleUsage
+     */
+    public static function intersection(string $first, string $second, string ...$rest): ArgumentMatcher
+    {
+        return new IntersectionTypeMatcher(self::typeNames('intersection', $first, $second, \array_values($rest)));
+    }
+
+    /**
+     * This matcher accepts values that have one or more specified types.
+     *
+     * @return ArgumentMatcher<mixed>
+     * @throws InvalidDoubleUsage
+     */
+    public static function union(string $first, string $second, string ...$rest): ArgumentMatcher
+    {
+        return new UnionTypeMatcher(self::typeNames('union', $first, $second, \array_values($rest)));
+    }
+
+    /**
      * This matcher accepts the value when the closure returns true.
      * The description identifies the constraint in failure messages.
      *
@@ -125,5 +147,24 @@ final class Argument
     public static function captor(): ArgumentCaptor
     {
         return new ArgumentCaptor();
+    }
+
+    /**
+     * @param list<string> $rest
+     *
+     * @return non-empty-list<string>
+     * @throws InvalidDoubleUsage
+     */
+    private static function typeNames(string $factory, string $first, string $second, array $rest): array
+    {
+        $types = [$first, $second, ...\array_values($rest)];
+
+        foreach ($types as $type) {
+            if (\trim($type) === '') {
+                throw InvalidDoubleUsage::invalidArgumentTypeCombination($factory);
+            }
+        }
+
+        return $types;
     }
 }

--- a/src/Doubles/IntersectionTypeMatcher.php
+++ b/src/Doubles/IntersectionTypeMatcher.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Doubles;
+
+/** @internal */
+final readonly class IntersectionTypeMatcher implements ArgumentMatcher
+{
+    /** @param non-empty-list<string> $types */
+    public function __construct(private array $types) {}
+
+    public function matches(mixed $value): bool
+    {
+        return \array_all(
+            $this->types,
+            static fn(string $type): bool => TypeMatcher::matchesType($value, $type),
+        );
+    }
+
+    public function describe(): string
+    {
+        return 'intersection(' . \implode(', ', $this->types) . ')';
+    }
+}

--- a/src/Doubles/InvalidDoubleUsage.php
+++ b/src/Doubles/InvalidDoubleUsage.php
@@ -300,6 +300,14 @@ final class InvalidDoubleUsage extends \LogicException
         return new self('Argument::type() requires a type name that contains a non-space character.');
     }
 
+    public static function invalidArgumentTypeCombination(string $factory): self
+    {
+        return new self(\sprintf(
+            'Argument::%s() requires type names that contain a non-space character.',
+            $factory,
+        ));
+    }
+
     public static function compositeArgumentCaptor(): self
     {
         return new self('Argument::allOf() does not accept a captor. Put the captor directly in with().');

--- a/src/Doubles/TypeMatcher.php
+++ b/src/Doubles/TypeMatcher.php
@@ -19,15 +19,16 @@ final readonly class TypeMatcher implements ArgumentMatcher
 
     public function matches(mixed $value): bool
     {
-        if ($value instanceof $this->type) {
-            return true;
-        }
-
-        return \get_debug_type($value) === $this->type;
+        return self::matchesType($value, $this->type);
     }
 
     public function describe(): string
     {
         return \sprintf('type(%s)', $this->type);
+    }
+
+    public static function matchesType(mixed $value, string $type): bool
+    {
+        return $value instanceof $type || \get_debug_type($value) === $type;
     }
 }

--- a/src/Doubles/UnionTypeMatcher.php
+++ b/src/Doubles/UnionTypeMatcher.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Doubles;
+
+/** @internal */
+final readonly class UnionTypeMatcher implements ArgumentMatcher
+{
+    /** @param non-empty-list<string> $types */
+    public function __construct(private array $types) {}
+
+    public function matches(mixed $value): bool
+    {
+        return \array_any(
+            $this->types,
+            static fn(string $type): bool => TypeMatcher::matchesType($value, $type),
+        );
+    }
+
+    public function describe(): string
+    {
+        return 'union(' . \implode(', ', $this->types) . ')';
+    }
+}

--- a/src/PhpStan/ArgumentTypeCombinationReturnTypeExtension.php
+++ b/src/PhpStan/ArgumentTypeCombinationReturnTypeExtension.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\PhpStan;
+
+use Greenlight\Doubles\Argument;
+use Greenlight\Doubles\ArgumentMatcher;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ArrayType;
+use PHPStan\Type\BooleanType;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+use PHPStan\Type\FloatType;
+use PHPStan\Type\Generic\GenericObjectType;
+use PHPStan\Type\IntegerType;
+use PHPStan\Type\MixedType;
+use PHPStan\Type\NullType;
+use PHPStan\Type\StringType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+/**
+ * Gets the combined value type for argument type matchers.
+ *
+ * @internal
+ */
+final class ArgumentTypeCombinationReturnTypeExtension implements DynamicStaticMethodReturnTypeExtension
+{
+    #[\Override]
+    public function getClass(): string
+    {
+        return Argument::class;
+    }
+
+    #[\Override]
+    public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return \in_array($methodReflection->getName(), ['intersection', 'union'], true);
+    }
+
+    #[\Override]
+    public function getTypeFromStaticMethodCall(
+        MethodReflection $methodReflection,
+        StaticCall $methodCall,
+        Scope $scope,
+    ): ?Type {
+        if (\array_any($methodCall->getArgs(), static fn(Arg $argument): bool => $argument->unpack)) {
+            return null;
+        }
+
+        $types = \array_map(
+            fn(Arg $argument): Type => $this->valueType($scope->getType($argument->value)),
+            $methodCall->getArgs(),
+        );
+        $combined = $methodReflection->getName() === 'intersection'
+            ? TypeCombinator::intersect(...$types)
+            : TypeCombinator::union(...$types);
+
+        return new GenericObjectType(ArgumentMatcher::class, [$combined]);
+    }
+
+    private function valueType(Type $argument): Type
+    {
+        $strings = $argument->getConstantStrings();
+
+        if ($strings !== []) {
+            return TypeCombinator::union(...\array_map($this->constantValueType(...), $strings));
+        }
+
+        return $argument->isClassString()->yes()
+            ? $argument->getClassStringObjectType()
+            : new MixedType();
+    }
+
+    private function constantValueType(ConstantStringType $type): Type
+    {
+        return match ($type->getValue()) {
+            'array' => new ArrayType(new MixedType(), new MixedType()),
+            'bool' => new BooleanType(),
+            'float' => new FloatType(),
+            'int' => new IntegerType(),
+            'null' => new NullType(),
+            'string' => new StringType(),
+            default => $type->isClassString()->yes()
+                ? $type->getClassStringObjectType()
+                : new MixedType(),
+        };
+    }
+}

--- a/tests/Acceptance/PhpStanArgumentMatcherTypeTest.php
+++ b/tests/Acceptance/PhpStanArgumentMatcherTypeTest.php
@@ -84,6 +84,81 @@ final readonly class PhpStanArgumentMatcherTypeTest
     }
 
     #[Test]
+    public function typeCombinationsPreserveUnionAndIntersectionTypes(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Doubles\Argument;
+            use Greenlight\Doubles\ArgumentMatcher;
+
+            interface FirstCombinedArgumentType {}
+            interface SecondCombinedArgumentType {}
+
+            /**
+             * @template T of object
+             * @param class-string<T> $type
+             * @return ArgumentMatcher<T|string>
+             */
+            function greenlightDynamicCombinedArgumentMatcherType(string $type): ArgumentMatcher
+            {
+                return Argument::union($type, 'string');
+            }
+
+            /**
+             * @return array{
+             *     ArgumentMatcher<FirstCombinedArgumentType&SecondCombinedArgumentType>,
+             *     ArgumentMatcher<FirstCombinedArgumentType|SecondCombinedArgumentType>,
+             *     ArgumentMatcher<int|string>,
+             *     ArgumentMatcher<FirstCombinedArgumentType>,
+             *     ArgumentMatcher<mixed>,
+             * }
+             */
+            function greenlightCombinedArgumentMatcherTypes(): array
+            {
+                return [
+                    Argument::intersection(FirstCombinedArgumentType::class, SecondCombinedArgumentType::class),
+                    Argument::union(FirstCombinedArgumentType::class, SecondCombinedArgumentType::class),
+                    Argument::union('int', 'string'),
+                    Argument::intersection(FirstCombinedArgumentType::class, 'resource (stream)'),
+                    Argument::union(FirstCombinedArgumentType::class, 'resource (stream)'),
+                ];
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Doubles\Argument;
+            use Greenlight\Doubles\ArgumentMatcher;
+
+            interface FirstWrongCombinedArgumentType {}
+            interface SecondWrongCombinedArgumentType {}
+
+            /** @return ArgumentMatcher<FirstWrongCombinedArgumentType> */
+            function greenlightWrongCombinedArgumentMatcherType(): ArgumentMatcher
+            {
+                return Argument::union(
+                    FirstWrongCombinedArgumentType::class,
+                    SecondWrongCombinedArgumentType::class,
+                );
+            }
+            PHP,
+        );
+
+        Expect::that($probe->exitCode)->because('PHPStan MUST preserve combined argument matcher types')->toBe(1);
+        Expect::that($probe->goodPassed)->because('PHPStan messages: ' . $probe->messages())->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(1);
+        Expect::that($probe->messages())
+            ->toContain('ArgumentMatcher<FirstWrongCombinedArgumentType|SecondWrongCombinedArgumentType>');
+    }
+
+    #[Test]
     public function allOfPreservesTheTypesOfItsMatchers(): void
     {
         $probe = PhpStanProbe::analyze(

--- a/tests/Unit/Doubles/ArgumentMatchingTest.php
+++ b/tests/Unit/Doubles/ArgumentMatchingTest.php
@@ -114,6 +114,58 @@ final readonly class ArgumentMatchingTest
     }
 
     #[Test]
+    public function typeIntersectionsRequireEveryType(): void
+    {
+        $matcher = Argument::intersection(FirstArgumentType::class, SecondArgumentType::class);
+
+        Expect::that($matcher->matches(new CombinedArgumentType()))
+            ->because('intersection() accepts a value that has every specified type')
+            ->toBeTrue();
+        Expect::that($matcher->matches(new FirstArgumentTypeOnly()))->toBeFalse();
+        Expect::that(Argument::intersection('int', 'int')->matches(42))->toBeTrue();
+        Expect::that(Argument::intersection('int', 'string')->matches(42))->toBeFalse();
+    }
+
+    #[Test]
+    public function typeUnionsRequireOneType(): void
+    {
+        $matcher = Argument::union(FirstArgumentType::class, SecondArgumentType::class);
+
+        Expect::that($matcher->matches(new CombinedArgumentType()))
+            ->because('union() accepts a value that has one or more specified types')
+            ->toBeTrue();
+        Expect::that($matcher->matches(new FirstArgumentTypeOnly()))->toBeTrue();
+        Expect::that($matcher->matches(new \stdClass()))->toBeFalse();
+        Expect::that(Argument::union('int', 'string')->matches('value'))->toBeTrue();
+    }
+
+    #[Test]
+    public function typeCombinationDiagnosticsPreserveTypeOrder(): void
+    {
+        Expect::that(Argument::intersection(FirstArgumentType::class, SecondArgumentType::class)->describe())
+            ->toBe('intersection(Greenlight\\Tests\\Unit\\Doubles\\FirstArgumentType, '
+                . 'Greenlight\\Tests\\Unit\\Doubles\\SecondArgumentType)');
+        Expect::that(Argument::union('int', 'string', \DateTimeInterface::class)->describe())
+            ->toBe('union(int, string, DateTimeInterface)');
+    }
+
+    #[Test]
+    public function typeCombinationsRejectMissingTypeNames(): void
+    {
+        Expect::that(static fn(): ArgumentMatcher => Argument::intersection('int', ''))
+            ->because('type combination matchers MUST identify every type')
+            ->toThrow(
+                InvalidDoubleUsage::class,
+                message: 'Argument::intersection() requires type names that contain a non-space character.',
+            );
+        Expect::that(static fn(): ArgumentMatcher => Argument::union('   ', 'string'))
+            ->toThrow(
+                InvalidDoubleUsage::class,
+                message: 'Argument::union() requires type names that contain a non-space character.',
+            );
+    }
+
+    #[Test]
     public function predicateMatchesWhenTheClosureReturnsTrue(): void
     {
         $calculator = $this->doubles->mock(Calculator::class, static function (MockPlan $plan): void {
@@ -363,3 +415,11 @@ final readonly class ArgumentMatchingTest
         Expect::that($second->values())->toEqual([20]);
     }
 }
+
+interface FirstArgumentType {}
+
+interface SecondArgumentType {}
+
+final class CombinedArgumentType implements FirstArgumentType, SecondArgumentType {}
+
+final class FirstArgumentTypeOnly implements FirstArgumentType {}


### PR DESCRIPTION
## Summary

- add `Argument::intersection()` and `Argument::union()` for runtime type-name matching
- preserve native, class-string, union, and intersection types through the bundled PHPStan extension
- use `mixed` for type names that PHPStan cannot represent and keep `allOf()` for arbitrary matcher composition
- document the new matchers and their inferred types