### PR TITLE
refactor(test): reuse XML query helper

### DIFF
--- a/tests/Acceptance/CoverageRunTest.php
+++ b/tests/Acceptance/CoverageRunTest.php
@@ -12,6 +12,7 @@ use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
 use Greenlight\Tests\Support\GreenlightCli;
 use Greenlight\Tests\Support\ProcessResult;
+use Greenlight\Tests\Support\SimpleXml;
 
 final readonly class CoverageRunTest
 {
@@ -105,12 +106,12 @@ final readonly class CoverageRunTest
             ->toBeString();
 
         $xml = new \SimpleXMLElement($document);
-        $children = $xml->xpath('/coverage/' . $expectedChild);
+        $children = SimpleXml::xpath($xml, '/coverage/' . $expectedChild);
 
         Expect::that($xml->getName())
             ->because('the configured XML exporter MUST write a coverage document')
             ->toBe('coverage');
-        Expect::that($children === false ? [] : $children)
+        Expect::that($children)
             ->not()
             ->toBe([]);
     }

--- a/tests/Unit/Reporting/JUnitReporterIncompleteRunTest.php
+++ b/tests/Unit/Reporting/JUnitReporterIncompleteRunTest.php
@@ -11,6 +11,7 @@ use Greenlight\Core\Result\TestResult;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Expect\Expect;
 use Greenlight\Reporting\JUnitReporter;
+use Greenlight\Tests\Support\SimpleXml;
 
 final class JUnitReporterIncompleteRunTest
 {
@@ -73,7 +74,7 @@ final class JUnitReporterIncompleteRunTest
             ->because('overflow protection MUST preserve a valid JUnit document')
             ->toBeInstanceOf(\SimpleXMLElement::class);
 
-        $suites = $document->xpath('//testsuite');
+        $suites = SimpleXml::xpath($document, '//testsuite');
         $maximum = \sprintf('%.6f', \PHP_FLOAT_MAX);
 
         Expect::that((string) $document['time'])
@@ -83,7 +84,7 @@ final class JUnitReporterIncompleteRunTest
             ->because('the report contains the overflowing class suite')
             ->toHaveCount(1);
 
-        if (!\is_array($suites) || $suites === []) {
+        if ($suites === []) {
             return;
         }
 


### PR DESCRIPTION
Use the shared SimpleXml query helper in the remaining coverage and JUnit tests. This removes duplicated false-result handling and keeps XPath failures explicit.