### PR TITLE
refactor(test): reuse class source lookup

### DIFF
--- a/tests/Acceptance/TeamCityRunTest.php
+++ b/tests/Acceptance/TeamCityRunTest.php
@@ -9,6 +9,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Fixture\DiscoveryBasic\AlphaTest;
 use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\ClassFile;
 use Greenlight\Tests\Support\GreenlightCli;
 
 final readonly class TeamCityRunTest
@@ -25,7 +26,7 @@ final readonly class TeamCityRunTest
         $result = GreenlightCli::run($project->directory, ['run', '--workers=2', '--reporter=teamcity']);
         $output = $result->output();
         $class = AlphaTest::class;
-        $file = (string) \realpath(\dirname(__DIR__) . '/Fixture/DiscoveryBasic/AlphaTest.php');
+        $file = ClassFile::of($class);
         Expect::that($result->exitCode)->because('parallel run emits location hints and flow IDs')->toBe(0);
         Expect::that($output)->toContain(
             "##teamcity[testSuiteStarted name='{$class}' locationHint='php_qn://{$file}::\\{$class}' flowId='{$class}']",

--- a/tests/Unit/Reporting/TeamCityReporterTest.php
+++ b/tests/Unit/Reporting/TeamCityReporterTest.php
@@ -17,6 +17,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Reporting\TeamCityReporter;
 use Greenlight\Sandbox\Autoloaders;
 use Greenlight\Tests\Fixture\DiscoveryBasic\AlphaTest;
+use Greenlight\Tests\Support\ClassFile;
 
 final readonly class TeamCityReporterTest
 {
@@ -164,7 +165,7 @@ final readonly class TeamCityReporterTest
         $reporter = new TeamCityReporter($output);
 
         $class = AlphaTest::class;
-        $file = (string) new \ReflectionClass($class)->getFileName();
+        $file = ClassFile::of($class);
 
         $reporter->onEvent(new TestClassStarted($class, 1.0, 'w-1'));
         $reporter->onEvent(new TestStarted(new TestId($class, 'one'), 1.1));


### PR DESCRIPTION
Use the shared ClassFile helper in both TeamCity location-hint tests. This removes duplicate Reflection and realpath source lookup logic and keeps missing source files explicit.