### PR TITLE
refactor(test): reuse memory stream helper

### DIFF
--- a/tests/Unit/Expect/CanonicalizingTest.php
+++ b/tests/Unit/Expect/CanonicalizingTest.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Test\Cleanup;
 use Greenlight\Tests\Fixture\Expect\CanonicalNode;
+use Greenlight\Tests\Support\MemoryStream;
 
 final readonly class CanonicalizingTest
 {
@@ -91,20 +92,10 @@ final readonly class CanonicalizingTest
     {
         $firstClosure = static fn(): string => 'first';
         $secondClosure = static fn(): string => 'second';
-        $firstStream = \fopen('php://memory', 'r');
-
-        if ($firstStream === false) {
-            throw new \RuntimeException('Could not open in-memory streams.');
-        }
-
-        $this->cleanup->defer(static fn(): bool => \fclose($firstStream));
-        $secondStream = \fopen('php://memory', 'r');
-
-        if ($secondStream === false) {
-            throw new \RuntimeException('Could not open in-memory streams.');
-        }
-
-        $this->cleanup->defer(static fn(): bool => \fclose($secondStream));
+        $firstStream = MemoryStream::open();
+        $this->cleanup->defer(static fn() => MemoryStream::close($firstStream));
+        $secondStream = MemoryStream::open();
+        $this->cleanup->defer(static fn() => MemoryStream::close($secondStream));
 
         Expect::that([$secondClosure, $firstClosure])
             ->because('canonical closure ordering uses object identity')

--- a/tests/Unit/Expect/ValueRendererTest.php
+++ b/tests/Unit/Expect/ValueRendererTest.php
@@ -7,14 +7,18 @@ namespace Greenlight\Tests\Unit\Expect;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\ValueRenderer;
+use Greenlight\Test\Cleanup;
 use Greenlight\Tests\Fixture\Expect\Credentials;
 use Greenlight\Tests\Fixture\Expect\Holder;
 use Greenlight\Tests\Fixture\Expect\HookedProperties;
 use Greenlight\Tests\Fixture\Expect\LateInit;
 use Greenlight\Tests\Fixture\Expect\Signal;
+use Greenlight\Tests\Support\MemoryStream;
 
-final class ValueRendererTest
+final readonly class ValueRendererTest
 {
+    public function __construct(private Cleanup $cleanup) {}
+
     #[Test]
     public function rendersScalarsAndNull(): void
     {
@@ -161,14 +165,11 @@ final class ValueRendererTest
     public function fallsBackToDebugTypeForUnrenderableValues(): void
     {
         $renderer = new ValueRenderer();
-        $stream = \fopen('php://memory', 'r');
+        $stream = MemoryStream::open();
+        $this->cleanup->defer(static fn() => MemoryStream::close($stream));
 
         Expect::that($renderer->render(static fn(): int => 1))->because('the renderer uses the debug type for unrenderable values')->toBe('Closure (unrendered)');
         Expect::that($renderer->render($stream))->because('the renderer uses the debug type for unrenderable values')->toBe('resource (stream) (unrendered)');
-
-        if (\is_resource($stream)) {
-            \fclose($stream);
-        }
     }
 
     #[Test]


### PR DESCRIPTION
Use the shared MemoryStream helper in expectation tests that only need ordinary in-memory resources. Register cleanup through the test cleanup service so resources close even when an expectation fails.