### PR TITLE
feat(phpstan): check argument matcher compatibility

### DIFF
--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -166,8 +166,9 @@ $plan->expects('save')->with(
 ```
 
 The bundled PHPStan extension preserves the combined value type in each
-`ArgumentMatcher` generic type. Other type names use `mixed`, as they do for
-`Argument::type()`.
+`ArgumentMatcher` generic type. It reports a matcher in `with()` when its type
+cannot match the selected method parameter. Other type names use `mixed`, as
+they do for `Argument::type()`.
 
 Use `Argument::allOf()` to apply two or more constraints to one argument:
 

--- a/src/PhpStan/DoublePlanRule.php
+++ b/src/PhpStan/DoublePlanRule.php
@@ -20,10 +20,13 @@ use PHPStan\Rules\IdentifierRuleError;
 use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleErrorBuilder;
 use PHPStan\Type\CallableType;
+use PHPStan\Type\ErrorType;
 use PHPStan\Type\MixedType;
+use PHPStan\Type\NeverType;
 use PHPStan\Type\ObjectType;
 use PHPStan\Type\StaticType;
 use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
 use PHPStan\Type\VerbosityLevel;
 
 /**
@@ -172,8 +175,37 @@ final readonly class DoublePlanRule implements Rule
         foreach (\array_values($arguments) as $index => $argument) {
             $parameter = $parameters[\min($index, \count($parameters) - 1)];
             $argumentType = $scope->getType($argument->value);
+            $matcherRelation = $matcher->isSuperTypeOf($argumentType);
 
-            if (!$matcher->isSuperTypeOf($argumentType)->no()
+            if ($matcherRelation->yes()) {
+                $matchedType = $argumentType->getTemplateType(ArgumentMatcher::class, 'TValue');
+
+                if ($matchedType instanceof ErrorType
+                    || $matchedType instanceof MixedType
+                    || !(TypeCombinator::intersect($parameter->getType(), $matchedType) instanceof NeverType)
+                ) {
+                    continue;
+                }
+
+                $errors[] = $this->error(
+                    \sprintf(
+                        '%s() argument #%d matcher for %s::%s() accepts %s, but parameter $%s requires %s.',
+                        $selector,
+                        $index + 1,
+                        $target->getDisplayName(),
+                        $method,
+                        $matchedType->describe(VerbosityLevel::typeOnly()),
+                        $parameter->getName(),
+                        $parameter->getType()->describe(VerbosityLevel::typeOnly()),
+                    ),
+                    'argument',
+                    $argument->getStartLine(),
+                );
+
+                continue;
+            }
+
+            if (!$matcherRelation->no()
                 || !$parameter->getType()->accepts($argumentType, $scope->isDeclareStrictTypes())->no()
             ) {
                 continue;

--- a/tests/Acceptance/PhpStanDoublePlanRuleTest.php
+++ b/tests/Acceptance/PhpStanDoublePlanRuleTest.php
@@ -28,6 +28,7 @@ final readonly class PhpStanDoublePlanRuleTest
             use Greenlight\Doubles\Argument;
             use Greenlight\Doubles\Doubles;
             use Greenlight\Doubles\MockPlan;
+            use Greenlight\Tests\Fixture\Doubles\Marker;
             use Greenlight\Tests\Fixture\Doubles\Wide;
 
             /** @param non-empty-string $method */
@@ -37,6 +38,8 @@ final readonly class PhpStanDoublePlanRuleTest
                     $plan->expects('withDefaults')->withNoArguments();
                     $plan->expects('unionType')->with(1);
                     $plan->expects('unionType')->with(Argument::any());
+                    $plan->expects('unionType')->with(Argument::union('int', 'string'));
+                    $plan->expects('intersectionType')->with(Argument::intersection(Marker::class, Countable::class));
                     $plan->expects('variadic')->with('head', 1, 2);
                     $plan->expects($method)->withNoArguments();
                 });
@@ -47,8 +50,10 @@ final readonly class PhpStanDoublePlanRuleTest
 
             declare(strict_types=1);
 
+            use Greenlight\Doubles\Argument;
             use Greenlight\Doubles\Doubles;
             use Greenlight\Doubles\MockPlan;
+            use Greenlight\Tests\Fixture\Doubles\Marker;
             use Greenlight\Tests\Fixture\Doubles\Wide;
 
             function greenlightBadDoublePlanProbe(Doubles $doubles): void
@@ -60,6 +65,8 @@ final readonly class PhpStanDoublePlanRuleTest
                     $plan->expects('withDefaults')->with('eleven');
                     $plan->expects('variadic')->with('head', 'not-an-int');
                     $plan->expects('withDefaults')->with();
+                    $plan->expects('unionType')->with(Argument::intersection(Marker::class, Countable::class));
+                    $plan->expects('intersectionType')->with(Argument::union('int', 'string'));
                 });
             }
             PHP,
@@ -67,12 +74,18 @@ final readonly class PhpStanDoublePlanRuleTest
 
         Expect::that($probe->exitCode)->because('mock plans must satisfy their doubled methods')->toBe(1);
         Expect::that($probe->goodPassed)->toBeTrue();
-        Expect::that(\count($probe->errors))->toBe(6);
+        Expect::that(\count($probe->errors))->toBe(8);
         Expect::that($probe->messages())
             ->toContain('Mock plan method Greenlight\\Tests\\Fixture\\Doubles\\Wide::missing() does not exist');
         Expect::that($probe->messages())->toContain('withNoArguments() supplies 0 arguments');
         Expect::that($probe->messages())->toContain('with() supplies 1 argument');
         Expect::that($probe->messages())->toContain('parameter $limit has type string, but the parameter requires int');
         Expect::that($probe->messages())->toContain('parameter $rest has type string, but the parameter requires int');
+        Expect::that($probe->messages())
+            ->toContain('matcher for Greenlight\\Tests\\Fixture\\Doubles\\Wide::unionType() accepts '
+                . 'Countable&Greenlight\\Tests\\Fixture\\Doubles\\Marker, but parameter $value requires int|string');
+        Expect::that($probe->messages())
+            ->toContain('matcher for Greenlight\\Tests\\Fixture\\Doubles\\Wide::intersectionType() accepts int|string, '
+                . 'but parameter $value requires Countable&Greenlight\\Tests\\Fixture\\Doubles\\Marker');
     }
 }


### PR DESCRIPTION
## Summary

- check the inferred `ArgumentMatcher<TValue>` type against the selected mock method parameter
- report only disjoint matcher and parameter types, while preserving broad and `mixed` matchers
- dogfood `Argument::union()` and `Argument::intersection()` with the existing union and intersection fixture methods
- document the new `with()` diagnostic