### PR TITLE
refactor(test): reuse shared fixture paths

### DIFF
--- a/tests/Acceptance/CommandErrorsTest.php
+++ b/tests/Acceptance/CommandErrorsTest.php
@@ -10,6 +10,7 @@ use Greenlight\Core\Test\SkipTest;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\FixturePath;
 use Greenlight\Tests\Support\GreenlightCli;
 
 final readonly class CommandErrorsTest
@@ -156,7 +157,7 @@ final readonly class CommandErrorsTest
         // A configuration without matchers does not write a file.
         // IdeHelperTest verifies that path. This test uses PhpStanExtension,
         // which has matchers that the helper can render.
-        $fixture = \dirname(__DIR__) . '/Fixture/PhpStanExtension';
+        $fixture = FixturePath::get('PhpStanExtension');
         $readOnlyDirectory = $this->tempDirectory->subdirectory('ide-helper-read-only');
         \chmod($readOnlyDirectory, 0o555);
         $outputPath = $readOnlyDirectory . '/helper.php';

--- a/tests/Acceptance/CoverageIgnoreRunTest.php
+++ b/tests/Acceptance/CoverageIgnoreRunTest.php
@@ -9,6 +9,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
 use Greenlight\Tests\Support\CoverageJson;
+use Greenlight\Tests\Support\FixturePath;
 use Greenlight\Tests\Support\GreenlightCli;
 
 final readonly class CoverageIgnoreRunTest
@@ -47,7 +48,6 @@ final readonly class CoverageIgnoreRunTest
 
     private function writeProject(): AcceptanceProject
     {
-        $root = \dirname(__DIR__, 2);
         $project = AcceptanceProject::create($this->tempDirectory, 'coverage-ignore');
         $project->writeFile('greenlight.php', \sprintf(
             <<<'PHP'
@@ -64,8 +64,8 @@ final readonly class CoverageIgnoreRunTest
                     ->export('json', 'coverage-out/coverage.json'));
 
             PHP,
-            \var_export($root . '/tests/Fixture/CoverageIgnoreSuite', true),
-            \var_export($root . '/tests/Fixture/CoverageIgnoreLib', true),
+            \var_export(FixturePath::get('CoverageIgnoreSuite'), true),
+            \var_export(FixturePath::get('CoverageIgnoreLib'), true),
         ));
 
         return $project;

--- a/tests/Acceptance/CoverageRunTest.php
+++ b/tests/Acceptance/CoverageRunTest.php
@@ -10,6 +10,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Runner\SubprocessCoverage;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\FixturePath;
 use Greenlight\Tests\Support\GreenlightCli;
 use Greenlight\Tests\Support\ProcessResult;
 use Greenlight\Tests\Support\SimpleXml;
@@ -334,8 +335,8 @@ final readonly class CoverageRunTest
                     ->include(%s)%s%s);
 
             PHP,
-            \var_export($root . '/tests/Fixture/CoverageSuite', true),
-            \var_export($root . '/tests/Fixture/CoverageLib', true),
+            \var_export(FixturePath::get('CoverageSuite'), true),
+            \var_export(FixturePath::get('CoverageLib'), true),
             $orchestratorInclude,
             $exports,
         ));

--- a/tests/Acceptance/DataRowRunTest.php
+++ b/tests/Acceptance/DataRowRunTest.php
@@ -6,6 +6,7 @@ namespace Greenlight\Tests\Acceptance;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\FixturePath;
 use Greenlight\Tests\Support\GreenlightCli;
 use Greenlight\Tests\Support\JsonlEvents;
 use Greenlight\Tests\Support\ProcessResult;
@@ -45,6 +46,6 @@ final class DataRowRunTest
 
     private function run(string ...$flags): ProcessResult
     {
-        return GreenlightCli::run(\dirname(__DIR__) . '/Fixture/DataRows', ['run', '--reporter=jsonl', ...\array_values($flags)]);
+        return GreenlightCli::run(FixturePath::get('DataRows'), ['run', '--reporter=jsonl', ...\array_values($flags)]);
     }
 }

--- a/tests/Acceptance/IdeHelperTest.php
+++ b/tests/Acceptance/IdeHelperTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Acceptance;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\FixturePath;
 use Greenlight\Tests\Support\GreenlightCli;
 use Greenlight\Tests\Support\Subprocess;
 
@@ -20,7 +21,7 @@ final readonly class IdeHelperTest
         $root = \dirname(__DIR__, 2);
         $target = $this->tempDirectory->path() . '/ide-helper.php';
 
-        $result = GreenlightCli::run($root . '/tests/Fixture/PhpStanExtension', ['ide-helper', '--output=' . $target]);
+        $result = GreenlightCli::run(FixturePath::get('PhpStanExtension'), ['ide-helper', '--output=' . $target]);
         Expect::that($result->exitCode)->because('writes a lintable helper and skips when nothing is configured')->toBe(0);
         Expect::that($result->output())->toContain('3 matchers');
 
@@ -33,7 +34,7 @@ final readonly class IdeHelperTest
         $lint = Subprocess::run($root, [\PHP_BINARY, '-l', $target]);
         Expect::that($lint->exitCode)->because('writes a lintable helper and skips when nothing is configured')->toBe(0);
 
-        $result = GreenlightCli::run($root . '/tests/Fixture/ListTestsConfig', ['ide-helper', '--output=' . $target . '.none']);
+        $result = GreenlightCli::run(FixturePath::get('ListTestsConfig'), ['ide-helper', '--output=' . $target . '.none']);
         Expect::that($result->exitCode)->because('writes a lintable helper and skips when nothing is configured')->toBe(0);
         Expect::that($result->output())->toContain('The configuration has no extension matchers');
         Expect::that(\is_file($target . '.none'))->toBeFalse();
@@ -42,7 +43,7 @@ final readonly class IdeHelperTest
     #[Test]
     public function invalidConfigurationFailsBeforeWritingAHelper(): void
     {
-        $project = \dirname(__DIR__) . '/Fixture/ConfigFiles/WrongReturn';
+        $project = FixturePath::get('ConfigFiles/WrongReturn');
         $config = $project . '/greenlight.php';
         $result = GreenlightCli::run($project, ['ide-helper', '--no-ansi']);
 

--- a/tests/Acceptance/LeakDetectionRunTest.php
+++ b/tests/Acceptance/LeakDetectionRunTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Acceptance;
 use Greenlight\Attribute\Test;
 use Greenlight\Core\Test\SkipTest;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\FixturePath;
 use Greenlight\Tests\Support\GreenlightCli;
 use Greenlight\Tests\Support\ProcessResult;
 
@@ -50,6 +51,6 @@ final readonly class LeakDetectionRunTest
      */
     private function run(array $arguments, array $env = []): ProcessResult
     {
-        return GreenlightCli::run(\dirname(__DIR__) . '/Fixture/LeakConfig', $arguments, $env);
+        return GreenlightCli::run(FixturePath::get('LeakConfig'), $arguments, $env);
     }
 }

--- a/tests/Acceptance/PhpStanMatcherSignatureTest.php
+++ b/tests/Acceptance/PhpStanMatcherSignatureTest.php
@@ -9,6 +9,7 @@ use Greenlight\Attribute\RequiresResource;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\FixturePath;
 use Greenlight\Tests\Support\PhpStanProbe;
 
 #[AllowParallel]
@@ -161,7 +162,7 @@ final readonly class PhpStanMatcherSignatureTest
                     ->toReturnText();
             }
             PHP,
-            \dirname(__DIR__) . '/Fixture/PhpStanMatcherReturn/probe.neon',
+            FixturePath::get('PhpStanMatcherReturn/probe.neon'),
         );
 
         Expect::that($probe->exitCode)->because('declared matcher return types must be boolean')->toBe(1);

--- a/tests/Acceptance/PhpStanMatcherSubjectTest.php
+++ b/tests/Acceptance/PhpStanMatcherSubjectTest.php
@@ -9,6 +9,7 @@ use Greenlight\Attribute\RequiresResource;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\FixturePath;
 use Greenlight\Tests\Support\PhpStanProbe;
 
 #[AllowParallel]
@@ -153,7 +154,7 @@ final readonly class PhpStanMatcherSubjectTest
                 Expect::that('value')->toAcceptParentArgument(new \stdClass());
             }
             PHP,
-            \dirname(__DIR__) . '/Fixture/PhpStanScopedMatcher/probe.neon',
+            FixturePath::get('PhpStanScopedMatcher/probe.neon'),
         );
 
         Expect::that($probe->exitCode)->because('relative matcher types use the closure scope')->toBe(1);

--- a/tests/Acceptance/PhpStanNativeMatcherTypeTest.php
+++ b/tests/Acceptance/PhpStanNativeMatcherTypeTest.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\RequiresResource;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\FixturePath;
 use Greenlight\Tests\Support\PhpStanProbe;
 
 #[RequiresResource('analysis-process')]
@@ -18,7 +19,6 @@ final readonly class PhpStanNativeMatcherTypeTest
     #[Test]
     public function nativeMatcherTypesKeepNullableUnionAndIntersectionShapes(): void
     {
-        $root = \dirname(__DIR__, 2);
         $probe = PhpStanProbe::analyze(
             $this->tempDirectory,
             <<<'PHP'
@@ -52,7 +52,7 @@ final readonly class PhpStanNativeMatcherTypeTest
                 Expect::that(new stdClass())->toAcceptSerializableString();
             }
             PHP,
-            $root . '/tests/Fixture/PhpStanNativeType/probe.neon',
+            FixturePath::get('PhpStanNativeType/probe.neon'),
         );
 
         Expect::that($probe->exitCode)

--- a/tests/Acceptance/RunDiscoveryErrorTest.php
+++ b/tests/Acceptance/RunDiscoveryErrorTest.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\FixturePath;
 use Greenlight\Tests\Support\GreenlightCli;
 
 final readonly class RunDiscoveryErrorTest
@@ -18,7 +19,7 @@ final readonly class RunDiscoveryErrorTest
     public function runReportsDiscoveryFailuresCleanly(): void
     {
         $project = AcceptanceProject::create($this->tempDirectory, 'run-discovery-error');
-        $fixture = \dirname(__DIR__) . '/Fixture/DiscoveryProviderMissing';
+        $fixture = FixturePath::get('DiscoveryProviderMissing');
         $project->writeFile('greenlight.php', \sprintf(
             <<<'PHP'
                 <?php

--- a/tests/Acceptance/SuitePathDiscoveryTest.php
+++ b/tests/Acceptance/SuitePathDiscoveryTest.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\FixturePath;
 use Greenlight\Tests\Support\GreenlightCli;
 
 final readonly class SuitePathDiscoveryTest
@@ -18,8 +19,8 @@ final readonly class SuitePathDiscoveryTest
     public function namedSuitePathsParticipateInTestDiscovery(): void
     {
         $project = AcceptanceProject::create($this->tempDirectory, 'suite-path-discovery');
-        $topLevel = \dirname(__DIR__) . '/Fixture/DiscoveryBasic';
-        $suite = \dirname(__DIR__) . '/Fixture/Lifecycle/Bail';
+        $topLevel = FixturePath::get('DiscoveryBasic');
+        $suite = FixturePath::get('Lifecycle/Bail');
 
         $project->writeFile('greenlight.php', \sprintf(
             <<<'PHP'

--- a/tests/Acceptance/WorkerFailureContainmentTest.php
+++ b/tests/Acceptance/WorkerFailureContainmentTest.php
@@ -12,6 +12,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\FixturePath;
 use Greenlight\Tests\Support\GreenlightCli;
 use Greenlight\Tests\Support\JsonlEvents;
 use Greenlight\Tests\Support\ProcessResult;
@@ -157,7 +158,7 @@ final readonly class WorkerFailureContainmentTest
      */
     private function runIn(string $fixtureConfigDir, array $arguments): ProcessResult
     {
-        return GreenlightCli::run(\dirname(__DIR__) . '/Fixture/' . $fixtureConfigDir, $arguments);
+        return GreenlightCli::run(FixturePath::get($fixtureConfigDir), $arguments);
     }
 
     private function summaryLine(string $output): string

--- a/tests/Acceptance/WorkerProcessRunTest.php
+++ b/tests/Acceptance/WorkerProcessRunTest.php
@@ -10,6 +10,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\FixturePath;
 use Greenlight\Tests\Support\GreenlightCli;
 use Greenlight\Tests\Support\ProcessResult;
 
@@ -71,7 +72,7 @@ final readonly class WorkerProcessRunTest
      */
     private function runIn(string $fixtureConfigDir, array $arguments): ProcessResult
     {
-        return GreenlightCli::run(\dirname(__DIR__) . '/Fixture/' . $fixtureConfigDir, $arguments);
+        return GreenlightCli::run(FixturePath::get($fixtureConfigDir), $arguments);
     }
 
     private function summaryLine(string $output): string

--- a/tests/Unit/Cli/ApplicationCoverageCleanupTest.php
+++ b/tests/Unit/Cli/ApplicationCoverageCleanupTest.php
@@ -13,6 +13,7 @@ use Greenlight\Sandbox\EnvironmentVariables;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Test\Cleanup;
 use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\FixturePath;
 use Greenlight\Tests\Support\MemoryStream;
 
 final readonly class ApplicationCoverageCleanupTest
@@ -28,7 +29,7 @@ final readonly class ApplicationCoverageCleanupTest
     {
         $this->environment->unset(SubprocessCoverage::DIRECTORY_ENV);
         $this->environment->unset(SubprocessCoverage::INCLUDE_ENV);
-        $fixtureDirectory = \dirname(__DIR__, 2) . '/Fixture/DiscoveryBasic';
+        $fixtureDirectory = FixturePath::get('DiscoveryBasic');
         $project = AcceptanceProject::create($this->tempDirectory, 'application-coverage-cleanup');
         $project->writeFile('greenlight.php', \sprintf(
             <<<'PHP'

--- a/tests/Unit/Config/ConfigLoaderTest.php
+++ b/tests/Unit/Config/ConfigLoaderTest.php
@@ -12,6 +12,7 @@ use Greenlight\Config\GreenlightConfig;
 use Greenlight\Core\ErrorTrap;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Support\FilesystemRestriction;
+use Greenlight\Tests\Support\FixturePath;
 
 final class ConfigLoaderTest
 {
@@ -117,6 +118,6 @@ final class ConfigLoaderTest
 
     private static function fixtureDir(string $name): string
     {
-        return \dirname(__DIR__, 2) . '/Fixture/ConfigFiles/' . $name;
+        return FixturePath::get('ConfigFiles/' . $name);
     }
 }

--- a/tests/Unit/Config/ConfigLoaderThrowableTest.php
+++ b/tests/Unit/Config/ConfigLoaderThrowableTest.php
@@ -8,13 +8,14 @@ use Greenlight\Attribute\Test;
 use Greenlight\Config\ConfigFileError;
 use Greenlight\Config\ConfigLoader;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\FixturePath;
 
 final readonly class ConfigLoaderThrowableTest
 {
     #[Test]
     public function wrapsErrorsThrownByConfigurationFiles(): void
     {
-        $directory = \dirname(__DIR__, 2) . '/Fixture/ConfigFiles/ThrowingError';
+        $directory = FixturePath::get('ConfigFiles/ThrowingError');
 
         Expect::that(static fn() => new ConfigLoader()->loadFromDirectory($directory))
             ->toThrow(

--- a/tests/Unit/Laravel/LaravelPluginTest.php
+++ b/tests/Unit/Laravel/LaravelPluginTest.php
@@ -30,6 +30,7 @@ use Greenlight\Tests\Fixture\Laravel\Greeter;
 use Greenlight\Tests\Fixture\Laravel\NamedGreeter;
 use Greenlight\Tests\Fixture\Laravel\VisitCounter;
 use Greenlight\Tests\Support\FilesystemRestriction;
+use Greenlight\Tests\Support\FixturePath;
 use Greenlight\Tests\Support\PluginLifecycle;
 use Greenlight\Tests\Support\ServiceResolverProbe;
 use Illuminate\Container\Container;
@@ -525,7 +526,7 @@ final class LaravelPluginTest
 
     private function fixtureDir(): string
     {
-        return \dirname(__DIR__, 2) . '/Fixture/Laravel';
+        return FixturePath::get('Laravel');
     }
 
     private function context(): TestContext

--- a/tests/Unit/PhpStan/IdeHelperTest.php
+++ b/tests/Unit/PhpStan/IdeHelperTest.php
@@ -8,13 +8,14 @@ use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\PhpStan\IdeHelper;
 use Greenlight\PhpStan\MatcherMap;
+use Greenlight\Tests\Support\FixturePath;
 
 final class IdeHelperTest
 {
     #[Test]
     public function rendersOneMethodAnnotationPerMatcherWithReflectedSignatures(): void
     {
-        $map = MatcherMap::fromConfigFiles([\dirname(__DIR__, 2) . '/Fixture/PhpStanExtension/greenlight.php']);
+        $map = MatcherMap::fromConfigFiles([FixturePath::get('PhpStanExtension/greenlight.php')]);
 
         $rendered = IdeHelper::render($map);
 
@@ -31,7 +32,7 @@ final class IdeHelperTest
     #[Test]
     public function preservesParenthesesAroundIntersectionsInsideUnions(): void
     {
-        $map = MatcherMap::fromConfigFiles([\dirname(__DIR__, 2) . '/Fixture/PhpStanIdeHelperDnf/greenlight.php']);
+        $map = MatcherMap::fromConfigFiles([FixturePath::get('PhpStanIdeHelperDnf/greenlight.php')]);
 
         Expect::that(IdeHelper::render($map))
             ->because('generated matcher annotations preserve disjunctive normal form types')

--- a/tests/Unit/Plugin/AfterTestSubscriberIsolationTest.php
+++ b/tests/Unit/Plugin/AfterTestSubscriberIsolationTest.php
@@ -16,6 +16,7 @@ use Greenlight\Plugin\TestContext;
 use Greenlight\Runner\DefaultServices;
 use Greenlight\Runner\Worker\Worker;
 use Greenlight\Tests\Support\CollectingEventSink;
+use Greenlight\Tests\Support\FixturePath;
 
 final readonly class AfterTestSubscriberIsolationTest
 {
@@ -52,7 +53,7 @@ final readonly class AfterTestSubscriberIsolationTest
                 return $result;
             }
         };
-        $directory = \dirname(__DIR__, 2) . '/Fixture/Lifecycle/Order';
+        $directory = FixturePath::get('Lifecycle/Order');
         $plan = new TestDiscoverer()->discover([$directory]);
         $sink = new CollectingEventSink();
         $plugins = PluginRegistry::forWorker([$observer, $broken]);

--- a/tests/Unit/Plugin/PluginTest.php
+++ b/tests/Unit/Plugin/PluginTest.php
@@ -37,6 +37,7 @@ use Greenlight\Tests\Fixture\Plugins\EvenNumbersExtension;
 use Greenlight\Tests\Fixture\Plugins\ProbeProvider;
 use Greenlight\Tests\Fixture\Plugins\QuarantinePlugin;
 use Greenlight\Tests\Support\CollectingEventSink;
+use Greenlight\Tests\Support\FixturePath;
 
 final readonly class PluginTest
 {
@@ -436,7 +437,7 @@ final readonly class PluginTest
      */
     private function runSuite(string $fixture, array $plugins): array
     {
-        $directory = \dirname(__DIR__, 2) . '/Fixture/' . $fixture;
+        $directory = FixturePath::get($fixture);
         $plan = new TestDiscoverer()->discover([$directory]);
         $sink = new CollectingEventSink();
         $registry = PluginRegistry::forWorker($plugins);

--- a/tests/Unit/Plugin/RetryDeciderOrderTest.php
+++ b/tests/Unit/Plugin/RetryDeciderOrderTest.php
@@ -15,6 +15,7 @@ use Greenlight\Plugin\RetryDecider;
 use Greenlight\Runner\DefaultServices;
 use Greenlight\Runner\Worker\Worker;
 use Greenlight\Tests\Support\CollectingEventSink;
+use Greenlight\Tests\Support\FixturePath;
 
 final readonly class RetryDeciderOrderTest
 {
@@ -59,7 +60,7 @@ final readonly class RetryDeciderOrderTest
                 return false;
             }
         };
-        $directory = \dirname(__DIR__, 2) . '/Fixture/RunFailingSuite';
+        $directory = FixturePath::get('RunFailingSuite');
         $plan = new TestDiscoverer()->discover([$directory]);
         $sink = new CollectingEventSink();
         $plugins = PluginRegistry::forWorker([$first, $second]);

--- a/tests/Unit/Runner/ConditionEvaluationTest.php
+++ b/tests/Unit/Runner/ConditionEvaluationTest.php
@@ -25,6 +25,7 @@ use Greenlight\Sandbox\EnvironmentVariables;
 use Greenlight\Tests\Fixture\Condition\ThrowingCondition;
 use Greenlight\Tests\Fixture\Lifecycle\ConditionArguments\ConditionArgumentsTest;
 use Greenlight\Tests\Support\CollectingEventSink;
+use Greenlight\Tests\Support\FixturePath;
 
 final readonly class ConditionEvaluationTest
 {
@@ -121,7 +122,7 @@ final readonly class ConditionEvaluationTest
      */
     private function runFixture(string $case): array
     {
-        $directory = \dirname(__DIR__, 2) . '/Fixture/Lifecycle/' . $case;
+        $directory = FixturePath::get('Lifecycle/' . $case);
         $plan = new TestDiscoverer()->discover([$directory]);
         $sink = new CollectingEventSink();
 

--- a/tests/Unit/Runner/RunCoordinatorTest.php
+++ b/tests/Unit/Runner/RunCoordinatorTest.php
@@ -31,6 +31,7 @@ use Greenlight\Sandbox\EnvironmentVariables;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Fixture\Plugins\RecordingRunSubscriber;
 use Greenlight\Tests\Support\CollectingEventSink;
+use Greenlight\Tests\Support\FixturePath;
 
 final readonly class RunCoordinatorTest
 {
@@ -49,7 +50,7 @@ final readonly class RunCoordinatorTest
             },
         )->build();
         $sink = new CollectingEventSink();
-        $fixtureDirectory = \dirname(__DIR__, 2) . '/Fixture/DiscoveryBasic';
+        $fixtureDirectory = FixturePath::get('DiscoveryBasic');
 
         $resolved = ConfigurationResolver::resolve($configuration, new CliOverrides());
         $result = $this->coordinator()->run(
@@ -81,7 +82,7 @@ final readonly class RunCoordinatorTest
         )->build();
         $sink = new CollectingEventSink();
         $root = \dirname(__DIR__, 3);
-        $fixtureDirectory = \dirname(__DIR__, 2) . '/Fixture/DiscoveryBasic';
+        $fixtureDirectory = FixturePath::get('DiscoveryBasic');
         $resolved = ConfigurationResolver::resolve($configuration, new CliOverrides());
 
         $result = $this->coordinator()->run(
@@ -163,7 +164,7 @@ final readonly class RunCoordinatorTest
     public function explicitSeedIsReportedAndReproducesTheRunOrder(): void
     {
         $configuration = GreenlightConfig::create()->randomizeOrder(seed: 4242)->build();
-        $fixtureDirectory = \dirname(__DIR__, 2) . '/Fixture/DiscoveryBasic';
+        $fixtureDirectory = FixturePath::get('DiscoveryBasic');
         $coordinator = $this->coordinator();
         $firstSink = new CollectingEventSink();
         $secondSink = new CollectingEventSink();
@@ -186,7 +187,7 @@ final readonly class RunCoordinatorTest
     {
         $coordinator = $this->coordinator();
         $base = GreenlightConfig::create()->build();
-        $fixtureDirectory = \dirname(__DIR__, 2) . '/Fixture/DiscoveryBasic';
+        $fixtureDirectory = FixturePath::get('DiscoveryBasic');
         $completeSink = new CollectingEventSink();
 
         $complete = ConfigurationResolver::resolve($base, new CliOverrides());
@@ -224,7 +225,7 @@ final readonly class RunCoordinatorTest
     {
         $this->environment->set('GREENLIGHT_CHANNEL', 'caller-channel');
         $configuration = GreenlightConfig::create()->build();
-        $fixtureDirectory = \dirname(__DIR__, 2) . '/Fixture/DiscoveryBasic';
+        $fixtureDirectory = FixturePath::get('DiscoveryBasic');
 
         $resolved = ConfigurationResolver::resolve($configuration, new CliOverrides());
         $this->coordinator()->run(
@@ -251,7 +252,7 @@ final readonly class RunCoordinatorTest
             static fn(): FailingWorkerBootstrapPlugin => new FailingWorkerBootstrapPlugin($failure),
         )->build();
         $resolved = ConfigurationResolver::resolve($configuration, new CliOverrides());
-        $fixtureDirectory = \dirname(__DIR__, 2) . '/Fixture/DiscoveryBasic';
+        $fixtureDirectory = FixturePath::get('DiscoveryBasic');
 
         Expect::that(fn() => $this->coordinator()->run(
             $resolved,

--- a/tests/Unit/Runner/SandboxLifecycleTest.php
+++ b/tests/Unit/Runner/SandboxLifecycleTest.php
@@ -14,6 +14,7 @@ use Greenlight\Runner\Worker\Worker;
 use Greenlight\Sandbox\EnvironmentVariables;
 use Greenlight\Tests\Fixture\Lifecycle\TraceLog;
 use Greenlight\Tests\Support\CollectingEventSink;
+use Greenlight\Tests\Support\FixturePath;
 
 final readonly class SandboxLifecycleTest
 {
@@ -31,7 +32,7 @@ final readonly class SandboxLifecycleTest
             $this->environment->set('GREENLIGHT_SANDBOX_E2E', $initialValue);
         }
 
-        $directory = \dirname(__DIR__, 2) . '/Fixture/Lifecycle/HarnessSandboxes';
+        $directory = FixturePath::get('Lifecycle/HarnessSandboxes');
         $plan = new TestDiscoverer()->discover([$directory]);
         $sink = new CollectingEventSink();
 

--- a/tests/Unit/Runner/WorkerTest.php
+++ b/tests/Unit/Runner/WorkerTest.php
@@ -39,6 +39,7 @@ use Greenlight\Tests\Fixture\Lifecycle\VerifyOnDispose\VerifyingProbe;
 use Greenlight\Tests\Fixture\Runner\OptionalConstructorProbe;
 use Greenlight\Tests\Fixture\Runner\UnsupportedConstructorProbe;
 use Greenlight\Tests\Support\CollectingEventSink;
+use Greenlight\Tests\Support\FixturePath;
 
 final class WorkerTest
 {
@@ -533,7 +534,7 @@ final class WorkerTest
     #[Test]
     public function drainRequestStopsBetweenTests(): void
     {
-        $directory = \dirname(__DIR__, 2) . '/Fixture/Lifecycle/Bail';
+        $directory = FixturePath::get('Lifecycle/Bail');
         $plan = new TestDiscoverer()->discover([$directory]);
         $sink = new CollectingEventSink();
 
@@ -552,7 +553,7 @@ final class WorkerTest
     {
         LeakyTest::$retained = [];
 
-        $directory = \dirname(__DIR__, 2) . '/Fixture/LeakSuite';
+        $directory = FixturePath::get('LeakSuite');
         $plan = new TestDiscoverer()->discover([$directory]);
         $sink = new CollectingEventSink();
 
@@ -593,7 +594,7 @@ final class WorkerTest
         ?CollectingEventSink $sink = null,
         array $plugins = [],
     ): array {
-        $directory = \dirname(__DIR__, 2) . '/Fixture/Lifecycle/' . $case;
+        $directory = FixturePath::get('Lifecycle/' . $case);
         $plan = new TestDiscoverer()->discover([$directory]);
         $sink ??= new CollectingEventSink();
 


### PR DESCRIPTION
Use FixturePath for shared test fixture directories and configuration files across acceptance and unit tests. This removes duplicated directory-depth calculations and applies the helper path validation to dynamic fixture names.