### PR TITLE
fix(ci): start releases at 0.0.1

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
     "packages": {
         ".": {
             "release-type": "php",
+            "initial-version": "0.0.1",
             "bump-minor-pre-major": true,
             "bump-patch-for-minor-pre-major": true,
             "include-component-in-tag": false,


### PR DESCRIPTION
## Summary

- configure Release Please to propose 0.0.1 for the initial release
- keep subsequent releases governed by Conventional Commits

This overrides the default PHP strategy version of 1.0.0 during repository bootstrap.

BEGIN_COMMIT_OVERRIDE
chore(ci): start releases at 0.0.1 (#1564)
END_COMMIT_OVERRIDE