### PR TITLE
refactor(test): reuse fixture paths in support helpers

### DIFF
--- a/tests/Support/AcceptanceProject.php
+++ b/tests/Support/AcceptanceProject.php
@@ -27,7 +27,7 @@ final readonly class AcceptanceProject
     public static function createWithDiscoveryBasicTests(TemporaryDirectory $workspace, string $name): self
     {
         $project = self::create($workspace, $name);
-        $discoveryBasic = \dirname(__DIR__) . '/Fixture/DiscoveryBasic';
+        $discoveryBasic = FixturePath::get('DiscoveryBasic');
 
         $project->writeFile('greenlight.php', \sprintf(
             <<<'PHP'

--- a/tests/Support/PhpStanProbe.php
+++ b/tests/Support/PhpStanProbe.php
@@ -27,7 +27,7 @@ final readonly class PhpStanProbe
         ?string $configFile = null,
     ): self {
         $root = \dirname(__DIR__, 2);
-        $configFile ??= $root . '/tests/Fixture/PhpStanExtension/probe.neon';
+        $configFile ??= FixturePath::get('PhpStanExtension/probe.neon');
         $files = ProjectFiles::create($workspace, 'phpstan-probe');
         $probeDirectory = $files->directory;
         $goodFile = $probeDirectory . '/GoodProbe.php';

--- a/tests/Support/RectorProbe.php
+++ b/tests/Support/RectorProbe.php
@@ -39,7 +39,7 @@ final readonly class RectorProbe
         $testFile = $testsDirectory . '/ProbeTest.php';
 
         $files->write('tests/ProbeTest.php', $testClassSource);
-        $files->write('rector.php', self::rectorConfig($root, $directory, $configuration));
+        $files->write('rector.php', self::rectorConfig($directory, $configuration));
 
         $result = Subprocess::run(
             $root,
@@ -101,7 +101,7 @@ final readonly class RectorProbe
     /**
      * @param array<string, bool> $configuration
      */
-    private static function rectorConfig(string $root, string $directory, array $configuration): string
+    private static function rectorConfig(string $directory, array $configuration): string
     {
         $rule = $configuration === []
             ? '->withRules([PhpUnitToGreenlightRector::class])'
@@ -127,7 +127,7 @@ final readonly class RectorProbe
                 %s;
 
             PHP,
-            \var_export($root . '/tests/Fixture/RectorMigration/phpunit-10-plus-stubs.php', true),
+            \var_export(FixturePath::get('RectorMigration/phpunit-10-plus-stubs.php'), true),
             \var_export($directory . '/tests', true),
             \var_export($directory . '/rector-cache', true),
             $rule,


### PR DESCRIPTION
Use FixturePath inside AcceptanceProject, PhpStanProbe, and RectorProbe. This removes the remaining duplicated shared-fixture path construction from support helpers.