### PR TITLE
refactor(test): reuse remaining memory streams

### DIFF
--- a/tests/Unit/Cli/ApplicationStreamOutputTest.php
+++ b/tests/Unit/Cli/ApplicationStreamOutputTest.php
@@ -12,6 +12,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\StreamWrappers;
 use Greenlight\Test\Cleanup;
 use Greenlight\Tests\Fixture\Reporting\PartialWriteStream;
+use Greenlight\Tests\Support\MemoryStream;
 
 final readonly class ApplicationStreamOutputTest
 {
@@ -42,12 +43,8 @@ final readonly class ApplicationStreamOutputTest
             ->toBeFalse();
         $this->cleanup->defer(static fn(): bool => \fclose($partial));
 
-        $other = ErrorTrap::run(static fn() => \fopen('php://memory', 'wb'));
-        Expect::that($other)
-            ->because('Greenlight MUST open the comparison CLI test stream.')
-            ->not()
-            ->toBeFalse();
-        $this->cleanup->defer(static fn(): bool => \fclose($other));
+        $other = MemoryStream::open();
+        $this->cleanup->defer(static fn() => MemoryStream::close($other));
 
         $application = $useStderr
             ? Application::forStreams($other, $partial)

--- a/tests/Unit/Cli/TerminalTest.php
+++ b/tests/Unit/Cli/TerminalTest.php
@@ -7,8 +7,8 @@ namespace Greenlight\Tests\Unit\Cli;
 use Greenlight\Attribute\Test;
 use Greenlight\Cli\Terminal;
 use Greenlight\Expect\Expect;
-use Greenlight\Expect\Fail;
 use Greenlight\Test\Cleanup;
+use Greenlight\Tests\Support\MemoryStream;
 
 final readonly class TerminalTest
 {
@@ -17,16 +17,8 @@ final readonly class TerminalTest
     #[Test]
     public function aNonTtyProbeDoesNotConsumeOrCloseTheStream(): void
     {
-        $stream = \fopen('php://temp', 'w+');
-
-        if ($stream === false) {
-            Fail::because('Expected php://temp to open.');
-        }
-
-        $this->cleanup->defer(static fn(): bool => \fclose($stream));
-
-        \fwrite($stream, 'sentinel');
-        \rewind($stream);
+        $stream = MemoryStream::open('sentinel');
+        $this->cleanup->defer(static fn() => MemoryStream::close($stream));
 
         Expect::that(Terminal::isTty($stream))
             ->because('an in-memory stream is not a TTY')

--- a/tests/Unit/Harness/IntegrationResourcesTest.php
+++ b/tests/Unit/Harness/IntegrationResourcesTest.php
@@ -9,6 +9,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Harness\FixtureResource;
 use Greenlight\Harness\IntegrationResources;
+use Greenlight\Tests\Support\MemoryStream;
 
 final class IntegrationResourcesTest
 {
@@ -114,8 +115,15 @@ final class IntegrationResourcesTest
     #[Test]
     public function nonJsonValuesAreRejectedBeforeTransport(): void
     {
-        Expect::that(static fn(): FixtureResource => FixtureResource::from(['stream' => \fopen('php://memory', 'rb')]))
-            ->toThrow(\InvalidArgumentException::class, matching: '/JSON-safe/');
+        $stream = MemoryStream::open();
+
+        try {
+            Expect::that(static fn(): FixtureResource => FixtureResource::from(['stream' => $stream]))
+                ->toThrow(\InvalidArgumentException::class, matching: '/JSON-safe/');
+        } finally {
+            MemoryStream::close($stream);
+        }
+
         Expect::that(static fn(): FixtureResource => FixtureResource::from(['number' => \INF]))
             ->toThrow(\InvalidArgumentException::class, matching: '/finite numbers/');
         Expect::that(static fn(): FixtureResource => FixtureResource::from(['text' => "\xB1\x31"]))

--- a/tests/Unit/Reporting/StreamOutputTest.php
+++ b/tests/Unit/Reporting/StreamOutputTest.php
@@ -12,6 +12,7 @@ use Greenlight\Reporting\ReportGenerationFailed;
 use Greenlight\Sandbox\StreamWrappers;
 use Greenlight\Test\Cleanup;
 use Greenlight\Tests\Fixture\Reporting\PartialWriteStream;
+use Greenlight\Tests\Support\MemoryStream;
 
 final readonly class StreamOutputTest
 {
@@ -25,13 +26,8 @@ final readonly class StreamOutputTest
     #[Test]
     public function writesAccumulateOnTheStream(): void
     {
-        $stream = ErrorTrap::run(static fn() => \fopen('php://memory', 'r+'));
-
-        Expect::that($stream)
-            ->because('Greenlight MUST open the in-memory stream.')
-            ->not()
-            ->toBeFalse();
-        $this->cleanup->defer(static fn(): bool => \fclose($stream));
+        $stream = MemoryStream::open();
+        $this->cleanup->defer(static fn() => MemoryStream::close($stream));
 
         $output = new StreamOutput($stream);
         $output->write('first ');
@@ -68,13 +64,8 @@ final readonly class StreamOutputTest
     #[Test]
     public function aClosedStreamThrowableBecomesAReportGenerationFailed(): void
     {
-        $stream = ErrorTrap::run(static fn() => \fopen('php://memory', 'r+'));
-
-        Expect::that($stream)
-            ->because('Greenlight MUST open the in-memory stream.')
-            ->not()
-            ->toBeFalse();
-        \fclose($stream);
+        $stream = MemoryStream::open();
+        MemoryStream::close($stream);
 
         $output = new StreamOutput($stream);
 


### PR DESCRIPTION
Use MemoryStream for ordinary in-memory streams in CLI, reporting, and integration-resource tests. Keep direct stream creation only where a specific access mode or wrapper behavior is under test.