### PR TITLE
refactor(test): reuse runner plan entry fixtures

### DIFF
--- a/tests/Unit/Runner/Orchestrator/OrchestratorRetirementTest.php
+++ b/tests/Unit/Runner/Orchestrator/OrchestratorRetirementTest.php
@@ -6,11 +6,8 @@ namespace Greenlight\Tests\Unit\Runner\Orchestrator;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Attribute\Timeout;
-use Greenlight\Core\Test\SchedulingPolicy;
-use Greenlight\Core\Test\TestDefinition;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Doubles\Fake;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
@@ -100,9 +97,7 @@ final readonly class OrchestratorRetirementTest
         for ($index = 1; $index <= 12; ++$index) {
             $class = 'Greenlight\\Tests\\Fixture\\MissingIsolated' . $index;
             $id = new TestId($class, 'doesNotExist');
-            $entries[] = new PlanEntry(
-                new TestDefinition($class, $id->method, scheduling: new SchedulingPolicy(isolated: true)),
-            );
+            $entries[] = PlanEntryFixture::create($class, $id->method, isolated: true);
         }
 
         $summary = $orchestrator->run(new ExecutionPlan($entries), new CollectingEventSink(), 1);

--- a/tests/Unit/Runner/Orchestrator/OrchestratorTest.php
+++ b/tests/Unit/Runner/Orchestrator/OrchestratorTest.php
@@ -12,10 +12,8 @@ use Greenlight\Core\Event\TestStarted;
 use Greenlight\Core\Result\ResultSummary;
 use Greenlight\Core\Result\TestResult;
 use Greenlight\Core\Result\ThrowableDetail;
-use Greenlight\Core\Test\TestDefinition;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Expect\Expect;
 use Greenlight\Runner\Orchestrator\Orchestrator;
 use Greenlight\Runner\Protocol\Message;
@@ -33,6 +31,7 @@ use Greenlight\Tests\Fixture\Lifecycle\Bail\BbTest;
 use Greenlight\Tests\Fixture\Runner\Orchestrator\DisconnectBeforeAssignmentWorker;
 use Greenlight\Tests\Support\CollectingEventSink;
 use Greenlight\Tests\Support\NativeOrchestrator;
+use Greenlight\Tests\Support\PlanEntryFixture;
 use Greenlight\Tests\Support\ScriptedWorkerTransport;
 
 final class OrchestratorTest
@@ -376,7 +375,7 @@ final class OrchestratorTest
         $id = new TestId('Example\NeverExecutedTest', 'irrelevant');
 
         return new ExecutionPlan([
-            new PlanEntry(new TestDefinition($id->class, $id->method)),
+            PlanEntryFixture::create($id->class, $id->method),
         ]);
     }
 
@@ -385,7 +384,7 @@ final class OrchestratorTest
         $id = new TestId(CleanTest::class, 'passesAndIsCollectable');
 
         return new ExecutionPlan([
-            new PlanEntry(new TestDefinition($id->class, $id->method)),
+            PlanEntryFixture::create($id->class, $id->method),
         ]);
     }
 
@@ -395,8 +394,8 @@ final class OrchestratorTest
         $passing = new TestId(BbTest::class, 'wouldAlsoPass');
 
         return new ExecutionPlan([
-            new PlanEntry(new TestDefinition($failing->class, $failing->method)),
-            new PlanEntry(new TestDefinition($passing->class, $passing->method)),
+            PlanEntryFixture::create($failing->class, $failing->method),
+            PlanEntryFixture::create($passing->class, $passing->method),
         ]);
     }
 
@@ -405,7 +404,7 @@ final class OrchestratorTest
         $id = new TestId(CrashDiagnosticsTest::class, 'writesDiagnosticsThenExits');
 
         return new ExecutionPlan([
-            new PlanEntry(new TestDefinition($id->class, $id->method)),
+            PlanEntryFixture::create($id->class, $id->method),
         ]);
     }
 
@@ -415,8 +414,8 @@ final class OrchestratorTest
         $passing = new TestId(CleanTest::class, 'passesAndIsCollectable');
 
         return new ExecutionPlan([
-            new PlanEntry(new TestDefinition($crash->class, $crash->method)),
-            new PlanEntry(new TestDefinition($passing->class, $passing->method)),
+            PlanEntryFixture::create($crash->class, $crash->method),
+            PlanEntryFixture::create($passing->class, $passing->method),
         ]);
     }
 
@@ -425,7 +424,7 @@ final class OrchestratorTest
         $id = new TestId(CrashUnicodeDiagnosticsTest::class, 'writesUnicodeDiagnosticsThenExits');
 
         return new ExecutionPlan([
-            new PlanEntry(new TestDefinition($id->class, $id->method)),
+            PlanEntryFixture::create($id->class, $id->method),
         ]);
     }
 }

--- a/tests/Unit/Runner/WorkerTest.php
+++ b/tests/Unit/Runner/WorkerTest.php
@@ -9,11 +9,8 @@ use Greenlight\Core\Event\TestClassStarted;
 use Greenlight\Core\Result\Outcome;
 use Greenlight\Core\Result\ResultSummary;
 use Greenlight\Core\Result\TestResult;
-use Greenlight\Core\Test\SchedulingPolicy;
-use Greenlight\Core\Test\TestDefinition;
 use Greenlight\Core\Test\TestId;
 use Greenlight\Discovery\ExecutionPlan;
-use Greenlight\Discovery\PlanEntry;
 use Greenlight\Discovery\TestDiscoverer;
 use Greenlight\Expect\Expect;
 use Greenlight\Harness\HarnessRegistry;
@@ -40,6 +37,7 @@ use Greenlight\Tests\Fixture\Runner\OptionalConstructorProbe;
 use Greenlight\Tests\Fixture\Runner\UnsupportedConstructorProbe;
 use Greenlight\Tests\Support\CollectingEventSink;
 use Greenlight\Tests\Support\FixturePath;
+use Greenlight\Tests\Support\PlanEntryFixture;
 
 final class WorkerTest
 {
@@ -48,11 +46,7 @@ final class WorkerTest
     {
         $id = new TestId(OptionalConstructorProbe::class, 'usesDeclaredDefault');
         $plan = new ExecutionPlan([
-            new PlanEntry(new TestDefinition(
-                $id->class,
-                $id->method,
-                scheduling: new SchedulingPolicy(isolated: true),
-            )),
+            PlanEntryFixture::create($id->class, $id->method, isolated: true),
         ]);
         $sink = new CollectingEventSink();
 
@@ -288,7 +282,7 @@ final class WorkerTest
     {
         $id = new TestId(OptionalConstructorProbe::class, 'usesDeclaredDefault');
         $plan = new ExecutionPlan([
-            new PlanEntry(new TestDefinition($id->class, $id->method)),
+            PlanEntryFixture::create($id->class, $id->method),
         ]);
         $sink = new CollectingEventSink();
 
@@ -308,7 +302,7 @@ final class WorkerTest
     {
         $id = new TestId(UnsupportedConstructorProbe::class, 'neverRuns');
         $plan = new ExecutionPlan([
-            new PlanEntry(new TestDefinition($id->class, $id->method)),
+            PlanEntryFixture::create($id->class, $id->method),
         ]);
         $sink = new CollectingEventSink();
 
@@ -332,7 +326,7 @@ final class WorkerTest
     {
         $id = new TestId('Missing\ExampleTest', 'neverRuns');
         $plan = new ExecutionPlan([
-            new PlanEntry(new TestDefinition($id->class, $id->method)),
+            PlanEntryFixture::create($id->class, $id->method),
         ]);
         $sink = new CollectingEventSink();
 
@@ -404,11 +398,7 @@ final class WorkerTest
     {
         $id = new TestId(ServicesTest::class, 'firstTouch');
         $plan = new ExecutionPlan([
-            new PlanEntry(new TestDefinition(
-                $id->class,
-                $id->method,
-                scheduling: new SchedulingPolicy(allowParallel: true),
-            )),
+            PlanEntryFixture::create($id->class, $id->method, allowParallel: true),
         ]);
         $registry = $this->registry();
         $registry->register(new ServiceDefinition(


### PR DESCRIPTION
Use PlanEntryFixture for ordinary runner and orchestrator plan entries, including supported isolation and parallel settings. Keep direct construction where tests require policies outside the helper contract.