### PR TITLE
ci: authenticate releases as GitHub App

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -9,10 +9,7 @@ on:
 concurrency:
   group: "release-please"
 
-permissions:
-  contents: "write"
-  issues: "write"
-  pull-requests: "write"
+permissions: {}
 
 jobs:
   release-please:
@@ -21,5 +18,17 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      - name: "Create release bot token"
+        id: "release-token"
+        uses: "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1" # v3
+        with:
+          client-id: "${{ vars.RELEASE_PLEASE_APP_CLIENT_ID }}"
+          private-key: "${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}"
+          permission-contents: "write"
+          permission-issues: "write"
+          permission-pull-requests: "write"
+
       - name: "Run Release Please"
         uses: "googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7" # v5.0.0
+        with:
+          token: "${{ steps.release-token.outputs.token }}"


### PR DESCRIPTION
## Summary

- mint a short-lived installation token for the Greenlight release bot
- scope the token to contents, issues, and pull requests
- use the bot token for Release Please so its pull requests trigger CI
- remove write permissions from the unused built-in GitHub Actions token