### PR TITLE
refactor(test): reuse generated class source lookup

### DIFF
--- a/tests/Unit/Doubles/ProxyStorageTest.php
+++ b/tests/Unit/Doubles/ProxyStorageTest.php
@@ -160,13 +160,7 @@ final readonly class ProxyStorageTest
 
             $doubles = new \Greenlight\Doubles\Doubles($argv[2]);
             $proxy = $doubles->stub(\Greenlight\Tests\Fixture\Doubles\ProxyStorageContract::class);
-            $file = new \ReflectionClass($proxy)->getFileName();
-
-            if (!is_string($file)) {
-                exit(2);
-            }
-
-            echo basename($file);
+            echo basename(\Greenlight\Tests\Support\ClassFile::of($proxy::class));
             PHP,
             $root . '/vendor/autoload.php',
             $directory,


### PR DESCRIPTION
Use ClassFile to resolve the generated proxy source file in the storage test subprocess. This removes the remaining manual ReflectionClass source lookup and its duplicate false guard.