### PR TITLE
refactor(test): reuse socket fixture memory streams

### DIFF
--- a/tests/Fixture/Runner/Orchestrator/ControlledServerSocketRuntime.php
+++ b/tests/Fixture/Runner/Orchestrator/ControlledServerSocketRuntime.php
@@ -6,6 +6,7 @@ namespace Greenlight\Tests\Fixture\Runner\Orchestrator;
 
 use Greenlight\Doubles\Fake;
 use Greenlight\Runner\Orchestrator\ServerSocketRuntime;
+use Greenlight\Tests\Support\MemoryStream;
 
 final class ControlledServerSocketRuntime implements Fake, ServerSocketRuntime
 {
@@ -35,13 +36,7 @@ final class ControlledServerSocketRuntime implements Fake, ServerSocketRuntime
             return false;
         }
 
-        $server = \fopen('php://temp', 'r+');
-
-        if (!\is_resource($server)) {
-            throw new \RuntimeException('The controlled socket runtime did not create its TCP stream.');
-        }
-
-        return $this->tcpServer = $server;
+        return $this->tcpServer = MemoryStream::open();
     }
 
     #[\Override]

--- a/tests/Fixture/Runner/Orchestrator/TruncatingServerSocketRuntime.php
+++ b/tests/Fixture/Runner/Orchestrator/TruncatingServerSocketRuntime.php
@@ -6,6 +6,7 @@ namespace Greenlight\Tests\Fixture\Runner\Orchestrator;
 
 use Greenlight\Doubles\Fake;
 use Greenlight\Runner\Orchestrator\ServerSocketRuntime;
+use Greenlight\Tests\Support\MemoryStream;
 
 final class TruncatingServerSocketRuntime implements Fake, ServerSocketRuntime
 {
@@ -20,11 +21,7 @@ final class TruncatingServerSocketRuntime implements Fake, ServerSocketRuntime
     #[\Override]
     public function listen(string $address, ?string &$errorMessage)
     {
-        $server = \fopen('php://temp', 'r+');
-
-        if (!\is_resource($server)) {
-            throw new \RuntimeException('The truncating socket runtime did not create its stream.');
-        }
+        $server = MemoryStream::open();
 
         if (\str_starts_with($address, 'unix://')) {
             $this->unixAddress = $address;


### PR DESCRIPTION
Use MemoryStream for the ordinary read/write resources returned by fake server-socket runtimes. This removes duplicate stream-open checks from both fixtures.