### PR TITLE
docs: define release impact classifications

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,4 +10,5 @@
 
 - [ ] `composer static-analysis` is green
 - [ ] `composer tests` is green
-- [ ] Pull request title follows the conventional commit format (it becomes the squash commit message)
+- [ ] Pull request title follows the [release classification rules](../CONTRIBUTING.md#release-classification)
+- [ ] Each breaking change uses `!` and gives replacement instructions in **Why**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,37 @@ chore: bump php-cs-fixer to 3.76
 Common types include `feat`, `fix`, `docs`, `refactor`, `test`, and `chore`.
 Add a scope if it gives useful context.
 
+### Release classification
+
+The pull request title controls the release version and changelog. Select the
+type from the effect on users. Do not select it from the changed code location.
+
+| Type | Use |
+| --- | --- |
+| `feat` | Add a documented user capability. Keep all valid uses valid. |
+| `fix` | Correct a defect in current public behavior. |
+| `perf` | Reduce time, memory, or resource use without a compatibility change. |
+| `docs` | Change only prose. Do not change a compatibility promise. |
+| `refactor` | Change internal structure. Do not change public behavior. |
+| `test` | Change only tests or test fixtures. |
+| `ci` | Change only repository automation. |
+| `build` | Change only development or package build tools. |
+| `style` | Change only code format. |
+| `chore` | Make maintenance changes that no other type describes. |
+
+A breaking change makes a valid documented use invalid. Put `!` before the
+colon for each breaking change:
+
+```text
+feat(expect)!: require a timeout for temporal expectations
+```
+
+A change to an `@internal` symbol is not breaking by itself. If that change
+alters public behavior, classify the public behavior.
+
+Read [Compatibility and public interfaces](docs/architecture/compatibility.md#release-impact)
+for the complete rules and version effects.
+
 ## IDE completion for the PHPStan API
 
 The `phpstan/phpstan` development dependency is a PHAR. Editors cannot index

--- a/docs/architecture/compatibility.md
+++ b/docs/architecture/compatibility.md
@@ -21,6 +21,89 @@ undocumented implementation class does not become public when this marker is
 absent. When Greenlight intends a symbol for users or plugin authors, document
 it in the user guide. Omit `@internal` from that symbol.
 
+## Release impact
+
+A change has release impact when it changes a public interface in this
+document. Assess the public behavior. Do not assess only the source file or
+namespace.
+
+An internal change is not a breaking change when all public interfaces stay
+compatible. This rule includes symbols marked `@internal`, the worker protocol,
+and private files. If an internal change alters public behavior, assess that
+behavior.
+
+### Feature
+
+A feature adds a documented user capability. It keeps all valid documented
+uses valid.
+
+Examples include a new matcher, attribute, optional configuration value,
+reporter, CLI option, or plugin capability. A new internal abstraction is not a
+feature by itself.
+
+Use `feat(scope): description` for a feature.
+
+### Fix
+
+A fix makes Greenlight agree with a current public contract or intended result.
+The defect must affect public behavior.
+
+A fix can correct behavior that the public interfaces do not promise. Such a
+correction is compatible, even when a user has observed the incorrect behavior.
+
+An internal code change can be a fix when it corrects public behavior. A test
+change that only improves coverage is not a fix.
+
+Use `fix(scope): description` for a fix.
+
+### Performance change
+
+A performance change reduces time, memory, or resource use. It does not change
+a documented result or make a valid use invalid.
+
+Use `perf(scope): description` for this change.
+
+### Breaking change
+
+A breaking change makes at least one valid documented use invalid. The changed
+code does not have to be in a public class.
+
+These changes are breaking:
+
+- Remove or rename a public symbol, command, option, key, tag, or event.
+- Add a required argument, method, configuration value, or data field.
+- Make an accepted input invalid.
+- Change a documented default, return meaning, thrown type, lifecycle order,
+  match rule, or exit meaning incompatibly.
+- Change a versioned format without its required version change.
+- Increase the minimum supported PHP version.
+
+A large internal rewrite is not breaking when all public interfaces stay
+compatible. Test size, code size, and implementation difficulty do not
+determine release impact.
+
+Put `!` before the colon in the pull request title. In the pull request body,
+identify the old valid use and its replacement.
+
+For example:
+
+```text
+feat(expect)!: require a timeout for temporal expectations
+```
+
+### Version effect
+
+Greenlight uses pre-major version rules before version `1.0.0`.
+
+| Change | Before `1.0.0` | From `1.0.0` |
+| --- | --- | --- |
+| Fix or performance change | Patch | Patch |
+| Feature | Patch | Minor |
+| Breaking change | Minor | Major |
+
+The `docs`, `refactor`, `test`, `ci`, `build`, `style`, and `chore` types do not
+state release impact. Use them only when the change has no release impact.
+
 ## PHP and CLI changes
 
 Make a compatibility decision before you change a public PHP interface. This

--- a/docs/architecture/technical-writing.md
+++ b/docs/architecture/technical-writing.md
@@ -102,6 +102,7 @@ and meaning. Use the singular form unless the context requires a plural.
 | benchmark shape | Technical noun | A generated test-suite structure that one benchmark measures |
 | binding | Technical noun | A container rule that maps an ID to a value or construction method |
 | boot latency | Technical noun | The time from worker-process creation to the start of its first test class |
+| breaking change | Technical noun | A change that makes at least one valid documented use invalid |
 | builder | Technical noun | A mutable object that collects configuration for one part of a run |
 | capability interface | Technical noun | A plugin interface that adds one defined type of behavior |
 | captor | Technical noun | An object that stores argument values from matched mock calls |
@@ -131,7 +132,9 @@ and meaning. Use the singular form unless the context requires a plural.
 | execution plan | Technical noun | The ordered test metadata that discovery sends for execution |
 | expectation | Technical noun | A required condition for a test value |
 | extension matcher | Technical noun | A matcher that an expectation extension supplies |
+| feature | Technical noun | A documented user capability that keeps all valid documented uses valid |
 | fixture | Technical noun | Test support code or data with a controlled purpose |
+| fix | Technical noun | A change that corrects a defect in public behavior |
 | filter | Technical noun | A set of rules that selects tests or coverage paths |
 | flat memory | Technical noun | Memory use that does not increase with the number of completed tests |
 | frame | Technical noun | One length-prefixed worker-protocol message |
@@ -153,6 +156,7 @@ and meaning. Use the singular form unless the context requires a plural.
 | orchestrator | Technical noun | The process that plans and controls a run |
 | output capture | Technical noun | The collection of test output and PHP diagnostics for one result |
 | payload | Technical noun | The data that an event envelope contains |
+| performance change | Technical noun | A change that reduces resource use without a compatibility change |
 | poll | Technical noun | One observation of a probe value |
 | poll | Technical verb | To observe a probe until a condition or deadline stops the operation |
 | probe | Technical noun | A callable that supplies values to a temporal expectation |
@@ -165,7 +169,10 @@ and meaning. Use the singular form unless the context requires a plural.
 | PSR-15 request handler | Technical noun | An object that accepts a PSR-7 server request and returns a PSR-7 response |
 | proxy class | Technical noun | A generated class that implements or extends a doubled type |
 | proxy object | Technical noun | An instance of a proxy class that acts as a double |
+| public behavior | Technical noun | A documented result or effect of a public interface |
+| public interface | Technical noun | A documented way that a user or external tool interacts with Greenlight |
 | reporter | Technical noun | A component that converts run events to output |
+| release impact | Technical noun | The effect of a change on the next version and changelog |
 | resource lease | Technical noun | A temporary grant of resource capacity to one scheduling unit |
 | resource limit | Technical noun | A limit on concurrent access to a named resource |
 | result policy | Technical noun | A rule that can change a test result after execution |


### PR DESCRIPTION
## Summary

- define public behavior, release impact, feature, fix, performance change, and breaking change in the technical-term register
- classify pull request types by their effect on documented user behavior
- make `@internal` changes non-breaking unless they alter a public result
- document the pre-major and stable version effects
- add release classification and breaking-change checks to the pull request template