### PR TITLE
chore(build): keep release notes on GitHub

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,6 +5,7 @@
         ".": {
             "release-type": "php",
             "initial-version": "0.0.1",
+            "skip-changelog": true,
             "bump-minor-pre-major": true,
             "bump-patch-for-minor-pre-major": true,
             "include-component-in-tag": false,


### PR DESCRIPTION
## Summary

- stop Release Please from creating or updating `CHANGELOG.md`
- keep generated notes in the release pull request and GitHub Release
- support separate release history for maintained major branches

After this merges, the next Release Please run will update #1572 and remove `CHANGELOG.md` from its proposed files.