### PR TITLE
chore(ci): customize release pull request copy

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,6 +9,8 @@
             "bump-minor-pre-major": true,
             "bump-patch-for-minor-pre-major": true,
             "include-component-in-tag": false,
+            "pull-request-header": "This pull request prepares the next Greenlight release. Review the version changes and release notes before you merge it.",
+            "pull-request-footer": "Release Please maintains this pull request. After merge, Release Please creates the GitHub Release.",
             "extra-files": [
                 {
                     "type": "generic",


### PR DESCRIPTION
## Summary

- replace the default robot header with clear review guidance
- explain what Release Please does after merge
- keep the generated version and change sections unchanged

## New copy

> This pull request prepares the next Greenlight release. Review the version changes and release notes before you merge it.
>
> Release Please maintains this pull request. After merge, Release Please creates the GitHub Release.