### PR TITLE
feat(reporting): separate skipped reasons

### DIFF
--- a/src/Reporting/SummaryFormat.php
+++ b/src/Reporting/SummaryFormat.php
@@ -68,6 +68,10 @@ final class SummaryFormat
         $lines = ["\n" . $style->warn('Skipped:')];
 
         foreach ($groups as $reason => $results) {
+            if (\count($lines) > 1) {
+                $lines[] = '';
+            }
+
             if (\count($results) === 1) {
                 $lines[] = \sprintf('  %s (%s)', $results[0]->id, $reason);
 

--- a/tests/Unit/Reporting/SummaryFormatTest.php
+++ b/tests/Unit/Reporting/SummaryFormatTest.php
@@ -48,16 +48,17 @@ final class SummaryFormatTest
     }
 
     #[Test]
-    public function aSingleTestPerReasonStaysInline(): void
+    public function anEmptyLineSeparatesDistinctSkipReasons(): void
     {
         $block = SummaryFormat::skipped([
             $this->skip('App\AlphaTest', 'one', 'needs redis'),
             $this->skip('App\BetaTest', 'two', null),
         ], new Style(ansi: false));
 
-        Expect::that($block)->because('a single test per reason stays inline')->toBe(
+        Expect::that($block)->because('an empty line separates each skip reason')->toBe(
             "\nSkipped:\n"
             . "  App\AlphaTest::one (needs redis)\n"
+            . "\n"
             . "  App\BetaTest::two (no reason given)\n",
         );
     }

--- a/tests/Unit/Reporting/TtyReporterTest.php
+++ b/tests/Unit/Reporting/TtyReporterTest.php
@@ -176,7 +176,7 @@ final class TtyReporterTest
         Expect::that($buffer)->because('skipped tests are unambiguous and listed with reasons')->toContain('− App\GammaTest (1 test, skipped, 0.010s)')
             ->toContain('✓ App\DeltaTest (2 tests, 1 skipped, 0.020s)')
             ->toContain('3 tests, 1 passed, 2 skipped, 0 expectations')
-            ->toContain("Skipped:\n  App\GammaTest::one (xdebug not loaded)\n  App\DeltaTest::two (no reason given)");
+            ->toContain("Skipped:\n  App\GammaTest::one (xdebug not loaded)\n\n  App\DeltaTest::two (no reason given)");
     }
 
     #[Test]


### PR DESCRIPTION
Adds an empty line between distinct skip-reason groups in the final summary. Updates formatter and TTY reporter contracts for the clearer layout.