### PR TITLE
fix(ci): refresh lock file in release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,6 +29,46 @@ jobs:
           permission-pull-requests: "write"
 
       - name: "Run Release Please"
+        id: "release"
         uses: "googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7" # v5.0.0
         with:
           token: "${{ steps.release-token.outputs.token }}"
+
+      - name: "Checkout release pull request"
+        if: "steps.release.outputs.prs_created == 'true'"
+        uses: "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1" # v7
+        with:
+          ref: "${{ fromJSON(steps.release.outputs.pr).headBranchName }}"
+          persist-credentials: false
+
+      - name: "Set up PHP"
+        if: "steps.release.outputs.prs_created == 'true'"
+        uses: "shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240" # v2
+        with:
+          php-version: "8.4"
+          coverage: "none"
+          tools: "composer:2.9"
+
+      - name: "Refresh the Composer lock file"
+        if: "steps.release.outputs.prs_created == 'true'"
+        run: "composer update --lock --no-install --no-interaction --no-progress --no-audit --no-plugins --no-scripts"
+
+      - name: "Commit the Composer lock file"
+        if: "steps.release.outputs.prs_created == 'true'"
+        env:
+          GH_TOKEN: "${{ steps.release-token.outputs.token }}"
+          RELEASE_BRANCH: "${{ fromJSON(steps.release.outputs.pr).headBranchName }}"
+        shell: "bash"
+        run: |
+          set -euo pipefail
+
+          if git diff --quiet -- composer.lock; then
+            exit 0
+          fi
+
+          git config user.name "greenlight-beacon[bot]"
+          git config user.email "319914495+greenlight-beacon[bot]@users.noreply.github.com"
+          git add composer.lock
+          git commit -m "chore: update Composer lock file"
+          gh auth setup-git
+          git push origin "HEAD:${RELEASE_BRANCH}"


### PR DESCRIPTION
## Summary

- check out the generated release branch after Release Please creates or updates its pull request
- refresh `composer.lock` with Composer 2.9 without installing packages or running plugins and scripts
- commit the lock file as Greenlight Beacon with the existing GitHub App token
- trigger standard pull request CI for the final release commit

Release Please can trigger an intermediate CI run before the lock commit. Branch concurrency supersedes that run when the final commit starts CI.

BEGIN_COMMIT_OVERRIDE
chore(ci): refresh lock file in release PRs (#1578)
END_COMMIT_OVERRIDE