### PR TITLE
feat(reporting): write reporters to files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,10 +391,7 @@ jobs:
       - name: "Tests with JUnit output"
         id: "tests_analytics"
         if: "matrix.analytics == true"
-        shell: "bash"
-        run: |
-          mkdir -p build/test-results
-          php bin/greenlight run --reporter=junit > build/test-results/greenlight.junit.xml
+        run: "php bin/greenlight run --reporter=junit=build/test-results/greenlight.junit.xml"
 
       - name: "Save Greenlight run state"
         if: "${{ !cancelled() && (steps.tests_lowest.outcome != 'skipped' || steps.tests_standard.outcome != 'skipped' || steps.tests_analytics.outcome != 'skipped') }}"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -670,7 +670,7 @@ Randomizes class order with this seed.
 Seeded runs do not use the timing-cache order. The seed determines the complete
 order.
 
-### `--reporter=<name>[=<file>]`
+### `--reporter=<name>[=<path>]`
 
 Selects the output format.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -670,7 +670,7 @@ Randomizes class order with this seed.
 Seeded runs do not use the timing-cache order. The seed determines the complete
 order.
 
-### `--reporter=<name>`
+### `--reporter=<name>[=<file>]`
 
 Selects the output format.
 
@@ -688,8 +688,18 @@ Repeatable. Multiple reporters write concurrently.
 `ReporterProvider` plugins can add names. Greenlight creates reporters in flag
 order. A repeated name creates a separate reporter for each occurrence.
 
-All selected reporters use the same Greenlight-owned standard output. A custom
-reporter does not close this output.
+Without a file, the reporter writes to standard output. Add a file to keep its
+output separate:
+
+```sh
+vendor/bin/greenlight run --reporter=tty --reporter=junit=reports/junit.xml
+```
+
+Greenlight resolves a relative file path from the command working directory.
+It creates missing parent directories and replaces an existing file. Each file
+can have only one selected reporter.
+
+Greenlight owns each supplied output. A custom reporter does not close it.
 
 Choose unique reporter names across built-ins and plugins. A duplicate name
 stops the command before test execution.
@@ -699,13 +709,13 @@ Shell completions suggest built-in names. Configured names remain valid.
 Default: `tty` on an interactive terminal, otherwise `plain`.
 
 The `jsonl` reporter writes one complete event sequence for each repeat
-iteration. Greenlight writes repeat status to standard error to keep standard
-output valid JSONL.
+iteration. When JSONL uses standard output, Greenlight writes repeat status to
+standard error to keep standard output valid JSONL.
 
-The `tty` reporter supports parallel work. It keeps one live line for each
-active class. Each line has a spinner and a current count. The reporter
-completes the line in place when the class finishes. Multi-worker output does
-not interleave randomly.
+The `tty` reporter supports parallel work. On a terminal, it keeps one live
+line for each active class. Each line has a spinner and a current count. The
+reporter completes the line in place when the class finishes. Multi-worker
+output does not interleave randomly. In a file, it uses append-only output.
 
 The `teamcity` reporter includes IDE navigation metadata: `php_qn://` location
 hints for click-to-source, plus a per-class `flowId` to keep parallel output

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -207,6 +207,14 @@ Repeat the flag to select more than one reporter:
 vendor/bin/greenlight run --reporter=tty --reporter=junit
 ```
 
+Add a file to keep a reporter separate from standard output:
+
+```sh
+vendor/bin/greenlight run --reporter=tty --reporter=junit=reports/junit.xml
+```
+
+Greenlight creates missing parent directories. It replaces an existing file.
+
 Plugins can register custom reporter factories. See
 [ReporterProvider](plugins.md#reporterprovider).
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -95,7 +95,8 @@ factory for each standard, repeat, or watch run. A repeated selection calls the
 factory one time for each occurrence.
 
 Return a new `Reporter` each time Greenlight calls the factory. Greenlight
-supplies and owns the `Output`. Do not close this output from a reporter.
+supplies and owns the `Output`. The selected output can be standard output or a
+file. Do not close this output from a reporter.
 
 Multiple selected reporters receive events in `--reporter` order. Greenlight
 also calls `finish()` in that order. It calls `finish()` one time after the

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -161,7 +161,9 @@ final readonly class Application
                              whole classes. They are stable across machines and
                              need no coordination.
           --seed=<n>         Randomize class order with this seed
-          --reporter=<name>  Select a built-in or configured reporter name.
+          --reporter=<name>[=<file>]
+                             Select a built-in or configured reporter name.
+                             Write to the file when one is specified.
                              Built-ins: tty, plain, junit, jsonl, github, teamcity.
                              You can repeat this option.
           --artifacts-dir=<path> Persistent directory for retained test attachments
@@ -374,6 +376,8 @@ final readonly class Application
         $workers = $resolved->workers->count->fixed ?? CpuCores::count();
         $workerBin = $this->workerBinPath($binPath);
 
+        $reporterOutputs = null;
+
         try {
             $reporterCatalog = $this->reporterCatalog(
                 $arguments,
@@ -383,143 +387,170 @@ final readonly class Application
                 $workingDirectory,
                 workerFallback: $workers > 1 && $workerBin === false,
             );
-            $reporter = $this->buildReporter($arguments, $reporterCatalog);
             $this->assertRepeatOutputsAreCompatible($arguments, $overrides->repeat, $resolved->coverage);
+            $standardCapabilities = TerminalCapabilities::detect(
+                Terminal::isTty($this->stdout),
+                ['CI' => \getenv('CI'), 'NO_COLOR' => \getenv('NO_COLOR')],
+                $arguments->has('no-ansi'),
+                $arguments->has('ansi'),
+            );
+            $fileCapabilities = TerminalCapabilities::detect(
+                false,
+                ['CI' => \getenv('CI'), 'NO_COLOR' => \getenv('NO_COLOR')],
+                $arguments->has('no-ansi'),
+                $arguments->has('ansi'),
+            );
+            $reporterOutputs = ReporterOutputPlan::create(
+                $arguments->values('reporter'),
+                $standardCapabilities->interactive || $standardCapabilities->color ? 'tty' : 'plain',
+                $reporterCatalog,
+                $this->stdout,
+                $workingDirectory,
+                $standardCapabilities,
+                $fileCapabilities,
+            );
+            $reporter = $this->buildReporter($arguments, $reporterCatalog, $reporterOutputs);
         } catch (CliError $error) {
+            $reporterOutputs?->close();
             $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
             return self::EXIT_USAGE;
-        } catch (ReporterProviderError $error) {
+        } catch (ReporterOutputError|ReporterProviderError $error) {
+            $reporterOutputs?->close();
             $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
             return self::EXIT_FAILURE;
         }
 
-        $shutdown = new GracefulShutdown();
-        SignalHandlers::install($shutdown);
+        try {
+            $shutdown = new GracefulShutdown();
+            SignalHandlers::install($shutdown);
 
-        if ($arguments->has('watch')) {
-            return $this->watchCommand($arguments, $workingDirectory, $workerBin, $resolved, $configFile, $shutdown, $reporterCatalog, $reporter);
-        }
-
-        $storage = StorageLayout::resolve($resolved->storage, $workingDirectory);
-        $state = RunState::forFile($storage->runStateFile);
-        $previousFailures = $state->failedTests();
-
-        if ($arguments->has('failed')) {
-            if ($previousFailures === null) {
-                $this->printError('--failed requires state from a previous run. Run Greenlight once without --failed.', $arguments->has('no-ansi'));
-
-                return self::EXIT_USAGE;
+            if ($arguments->has('watch')) {
+                return $this->watchCommand($arguments, $workingDirectory, $workerBin, $resolved, $configFile, $shutdown, $reporterCatalog, $reporterOutputs, $reporter);
             }
 
-            if ($previousFailures === []) {
-                ($this->out)("No tests failed in the previous run. There are no tests to run again.\n");
+            $storage = StorageLayout::resolve($resolved->storage, $workingDirectory);
+            $state = RunState::forFile($storage->runStateFile);
+            $previousFailures = $state->failedTests();
+
+            if ($arguments->has('failed')) {
+                if ($previousFailures === null) {
+                    $this->printError('--failed requires state from a previous run. Run Greenlight once without --failed.', $arguments->has('no-ansi'));
+
+                    return self::EXIT_USAGE;
+                }
+
+                if ($previousFailures === []) {
+                    ($this->out)("No tests failed in the previous run. There are no tests to run again.\n");
+
+                    return self::EXIT_OK;
+                }
+
+                $selection = $resolved->selection->withExactIds($previousFailures);
+            } else {
+                $selection = $resolved->selection;
+            }
+
+            $priorityClasses = [];
+            $priorityClassSet = [];
+
+            if (!$resolved->order->isRandomized() && \is_array($previousFailures)) {
+                foreach ($previousFailures as $id) {
+                    $class = \strstr($id, '::', true);
+
+                    if (\is_string($class) && $class !== '' && !isset($priorityClassSet[$class])) {
+                        $priorityClassSet[$class] = true;
+                        $priorityClasses[] = $class;
+                    }
+                }
+            }
+
+            $classSeconds = $resolved->order->isRandomized() ? [] : $state->classSeconds();
+            $this->warnWhenLeakDetectionIsUnreliable($arguments->has('detect-leaks'), $arguments->has('no-ansi'));
+
+            // --repeat=1 specifies one standard run. Show the loop, banners, and
+            // summary only when more than one iteration is possible.
+            if (($overrides->repeat->count === null || $overrides->repeat->count === 1) && !$overrides->repeat->untilFailure) {
+                $failedTap = new FailedTestsTap(new ReporterSink($reporter));
+
+                return $this->executeRun($arguments, $resolved, $selection, $configFile, $workingDirectory, $workerBin, $shutdown, $priorityClasses, $classSeconds, $reporter, $failedTap, $state);
+            }
+
+            // Without an explicit --repeat, --repeat-until-failure has a limit of
+            // 100 iterations.
+            $limit = $overrides->repeat->count ?? 100;
+            $bounded = $overrides->repeat->count !== null;
+            $failedIterations = [];
+            $failedTests = [];
+            $failedTestSet = [];
+            $lastClassSeconds = [];
+            $repeatOutput = $reporterOutputs->writesReporterToStandardOutput('jsonl')
+                ? $this->err
+                : $this->out;
+
+            for ($iteration = 1; $iteration <= $limit; $iteration++) {
+                $repeatOutput($bounded
+                    ? \sprintf("Repeat: iteration %d of %d\n", $iteration, $limit)
+                    : \sprintf("Repeat: iteration %d of at most %d\n", $iteration, $limit));
+
+                if ($iteration > 1) {
+                    try {
+                        $reporter = $this->buildReporter($arguments, $reporterCatalog, $reporterOutputs);
+                    } catch (CliError $error) {
+                        $this->printError($error->getMessage(), $arguments->has('no-ansi'));
+
+                        return self::EXIT_USAGE;
+                    } catch (ReporterProviderError $error) {
+                        $this->printError($error->getMessage(), $arguments->has('no-ansi'));
+
+                        return self::EXIT_FAILURE;
+                    }
+                }
+
+                $failedTap = new FailedTestsTap(new ReporterSink($reporter));
+                $exit = $this->executeRun($arguments, $resolved, $selection, $configFile, $workingDirectory, $workerBin, $shutdown, $priorityClasses, $classSeconds, $reporter, $failedTap, $state);
+
+                foreach ($failedTap->failedTests() as $id) {
+                    if (!isset($failedTestSet[$id])) {
+                        $failedTestSet[$id] = true;
+                        $failedTests[] = $id;
+                    }
+                }
+
+                $lastClassSeconds = $failedTap->classSeconds();
+
+                $interruptExit = $shutdown->exitCode();
+
+                if ($interruptExit !== null) {
+                    return $interruptExit;
+                }
+
+                if ($exit !== self::EXIT_OK) {
+                    $failedIterations[] = $iteration;
+
+                    if ($overrides->repeat->untilFailure) {
+                        break;
+                    }
+                }
+            }
+
+            if ($failedIterations === []) {
+                $repeatOutput(\sprintf("Repeat: %d iterations, all passed\n", $limit));
 
                 return self::EXIT_OK;
             }
 
-            $selection = $resolved->selection->withExactIds($previousFailures);
-        } else {
-            $selection = $resolved->selection;
+            // Record each test that fails in an iteration. Thus, a later --failed
+            // run includes it even if it passes in another iteration.
+            $this->persistRunState($state, $failedTests, $lastClassSeconds);
+
+            $repeatOutput(\sprintf("Repeat: failed iterations: %s\n", \implode(', ', $failedIterations)));
+
+            return self::EXIT_FAILURE;
+        } finally {
+            $reporterOutputs->close();
         }
-
-        $priorityClasses = [];
-        $priorityClassSet = [];
-
-        if (!$resolved->order->isRandomized() && \is_array($previousFailures)) {
-            foreach ($previousFailures as $id) {
-                $class = \strstr($id, '::', true);
-
-                if (\is_string($class) && $class !== '' && !isset($priorityClassSet[$class])) {
-                    $priorityClassSet[$class] = true;
-                    $priorityClasses[] = $class;
-                }
-            }
-        }
-
-        $classSeconds = $resolved->order->isRandomized() ? [] : $state->classSeconds();
-        $this->warnWhenLeakDetectionIsUnreliable($arguments->has('detect-leaks'), $arguments->has('no-ansi'));
-
-        // --repeat=1 specifies one standard run. Show the loop, banners, and
-        // summary only when more than one iteration is possible.
-        if (($overrides->repeat->count === null || $overrides->repeat->count === 1) && !$overrides->repeat->untilFailure) {
-            $failedTap = new FailedTestsTap(new ReporterSink($reporter));
-
-            return $this->executeRun($arguments, $resolved, $selection, $configFile, $workingDirectory, $workerBin, $shutdown, $priorityClasses, $classSeconds, $reporter, $failedTap, $state);
-        }
-
-        // Without an explicit --repeat, --repeat-until-failure has a limit of
-        // 100 iterations.
-        $limit = $overrides->repeat->count ?? 100;
-        $bounded = $overrides->repeat->count !== null;
-        $failedIterations = [];
-        $failedTests = [];
-        $failedTestSet = [];
-        $lastClassSeconds = [];
-        $repeatOutput = \in_array('jsonl', $arguments->values('reporter'), true)
-            ? $this->err
-            : $this->out;
-
-        for ($iteration = 1; $iteration <= $limit; $iteration++) {
-            $repeatOutput($bounded
-                ? \sprintf("Repeat: iteration %d of %d\n", $iteration, $limit)
-                : \sprintf("Repeat: iteration %d of at most %d\n", $iteration, $limit));
-
-            if ($iteration > 1) {
-                try {
-                    $reporter = $this->buildReporter($arguments, $reporterCatalog);
-                } catch (CliError $error) {
-                    $this->printError($error->getMessage(), $arguments->has('no-ansi'));
-
-                    return self::EXIT_USAGE;
-                } catch (ReporterProviderError $error) {
-                    $this->printError($error->getMessage(), $arguments->has('no-ansi'));
-
-                    return self::EXIT_FAILURE;
-                }
-            }
-
-            $failedTap = new FailedTestsTap(new ReporterSink($reporter));
-            $exit = $this->executeRun($arguments, $resolved, $selection, $configFile, $workingDirectory, $workerBin, $shutdown, $priorityClasses, $classSeconds, $reporter, $failedTap, $state);
-
-            foreach ($failedTap->failedTests() as $id) {
-                if (!isset($failedTestSet[$id])) {
-                    $failedTestSet[$id] = true;
-                    $failedTests[] = $id;
-                }
-            }
-
-            $lastClassSeconds = $failedTap->classSeconds();
-
-            $interruptExit = $shutdown->exitCode();
-
-            if ($interruptExit !== null) {
-                return $interruptExit;
-            }
-
-            if ($exit !== self::EXIT_OK) {
-                $failedIterations[] = $iteration;
-
-                if ($overrides->repeat->untilFailure) {
-                    break;
-                }
-            }
-        }
-
-        if ($failedIterations === []) {
-            $repeatOutput(\sprintf("Repeat: %d iterations, all passed\n", $limit));
-
-            return self::EXIT_OK;
-        }
-
-        // Record each test that fails in an iteration. Thus, a later --failed
-        // run includes it even if it passes in another iteration.
-        $this->persistRunState($state, $failedTests, $lastClassSeconds);
-
-        $repeatOutput(\sprintf("Repeat: failed iterations: %s\n", \implode(', ', $failedIterations)));
-
-        return self::EXIT_FAILURE;
     }
 
     /**
@@ -536,7 +567,7 @@ final readonly class Application
 
         $outputs = [];
 
-        if (\in_array('junit', $arguments->values('reporter'), true)) {
+        if (ReporterOutputPlan::selects($arguments->values('reporter'), 'junit')) {
             $outputs[] = 'JUnit output';
         }
 
@@ -838,6 +869,7 @@ final readonly class Application
         string $configFile,
         GracefulShutdown $shutdown,
         ReporterCatalog $reporterCatalog,
+        ReporterOutputPlan $reporterOutputs,
         Reporter $initialReporter,
     ): int {
         $directories = $this->directories($resolved, $workingDirectory);
@@ -859,13 +891,13 @@ final readonly class Application
         $nextReporter = $initialReporter;
 
         $runOnce =
-            function (array $priorityClasses) use ($arguments, $resolved, $directories, $workers, $workerBin, $workingDirectory, $coverageSettings, $configFile, $detectLeaks, $shutdown, $storage, $reporterCatalog, &$nextReporter): array {
+            function (array $priorityClasses) use ($arguments, $resolved, $directories, $workers, $workerBin, $workingDirectory, $coverageSettings, $configFile, $detectLeaks, $shutdown, $storage, $reporterCatalog, $reporterOutputs, &$nextReporter): array {
                 $priorityClasses = \array_values(\array_filter(
                     $priorityClasses,
                     static fn(mixed $class): bool => \is_string($class) && $class !== '',
                 ));
 
-                $reporter = $nextReporter ?? $this->buildReporter($arguments, $reporterCatalog);
+                $reporter = $nextReporter ?? $this->buildReporter($arguments, $reporterCatalog, $reporterOutputs);
                 $nextReporter = null;
 
                 $tap = new ClassFailureTap($failedTap = new FailedTestsTap(new ReporterSink($reporter)));
@@ -1085,15 +1117,19 @@ final readonly class Application
         $definitions = [
             new ReporterDefinition(
                 'tty',
-                static fn(Output $output): Reporter => new TtyReporter(
-                    $output,
-                    $capabilities->color,
-                    $capabilities->interactive,
-                    $header,
-                    extendedSlowTests: $profile,
-                    verbose: $arguments->has('verbose'),
-                    terminalRows: TerminalRowsResolver::resolve(),
-                ),
+                static function (Output $output) use ($capabilities, $header, $profile, $arguments): Reporter {
+                    $selectedCapabilities = $output instanceof ReporterOutput ? $output->capabilities : $capabilities;
+
+                    return new TtyReporter(
+                        $output,
+                        $selectedCapabilities->color,
+                        $selectedCapabilities->interactive,
+                        $header,
+                        extendedSlowTests: $profile,
+                        verbose: $arguments->has('verbose'),
+                        terminalRows: TerminalRowsResolver::resolve(),
+                    );
+                },
             ),
             new ReporterDefinition(
                 'plain',
@@ -1142,29 +1178,18 @@ final readonly class Application
      * @throws CliError
      * @throws ReporterProviderError
      */
-    private function buildReporter(ParsedArguments $arguments, ReporterCatalog $catalog): Reporter
-    {
-        $output = new StreamOutput($this->stdout);
-        $capabilities = TerminalCapabilities::detect(
-            Terminal::isTty($this->stdout),
-            ['CI' => \getenv('CI'), 'NO_COLOR' => \getenv('NO_COLOR')],
-            $arguments->has('no-ansi'),
-            $arguments->has('ansi'),
-        );
-        $names = $arguments->values('reporter');
-
-        if ($names === []) {
-            $names = [$capabilities->interactive || $capabilities->color ? 'tty' : 'plain'];
-        }
-
-        $reporters = [];
-
-        foreach ($names as $name) {
-            $reporters[] = $catalog->create($name, $output);
-        }
+    private function buildReporter(
+        ParsedArguments $arguments,
+        ReporterCatalog $catalog,
+        ReporterOutputPlan $outputs,
+    ): Reporter {
+        $reporters = $outputs->createReporters($catalog);
 
         if ($arguments->has('profile')) {
-            $reporters[] = new ProfileReporter($output, new Style($capabilities->color));
+            $reporters[] = new ProfileReporter(
+                $outputs->standardOutput,
+                new Style($outputs->standardOutput->capabilities->color),
+            );
         }
 
         return \count($reporters) === 1 ? $reporters[0] : new CompositeReporter($reporters);

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -161,7 +161,7 @@ final readonly class Application
                              whole classes. They are stable across machines and
                              need no coordination.
           --seed=<n>         Randomize class order with this seed
-          --reporter=<name>[=<file>]
+          --reporter=<name>[=<path>]
                              Select a built-in or configured reporter name.
                              Write to the file when one is specified.
                              Built-ins: tty, plain, junit, jsonl, github, teamcity.

--- a/src/Cli/CliError.php
+++ b/src/Cli/CliError.php
@@ -119,4 +119,17 @@ final class CliError extends \RuntimeException
             \implode(' or ', $outputs),
         ));
     }
+
+    public static function malformedReporterSelection(string $value): self
+    {
+        return new self(\sprintf(
+            '--reporter requires <name> or <name>=<file>. Received "%s".',
+            $value,
+        ));
+    }
+
+    public static function duplicateReporterOutput(string $path): self
+    {
+        return new self(\sprintf('Write reporter output to file "%s" only once.', $path));
+    }
 }

--- a/src/Cli/CliError.php
+++ b/src/Cli/CliError.php
@@ -123,7 +123,7 @@ final class CliError extends \RuntimeException
     public static function malformedReporterSelection(string $value): self
     {
         return new self(\sprintf(
-            '--reporter requires <name> or <name>=<file>. Received "%s".',
+            '--reporter requires <name> or <name>=<path>. Received "%s".',
             $value,
         ));
     }

--- a/src/Cli/ReporterCatalog.php
+++ b/src/Cli/ReporterCatalog.php
@@ -45,6 +45,11 @@ final readonly class ReporterCatalog
         return \array_keys($this->factories);
     }
 
+    public function has(string $name): bool
+    {
+        return isset($this->factories[$name]);
+    }
+
     /**
      * @throws CliError
      * @throws ReporterProviderError

--- a/src/Cli/ReporterOutput.php
+++ b/src/Cli/ReporterOutput.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli;
+
+use Greenlight\Internal\Php\ErrorTrap;
+use Greenlight\Reporting\Output\Output;
+use Greenlight\Reporting\Output\StreamOutput;
+
+/**
+ * Supplies one reporter destination and its terminal capabilities.
+ *
+ * Greenlight closes an owned file stream. It does not close standard output.
+ *
+ * @internal
+ */
+final class ReporterOutput implements Output
+{
+    private readonly StreamOutput $output;
+
+    private bool $closed = false;
+
+    /**
+     * @param resource $stream
+     */
+    public function __construct(
+        private $stream,
+        public readonly TerminalCapabilities $capabilities,
+        private readonly bool $owned,
+    ) {
+        $this->output = new StreamOutput($stream);
+    }
+
+    #[\Override]
+    public function write(string $text): void
+    {
+        $this->output->write($text);
+    }
+
+    public function close(): void
+    {
+        if (!$this->owned || $this->closed) {
+            return;
+        }
+
+        $this->closed = true;
+        ErrorTrap::run(fn() => \fclose($this->stream));
+    }
+}

--- a/src/Cli/ReporterOutputError.php
+++ b/src/Cli/ReporterOutputError.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli;
+
+/**
+ * Greenlight could not prepare a selected reporter output file.
+ *
+ * @internal
+ */
+final class ReporterOutputError extends \RuntimeException
+{
+    private function __construct(string $message, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, previous: $previous);
+    }
+
+    public static function directoryCreationFailed(
+        string $path,
+        ?string $reason,
+        ?\Throwable $previous = null,
+    ): self {
+        return new self(\sprintf(
+            'Greenlight could not create reporter output directory "%s"%s.',
+            $path,
+            $reason === null ? '' : ': ' . $reason,
+        ), $previous);
+    }
+
+    public static function fileOpenFailed(
+        string $path,
+        ?string $reason,
+        ?\Throwable $previous = null,
+    ): self {
+        return new self(\sprintf(
+            'Greenlight could not open reporter output file "%s"%s.',
+            $path,
+            $reason === null ? '' : ': ' . $reason,
+        ), $previous);
+    }
+}

--- a/src/Cli/ReporterOutputPlan.php
+++ b/src/Cli/ReporterOutputPlan.php
@@ -17,16 +17,16 @@ use Greenlight\Reporting\ReporterProviderError;
  *
  * @internal
  */
-final class ReporterOutputPlan
+final readonly class ReporterOutputPlan
 {
     /**
      * @param list<array{name: non-empty-string, output: ReporterOutput}> $selections
      * @param list<ReporterOutput> $ownedOutputs
      */
     private function __construct(
-        private readonly array $selections,
-        public readonly ReporterOutput $standardOutput,
-        private readonly array $ownedOutputs,
+        private array $selections,
+        public ReporterOutput $standardOutput,
+        private array $ownedOutputs,
     ) {}
 
     /**
@@ -103,13 +103,7 @@ final class ReporterOutputPlan
      */
     public static function selects(array $values, string $name): bool
     {
-        foreach ($values as $value) {
-            if (self::parse($value)[0] === $name) {
-                return true;
-            }
-        }
-
-        return false;
+        return \array_any($values, fn($value) => self::parse($value)[0] === $name);
     }
 
     /**
@@ -138,16 +132,17 @@ final class ReporterOutputPlan
 
     public function writesReporterToStandardOutput(string $name): bool
     {
-        foreach ($this->selections as $selection) {
-            if ($selection['name'] === $name && $selection['output'] === $this->standardOutput) {
-                return true;
-            }
-        }
-
-        return false;
+        return \array_any(
+            $this->selections,
+            fn($selection) => $selection['name'] === $name && $selection['output'] === $this->standardOutput,
+        );
     }
 
-    /** @return array{non-empty-string, ?non-empty-string} */
+    /**
+     * @return array{non-empty-string, ?non-empty-string}
+     *
+     * @throws CliError
+     */
     private static function parse(string $value): array
     {
         $separator = \strpos($value, '=');
@@ -171,11 +166,7 @@ final class ReporterOutputPlan
         return \rtrim($workingDirectory, '/') . '/' . $path;
     }
 
-    /**
-     * @return ReporterOutput
-     *
-     * @throws ReporterOutputError
-     */
+    /** @throws ReporterOutputError */
     private static function openFile(string $path, TerminalCapabilities $capabilities): ReporterOutput
     {
         $directory = \dirname($path);

--- a/src/Cli/ReporterOutputPlan.php
+++ b/src/Cli/ReporterOutputPlan.php
@@ -11,7 +11,7 @@ use Greenlight\Reporting\ReporterProviderError;
 /**
  * Resolves reporter selections and owns their file output streams.
  *
- * A selection has the form <name> or <name>=<file>. Relative file paths use
+ * A selection has the form <name> or <name>=<path>. Relative file paths use
  * the command working directory. The plan reuses each output for all runs in
  * one command.
  *

--- a/src/Cli/ReporterOutputPlan.php
+++ b/src/Cli/ReporterOutputPlan.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli;
+
+use Greenlight\Internal\Php\ErrorTrap;
+use Greenlight\Reporting\Reporter;
+use Greenlight\Reporting\ReporterProviderError;
+
+/**
+ * Resolves reporter selections and owns their file output streams.
+ *
+ * A selection has the form <name> or <name>=<file>. Relative file paths use
+ * the command working directory. The plan reuses each output for all runs in
+ * one command.
+ *
+ * @internal
+ */
+final class ReporterOutputPlan
+{
+    /**
+     * @param list<array{name: non-empty-string, output: ReporterOutput}> $selections
+     * @param list<ReporterOutput> $ownedOutputs
+     */
+    private function __construct(
+        private readonly array $selections,
+        public readonly ReporterOutput $standardOutput,
+        private readonly array $ownedOutputs,
+    ) {}
+
+    /**
+     * @param list<string> $values
+     * @param resource $stdout
+     *
+     * @throws CliError
+     * @throws ReporterOutputError
+     */
+    public static function create(
+        array $values,
+        string $defaultName,
+        ReporterCatalog $catalog,
+        $stdout,
+        string $workingDirectory,
+        TerminalCapabilities $standardCapabilities,
+        TerminalCapabilities $fileCapabilities,
+    ): self {
+        $values = $values === [] ? [$defaultName] : $values;
+        $resolved = [];
+        $targets = [];
+
+        foreach ($values as $value) {
+            [$name, $file] = self::parse($value);
+
+            if (!$catalog->has($name)) {
+                throw CliError::unknownReporter($name, $catalog->names());
+            }
+
+            $path = $file === null ? null : self::absolutePath($file, $workingDirectory);
+
+            if ($path !== null && isset($targets[$path])) {
+                throw CliError::duplicateReporterOutput($file);
+            }
+
+            if ($path !== null) {
+                $targets[$path] = true;
+            }
+
+            $resolved[] = ['name' => $name, 'path' => $path];
+        }
+
+        $standardOutput = new ReporterOutput($stdout, $standardCapabilities, false);
+        $selections = [];
+        $ownedOutputs = [];
+
+        try {
+            foreach ($resolved as $selection) {
+                $output = $selection['path'] === null
+                    ? $standardOutput
+                    : self::openFile($selection['path'], $fileCapabilities);
+
+                if ($selection['path'] !== null) {
+                    $ownedOutputs[] = $output;
+                }
+
+                $selections[] = ['name' => $selection['name'], 'output' => $output];
+            }
+        } catch (\Throwable $failure) {
+            foreach ($ownedOutputs as $output) {
+                $output->close();
+            }
+
+            throw $failure;
+        }
+
+        return new self($selections, $standardOutput, $ownedOutputs);
+    }
+
+    /**
+     * @param list<string> $values
+     *
+     * @throws CliError
+     */
+    public static function selects(array $values, string $name): bool
+    {
+        foreach ($values as $value) {
+            if (self::parse($value)[0] === $name) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return list<Reporter>
+     *
+     * @throws CliError
+     * @throws ReporterProviderError
+     */
+    public function createReporters(ReporterCatalog $catalog): array
+    {
+        $reporters = [];
+
+        foreach ($this->selections as $selection) {
+            $reporters[] = $catalog->create($selection['name'], $selection['output']);
+        }
+
+        return $reporters;
+    }
+
+    public function close(): void
+    {
+        foreach ($this->ownedOutputs as $output) {
+            $output->close();
+        }
+    }
+
+    public function writesReporterToStandardOutput(string $name): bool
+    {
+        foreach ($this->selections as $selection) {
+            if ($selection['name'] === $name && $selection['output'] === $this->standardOutput) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /** @return array{non-empty-string, ?non-empty-string} */
+    private static function parse(string $value): array
+    {
+        $separator = \strpos($value, '=');
+        $name = $separator === false ? $value : \substr($value, 0, $separator);
+        $file = $separator === false ? null : \substr($value, $separator + 1);
+
+        if ($name === '' || $file === '') {
+            throw CliError::malformedReporterSelection($value);
+        }
+
+        return [$name, $file];
+    }
+
+    /** @return non-empty-string */
+    private static function absolutePath(string $path, string $workingDirectory): string
+    {
+        if (\str_starts_with($path, '/')) {
+            return $path;
+        }
+
+        return \rtrim($workingDirectory, '/') . '/' . $path;
+    }
+
+    /**
+     * @return ReporterOutput
+     *
+     * @throws ReporterOutputError
+     */
+    private static function openFile(string $path, TerminalCapabilities $capabilities): ReporterOutput
+    {
+        $directory = \dirname($path);
+
+        if (!\is_dir($directory)) {
+            try {
+                $created = ErrorTrap::run(static fn() => \mkdir($directory, 0o777, true), $warning);
+            } catch (\Throwable $failure) {
+                throw ReporterOutputError::directoryCreationFailed($directory, $failure->getMessage(), $failure);
+            }
+
+            if (!$created && !\is_dir($directory)) {
+                throw ReporterOutputError::directoryCreationFailed($directory, $warning);
+            }
+        }
+
+        try {
+            $stream = ErrorTrap::run(static fn() => \fopen($path, 'wb'), $warning);
+        } catch (\Throwable $failure) {
+            throw ReporterOutputError::fileOpenFailed($path, $failure->getMessage(), $failure);
+        }
+
+        if ($stream === false) {
+            throw ReporterOutputError::fileOpenFailed($path, $warning);
+        }
+
+        return new ReporterOutput($stream, $capabilities, true);
+    }
+}

--- a/tests/Acceptance/CustomReporterTest.php
+++ b/tests/Acceptance/CustomReporterTest.php
@@ -15,7 +15,7 @@ final readonly class CustomReporterTest
     public function __construct(private TemporaryDirectory $tempDirectory) {}
 
     #[Test]
-    public function configuredReportersUseSelectionOrderAndFreshRepeatState(): void
+    public function configuredReportersUseSelectionOrderFreshRepeatStateAndFileOutputs(): void
     {
         $project = $this->project('custom-reporter');
         $project->writeFile('greenlight.php', <<<'PHP'
@@ -95,6 +95,19 @@ final readonly class CustomReporterTest
             ->toContain("second\nfirst-1\n")
             ->toContain("second\nfirst-2\n");
         Expect::that($result->stderr)->toBe('');
+
+        $fileResult = GreenlightCli::run($project->directory, [
+            'run',
+            '--reporter=second=reports/custom.txt',
+            '--no-ansi',
+        ]);
+
+        Expect::that($fileResult->exitCode)->toBe(0);
+        Expect::that($fileResult->stdout)->toBe('');
+        Expect::that($fileResult->stderr)->toBe('');
+        Expect::that((string) \file_get_contents($project->path('reports/custom.txt')))
+            ->because('configured reporter factories MUST receive their selected file output')
+            ->toBe("second\n");
     }
 
     #[Test]

--- a/tests/Acceptance/RepeatOutputCompatibilityTest.php
+++ b/tests/Acceptance/RepeatOutputCompatibilityTest.php
@@ -61,6 +61,28 @@ final readonly class RepeatOutputCompatibilityTest
     }
 
     #[Test]
+    public function repeatRejectsAFileJUnitReporterBeforeItCreatesTheFile(): void
+    {
+        $project = $this->writeProject('repeat-file-junit');
+        $report = $project->path('reports/junit.xml');
+        $result = GreenlightCli::run($project->directory, [
+            'run',
+            '--reporter=junit=reports/junit.xml',
+            '--workers=1',
+            '--no-ansi',
+            '--repeat=2',
+        ]);
+
+        Expect::that($result->exitCode)->toBe(64);
+        Expect::that($result->stderr)
+            ->toContain('Do not use --repeat or --repeat-until-failure with JUnit output.');
+        Expect::that($result->stdout)->toBe('');
+        Expect::that(\file_exists($report))
+            ->because('Greenlight MUST validate repeat output before it creates the report file')
+            ->toBeFalse();
+    }
+
+    #[Test]
     #[DataSet('coverageConfigurations')]
     public function repeatRejectsEnabledCoverage(string $coverageConfiguration, string $repeatOption): void
     {
@@ -133,6 +155,36 @@ final readonly class RepeatOutputCompatibilityTest
         Expect::that($result->stderr)
             ->because('repeat status MUST not invalidate JSONL on standard output')
             ->toContain('Repeat: 2 iterations, all passed');
+    }
+
+    #[Test]
+    public function repeatKeepsAValidJsonlFileAndStatusOnStandardOutput(): void
+    {
+        $project = $this->writeProject('repeat-file-jsonl');
+        $report = $project->path('reports/events.jsonl');
+        $result = GreenlightCli::run($project->directory, [
+            'run',
+            '--reporter=jsonl=reports/events.jsonl',
+            '--workers=1',
+            '--no-ansi',
+            '--repeat=2',
+        ]);
+        $lines = \file($report, \FILE_IGNORE_NEW_LINES | \FILE_SKIP_EMPTY_LINES);
+        $events = [];
+
+        foreach ($lines === false ? [] : $lines as $line) {
+            /** @var array{event: string} $envelope */
+            $envelope = \json_decode($line, true, flags: \JSON_THROW_ON_ERROR);
+            $events[] = $envelope['event'];
+        }
+
+        Expect::that($result->exitCode)->toBe(0);
+        Expect::that(\array_count_values($events)['run-started'] ?? 0)->toBe(2);
+        Expect::that(\array_count_values($events)['run-finished'] ?? 0)->toBe(2);
+        Expect::that($result->stdout)
+            ->because('the JSONL file leaves standard output available for repeat status')
+            ->toContain('Repeat: 2 iterations, all passed');
+        Expect::that($result->stderr)->toBe('');
     }
 
     /**

--- a/tests/Acceptance/ReporterSelectionTest.php
+++ b/tests/Acceptance/ReporterSelectionTest.php
@@ -105,7 +105,7 @@ final readonly class ReporterSelectionTest
         Expect::that($result->exitCode)->toBe(64);
         Expect::that($result->stdout)->toBe('');
         Expect::that($result->stderr)
-            ->toBe('greenlight: --reporter requires <name> or <name>=<file>. Received "junit=".');
+            ->toBe('greenlight: --reporter requires <name> or <name>=<path>. Received "junit=".');
     }
 
     #[Test]

--- a/tests/Acceptance/ReporterSelectionTest.php
+++ b/tests/Acceptance/ReporterSelectionTest.php
@@ -52,4 +52,108 @@ final readonly class ReporterSelectionTest
         Expect::that($result->stderr)
             ->toBe('');
     }
+
+    #[Test]
+    public function reportersCanWriteToSeparateStandardAndFileOutputs(): void
+    {
+        $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'reporter-file-output');
+        $junit = $project->path('reports/junit.xml');
+        $result = GreenlightCli::run(
+            $project->directory,
+            ['run', '--workers=1', '--no-ansi', '--reporter=plain', '--reporter=junit=reports/junit.xml'],
+        );
+
+        Expect::that($result->exitCode)->toBe(0);
+        Expect::that($result->stdout)
+            ->because('the reporter without a file MUST continue to use standard output')
+            ->toContain('7 tests, 7 passed')
+            ->not()
+            ->toContain('<?xml');
+        Expect::that((string) \file_get_contents($junit))
+            ->because('the reporter file path MUST resolve from the command working directory')
+            ->toStartWith("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
+            ->toContain('<testsuites name="greenlight" tests="7"');
+        Expect::that($result->stderr)->toBe('');
+    }
+
+    #[Test]
+    public function aFileTtyReporterUsesAppendOnlyOutput(): void
+    {
+        $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'file-tty-reporter');
+        $report = $project->path('reports/tty.txt');
+        $result = GreenlightCli::run(
+            $project->directory,
+            ['run', '--workers=1', '--reporter=tty=reports/tty.txt'],
+        );
+
+        Expect::that($result->exitCode)->toBe(0);
+        Expect::that($result->stdout)->toBe('');
+        Expect::that((string) \file_get_contents($report))
+            ->because('a file is not an interactive terminal')
+            ->toContain('7 tests, 7 passed')
+            ->not()
+            ->toContain("\x1b[");
+        Expect::that($result->stderr)->toBe('');
+    }
+
+    #[Test]
+    public function anEmptyReporterFileIsAUsageError(): void
+    {
+        $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'empty-reporter-file');
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=junit=']);
+
+        Expect::that($result->exitCode)->toBe(64);
+        Expect::that($result->stdout)->toBe('');
+        Expect::that($result->stderr)
+            ->toBe('greenlight: --reporter requires <name> or <name>=<file>. Received "junit=".');
+    }
+
+    #[Test]
+    public function anUnknownReporterDoesNotCreateItsOutputDirectory(): void
+    {
+        $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'unknown-file-reporter');
+        $directory = $project->path('reports');
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=unknown=reports/output.txt']);
+
+        Expect::that($result->exitCode)->toBe(64);
+        Expect::that($result->stdout)->toBe('');
+        Expect::that($result->stderr)
+            ->toContain('greenlight: Unknown reporter "unknown".');
+        Expect::that(\is_dir($directory))
+            ->because('Greenlight MUST validate reporter names before it changes the file system')
+            ->toBeFalse();
+    }
+
+    #[Test]
+    public function reportersCannotShareOneFile(): void
+    {
+        $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'duplicate-reporter-file');
+        $result = GreenlightCli::run($project->directory, [
+            'run',
+            '--reporter=plain=report.txt',
+            '--reporter=junit=report.txt',
+        ]);
+
+        Expect::that($result->exitCode)->toBe(64);
+        Expect::that($result->stdout)->toBe('');
+        Expect::that($result->stderr)
+            ->toBe('greenlight: Write reporter output to file "report.txt" only once.');
+        Expect::that(\file_exists($project->path('report.txt')))
+            ->because('Greenlight MUST validate reporter targets before it creates them')
+            ->toBeFalse();
+    }
+
+    #[Test]
+    public function anUnavailableReporterFileStopsBeforeTheTestRun(): void
+    {
+        $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'unavailable-reporter-file');
+        $project->writeFile('blocked', 'not a directory');
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=junit=blocked/junit.xml']);
+
+        Expect::that($result->exitCode)->toBe(1);
+        Expect::that($result->stdout)->toBe('');
+        Expect::that($result->stderr)
+            ->toContain('greenlight: Greenlight could not create reporter output directory "')
+            ->toContain('/blocked":');
+    }
 }

--- a/tests/Unit/Cli/CliErrorTest.php
+++ b/tests/Unit/Cli/CliErrorTest.php
@@ -96,5 +96,13 @@ final class CliErrorTest
             static fn(): CliError => CliError::unknownReporter('verbose', ['plain', 'custom']),
             'Unknown reporter "verbose". Select one of: plain, custom.',
         ];
+        yield 'malformed reporter selection' => [
+            static fn(): CliError => CliError::malformedReporterSelection('junit='),
+            '--reporter requires <name> or <name>=<file>. Received "junit=".',
+        ];
+        yield 'duplicate reporter output' => [
+            static fn(): CliError => CliError::duplicateReporterOutput('reports/results.xml'),
+            'Write reporter output to file "reports/results.xml" only once.',
+        ];
     }
 }

--- a/tests/Unit/Cli/CliErrorTest.php
+++ b/tests/Unit/Cli/CliErrorTest.php
@@ -98,7 +98,7 @@ final class CliErrorTest
         ];
         yield 'malformed reporter selection' => [
             static fn(): CliError => CliError::malformedReporterSelection('junit='),
-            '--reporter requires <name> or <name>=<file>. Received "junit=".',
+            '--reporter requires <name> or <name>=<path>. Received "junit=".',
         ];
         yield 'duplicate reporter output' => [
             static fn(): CliError => CliError::duplicateReporterOutput('reports/results.xml'),

--- a/tests/Unit/Cli/ReporterOutputErrorTest.php
+++ b/tests/Unit/Cli/ReporterOutputErrorTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\ReporterOutputError;
+use Greenlight\Expect\Expect;
+
+final class ReporterOutputErrorTest
+{
+    #[Test]
+    public function directoryFailureIncludesThePathAndReason(): void
+    {
+        Expect::that(ReporterOutputError::directoryCreationFailed('/project/reports', 'Permission denied')->getMessage())
+            ->toBe('Greenlight could not create reporter output directory "/project/reports": Permission denied.');
+    }
+
+    #[Test]
+    public function fileFailureIncludesThePathAndReason(): void
+    {
+        Expect::that(ReporterOutputError::fileOpenFailed('/project/report.xml', 'Permission denied')->getMessage())
+            ->toBe('Greenlight could not open reporter output file "/project/report.xml": Permission denied.');
+    }
+}


### PR DESCRIPTION
## Summary

- Allow each reporter selection to target a file with --reporter=<name>=<file>.
- Keep reporter stream ownership and TTY behavior inside the CLI.
- Preserve repeat compatibility by rejecting file-targeted JUnit before file creation and keeping repeated JSONL output valid.