### PR TITLE
refactor(test): throw aggregate cleanup failures

### DIFF
--- a/src/Execution/Worker/TestExecutor.php
+++ b/src/Execution/Worker/TestExecutor.php
@@ -27,6 +27,7 @@ use Greenlight\Result\ResultPolicy;
 use Greenlight\Result\TestResult;
 use Greenlight\Result\ThrowableDetail;
 use Greenlight\Test\Cleanup;
+use Greenlight\Test\CleanupFailed;
 use Greenlight\Test\ExpectationCounter;
 use Greenlight\Test\SkipTest;
 use Greenlight\Test\TestId;
@@ -286,32 +287,34 @@ final readonly class TestExecutor
                 $captured = $capture?->stop();
             } finally {
                 try {
-                    $cleanupFailures = $cleanup->close();
+                    try {
+                        $cleanup->close();
+                    } catch (CleanupFailed $cleanupFailed) {
+                        foreach ($cleanupFailed->failures as $cleanupFailure) {
+                            if (!$cause instanceof \Throwable) {
+                                $cause = $cleanupFailure;
+                                $skipReason = null;
 
-                    foreach ($cleanupFailures as $cleanupFailure) {
-                        if (!$cause instanceof \Throwable) {
-                            $cause = $cleanupFailure;
-                            $skipReason = null;
+                                if ($cleanupFailure instanceof ExpectationFailed) {
+                                    $failures = $cleanupFailure->details;
+                                } else {
+                                    $error = ThrowableDetail::fromThrowable($cleanupFailure);
+                                }
 
-                            if ($cleanupFailure instanceof ExpectationFailed) {
-                                $failures = $cleanupFailure->details;
-                            } else {
-                                $error = ThrowableDetail::fromThrowable($cleanupFailure);
+                                continue;
                             }
 
-                            continue;
+                            if ($cleanupFailure instanceof ExpectationFailed) {
+                                $failures = [...$failures, ...$cleanupFailure->details];
+
+                                continue;
+                            }
+
+                            $failures[] = new FailureDetail(\sprintf(
+                                'Cleanup callback caused an error: %s',
+                                $cleanupFailure->getMessage(),
+                            ));
                         }
-
-                        if ($cleanupFailure instanceof ExpectationFailed) {
-                            $failures = [...$failures, ...$cleanupFailure->details];
-
-                            continue;
-                        }
-
-                        $failures[] = new FailureDetail(\sprintf(
-                            'Cleanup callback caused an error: %s',
-                            $cleanupFailure->getMessage(),
-                        ));
                     }
                 } finally {
                     try {

--- a/src/Test/Cleanup.php
+++ b/src/Test/Cleanup.php
@@ -40,16 +40,16 @@ final class Cleanup
     }
 
     /**
-     * Runs each callback and returns its failures.
+     * Runs each callback.
      *
      * @internal
      *
-     * @return list<\Throwable>
+     * @throws CleanupFailed If one or more callbacks fail.
      */
-    public function close(): array
+    public function close(): void
     {
         if ($this->closed) {
-            return [];
+            return;
         }
 
         $this->closed = true;
@@ -65,6 +65,8 @@ final class Cleanup
             }
         }
 
-        return $failures;
+        if ($failures !== []) {
+            throw CleanupFailed::fromFailures($failures);
+        }
     }
 }

--- a/src/Test/CleanupFailed.php
+++ b/src/Test/CleanupFailed.php
@@ -17,7 +17,7 @@ final class CleanupFailed extends \RuntimeException
     private function __construct(
         public readonly array $failures,
     ) {
-        parent::__construct('Test cleanup failed.', previous: $failures[0]);
+        parent::__construct('Test cleanup failed.');
     }
 
     /**

--- a/src/Test/CleanupFailed.php
+++ b/src/Test/CleanupFailed.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Test;
+
+/**
+ * One or more cleanup callbacks failed.
+ *
+ * @internal
+ */
+final class CleanupFailed extends \RuntimeException
+{
+    /**
+     * @param non-empty-list<\Throwable> $failures
+     */
+    private function __construct(
+        public readonly array $failures,
+    ) {
+        parent::__construct('Test cleanup failed.', previous: $failures[0]);
+    }
+
+    /**
+     * @param non-empty-list<\Throwable> $failures
+     */
+    public static function fromFailures(array $failures): self
+    {
+        return new self($failures);
+    }
+}

--- a/tests/Unit/Test/CleanupTest.php
+++ b/tests/Unit/Test/CleanupTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Unit\Test;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Test\Cleanup;
+use Greenlight\Test\CleanupFailed;
 
 final readonly class CleanupTest
 {
@@ -22,40 +23,47 @@ final readonly class CleanupTest
             $trace[] = 'second';
         });
 
-        $firstFailures = $cleanup->close();
-        $secondFailures = $cleanup->close();
+        $cleanup->close();
+        $cleanup->close();
 
         Expect::that($trace)
             ->because('cleanup callbacks run once in reverse registration order')
             ->toBe(['second', 'first']);
-        Expect::that($firstFailures)->toBe([]);
-        Expect::that($secondFailures)->toBe([]);
     }
 
     #[Test]
-    public function closeContinuesAfterACallbackFailure(): void
+    public function closeReportsEveryFailureAfterAllCallbacksRun(): void
     {
         $cleanup = new Cleanup();
         $trace = [];
-        $failure = new \RuntimeException('cleanup broke');
+        $firstFailure = new \RuntimeException('first cleanup broke');
+        $secondFailure = new \LogicException('second cleanup broke');
         $cleanup->defer(static function () use (&$trace): void {
             $trace[] = 'last';
         });
-        $cleanup->defer(static function () use (&$trace, $failure): never {
-            $trace[] = 'failure';
+        $cleanup->defer(static function () use (&$trace, $secondFailure): never {
+            $trace[] = 'second failure';
 
-            throw $failure;
+            throw $secondFailure;
+        });
+        $cleanup->defer(static function () use (&$trace, $firstFailure): never {
+            $trace[] = 'first failure';
+
+            throw $firstFailure;
         });
         $cleanup->defer(static function () use (&$trace): void {
             $trace[] = 'first';
         });
 
-        $failures = $cleanup->close();
-
-        Expect::that($trace)
-            ->because('a callback failure MUST NOT prevent later cleanup')
-            ->toBe(['first', 'failure', 'last']);
-        Expect::that($failures)->toBe([$failure]);
+        Expect::that(static fn() => $cleanup->close())
+            ->because('callback failures MUST NOT prevent later cleanup')
+            ->toThrow(
+                static function (CleanupFailed $cleanupFailed) use ($firstFailure, $secondFailure, &$trace): void {
+                    Expect::that($trace)->toBe(['first', 'first failure', 'second failure', 'last']);
+                    Expect::that($cleanupFailed->failures)->toBe([$firstFailure, $secondFailure]);
+                    Expect::that($cleanupFailed->getPrevious())->toBe($firstFailure);
+                },
+            );
     }
 
     #[Test]
@@ -72,10 +80,9 @@ final readonly class CleanupTest
             return 'ignored';
         });
 
-        $failures = $cleanup->close();
+        $cleanup->close();
 
         Expect::that($trace)->toBe(['value', 'void']);
-        Expect::that($failures)->toBe([]);
     }
 
     #[Test]

--- a/tests/Unit/Test/CleanupTest.php
+++ b/tests/Unit/Test/CleanupTest.php
@@ -61,7 +61,7 @@ final readonly class CleanupTest
                 static function (CleanupFailed $cleanupFailed) use ($firstFailure, $secondFailure, &$trace): void {
                     Expect::that($trace)->toBe(['first', 'first failure', 'second failure', 'last']);
                     Expect::that($cleanupFailed->failures)->toBe([$firstFailure, $secondFailure]);
-                    Expect::that($cleanupFailed->getPrevious())->toBe($firstFailure);
+                    Expect::that($cleanupFailed->getPrevious())->toBeNull();
                 },
             );
     }


### PR DESCRIPTION
## Summary

- make Cleanup::close() throw CleanupFailed when one or more callbacks fail
- retain each independent callback failure in execution order without a causal exception chain
- preserve test-result precedence while all callbacks and service disposal continue