### PR TITLE
fix(ci): stream output during JUnit test run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,7 +391,7 @@ jobs:
       - name: "Tests with JUnit output"
         id: "tests_analytics"
         if: "matrix.analytics == true"
-        run: "php bin/greenlight run --reporter=junit=build/test-results/greenlight.junit.xml"
+        run: "php bin/greenlight run --ansi --reporter=tty --reporter=junit=build/test-results/greenlight.junit.xml"
 
       - name: "Save Greenlight run state"
         if: "${{ !cancelled() && (steps.tests_lowest.outcome != 'skipped' || steps.tests_standard.outcome != 'skipped' || steps.tests_analytics.outcome != 'skipped') }}"


### PR DESCRIPTION
## Summary

- stream the standard TTY reporter during the analytics test run
- continue writing JUnit results to the Codecov upload file