### PR TITLE
fix(psr15): type handler factory returns

### DIFF
--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -426,7 +426,7 @@ public function __construct(
 
 PHPDoc:
 
-- `@param RequestHandlerInterface|\Closure(): mixed $handler`
+- `@param RequestHandlerInterface|\Closure(): RequestHandlerInterface $handler`
 - `@param null|\Closure(RequestHandlerInterface): void $release`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/HttpHarness.php#L29)
@@ -538,7 +538,7 @@ public function __construct(
 
 PHPDoc:
 
-- `@param RequestHandlerInterface|\Closure(): mixed $handler A handler or a factory that returns a handler.`
+- `@param RequestHandlerInterface|\Closure(): RequestHandlerInterface $handler A handler or a factory that returns a handler.`
 - `@param null|\Closure(RequestHandlerInterface): void $release A callback that releases the active handler when its scope closes.`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/Psr15Plugin.php#L27)

--- a/src/Psr15/HttpHarness.php
+++ b/src/Psr15/HttpHarness.php
@@ -15,7 +15,7 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 final class HttpHarness implements Disposable
 {
-    /** @var null|\Closure(): mixed */
+    /** @var null|\Closure(): RequestHandlerInterface */
     private readonly ?\Closure $factory;
 
     private ?RequestHandlerInterface $handler = null;
@@ -23,7 +23,7 @@ final class HttpHarness implements Disposable
     private bool $disposed = false;
 
     /**
-     * @param RequestHandlerInterface|\Closure(): mixed $handler
+     * @param RequestHandlerInterface|\Closure(): RequestHandlerInterface $handler
      * @param null|\Closure(RequestHandlerInterface): void $release
      */
     public function __construct(

--- a/src/Psr15/Psr15Plugin.php
+++ b/src/Psr15/Psr15Plugin.php
@@ -15,11 +15,11 @@ use Psr\Http\Server\RequestHandlerInterface;
  */
 final readonly class Psr15Plugin implements HarnessProvider
 {
-    /** @var \Closure(): mixed */
+    /** @var \Closure(): RequestHandlerInterface */
     private \Closure $factory;
 
     /**
-     * @param RequestHandlerInterface|\Closure(): mixed $handler
+     * @param RequestHandlerInterface|\Closure(): RequestHandlerInterface $handler
      *   A handler or a factory that returns a handler.
      * @param null|\Closure(RequestHandlerInterface): void $release
      *   A callback that releases the active handler when its scope closes.

--- a/tests/Unit/Psr15/HttpHarnessTest.php
+++ b/tests/Unit/Psr15/HttpHarnessTest.php
@@ -90,7 +90,9 @@ final class HttpHarnessTest
     #[Test]
     public function reportsAFactoryResultThatIsNotAHandler(): void
     {
-        $harness = new HttpHarness($this->invalidHandlerFactory());
+        $harness = new HttpHarness(
+            $this->invalidHandlerFactory(), // @phpstan-ignore argument.type (This test supplies an invalid handler factory.)
+        );
 
         Expect::that(static fn(): ResponseInterface => $harness->send(
             new ServerRequest([], [], '/status', 'GET'),


### PR DESCRIPTION
Type PSR-15 handler factory callbacks as returning RequestHandlerInterface in the harness and plugin contracts.

Retain the runtime invalid-result validation and its focused test, with a narrow PHPStan suppression for the deliberate contract violation. Regenerate the integration API reference.