### PR TITLE
fix(symfony): validate kernel factory results

### DIFF
--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -694,7 +694,7 @@ public function __construct(
 
 PHPDoc:
 
-- `@param string|\Closure(): KernelInterface $kernel A kernel class name that Greenlight constructs as new $kernel($env, $debug), or a closure that constructs the kernel. Use a closure for other constructor requirements.`
+- `@param class-string<KernelInterface>|\Closure(): KernelInterface $kernel A kernel class name that Greenlight constructs as new $kernel($env, $debug), or a closure that constructs the kernel. Use a closure for other constructor requirements.`
 - `@param non-empty-string $env`
 - `@param bool $resetBetweenTests For a container without stateful services, use false to disable resets. Tests on one worker then share all service instances.`
 

--- a/src/Symfony/SymfonyBridgeError.php
+++ b/src/Symfony/SymfonyBridgeError.php
@@ -70,6 +70,14 @@ final class SymfonyBridgeError extends ServiceResolutionFailed
         ));
     }
 
+    public static function notAKernelFromFactory(string $actual): self
+    {
+        return new self(\sprintf(
+            'The Symfony kernel factory returned "%s". Return an instance of Symfony\Component\HttpKernel\KernelInterface.',
+            $actual,
+        ));
+    }
+
     public static function serviceResolutionFailed(string $id, string $type, \Throwable $previous): self
     {
         return new self(

--- a/src/Symfony/SymfonyPlugin.php
+++ b/src/Symfony/SymfonyPlugin.php
@@ -42,7 +42,7 @@ final class SymfonyPlugin implements AfterTestSubscriber, HarnessProvider, Servi
     private ?ResetInterface $resetter = null;
 
     /**
-     * @param string|\Closure(): KernelInterface $kernel
+     * @param class-string<KernelInterface>|\Closure(): KernelInterface $kernel
      *   A kernel class name that Greenlight constructs as
      *   new $kernel($env, $debug), or a closure that constructs the kernel.
      *   Use a closure for other constructor requirements.

--- a/src/Symfony/SymfonyPlugin.php
+++ b/src/Symfony/SymfonyPlugin.php
@@ -140,7 +140,12 @@ final class SymfonyPlugin implements AfterTestSubscriber, HarnessProvider, Servi
             return $this->kernel;
         }
 
-        $kernel = ($this->factory)();
+        $kernel = $this->createKernel();
+
+        if (!$kernel instanceof KernelInterface) {
+            throw SymfonyBridgeError::notAKernelFromFactory(\get_debug_type($kernel));
+        }
+
         $kernel->boot();
         $container = $kernel->getContainer();
 
@@ -166,6 +171,11 @@ final class SymfonyPlugin implements AfterTestSubscriber, HarnessProvider, Servi
         $this->kernel = $kernel;
 
         return $kernel;
+    }
+
+    private function createKernel(): mixed
+    {
+        return ($this->factory)();
     }
 
     /**

--- a/src/Symfony/SymfonyPlugin.php
+++ b/src/Symfony/SymfonyPlugin.php
@@ -140,7 +140,7 @@ final class SymfonyPlugin implements AfterTestSubscriber, HarnessProvider, Servi
             return $this->kernel;
         }
 
-        $kernel = $this->createKernel();
+        $kernel = ($this->factory)();
 
         if (!$kernel instanceof KernelInterface) {
             throw SymfonyBridgeError::notAKernelFromFactory(\get_debug_type($kernel));
@@ -171,11 +171,6 @@ final class SymfonyPlugin implements AfterTestSubscriber, HarnessProvider, Servi
         $this->kernel = $kernel;
 
         return $kernel;
-    }
-
-    private function createKernel(): mixed
-    {
-        return ($this->factory)();
     }
 
     /**

--- a/tests/Unit/Symfony/SymfonyPluginTest.php
+++ b/tests/Unit/Symfony/SymfonyPluginTest.php
@@ -193,14 +193,10 @@ final class SymfonyPluginTest
         $plugin = new SymfonyPlugin(static fn(): KernelInterface => new FixtureKernel('test', true));
 
         Expect::that($plugin->resolve(Greeter::class, [])->value())->because('a closure factory boots the kernel it produces')->toBeInstanceOf(Greeter::class);
-    }
 
-    #[Test]
-    public function aClosureFactoryMustReturnAKernel(): void
-    {
-        $plugin = new SymfonyPlugin($this->invalidKernelFactory()); // @phpstan-ignore argument.type (This test deliberately supplies an invalid factory result.)
+        $invalid = new SymfonyPlugin(static fn(): object => new \stdClass()); // @phpstan-ignore argument.type (This test deliberately supplies an invalid factory result.)
 
-        Expect::that(static fn(): object => ($plugin->services()[0]->factory)())->toThrow(
+        Expect::that(static fn(): object => ($invalid->services()[0]->factory)())->toThrow(
             SymfonyBridgeError::class,
             matching: '/returned "stdClass".*KernelInterface/',
         );
@@ -255,12 +251,6 @@ final class SymfonyPluginTest
     private function plugin(): SymfonyPlugin
     {
         return new SymfonyPlugin(FixtureKernel::class, env: 'test', debug: true);
-    }
-
-    /** @return \Closure(): \stdClass */
-    private function invalidKernelFactory(): \Closure
-    {
-        return static fn(): object => new \stdClass();
     }
 
     private function context(): TestContext

--- a/tests/Unit/Symfony/SymfonyPluginTest.php
+++ b/tests/Unit/Symfony/SymfonyPluginTest.php
@@ -205,7 +205,7 @@ final class SymfonyPluginTest
     #[Test]
     public function aClassThatIsNotAKernelFailsLoudly(): void
     {
-        $plugin = new SymfonyPlugin(\ArrayObject::class);
+        $plugin = new SymfonyPlugin(\ArrayObject::class); // @phpstan-ignore argument.type (This test deliberately supplies an invalid kernel class.)
 
         Expect::that(static function () use ($plugin): void {
             $plugin->resolve(Greeter::class, [])->value();

--- a/tests/Unit/Symfony/SymfonyPluginTest.php
+++ b/tests/Unit/Symfony/SymfonyPluginTest.php
@@ -196,6 +196,17 @@ final class SymfonyPluginTest
     }
 
     #[Test]
+    public function aClosureFactoryMustReturnAKernel(): void
+    {
+        $plugin = new SymfonyPlugin($this->invalidKernelFactory()); // @phpstan-ignore argument.type (This test deliberately supplies an invalid factory result.)
+
+        Expect::that(static fn(): object => ($plugin->services()[0]->factory)())->toThrow(
+            SymfonyBridgeError::class,
+            matching: '/returned "stdClass".*KernelInterface/',
+        );
+    }
+
+    #[Test]
     public function aClassThatIsNotAKernelFailsLoudly(): void
     {
         $plugin = new SymfonyPlugin(\ArrayObject::class);
@@ -244,6 +255,12 @@ final class SymfonyPluginTest
     private function plugin(): SymfonyPlugin
     {
         return new SymfonyPlugin(FixtureKernel::class, env: 'test', debug: true);
+    }
+
+    /** @return \Closure(): \stdClass */
+    private function invalidKernelFactory(): \Closure
+    {
+        return static fn(): object => new \stdClass();
     }
 
     private function context(): TestContext


### PR DESCRIPTION
Declare the public kernel argument as either class-string<KernelInterface> or a closure that returns KernelInterface so PHPStan checks both configuration forms. Retain the runtime class-name check, invoke closure factories directly, and validate closure results before Greenlight calls kernel methods. Report invalid results with SymfonyBridgeError and cover both defensive paths with focused tests.