### PR TITLE
fix(laravel): type application factory precisely

### DIFF
--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -214,7 +214,7 @@ PHPDoc:
 - `@param non-empty-string $env`
 - `@param bool $refreshBetweenTests Set to false only when no service carries state; tests on one worker then share one unreset application for the worker lifetime.`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L49)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L47)
 
 ### `services()`
 
@@ -227,7 +227,7 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L70)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L74)
 
 ### `resolve()`
 
@@ -241,7 +241,7 @@ PHPDoc:
 - `@param class-string $type`
 - `@param list<object> $attributes`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L86)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L90)
 
 ### `afterTest()`
 
@@ -250,7 +250,7 @@ PHPDoc:
 public function afterTest(TestContext $context, TestResult $result): TestResult
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L122)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L126)
 
 ## `Laravel\Service`
 

--- a/src/Laravel/LaravelPlugin.php
+++ b/src/Laravel/LaravelPlugin.php
@@ -26,9 +26,7 @@ use Illuminate\Foundation\Bootstrap\RegisterProviders;
  */
 final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, ServiceResolver
 {
-    /**
-     * @var \Closure(): mixed
-     */
+    /** @var \Closure(): Application */
     private readonly \Closure $factory;
 
     /** The active application belongs to the current test attempt. */
@@ -53,14 +51,20 @@ final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, Servi
     ) {
         $this->factory = $application instanceof \Closure
             ? $application
-            : static function () use ($application): mixed {
+            : static function () use ($application): Application {
                 $applicationExists = ErrorTrap::run(static fn() => \is_file($application));
 
                 if (!$applicationExists) {
                     throw LaravelBridgeError::bootstrapFileMissing($application);
                 }
 
-                return require $application;
+                $app = require $application;
+
+                if (!$app instanceof Application) {
+                    throw LaravelBridgeError::notAnApplication(\get_debug_type($app));
+                }
+
+                return $app;
             };
     }
 

--- a/tests/Unit/Laravel/LaravelPluginTest.php
+++ b/tests/Unit/Laravel/LaravelPluginTest.php
@@ -228,6 +228,18 @@ final class LaravelPluginTest
     }
 
     #[Test]
+    public function aClosureThatDoesNotReturnAnApplicationFailsLoudly(): void
+    {
+        $plugin = $this->track(new LaravelPlugin(
+            static fn(): \stdClass => new \stdClass(), // @phpstan-ignore argument.type (This test deliberately supplies an invalid application factory.)
+        ));
+
+        Expect::that(static function () use ($plugin): void {
+            $plugin->resolve(Greeter::class, [])->value();
+        })->toThrow(LaravelBridgeError::class, matching: '/returned "stdClass".*Application::configure/s');
+    }
+
+    #[Test]
     public function anApplicationWithoutAConsoleKernelFailsLoudly(): void
     {
         $plugin = $this->track(new LaravelPlugin(


### PR DESCRIPTION
## Summary

- Type the stored Laravel application factory as Closure(): Application.
- Invoke the factory through a mixed-return trampoline so runtime validation keeps LaravelBridgeError diagnostics.
- Cover invalid closure results and refresh generated API source links.