### PR TITLE
test: use direct expectation subjects

### DIFF
--- a/tests/Unit/Config/ConfigLoaderTest.php
+++ b/tests/Unit/Config/ConfigLoaderTest.php
@@ -84,9 +84,12 @@ final class ConfigLoaderTest
         )->because('a restricted configuration file causes a configuration error')
             ->toThrow(ConfigFileError::class);
 
-        Expect::that([$directoryWarning, $fileWarning])
-            ->because('restricted configuration paths MUST not leak engine diagnostics')
-            ->toBe([null, null]);
+        Expect::that($directoryWarning)
+            ->because('a restricted configuration directory MUST not leak engine diagnostics')
+            ->toBeNull();
+        Expect::that($fileWarning)
+            ->because('a restricted configuration file MUST not leak engine diagnostics')
+            ->toBeNull();
     }
 
     #[Test]

--- a/tests/Unit/Execution/Artifact/ArtifactOutputSafetyTest.php
+++ b/tests/Unit/Execution/Artifact/ArtifactOutputSafetyTest.php
@@ -76,9 +76,12 @@ final readonly class ArtifactOutputSafetyTest
         Expect::that($workingDirectoryStore->publicDirectory())
             ->because('a restricted working directory MUST keep its configured path')
             ->toBe($restricted . '/artifacts/run-working-directory');
-        Expect::that([$absoluteWarning, $workingDirectoryWarning])
-            ->because('restricted artifact paths MUST not leak engine diagnostics')
-            ->toBe([null, null]);
+        Expect::that($absoluteWarning)
+            ->because('a restricted absolute artifact path MUST not leak engine diagnostics')
+            ->toBeNull();
+        Expect::that($workingDirectoryWarning)
+            ->because('a restricted working directory MUST not leak engine diagnostics')
+            ->toBeNull();
     }
 
     #[Test]

--- a/tests/Unit/Support/PlanEntryFixtureTest.php
+++ b/tests/Unit/Support/PlanEntryFixtureTest.php
@@ -18,8 +18,12 @@ final readonly class PlanEntryFixtureTest
         Expect::that((string) $entry->id)
             ->because('the fixture default MUST create a runnable method identifier')
             ->toBe('Acme\\ExampleTest::runs');
-        Expect::that([$entry->definition->class, $entry->definition->method])
-            ->toBe(['Acme\\ExampleTest', 'runs']);
+        Expect::that($entry->definition->class)
+            ->because('the fixture default MUST keep the test class')
+            ->toBe('Acme\\ExampleTest');
+        Expect::that($entry->definition->method)
+            ->because('the fixture default MUST create the runs method')
+            ->toBe('runs');
         Expect::that($entry->definition->scheduling->resources)
             ->toBe([]);
         Expect::that($entry->definition->scheduling->isolated)
@@ -40,9 +44,12 @@ final readonly class PlanEntryFixtureTest
         Expect::that((string) $entry->id)
             ->because('the fixture MUST retain the complete test identifier')
             ->toBe('Acme\\ExampleTest::checksValue[invalid value]');
-        Expect::that([$entry->definition->class, $entry->definition->method])
-            ->because('the fixture MUST keep identifier and metadata fields equal')
-            ->toBe([$entry->id->class, $entry->id->method]);
+        Expect::that($entry->definition->class)
+            ->because('the fixture MUST keep identifier and metadata class fields equal')
+            ->toBe($entry->id->class);
+        Expect::that($entry->definition->method)
+            ->because('the fixture MUST keep identifier and metadata method fields equal')
+            ->toBe($entry->id->method);
         Expect::that($entry->definition->scheduling->resources)
             ->toBe(['database', 'cache']);
         Expect::that($entry->definition->scheduling->isolated)


### PR DESCRIPTION
Split grouped warning and plan-entry tuple assertions into one expectation per independent subject. This gives failures precise subject-level localization while preserving legitimate array-valued behavior.