### PR TITLE
refactor(reporting): register bundled reporters as plugin

### DIFF
--- a/src/Cli/Output/TerminalRowsResolver.php
+++ b/src/Cli/Output/TerminalRowsResolver.php
@@ -17,6 +17,7 @@ final class TerminalRowsResolver
     /** @codeCoverageIgnore */
     private function __construct() {}
 
+    /** @return positive-int */
     public static function resolve(): int
     {
         $lines = self::positiveRows(\getenv('LINES'));

--- a/src/Cli/Reporting/BundledReporters.php
+++ b/src/Cli/Reporting/BundledReporters.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli\Reporting;
+
+use Greenlight\Cli\Input\ParsedArguments;
+use Greenlight\Cli\Output\TerminalCapabilities;
+use Greenlight\Plugin\ReporterProvider;
+use Greenlight\Reporting\GithubReporter;
+use Greenlight\Reporting\JsonLinesReporter;
+use Greenlight\Reporting\JUnitReporter;
+use Greenlight\Reporting\Output;
+use Greenlight\Reporting\PlainReporter;
+use Greenlight\Reporting\Reporter;
+use Greenlight\Reporting\ReporterDefinition;
+use Greenlight\Reporting\RunHeader;
+use Greenlight\Reporting\TeamCityReporter;
+use Greenlight\Reporting\TtyReporter;
+
+/**
+ * Supplies the reporters that Greenlight includes.
+ *
+ * @internal
+ */
+final readonly class BundledReporters implements ReporterProvider
+{
+    /**
+     * @param positive-int $terminalRows
+     */
+    public function __construct(
+        private TerminalCapabilities $capabilities,
+        private RunHeader $header,
+        private ParsedArguments $arguments,
+        private int $terminalRows,
+    ) {}
+
+    /** @return list<ReporterDefinition> */
+    #[\Override]
+    public function reporters(): array
+    {
+        $profile = $this->arguments->has('profile');
+
+        return [
+            new ReporterDefinition('tty', function (Output $output) use ($profile): Reporter {
+                $capabilities = $output instanceof ReporterOutput ? $output->capabilities : $this->capabilities;
+
+                return new TtyReporter(
+                    $output,
+                    $capabilities->color,
+                    $capabilities->interactive,
+                    $this->header,
+                    extendedSlowTests: $profile,
+                    verbose: $this->arguments->has('verbose'),
+                    terminalRows: $this->terminalRows,
+                );
+            }),
+            new ReporterDefinition('plain', fn(Output $output): Reporter => new PlainReporter($output, $this->header, extendedSlowTests: $profile)),
+            new ReporterDefinition('junit', static fn(Output $output): Reporter => new JUnitReporter($output)),
+            new ReporterDefinition('jsonl', static fn(Output $output): Reporter => new JsonLinesReporter($output)),
+            new ReporterDefinition('github', static fn(Output $output): Reporter => new GithubReporter($output)),
+            new ReporterDefinition('teamcity', static fn(Output $output): Reporter => new TeamCityReporter($output)),
+        ];
+    }
+}

--- a/src/Cli/Reporting/ReporterFactory.php
+++ b/src/Cli/Reporting/ReporterFactory.php
@@ -12,18 +12,11 @@ use Greenlight\Cli\Output\TerminalRowsResolver;
 use Greenlight\Plugin\PluginDefinition;
 use Greenlight\Plugin\ReporterProvider;
 use Greenlight\Reporting\CompositeReporter;
-use Greenlight\Reporting\GithubReporter;
-use Greenlight\Reporting\JsonLinesReporter;
-use Greenlight\Reporting\JUnitReporter;
-use Greenlight\Reporting\Output;
-use Greenlight\Reporting\PlainReporter;
 use Greenlight\Reporting\Profile\ProfileReporter;
 use Greenlight\Reporting\Reporter;
 use Greenlight\Reporting\ReporterDefinition;
 use Greenlight\Reporting\RunHeader;
 use Greenlight\Reporting\Style;
-use Greenlight\Reporting\TeamCityReporter;
-use Greenlight\Reporting\TtyReporter;
 
 /**
  * Builds the reporter catalog and fresh reporters for one command.
@@ -45,29 +38,17 @@ final readonly class ReporterFactory
         $prefix = \rtrim($workingDirectory, '/') . '/';
         $displayedConfig = \str_starts_with($configFile, $prefix) ? \substr($configFile, \strlen($prefix)) : $configFile;
         $header = new RunHeader($version, $displayedConfig, $seed, workerFallback: $workerFallback);
-        $profile = $arguments->has('profile');
-        $definitions = [
-            new ReporterDefinition('tty', static function (Output $output) use ($capabilities, $header, $profile, $arguments): Reporter {
-                $selectedCapabilities = $output instanceof ReporterOutput ? $output->capabilities : $capabilities;
+        $definitions = [];
+        $bundled = PluginDefinition::fromFactory(
+            fn(): BundledReporters => new BundledReporters(
+                $capabilities,
+                $header,
+                $arguments,
+                TerminalRowsResolver::resolve(),
+            ),
+        );
 
-                return new TtyReporter(
-                    $output,
-                    $selectedCapabilities->color,
-                    $selectedCapabilities->interactive,
-                    $header,
-                    extendedSlowTests: $profile,
-                    verbose: $arguments->has('verbose'),
-                    terminalRows: TerminalRowsResolver::resolve(),
-                );
-            }),
-            new ReporterDefinition('plain', static fn(Output $output): Reporter => new PlainReporter($output, $header, extendedSlowTests: $profile)),
-            new ReporterDefinition('junit', static fn(Output $output): Reporter => new JUnitReporter($output)),
-            new ReporterDefinition('jsonl', static fn(Output $output): Reporter => new JsonLinesReporter($output)),
-            new ReporterDefinition('github', static fn(Output $output): Reporter => new GithubReporter($output)),
-            new ReporterDefinition('teamcity', static fn(Output $output): Reporter => new TeamCityReporter($output)),
-        ];
-
-        foreach ($plugins as $pluginDefinition) {
+        foreach ([$bundled, ...$plugins] as $pluginDefinition) {
             if (!$pluginDefinition->supports(ReporterProvider::class)) {
                 continue;
             }

--- a/tests/Unit/Cli/Reporting/BundledReportersTest.php
+++ b/tests/Unit/Cli/Reporting/BundledReportersTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\Input\ParsedArguments;
+use Greenlight\Cli\Output\TerminalCapabilities;
+use Greenlight\Cli\Reporting\BundledReporters;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\GithubReporter;
+use Greenlight\Reporting\JsonLinesReporter;
+use Greenlight\Reporting\JUnitReporter;
+use Greenlight\Reporting\PlainReporter;
+use Greenlight\Reporting\RunHeader;
+use Greenlight\Reporting\TeamCityReporter;
+use Greenlight\Reporting\TtyReporter;
+use Greenlight\Tests\Unit\Reporting\BufferOutput;
+
+final readonly class BundledReportersTest
+{
+    #[Test]
+    public function suppliesEachBundledReporterThroughThePluginCapability(): void
+    {
+        $definitions = new BundledReporters(
+            new TerminalCapabilities(false, false),
+            new RunHeader('1.0.0'),
+            new ParsedArguments(null, []),
+            24,
+        )->reporters();
+        $output = new BufferOutput();
+        $reporters = [];
+
+        foreach ($definitions as $definition) {
+            $reporters[$definition->name] = ($definition->factory)($output)::class;
+        }
+
+        Expect::that($reporters)->toBe([
+            'tty' => TtyReporter::class,
+            'plain' => PlainReporter::class,
+            'junit' => JUnitReporter::class,
+            'jsonl' => JsonLinesReporter::class,
+            'github' => GithubReporter::class,
+            'teamcity' => TeamCityReporter::class,
+        ]);
+    }
+}


### PR DESCRIPTION
Move Greenlight reporter definitions into a bundled ReporterProvider. Route bundled and configured reporter providers through one registration path, while preserving reporter order and collision checks.