### PR TITLE
test: harden PHP subprocess support

### DIFF
--- a/tests/Acceptance/DocsPhpCheckTest.php
+++ b/tests/Acceptance/DocsPhpCheckTest.php
@@ -7,9 +7,9 @@ namespace Greenlight\Tests\Acceptance;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\PhpSubprocess;
 use Greenlight\Tests\Support\ProcessResult;
 use Greenlight\Tests\Support\ProjectFiles;
-use Greenlight\Tests\Support\Subprocess;
 
 final readonly class DocsPhpCheckTest
 {
@@ -390,7 +390,6 @@ final readonly class DocsPhpCheckTest
         string ...$arguments,
     ): ProcessResult {
         $processCommand = [
-            \PHP_BINARY,
             \dirname(__DIR__, 2) . '/tools/docs-php.php',
             $command,
             '--root=' . $project->directory,
@@ -400,6 +399,6 @@ final readonly class DocsPhpCheckTest
             $processCommand[] = $argument;
         }
 
-        return Subprocess::run($project->directory, $processCommand, $environment);
+        return PhpSubprocess::run($project->directory, $processCommand, $environment);
     }
 }

--- a/tests/Acceptance/IdeHelperTest.php
+++ b/tests/Acceptance/IdeHelperTest.php
@@ -9,7 +9,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\FixturePath;
 use Greenlight\Tests\Support\GreenlightCli;
-use Greenlight\Tests\Support\Subprocess;
+use Greenlight\Tests\Support\PhpSubprocess;
 
 final readonly class IdeHelperTest
 {
@@ -31,7 +31,7 @@ final readonly class IdeHelperTest
             ->toContain('@method Expectation<T> toHaveDigestLength(int $length)')
             ->toContain('abstract class TemporalExpectation');
 
-        $lint = Subprocess::run($root, [\PHP_BINARY, '-l', $target]);
+        $lint = PhpSubprocess::run($root, ['-l', $target]);
         Expect::that($lint->exitCode)->because('writes a lintable helper and skips when nothing is configured')->toBe(0);
 
         $result = GreenlightCli::run(FixturePath::get('ListTestsConfig'), ['ide-helper', '--output=' . $target . '.none']);

--- a/tests/Acceptance/LocalCiLockTest.php
+++ b/tests/Acceptance/LocalCiLockTest.php
@@ -8,7 +8,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Test\Cleanup;
-use Greenlight\Tests\Support\Subprocess;
+use Greenlight\Tests\Support\PhpSubprocess;
 
 final readonly class LocalCiLockTest
 {
@@ -27,26 +27,24 @@ final readonly class LocalCiLockTest
             'GREENLIGHT_LOCAL_CI_LOCK_DIRECTORY' => $lockDirectory,
             'GREENLIGHT_LOCAL_CI_MAX_PARALLELISM' => '1',
         ];
-        $first = Subprocess::start(
+        $first = PhpSubprocess::start(
             $this->tempDirectory->path(),
-            $this->lockCommand([
-                \PHP_BINARY,
+            $this->lockCommand(PhpSubprocess::command([
                 '-r',
                 'fwrite(STDOUT, "ready\\n"); fflush(STDOUT); fgets(STDIN);',
-            ]),
+            ])),
             $environment,
         );
         $this->cleanup->defer($first->terminate(...));
 
         $first->readStdoutUntil('ready', 2.0);
-        $second = Subprocess::start(
+        $second = PhpSubprocess::start(
             $this->tempDirectory->path(),
-            $this->lockCommand([
-                \PHP_BINARY,
+            $this->lockCommand(PhpSubprocess::command([
                 '-r',
                 'file_put_contents($argv[1], "started");',
                 $startedMarker,
-            ]),
+            ])),
             $environment,
         );
         $this->cleanup->defer($second->terminate(...));
@@ -67,9 +65,9 @@ final readonly class LocalCiLockTest
     {
         $invalidLockDirectory = $this->tempDirectory->path() . '/not-a-directory';
         \file_put_contents($invalidLockDirectory, 'file');
-        $result = Subprocess::run(
+        $result = PhpSubprocess::run(
             $this->tempDirectory->path(),
-            $this->lockCommand([\PHP_BINARY, '-r', 'exit(7);']),
+            $this->lockCommand(PhpSubprocess::command(['-r', 'exit(7);'])),
             [
                 'CI' => 'true',
                 'GREENLIGHT_LOCAL_CI_LOCK_DIRECTORY' => $invalidLockDirectory,
@@ -87,21 +85,20 @@ final readonly class LocalCiLockTest
             'GREENLIGHT_LOCAL_CI_LOCK_DIRECTORY' => $this->tempDirectory->subdirectory('two-locks'),
             'GREENLIGHT_LOCAL_CI_MAX_PARALLELISM' => '2',
         ];
-        $first = Subprocess::start(
+        $first = PhpSubprocess::start(
             $this->tempDirectory->path(),
-            $this->lockCommand([
-                \PHP_BINARY,
+            $this->lockCommand(PhpSubprocess::command([
                 '-r',
                 'fwrite(STDOUT, "ready\\n"); fflush(STDOUT); fgets(STDIN);',
-            ]),
+            ])),
             $environment,
         );
         $this->cleanup->defer($first->terminate(...));
 
         $first->readStdoutUntil('ready', 2.0);
-        $second = Subprocess::run(
+        $second = PhpSubprocess::run(
             $this->tempDirectory->path(),
-            $this->lockCommand([\PHP_BINARY, '-r', 'exit(9);']),
+            $this->lockCommand(PhpSubprocess::command(['-r', 'exit(9);'])),
             $environment,
         );
 
@@ -120,7 +117,6 @@ final readonly class LocalCiLockTest
     private function lockCommand(array $command): array
     {
         return [
-            \PHP_BINARY,
             \dirname(__DIR__, 2) . '/tools/local-ci-lock.php',
             '--',
             ...$command,

--- a/tests/Acceptance/ProseCheckBehaviorTest.php
+++ b/tests/Acceptance/ProseCheckBehaviorTest.php
@@ -7,9 +7,9 @@ namespace Greenlight\Tests\Acceptance;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\PhpSubprocess;
 use Greenlight\Tests\Support\ProcessResult;
 use Greenlight\Tests\Support\ProjectFiles;
-use Greenlight\Tests\Support\Subprocess;
 
 final readonly class ProseCheckBehaviorTest
 {
@@ -779,8 +779,7 @@ final readonly class ProseCheckBehaviorTest
     {
         $root = $this->workspace('removed-baseline');
         $this->write($root, 'sample.md', "The worker stops.\n");
-        $result = Subprocess::run($root, [
-            \PHP_BINARY,
+        $result = PhpSubprocess::run($root, [
             \dirname(__DIR__, 2) . '/tools/prose-check.php',
             'check',
             '--root=' . $root,
@@ -803,8 +802,7 @@ final readonly class ProseCheckBehaviorTest
 
     private function run(string $command, string $root): ProcessResult
     {
-        return Subprocess::run($root, [
-            \PHP_BINARY,
+        return PhpSubprocess::run($root, [
             \dirname(__DIR__, 2) . '/tools/prose-check.php',
             $command,
             '--root=' . $root,

--- a/tests/Acceptance/TemporalExpectationRunTest.php
+++ b/tests/Acceptance/TemporalExpectationRunTest.php
@@ -27,6 +27,7 @@ final readonly class TemporalExpectationRunTest
 
         use Greenlight\Attribute\Test;
         use Greenlight\Expect\Expect;
+        use Greenlight\Tests\Support\PhpSubprocess;
 
         final class AsynchronousAdapterTest
         {
@@ -40,8 +41,7 @@ final readonly class TemporalExpectationRunTest
                 }
 
                 \unlink($marker);
-                $process = \proc_open([
-                    \PHP_BINARY,
+                $process = \proc_open(PhpSubprocess::command([
                     '-r',
                     <<<'PHP'
                     fwrite(STDOUT, "ready\n");
@@ -52,7 +52,7 @@ final readonly class TemporalExpectationRunTest
                     }
                     PHP,
                     $marker,
-                ], [
+                ]), [
                     ['pipe', 'r'],
                     ['pipe', 'w'],
                 ], $pipes);

--- a/tests/Acceptance/WorkflowShellCheckTest.php
+++ b/tests/Acceptance/WorkflowShellCheckTest.php
@@ -7,8 +7,8 @@ namespace Greenlight\Tests\Acceptance;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\PhpSubprocess;
 use Greenlight\Tests\Support\ProcessResult;
-use Greenlight\Tests\Support\Subprocess;
 
 final readonly class WorkflowShellCheckTest
 {
@@ -104,8 +104,7 @@ final readonly class WorkflowShellCheckTest
 
     private function run(string $root): ProcessResult
     {
-        return Subprocess::run($root, [
-            \PHP_BINARY,
+        return PhpSubprocess::run($root, [
             \dirname(__DIR__, 2) . '/tools/workflow-shell-check.php',
             'workflow.yml',
         ]);

--- a/tests/Support/GreenlightCli.php
+++ b/tests/Support/GreenlightCli.php
@@ -40,15 +40,14 @@ final class GreenlightCli
     ): Subprocess {
         $root = \dirname(__DIR__, 2);
 
-        return Subprocess::start(
+        return PhpSubprocess::start(
             $workingDirectory,
             [
-                \PHP_BINARY,
-                ...$phpArguments,
                 $root . '/bin/greenlight',
                 ...$arguments,
             ],
             $environment,
+            $phpArguments,
         );
     }
 }

--- a/tests/Support/PhpStanProbe.php
+++ b/tests/Support/PhpStanProbe.php
@@ -42,10 +42,9 @@ final readonly class PhpStanProbe
             self::neonString($probeDirectory . '/cache'),
         ));
 
-        $result = Subprocess::run(
+        $result = PhpSubprocess::run(
             $root,
             [
-                \PHP_BINARY,
                 $root . '/vendor/bin/phpstan',
                 'analyse',
                 '--no-progress',

--- a/tests/Support/PhpSubprocess.php
+++ b/tests/Support/PhpSubprocess.php
@@ -4,17 +4,9 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Support;
 
-/** Runs PHP test processes with the required isolated configuration. */
+/** Runs PHP test processes through the shared process support. */
 final readonly class PhpSubprocess
 {
-    /** @var array<string, string> */
-    private const array ENVIRONMENT = [
-        'DD_TRACE_ENABLED' => '0',
-        'DD_TRACE_CLI_ENABLED' => '0',
-        'DD_TRACE_STARTUP_LOGS' => '0',
-        'DD_INSTRUMENTATION_TELEMETRY_ENABLED' => '0',
-    ];
-
     private function __construct() {}
 
     /**
@@ -33,7 +25,7 @@ final readonly class PhpSubprocess
         return Subprocess::run(
             $workingDirectory,
             self::command($arguments, $phpArguments),
-            [...$environment, ...self::ENVIRONMENT],
+            $environment,
         );
     }
 
@@ -53,7 +45,7 @@ final readonly class PhpSubprocess
         return Subprocess::start(
             $workingDirectory,
             self::command($arguments, $phpArguments),
-            [...$environment, ...self::ENVIRONMENT],
+            $environment,
         );
     }
 
@@ -70,8 +62,6 @@ final readonly class PhpSubprocess
         return [
             \PHP_BINARY,
             ...$phpArguments,
-            '-d',
-            'ddtrace.disable=1',
             ...$arguments,
         ];
     }

--- a/tests/Support/PhpSubprocess.php
+++ b/tests/Support/PhpSubprocess.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Support;
+
+/** Runs PHP test processes with the required isolated configuration. */
+final readonly class PhpSubprocess
+{
+    /** @var array<string, string> */
+    private const array ENVIRONMENT = [
+        'DD_TRACE_ENABLED' => '0',
+        'DD_TRACE_CLI_ENABLED' => '0',
+        'DD_TRACE_STARTUP_LOGS' => '0',
+        'DD_INSTRUMENTATION_TELEMETRY_ENABLED' => '0',
+    ];
+
+    private function __construct() {}
+
+    /**
+     * @param non-empty-list<string> $arguments
+     * @param array<string, string> $environment
+     * @param list<string> $phpArguments
+     *
+     * @throws \RuntimeException when the process cannot start or its output cannot be read
+     */
+    public static function run(
+        string $workingDirectory,
+        array $arguments,
+        array $environment = [],
+        array $phpArguments = [],
+    ): ProcessResult {
+        return Subprocess::run(
+            $workingDirectory,
+            self::command($arguments, $phpArguments),
+            [...$environment, ...self::ENVIRONMENT],
+        );
+    }
+
+    /**
+     * @param non-empty-list<string> $arguments
+     * @param array<string, string> $environment
+     * @param list<string> $phpArguments
+     *
+     * @throws \RuntimeException when the process cannot start
+     */
+    public static function start(
+        string $workingDirectory,
+        array $arguments,
+        array $environment = [],
+        array $phpArguments = [],
+    ): Subprocess {
+        return Subprocess::start(
+            $workingDirectory,
+            self::command($arguments, $phpArguments),
+            [...$environment, ...self::ENVIRONMENT],
+        );
+    }
+
+    /**
+     * @template T of string
+     *
+     * @param non-empty-list<T> $arguments
+     * @param list<T> $phpArguments
+     *
+     * @return non-empty-list<T|non-empty-string>
+     */
+    public static function command(array $arguments, array $phpArguments = []): array
+    {
+        return [
+            \PHP_BINARY,
+            ...$phpArguments,
+            '-d',
+            'ddtrace.disable=1',
+            ...$arguments,
+        ];
+    }
+}

--- a/tests/Support/ProseCheckRuleProbe.php
+++ b/tests/Support/ProseCheckRuleProbe.php
@@ -38,8 +38,7 @@ final readonly class ProseCheckRuleProbe
 
     private static function run(string $root): ProcessResult
     {
-        return Subprocess::run($root, [
-            \PHP_BINARY,
+        return PhpSubprocess::run($root, [
             \dirname(__DIR__, 2) . '/tools/prose-check.php',
             'check',
             '--root=' . $root,

--- a/tests/Support/RectorProbe.php
+++ b/tests/Support/RectorProbe.php
@@ -41,10 +41,9 @@ final readonly class RectorProbe
         $files->write('tests/ProbeTest.php', $testClassSource);
         $files->write('rector.php', self::rectorConfig($directory, $configuration));
 
-        $result = Subprocess::run(
+        $result = PhpSubprocess::run(
             $root,
             [
-                \PHP_BINARY,
                 $root . '/vendor/bin/rector',
                 'process',
                 '--config',

--- a/tests/Support/SourceOnlyPhp.php
+++ b/tests/Support/SourceOnlyPhp.php
@@ -44,7 +44,6 @@ final readonly class SourceOnlyPhp
         array $arguments = [],
     ): array {
         return [
-            \PHP_BINARY,
             '-n',
             ...$phpOptions,
             '-r',

--- a/tests/Unit/Cli/Output/TerminalRowsResolverUnavailableExecTest.php
+++ b/tests/Unit/Cli/Output/TerminalRowsResolverUnavailableExecTest.php
@@ -6,7 +6,7 @@ namespace Greenlight\Tests\Unit\Cli\Output;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
-use Greenlight\Tests\Support\Subprocess;
+use Greenlight\Tests\Support\PhpSubprocess;
 
 final readonly class TerminalRowsResolverUnavailableExecTest
 {
@@ -14,10 +14,9 @@ final readonly class TerminalRowsResolverUnavailableExecTest
     public function unavailableExecUsesDefaultRows(): void
     {
         $root = \dirname(__DIR__, 4);
-        $result = Subprocess::run(
+        $result = PhpSubprocess::run(
             $root,
             [
-                \PHP_BINARY,
                 '-n',
                 '-d',
                 'disable_functions=exec',

--- a/tests/Unit/Cli/Signal/SystemSignalOperationsTest.php
+++ b/tests/Unit/Cli/Signal/SystemSignalOperationsTest.php
@@ -9,7 +9,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Cli\Signal\SystemSignalOperations;
 use Greenlight\Expect\Expect;
 use Greenlight\Test\Cleanup;
-use Greenlight\Tests\Support\Subprocess;
+use Greenlight\Tests\Support\PhpSubprocess;
 
 final readonly class SystemSignalOperationsTest
 {
@@ -51,8 +51,7 @@ final readonly class SystemSignalOperationsTest
     public function availabilityRequiresEveryPcntlFunction(string $function): void
     {
         $root = \dirname(__DIR__, 4);
-        $result = Subprocess::run($root, [
-            \PHP_BINARY,
+        $result = PhpSubprocess::run($root, [
             '-d',
             'disable_functions=' . $function,
             '-r',

--- a/tests/Unit/Cli/WorkerCapacity/CpuCoresTest.php
+++ b/tests/Unit/Cli/WorkerCapacity/CpuCoresTest.php
@@ -17,9 +17,9 @@ use Greenlight\Expect\Fail;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Fixture\Cli\WorkerCapacity\FakeCpuCoreCounter;
 use Greenlight\Tests\Fixture\Cli\WorkerCapacity\FakeNumberOfCpuCoreNotFound;
+use Greenlight\Tests\Support\PhpSubprocess;
 use Greenlight\Tests\Support\ProcessResult;
 use Greenlight\Tests\Support\SourceOnlyPhp;
-use Greenlight\Tests\Support\Subprocess;
 
 final readonly class CpuCoresTest
 {
@@ -120,7 +120,7 @@ final readonly class CpuCoresTest
     {
         $root = \dirname(__DIR__, 4);
 
-        return Subprocess::run($root, SourceOnlyPhp::command(
+        return PhpSubprocess::run($root, SourceOnlyPhp::command(
             $root . '/src',
             <<<'PHP'
             if (class_exists(\Fidry\CpuCoreCounter\CpuCoreCounter::class)) {

--- a/tests/Unit/Coverage/Collection/XdebugDriverIniFallbackTest.php
+++ b/tests/Unit/Coverage/Collection/XdebugDriverIniFallbackTest.php
@@ -8,7 +8,7 @@ use Greenlight\Attribute\SkipUnless;
 use Greenlight\Attribute\Test;
 use Greenlight\Condition\ExtensionLoaded;
 use Greenlight\Expect\Expect;
-use Greenlight\Tests\Support\Subprocess;
+use Greenlight\Tests\Support\PhpSubprocess;
 
 final class XdebugDriverIniFallbackTest
 {
@@ -17,8 +17,7 @@ final class XdebugDriverIniFallbackTest
     public function availabilityUsesTheIniModeWhenXdebugInfoIsDisabled(): void
     {
         $root = \dirname(__DIR__, 4);
-        $result = Subprocess::run($root, [
-            \PHP_BINARY,
+        $result = PhpSubprocess::run($root, [
             '-d',
             'xdebug.mode=coverage',
             '-d',

--- a/tests/Unit/Coverage/Relay/SubprocessCoverageTest.php
+++ b/tests/Unit/Coverage/Relay/SubprocessCoverageTest.php
@@ -19,8 +19,8 @@ use Greenlight\Tests\Fixture\Coverage\AvailableFakeDriver;
 use Greenlight\Tests\Fixture\Coverage\RecordingFakeDriver;
 use Greenlight\Tests\Fixture\Coverage\UnavailableFakeDriver;
 use Greenlight\Tests\Support\CoverageJson;
+use Greenlight\Tests\Support\PhpSubprocess;
 use Greenlight\Tests\Support\SourceOnlyPhp;
-use Greenlight\Tests\Support\Subprocess;
 
 final readonly class SubprocessCoverageTest
 {
@@ -61,7 +61,7 @@ final readonly class SubprocessCoverageTest
             ->toBe(7);
 
         $root = \dirname(__DIR__, 4);
-        $result = Subprocess::run($root, SourceOnlyPhp::command(
+        $result = PhpSubprocess::run($root, SourceOnlyPhp::command(
             $root . '/src',
             <<<'PHP'
             $blocker = $argv[1];

--- a/tests/Unit/Doubles/ProxyGenerationTest.php
+++ b/tests/Unit/Doubles/ProxyGenerationTest.php
@@ -20,7 +20,7 @@ use Greenlight\Tests\Fixture\Doubles\ProxyFileProbe;
 use Greenlight\Tests\Fixture\Doubles\SelfConstantDefault;
 use Greenlight\Tests\Fixture\Doubles\StaticMethodFixture;
 use Greenlight\Tests\Fixture\Doubles\Wide;
-use Greenlight\Tests\Support\Subprocess;
+use Greenlight\Tests\Support\PhpSubprocess;
 
 final readonly class ProxyGenerationTest
 {
@@ -52,8 +52,7 @@ final readonly class ProxyGenerationTest
     {
         $root = \dirname(__DIR__, 3);
         $temporaryRoot = $this->tempDirectory->subdirectory('default-proxy-cache');
-        $result = Subprocess::run($root, [
-            \PHP_BINARY,
+        $result = PhpSubprocess::run($root, [
             '-d',
             'sys_temp_dir=' . $temporaryRoot,
             '-r',

--- a/tests/Unit/Doubles/ProxyStorageTest.php
+++ b/tests/Unit/Doubles/ProxyStorageTest.php
@@ -16,7 +16,7 @@ use Greenlight\Internal\Php\ErrorTrap;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Fixture\Doubles\ProxyStorageContract;
 use Greenlight\Tests\Support\FilesystemRestriction;
-use Greenlight\Tests\Support\Subprocess;
+use Greenlight\Tests\Support\PhpSubprocess;
 
 final readonly class ProxyStorageTest
 {
@@ -152,8 +152,7 @@ final readonly class ProxyStorageTest
     private function generatedProxyFileName(string $directory): string
     {
         $root = \dirname(__DIR__, 3);
-        $result = Subprocess::run($root, [
-            \PHP_BINARY,
+        $result = PhpSubprocess::run($root, [
             '-r',
             <<<'PHP'
             require $argv[1];

--- a/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorInitialAssignmentTest.php
+++ b/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorInitialAssignmentTest.php
@@ -15,6 +15,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\CollectingEventSink;
 use Greenlight\Tests\Support\NativeOrchestrator;
+use Greenlight\Tests\Support\PhpSubprocess;
 use Greenlight\Tests\Support\PlanEntryFixture;
 
 final readonly class OrchestratorInitialAssignmentTest
@@ -200,7 +201,7 @@ final readonly class OrchestratorInitialAssignmentTest
         );
 
         return NativeOrchestrator::create(
-            workerCommand: [\PHP_BINARY, '-r', $script],
+            workerCommand: PhpSubprocess::command(['-r', $script]),
             workingDirectory: $directory,
             resourceLimits: ['database' => 1],
             initialWorkerAssignment: $assignment,

--- a/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorRetirementTest.php
+++ b/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorRetirementTest.php
@@ -19,6 +19,7 @@ use Greenlight\Tests\Fixture\LeakSuite\CleanTest;
 use Greenlight\Tests\Fixture\ResourceScheduling\WaitingResourceTest;
 use Greenlight\Tests\Support\CollectingEventSink;
 use Greenlight\Tests\Support\NativeOrchestrator;
+use Greenlight\Tests\Support\PhpSubprocess;
 use Greenlight\Tests\Support\PlanEntryFixture;
 
 final readonly class OrchestratorRetirementTest
@@ -139,7 +140,7 @@ final readonly class OrchestratorRetirementTest
             $worker,
         );
 
-        return [\PHP_BINARY, '-r', $bootstrap];
+        return PhpSubprocess::command(['-r', $bootstrap]);
     }
 
     /**

--- a/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorTest.php
+++ b/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorTest.php
@@ -31,6 +31,7 @@ use Greenlight\Tests\Fixture\Lifecycle\Bail\AaTest;
 use Greenlight\Tests\Fixture\Lifecycle\Bail\BbTest;
 use Greenlight\Tests\Support\CollectingEventSink;
 use Greenlight\Tests\Support\NativeOrchestrator;
+use Greenlight\Tests\Support\PhpSubprocess;
 use Greenlight\Tests\Support\PlanEntryFixture;
 use Greenlight\Tests\Support\ScriptedWorkerTransport;
 
@@ -44,7 +45,7 @@ final class OrchestratorTest
         // socket. It represents a worker that cannot complete interpreter
         // startup on a machine without available resources.
         $orchestrator = NativeOrchestrator::create(
-            workerCommand: [\PHP_BINARY, '-r', 'fwrite(STDERR, "booting, honest"); sleep(60);'],
+            workerCommand: PhpSubprocess::command(['-r', 'fwrite(STDERR, "booting, honest"); sleep(60);']),
             workingDirectory: \sys_get_temp_dir(),
             connectDeadlineSeconds: 0.5,
         );
@@ -59,7 +60,7 @@ final class OrchestratorTest
         $missingDirectory = \sys_get_temp_dir()
             . '/greenlight-missing-' . \bin2hex(\random_bytes(8));
         $orchestrator = NativeOrchestrator::create(
-            workerCommand: [\PHP_BINARY, 'bin/greenlight'],
+            workerCommand: PhpSubprocess::command(['bin/greenlight']),
             workingDirectory: $missingDirectory,
         );
 
@@ -106,7 +107,7 @@ final class OrchestratorTest
             \var_export($root . '/vendor/autoload.php', true),
         );
         $orchestrator = NativeOrchestrator::create(
-            workerCommand: [\PHP_BINARY, '-r', $script],
+            workerCommand: PhpSubprocess::command(['-r', $script]),
             workingDirectory: $root,
         );
         $sink = new CollectingEventSink();
@@ -134,7 +135,7 @@ final class OrchestratorTest
             DisconnectBeforeAssignmentWorker::class,
         );
         $orchestrator = NativeOrchestrator::create(
-            workerCommand: [\PHP_BINARY, '-r', $bootstrap],
+            workerCommand: PhpSubprocess::command(['-r', $bootstrap]),
             workingDirectory: $root,
         );
         $sink = new CollectingEventSink();
@@ -174,7 +175,7 @@ final class OrchestratorTest
             PHP;
 
         $orchestrator = NativeOrchestrator::create(
-            workerCommand: [\PHP_BINARY, '-r', $script],
+            workerCommand: PhpSubprocess::command(['-r', $script]),
             workingDirectory: \sys_get_temp_dir(),
             progressDeadlineSeconds: 0.5,
         );
@@ -250,7 +251,7 @@ final class OrchestratorTest
         $root = \dirname(__DIR__, 5);
         $sink = new CollectingEventSink();
         $orchestrator = NativeOrchestrator::create(
-            workerCommand: [\PHP_BINARY, $root . '/bin/greenlight'],
+            workerCommand: PhpSubprocess::command([$root . '/bin/greenlight']),
             workingDirectory: $root,
             stopAfterFailures: 1,
         );
@@ -284,7 +285,7 @@ final class OrchestratorTest
         $root = \dirname(__DIR__, 5);
         $sink = new CollectingEventSink();
         $orchestrator = NativeOrchestrator::create(
-            workerCommand: [\PHP_BINARY, $root . '/bin/greenlight'],
+            workerCommand: PhpSubprocess::command([$root . '/bin/greenlight']),
             workingDirectory: $root,
         );
 
@@ -312,7 +313,7 @@ final class OrchestratorTest
         $root = \dirname(__DIR__, 5);
         $sink = new CollectingEventSink();
         $orchestrator = NativeOrchestrator::create(
-            workerCommand: [\PHP_BINARY, $root . '/bin/greenlight'],
+            workerCommand: PhpSubprocess::command([$root . '/bin/greenlight']),
             workingDirectory: $root,
         );
 
@@ -348,7 +349,7 @@ final class OrchestratorTest
         $root = \dirname(__DIR__, 5);
         $sink = new CollectingEventSink();
         $orchestrator = NativeOrchestrator::create(
-            workerCommand: [\PHP_BINARY, $root . '/bin/greenlight'],
+            workerCommand: PhpSubprocess::command([$root . '/bin/greenlight']),
             workingDirectory: $root,
         );
 

--- a/tests/Unit/Execution/ProcessPool/Orchestrator/WorkerHandleRetirementTest.php
+++ b/tests/Unit/Execution/ProcessPool/Orchestrator/WorkerHandleRetirementTest.php
@@ -13,6 +13,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Internal\Php\ErrorTrap;
 use Greenlight\Tests\Support\ConnectedStreamPair;
+use Greenlight\Tests\Support\PhpSubprocess;
 
 final readonly class WorkerHandleRetirementTest
 {
@@ -69,7 +70,7 @@ final readonly class WorkerHandleRetirementTest
     private function handle(string $script): array
     {
         $process = \proc_open(
-            [\PHP_BINARY, '-r', $script],
+            PhpSubprocess::command(['-r', $script]),
             [
                 0 => ['pipe', 'r'],
                 1 => ['pipe', 'w'],

--- a/tests/Unit/Execution/ProcessPool/Orchestrator/WorkerHandleTerminationTest.php
+++ b/tests/Unit/Execution/ProcessPool/Orchestrator/WorkerHandleTerminationTest.php
@@ -12,6 +12,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Internal\Php\ErrorTrap;
 use Greenlight\Tests\Support\ConnectedStreamPair;
+use Greenlight\Tests\Support\PhpSubprocess;
 
 final readonly class WorkerHandleTerminationTest
 {
@@ -25,11 +26,10 @@ final readonly class WorkerHandleTerminationTest
 
         try {
             $process = \proc_open(
-                [
-                    \PHP_BINARY,
+                PhpSubprocess::command([
                     '-r',
                     'fwrite(STDOUT, "ready\n"); fflush(STDOUT); while (true) { usleep(10000); }',
-                ],
+                ]),
                 [
                     0 => ['pipe', 'r'],
                     1 => ['pipe', 'w'],

--- a/tests/Unit/Execution/ProcessPool/Worker/WorkerArtifactSessionTest.php
+++ b/tests/Unit/Execution/ProcessPool/Worker/WorkerArtifactSessionTest.php
@@ -12,7 +12,7 @@ use Greenlight\Expect\Fail;
 use Greenlight\Sandbox\EnvironmentVariables;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Test\Cleanup;
-use Greenlight\Tests\Support\Subprocess;
+use Greenlight\Tests\Support\PhpSubprocess;
 
 final readonly class WorkerArtifactSessionTest
 {
@@ -28,8 +28,7 @@ final readonly class WorkerArtifactSessionTest
     {
         $root = \dirname(__DIR__, 5);
         $artifactRoot = $this->tempDirectory->subdirectory('worker-artifact-session');
-        $server = Subprocess::start($root, [
-            \PHP_BINARY,
+        $server = PhpSubprocess::start($root, [
             '-r',
             <<<'PHP'
             require $argv[1];

--- a/tests/Unit/Execution/ProcessPool/Worker/WorkerProcessFatalSendFailureTest.php
+++ b/tests/Unit/Execution/ProcessPool/Worker/WorkerProcessFatalSendFailureTest.php
@@ -12,7 +12,7 @@ use Greenlight\Expect\Fail;
 use Greenlight\Sandbox\EnvironmentVariables;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Test\Cleanup;
-use Greenlight\Tests\Support\Subprocess;
+use Greenlight\Tests\Support\PhpSubprocess;
 
 final readonly class WorkerProcessFatalSendFailureTest
 {
@@ -31,8 +31,7 @@ final readonly class WorkerProcessFatalSendFailureTest
         $config = $temporaryDirectory . '/failing-config.php';
         $ready = $temporaryDirectory . '/failing-config-ready';
         $release = $temporaryDirectory . '/failing-config-release';
-        $server = Subprocess::start($root, [
-            \PHP_BINARY,
+        $server = PhpSubprocess::start($root, [
             '-r',
             <<<'PHP'
             require $argv[1];

--- a/tests/Unit/Execution/ProcessPool/Worker/WorkerProcessTest.php
+++ b/tests/Unit/Execution/ProcessPool/Worker/WorkerProcessTest.php
@@ -15,7 +15,7 @@ use Greenlight\Expect\Fail;
 use Greenlight\Sandbox\EnvironmentVariables;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Test\Cleanup;
-use Greenlight\Tests\Support\Subprocess;
+use Greenlight\Tests\Support\PhpSubprocess;
 
 final readonly class WorkerProcessTest
 {
@@ -31,8 +31,7 @@ final readonly class WorkerProcessTest
         $root = \dirname(__DIR__, 5);
         $address = 'unix://' . $this->tempDirectory->path() . '/missing-worker.sock';
 
-        $result = Subprocess::run($root, [
-            \PHP_BINARY,
+        $result = PhpSubprocess::run($root, [
             '-r',
             <<<'PHP'
             require $argv[1];
@@ -83,8 +82,7 @@ final readonly class WorkerProcessTest
     {
         $root = \dirname(__DIR__, 5);
         $missingConfig = $this->tempDirectory->path() . '/missing-config.php';
-        $server = Subprocess::start($root, [
-            \PHP_BINARY,
+        $server = PhpSubprocess::start($root, [
             '-r',
             <<<'PHP'
             require $argv[1];
@@ -246,8 +244,7 @@ final readonly class WorkerProcessTest
     private function runScenario(string $scenario, string $environmentChannel = '1'): array
     {
         $root = \dirname(__DIR__, 5);
-        $server = Subprocess::start($root, [
-            \PHP_BINARY,
+        $server = PhpSubprocess::start($root, [
             '-r',
             <<<'PHP'
             require $argv[1];

--- a/tests/Unit/Execution/RunCoordinatorTest.php
+++ b/tests/Unit/Execution/RunCoordinatorTest.php
@@ -33,6 +33,7 @@ use Greenlight\Test\TestSelection;
 use Greenlight\Tests\Fixture\Plugins\RecordingRunSubscriber;
 use Greenlight\Tests\Support\CollectingEventSink;
 use Greenlight\Tests\Support\FixturePath;
+use Greenlight\Tests\Support\PhpSubprocess;
 use Greenlight\Tests\Support\ScriptedWorkerTransport;
 
 final readonly class RunCoordinatorTest
@@ -93,7 +94,7 @@ final readonly class RunCoordinatorTest
             [$fixtureDirectory],
             $sink,
             new ProcessPoolExecution(
-                [\PHP_BINARY, $root . '/bin/greenlight'],
+                PhpSubprocess::command([$root . '/bin/greenlight']),
                 $this->tempDirectory->path(),
                 2,
                 $resolved->workers,
@@ -123,7 +124,7 @@ final readonly class RunCoordinatorTest
             [FixturePath::get('DiscoveryBasic')],
             new CollectingEventSink(),
             new ProcessPoolExecution(
-                [\PHP_BINARY, \dirname(__DIR__, 3) . '/bin/greenlight'],
+                PhpSubprocess::command([\dirname(__DIR__, 3) . '/bin/greenlight']),
                 $this->tempDirectory->path(),
                 2,
                 $resolved->workers,

--- a/tests/Unit/Execution/Worker/Capture/OutputCaptureTest.php
+++ b/tests/Unit/Execution/Worker/Capture/OutputCaptureTest.php
@@ -11,7 +11,7 @@ use Greenlight\Execution\Worker\OutputCapture;
 use Greenlight\Expect\Expect;
 use Greenlight\Result\DiagnosticSeverity;
 use Greenlight\Test\Cleanup;
-use Greenlight\Tests\Support\Subprocess;
+use Greenlight\Tests\Support\PhpSubprocess;
 
 final readonly class OutputCaptureTest
 {
@@ -368,8 +368,7 @@ final readonly class OutputCaptureTest
     public function aNonRemovableNestedBufferDoesNotHangStop(): void
     {
         $root = \dirname(__DIR__, 5);
-        $process = Subprocess::start($root, [
-            \PHP_BINARY,
+        $process = PhpSubprocess::start($root, [
             '-r',
             <<<'PHP_WRAP'
             require $argv[1];

--- a/tests/Unit/Execution/Worker/LeakDetectorWhitespaceIniModeTest.php
+++ b/tests/Unit/Execution/Worker/LeakDetectorWhitespaceIniModeTest.php
@@ -7,7 +7,7 @@ namespace Greenlight\Tests\Unit\Execution\Worker;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Test\SkipTest;
-use Greenlight\Tests\Support\Subprocess;
+use Greenlight\Tests\Support\PhpSubprocess;
 
 final readonly class LeakDetectorWhitespaceIniModeTest
 {
@@ -19,10 +19,9 @@ final readonly class LeakDetectorWhitespaceIniModeTest
         }
 
         $root = \dirname(__DIR__, 4);
-        $result = Subprocess::run(
+        $result = PhpSubprocess::run(
             $root,
             [
-                \PHP_BINARY,
                 '-d',
                 'xdebug.mode=coverage, develop',
                 '-d',

--- a/tests/Unit/Execution/Worker/WorkerCaptureCleanupTest.php
+++ b/tests/Unit/Execution/Worker/WorkerCaptureCleanupTest.php
@@ -6,7 +6,7 @@ namespace Greenlight\Tests\Unit\Execution\Worker;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
-use Greenlight\Tests\Support\Subprocess;
+use Greenlight\Tests\Support\PhpSubprocess;
 
 final readonly class WorkerCaptureCleanupTest
 {
@@ -14,8 +14,7 @@ final readonly class WorkerCaptureCleanupTest
     public function captureFailureStillRunsAllCleanupStages(): void
     {
         $root = \dirname(__DIR__, 4);
-        $process = Subprocess::start($root, [
-            \PHP_BINARY,
+        $process = PhpSubprocess::start($root, [
             '-r',
             <<<'PHP_WRAP'
             require $argv[1];

--- a/tests/Unit/Laravel/LaravelFrameworkUnavailableTest.php
+++ b/tests/Unit/Laravel/LaravelFrameworkUnavailableTest.php
@@ -6,8 +6,8 @@ namespace Greenlight\Tests\Unit\Laravel;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\PhpSubprocess;
 use Greenlight\Tests\Support\SourceOnlyPhp;
-use Greenlight\Tests\Support\Subprocess;
 
 final readonly class LaravelFrameworkUnavailableTest
 {
@@ -16,7 +16,7 @@ final readonly class LaravelFrameworkUnavailableTest
     {
         $root = \dirname(__DIR__, 3);
 
-        $result = Subprocess::run($root, SourceOnlyPhp::command(
+        $result = PhpSubprocess::run($root, SourceOnlyPhp::command(
             $root . '/src',
             <<<'PHP'
             if (class_exists(\Illuminate\Foundation\Application::class)) {

--- a/tests/Unit/Sandbox/TemporaryDirectoryRestrictedDisposalTest.php
+++ b/tests/Unit/Sandbox/TemporaryDirectoryRestrictedDisposalTest.php
@@ -7,7 +7,7 @@ namespace Greenlight\Tests\Unit\Sandbox;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
-use Greenlight\Tests\Support\Subprocess;
+use Greenlight\Tests\Support\PhpSubprocess;
 
 final readonly class TemporaryDirectoryRestrictedDisposalTest
 {
@@ -17,8 +17,7 @@ final readonly class TemporaryDirectoryRestrictedDisposalTest
     public function restrictedRootDisposalFailsWithoutEngineDiagnostics(): void
     {
         $root = \dirname(__DIR__, 3);
-        $result = Subprocess::run($root, [
-            \PHP_BINARY,
+        $result = PhpSubprocess::run($root, [
             '-r',
             <<<'PHP'
                 require $argv[1];

--- a/tests/Unit/Sandbox/TemporaryDirectoryTest.php
+++ b/tests/Unit/Sandbox/TemporaryDirectoryTest.php
@@ -14,7 +14,7 @@ use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Sandbox\TemporaryDirectoryError;
 use Greenlight\Test\SkipTest;
 use Greenlight\Tests\Support\FilesystemRestriction;
-use Greenlight\Tests\Support\Subprocess;
+use Greenlight\Tests\Support\PhpSubprocess;
 
 final class TemporaryDirectoryTest
 {
@@ -68,10 +68,9 @@ final class TemporaryDirectoryTest
 
         try {
             $root = \dirname(__DIR__, 3);
-            $result = Subprocess::run(
+            $result = PhpSubprocess::run(
                 $root,
                 [
-                    \PHP_BINARY,
                     '-r',
                     <<<'PHP'
                         require $argv[1];

--- a/tests/Unit/Support/PhpSubprocessTest.php
+++ b/tests/Unit/Support/PhpSubprocessTest.php
@@ -14,31 +14,15 @@ final readonly class PhpSubprocessTest
     public function __construct(private TemporaryDirectory $workspace) {}
 
     #[Test]
-    public function runSuppliesPhpAndTheRequiredEnvironment(): void
+    public function runSuppliesPhp(): void
     {
         $result = PhpSubprocess::run($this->workspace->path(), [
             '-r',
-            <<<'PHP_WRAP'
-            echo json_encode([
-                PHP_BINARY,
-                getenv('DD_TRACE_ENABLED'),
-                getenv('DD_TRACE_CLI_ENABLED'),
-                getenv('DD_TRACE_STARTUP_LOGS'),
-                getenv('DD_INSTRUMENTATION_TELEMETRY_ENABLED'),
-                extension_loaded('ddtrace') ? ini_get('ddtrace.disable') : 'not-loaded',
-            ], JSON_THROW_ON_ERROR);
-            PHP_WRAP,
+            'echo PHP_BINARY;',
         ]);
 
         Expect::that($result->exitCode)->toBe(0);
-        Expect::that($result->stdout)->toBe(\json_encode([
-            \PHP_BINARY,
-            '0',
-            '0',
-            '0',
-            '0',
-            \extension_loaded('ddtrace') ? '1' : 'not-loaded',
-        ], \JSON_THROW_ON_ERROR));
+        Expect::that($result->stdout)->toBe(\PHP_BINARY);
         Expect::that($result->stderr)->toBe('');
     }
 
@@ -64,30 +48,27 @@ final readonly class PhpSubprocessTest
             \PHP_BINARY,
             '-d',
             'precision=3',
-            '-d',
-            'ddtrace.disable=1',
             'probe.php',
             'program-argument',
         ]);
     }
 
     #[Test]
-    public function callerValuesDoNotOverrideTheRequiredEnvironment(): void
+    public function callerEnvironmentValuesReachTheProcess(): void
     {
         $result = PhpSubprocess::run(
             $this->workspace->path(),
             [
                 '-r',
-                'echo getenv("GREENLIGHT_PHP_PROCESS_PROBE") . ":" . getenv("DD_TRACE_ENABLED");',
+                'echo getenv("GREENLIGHT_PHP_PROCESS_PROBE");',
             ],
             [
                 'GREENLIGHT_PHP_PROCESS_PROBE' => 'caller',
-                'DD_TRACE_ENABLED' => '1',
             ],
         );
 
         Expect::that($result->exitCode)->toBe(0);
-        Expect::that($result->stdout)->toBe('caller:0');
+        Expect::that($result->stdout)->toBe('caller');
         Expect::that($result->stderr)->toBe('');
     }
 }

--- a/tests/Unit/Support/PhpSubprocessTest.php
+++ b/tests/Unit/Support/PhpSubprocessTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Support;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\PhpSubprocess;
+
+final readonly class PhpSubprocessTest
+{
+    public function __construct(private TemporaryDirectory $workspace) {}
+
+    #[Test]
+    public function runSuppliesPhpAndTheRequiredEnvironment(): void
+    {
+        $result = PhpSubprocess::run($this->workspace->path(), [
+            '-r',
+            <<<'PHP_WRAP'
+            echo json_encode([
+                PHP_BINARY,
+                getenv('DD_TRACE_ENABLED'),
+                getenv('DD_TRACE_CLI_ENABLED'),
+                getenv('DD_TRACE_STARTUP_LOGS'),
+                getenv('DD_INSTRUMENTATION_TELEMETRY_ENABLED'),
+                extension_loaded('ddtrace') ? ini_get('ddtrace.disable') : 'not-loaded',
+            ], JSON_THROW_ON_ERROR);
+            PHP_WRAP,
+        ]);
+
+        Expect::that($result->exitCode)->toBe(0);
+        Expect::that($result->stdout)->toBe(\json_encode([
+            \PHP_BINARY,
+            '0',
+            '0',
+            '0',
+            '0',
+            \extension_loaded('ddtrace') ? '1' : 'not-loaded',
+        ], \JSON_THROW_ON_ERROR));
+        Expect::that($result->stderr)->toBe('');
+    }
+
+    #[Test]
+    public function runPreservesTheProcessOutput(): void
+    {
+        $result = PhpSubprocess::run($this->workspace->path(), [
+            '-r',
+            'fwrite(STDOUT, "stdout:exact"); fwrite(STDERR, "stderr:exact");',
+        ]);
+
+        Expect::that($result->stdout)->toBe('stdout:exact');
+        Expect::that($result->stderr)->toBe('stderr:exact');
+    }
+
+    #[Test]
+    public function commandPlacesPhpArgumentsBeforeTheProgram(): void
+    {
+        Expect::that(PhpSubprocess::command(
+            ['probe.php', 'program-argument'],
+            ['-d', 'precision=3'],
+        ))->toBe([
+            \PHP_BINARY,
+            '-d',
+            'precision=3',
+            '-d',
+            'ddtrace.disable=1',
+            'probe.php',
+            'program-argument',
+        ]);
+    }
+
+    #[Test]
+    public function callerValuesDoNotOverrideTheRequiredEnvironment(): void
+    {
+        $result = PhpSubprocess::run(
+            $this->workspace->path(),
+            [
+                '-r',
+                'echo getenv("GREENLIGHT_PHP_PROCESS_PROBE") . ":" . getenv("DD_TRACE_ENABLED");',
+            ],
+            [
+                'GREENLIGHT_PHP_PROCESS_PROBE' => 'caller',
+                'DD_TRACE_ENABLED' => '1',
+            ],
+        );
+
+        Expect::that($result->exitCode)->toBe(0);
+        Expect::that($result->stdout)->toBe('caller:0');
+        Expect::that($result->stderr)->toBe('');
+    }
+}

--- a/tests/Unit/Support/SubprocessTest.php
+++ b/tests/Unit/Support/SubprocessTest.php
@@ -10,8 +10,8 @@ use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Test\Cleanup;
 use Greenlight\Test\SkipTest;
+use Greenlight\Tests\Support\PhpSubprocess;
 use Greenlight\Tests\Support\ProcessResult;
-use Greenlight\Tests\Support\Subprocess;
 
 final readonly class SubprocessTest
 {
@@ -23,10 +23,9 @@ final readonly class SubprocessTest
     #[Test]
     public function runCapturesTheResultAndHonorsItsExecutionContext(): void
     {
-        $result = Subprocess::run(
+        $result = PhpSubprocess::run(
             $this->workspace->path(),
             [
-                \PHP_BINARY,
                 '-r',
                 <<<'PHP'
                 fwrite(STDOUT, getcwd() . "\r\n" . getenv('GREENLIGHT_SUBPROCESS_PROBE') . "\r\n");
@@ -53,10 +52,9 @@ final readonly class SubprocessTest
     #[Test]
     public function runDrainsLargeOutputsFromBothStreams(): void
     {
-        $result = Subprocess::run(
+        $result = PhpSubprocess::run(
             $this->workspace->path(),
             [
-                \PHP_BINARY,
                 '-r',
                 <<<'PHP'
                 fwrite(STDOUT, str_repeat('o', 131072));
@@ -72,10 +70,9 @@ final readonly class SubprocessTest
     #[Test]
     public function interactiveProcessAcceptsInputAndReturnsItsFinalResult(): void
     {
-        $process = Subprocess::start(
+        $process = PhpSubprocess::start(
             $this->workspace->path(),
             [
-                \PHP_BINARY,
                 '-r',
                 <<<'PHP'
                 fwrite(STDOUT, "ready\n");
@@ -103,10 +100,9 @@ final readonly class SubprocessTest
     public function interactiveProcessReceivesTheCompleteInput(): void
     {
         $input = \str_repeat('payload', 131_072);
-        $process = Subprocess::start(
+        $process = PhpSubprocess::start(
             $this->workspace->path(),
             [
-                \PHP_BINARY,
                 '-r',
                 <<<'PHP'
                 $input = stream_get_contents(STDIN);
@@ -129,9 +125,9 @@ final readonly class SubprocessTest
     #[Test]
     public function readStdoutUntilReportsAProcessThatAlreadyExited(): void
     {
-        $process = Subprocess::start(
+        $process = PhpSubprocess::start(
             $this->workspace->path(),
-            [\PHP_BINARY, '-r', 'fwrite(STDERR, "failed\n"); exit(9);'],
+            ['-r', 'fwrite(STDERR, "failed\n"); exit(9);'],
         );
         $this->cleanup->defer($process->terminate(...));
 
@@ -147,9 +143,9 @@ final readonly class SubprocessTest
     #[Test]
     public function waitReportsWhenTheProcessMissesItsDeadline(): void
     {
-        $process = Subprocess::start(
+        $process = PhpSubprocess::start(
             $this->workspace->path(),
-            [\PHP_BINARY, '-r', 'usleep(2_000_000);'],
+            ['-r', 'usleep(2_000_000);'],
         );
         $this->cleanup->defer($process->terminate(...));
 
@@ -161,10 +157,9 @@ final readonly class SubprocessTest
     #[DataSet('nonFiniteTimeouts')]
     public function deadlineOperationsRejectNonFiniteTimeouts(string $operation, float $timeoutSeconds): void
     {
-        $process = Subprocess::start(
+        $process = PhpSubprocess::start(
             $this->workspace->path(),
             [
-                \PHP_BINARY,
                 '-r',
                 $operation === 'wait' ? 'exit(0);' : 'fwrite(STDOUT, "ready");',
             ],
@@ -202,10 +197,9 @@ final readonly class SubprocessTest
             throw new SkipTest('The pcntl extension is not available.');
         }
 
-        $process = Subprocess::start(
+        $process = PhpSubprocess::start(
             $this->workspace->path(),
             [
-                \PHP_BINARY,
                 '-r',
                 <<<'PHP'
                 $pid = pcntl_fork();

--- a/tests/Unit/Tempest/TempestFrameworkUnavailableTest.php
+++ b/tests/Unit/Tempest/TempestFrameworkUnavailableTest.php
@@ -6,8 +6,8 @@ namespace Greenlight\Tests\Unit\Tempest;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\PhpSubprocess;
 use Greenlight\Tests\Support\SourceOnlyPhp;
-use Greenlight\Tests\Support\Subprocess;
 
 final readonly class TempestFrameworkUnavailableTest
 {
@@ -16,7 +16,7 @@ final readonly class TempestFrameworkUnavailableTest
     {
         $root = \dirname(__DIR__, 3);
 
-        $result = Subprocess::run($root, SourceOnlyPhp::command(
+        $result = PhpSubprocess::run($root, SourceOnlyPhp::command(
             $root . '/src',
             <<<'PHP'
             if (class_exists(\Tempest\Core\FrameworkKernel::class)) {

--- a/tests/Unit/Tools/RuntimeMessageTest.php
+++ b/tests/Unit/Tools/RuntimeMessageTest.php
@@ -7,7 +7,7 @@ namespace Greenlight\Tests\Unit\Tools;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
-use Greenlight\Tests\Support\Subprocess;
+use Greenlight\Tests\Support\PhpSubprocess;
 
 final readonly class RuntimeMessageTest
 {
@@ -18,9 +18,9 @@ final readonly class RuntimeMessageTest
     {
         [$root, $script] = $this->toolSandbox('coverage-missing', 'coverage-gate.php');
         $summary = $root . '/summary.md';
-        $result = Subprocess::run(
+        $result = PhpSubprocess::run(
             $root,
-            [\PHP_BINARY, $script],
+            [$script],
             ['GITHUB_STEP_SUMMARY' => $summary],
         );
 
@@ -42,9 +42,9 @@ final readonly class RuntimeMessageTest
     {
         [$root, $script] = $this->toolSandbox('coverage-summary-write', 'coverage-gate.php');
         $summaryDirectory = $this->tempDirectory->subdirectory('coverage-summary-write/summary');
-        $result = Subprocess::run(
+        $result = PhpSubprocess::run(
             $root,
-            [\PHP_BINARY, $script],
+            [$script],
             ['GITHUB_STEP_SUMMARY' => $summaryDirectory],
         );
 
@@ -58,7 +58,7 @@ final readonly class RuntimeMessageTest
     public function phpStanExtractionReportsMissingAndExtractedSourcesExactly(): void
     {
         [$missingRoot, $missingScript] = $this->toolSandbox('phpstan-missing', 'extract-phpstan-api.php');
-        $missing = Subprocess::run($missingRoot, [\PHP_BINARY, $missingScript]);
+        $missing = PhpSubprocess::run($missingRoot, [$missingScript]);
 
         Expect::that($missing->exitCode)->toBe(0);
         Expect::that($missing->stdout)->toBe(
@@ -68,10 +68,9 @@ final readonly class RuntimeMessageTest
         [$successRoot, $successScript] = $this->toolSandbox('phpstan-success', 'extract-phpstan-api.php');
         $pharPath = $successRoot . '/vendor/phpstan/phpstan/phpstan.phar';
         \mkdir(\dirname($pharPath), 0o777, true);
-        $builder = Subprocess::run(
+        $builder = PhpSubprocess::run(
             $successRoot,
             [
-                \PHP_BINARY,
                 '-d',
                 'phar.readonly=0',
                 '-r',
@@ -88,7 +87,7 @@ final readonly class RuntimeMessageTest
 
         Expect::that($builder->exitCode)->toBe(0);
 
-        $success = Subprocess::run($successRoot, [\PHP_BINARY, $successScript]);
+        $success = PhpSubprocess::run($successRoot, [$successScript]);
         $target = \realpath($successRoot) . '/.phpstan-api-stubs';
 
         Expect::that($success->exitCode)->toBe(0);
@@ -112,8 +111,7 @@ final readonly class RuntimeMessageTest
             . "to each available worker before the test run starts in parallel.\n",
         );
         $script = $this->repositoryRoot() . '/tools/prose-check.php';
-        $sentence = Subprocess::run($root, [
-            \PHP_BINARY,
+        $sentence = PhpSubprocess::run($root, [
             $script,
             'check',
             '--root=' . $root,
@@ -125,8 +123,7 @@ final readonly class RuntimeMessageTest
         );
 
         \file_put_contents($root . '/sample.md', "# Sample\n\nThe worker stops.\n");
-        $removedOption = Subprocess::run($root, [
-            \PHP_BINARY,
+        $removedOption = PhpSubprocess::run($root, [
             $script,
             'check',
             '--root=' . $root,
@@ -141,7 +138,7 @@ final readonly class RuntimeMessageTest
     public function memoryGateReportsMissingSamplesAndTheFinalMeasurementsExactly(): void
     {
         [$missingRoot, $missingScript] = $this->toolSandbox('memory-missing', 'memory-gate.php');
-        $missing = Subprocess::run($missingRoot, [\PHP_BINARY, $missingScript]);
+        $missing = PhpSubprocess::run($missingRoot, [$missingScript]);
 
         Expect::that($missing->exitCode)->toBe(1);
         Expect::that($missing->stderr)->toContain(
@@ -165,7 +162,7 @@ final readonly class RuntimeMessageTest
             PHP,
         );
 
-        $success = Subprocess::run($successRoot, [\PHP_BINARY, $successScript]);
+        $success = PhpSubprocess::run($successRoot, [$successScript]);
 
         Expect::that($success->exitCode)->toBe(0);
         Expect::that($success->stdout)->toContain(
@@ -180,8 +177,7 @@ final readonly class RuntimeMessageTest
         [$root, $script] = $this->toolSandbox('memory-directory', 'memory-gate.php');
         $blockedTemp = $root . '/not-a-directory';
         \file_put_contents($blockedTemp, 'blocked');
-        $result = Subprocess::run($root, [
-            \PHP_BINARY,
+        $result = PhpSubprocess::run($root, [
             '-d',
             'sys_temp_dir=' . $blockedTemp,
             $script,
@@ -198,8 +194,7 @@ final readonly class RuntimeMessageTest
         [$blockedRoot, $blockedScript] = $this->toolSandbox('benchmark-directory', 'benchmark.php');
         $blockedTemp = $blockedRoot . '/not-a-directory';
         \file_put_contents($blockedTemp, 'blocked');
-        $directoryFailure = Subprocess::run($blockedRoot, [
-            \PHP_BINARY,
+        $directoryFailure = PhpSubprocess::run($blockedRoot, [
             '-d',
             'sys_temp_dir=' . $blockedTemp,
             $blockedScript,
@@ -221,10 +216,9 @@ final readonly class RuntimeMessageTest
         \chmod($fakeBin . '/composer', 0o700);
         $benchmarkTemp = $this->tempDirectory->subdirectory('benchmark-composer/temp');
         $path = \getenv('PATH');
-        $composerFailure = Subprocess::run(
+        $composerFailure = PhpSubprocess::run(
             $this->repositoryRoot(),
             [
-                \PHP_BINARY,
                 '-d',
                 'sys_temp_dir=' . $benchmarkTemp,
                 $this->repositoryRoot() . '/tools/benchmark.php',


### PR DESCRIPTION
Add one PHP-specific subprocess seam for tests.

- Supply PHP_BINARY for each PHP test process.
- Support caller PHP arguments and environment values without shell parsing.
- Migrate PHP CLI, probe, tool, and worker commands while retaining Subprocess for non-PHP commands.
- Add focused coverage for binary selection, environment forwarding, exact output, and argument placement.