### PR TITLE
test: add minimal acceptance project presets

### DIFF
--- a/tests/Acceptance/CliTest.php
+++ b/tests/Acceptance/CliTest.php
@@ -73,10 +73,10 @@ final readonly class CliTest
     #[Test]
     public function runExecutesAPassingSuiteAndExitsZero(): void
     {
-        $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'cli');
+        $project = AcceptanceProject::createWithOnePassingTest($this->tempDirectory, 'cli-run');
         $result = GreenlightCli::run($project->directory, ['run']);
         Expect::that($result->exitCode)->because('run executes a passing suite and exits zero')->toBe(0);
-        Expect::that($result->output())->because('run executes a passing suite and exits zero')->toContain('7 tests, 7 passed');
+        Expect::that($result->output())->because('run executes a passing suite and exits zero')->toContain('1 test, 1 passed');
         Expect::that($result->output())->because('run executes a passing suite and exits zero')->not()->toContain('alpha:one');
     }
 
@@ -87,11 +87,11 @@ final readonly class CliTest
         // output with or without the flag. This verifies the flags and the
         // no-escape contract. TerminalCapabilitiesTest and TtyReporterTest
         // verify terminal behavior.
-        $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'cli');
+        $project = AcceptanceProject::createWithOnePassingTest($this->tempDirectory, 'cli-output-flags');
         $result = GreenlightCli::run($project->directory, ['run', '--no-ansi', '--verbose']);
         Expect::that($result->exitCode)->because('no ANSI and verbose are accepted and output stays escape free')->toBe(0);
         Expect::that($result->output())->because('no ANSI and verbose are accepted and output stays escape free')->not()->toContain("\x1b[");
-        Expect::that($result->output())->because('no ANSI and verbose are accepted and output stays escape free')->toContain('7 tests, 7 passed');
+        Expect::that($result->output())->because('no ANSI and verbose are accepted and output stays escape free')->toContain('1 test, 1 passed');
     }
 
     #[Test]

--- a/tests/Acceptance/ProfileRunTest.php
+++ b/tests/Acceptance/ProfileRunTest.php
@@ -18,9 +18,7 @@ final readonly class ProfileRunTest
     public function liveProfileAndOfflineReportAgree(): void
     {
         $root = \dirname(__DIR__, 2);
-        // An isolated project prevents a conflict with another acceptance
-        // test in the same directory.
-        $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'profile');
+        $project = AcceptanceProject::createWithTwoPassingTests($this->tempDirectory, 'profile');
         $artifact = $project->path('profile.jsonl');
 
         $result = GreenlightCli::run(

--- a/tests/Acceptance/ReporterSelectionTest.php
+++ b/tests/Acceptance/ReporterSelectionTest.php
@@ -17,7 +17,7 @@ final readonly class ReporterSelectionTest
     #[Test]
     public function unknownReporterFailsBeforeTheTestRunStarts(): void
     {
-        $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'unknown-reporter');
+        $project = AcceptanceProject::createWithOnePassingTest($this->tempDirectory, 'unknown-reporter');
         $result = GreenlightCli::run($project->directory, ['run', '--no-ansi', '--reporter=unknown']);
 
         Expect::that($result->exitCode)
@@ -36,7 +36,7 @@ final readonly class ReporterSelectionTest
     #[Test]
     public function explicitTtyReporterRunsWithoutAnInteractiveTerminal(): void
     {
-        $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'tty-reporter');
+        $project = AcceptanceProject::createWithOnePassingTest($this->tempDirectory, 'tty-reporter');
         $result = GreenlightCli::run(
             $project->directory,
             ['run', '--workers=1', '--no-ansi', '--reporter=tty'],
@@ -46,7 +46,7 @@ final readonly class ReporterSelectionTest
             ->because('an explicitly selected TTY reporter MUST run without a terminal')
             ->toBe(0);
         Expect::that($result->stdout)
-            ->toContain('7 tests, 7 passed')
+            ->toContain('1 test, 1 passed')
             ->not()
             ->toContain("\x1b[");
         Expect::that($result->stderr)
@@ -56,7 +56,7 @@ final readonly class ReporterSelectionTest
     #[Test]
     public function reportersCanWriteToSeparateStandardAndFileOutputs(): void
     {
-        $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'reporter-file-output');
+        $project = AcceptanceProject::createWithOnePassingTest($this->tempDirectory, 'reporter-file-output');
         $junit = $project->path('reports/junit.xml');
         $result = GreenlightCli::run(
             $project->directory,
@@ -66,20 +66,20 @@ final readonly class ReporterSelectionTest
         Expect::that($result->exitCode)->toBe(0);
         Expect::that($result->stdout)
             ->because('the reporter without a file MUST continue to use standard output')
-            ->toContain('7 tests, 7 passed')
+            ->toContain('1 test, 1 passed')
             ->not()
             ->toContain('<?xml');
         Expect::that((string) \file_get_contents($junit))
             ->because('the reporter file path MUST resolve from the command working directory')
             ->toStartWith("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
-            ->toContain('<testsuites name="greenlight" tests="7"');
+            ->toContain('<testsuites name="greenlight" tests="1"');
         Expect::that($result->stderr)->toBe('');
     }
 
     #[Test]
     public function aFileTtyReporterUsesAppendOnlyOutput(): void
     {
-        $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'file-tty-reporter');
+        $project = AcceptanceProject::createWithOnePassingTest($this->tempDirectory, 'file-tty-reporter');
         $report = $project->path('reports/tty.txt');
         $result = GreenlightCli::run(
             $project->directory,
@@ -90,7 +90,7 @@ final readonly class ReporterSelectionTest
         Expect::that($result->stdout)->toBe('');
         Expect::that((string) \file_get_contents($report))
             ->because('a file is not an interactive terminal')
-            ->toContain('7 tests, 7 passed')
+            ->toContain('1 test, 1 passed')
             ->not()
             ->toContain("\x1b[");
         Expect::that($result->stderr)->toBe('');
@@ -99,7 +99,7 @@ final readonly class ReporterSelectionTest
     #[Test]
     public function anEmptyReporterFileIsAUsageError(): void
     {
-        $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'empty-reporter-file');
+        $project = AcceptanceProject::createWithOnePassingTest($this->tempDirectory, 'empty-reporter-file');
         $result = GreenlightCli::run($project->directory, ['run', '--reporter=junit=']);
 
         Expect::that($result->exitCode)->toBe(64);
@@ -111,7 +111,7 @@ final readonly class ReporterSelectionTest
     #[Test]
     public function anUnknownReporterDoesNotCreateItsOutputDirectory(): void
     {
-        $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'unknown-file-reporter');
+        $project = AcceptanceProject::createWithOnePassingTest($this->tempDirectory, 'unknown-file-reporter');
         $directory = $project->path('reports');
         $result = GreenlightCli::run($project->directory, ['run', '--reporter=unknown=reports/output.txt']);
 
@@ -127,7 +127,7 @@ final readonly class ReporterSelectionTest
     #[Test]
     public function reportersCannotShareOneFile(): void
     {
-        $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'duplicate-reporter-file');
+        $project = AcceptanceProject::createWithOnePassingTest($this->tempDirectory, 'duplicate-reporter-file');
         $result = GreenlightCli::run($project->directory, [
             'run',
             '--reporter=plain=report.txt',
@@ -146,7 +146,7 @@ final readonly class ReporterSelectionTest
     #[Test]
     public function anUnavailableReporterFileStopsBeforeTheTestRun(): void
     {
-        $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'unavailable-reporter-file');
+        $project = AcceptanceProject::createWithOnePassingTest($this->tempDirectory, 'unavailable-reporter-file');
         $project->writeFile('blocked', 'not a directory');
         $result = GreenlightCli::run($project->directory, ['run', '--reporter=junit=blocked/junit.xml']);
 

--- a/tests/Acceptance/SequentialFallbackTest.php
+++ b/tests/Acceptance/SequentialFallbackTest.php
@@ -19,9 +19,7 @@ final readonly class SequentialFallbackTest
     #[DataSet('unavailableParallelCapabilities')]
     public function unavailableParallelCapabilitiesFallBackToInProcess(string $function): void
     {
-        // An isolated project prevents a conflict with another acceptance
-        // test in the same directory.
-        $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'sequential-fallback');
+        $project = AcceptanceProject::createWithOnePassingTest($this->tempDirectory, 'sequential-fallback');
         $result = GreenlightCli::run(
             $project->directory,
             ['run', '--workers=4', '--reporter=plain'],
@@ -31,7 +29,7 @@ final readonly class SequentialFallbackTest
         Expect::that($result->exitCode)
             ->because(\sprintf('the runner uses in-process execution when PHP disables %s', $function))
             ->toBe(0);
-        Expect::that($result->output())->toContain('7 tests, 7 passed')
+        Expect::that($result->output())->toContain('1 test, 1 passed')
             ->not()->toContain($function);
     }
 

--- a/tests/Acceptance/TeamCityRunTest.php
+++ b/tests/Acceptance/TeamCityRunTest.php
@@ -7,9 +7,7 @@ namespace Greenlight\Tests\Acceptance;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
-use Greenlight\Tests\Fixture\DiscoveryBasic\AlphaTest;
 use Greenlight\Tests\Support\AcceptanceProject;
-use Greenlight\Tests\Support\ClassFile;
 use Greenlight\Tests\Support\GreenlightCli;
 
 final readonly class TeamCityRunTest
@@ -19,20 +17,17 @@ final readonly class TeamCityRunTest
     #[Test]
     public function parallelRunEmitsLocationHintsAndFlowIds(): void
     {
-        // An isolated project prevents a conflict with another acceptance
-        // test in the same directory. DiscoveryBasic remains the single shared
-        // copy in tests/Fixture. Thus, location hints identify its actual file.
-        $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'teamcity');
+        $project = AcceptanceProject::createWithTwoPassingTests($this->tempDirectory, 'teamcity');
         $result = GreenlightCli::run($project->directory, ['run', '--workers=2', '--reporter=teamcity']);
         $output = $result->output();
-        $class = AlphaTest::class;
-        $file = ClassFile::of($class);
+        $class = $project->testClasses()[0];
+        $file = $project->path('tests/FirstPassingTest.php');
         Expect::that($result->exitCode)->because('parallel run emits location hints and flow IDs')->toBe(0);
         Expect::that($output)->toContain(
             "##teamcity[testSuiteStarted name='{$class}' locationHint='php_qn://{$file}::\\{$class}' flowId='{$class}']",
         )
             ->toContain(
-                "##teamcity[testStarted name='{$class}::one' locationHint='php_qn://{$file}::\\{$class}::one' flowId='{$class}']",
+                "##teamcity[testStarted name='{$class}::passes' locationHint='php_qn://{$file}::\\{$class}::passes' flowId='{$class}']",
             )
             ->toContain("##teamcity[testSuiteFinished name='{$class}' flowId='{$class}']");
         foreach (\explode("\n", $output) as $line) {

--- a/tests/Acceptance/WorkerProcessRunTest.php
+++ b/tests/Acceptance/WorkerProcessRunTest.php
@@ -21,15 +21,13 @@ final readonly class WorkerProcessRunTest
     #[Test]
     public function parallelResultsMatchSequentialResults(): void
     {
-        // An isolated project prevents a conflict with another acceptance
-        // test in the same directory.
-        $project = AcceptanceProject::createWithDiscoveryBasicTests($this->tempDirectory, 'parallel');
+        $project = AcceptanceProject::createWithTwoPassingTests($this->tempDirectory, 'parallel');
         $sequential = GreenlightCli::run($project->directory, ['run', '--workers=1']);
         $parallel = GreenlightCli::run($project->directory, ['run', '--workers=3']);
         Expect::that($sequential->exitCode)->because('parallel results match sequential results')->toBe(0);
         Expect::that($parallel->exitCode)->toBe(0);
-        Expect::that($this->summaryLine($sequential->output()))->toBe('7 tests, 7 passed, 0 expectations');
-        Expect::that($this->summaryLine($parallel->output()))->toBe('7 tests, 7 passed, 0 expectations');
+        Expect::that($this->summaryLine($sequential->output()))->toBe('2 tests, 2 passed, 0 expectations');
+        Expect::that($this->summaryLine($parallel->output()))->toBe('2 tests, 2 passed, 0 expectations');
     }
 
     #[Test]

--- a/tests/Support/AcceptanceProject.php
+++ b/tests/Support/AcceptanceProject.php
@@ -11,6 +11,8 @@ final readonly class AcceptanceProject
     private function __construct(
         private ProjectFiles $files,
         public string $directory,
+        /** @var list<non-empty-string> */
+        private array $testClasses = [],
     ) {}
 
     public static function create(TemporaryDirectory $workspace, string $name): self
@@ -47,6 +49,34 @@ final readonly class AcceptanceProject
         return $project;
     }
 
+    public static function createWithOnePassingTest(TemporaryDirectory $workspace, string $name): self
+    {
+        $project = self::create($workspace, $name);
+        $namespace = self::generatedNamespace($name);
+        $class = 'PassingTest';
+        $project->writePassingTest('tests/PassingTest.php', $namespace, $class);
+        $project->configureWithTestFiles(['tests/PassingTest.php']);
+
+        return new self($project->files, $project->directory, [$namespace . '\\' . $class]);
+    }
+
+    public static function createWithTwoPassingTests(TemporaryDirectory $workspace, string $name): self
+    {
+        $project = self::create($workspace, $name);
+        $namespace = self::generatedNamespace($name);
+        $project->writePassingTest('tests/FirstPassingTest.php', $namespace, 'FirstPassingTest');
+        $project->writePassingTest('tests/SecondPassingTest.php', $namespace, 'SecondPassingTest');
+        $project->configureWithTestFiles([
+            'tests/FirstPassingTest.php',
+            'tests/SecondPassingTest.php',
+        ]);
+
+        return new self($project->files, $project->directory, [
+            $namespace . '\\FirstPassingTest',
+            $namespace . '\\SecondPassingTest',
+        ]);
+    }
+
     public function path(string $relative): string
     {
         return $this->files->path($relative);
@@ -55,6 +85,12 @@ final readonly class AcceptanceProject
     public function writeFile(string $relativePath, string $contents): void
     {
         $this->files->write($relativePath, $contents);
+    }
+
+    /** @return list<non-empty-string> */
+    public function testClasses(): array
+    {
+        return $this->testClasses;
     }
 
     /**
@@ -91,6 +127,35 @@ final readonly class AcceptanceProject
             PHP,
             \implode("\n", $requires),
             $workers,
+        ));
+    }
+
+    private static function generatedNamespace(string $name): string
+    {
+        return 'Greenlight\\Tests\\Generated\\Project' . \substr(\hash('sha256', $name), 0, 16);
+    }
+
+    private function writePassingTest(string $relativePath, string $namespace, string $class): void
+    {
+        $this->writeFile($relativePath, \sprintf(
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace %s;
+
+            use Greenlight\Attribute\Test;
+
+            final class %s
+            {
+                #[Test]
+                public function passes(): void {}
+            }
+
+            PHP,
+            $namespace,
+            $class,
         ));
     }
 

--- a/tests/Unit/Cli/ApplicationReporterStreamTest.php
+++ b/tests/Unit/Cli/ApplicationReporterStreamTest.php
@@ -25,7 +25,7 @@ final readonly class ApplicationReporterStreamTest
     public function runReportersUseTheConfiguredOutputStream(): void
     {
         $this->environment->unset('GREENLIGHT_CHANNEL');
-        $project = AcceptanceProject::createWithDiscoveryBasicTests(
+        $project = AcceptanceProject::createWithOnePassingTest(
             $this->tempDirectory,
             'application-reporter-stream',
         );
@@ -49,7 +49,7 @@ final readonly class ApplicationReporterStreamTest
         Expect::that($output)
             ->because('the configured output stream MUST receive the complete run report')
             ->toContain('Greenlight ' . Application::VERSION)
-            ->toContain('7 tests, 7 passed');
+            ->toContain('1 test, 1 passed');
         Expect::that($errors)
             ->toBe('');
     }
@@ -60,7 +60,7 @@ final readonly class ApplicationReporterStreamTest
         $this->environment->unset('GREENLIGHT_CHANNEL');
         $this->environment->set('CI', 'true');
         $this->environment->unset('NO_COLOR');
-        $project = AcceptanceProject::createWithDiscoveryBasicTests(
+        $project = AcceptanceProject::createWithOnePassingTest(
             $this->tempDirectory,
             'application-ansi-output',
         );

--- a/tests/Unit/Cli/ApplicationWorkerBinPathTest.php
+++ b/tests/Unit/Cli/ApplicationWorkerBinPathTest.php
@@ -27,7 +27,7 @@ final readonly class ApplicationWorkerBinPathTest
     public function inaccessibleWorkerBinaryFallsBackWithoutEngineDiagnostics(): void
     {
         $this->environment->unset('GREENLIGHT_CHANNEL');
-        $project = AcceptanceProject::createWithDiscoveryBasicTests(
+        $project = AcceptanceProject::createWithTwoPassingTests(
             $this->tempDirectory,
             'application-worker-bin-path',
         );

--- a/tests/Unit/Support/AcceptanceProjectTest.php
+++ b/tests/Unit/Support/AcceptanceProjectTest.php
@@ -7,6 +7,7 @@ namespace Greenlight\Tests\Unit\Support;
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\GreenlightConfig;
+use Greenlight\Discovery\TestDiscoverer;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
@@ -168,5 +169,35 @@ final readonly class AcceptanceProjectTest
         Expect::that($builder->build()->discovery->paths)->because('project with discovery basic tests targets the shared fixture')->toBe([
             \dirname(__DIR__, 2) . '/Fixture/DiscoveryBasic',
         ]);
+    }
+
+    #[Test]
+    public function passingProjectPresetsHaveSmallSuitesAndDeterministicNamespaces(): void
+    {
+        $one = AcceptanceProject::createWithOnePassingTest($this->workspace, 'one-passing-test');
+        $two = AcceptanceProject::createWithTwoPassingTests($this->workspace, 'two-passing-tests');
+        $sameOne = AcceptanceProject::createWithOnePassingTest($this->workspace, 'one-passing-test');
+        $oneConfiguration = require $one->path('greenlight.php');
+        $twoConfiguration = require $two->path('greenlight.php');
+        $discoverer = new TestDiscoverer();
+
+        Expect::that($oneConfiguration)
+            ->because('the one-test preset MUST generate a Greenlight configuration')
+            ->toBeInstanceOf(GreenlightConfig::class);
+        Expect::that($twoConfiguration)
+            ->because('the two-test preset MUST generate a Greenlight configuration')
+            ->toBeInstanceOf(GreenlightConfig::class);
+        Expect::that($discoverer->discover($oneConfiguration->build()->discovery->paths)->classes())
+            ->because('the one-test preset MUST contain one generated test class')
+            ->toBe($one->testClasses());
+        Expect::that($discoverer->discover($twoConfiguration->build()->discovery->paths)->classes())
+            ->because('the two-test preset MUST contain two generated test classes')
+            ->toBe($two->testClasses());
+        Expect::that($one->testClasses())
+            ->because('the same project name MUST produce the same test namespace')
+            ->toBe($sameOne->testClasses());
+        Expect::that(\array_intersect($one->testClasses(), $two->testClasses()))
+            ->because('different project names MUST produce unique test namespaces')
+            ->toBe([]);
     }
 }


### PR DESCRIPTION
## Summary

- Add deterministic one-test and two-class passing project presets.
- Keep DiscoveryBasic for listing, selection, and sharding contracts.
- Reduce migrated fixture-test executions from 154 to 27.