### PR TITLE
test: batch prose-check rule fixtures

### DIFF
--- a/tests/Acceptance/ProseCheckBehaviorTest.php
+++ b/tests/Acceptance/ProseCheckBehaviorTest.php
@@ -714,64 +714,40 @@ final readonly class ProseCheckBehaviorTest
     }
 
     #[Test]
-    public function excludesSharedFixtureDirectories(): void
+    public function excludesFixturesCachesDependenciesAndNestedWorktrees(): void
     {
-        $root = $this->workspace('fixture-exclusion');
+        $root = $this->workspace('ignored-path-exclusions');
+        $invalid = "The worker doesn't use the configured colour; it stops.\n";
+
         $this->write(
             $root,
             'tests/Fixture/Invalid.php',
-            "<?php\n\n// The worker doesn't use the configured colour; it stops.\n",
+            "<?php\n\n// " . $invalid,
         );
-
-        $result = $this->run('check', $root);
-        Expect::that($result->exitCode)->because('excludes shared fixture directories')->toBe(0);
-    }
-
-    #[Test]
-    public function excludesGeneratedAnalysisFiles(): void
-    {
-        $root = $this->workspace('tool-cache-exclusion');
         $this->write(
             $root,
             'build/cache/phpstan/cache.php',
-            "<?php\n\n// The worker doesn't use the configured colour; it stops.\n",
+            "<?php\n\n// " . $invalid,
         );
         $this->write(
             $root,
             'build/docs-php/example/snippet.php',
-            "<?php\n\n// The worker doesn't use the configured colour; it stops.\n",
+            "<?php\n\n// " . $invalid,
         );
-
-        $result = $this->run('check', $root);
-        Expect::that($result->exitCode)->because('excludes generated analysis files')->toBe(0);
-    }
-
-    #[Test]
-    public function excludesDependenciesAtAnyDirectoryDepth(): void
-    {
-        $root = $this->workspace('dependency-exclusion');
-        $invalid = "The worker doesn't use the configured colour; it stops.\n";
         $this->write($root, 'vendor/package/README.md', $invalid);
         $this->write($root, 'website/node_modules/package/README.md', $invalid);
         $this->write($root, 'packages/example/vendor/package/README.md', $invalid);
         $this->write($root, 'packages/example/node_modules/package/README.md', $invalid);
-
-        $result = $this->run('check', $root);
-        Expect::that($result->exitCode)->because('excludes dependencies at all directory depths')->toBe(0);
-    }
-
-    #[Test]
-    public function excludesNestedClaudeWorktrees(): void
-    {
-        $root = $this->workspace('nested-worktree-exclusion');
         $this->write(
             $root,
             '.claude/worktrees/example/README.md',
-            "The worker doesn't use the configured colour; it stops.\n",
+            $invalid,
         );
 
         $result = $this->run('check', $root);
-        Expect::that($result->exitCode)->because('excludes nested Claude worktrees')->toBe(0);
+        Expect::that($result->exitCode)
+            ->because('excludes fixture, cache, dependency, and nested worktree paths')
+            ->toBe(0);
     }
 
     #[Test]

--- a/tests/Acceptance/ProseCheckLanguageRuleTest.php
+++ b/tests/Acceptance/ProseCheckLanguageRuleTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Acceptance;
 
-use Greenlight\Attribute\DataRow;
 use Greenlight\Attribute\Test;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\ProseCheckRuleProbe;
@@ -14,27 +13,49 @@ final readonly class ProseCheckLanguageRuleTest
     public function __construct(private TemporaryDirectory $tempDirectory) {}
 
     #[Test]
-    #[DataRow(['semicolon', 'The worker stops; the orchestrator continues.', 'The worker stops. The orchestrator continues.'], 'semicolon')]
-    #[DataRow(['contraction', "The worker doesn't stop.", 'The worker does not stop.'], 'contraction')]
-    #[DataRow(['contraction', 'The worker doesn’t stop.', 'The worker does not stop.'], 'Unicode contraction')]
-    #[DataRow(['contraction', "Let's start the worker.", 'Start the worker.'], 'additional contraction')]
-    #[DataRow(['contraction', "Here's why that should've worked.", 'Here is why that should have worked.'], 'missing forms')]
-    #[DataRow(['contraction', "There'll be capacity, so that'll work.", 'There will be capacity, so that will work.'], 'future forms')]
-    #[DataRow([
-        'sentence-length',
-        'The orchestrator collects every selected test class from the configured directories and sends one complete assignment to each available worker before the test run starts in parallel.',
-        'The orchestrator collects every selected test class from the configured directories and sends one complete assignment to each available worker before the test run starts.',
-    ], 'sentence length')]
-    #[DataRow([
-        'paragraph-length',
-        'A worker starts. It reads the configuration. It runs tests. It records results. It sends events. It releases resources. It stops.',
-        'A worker starts. It reads the configuration. It runs tests. It records results. It sends events. It stops.',
-    ], 'paragraph length')]
-    public function blockingRulesRejectInvalidProseAndAcceptTheValidCounterpart(
-        string $rule,
-        string $invalid,
-        string $valid,
-    ): void {
-        ProseCheckRuleProbe::assertBlocks($this->tempDirectory, $rule, $invalid, $valid);
+    public function blockingRulesRejectInvalidProseAndAcceptValidCounterparts(): void
+    {
+        ProseCheckRuleProbe::assertBlocks($this->tempDirectory, [
+            'semicolon' => [
+                'rule' => 'semicolon',
+                'invalid' => 'The worker stops; the orchestrator continues.',
+                'valid' => 'The worker stops. The orchestrator continues.',
+            ],
+            'contraction' => [
+                'rule' => 'contraction',
+                'invalid' => "The worker doesn't stop.",
+                'valid' => 'The worker does not stop.',
+            ],
+            'unicode-contraction' => [
+                'rule' => 'contraction',
+                'invalid' => 'The worker doesn’t stop.',
+                'valid' => 'The worker does not stop.',
+            ],
+            'additional-contraction' => [
+                'rule' => 'contraction',
+                'invalid' => "Let's start the worker.",
+                'valid' => 'Start the worker.',
+            ],
+            'missing-forms' => [
+                'rule' => 'contraction',
+                'invalid' => "Here's why that should've worked.",
+                'valid' => 'Here is why that should have worked.',
+            ],
+            'future-forms' => [
+                'rule' => 'contraction',
+                'invalid' => "There'll be capacity, so that'll work.",
+                'valid' => 'There will be capacity, so that will work.',
+            ],
+            'sentence-length' => [
+                'rule' => 'sentence-length',
+                'invalid' => 'The orchestrator collects every selected test class from the configured directories and sends one complete assignment to each available worker before the test run starts in parallel.',
+                'valid' => 'The orchestrator collects every selected test class from the configured directories and sends one complete assignment to each available worker before the test run starts.',
+            ],
+            'paragraph-length' => [
+                'rule' => 'paragraph-length',
+                'invalid' => 'A worker starts. It reads the configuration. It runs tests. It records results. It sends events. It releases resources. It stops.',
+                'valid' => 'A worker starts. It reads the configuration. It runs tests. It records results. It sends events. It stops.',
+            ],
+        ]);
     }
 }

--- a/tests/Acceptance/ProseCheckSpellingRuleTest.php
+++ b/tests/Acceptance/ProseCheckSpellingRuleTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Acceptance;
 
-use Greenlight\Attribute\DataRow;
 use Greenlight\Attribute\Test;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\ProseCheckRuleProbe;
@@ -14,23 +13,49 @@ final readonly class ProseCheckSpellingRuleTest
     public function __construct(private TemporaryDirectory $tempDirectory) {}
 
     #[Test]
-    #[DataRow(['british-spelling', 'The reporter uses a different colour.', 'The reporter uses a different color.'], 'colour')]
-    #[DataRow(['british-spelling', 'The runner favours one worker.', 'The runner favors one worker.'], 'favour')]
-    #[DataRow(['british-spelling', 'The runner honours a labelled test.', 'The runner honors a labeled test.'], 'honour and labelled')]
-    #[DataRow(['british-spelling', 'The driver normalises the data.', 'The driver normalizes the data.'], 'normalise')]
-    #[DataRow(['british-spelling', 'The runner parameterises tests.', 'The runner parameterizes tests.'], 'parameterise')]
-    #[DataRow(['british-spelling', 'The reporter deserialises the event.', 'The reporter deserializes the event.'], 'deserialise')]
-    #[DataRow(['british-spelling', 'The worker fulfils the request.', 'The worker fulfills the request.'], 'fulfil')]
-    #[DataRow([
-        'british-spelling',
-        'Organise the authorised customisation.',
-        'Organize the authorized customization.',
-    ], 'other spellings')]
-    public function blockingRulesRejectInvalidProseAndAcceptTheValidCounterpart(
-        string $rule,
-        string $invalid,
-        string $valid,
-    ): void {
-        ProseCheckRuleProbe::assertBlocks($this->tempDirectory, $rule, $invalid, $valid);
+    public function blockingRulesRejectInvalidProseAndAcceptValidCounterparts(): void
+    {
+        ProseCheckRuleProbe::assertBlocks($this->tempDirectory, [
+            'colour' => [
+                'rule' => 'british-spelling',
+                'invalid' => 'The reporter uses a different colour.',
+                'valid' => 'The reporter uses a different color.',
+            ],
+            'favour' => [
+                'rule' => 'british-spelling',
+                'invalid' => 'The runner favours one worker.',
+                'valid' => 'The runner favors one worker.',
+            ],
+            'honour-and-labelled' => [
+                'rule' => 'british-spelling',
+                'invalid' => 'The runner honours a labelled test.',
+                'valid' => 'The runner honors a labeled test.',
+            ],
+            'normalise' => [
+                'rule' => 'british-spelling',
+                'invalid' => 'The driver normalises the data.',
+                'valid' => 'The driver normalizes the data.',
+            ],
+            'parameterise' => [
+                'rule' => 'british-spelling',
+                'invalid' => 'The runner parameterises tests.',
+                'valid' => 'The runner parameterizes tests.',
+            ],
+            'deserialise' => [
+                'rule' => 'british-spelling',
+                'invalid' => 'The reporter deserialises the event.',
+                'valid' => 'The reporter deserializes the event.',
+            ],
+            'fulfil' => [
+                'rule' => 'british-spelling',
+                'invalid' => 'The worker fulfils the request.',
+                'valid' => 'The worker fulfills the request.',
+            ],
+            'other-spellings' => [
+                'rule' => 'british-spelling',
+                'invalid' => 'Organise the authorised customisation.',
+                'valid' => 'Organize the authorized customization.',
+            ],
+        ]);
     }
 }

--- a/tests/Support/ProseCheckRuleProbe.php
+++ b/tests/Support/ProseCheckRuleProbe.php
@@ -8,32 +8,51 @@ use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 
 /**
- * Checks one invalid prose sample and its valid equivalent.
+ * Checks named invalid prose samples and their valid counterparts.
  *
  * @internal
  */
 final readonly class ProseCheckRuleProbe
 {
+    /**
+     * @param non-empty-array<non-empty-string, array{
+     *     rule: non-empty-string,
+     *     invalid: non-empty-string,
+     *     valid: non-empty-string
+     * }> $cases
+     */
     public static function assertBlocks(
         TemporaryDirectory $tempDirectory,
-        string $rule,
-        string $invalid,
-        string $valid,
+        array $cases,
     ): void {
-        $files = ProjectFiles::create($tempDirectory, 'blocking-' . $rule . '/project');
-        $root = $files->directory;
+        \ksort($cases);
 
-        $files->write('sample.md', "# Sample\n\n" . $invalid . "\n");
+        $invalidFiles = ProjectFiles::create($tempDirectory, 'blocking-rules/invalid-project');
+        $validFiles = ProjectFiles::create($tempDirectory, 'blocking-rules/valid-project');
 
-        $invalidResult = self::run($root);
-        Expect::that($invalidResult->exitCode)->because('blocking rules reject invalid prose and accept the valid counterpart')->toBe(1);
-        Expect::that($invalidResult->output())->toContain($rule);
+        foreach ($cases as $name => $case) {
+            $filename = $name . '.md';
+            $invalidFiles->write($filename, "# Sample\n\n" . $case['invalid'] . "\n");
+            $validFiles->write($filename, "# Sample\n\n" . $case['valid'] . "\n");
+        }
 
-        $files->write('sample.md', "# Sample\n\n" . $valid . "\n");
+        $invalidResult = self::run($invalidFiles->directory);
+        Expect::that($invalidResult->exitCode)->because('blocking rules reject all invalid prose cases')->toBe(1);
 
-        $validResult = self::run($root);
-        Expect::that($validResult->exitCode)->because('blocking rules reject invalid prose and accept the valid counterpart')->toBe(0);
-        Expect::that($validResult->output())->not()->toContain($rule);
+        foreach ($cases as $name => $case) {
+            Expect::that($invalidResult->output())
+                ->because('reports each rule with its invalid case filename')
+                ->toContain($name . '.md:3: ' . $case['rule'] . ':');
+        }
+
+        $validResult = self::run($validFiles->directory);
+        Expect::that($validResult->exitCode)->because('blocking rules accept all valid prose cases')->toBe(0);
+
+        foreach (\array_keys($cases) as $name) {
+            Expect::that($validResult->output())
+                ->because('reports no diagnostic for each valid case filename')
+                ->not()->toContain($name . '.md:');
+        }
     }
 
     private static function run(string $root): ProcessResult


### PR DESCRIPTION
Batch named spelling and language cases into one invalid and one valid CLI run per rule class. Preserve case-level diagnostics with deterministic filenames and rule assertions, and batch the cohesive ignored-path behavior fixtures.

This reduces prose-check process launches from 68 to 37 across ProseCheck-matched tests, including 32 to 4 in the migrated rule classes. The median one-worker runtime fell from 11.11 seconds to 5.31 seconds.