### PR TITLE
feat(cli): add selectable suites

### DIFF
--- a/docs/api-configuration.md
+++ b/docs/api-configuration.md
@@ -170,8 +170,8 @@ public static function create(): self
 
 ### `paths()`
 
-Sets the top-level test-discovery directories. Greenlight combines these
-paths with the paths from all named suites.
+Sets the base test-discovery directories. Greenlight combines these paths with
+all suite paths when the command has no suite selector.
 
 ```php
 public function paths(array $tests): self
@@ -186,7 +186,8 @@ PHPDoc:
 
 ### `suite()`
 
-Declares a named suite. Greenlight adds its paths to test discovery.
+Declares a named suite. Greenlight adds its paths to default discovery and
+makes the suite available to CLI selectors.
 
 The configurator receives a `SuiteBuilder`. It must add at least one path
 with `in()`. Greenlight ignores its return value, which permits short

--- a/docs/api-configuration.md
+++ b/docs/api-configuration.md
@@ -170,8 +170,8 @@ public static function create(): self
 
 ### `paths()`
 
-Sets the base test-discovery directories. Greenlight combines these paths with
-all suite paths when the command has no suite selector.
+Sets the base test-discovery directories. Greenlight combines these
+paths with all suite paths when the command has no suite selector.
 
 ```php
 public function paths(array $tests): self
@@ -186,8 +186,8 @@ PHPDoc:
 
 ### `suite()`
 
-Declares a named suite. Greenlight adds its paths to default discovery and
-makes the suite available to CLI selectors.
+Declares a named suite. Greenlight adds its paths to default discovery
+and makes the suite available to CLI selectors.
 
 The configurator receives a `SuiteBuilder`. It must add at least one path
 with `in()`. Greenlight ignores its return value, which permits short
@@ -203,7 +203,7 @@ PHPDoc:
 - `@param callable(SuiteBuilder): mixed $configurator`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L143)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L144)
 
 ### `workers()`
 
@@ -218,7 +218,7 @@ PHPDoc:
 - `@param positive-int|'auto' $count`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L167)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L168)
 
 ### `resourceLimit()`
 
@@ -237,7 +237,7 @@ PHPDoc:
 - `@param positive-int $limit`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L185)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L186)
 
 ### `coverage()`
 
@@ -249,7 +249,7 @@ PHPDoc:
 
 - `@param callable(CoverageBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L213)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L214)
 
 ### `watch()`
 
@@ -261,7 +261,7 @@ PHPDoc:
 
 - `@param callable(WatchBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L226)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L227)
 
 ### `artifacts()`
 
@@ -273,7 +273,7 @@ PHPDoc:
 
 - `@param callable(ArtifactBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L238)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L239)
 
 ### `storage()`
 
@@ -288,7 +288,7 @@ PHPDoc:
 
 - `@param callable(StorageBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L253)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L254)
 
 ### `failOnDeprecation()`
 
@@ -304,7 +304,7 @@ PHPDoc:
 
 - `@see self::ignoreDeprecationsMatching()`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L269)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L270)
 
 ### `failOnNotice()`
 
@@ -312,7 +312,7 @@ PHPDoc:
 public function failOnNotice(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L276)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L277)
 
 ### `failOnRisky()`
 
@@ -324,7 +324,7 @@ expectations.
 public function failOnRisky(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L288)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L289)
 
 ### `ignoreDeprecationsMatching()`
 
@@ -341,7 +341,7 @@ PHPDoc:
 - `@param non-empty-string ...$patterns`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L304)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L305)
 
 ### `plugins()`
 
@@ -354,7 +354,7 @@ PHPDoc:
 - `@param \Closure(): Plugin ...$plugins`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L325)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L326)
 
 ### `failFast()`
 
@@ -362,7 +362,7 @@ PHPDoc:
 public function failFast(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L342)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L343)
 
 ### `randomizeOrder()`
 
@@ -372,7 +372,7 @@ If the seed is null, Greenlight selects and prints a seed when it resolves the c
 public function randomizeOrder(?int $seed = null): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L350)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L351)
 
 ## `InvalidConfiguration`
 

--- a/docs/architecture/worker-lifecycle.md
+++ b/docs/architecture/worker-lifecycle.md
@@ -168,8 +168,9 @@ worker-side instances. Thus, plugin properties cannot transfer data between
 the two sides in any worker mode. A repeat iteration and a watch rerun are new
 selected runs and construct new instances.
 
-Configured suites add named paths and descriptive tags to discovery. They do
-not add boundaries to the execution plan or event stream.
+Configured suites add named and tagged path groups to discovery. CLI selectors
+can choose a union of these groups. Suites do not add boundaries to the
+execution plan or event stream.
 
 The default scheduling unit contains the selected non-isolated tests from one
 class. `#[AllowParallel]` changes each selected test or data set into a pooled

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,11 +46,14 @@ Every builder method returns `$this`. Thus, you can chain method calls.
 
 Default: `['tests']`.
 
-Sets the top-level directories that Greenlight scans.
+Sets the base directories that Greenlight scans.
 
 Paths must be non-empty strings. The list itself must not be empty.
 
-Each run also scans every path from `suite()`.
+Without a suite selector, each run also scans every path from `suite()`.
+
+An explicit suite selector excludes these base paths. This rule prevents the
+default `paths(['tests'])` value from scanning tests outside selected suites.
 
 ### `suite(string $name, callable $configurator): self`
 
@@ -60,9 +63,19 @@ Declares a named suite. Greenlight gives a `SuiteBuilder` to the configurator.
 The configurator must add at least one path. Greenlight ignores its return
 value. Thus, you can use an arrow function.
 
-Each run includes every named suite. Suite names and tags are descriptive. A
-suite does not create a selection or execution boundary. It does not cause
-lifecycle events. The `--dry-run` and `--list-suites` options print suites.
+Without a suite selector, each run includes every named suite. This behavior is
+compatible with configurations that use suites only to add paths.
+
+Use `--suite=<name>` or `--suite-tag=<tag>` to select suites. Repeat either
+option to select a union. A suite is selected if its name or one of its tags
+matches a selector.
+
+An explicit selection scans only paths from selected suites. It does not scan
+base `paths()`. Test filters and sharding apply after this path selection.
+
+A suite does not create an execution or lifecycle boundary. Coverage include
+paths are global and do not belong to a suite. A selected coverage run measures
+all configured coverage include paths.
 
 A second declaration with the same suite name causes an error.
 
@@ -76,6 +89,8 @@ A second declaration with the same suite name causes an error.
 
 * `in(string ...$paths): self` adds directories to the suite. Required.
 * `tag(string ...$tags): self` adds tags to the suite. Optional.
+
+Suite names and tags use case-sensitive exact matching.
 
 ### `workers(int|string $count = 'auto'): self`
 
@@ -337,8 +352,10 @@ Use separate areas when their retention or trust requirements differ:
     ->temporaryDirectory('/var/tmp/greenlight'))
 ```
 
-The state directory contains `run-state.json`. This file has the failed test
-IDs and class durations from the previous run.
+The state directory contains `run-state.json` for a run without suite
+selectors. An explicit suite selection uses a file with a canonical suite-set
+suffix. Each file has failed test IDs and class durations from the previous
+matching run.
 
 Do not share one state directory between concurrent shards. Each shard writes
 one complete snapshot and can replace data from another shard.
@@ -536,6 +553,22 @@ Stops after `<n>` failures.
 
 Bare `--bail` means `--bail=1`.
 
+### `--suite=<name>`
+
+Selects the configured suite with this exact name.
+
+Repeatable. Greenlight creates one union from all `--suite` and `--suite-tag`
+values. An unknown name is a usage error.
+
+If you use a suite selector, Greenlight excludes base `paths()` from discovery.
+
+### `--suite-tag=<tag>`
+
+Selects each configured suite with this exact tag.
+
+Repeatable. An unknown tag is a usage error. Use `--list-suites` to see the
+configured names and tags.
+
 ### `--group=<name>`
 
 Runs only tests in the given group.
@@ -611,7 +644,8 @@ Prints each selected group and its test count. It does not run tests.
 
 ### `--list-suites`
 
-Prints the configured named suites. It does not discover or run tests.
+Prints all configured named suites and their tags. It does not discover or run
+tests. Suite selectors do not hide entries from this catalog.
 
 ### `--repeat=<n>`
 
@@ -739,8 +773,9 @@ Sets the current coverage JSON file for `coverage:diff`.
 
 Starts with a complete run, then reruns all selected tests after a file change.
 
-Greenlight watches all configured test paths and coverage include paths. After
-a change, classes that failed in the previous watch iteration run first.
+Greenlight watches the effective test paths and all coverage include paths. An
+explicit suite selection limits the effective test paths to selected suites.
+After a change, classes that failed in the previous watch iteration run first.
 
 Watch mode does not publish coverage totals or coverage exports.
 
@@ -881,9 +916,10 @@ behavior and exits immediately.
 
 Greenlight caches discovery results per file under the system temp directory.
 
-The cache key includes the file path, mtime, and size. Greenlight can reuse
-discovery data for an unchanged file in the next run. If the cache data is
-uncertain, Greenlight parses the file again.
+The cache identity includes the effective discovery paths. The cache key for
+each entry includes the file path, mtime, and size. Greenlight can reuse data
+for an unchanged file. If the cache data is uncertain, Greenlight parses the
+file again.
 
 Watch mode benefits most because every iteration rediscovers the suite.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -236,7 +236,7 @@ vendor/bin/greenlight run --watch
 ```
 
 Watch mode runs all selected tests at startup and after each file change. It
-watches configured test paths and coverage include paths.
+watches effective test paths and coverage include paths.
 
 Classes that failed in the previous watch iteration run first.
 

--- a/src/Cli/Configuration/CliOverrides.php
+++ b/src/Cli/Configuration/CliOverrides.php
@@ -26,6 +26,10 @@ final readonly class CliOverrides
     public function __construct(
         public ExecutionOverrides $execution = new ExecutionOverrides(),
         public TestSelection $selection = new TestSelection(),
+        /** @var list<non-empty-string> */
+        public array $suiteNames = [],
+        /** @var list<non-empty-string> */
+        public array $suiteTags = [],
         public ?int $seed = null,
         public RepeatConfiguration $repeat = new RepeatConfiguration(),
     ) {}
@@ -176,6 +180,8 @@ final readonly class CliOverrides
                 exclude: new TestExclusions($excludeGroups, $excludeClasses, $excludeMethods, $excludePaths),
                 shard: $shard,
             ),
+            suiteNames: self::nonEmptyValues($arguments, 'suite'),
+            suiteTags: self::nonEmptyValues($arguments, 'suite-tag'),
             seed: $seed,
             repeat: new RepeatConfiguration($repeat, $repeatUntilFailure),
         );

--- a/src/Cli/Configuration/ConfigurationLoader.php
+++ b/src/Cli/Configuration/ConfigurationLoader.php
@@ -47,6 +47,8 @@ final readonly class ConfigurationLoader
         $resolved = ConfigurationResolver::resolve($builder->build(), new CliOverrides(
             execution: $overrides->execution,
             selection: $selection,
+            suiteNames: $overrides->suiteNames,
+            suiteTags: $overrides->suiteTags,
             seed: $overrides->seed,
             repeat: $overrides->repeat,
         ));
@@ -78,10 +80,7 @@ final readonly class ConfigurationLoader
     /** @return list<non-empty-string> */
     public static function directories(ResolvedConfiguration $configuration, string $workingDirectory): array
     {
-        $paths = $configuration->discovery->paths;
-        foreach ($configuration->discovery->suites as $suite) {
-            $paths = [...$paths, ...$suite->paths];
-        }
+        $paths = $configuration->suiteSelection->paths($configuration->discovery);
         $directories = [];
         foreach ($paths as $path) {
             $absolute = self::absolutePath($path, $workingDirectory);

--- a/src/Cli/Configuration/ConfigurationResolver.php
+++ b/src/Cli/Configuration/ConfigurationResolver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Cli\Configuration;
 
+use Greenlight\Cli\Input\CliError;
 use Greenlight\Config\Configuration;
 use Greenlight\Config\ExecutionConfiguration;
 use Greenlight\Config\ResolvedConfiguration;
@@ -27,6 +28,7 @@ final class ConfigurationResolver
     /** @codeCoverageIgnore */
     private function __construct() {}
 
+    /** @throws CliError */
     public static function resolve(Configuration $configuration, CliOverrides $overrides): ResolvedConfiguration
     {
         $executionOverrides = $overrides->execution;
@@ -38,6 +40,11 @@ final class ConfigurationResolver
 
         return new ResolvedConfiguration(
             discovery: $configuration->discovery,
+            suiteSelection: SuiteSelectionResolver::resolve(
+                $configuration->discovery,
+                $overrides->suiteNames,
+                $overrides->suiteTags,
+            ),
             workers: new WorkerConfiguration(
                 count: $executionOverrides->workers ?? $configuration->workers->count,
                 resourceLimits: \array_replace($configuration->workers->resourceLimits, $executionOverrides->resourceLimits),

--- a/src/Cli/Configuration/PlanFormatter.php
+++ b/src/Cli/Configuration/PlanFormatter.php
@@ -26,12 +26,20 @@ final class PlanFormatter
         $lines = [];
         $lines[] = 'Run plan';
         $lines[] = '  configuration file: ' . $configFile;
-        $lines[] = '  test paths: ' . \implode(', ', $configuration->discovery->paths);
+        $suiteSelection = $configuration->suiteSelection;
+        $lines[] = '  test paths: ' . ($suiteSelection->explicit
+            ? '(excluded by suite selection)'
+            : \implode(', ', $configuration->discovery->paths));
 
-        if ($configuration->discovery->suites === []) {
+        if ($suiteSelection->explicit) {
+            $lines[] = '  suite names: ' . ($suiteSelection->names === [] ? '(none)' : \implode(', ', $suiteSelection->names));
+            $lines[] = '  suite tags: ' . ($suiteSelection->tags === [] ? '(none)' : \implode(', ', $suiteSelection->tags));
+        }
+
+        if ($suiteSelection->suites === []) {
             $lines[] = '  suites: (none)';
         } else {
-            foreach ($configuration->discovery->suites as $suite) {
+            foreach ($suiteSelection->suites as $suite) {
                 $tags = $suite->tags === [] ? '' : ' [tags: ' . \implode(', ', $suite->tags) . ']';
                 $lines[] = \sprintf('  suite %s: %s%s', $suite->name, \implode(', ', $suite->paths), $tags);
             }
@@ -69,7 +77,11 @@ final class PlanFormatter
 
         $lines[] = '  plugins: ' . ($plugins === [] ? '(none)' : \implode(', ', $plugins));
         $lines[] = '  artifacts: ' . $configuration->execution->artifacts->directory;
-        $storage = StorageLayout::resolve($configuration->storage, $workingDirectory);
+        $storage = StorageLayout::resolve(
+            $configuration->storage,
+            $workingDirectory,
+            $suiteSelection->stateIdentity(),
+        );
         $lines[] = '  storage state: ' . $storage->runStateFile;
         $lines[] = '  storage cache: ' . $storage->cacheDirectory;
         $lines[] = '  storage generated code: ' . $storage->generatedCodeDirectory;

--- a/src/Cli/Configuration/SuiteSelectionResolver.php
+++ b/src/Cli/Configuration/SuiteSelectionResolver.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli\Configuration;
+
+use Greenlight\Cli\Input\CliError;
+use Greenlight\Config\DiscoveryConfiguration;
+use Greenlight\Config\SuiteSelection;
+
+/**
+ * Resolves suite selectors against the configured suite catalog.
+ *
+ * @internal
+ */
+final class SuiteSelectionResolver
+{
+    /** @codeCoverageIgnore */
+    private function __construct() {}
+
+    /**
+     * @param list<non-empty-string> $names
+     * @param list<non-empty-string> $tags
+     *
+     * @throws CliError
+     */
+    public static function resolve(DiscoveryConfiguration $configuration, array $names, array $tags): SuiteSelection
+    {
+        $explicit = $names !== [] || $tags !== [];
+
+        if (!$explicit) {
+            return new SuiteSelection([], [], $configuration->suites, false);
+        }
+
+        $names = self::unique($names);
+        $tags = self::unique($tags);
+        $availableNames = [];
+        $availableTags = [];
+
+        foreach ($configuration->suites as $suite) {
+            $availableNames[$suite->name] = true;
+
+            foreach ($suite->tags as $tag) {
+                $availableTags[$tag] = true;
+            }
+        }
+
+        $unknownNames = \array_values(\array_filter(
+            $names,
+            static fn(string $name): bool => !isset($availableNames[$name]),
+        ));
+
+        if ($unknownNames !== []) {
+            throw CliError::unknownSuites($unknownNames);
+        }
+
+        $unknownTags = \array_values(\array_filter(
+            $tags,
+            static fn(string $tag): bool => !isset($availableTags[$tag]),
+        ));
+
+        if ($unknownTags !== []) {
+            throw CliError::unknownSuiteTags($unknownTags);
+        }
+
+        $selected = [];
+
+        foreach ($configuration->suites as $suite) {
+            if (\in_array($suite->name, $names, true) || \array_intersect($suite->tags, $tags) !== []) {
+                $selected[] = $suite;
+            }
+        }
+
+        return new SuiteSelection($names, $tags, $selected, true);
+    }
+
+    /**
+     * @param list<non-empty-string> $values
+     * @return list<non-empty-string>
+     */
+    private static function unique(array $values): array
+    {
+        $unique = [];
+
+        foreach ($values as $value) {
+            if (!\in_array($value, $unique, true)) {
+                $unique[] = $value;
+            }
+        }
+
+        return $unique;
+    }
+}

--- a/src/Cli/Input/CliError.php
+++ b/src/Cli/Input/CliError.php
@@ -61,6 +61,26 @@ final class CliError extends \RuntimeException
         return new self('--filter requires a pattern.');
     }
 
+    /** @param non-empty-list<non-empty-string> $names */
+    public static function unknownSuites(array $names): self
+    {
+        return new self(\sprintf(
+            'Unknown %s %s. Use --list-suites to list configured suites.',
+            \count($names) === 1 ? 'suite' : 'suites',
+            self::quotedList($names),
+        ));
+    }
+
+    /** @param non-empty-list<non-empty-string> $tags */
+    public static function unknownSuiteTags(array $tags): self
+    {
+        return new self(\sprintf(
+            'Unknown suite %s %s. Use --list-suites to list configured suite tags.',
+            \count($tags) === 1 ? 'tag' : 'tags',
+            self::quotedList($tags),
+        ));
+    }
+
     public static function malformedShard(string $raw): self
     {
         return new self(\sprintf('--shard requires <n>/<m>, such as 1/4. Received "%s".', $raw));
@@ -132,5 +152,11 @@ final class CliError extends \RuntimeException
             'Do not use --repeat or --repeat-until-failure with %s. Run Greenlight separately for each required report.',
             \implode(' or ', $outputs),
         ));
+    }
+
+    /** @param non-empty-list<non-empty-string> $values */
+    private static function quotedList(array $values): string
+    {
+        return \implode(', ', \array_map(static fn(string $value): string => '"' . $value . '"', $values));
     }
 }

--- a/src/Cli/Input/Definition.php
+++ b/src/Cli/Input/Definition.php
@@ -56,6 +56,8 @@ final readonly class Definition
           --resource-limit=<name>=<n>
                              Set a named resource limit. You can repeat this option.
           --bail[=<n>]       Stop after <n> failures (default 1)
+          --suite=<name>     Select a named suite. You can repeat this option.
+          --suite-tag=<tag>  Select suites with this tag. You can repeat this option.
           --group=<name>     Run only this group. You can repeat this option.
           --filter=<pattern> Run only tests with a matching test ID. Use a
                              substring or a full match with * wildcards.
@@ -124,6 +126,8 @@ final readonly class Definition
             new OptionSpec('workers', OptionValue::Required),
             new OptionSpec('resource-limit', OptionValue::Required, repeatable: true),
             new OptionSpec('bail', OptionValue::Optional),
+            new OptionSpec('suite', OptionValue::Required, repeatable: true),
+            new OptionSpec('suite-tag', OptionValue::Required, repeatable: true),
             new OptionSpec('group', OptionValue::Required, repeatable: true),
             new OptionSpec('filter', OptionValue::Required, repeatable: true),
             new OptionSpec('test-id', OptionValue::Required, repeatable: true),

--- a/src/Cli/Run/RunCommand.php
+++ b/src/Cli/Run/RunCommand.php
@@ -152,7 +152,11 @@ final readonly class RunCommand
                 return new WatchRuns($this->console)->run($arguments, $workingDirectory, $workerBin, $configuration, $shutdown, $reporterCatalog, $reporterOutputs, $reporter);
             }
 
-            $storage = StorageLayout::resolve($resolved->storage, $workingDirectory);
+            $storage = StorageLayout::resolve(
+                $resolved->storage,
+                $workingDirectory,
+                $resolved->suiteSelection->stateIdentity(),
+            );
             $state = RunState::forFile($storage->runStateFile);
             $previousFailures = $state->failedTests();
 

--- a/src/Cli/Run/WatchRuns.php
+++ b/src/Cli/Run/WatchRuns.php
@@ -45,7 +45,11 @@ final readonly class WatchRuns
             }
         }
         $detectLeaks = $arguments->has('detect-leaks');
-        $storage = StorageLayout::resolve($resolved->storage, $workingDirectory);
+        $storage = StorageLayout::resolve(
+            $resolved->storage,
+            $workingDirectory,
+            $resolved->suiteSelection->stateIdentity(),
+        );
         $warning = $detectLeaks ? LeakDetector::environmentWarning() : null;
         if ($warning !== null) {
             $this->console->err($this->console->stderrStyle($arguments->has('no-ansi'))->warn($warning) . "\n");

--- a/src/Config/GreenlightConfig.php
+++ b/src/Config/GreenlightConfig.php
@@ -76,8 +76,8 @@ final class GreenlightConfig
     }
 
     /**
-     * Sets the top-level test-discovery directories. Greenlight combines these
-     * paths with the paths from all named suites.
+     * Sets the base test-discovery directories. Greenlight combines these
+     * paths with all suite paths when the command has no suite selector.
      *
      * @param non-empty-list<non-empty-string> $tests
      *
@@ -129,7 +129,8 @@ final class GreenlightConfig
     }
 
     /**
-     * Declares a named suite. Greenlight adds its paths to test discovery.
+     * Declares a named suite. Greenlight adds its paths to default discovery
+     * and makes the suite available to CLI selectors.
      *
      * The configurator receives a `SuiteBuilder`. It must add at least one path
      * with `in()`. Greenlight ignores its return value, which permits short

--- a/src/Config/ResolvedConfiguration.php
+++ b/src/Config/ResolvedConfiguration.php
@@ -15,6 +15,7 @@ final readonly class ResolvedConfiguration
 {
     public function __construct(
         public DiscoveryConfiguration $discovery,
+        public SuiteSelection $suiteSelection,
         public WorkerConfiguration $workers,
         public ExecutionConfiguration $execution,
         public RunOrder $order,

--- a/src/Config/StorageLayout.php
+++ b/src/Config/StorageLayout.php
@@ -19,8 +19,12 @@ final readonly class StorageLayout
         public string $temporaryDirectory,
     ) {}
 
-    public static function resolve(StorageConfiguration $configuration, string $workingDirectory): self
-    {
+    /** @param non-empty-string|null $stateIdentity */
+    public static function resolve(
+        StorageConfiguration $configuration,
+        string $workingDirectory,
+        ?string $stateIdentity = null,
+    ): self {
         $temporary = \rtrim(\sys_get_temp_dir(), '/');
         $root = self::configured($configuration->rootDirectory, $workingDirectory);
         $state = self::area($configuration->stateDirectory, $root, 'state', $workingDirectory);
@@ -33,11 +37,13 @@ final readonly class StorageLayout
         );
         $runtime = self::area($configuration->temporaryDirectory, $root, 'temporary', $workingDirectory);
         $projectKey = \substr(\sha1($workingDirectory), 0, 12);
+        $stateFile = $stateIdentity === null ? 'run-state.json' : 'run-state-' . $stateIdentity . '.json';
+        $temporaryStateSuffix = $stateIdentity === null ? '' : '-' . $stateIdentity;
 
         return new self(
             $state === null
-                ? \sprintf('%s/greenlight-state-%s.json', $temporary, $projectKey)
-                : $state . '/run-state.json',
+                ? \sprintf('%s/greenlight-state-%s%s.json', $temporary, $projectKey, $temporaryStateSuffix)
+                : $state . '/' . $stateFile,
             $cache ?? $temporary,
             $generatedCode ?? \sprintf('%s/greenlight-proxies-%s', $temporary, $projectKey),
             $runtime ?? $temporary,

--- a/src/Config/SuiteSelection.php
+++ b/src/Config/SuiteSelection.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Config;
+
+/**
+ * Contains one canonical set of suites for a resolved command.
+ *
+ * @internal
+ */
+final readonly class SuiteSelection
+{
+    /**
+     * @param list<non-empty-string> $names
+     * @param list<non-empty-string> $tags
+     * @param list<SuiteConfiguration> $suites
+     */
+    public function __construct(
+        public array $names,
+        public array $tags,
+        public array $suites,
+        public bool $explicit,
+    ) {}
+
+    /** @return list<non-empty-string> */
+    public function paths(DiscoveryConfiguration $configuration): array
+    {
+        $paths = $this->explicit ? [] : $configuration->paths;
+
+        foreach ($this->suites as $suite) {
+            foreach ($suite->paths as $path) {
+                if (!\in_array($path, $paths, true)) {
+                    $paths[] = $path;
+                }
+            }
+        }
+
+        return $paths;
+    }
+
+    /**
+     * Returns null for the compatibility selection that includes all paths.
+     *
+     * @return non-empty-string|null
+     */
+    public function stateIdentity(): ?string
+    {
+        if (!$this->explicit) {
+            return null;
+        }
+
+        $names = \array_map(static fn(SuiteConfiguration $suite): string => $suite->name, $this->suites);
+        \sort($names, \SORT_STRING);
+
+        return 'suites-' . \substr(\sha1(\implode("\n", $names)), 0, 12);
+    }
+}

--- a/tests/Acceptance/SuiteSelectionTest.php
+++ b/tests/Acceptance/SuiteSelectionTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\GreenlightCli;
+
+final readonly class SuiteSelectionTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function suiteNameSelectionRunsOnlyTheSelectedSuite(): void
+    {
+        $project = $this->writeProject('suite-name-run');
+        $result = GreenlightCli::run($project->directory, ['run', '--suite=unit', '--reporter=plain']);
+
+        Expect::that($result->exitCode)
+            ->because('a suite name MUST exclude failing base paths and other suites from a run')
+            ->toBe(0);
+        Expect::that($result->output())
+            ->toContain('1 test, 1 passed');
+    }
+
+    #[Test]
+    public function repeatedNameAndTagSelectorsFormTheListedAndShardedUnion(): void
+    {
+        $project = $this->writeProject('suite-selector-union');
+        $flags = ['--suite=unit', '--suite-tag=io'];
+        $full = GreenlightCli::run($project->directory, ['list-tests', ...$flags])->stdoutLines();
+        $first = GreenlightCli::run($project->directory, ['list-tests', ...$flags, '--shard=1/2'])->stdoutLines();
+        $second = GreenlightCli::run($project->directory, ['list-tests', ...$flags, '--shard=2/2'])->stdoutLines();
+
+        Expect::that($full)
+            ->because('suite names and tags MUST select one union before sharding')
+            ->toContain('SelectableSuites\\UnitTest::passes')
+            ->toContain('SelectableSuites\\IntegrationTest::fails')
+            ->not()
+            ->toContain('SelectableSuites\\BaseTest::fails');
+
+        $union = [...$this->testIds($first), ...$this->testIds($second)];
+        \sort($union);
+        $expected = $this->testIds($full);
+        \sort($expected);
+
+        Expect::that($union)
+            ->because('selected suites MUST divide into disjoint shards after suite selection')
+            ->toBe($expected);
+    }
+
+    #[Test]
+    public function listGroupsAndDryRunUseTheSuiteSelection(): void
+    {
+        $project = $this->writeProject('suite-list-and-plan');
+        $groups = GreenlightCli::run($project->directory, ['run', '--list-groups', '--suite=unit']);
+        $plan = GreenlightCli::run($project->directory, ['run', '--dry-run', '--suite-tag=io']);
+
+        Expect::that($groups->output())
+            ->because('group listing MUST discover only the selected suites')
+            ->toContain('unit (1 tests)')
+            ->not()
+            ->toContain('base')
+            ->not()
+            ->toContain('integration');
+        Expect::that($plan->output())
+            ->because('dry-run output MUST show the effective suite selection')
+            ->toContain('test paths: (excluded by suite selection)')
+            ->toContain('suite names: (none)')
+            ->toContain('suite tags: io')
+            ->toContain('suite integration: tests/Integration [tags: io]')
+            ->toContain('coverage include paths: src')
+            ->not()
+            ->toContain('suite unit:');
+    }
+
+    #[Test]
+    public function unknownSelectorsFailBeforeDiscoveryWithListingGuidance(): void
+    {
+        $project = $this->writeProject('suite-unknown');
+        $name = GreenlightCli::run($project->directory, ['run', '--suite=missing', '--no-ansi']);
+        $tag = GreenlightCli::run($project->directory, ['list-tests', '--suite-tag=missing', '--no-ansi']);
+
+        Expect::that($name->exitCode)
+            ->because('an unknown suite name MUST be a usage error')
+            ->toBe(64);
+        Expect::that($name->output())
+            ->toContain('Unknown suite "missing". Use --list-suites to list configured suites.');
+        Expect::that($tag->exitCode)
+            ->because('an unknown suite tag MUST be a usage error')
+            ->toBe(64);
+        Expect::that($tag->output())
+            ->toContain('Unknown suite tag "missing". Use --list-suites to list configured suite tags.');
+    }
+
+    #[Test]
+    public function listSuitesKeepsAllConfiguredNamesAndTagsVisible(): void
+    {
+        $project = $this->writeProject('suite-list-suites');
+        $result = GreenlightCli::run($project->directory, ['run', '--list-suites', '--suite=unit']);
+
+        Expect::that($result->exitCode)
+            ->because('--list-suites MUST validate selectors and list the complete configured catalog')
+            ->toBe(0);
+        Expect::that($result->output())
+            ->toContain('unit: tests/Unit [tags: fast]')
+            ->toContain('integration: tests/Integration [tags: io]')
+            ->toContain('2 suites');
+    }
+
+    private function writeProject(string $name): AcceptanceProject
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, $name);
+        $project->writeFile('tests/BaseTest.php', $this->testSource('BaseTest', 'base', fails: true));
+        $project->writeFile('tests/Unit/UnitTest.php', $this->testSource('UnitTest', 'unit'));
+        $project->writeFile('tests/Integration/IntegrationTest.php', $this->testSource('IntegrationTest', 'integration', fails: true));
+        $project->writeFile('greenlight.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Config\CoverageBuilder;
+            use Greenlight\Config\GreenlightConfig;
+            use Greenlight\Config\SuiteBuilder;
+
+            require_once __DIR__ . '/tests/BaseTest.php';
+            require_once __DIR__ . '/tests/Unit/UnitTest.php';
+            require_once __DIR__ . '/tests/Integration/IntegrationTest.php';
+
+            return GreenlightConfig::create()
+                ->suite('unit', static fn(SuiteBuilder $suite) => $suite->in('tests/Unit')->tag('fast'))
+                ->suite('integration', static fn(SuiteBuilder $suite) => $suite->in('tests/Integration')->tag('io'))
+                ->coverage(static fn(CoverageBuilder $coverage) => $coverage->include('src'))
+                ->workers(1);
+
+            PHP);
+
+        return $project;
+    }
+
+    private function testSource(string $class, string $group, bool $fails = false): string
+    {
+        $assertion = $fails ? 'Expect::that(false)->toBeTrue();' : 'Expect::that(true)->toBeTrue();';
+
+        return \sprintf(
+            <<<'PHP'
+                <?php
+
+                declare(strict_types=1);
+
+                namespace SelectableSuites;
+
+                use Greenlight\Attribute\Group;
+                use Greenlight\Attribute\Test;
+                use Greenlight\Expect\Expect;
+
+                final class %s
+                {
+                    #[Test]
+                    #[Group('%s')]
+                    public function %s(): void
+                    {
+                        %s
+                    }
+                }
+
+                PHP,
+            $class,
+            $group,
+            $fails ? 'fails' : 'passes',
+            $assertion,
+        );
+    }
+
+    /**
+     * @param list<string> $lines
+     * @return list<string>
+     */
+    private function testIds(array $lines): array
+    {
+        return \array_values(\array_filter(
+            $lines,
+            static fn(string $line): bool => \str_contains($line, '::'),
+        ));
+    }
+}

--- a/tests/Unit/Cli/Configuration/CliOverridesTest.php
+++ b/tests/Unit/Cli/Configuration/CliOverridesTest.php
@@ -32,6 +32,8 @@ final class CliOverridesTest
         Expect::that($overrides->repeat->untilFailure)->because('absent flags mean no overrides')->toBe(false);
         Expect::that($overrides->execution->artifactsDirectory)->because('absent flags mean no overrides')->toBe(null);
         Expect::that($overrides->execution->resourceLimits)->because('absent flags mean no overrides')->toBe([]);
+        Expect::that($overrides->suiteNames)->because('absent flags mean no overrides')->toBe([]);
+        Expect::that($overrides->suiteTags)->because('absent flags mean no overrides')->toBe([]);
     }
 
     #[Test]
@@ -103,6 +105,8 @@ final class CliOverridesTest
             'workers' => ['4'],
             'bail' => ['3'],
             'group' => ['slow', 'io'],
+            'suite' => ['unit', 'acceptance'],
+            'suite-tag' => ['fast', 'io'],
             'seed' => ['0'],
             'test-id' => ['App\ExampleTest::one', 'App\ExampleTest::two'],
             'artifacts-dir' => ['build/evidence'],
@@ -112,6 +116,8 @@ final class CliOverridesTest
         Expect::that($overrides->execution->workers?->fixed)->because('extracts typed values')->toBe(4);
         Expect::that($overrides->execution->stopAfterFailures)->because('extracts typed values')->toBe(3);
         Expect::that($overrides->selection->include->groups)->because('extracts typed values')->toBe(['slow', 'io']);
+        Expect::that($overrides->suiteNames)->because('extracts typed values')->toBe(['unit', 'acceptance']);
+        Expect::that($overrides->suiteTags)->because('extracts typed values')->toBe(['fast', 'io']);
         Expect::that($overrides->seed)->because('extracts typed values')->toBe(0);
         Expect::that($overrides->selection->include->exactIds)->because('extracts typed values')->toBe(['App\ExampleTest::one', 'App\ExampleTest::two']);
         Expect::that($overrides->execution->artifactsDirectory)->because('extracts typed values')->toBe('build/evidence');

--- a/tests/Unit/Cli/Configuration/SuiteSelectionTest.php
+++ b/tests/Unit/Cli/Configuration/SuiteSelectionTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli\Configuration;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\Configuration\SuiteSelectionResolver;
+use Greenlight\Cli\Input\CliError;
+use Greenlight\Config\DiscoveryConfiguration;
+use Greenlight\Config\SuiteConfiguration;
+use Greenlight\Config\SuiteSelection;
+use Greenlight\Expect\Expect;
+
+final readonly class SuiteSelectionTest
+{
+    #[Test]
+    public function absentSelectorsIncludeBasePathsAndAllSuites(): void
+    {
+        $configuration = $this->configuration();
+        $selection = SuiteSelectionResolver::resolve($configuration, [], []);
+
+        Expect::that($selection->paths($configuration))
+            ->because('the compatibility selection MUST include base paths and all suite paths')
+            ->toBe(['tests', 'tests/Unit', 'tests/Integration', 'tests/Api']);
+        Expect::that($selection->stateIdentity())
+            ->because('the compatibility selection MUST keep the existing run-state identity')
+            ->toBeNull();
+    }
+
+    #[Test]
+    public function nameAndTagSelectorsFormAUnionWithoutBasePaths(): void
+    {
+        $configuration = $this->configuration();
+        $selection = SuiteSelectionResolver::resolve($configuration, ['unit'], ['io']);
+
+        Expect::that(\array_map(static fn(SuiteConfiguration $suite): string => $suite->name, $selection->suites))
+            ->because('suite names and tags MUST form one union in configuration order')
+            ->toBe(['unit', 'integration', 'api']);
+        Expect::that($selection->paths($configuration))
+            ->because('an explicit suite selection MUST exclude unrelated base paths')
+            ->toBe(['tests/Unit', 'tests/Integration', 'tests/Api']);
+        Expect::that($selection->stateIdentity())
+            ->because('an explicit suite selection MUST have a separate run-state identity')
+            ->toStartWith('suites-');
+    }
+
+    #[Test]
+    public function equivalentSelectorsHaveTheSameCanonicalIdentity(): void
+    {
+        $configuration = $this->configuration();
+        $byNames = SuiteSelectionResolver::resolve($configuration, ['api', 'integration'], []);
+        $byTag = SuiteSelectionResolver::resolve($configuration, [], ['io']);
+
+        Expect::that($byNames->stateIdentity())
+            ->because('equivalent suite unions MUST share run state and timing data')
+            ->toBe($byTag->stateIdentity());
+    }
+
+    #[Test]
+    public function unknownNamesAndTagsGiveActionableUsageErrors(): void
+    {
+        $configuration = $this->configuration();
+
+        Expect::that(static fn(): SuiteSelection => SuiteSelectionResolver::resolve($configuration, ['missing'], []))
+            ->because('an unknown suite name MUST identify the selector and the listing command')
+            ->toThrow(CliError::class, message: 'Unknown suite "missing". Use --list-suites to list configured suites.');
+        Expect::that(static fn(): SuiteSelection => SuiteSelectionResolver::resolve($configuration, [], ['missing']))
+            ->because('an unknown suite tag MUST identify the selector and the listing command')
+            ->toThrow(CliError::class, message: 'Unknown suite tag "missing". Use --list-suites to list configured suite tags.');
+    }
+
+    private function configuration(): DiscoveryConfiguration
+    {
+        return new DiscoveryConfiguration(
+            ['tests'],
+            [
+                new SuiteConfiguration('unit', ['tests/Unit'], ['fast']),
+                new SuiteConfiguration('integration', ['tests/Integration'], ['io']),
+                new SuiteConfiguration('api', ['tests/Api'], ['io']),
+            ],
+        );
+    }
+}

--- a/tests/Unit/Config/StorageLayoutTest.php
+++ b/tests/Unit/Config/StorageLayoutTest.php
@@ -55,4 +55,21 @@ final readonly class StorageLayoutTest
             ->because('relative area overrides MUST resolve against the initial working directory')
             ->toBe('/project/build/runtime');
     }
+
+    #[Test]
+    public function suiteIdentitySeparatesRunStateWithoutMovingOtherStorage(): void
+    {
+        $layout = StorageLayout::resolve(
+            new StorageConfiguration(rootDirectory: '.greenlight'),
+            '/project',
+            'suites-123456789abc',
+        );
+
+        Expect::that($layout->runStateFile)
+            ->because('suite selections MUST have separate failure and timing state')
+            ->toBe('/project/.greenlight/state/run-state-suites-123456789abc.json');
+        Expect::that($layout->cacheDirectory)
+            ->because('suite selections MUST keep the configured discovery-cache directory')
+            ->toBe('/project/.greenlight/cache');
+    }
 }


### PR DESCRIPTION
## Summary

- add repeatable `--suite` and `--suite-tag` selectors with union semantics and actionable unknown-selector errors
- preserve the no-selector behavior while excluding base paths from explicit suite selections
- apply the resolved suite set to discovery, listings, dry runs, watch paths, sharding, discovery cache identity, and run state
- document global coverage include behavior and suite-selection compatibility