### PR TITLE
feat: add strict warning and skipped policies

### DIFF
--- a/docs/api-configuration.md
+++ b/docs/api-configuration.md
@@ -158,7 +158,7 @@ Collects the configuration that `greenlight.php` returns.
 final class GreenlightConfig
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L13)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L14)
 
 ### `create()`
 
@@ -166,7 +166,7 @@ final class GreenlightConfig
 public static function create(): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L73)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L78)
 
 ### `paths()`
 
@@ -182,7 +182,7 @@ PHPDoc:
 - `@param non-empty-list<non-empty-string> $tests`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L86)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L91)
 
 ### `suite()`
 
@@ -203,7 +203,7 @@ PHPDoc:
 - `@param callable(SuiteBuilder): mixed $configurator`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L144)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L149)
 
 ### `workers()`
 
@@ -218,7 +218,7 @@ PHPDoc:
 - `@param positive-int|'auto' $count`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L168)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L173)
 
 ### `resourceLimit()`
 
@@ -237,7 +237,7 @@ PHPDoc:
 - `@param positive-int $limit`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L186)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L191)
 
 ### `coverage()`
 
@@ -249,7 +249,7 @@ PHPDoc:
 
 - `@param callable(CoverageBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L214)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L219)
 
 ### `watch()`
 
@@ -261,7 +261,7 @@ PHPDoc:
 
 - `@param callable(WatchBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L227)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L232)
 
 ### `artifacts()`
 
@@ -273,7 +273,7 @@ PHPDoc:
 
 - `@param callable(ArtifactBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L239)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L244)
 
 ### `storage()`
 
@@ -288,7 +288,7 @@ PHPDoc:
 
 - `@param callable(StorageBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L254)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L259)
 
 ### `failOnDeprecation()`
 
@@ -304,15 +304,27 @@ PHPDoc:
 
 - `@see self::ignoreDeprecationsMatching()`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L270)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L275)
 
 ### `failOnNotice()`
+
+Fails an otherwise passed test if captured output contains a notice.
 
 ```php
 public function failOnNotice(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L277)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L283)
+
+### `failOnWarning()`
+
+Fails an otherwise passed test if captured output contains a warning.
+
+```php
+public function failOnWarning(bool $enabled = true): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L291)
 
 ### `failOnRisky()`
 
@@ -324,7 +336,18 @@ expectations.
 public function failOnRisky(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L289)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L303)
+
+### `failOnSkipped()`
+
+Fails the run if its final summary contains a skipped test. The test
+keeps its skipped outcome and reason.
+
+```php
+public function failOnSkipped(bool $enabled = true): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L314)
 
 ### `ignoreDeprecationsMatching()`
 
@@ -341,7 +364,7 @@ PHPDoc:
 - `@param non-empty-string ...$patterns`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L305)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L330)
 
 ### `plugins()`
 
@@ -354,7 +377,7 @@ PHPDoc:
 - `@param \Closure(): Plugin ...$plugins`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L326)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L351)
 
 ### `failFast()`
 
@@ -362,7 +385,7 @@ PHPDoc:
 public function failFast(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L343)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L368)
 
 ### `randomizeOrder()`
 
@@ -372,7 +395,7 @@ If the seed is null, Greenlight selects and prints a seed when it resolves the c
 public function randomizeOrder(?int $seed = null): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L351)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L376)
 
 ## `InvalidConfiguration`
 

--- a/docs/architecture/technical-writing.md
+++ b/docs/architecture/technical-writing.md
@@ -182,6 +182,7 @@ and meaning. Use the singular form unless the context requires a plural.
 | run | Technical noun | One execution of a selected test suite |
 | run | Technical verb | To execute a command, test, or test suite |
 | run directory | Technical noun | The directory that contains published attachments for one run |
+| run policy | Technical noun | A rule that evaluates the final run summary without changing a test result |
 | run profile | Technical noun | A report that summarizes worker use, scheduling, and boot latency for one run |
 | run state | Technical noun | Saved failure and duration data that can control a later run |
 | run subscriber | Technical noun | An orchestrator plugin that observes run events |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -247,6 +247,18 @@ subscribers.
 
 Also available as `--fail-on-notice`.
 
+### `failOnWarning(bool $enabled = true): self`
+
+Default: off.
+
+Fails a test that otherwise passed if its captured diagnostics contain a
+warning.
+
+The worker records the change as a result transformation. It applies the
+change after retries and `afterTest()` subscribers.
+
+Also available as `--fail-on-warning`.
+
 ### `ignoreDeprecationsMatching(string ...$patterns): self`
 
 Default: none.
@@ -277,6 +289,26 @@ Use `#[NoExpectations]` for a test that intentionally verifies no expectations.
 Each `eventually()` or `consistently()` matcher counts once.
 
 Also available as `--fail-on-risky`.
+
+### `failOnSkipped(bool $enabled = true): self`
+
+Default: off.
+
+Fails a run if its final summary contains one or more skipped tests.
+
+This run policy does not change a skipped test to a failure. Reporters keep the
+skipped outcome and its reason. JUnit uses a `skipped` element. JSONL uses the
+`skipped` outcome. TeamCity uses `testIgnored`. The GitHub reporter does not
+create an error annotation for a skipped test.
+
+The policy evaluates terminal results after plugins and retries. A plugin that
+changes the terminal outcome changes the run-policy input.
+
+A skipped test does not count toward `--bail` because its outcome is not a test
+failure. The policy fails the completed iteration instead. Thus, repeat mode
+records that iteration as failed. `--repeat-until-failure` stops after it.
+
+Also available as `--fail-on-skipped`.
 
 ### `plugins(Closure ...$plugins): self`
 
@@ -803,9 +835,17 @@ Enables the deprecation policy for this run.
 
 Enables the notice policy for this run.
 
+### `--fail-on-warning`
+
+Enables the warning policy for this run.
+
 ### `--fail-on-risky`
 
 Enables the risky-test policy for this run.
+
+### `--fail-on-skipped`
+
+Enables the skipped-test run policy for this run.
 
 ### `--profile`
 

--- a/resources/schema/worker-protocol-v3.schema.json
+++ b/resources/schema/worker-protocol-v3.schema.json
@@ -314,6 +314,7 @@
             "properties": {
                 "failOnDeprecation": {"type": "boolean"},
                 "failOnNotice": {"type": "boolean"},
+                "failOnWarning": {"type": "boolean"},
                 "ignoreDeprecations": {
                     "type": "array",
                     "items": {"type": "string", "minLength": 1}

--- a/src/Cli/Configuration/CliOverrides.php
+++ b/src/Cli/Configuration/CliOverrides.php
@@ -10,6 +10,7 @@ use Greenlight\Config\InvalidConfiguration;
 use Greenlight\Config\WorkerCount;
 use Greenlight\Internal\Text\DecimalInteger;
 use Greenlight\Result\ResultPolicy;
+use Greenlight\Result\RunPolicy;
 use Greenlight\Test\ResourceName;
 use Greenlight\Test\TestExclusions;
 use Greenlight\Test\TestInclusions;
@@ -170,7 +171,11 @@ final readonly class CliOverrides
                 policy: new ResultPolicy(
                     failOnDeprecation: $arguments->has('fail-on-deprecation'),
                     failOnNotice: $arguments->has('fail-on-notice'),
+                    failOnWarning: $arguments->has('fail-on-warning'),
                     failOnRisky: $arguments->has('fail-on-risky'),
+                ),
+                runPolicy: new RunPolicy(
+                    failOnSkipped: $arguments->has('fail-on-skipped'),
                 ),
                 artifactsDirectory: $artifactsDirectory,
                 resourceLimits: $resourceLimits,

--- a/src/Cli/Configuration/ConfigurationResolver.php
+++ b/src/Cli/Configuration/ConfigurationResolver.php
@@ -10,6 +10,7 @@ use Greenlight\Config\ExecutionConfiguration;
 use Greenlight\Config\ResolvedConfiguration;
 use Greenlight\Config\WorkerConfiguration;
 use Greenlight\Result\ResultPolicy;
+use Greenlight\Result\RunPolicy;
 
 /**
  * Applies settings in this order:
@@ -54,8 +55,12 @@ final class ConfigurationResolver
                 policy: new ResultPolicy(
                     $configuration->execution->policy->failOnDeprecation || $executionOverrides->policy->failOnDeprecation,
                     $configuration->execution->policy->failOnNotice || $executionOverrides->policy->failOnNotice,
+                    $configuration->execution->policy->failOnWarning || $executionOverrides->policy->failOnWarning,
                     $configuration->execution->policy->ignoreDeprecations,
                     $configuration->execution->policy->failOnRisky || $executionOverrides->policy->failOnRisky,
+                ),
+                runPolicy: new RunPolicy(
+                    $configuration->execution->runPolicy->failOnSkipped || $executionOverrides->runPolicy->failOnSkipped,
                 ),
                 stopAfterFailures: $executionOverrides->stopAfterFailures ?? $configuration->execution->stopAfterFailures,
                 artifacts: $artifacts,

--- a/src/Cli/Configuration/ExecutionOverrides.php
+++ b/src/Cli/Configuration/ExecutionOverrides.php
@@ -6,6 +6,7 @@ namespace Greenlight\Cli\Configuration;
 
 use Greenlight\Config\WorkerCount;
 use Greenlight\Result\ResultPolicy;
+use Greenlight\Result\RunPolicy;
 
 /**
  * Contains command-line values that override execution settings.
@@ -22,6 +23,7 @@ final readonly class ExecutionOverrides
         public ?WorkerCount $workers = null,
         public ?int $stopAfterFailures = null,
         public ResultPolicy $policy = new ResultPolicy(),
+        public RunPolicy $runPolicy = new RunPolicy(),
         public ?string $artifactsDirectory = null,
         public array $resourceLimits = [],
     ) {}

--- a/src/Cli/Input/Definition.php
+++ b/src/Cli/Input/Definition.php
@@ -102,7 +102,9 @@ final readonly class Definition
                              Use plain append-only output.
           --fail-on-deprecation  Fail passed tests that captured a deprecation
           --fail-on-notice   Fail passed tests that captured a notice
+          --fail-on-warning  Fail passed tests that captured a warning
           --fail-on-risky    Fail passed tests that verified no expectations
+          --fail-on-skipped  Fail the run if its final summary contains a skipped test
           --profile          Add a run profile after the summary. It contains worker
                              utilization, boot latency, makespan spread, and slow classes.
                              It also extends the slow-test list.
@@ -138,7 +140,8 @@ final readonly class Definition
             new OptionSpec('list-tests'), new OptionSpec('list-groups'), new OptionSpec('list-suites'),
             new OptionSpec('repeat', OptionValue::Required), new OptionSpec('repeat-until-failure'),
             new OptionSpec('failed'), new OptionSpec('shard', OptionValue::Required),
-            new OptionSpec('fail-on-deprecation'), new OptionSpec('fail-on-notice'), new OptionSpec('fail-on-risky'),
+            new OptionSpec('fail-on-deprecation'), new OptionSpec('fail-on-notice'), new OptionSpec('fail-on-warning'),
+            new OptionSpec('fail-on-risky'), new OptionSpec('fail-on-skipped'),
             new OptionSpec('seed', OptionValue::Required),
             new OptionSpec('reporter', OptionValue::Required, repeatable: true),
             new OptionSpec('artifacts-dir', OptionValue::Required),

--- a/src/Cli/Run/RunSession.php
+++ b/src/Cli/Run/RunSession.php
@@ -176,7 +176,19 @@ final readonly class RunSession
             return 1;
         }
 
-        return $run->summary->isSuccessful() ? 0 : 1;
+        if (!$resolved->execution->runPolicy->accepts($run->summary)) {
+            if ($run->summary->isSuccessful()) {
+                $this->console->err(\sprintf(
+                    "Greenlight failed because the fail-on-skipped policy found %d skipped %s.\n",
+                    $run->summary->skipped,
+                    $run->summary->skipped === 1 ? 'test' : 'tests',
+                ));
+            }
+
+            return 1;
+        }
+
+        return 0;
     }
 
     /**

--- a/src/Config/ExecutionConfiguration.php
+++ b/src/Config/ExecutionConfiguration.php
@@ -6,6 +6,7 @@ namespace Greenlight\Config;
 
 use Greenlight\Plugin\PluginDefinition;
 use Greenlight\Result\ResultPolicy;
+use Greenlight\Result\RunPolicy;
 
 /**
  * Defines policy, extensions, and retained output for test execution.
@@ -21,6 +22,7 @@ final readonly class ExecutionConfiguration
     public function __construct(
         public array $plugins,
         public ResultPolicy $policy,
+        public RunPolicy $runPolicy,
         public ?int $stopAfterFailures,
         public ArtifactConfiguration $artifacts,
     ) {}

--- a/src/Config/GreenlightConfig.php
+++ b/src/Config/GreenlightConfig.php
@@ -7,6 +7,7 @@ namespace Greenlight\Config;
 use Greenlight\Plugin\Plugin;
 use Greenlight\Plugin\PluginDefinition;
 use Greenlight\Result\ResultPolicy;
+use Greenlight\Result\RunPolicy;
 use Greenlight\Test\ResourceName;
 
 /** Collects the configuration that `greenlight.php` returns. */
@@ -43,7 +44,11 @@ final class GreenlightConfig
 
     private bool $failOnNotice = false;
 
+    private bool $failOnWarning = false;
+
     private bool $failOnRisky = false;
+
+    private bool $failOnSkipped = false;
 
     /**
      * @var list<non-empty-string>
@@ -274,9 +279,18 @@ final class GreenlightConfig
         return $this;
     }
 
+    /** Fails an otherwise passed test if captured output contains a notice. */
     public function failOnNotice(bool $enabled = true): self
     {
         $this->failOnNotice = $enabled;
+
+        return $this;
+    }
+
+    /** Fails an otherwise passed test if captured output contains a warning. */
+    public function failOnWarning(bool $enabled = true): self
+    {
+        $this->failOnWarning = $enabled;
 
         return $this;
     }
@@ -289,6 +303,17 @@ final class GreenlightConfig
     public function failOnRisky(bool $enabled = true): self
     {
         $this->failOnRisky = $enabled;
+
+        return $this;
+    }
+
+    /**
+     * Fails the run if its final summary contains a skipped test. The test
+     * keeps its skipped outcome and reason.
+     */
+    public function failOnSkipped(bool $enabled = true): self
+    {
+        $this->failOnSkipped = $enabled;
 
         return $this;
     }
@@ -397,9 +422,11 @@ final class GreenlightConfig
                 policy: new ResultPolicy(
                     $this->failOnDeprecation,
                     $this->failOnNotice,
+                    $this->failOnWarning,
                     $this->ignoreDeprecations,
                     $this->failOnRisky,
                 ),
+                runPolicy: new RunPolicy($this->failOnSkipped),
                 stopAfterFailures: $this->failFast ? 1 : null,
                 artifacts: $this->artifacts->toConfiguration(),
             ),

--- a/src/Result/ResultPolicy.php
+++ b/src/Result/ResultPolicy.php
@@ -15,9 +15,9 @@ use Greenlight\Internal\Wire\WireCommunicationFailed;
  * retries and afterTest subscribers. Thus, each consumer receives the same
  * result.
  *
- * The applicable flag changes a passed test with a captured deprecation or
- * notice to a failed test. The diagnostic becomes the failure detail. The
- * transformation log records the change.
+ * The applicable flag changes a passed test with a captured deprecation,
+ * notice, or warning to a failed test. The diagnostic becomes the failure
+ * detail. The transformation log records the change.
  *
  * A pattern without "*" or "?" matches part of a deprecation message without
  * case sensitivity. A pattern with either character matches the complete
@@ -43,6 +43,7 @@ final readonly class ResultPolicy
     public function __construct(
         public bool $failOnDeprecation = false,
         public bool $failOnNotice = false,
+        public bool $failOnWarning = false,
         array $ignoreDeprecations = [],
         public bool $failOnRisky = false,
     ) {
@@ -63,7 +64,7 @@ final readonly class ResultPolicy
 
     public function isNoOp(): bool
     {
-        return !$this->failOnDeprecation && !$this->failOnNotice && !$this->failOnRisky;
+        return !$this->failOnDeprecation && !$this->failOnNotice && !$this->failOnWarning && !$this->failOnRisky;
     }
 
     public function apply(TestResult $result): TestResult
@@ -78,7 +79,7 @@ final readonly class ResultPolicy
             $offends = match ($diagnostic->severity) {
                 DiagnosticSeverity::Deprecation => $this->failOnDeprecation && !$this->ignored($diagnostic->message),
                 DiagnosticSeverity::Notice => $this->failOnNotice,
-                default => false,
+                DiagnosticSeverity::Warning => $this->failOnWarning,
             };
 
             if ($offends) {
@@ -119,6 +120,7 @@ final readonly class ResultPolicy
         return [
             'failOnDeprecation' => $this->failOnDeprecation,
             'failOnNotice' => $this->failOnNotice,
+            'failOnWarning' => $this->failOnWarning,
             'ignoreDeprecations' => $this->ignoreDeprecations,
             'failOnRisky' => $this->failOnRisky,
         ];
@@ -141,6 +143,7 @@ final readonly class ResultPolicy
         return new self(
             Wire::bool($payload, 'failOnDeprecation'),
             Wire::bool($payload, 'failOnNotice'),
+            \array_key_exists('failOnWarning', $payload) && Wire::bool($payload, 'failOnWarning'),
             $patterns,
             Wire::bool($payload, 'failOnRisky'),
         );

--- a/src/Result/RunPolicy.php
+++ b/src/Result/RunPolicy.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Result;
+
+/**
+ * Applies CI rules that affect the run without changing test outcomes.
+ *
+ * @internal
+ */
+final readonly class RunPolicy
+{
+    public function __construct(public bool $failOnSkipped = false) {}
+
+    public function accepts(ResultSummary $summary): bool
+    {
+        return $summary->isSuccessful() && (!$this->failOnSkipped || $summary->skipped === 0);
+    }
+}

--- a/tests/Acceptance/PolicyTest.php
+++ b/tests/Acceptance/PolicyTest.php
@@ -16,30 +16,34 @@ final readonly class PolicyTest
     public function __construct(private TemporaryDirectory $tempDirectory) {}
 
     #[Test]
-    public function deprecationAndNoticePoliciesFlipPassedTests(): void
+    public function diagnosticPoliciesFlipPassedTests(): void
     {
         $project = $this->writeProject();
         // Without flags, all tests pass. Greenlight records deprecations but
         // does not make them fatal.
         $result = $this->run($project, '--filter=DiagnosticProbeTest');
-        Expect::that($result->exitCode)->because('deprecation and notice policies change passed tests to failed')->toBe(0);
-        Expect::that($result->output())->toContain('3 tests, 3 passed')
+        Expect::that($result->exitCode)->because('diagnostic policies change passed tests to failed')->toBe(0);
+        Expect::that($result->output())->toContain('4 tests, 4 passed')
         // Each test uses one matcher. The summary contains those expectations
         // after transfer from the worker.
-            ->toContain('3 expectations');
+            ->toContain('4 expectations');
         $result = $this->run($project, '--filter=DiagnosticProbeTest', '--fail-on-deprecation');
-        Expect::that($result->exitCode)->because('deprecation and notice policies change passed tests to failed')->toBe(1);
-        Expect::that($result->output())->toContain('3 tests, 2 passed, 1 failed')
+        Expect::that($result->exitCode)->because('diagnostic policies change passed tests to failed')->toBe(1);
+        Expect::that($result->output())->toContain('4 tests, 3 passed, 1 failed')
             ->toContain('deprecation policy changed this test from passed to failed')
             ->toContain('old api is deprecated')
         // The result change MUST NOT remove verified expectations.
-            ->toContain('3 expectations')
+            ->toContain('4 expectations')
         // The deprecation in the allow list does not fail the test.
             ->toContain('PASS PolicyProbe\DiagnosticProbeTest::ignorableDeprecation');
         $result = $this->run($project, '--filter=DiagnosticProbeTest', '--fail-on-notice');
-        Expect::that($result->exitCode)->because('deprecation and notice policies change passed tests to failed')->toBe(1);
+        Expect::that($result->exitCode)->because('diagnostic policies change passed tests to failed')->toBe(1);
         Expect::that($result->output())->toContain('notice policy changed this test from passed to failed')
             ->toContain('a probe notice');
+        $result = $this->run($project, '--filter=DiagnosticProbeTest', '--fail-on-warning');
+        Expect::that($result->exitCode)->because('diagnostic policies change passed tests to failed')->toBe(1);
+        Expect::that($result->output())->toContain('warning policy changed this test from passed to failed')
+            ->toContain('a probe warning');
     }
 
     #[Test]
@@ -63,6 +67,83 @@ final readonly class PolicyTest
         Expect::that($result->exitCode)->because('risky tests warn by default and fail under the flag')->toBe(1);
         Expect::that($result->output())->toContain('3 tests, 2 passed, 1 failed')
             ->toContain('fail-on-risky policy changed this test from passed to failed');
+    }
+
+    #[Test]
+    public function skippedPolicyFailsTheRunAndPreservesReporterOutcomes(): void
+    {
+        $project = $this->writeProject();
+        $result = GreenlightCli::run($project->directory, [
+            'run',
+            '--workers=1',
+            '--filter=SkipProbeTest',
+            '--bail=1',
+            '--fail-on-skipped',
+            '--reporter=plain',
+            '--reporter=junit=reports/junit.xml',
+            '--reporter=jsonl=reports/events.jsonl',
+            '--reporter=teamcity=reports/teamcity.txt',
+            '--reporter=github=reports/github.txt',
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('the skipped policy MUST fail the run without changing skipped results')
+            ->toBe(1);
+        Expect::that($result->output())
+            ->toContain('SKIP PolicyProbe\SkipProbeTest::skips')
+            ->toContain('2 tests, 1 passed, 1 skipped')
+            ->toContain('integration service is unavailable')
+            ->toContain('fail-on-skipped policy found 1 skipped test');
+
+        $junit = (string) \file_get_contents($project->path('reports/junit.xml'));
+        Expect::that($junit)
+            ->because('JUnit MUST retain the skipped testcase')
+            ->toContain('failures="0"')
+            ->toContain('skipped="1"')
+            ->toContain('<skipped message="integration service is unavailable"/>');
+
+        $jsonl = (string) \file_get_contents($project->path('reports/events.jsonl'));
+        Expect::that($jsonl)
+            ->because('JSONL MUST retain skipped result and summary fields')
+            ->toContain('"outcome":"skipped"')
+            ->toContain('"summary":{"passed":1,"failed":0,"errored":0,"skipped":1}');
+
+        $teamCity = (string) \file_get_contents($project->path('reports/teamcity.txt'));
+        Expect::that($teamCity)
+            ->because('TeamCity MUST retain its ignored-test message')
+            ->toContain("##teamcity[testIgnored name='PolicyProbe\\SkipProbeTest::skips' message='integration service is unavailable'");
+
+        Expect::that((string) \file_get_contents($project->path('reports/github.txt')))
+            ->because('GitHub MUST NOT misreport a skipped test as a failed test')
+            ->toBe('');
+    }
+
+    #[Test]
+    public function skippedPolicyWorksAcrossWorkersAndRepeatMode(): void
+    {
+        $project = $this->writeProject();
+        $parallel = $this->run(
+            $project,
+            '--workers=2',
+            '--filter=SkipProbeTest',
+            '--fail-on-skipped',
+        );
+
+        Expect::that($parallel->exitCode)
+            ->because('the run policy MUST use the final process-pool summary')
+            ->toBe(1);
+        Expect::that($parallel->output())->toContain('2 tests, 1 passed, 1 skipped');
+
+        $repeated = $this->run(
+            $project,
+            '--filter=SkipProbeTest',
+            '--fail-on-skipped',
+            '--repeat=2',
+        );
+        Expect::that($repeated->exitCode)
+            ->because('each iteration with a skipped test MUST fail repeat mode')
+            ->toBe(1);
+        Expect::that($repeated->output())->toContain('Repeat: failed iterations: 1, 2');
     }
 
     private function run(AcceptanceProject $project, string ...$flags): ProcessResult
@@ -104,6 +185,40 @@ final readonly class PolicyTest
                 public function triggersNotice(): void
                 {
                     \trigger_error('a probe notice', \E_USER_NOTICE);
+                    Expect::that(true)->toBeTrue();
+                }
+
+                #[Test]
+                public function triggersWarning(): void
+                {
+                    \trigger_error('a probe warning', \E_USER_WARNING);
+                    Expect::that(true)->toBeTrue();
+                }
+            }
+            PHP);
+
+        $project->writeFile('tests/SkipProbeTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace PolicyProbe;
+
+            use Greenlight\Attribute\Test;
+            use Greenlight\Expect\Expect;
+            use Greenlight\Test\SkipTest;
+
+            final class SkipProbeTest
+            {
+                #[Test]
+                public function skips(): never
+                {
+                    throw new SkipTest('integration service is unavailable');
+                }
+
+                #[Test]
+                public function stillRunsAfterTheSkip(): void
+                {
                     Expect::that(true)->toBeTrue();
                 }
             }
@@ -157,6 +272,7 @@ final readonly class PolicyTest
 
             require_once __DIR__ . '/tests/DiagnosticProbeTest.php';
             require_once __DIR__ . '/tests/RiskyProbeTest.php';
+            require_once __DIR__ . '/tests/SkipProbeTest.php';
 
             return GreenlightConfig::create()
                 ->paths([__DIR__ . '/tests'])

--- a/tests/Unit/Cli/Configuration/ConfigurationResolverSelectionTest.php
+++ b/tests/Unit/Cli/Configuration/ConfigurationResolverSelectionTest.php
@@ -13,6 +13,7 @@ use Greenlight\Config\GreenlightConfig;
 use Greenlight\Config\ResolvedConfiguration;
 use Greenlight\Expect\Expect;
 use Greenlight\Result\ResultPolicy;
+use Greenlight\Result\RunPolicy;
 use Greenlight\Test\TestExclusions;
 use Greenlight\Test\TestInclusions;
 use Greenlight\Test\TestSelection;
@@ -54,7 +55,7 @@ final readonly class ConfigurationResolverSelectionTest
     }
 
     /**
-     * @param array{bool, bool, bool} $expected
+     * @param array{bool, bool, bool, bool, bool} $expected
      */
     #[Test]
     #[DataSet('failurePolicyOverrides')]
@@ -73,24 +74,38 @@ final readonly class ConfigurationResolverSelectionTest
         Expect::that($policy->failOnRisky)
             ->because('the risky-test policy flag MUST map to failOnRisky')
             ->toBe($expected[2]);
+        Expect::that($policy->failOnWarning)
+            ->because('the warning policy flag MUST map to failOnWarning')
+            ->toBe($expected[3]);
+        Expect::that($this->resolve($overrides)->execution->runPolicy->failOnSkipped)
+            ->because('the skipped-test policy flag MUST map to failOnSkipped')
+            ->toBe($expected[4]);
     }
 
     /**
-     * @return iterable<string, array{CliOverrides, array{bool, bool, bool}}>
+     * @return iterable<string, array{CliOverrides, array{bool, bool, bool, bool, bool}}>
      */
     public static function failurePolicyOverrides(): iterable
     {
         yield 'deprecation' => [
             new CliOverrides(execution: new ExecutionOverrides(policy: new ResultPolicy(failOnDeprecation: true))),
-            [true, false, false],
+            [true, false, false, false, false],
         ];
         yield 'notice' => [
             new CliOverrides(execution: new ExecutionOverrides(policy: new ResultPolicy(failOnNotice: true))),
-            [false, true, false],
+            [false, true, false, false, false],
         ];
         yield 'risky' => [
             new CliOverrides(execution: new ExecutionOverrides(policy: new ResultPolicy(failOnRisky: true))),
-            [false, false, true],
+            [false, false, true, false, false],
+        ];
+        yield 'warning' => [
+            new CliOverrides(execution: new ExecutionOverrides(policy: new ResultPolicy(failOnWarning: true))),
+            [false, false, false, true, false],
+        ];
+        yield 'skipped' => [
+            new CliOverrides(execution: new ExecutionOverrides(runPolicy: new RunPolicy(failOnSkipped: true))),
+            [false, false, false, false, true],
         ];
     }
 

--- a/tests/Unit/Config/GreenlightConfigApiTest.php
+++ b/tests/Unit/Config/GreenlightConfigApiTest.php
@@ -35,6 +35,8 @@ final class GreenlightConfigApiTest
             'failOnDeprecation',
             'failOnNotice',
             'failOnRisky',
+            'failOnSkipped',
+            'failOnWarning',
             'ignoreDeprecationsMatching',
             'paths',
             'plugins',

--- a/tests/Unit/Config/ResultPolicyConfigurationTest.php
+++ b/tests/Unit/Config/ResultPolicyConfigurationTest.php
@@ -64,6 +64,20 @@ final class ResultPolicyConfigurationTest
             'failOnNotice',
             false,
         ];
+        yield 'fail on warning enabled' => [
+            static function (GreenlightConfig $config): void {
+                $config->failOnWarning();
+            },
+            'failOnWarning',
+            true,
+        ];
+        yield 'fail on warning disabled' => [
+            static function (GreenlightConfig $config): void {
+                $config->failOnWarning()->failOnWarning(false);
+            },
+            'failOnWarning',
+            false,
+        ];
         yield 'fail on risky enabled' => [
             static function (GreenlightConfig $config): void {
                 $config->failOnRisky();
@@ -78,6 +92,20 @@ final class ResultPolicyConfigurationTest
             'failOnRisky',
             false,
         ];
+    }
+
+    #[Test]
+    public function skippedPolicyFlowsIntoTheBuiltConfiguration(): void
+    {
+        $policy = GreenlightConfig::create()
+            ->failOnSkipped()
+            ->build()
+            ->execution
+            ->runPolicy;
+
+        Expect::that($policy->failOnSkipped)
+            ->because('the public configuration flag MUST reach the run policy')
+            ->toBeTrue();
     }
 
     #[Test]

--- a/tests/Unit/Execution/ProcessPool/Protocol/WorkerProtocolSchemaTest.php
+++ b/tests/Unit/Execution/ProcessPool/Protocol/WorkerProtocolSchemaTest.php
@@ -105,6 +105,7 @@ final class WorkerProtocolSchemaTest
             ['artifactSession'],
             ['artifactConfiguration'],
             ['stopAfterFailures'],
+            ['policy', 'failOnWarning'],
         ]);
         $eventPayload = $this->withoutPaths($this->messages()['event']->toWire(), [
             ['data', 'result', 'risky'],
@@ -223,7 +224,13 @@ final class WorkerProtocolSchemaTest
                 ['/project/src'],
                 'pcov',
                 true,
-                new ResultPolicy(true, true, ['known deprecation*'], true),
+                new ResultPolicy(
+                    failOnDeprecation: true,
+                    failOnNotice: true,
+                    failOnWarning: true,
+                    ignoreDeprecations: ['known deprecation*'],
+                    failOnRisky: true,
+                ),
                 new ArtifactSession('/tmp/greenlight-staging', 'build/greenlight-artifacts/run-1'),
                 new ArtifactConfiguration(maxRunAttachments: 100),
                 stopAfterFailures: 3,

--- a/tests/Unit/Result/ResultPolicyTest.php
+++ b/tests/Unit/Result/ResultPolicyTest.php
@@ -45,6 +45,7 @@ final class ResultPolicyTest
         ];
         yield 'deprecation enforcement' => [new ResultPolicy(failOnDeprecation: true), false];
         yield 'notice enforcement' => [new ResultPolicy(failOnNotice: true), false];
+        yield 'warning enforcement' => [new ResultPolicy(failOnWarning: true), false];
         yield 'risky-test enforcement' => [new ResultPolicy(failOnRisky: true), false];
     }
 
@@ -228,6 +229,28 @@ final class ResultPolicyTest
     }
 
     #[Test]
+    public function theWarningPolicyFailsAPassedTestWithAWarning(): void
+    {
+        $before = new TestResult(
+            new TestId('App\ProbeTest', 'warns'),
+            Outcome::Passed,
+            durationSeconds: 0.1,
+            memoryDeltaBytes: 0,
+            output: new CapturedOutput('', [
+                new Diagnostic(DiagnosticSeverity::Warning, 'a warning', '/src/a.php', 2),
+            ]),
+        );
+
+        $result = new ResultPolicy(failOnWarning: true)->apply($before);
+
+        Expect::that($result->outcome)
+            ->because('the warning policy fails a passed test that captures a warning')
+            ->toBe(Outcome::Failed);
+        Expect::that($result->failures[0]->message)
+            ->toBe('The warning policy changed this test from passed to failed: a warning at /src/a.php:2');
+    }
+
+    #[Test]
     public function diagnosticFailuresAggregateBeforeTheRiskyPolicy(): void
     {
         $before = new TestResult(
@@ -305,6 +328,7 @@ final class ResultPolicyTest
         $restored = ResultPolicy::fromWire([
             'failOnDeprecation' => true,
             'failOnNotice' => true,
+            'failOnWarning' => true,
             'ignoreDeprecations' => ['legacy *', ''],
             'failOnRisky' => true,
         ]);
@@ -314,9 +338,25 @@ final class ResultPolicyTest
             ->toBe([
                 'failOnDeprecation' => true,
                 'failOnNotice' => true,
+                'failOnWarning' => true,
                 'ignoreDeprecations' => ['legacy *'],
                 'failOnRisky' => true,
             ]);
+    }
+
+    #[Test]
+    public function aCompatibleWirePayloadWithoutTheWarningPolicyUsesTheDefault(): void
+    {
+        $restored = ResultPolicy::fromWire([
+            'failOnDeprecation' => false,
+            'failOnNotice' => false,
+            'ignoreDeprecations' => [],
+            'failOnRisky' => false,
+        ]);
+
+        Expect::that($restored->failOnWarning)
+            ->because('a compatible worker payload MUST disable the new warning policy')
+            ->toBeFalse();
     }
 
     private function passedWithDeprecation(string $message = 'rusty api'): TestResult

--- a/tests/Unit/Result/RunPolicyTest.php
+++ b/tests/Unit/Result/RunPolicyTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Result;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Result\ResultSummary;
+use Greenlight\Result\RunPolicy;
+
+final readonly class RunPolicyTest
+{
+    /**
+     * @param array{bool, int, int, int} $case
+     */
+    #[Test]
+    #[DataSet('summaries')]
+    public function skippedPolicyEvaluatesTheFinalSummaryWithoutChangingIt(array $case, bool $expected): void
+    {
+        [$failOnSkipped, $failed, $errored, $skipped] = $case;
+        $summary = new ResultSummary(failed: $failed, errored: $errored, skipped: $skipped);
+
+        Expect::that(new RunPolicy($failOnSkipped)->accepts($summary))
+            ->because('the run policy MUST evaluate the final summary without changing test outcomes')
+            ->toBe($expected);
+    }
+
+    /**
+     * @return iterable<string, array{array{bool, int, int, int}, bool}>
+     */
+    public static function summaries(): iterable
+    {
+        yield 'default accepts skipped tests' => [[false, 0, 0, 1], true];
+        yield 'enabled accepts a clean summary' => [[true, 0, 0, 0], true];
+        yield 'enabled rejects skipped tests' => [[true, 0, 0, 1], false];
+        yield 'enabled rejects failed tests' => [[true, 1, 0, 0], false];
+        yield 'enabled rejects errored tests' => [[true, 0, 1, 0], false];
+    }
+}


### PR DESCRIPTION
## Summary

- Add failOnWarning() and --fail-on-warning as captured-diagnostic result policies.
- Add failOnSkipped() and --fail-on-skipped as a run policy that preserves skipped outcomes and reasons.
- Keep bail, retries, plugins, repeat mode, worker transport, exit status, and reporter output consistent with terminal results.
- Document the policy semantics and regenerate the public configuration API.