### PR TITLE
refactor(results): apply terminal policies as plugins

### DIFF
--- a/docs/api-plugins.md
+++ b/docs/api-plugins.md
@@ -126,13 +126,14 @@ Identifies an object as a Greenlight plugin.
 Plugins implement one or more capability interfaces such as
 `WorkerRuntimeRunner`, `TestAttemptRunner`, `BeforeTestSubscriber`,
 `AfterTestSubscriber`, `RunLifecycleSubscriber`, `RetryDecider`,
-`HarnessProvider`, `ReporterProvider`, or `ExpectationExtension`.
+`HarnessProvider`, `ReporterProvider`, `TerminalResultTransformer`, or
+`ExpectationExtension`.
 
 ```php
 interface Plugin
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/Plugin.php#L15)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/Plugin.php#L16)
 
 This type does not declare public members.
 
@@ -240,6 +241,36 @@ public function onRunEvent(Event $event): void;
 ```
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/RunLifecycleSubscriber.php#L18)
+
+## `TerminalResultTransformer`
+
+Namespace: `Greenlight\Plugin`
+
+Transforms a test result after retries and test-scope teardown complete.
+
+Greenlight runs lower priorities first. It uses registration order for
+equal priorities. Greenlight calls each transformer one time for each
+executed test, before the worker finalizes the class scope and publishes the
+result.
+
+A plugin can return the same result or a replacement. It MUST preserve the
+test identity. Use `TestResult::withOutcome()` for outcome changes so that
+the result records their source. Greenlight contains transformer failures
+and continues with the remaining transformers.
+
+```php
+interface TerminalResultTransformer extends Plugin
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TerminalResultTransformer.php#L23)
+
+### `transformTerminalResult()`
+
+```php
+public function transformTerminalResult(TestDefinition $definition, TestResult $result): TestResult;
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TerminalResultTransformer.php#L25)
 
 ## `TestAttemptRunner`
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -421,6 +421,29 @@ content.
 
 The built-in `#[Retry]` attribute uses this interface.
 
+### TerminalResultTransformer
+
+Worker-side.
+
+<!-- php-example {"mode":"display","reason":"Shows one method signature without its interface declaration."} -->
+```php
+public function transformTerminalResult(TestDefinition $definition, TestResult $result): TestResult;
+```
+
+Greenlight calls a terminal-result transformer one time after the last attempt.
+The test scope is closed. The worker has not yet closed the class scope or
+published `TestFinished`.
+
+The transformer receives the test definition and the result that remains after
+retries. It must return the same result or a replacement. It MUST preserve the
+test identity. Use `TestResult::withOutcome()` for each outcome change.
+
+Greenlight runs all terminal-result transformers. If a transformer throws,
+Greenlight records the failure on the result and continues with the remaining
+transformers.
+
+The built-in diagnostic and risky-test policies use this interface.
+
 ### RunLifecycleSubscriber
 
 Orchestrator-side.
@@ -629,6 +652,7 @@ Priority applies to these capabilities:
 * `BeforeTestSubscriber`
 * `AfterTestSubscriber`
 * `RetryDecider`
+* `TerminalResultTransformer`
 * `RunLifecycleSubscriber`
 * `HarnessProvider`
 * `ServiceResolver`

--- a/resources/schema/worker-protocol-v3.schema.json
+++ b/resources/schema/worker-protocol-v3.schema.json
@@ -91,7 +91,13 @@
                 "configFile": {"type": ["string", "null"]},
                 "resources": {"$ref": "#/definitions/integrationResources"},
                 "generatedCodeDirectory": {"type": ["string", "null"]},
-                "temporaryDirectory": {"type": ["string", "null"]}
+                "temporaryDirectory": {"type": ["string", "null"]},
+                "policy": {
+                    "oneOf": [
+                        {"type": "null"},
+                        {"$ref": "#/definitions/resultPolicy"}
+                    ]
+                }
             }
         },
         "integrationResources": {

--- a/src/Execution/Adapter/InProcessExecution.php
+++ b/src/Execution/Adapter/InProcessExecution.php
@@ -17,6 +17,7 @@ use Greenlight\Execution\ExecutionTopology;
 use Greenlight\Execution\Plugin\WorkerPluginRuntime;
 use Greenlight\Execution\Worker\HarnessServiceDisposal;
 use Greenlight\Execution\Worker\LeakDetector;
+use Greenlight\Execution\Worker\ResultPolicyPlugin;
 use Greenlight\Execution\Worker\StandardHarnessPlugin;
 use Greenlight\Execution\Worker\Worker;
 use Greenlight\Execution\Worker\WorkerError;
@@ -68,6 +69,7 @@ final readonly class InProcessExecution implements ExecutionAdapter
                 $context->storage->generatedCodeDirectory,
                 $context->storage->temporaryDirectory,
             ),
+            ...($execution->policy->isNoOp() ? [] : [new ResultPolicyPlugin($execution->policy)]),
         ]);
         $channelEnvironment = EnvironmentBackup::capture('GREENLIGHT_CHANNEL');
         \putenv('GREENLIGHT_CHANNEL=1');
@@ -105,7 +107,6 @@ final readonly class InProcessExecution implements ExecutionAdapter
                             $plugins,
                             $this->detectLeaks ? new LeakDetector() : null,
                             'in-process',
-                            $execution->policy->isNoOp() ? null : $execution->policy,
                             $context->artifacts,
                         )->run(
                             $plan,

--- a/src/Execution/Plugin/PluginRuntimeError.php
+++ b/src/Execution/Plugin/PluginRuntimeError.php
@@ -31,11 +31,16 @@ final class PluginRuntimeError extends \RuntimeException
     }
 
     /** @param class-string $plugin */
-    public static function changedTestIdentity(string $plugin, TestId $before, TestId $after): self
-    {
+    public static function changedTestIdentity(
+        string $plugin,
+        TestId $before,
+        TestId $after,
+        string $hook = 'afterTest',
+    ): self {
         return new self(\sprintf(
-            'Plugin "%s" changed the test identity during afterTest() from "%s" to "%s".',
+            'Plugin "%s" changed the test identity during %s() from "%s" to "%s".',
             $plugin,
+            $hook,
             $before,
             $after,
         ));

--- a/src/Execution/Plugin/WorkerPluginRuntime.php
+++ b/src/Execution/Plugin/WorkerPluginRuntime.php
@@ -16,6 +16,7 @@ use Greenlight\Plugin\HarnessProvider;
 use Greenlight\Plugin\Plugin;
 use Greenlight\Plugin\PluginDefinition;
 use Greenlight\Plugin\RetryDecider;
+use Greenlight\Plugin\TerminalResultTransformer;
 use Greenlight\Plugin\TestAttemptRunner;
 use Greenlight\Plugin\TestContext;
 use Greenlight\Plugin\WorkerBootstrapContext;
@@ -26,6 +27,7 @@ use Greenlight\Result\TestResult;
 use Greenlight\Result\ThrowableDetail;
 use Greenlight\Test\RetryPolicy;
 use Greenlight\Test\SkipTest;
+use Greenlight\Test\TestDefinition;
 
 /**
  * Executes the plugin capabilities that one physical worker owns.
@@ -44,6 +46,7 @@ final readonly class WorkerPluginRuntime extends PluginRuntime
         HarnessProvider::class,
         RetryDecider::class,
         ServiceResolver::class,
+        TerminalResultTransformer::class,
         TestAttemptRunner::class,
         WorkerBootstrapSubscriber::class,
         WorkerRuntimeRunner::class,
@@ -172,47 +175,39 @@ final readonly class WorkerPluginRuntime extends PluginRuntime
             try {
                 $replacement = $subscriber->afterTest($context, $result);
             } catch (\Throwable $failure) {
-                if ($result->outcome->isSuccessful()) {
-                    $result = $result->erroredBy(ThrowableDetail::fromThrowable(
-                        PluginRuntimeError::hookFailed($subscriber::class, 'afterTest', $failure),
-                    ));
-                } else {
-                    $result = $result->withFailures([
-                        ...$result->failures,
-                        new FailureDetail(\sprintf(
-                            'Plugin "%s" caused an error during afterTest(): %s',
-                            $subscriber::class,
-                            $failure->getMessage(),
-                        )),
-                    ]);
-                }
+                $result = $this->hookFailure($subscriber::class, 'afterTest', $result, $failure);
 
                 continue;
             }
 
-            if (!$replacement->id->equals($result->id)) {
-                $result = $result->erroredBy(ThrowableDetail::fromThrowable(
-                    PluginRuntimeError::changedTestIdentity($subscriber::class, $result->id, $replacement->id),
-                ));
+            $result = $this->validatedReplacement($subscriber::class, 'afterTest', $result, $replacement);
+        }
+
+        return $result;
+    }
+
+    public function terminalResult(TestDefinition $definition, TestResult $result): TestResult
+    {
+        foreach ($this->ordered(TerminalResultTransformer::class) as $transformer) {
+            try {
+                $replacement = $transformer->transformTerminalResult($definition, $result);
+            } catch (\Throwable $failure) {
+                $result = $this->hookFailure(
+                    $transformer::class,
+                    'transformTerminalResult',
+                    $result,
+                    $failure,
+                );
 
                 continue;
             }
 
-            if ($replacement->outcome !== $result->outcome
-                && \count($replacement->transformations) <= \count($result->transformations)
-            ) {
-                $result = $result->erroredBy(ThrowableDetail::fromThrowable(
-                    PluginRuntimeError::changedOutcome(
-                        $subscriber::class,
-                        $result->outcome,
-                        $replacement->outcome,
-                    ),
-                ));
-
-                continue;
-            }
-
-            $result = $replacement;
+            $result = $this->validatedReplacement(
+                $transformer::class,
+                'transformTerminalResult',
+                $result,
+                $replacement,
+            );
         }
 
         return $result;
@@ -228,5 +223,57 @@ final readonly class WorkerPluginRuntime extends PluginRuntime
             $this->ordered(RetryDecider::class),
             static fn(RetryDecider $decider): bool => $decider->shouldRetry($policy, $result, $attempt, $cause),
         );
+    }
+
+    /** @param class-string $plugin */
+    private function hookFailure(
+        string $plugin,
+        string $hook,
+        TestResult $result,
+        \Throwable $failure,
+    ): TestResult {
+        if ($result->outcome->isSuccessful()) {
+            return $result->erroredBy(ThrowableDetail::fromThrowable(
+                PluginRuntimeError::hookFailed($plugin, $hook, $failure),
+            ));
+        }
+
+        return $result->withFailures([
+            ...$result->failures,
+            new FailureDetail(\sprintf(
+                'Plugin "%s" caused an error during %s(): %s',
+                $plugin,
+                $hook,
+                $failure->getMessage(),
+            )),
+        ]);
+    }
+
+    /** @param class-string $plugin */
+    private function validatedReplacement(
+        string $plugin,
+        string $hook,
+        TestResult $result,
+        TestResult $replacement,
+    ): TestResult {
+        if (!$replacement->id->equals($result->id)) {
+            return $result->erroredBy(ThrowableDetail::fromThrowable(
+                PluginRuntimeError::changedTestIdentity($plugin, $result->id, $replacement->id, $hook),
+            ));
+        }
+
+        if ($replacement->outcome !== $result->outcome
+            && \count($replacement->transformations) <= \count($result->transformations)
+        ) {
+            return $result->erroredBy(ThrowableDetail::fromThrowable(
+                PluginRuntimeError::changedOutcome(
+                    $plugin,
+                    $result->outcome,
+                    $replacement->outcome,
+                ),
+            ));
+        }
+
+        return $replacement;
     }
 }

--- a/src/Execution/ProcessPool/Orchestrator/Orchestrator.php
+++ b/src/Execution/ProcessPool/Orchestrator/Orchestrator.php
@@ -397,6 +397,7 @@ final class Orchestrator
                 $this->configuration->integrationFixtures->forChannel($handle->channelNumber),
                 $this->configuration->generatedCodeDirectory,
                 $this->configuration->temporaryDirectory,
+                $this->configuration->policy,
             ));
         } catch (ProtocolError) {
             $this->containCrash($handle, $sink, 'the worker exited before receiving bootstrap data');

--- a/src/Execution/ProcessPool/Protocol/Messages/Bootstrap.php
+++ b/src/Execution/ProcessPool/Protocol/Messages/Bootstrap.php
@@ -7,6 +7,7 @@ namespace Greenlight\Execution\ProcessPool\Protocol\Messages;
 use Greenlight\Execution\ProcessPool\Protocol\Message;
 use Greenlight\IntegrationFixture\IntegrationResources;
 use Greenlight\Internal\Wire\Wire;
+use Greenlight\Result\ResultPolicy;
 
 /**
  * Orchestrator to worker: immutable worker-lifetime configuration.
@@ -25,6 +26,7 @@ final readonly class Bootstrap implements Message
         public IntegrationResources $resources,
         public ?string $generatedCodeDirectory = null,
         public ?string $temporaryDirectory = null,
+        public ?ResultPolicy $policy = null,
     ) {}
 
     #[\Override]
@@ -42,6 +44,7 @@ final readonly class Bootstrap implements Message
             'resources' => $this->resources->toWire(),
             'generatedCodeDirectory' => $this->generatedCodeDirectory,
             'temporaryDirectory' => $this->temporaryDirectory,
+            'policy' => $this->policy?->toWire(),
         ];
     }
 
@@ -60,6 +63,9 @@ final readonly class Bootstrap implements Message
             ($temporary = \array_key_exists('temporaryDirectory', $payload)
                 ? Wire::nullableString($payload, 'temporaryDirectory')
                 : null) === '' ? null : $temporary,
+            ($policy = \array_key_exists('policy', $payload) ? Wire::nullableMap($payload, 'policy') : null) === null
+                ? null
+                : ResultPolicy::fromWire($policy),
         );
     }
 }

--- a/src/Execution/ProcessPool/Worker/WorkerProcess.php
+++ b/src/Execution/ProcessPool/Worker/WorkerProcess.php
@@ -25,6 +25,7 @@ use Greenlight\Execution\ProcessPool\Protocol\SocketChannel;
 use Greenlight\Execution\Worker\ChannelEnvironment;
 use Greenlight\Execution\Worker\HarnessServiceDisposal;
 use Greenlight\Execution\Worker\LeakDetector;
+use Greenlight\Execution\Worker\ResultPolicyPlugin;
 use Greenlight\Execution\Worker\StandardHarnessPlugin;
 use Greenlight\Execution\Worker\Worker;
 use Greenlight\Execution\Worker\WorkerError;
@@ -32,6 +33,7 @@ use Greenlight\Harness\HarnessScopes;
 use Greenlight\Internal\Php\ErrorTrap;
 use Greenlight\Internal\Wire\WireCommunicationFailed;
 use Greenlight\Plugin\WorkerBootstrapContext;
+use Greenlight\Result\ResultPolicy;
 use Greenlight\Result\ThrowableDetail;
 use Greenlight\Test\TestChannel;
 use Greenlight\Test\TestId;
@@ -148,6 +150,9 @@ final readonly class WorkerProcess
                         $message->generatedCodeDirectory,
                         $message->temporaryDirectory,
                     ),
+                    ...(!$message->policy instanceof ResultPolicy
+                        ? []
+                        : [new ResultPolicyPlugin($message->policy)]),
                 ]);
                 $scopes = $plugins->prepareWorker(
                     $bootstrap,
@@ -252,7 +257,6 @@ final readonly class WorkerProcess
                 $plugins,
                 $leakDetector,
                 $workerId,
-                $message->policy,
                 $artifactStore,
             )->run(
                 $message->slice,

--- a/src/Execution/Worker/ResultPolicyPlugin.php
+++ b/src/Execution/Worker/ResultPolicyPlugin.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Execution\Worker;
+
+use Greenlight\Plugin\TerminalResultTransformer;
+use Greenlight\Result\ResultPolicy;
+use Greenlight\Result\TestResult;
+use Greenlight\Test\TestDefinition;
+
+/**
+ * Applies the configured result policy through the terminal-result plugin
+ * capability.
+ *
+ * @internal
+ */
+final readonly class ResultPolicyPlugin implements TerminalResultTransformer
+{
+    public function __construct(private ResultPolicy $policy) {}
+
+    #[\Override]
+    public function transformTerminalResult(TestDefinition $definition, TestResult $result): TestResult
+    {
+        return $this->policy->apply($result);
+    }
+}

--- a/src/Execution/Worker/TestExecutor.php
+++ b/src/Execution/Worker/TestExecutor.php
@@ -22,7 +22,6 @@ use Greenlight\Harness\UnresolvableService;
 use Greenlight\Plugin\TestContext;
 use Greenlight\Result\FailureDetail;
 use Greenlight\Result\Outcome;
-use Greenlight\Result\ResultPolicy;
 use Greenlight\Result\TestResult;
 use Greenlight\Result\ThrowableDetail;
 use Greenlight\Test\Cleanup;
@@ -65,7 +64,6 @@ final readonly class TestExecutor
         private ClassContext $context,
         private WorkerPluginRuntime $plugins,
         private ?LeakDetector $leakDetector = null,
-        private ?ResultPolicy $policy = null,
         private ?ArtifactStore $artifactStore = null,
         private ?\Closure $attemptStarted = null,
     ) {}
@@ -137,7 +135,6 @@ final readonly class TestExecutor
             }
 
             if ($result->outcome->isSuccessful()) {
-                $result = $this->policy?->apply($result) ?? $result;
                 $sealed = $attachments?->seal() ?? [];
 
                 return $result->withAttachments([...$retainedAttachments, ...$sealed]);
@@ -155,8 +152,6 @@ final readonly class TestExecutor
             $sealed = $attachments?->seal() ?? [];
 
             if (!$retry) {
-                $result = $this->policy?->apply($result) ?? $result;
-
                 return $result->withAttachments([...$retainedAttachments, ...$sealed]);
             }
 

--- a/src/Execution/Worker/Worker.php
+++ b/src/Execution/Worker/Worker.php
@@ -16,7 +16,6 @@ use Greenlight\Execution\Plugin\WorkerPluginRuntime;
 use Greenlight\Harness\HarnessScopes;
 use Greenlight\Harness\ServiceDefinition;
 use Greenlight\Result\Outcome;
-use Greenlight\Result\ResultPolicy;
 use Greenlight\Result\ResultSummary;
 use Greenlight\Result\TestResult;
 use Greenlight\Result\ThrowableDetail;
@@ -45,7 +44,6 @@ final readonly class Worker
         private ?WorkerPluginRuntime $plugins = null,
         private ?LeakDetector $leakDetector = null,
         private string $workerId = '',
-        private ?ResultPolicy $policy = null,
         private ?ArtifactStore $artifactStore = null,
     ) {}
 
@@ -100,7 +98,6 @@ final readonly class Worker
                         $context,
                         $plugins,
                         $this->leakDetector,
-                        $this->policy,
                         $this->artifactStore,
                         $attemptStarted,
                     );
@@ -114,6 +111,8 @@ final readonly class Worker
                         error: ThrowableDetail::fromThrowable($threw),
                     );
                 }
+
+                $result = $plugins->terminalResult($entry->definition, $result);
 
                 $candidateSummary = $summary->add($result->outcome);
                 $failureLimitReached = $stopAfterFailures !== null

--- a/src/Plugin/Plugin.php
+++ b/src/Plugin/Plugin.php
@@ -10,6 +10,7 @@ namespace Greenlight\Plugin;
  * Plugins implement one or more capability interfaces such as
  * `WorkerRuntimeRunner`, `TestAttemptRunner`, `BeforeTestSubscriber`,
  * `AfterTestSubscriber`, `RunLifecycleSubscriber`, `RetryDecider`,
- * `HarnessProvider`, `ReporterProvider`, or `ExpectationExtension`.
+ * `HarnessProvider`, `ReporterProvider`, `TerminalResultTransformer`, or
+ * `ExpectationExtension`.
  */
 interface Plugin {}

--- a/src/Plugin/TerminalResultTransformer.php
+++ b/src/Plugin/TerminalResultTransformer.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Plugin;
+
+use Greenlight\Result\TestResult;
+use Greenlight\Test\TestDefinition;
+
+/**
+ * Transforms a test result after retries and test-scope teardown complete.
+ *
+ * Greenlight runs lower priorities first. It uses registration order for
+ * equal priorities. Greenlight calls each transformer one time for each
+ * executed test, before the worker finalizes the class scope and publishes the
+ * result.
+ *
+ * A plugin can return the same result or a replacement. It MUST preserve the
+ * test identity. Use `TestResult::withOutcome()` for outcome changes so that
+ * the result records their source. Greenlight contains transformer failures
+ * and continues with the remaining transformers.
+ */
+interface TerminalResultTransformer extends Plugin
+{
+    public function transformTerminalResult(TestDefinition $definition, TestResult $result): TestResult;
+}

--- a/src/Result/ResultPolicy.php
+++ b/src/Result/ResultPolicy.php
@@ -11,9 +11,9 @@ use Greenlight\Internal\Wire\WireCommunicationFailed;
 /**
  * CI rules that can change a passed test to a failed test.
  *
- * The worker calls apply() for each final result. This call occurs after
- * retries and afterTest subscribers. Thus, each consumer receives the same
- * result.
+ * Greenlight applies the policy through its terminal-result plugin. This call
+ * occurs after retries and afterTest subscribers. Thus, each consumer receives
+ * the same result.
  *
  * The applicable flag changes a passed test with a captured deprecation,
  * notice, or warning to a failed test. The diagnostic becomes the failure

--- a/tests/Unit/Execution/ProcessPool/Protocol/ProtocolTest.php
+++ b/tests/Unit/Execution/ProcessPool/Protocol/ProtocolTest.php
@@ -29,6 +29,7 @@ use Greenlight\IntegrationFixture\FixtureResource;
 use Greenlight\IntegrationFixture\IntegrationResources;
 use Greenlight\Result\FailureDetail;
 use Greenlight\Result\Outcome;
+use Greenlight\Result\ResultPolicy;
 use Greenlight\Result\ResultSummary;
 use Greenlight\Result\TestResult;
 use Greenlight\Result\ThrowableDetail;
@@ -62,7 +63,7 @@ final class ProtocolTest
                     ['database' => 'test_2'],
                     ['password' => 'secret'],
                 ),
-            ])),
+            ]), policy: new ResultPolicy(failOnRisky: true)),
             new Ready(),
             new Assign(new ExecutionPlan([$entry], 7)),
             new Drain(),
@@ -162,6 +163,17 @@ final class ProtocolTest
             ->toBeNull();
         Expect::that($assign->stopAfterFailures)
             ->because('legacy assignments have no local failure allowance')
+            ->toBeNull();
+    }
+
+    #[Test]
+    public function legacyBootstrapPayloadsDefaultTheResultPolicy(): void
+    {
+        $payload = new Bootstrap(1, null, new IntegrationResources())->toWire();
+        unset($payload['policy']);
+
+        Expect::that(Bootstrap::fromWire($payload)->policy)
+            ->because('legacy bootstrap payloads do not contain a result policy')
             ->toBeNull();
     }
 

--- a/tests/Unit/Execution/ProcessPool/Protocol/WorkerProtocolSchemaTest.php
+++ b/tests/Unit/Execution/ProcessPool/Protocol/WorkerProtocolSchemaTest.php
@@ -101,6 +101,9 @@ final class WorkerProtocolSchemaTest
     #[Test]
     public function compatiblePayloadsWithoutNewOptionalFieldsValidateAgainstTheSchema(): void
     {
+        $bootstrapPayload = $this->withoutPaths($this->messages()['bootstrap']->toWire(), [
+            ['policy'],
+        ]);
         $assignPayload = $this->withoutPaths($this->messages()['assign']->toWire(), [
             ['artifactSession'],
             ['artifactConfiguration'],
@@ -113,6 +116,9 @@ final class WorkerProtocolSchemaTest
             ['data', 'result', 'attachments'],
         ]);
 
+        Expect::that($this->validationErrors($this->asJsonObject(['v' => 3, 't' => 'bootstrap', 'p' => $bootstrapPayload])))
+            ->because('the schema MUST accept compatible bootstrap payloads')
+            ->toBe([]);
         Expect::that($this->validationErrors($this->asJsonObject(['v' => 3, 't' => 'assign', 'p' => $assignPayload])))
             ->because('the schema MUST accept compatible assignment payloads')
             ->toBe([]);
@@ -217,6 +223,13 @@ final class WorkerProtocolSchemaTest
                         ['password' => 'test-secret'],
                     ),
                 ]),
+                policy: new ResultPolicy(
+                    failOnDeprecation: true,
+                    failOnNotice: true,
+                    failOnWarning: true,
+                    ignoreDeprecations: ['known deprecation*'],
+                    failOnRisky: true,
+                ),
             ),
             'ready' => new Ready(),
             'assign' => new Assign(

--- a/tests/Unit/Plugin/TerminalResultTransformerTest.php
+++ b/tests/Unit/Plugin/TerminalResultTransformerTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Plugin;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\TestDiscoverer;
+use Greenlight\Doubles\Fake;
+use Greenlight\Execution\Plugin\PluginRuntimeError;
+use Greenlight\Execution\Plugin\WorkerPluginRuntime;
+use Greenlight\Execution\Worker\StandardHarnessPlugin;
+use Greenlight\Execution\Worker\Worker;
+use Greenlight\Expect\Expect;
+use Greenlight\Plugin\RetryDecider;
+use Greenlight\Plugin\TerminalResultTransformer;
+use Greenlight\Result\Outcome;
+use Greenlight\Result\TestResult;
+use Greenlight\Test\RetryPolicy;
+use Greenlight\Test\TestDefinition;
+use Greenlight\Test\TestId;
+use Greenlight\Tests\Support\CollectingEventSink;
+use Greenlight\Tests\Support\FixturePath;
+
+final readonly class TerminalResultTransformerTest
+{
+    #[Test]
+    public function transformerRunsOnceAfterTheLastAttempt(): void
+    {
+        /** @var \ArrayObject<int, string> $calls */
+        $calls = new \ArrayObject();
+        $plugin = new readonly class ($calls) implements Fake, RetryDecider, TerminalResultTransformer {
+            /** @param \ArrayObject<int, string> $calls */
+            public function __construct(private \ArrayObject $calls) {}
+
+            #[\Override]
+            public function shouldRetry(
+                RetryPolicy $policy,
+                TestResult $result,
+                int $attempt,
+                ?\Throwable $cause,
+            ): bool {
+                return $result->outcome === Outcome::Errored && $attempt === 1;
+            }
+
+            #[\Override]
+            public function transformTerminalResult(TestDefinition $definition, TestResult $result): TestResult
+            {
+                $this->calls->append(\sprintf(
+                    '%s:%d:%s',
+                    $definition->method,
+                    $result->attempts,
+                    $result->outcome->value,
+                ));
+
+                return $result->outcome === Outcome::Errored
+                    ? $result->withOutcome(Outcome::Skipped, self::class)
+                    : $result;
+            }
+        };
+        $plan = new TestDiscoverer()->discover([FixturePath::get('RunFailingSuite')]);
+        $sink = new CollectingEventSink();
+        $runtime = WorkerPluginRuntime::fromPlugins([$plugin]);
+
+        new Worker(new StandardHarnessPlugin()->services(), $runtime)->run($plan, $sink);
+
+        Expect::that($calls->getArrayCopy())
+            ->because('a terminal transformer MUST receive only the result that remains after retries')
+            ->toBe([
+                'passes:1:passed',
+                'explodes:2:errored',
+            ]);
+        Expect::that($sink->results()[1]->outcome)->toBe(Outcome::Skipped);
+        Expect::that($sink->results()[1]->transformations)->toHaveCount(1);
+    }
+
+    #[Test]
+    public function transformerFailureDoesNotStopLaterTransformers(): void
+    {
+        /** @var \ArrayObject<int, string> $calls */
+        $calls = new \ArrayObject();
+        $broken = new readonly class ($calls) implements Fake, TerminalResultTransformer {
+            /** @param \ArrayObject<int, string> $calls */
+            public function __construct(private \ArrayObject $calls) {}
+
+            #[\Override]
+            public function transformTerminalResult(TestDefinition $definition, TestResult $result): TestResult
+            {
+                $this->calls->append('broken');
+
+                throw new \RuntimeException('terminal policy failed');
+            }
+        };
+        $observer = new readonly class ($calls) implements Fake, TerminalResultTransformer {
+            /** @param \ArrayObject<int, string> $calls */
+            public function __construct(private \ArrayObject $calls) {}
+
+            #[\Override]
+            public function transformTerminalResult(TestDefinition $definition, TestResult $result): TestResult
+            {
+                $this->calls->append('observer:' . $result->outcome->value);
+
+                return $result;
+            }
+        };
+        $definition = new TestDefinition(self::class, __FUNCTION__);
+        $result = new TestResult(new TestId(self::class, __FUNCTION__), Outcome::Passed, 0.0, 0);
+
+        $transformed = WorkerPluginRuntime::fromPlugins([$broken, $observer])
+            ->terminalResult($definition, $result);
+
+        Expect::that($calls->getArrayCopy())->toBe(['broken', 'observer:errored']);
+        Expect::that($transformed->outcome)->toBe(Outcome::Errored);
+        Expect::that($transformed->error?->class)->toBe(PluginRuntimeError::class);
+        Expect::that($transformed->error?->message)
+            ->toContain('caused an error during transformTerminalResult(): terminal policy failed');
+    }
+
+    #[Test]
+    public function transformerCannotReplaceTheTestIdentity(): void
+    {
+        $rogue = new class implements Fake, TerminalResultTransformer {
+            #[\Override]
+            public function transformTerminalResult(TestDefinition $definition, TestResult $result): TestResult
+            {
+                return new TestResult(new TestId('Rogue\\ReplacementTest', 'replacement'), Outcome::Passed, 0.0, 0);
+            }
+        };
+        $definition = new TestDefinition(self::class, __FUNCTION__);
+        $result = new TestResult(new TestId(self::class, __FUNCTION__), Outcome::Passed, 0.0, 0);
+
+        $transformed = WorkerPluginRuntime::fromPlugins([$rogue])->terminalResult($definition, $result);
+
+        Expect::that($transformed->id)->toEqual($result->id);
+        Expect::that($transformed->outcome)->toBe(Outcome::Errored);
+        Expect::that($transformed->error?->message)
+            ->toContain('changed the test identity during transformTerminalResult()');
+    }
+}


### PR DESCRIPTION
Add a public TerminalResultTransformer worker capability for one-time result policy after retries. Register Greenlight result policy through a bundled adapter, move its authoritative transport to worker bootstrap, and preserve the existing worker-protocol v3 assignment field for compatibility.