### PR TITLE
feat: add retried pass policy

### DIFF
--- a/docs/api-configuration.md
+++ b/docs/api-configuration.md
@@ -166,7 +166,7 @@ final class GreenlightConfig
 public static function create(): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L78)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L80)
 
 ### `paths()`
 
@@ -182,7 +182,7 @@ PHPDoc:
 - `@param non-empty-list<non-empty-string> $tests`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L91)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L93)
 
 ### `suite()`
 
@@ -203,7 +203,7 @@ PHPDoc:
 - `@param callable(SuiteBuilder): mixed $configurator`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L149)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L151)
 
 ### `workers()`
 
@@ -218,7 +218,7 @@ PHPDoc:
 - `@param positive-int|'auto' $count`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L173)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L175)
 
 ### `resourceLimit()`
 
@@ -237,7 +237,7 @@ PHPDoc:
 - `@param positive-int $limit`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L191)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L193)
 
 ### `coverage()`
 
@@ -249,7 +249,7 @@ PHPDoc:
 
 - `@param callable(CoverageBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L219)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L221)
 
 ### `watch()`
 
@@ -261,7 +261,7 @@ PHPDoc:
 
 - `@param callable(WatchBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L232)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L234)
 
 ### `artifacts()`
 
@@ -273,7 +273,7 @@ PHPDoc:
 
 - `@param callable(ArtifactBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L244)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L246)
 
 ### `storage()`
 
@@ -288,7 +288,7 @@ PHPDoc:
 
 - `@param callable(StorageBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L259)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L261)
 
 ### `failOnDeprecation()`
 
@@ -304,7 +304,7 @@ PHPDoc:
 
 - `@see self::ignoreDeprecationsMatching()`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L275)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L277)
 
 ### `failOnNotice()`
 
@@ -314,7 +314,7 @@ Fails an otherwise passed test if captured output contains a notice.
 public function failOnNotice(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L283)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L285)
 
 ### `failOnWarning()`
 
@@ -324,7 +324,7 @@ Fails an otherwise passed test if captured output contains a warning.
 public function failOnWarning(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L291)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L293)
 
 ### `failOnRisky()`
 
@@ -336,7 +336,7 @@ expectations.
 public function failOnRisky(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L303)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L305)
 
 ### `failOnSkipped()`
 
@@ -347,7 +347,18 @@ keeps its skipped outcome and reason.
 public function failOnSkipped(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L314)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L316)
+
+### `failOnRetriedPass()`
+
+Fails the run if a test passes after retry. The test keeps its passed
+outcome and attempt count.
+
+```php
+public function failOnRetriedPass(bool $enabled = true): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L327)
 
 ### `ignoreDeprecationsMatching()`
 
@@ -364,7 +375,7 @@ PHPDoc:
 - `@param non-empty-string ...$patterns`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L330)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L343)
 
 ### `plugins()`
 
@@ -377,7 +388,7 @@ PHPDoc:
 - `@param \Closure(): Plugin ...$plugins`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L351)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L364)
 
 ### `failFast()`
 
@@ -385,7 +396,7 @@ PHPDoc:
 public function failFast(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L368)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L381)
 
 ### `randomizeOrder()`
 
@@ -395,7 +406,7 @@ If the seed is null, Greenlight selects and prints a seed when it resolves the c
 public function randomizeOrder(?int $seed = null): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L376)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L389)
 
 ## `InvalidConfiguration`
 

--- a/docs/architecture/jsonl.md
+++ b/docs/architecture/jsonl.md
@@ -163,6 +163,9 @@ The number of attempts used.
 
 This value is `1` unless the test used more than one attempt.
 
+For a `passed` outcome, a value greater than `1` identifies a retried pass.
+This combination is evidence of instability.
+
 ### failures
 
 A list of expectation failures.

--- a/docs/architecture/technical-writing.md
+++ b/docs/architecture/technical-writing.md
@@ -143,6 +143,7 @@ and meaning. Use the singular form unless the context requires a plural.
 | harness service | Technical noun | An object that the harness supplies to a test constructor |
 | Hyperf bridge | Technical noun | The component that connects the Greenlight harness to a Hyperf application, container, and coroutine runtime |
 | integration fixture | Technical noun | External infrastructure that the orchestrator owns for one run |
+| instability | Technical noun | Test behavior that can produce different outcomes without a relevant code change |
 | hook | Technical noun | A method or subscriber callback that runs before or after a test |
 | interaction | Technical noun | One call from code under test to a double |
 | Laravel bridge | Technical noun | The component that connects the Greenlight harness to a Laravel application and container |
@@ -177,6 +178,7 @@ and meaning. Use the singular form unless the context requires a plural.
 | resource limit | Technical noun | A limit on concurrent access to a named resource |
 | result policy | Technical noun | A rule that can change a test result after execution |
 | retention | Technical noun | The rule that determines if Greenlight publishes an attachment |
+| retried pass | Technical noun | A successful terminal result that used more than one test attempt |
 | retry decider | Technical noun | A plugin that determines if Greenlight starts another test attempt |
 | risky test | Technical noun | A passed test that verifies no expectations and has no `#[NoExpectations]` attribute |
 | run | Technical noun | One execution of a selected test suite |

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -337,6 +337,12 @@ Each retry also starts `eventually()` and `consistently()` with a new deadline
 and an empty observation log. `retryOnException()` retries a probe within the
 same test attempt, while `#[Retry]` starts the whole test again.
 
+If a test passes after retry, reporters keep its passed outcome and attempt
+count. They also report the retried pass as evidence of instability.
+
+Use `failOnRetriedPass()` or `--fail-on-retried-pass` to fail the run for this
+evidence. The policy does not change the test outcome.
+
 <!-- php-example {"mode":"display","reason":"Uses an ellipsis to omit code that is not relevant to the example."} -->
 ```php
 #[Test]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -310,6 +310,36 @@ records that iteration as failed. `--repeat-until-failure` stops after it.
 
 Also available as `--fail-on-skipped`.
 
+### `failOnRetriedPass(bool $enabled = true): self`
+
+Default: off.
+
+Fails a run if one or more tests pass after retry.
+
+The run policy does not change the passed outcome. It keeps the attempt count
+and attachments from failed attempts.
+
+The `tty` reporter keeps each affected class in interactive output. The `tty`
+and `plain` reporters list each retried pass after the summary.
+
+JUnit uses the Surefire-compatible `flakyFailure` element. JSONL uses the
+existing `attempts` field. TeamCity uses numeric test metadata. GitHub creates a
+warning annotation.
+
+A retried pass does not count toward `--bail`. Plugins determine the terminal
+outcome before Greenlight evaluates the policy.
+
+The policy evaluates only tests in the selected shard. Repeat mode records an
+affected iteration as failed. `--repeat-until-failure` stops after it.
+
+Watch mode reports the policy failure after each affected run. The watch
+process continues, and `q` keeps its documented exit code.
+
+A retried pass is evidence of instability. It does not prove that a test has
+permanent flaky behavior.
+
+Also available as `--fail-on-retried-pass`.
+
 ### `plugins(Closure ...$plugins): self`
 
 Default: none.
@@ -856,6 +886,10 @@ Enables the risky-test policy for this run.
 ### `--fail-on-skipped`
 
 Enables the skipped-test run policy for this run.
+
+### `--fail-on-retried-pass`
+
+Enables the retried-pass run policy for this run.
 
 ### `--profile`
 

--- a/src/Cli/Configuration/CliOverrides.php
+++ b/src/Cli/Configuration/CliOverrides.php
@@ -176,6 +176,7 @@ final readonly class CliOverrides
                 ),
                 runPolicy: new RunPolicy(
                     failOnSkipped: $arguments->has('fail-on-skipped'),
+                    failOnRetriedPass: $arguments->has('fail-on-retried-pass'),
                 ),
                 artifactsDirectory: $artifactsDirectory,
                 resourceLimits: $resourceLimits,

--- a/src/Cli/Configuration/ConfigurationResolver.php
+++ b/src/Cli/Configuration/ConfigurationResolver.php
@@ -60,7 +60,8 @@ final class ConfigurationResolver
                     $configuration->execution->policy->failOnRisky || $executionOverrides->policy->failOnRisky,
                 ),
                 runPolicy: new RunPolicy(
-                    $configuration->execution->runPolicy->failOnSkipped || $executionOverrides->runPolicy->failOnSkipped,
+                    failOnSkipped: $configuration->execution->runPolicy->failOnSkipped || $executionOverrides->runPolicy->failOnSkipped,
+                    failOnRetriedPass: $configuration->execution->runPolicy->failOnRetriedPass || $executionOverrides->runPolicy->failOnRetriedPass,
                 ),
                 stopAfterFailures: $executionOverrides->stopAfterFailures ?? $configuration->execution->stopAfterFailures,
                 artifacts: $artifacts,

--- a/src/Cli/Input/Definition.php
+++ b/src/Cli/Input/Definition.php
@@ -107,6 +107,8 @@ final readonly class Definition
           --fail-on-warning  Fail passed tests that captured a warning
           --fail-on-risky    Fail passed tests that verified no expectations
           --fail-on-skipped  Fail the run if its final summary contains a skipped test
+          --fail-on-retried-pass
+                             Fail the run if a test passes after retry
           --profile          Add a run profile after the summary. It contains worker
                              utilization, boot latency, makespan spread, and slow classes.
                              It also extends the slow-test list.
@@ -144,7 +146,7 @@ final readonly class Definition
             new OptionSpec('repeat', OptionValue::Required), new OptionSpec('repeat-until-failure'),
             new OptionSpec('failed'), new OptionSpec('shard', OptionValue::Required),
             new OptionSpec('fail-on-deprecation'), new OptionSpec('fail-on-notice'), new OptionSpec('fail-on-warning'),
-            new OptionSpec('fail-on-risky'), new OptionSpec('fail-on-skipped'),
+            new OptionSpec('fail-on-risky'), new OptionSpec('fail-on-skipped'), new OptionSpec('fail-on-retried-pass'),
             new OptionSpec('seed', OptionValue::Required),
             new OptionSpec('reporter', OptionValue::Required, repeatable: true),
             new OptionSpec('artifacts-dir', OptionValue::Required),

--- a/src/Cli/Reporting/FailedTestsTap.php
+++ b/src/Cli/Reporting/FailedTestsTap.php
@@ -11,18 +11,23 @@ use Greenlight\Event\TestClassStarted;
 use Greenlight\Event\TestFinished;
 
 /**
- * Records failed test IDs and class durations while it forwards the stream.
+ * Records failed test IDs, class durations, and retried passes while it
+ * forwards the stream.
  *
  * emit() sends each event to the inner sink. It records the test IDs of failed
  * and errored tests. It also records each test-class duration.
  *
  * failedTests() and classSeconds() supply run state. --failed, failed-first
- * order, and longest-first order use this state.
+ * order, and longest-first order use this state. retriedPasses() supplies the
+ * run policy.
  *
  * @internal
  */
 final class FailedTestsTap implements EventSink
 {
+    /** @var non-negative-int */
+    private int $retriedPasses = 0;
+
     /**
      * @var array<non-empty-string, true>
      */
@@ -57,6 +62,10 @@ final class FailedTestsTap implements EventSink
                 if ($id !== '') {
                     $this->failedTests[$id] = true;
                 }
+            } elseif ($event->result->outcome->value === 'passed' && $event->result->attempts > 1) {
+                $this->retriedPasses = $this->retriedPasses === \PHP_INT_MAX
+                    ? \PHP_INT_MAX
+                    : $this->retriedPasses + 1;
             }
         }
 
@@ -103,5 +112,11 @@ final class FailedTestsTap implements EventSink
     public function classSeconds(): array
     {
         return $this->classSeconds;
+    }
+
+    /** @return non-negative-int */
+    public function retriedPasses(): int
+    {
+        return $this->retriedPasses;
     }
 }

--- a/src/Cli/Run/RunSession.php
+++ b/src/Cli/Run/RunSession.php
@@ -86,7 +86,7 @@ final readonly class RunSession
         $coverageSettings = CoverageSettingsResolver::resolve($this->configuration->resolved->coverage, $this->workingDirectory);
 
         try {
-            $this->coordinate($reporter, $tap, $priorityClasses, $classSeconds, $workers, $coverageSettings);
+            $run = $this->coordinate($reporter, $tap, $priorityClasses, $classSeconds, $workers, $coverageSettings);
         } catch (AttachmentError|DiscoveryError|ExecutionFailed|IntegrationFixtureError $error) {
             $reporter->finish();
             $this->console->error($error->getMessage(), $this->arguments->has('no-ansi'));
@@ -96,6 +96,7 @@ final readonly class RunSession
 
         $reporter->finish();
         $this->persist($failedTap->failedTests(), $failedTap->classSeconds());
+        $this->reportRunPolicyFailure($run, $failedTap);
 
         return $tap->failedClasses();
     }
@@ -176,19 +177,38 @@ final readonly class RunSession
             return 1;
         }
 
-        if (!$resolved->execution->runPolicy->accepts($run->summary)) {
-            if ($run->summary->isSuccessful()) {
-                $this->console->err(\sprintf(
-                    "Greenlight failed because the fail-on-skipped policy found %d skipped %s.\n",
-                    $run->summary->skipped,
-                    $run->summary->skipped === 1 ? 'test' : 'tests',
-                ));
-            }
+        if (!$resolved->execution->runPolicy->accepts($run->summary, $failedTap->retriedPasses())) {
+            $this->reportRunPolicyFailure($run, $failedTap);
 
             return 1;
         }
 
         return 0;
+    }
+
+    private function reportRunPolicyFailure(RunResult $run, FailedTestsTap $tap): void
+    {
+        if (!$run->summary->isSuccessful()) {
+            return;
+        }
+
+        $policy = $this->configuration->resolved->execution->runPolicy;
+
+        if ($policy->failOnSkipped && $run->summary->skipped > 0) {
+            $this->console->err(\sprintf(
+                "Greenlight failed because the fail-on-skipped policy found %d skipped %s.\n",
+                $run->summary->skipped,
+                $run->summary->skipped === 1 ? 'test' : 'tests',
+            ));
+        }
+
+        if ($policy->failOnRetriedPass && $tap->retriedPasses() > 0) {
+            $this->console->err(\sprintf(
+                "Greenlight failed because the fail-on-retried-pass policy found %d %s that passed after retry.\n",
+                $tap->retriedPasses(),
+                $tap->retriedPasses() === 1 ? 'test' : 'tests',
+            ));
+        }
     }
 
     /**

--- a/src/Config/GreenlightConfig.php
+++ b/src/Config/GreenlightConfig.php
@@ -50,6 +50,8 @@ final class GreenlightConfig
 
     private bool $failOnSkipped = false;
 
+    private bool $failOnRetriedPass = false;
+
     /**
      * @var list<non-empty-string>
      */
@@ -319,6 +321,17 @@ final class GreenlightConfig
     }
 
     /**
+     * Fails the run if a test passes after retry. The test keeps its passed
+     * outcome and attempt count.
+     */
+    public function failOnRetriedPass(bool $enabled = true): self
+    {
+        $this->failOnRetriedPass = $enabled;
+
+        return $this;
+    }
+
+    /**
      * Exempts deprecation messages from `failOnDeprecation()`. A pattern matches
      * part of a message without case sensitivity. A pattern that contains "*"
      * or "?" matches the complete message. Multiple calls add patterns.
@@ -426,7 +439,10 @@ final class GreenlightConfig
                     $this->ignoreDeprecations,
                     $this->failOnRisky,
                 ),
-                runPolicy: new RunPolicy($this->failOnSkipped),
+                runPolicy: new RunPolicy(
+                    failOnSkipped: $this->failOnSkipped,
+                    failOnRetriedPass: $this->failOnRetriedPass,
+                ),
                 stopAfterFailures: $this->failFast ? 1 : null,
                 artifacts: $this->artifacts->toConfiguration(),
             ),

--- a/src/Reporting/GithubReporter.php
+++ b/src/Reporting/GithubReporter.php
@@ -45,6 +45,12 @@ final class GithubReporter implements Reporter
         $result = $event->result;
         $this->hasAttachments = $this->hasAttachments || $result->attachments !== [];
 
+        if ($result->outcome === Outcome::Passed && $result->attempts > 1) {
+            $this->writeWarning($result);
+
+            return;
+        }
+
         if ($result->outcome === Outcome::Failed) {
             $this->writeFailures($result);
 
@@ -130,6 +136,22 @@ final class GithubReporter implements Reporter
         }
 
         $this->write($error->file, $error->line, $message);
+    }
+
+    /**
+     * @throws ReportGenerationFailed
+     */
+    private function writeWarning(TestResult $result): void
+    {
+        $this->output->write(
+            '::warning title=Passed after retry::'
+            . $this->escapeData(\sprintf(
+                '%s passed after %d attempts. This result is evidence of instability.',
+                $result->id,
+                $result->attempts,
+            ))
+            . "\n",
+        );
     }
 
     /**

--- a/src/Reporting/JUnitReporter.php
+++ b/src/Reporting/JUnitReporter.php
@@ -183,6 +183,14 @@ final class JUnitReporter implements Reporter
             $writer->writeAttribute('file', $this->xml($sourceFile));
         }
 
+        if ($result->outcome === Outcome::Passed && $result->attempts > 1) {
+            $writer->startElement('flakyFailure');
+            $writer->writeAttribute('type', 'retry');
+            $writer->writeAttribute('message', \sprintf('Passed after %d attempts.', $result->attempts));
+            $writer->text('Greenlight recorded a successful terminal result after retry.');
+            $writer->endElement();
+        }
+
         if ($result->outcome === Outcome::Failed) {
             if ($result->failures === []) {
                 $writer->startElement('failure');

--- a/src/Reporting/PlainReporter.php
+++ b/src/Reporting/PlainReporter.php
@@ -17,7 +17,8 @@ use Greenlight\Result\TestResult;
  *
  * onEvent() writes one line for each completed test when its event arrives.
  * After the run, finish() writes failure and error details. It then writes a
- * final summary with worker process counts and skipped-test reasons.
+ * final summary with worker process counts, skipped-test reasons, and retried
+ * passes.
  *
  * The reporter does not use color or cursor control. Identical event streams
  * produce identical bytes. If a header is available, the reporter writes it
@@ -36,6 +37,11 @@ final class PlainReporter implements Reporter
      * @var list<TestResult>
      */
     private array $skipped = [];
+
+    /**
+     * @var list<TestResult>
+     */
+    private array $retriedPasses = [];
 
     /**
      * @var list<non-empty-string>
@@ -86,7 +92,11 @@ final class PlainReporter implements Reporter
             $this->slowTests->record($event);
             $result = $event->result;
             $this->expectations = SaturatingCount::add($this->expectations, $result->expectations);
-            $attempts = $result->attempts > 1 ? \sprintf(' (attempts: %d)', $result->attempts) : '';
+            $attempts = $result->attempts > 1
+                ? ($result->outcome === Outcome::Passed
+                    ? \sprintf(' (passed after %d attempts)', $result->attempts)
+                    : \sprintf(' (attempts: %d)', $result->attempts))
+                : '';
 
             $this->output->write(\sprintf(
                 "%s %s (%.3fs)%s\n",
@@ -106,6 +116,10 @@ final class PlainReporter implements Reporter
 
             if ($result->outcome === Outcome::Skipped) {
                 $this->skipped[] = $result;
+            }
+
+            if ($result->outcome === Outcome::Passed && $result->attempts > 1) {
+                $this->retriedPasses[] = $result;
             }
 
             if ($result->risky && $result->outcome->isSuccessful() && ($id = (string) $result->id) !== '') {
@@ -143,7 +157,7 @@ final class PlainReporter implements Reporter
         if ($finished instanceof RunFinished) {
             $this->output->write(\sprintf(
                 "\n%s\nTime: %.3fs\n",
-                SummaryFormat::tests($finished->summary, $this->expectations, $this->style),
+                SummaryFormat::tests($finished->summary, $this->expectations, $this->style, \count($this->retriedPasses)),
                 $finished->durationSeconds,
             ));
         }
@@ -155,6 +169,7 @@ final class PlainReporter implements Reporter
         }
 
         $this->output->write(SummaryFormat::skipped($this->skipped, $this->style));
+        $this->output->write(SummaryFormat::retriedPasses($this->retriedPasses, $this->style));
         $this->output->write($this->slowTests->render($this->style));
 
         if ($this->risky !== []) {

--- a/src/Reporting/SummaryFormat.php
+++ b/src/Reporting/SummaryFormat.php
@@ -16,7 +16,8 @@ final class SummaryFormat
     /** @codeCoverageIgnore */
     private function __construct() {}
 
-    public static function tests(ResultSummary $summary, int $expectations, Style $style): string
+    /** @param non-negative-int $retriedPasses */
+    public static function tests(ResultSummary $summary, int $expectations, Style $style, int $retriedPasses = 0): string
     {
         $parts = [Plural::count($summary->total(), 'test')];
 
@@ -33,6 +34,10 @@ final class SummaryFormat
 
         if ($summary->skipped > 0) {
             $parts[] = $style->warn(\sprintf('%d skipped', $summary->skipped));
+        }
+
+        if ($retriedPasses > 0) {
+            $parts[] = $style->warn(\sprintf('%d passed after retry', $retriedPasses));
         }
 
         $parts[] = Plural::count($expectations, 'expectation');
@@ -88,6 +93,26 @@ final class SummaryFormat
                 $lines[] = \sprintf('    … and %d more', \count($results) - self::MAX_IDS_PER_GROUP);
             }
         }
+
+        return \implode("\n", $lines) . "\n";
+    }
+
+    /**
+     * @param list<TestResult> $retriedPasses
+     */
+    public static function retriedPasses(array $retriedPasses, Style $style): string
+    {
+        if ($retriedPasses === []) {
+            return '';
+        }
+
+        $lines = ["\n" . $style->warn('Passed after retry:')];
+
+        foreach ($retriedPasses as $result) {
+            $lines[] = \sprintf('  %s (%d attempts)', $result->id, $result->attempts);
+        }
+
+        $lines[] = 'These results are evidence of instability.';
 
         return \implode("\n", $lines) . "\n";
     }

--- a/src/Reporting/TeamCityReporter.php
+++ b/src/Reporting/TeamCityReporter.php
@@ -160,6 +160,16 @@ final class TeamCityReporter implements Reporter
             ]);
         }
 
+        if ($result->outcome === Outcome::Passed && $result->attempts > 1) {
+            $this->message('testMetadata', [
+                'testName' => $name,
+                'name' => 'greenlight.attempts',
+                'type' => 'number',
+                'value' => (string) $result->attempts,
+                'flowId' => $flowId,
+            ]);
+        }
+
         $this->message('testFinished', [
             'name' => $name,
             'duration' => (string) $this->durationMilliseconds($result->durationSeconds),

--- a/src/Reporting/TtyReporter.php
+++ b/src/Reporting/TtyReporter.php
@@ -19,9 +19,9 @@ use Greenlight\Result\TestResult;
  * more than one time in 50 ms.
  *
  * In bounded mode, a passed test class produces no permanent line. A class
- * with failures or skipped tests adds a line when it completes. --verbose
- * adds a permanent line for each class. Without cursor support, each class
- * adds a line.
+ * with failures, skipped tests, or retried passes adds a line when it
+ * completes. --verbose adds a permanent line for each class. Without cursor
+ * support, each class adds a line.
  *
  * @internal
  */
@@ -32,7 +32,7 @@ final class TtyReporter implements Reporter, Ticking
     private const float REDRAW_INTERVAL_SECONDS = 0.05;
 
     /**
-     * @var array<string, array{done: int, failed: int, skipped: int, duration: float, startedAt: float}>
+     * @var array<string, array{done: int, failed: int, skipped: int, retried: int, duration: float, startedAt: float}>
      */
     private array $live = [];
 
@@ -50,6 +50,11 @@ final class TtyReporter implements Reporter, Ticking
      * @var list<TestResult>
      */
     private array $skipped = [];
+
+    /**
+     * @var list<TestResult>
+     */
+    private array $retriedPasses = [];
 
     /**
      * @var list<non-empty-string>
@@ -143,7 +148,7 @@ final class TtyReporter implements Reporter, Ticking
             $this->activeClassAssignments[$event->class] = $active + 1;
 
             if ($active === 0) {
-                $this->live[$event->class] = ['done' => 0, 'failed' => 0, 'skipped' => 0, 'duration' => 0.0, 'startedAt' => $event->occurredAt];
+                $this->live[$event->class] = ['done' => 0, 'failed' => 0, 'skipped' => 0, 'retried' => 0, 'duration' => 0.0, 'startedAt' => $event->occurredAt];
             }
 
             $this->redraw();
@@ -182,6 +187,14 @@ final class TtyReporter implements Reporter, Ticking
 
             if ($result->outcome === Outcome::Skipped) {
                 $this->skipped[] = $result;
+            }
+
+            if ($result->outcome === Outcome::Passed && $result->attempts > 1) {
+                $this->retriedPasses[] = $result;
+
+                if (isset($this->live[$class])) {
+                    ++$this->live[$class]['retried'];
+                }
             }
 
             if ($result->risky && $result->outcome->isSuccessful() && ($id = (string) $result->id) !== '') {
@@ -263,7 +276,7 @@ final class TtyReporter implements Reporter, Ticking
         if ($finished instanceof RunFinished) {
             $this->output->write(\sprintf(
                 "\n%s\nTime: %.3fs\n",
-                SummaryFormat::tests($finished->summary, $this->expectations, $this->style),
+                SummaryFormat::tests($finished->summary, $this->expectations, $this->style, \count($this->retriedPasses)),
                 $finished->durationSeconds,
             ));
         }
@@ -275,6 +288,7 @@ final class TtyReporter implements Reporter, Ticking
         }
 
         $this->output->write(SummaryFormat::skipped($this->skipped, $this->style));
+        $this->output->write(SummaryFormat::retriedPasses($this->retriedPasses, $this->style));
         $this->output->write($this->slowTests->render($this->style));
 
         if ($this->successfulAttachments !== []) {
@@ -301,10 +315,10 @@ final class TtyReporter implements Reporter, Ticking
      */
     private function finalizeClass(string $class): void
     {
-        $state = $this->live[$class] ?? ['done' => 0, 'failed' => 0, 'skipped' => 0, 'duration' => 0.0, 'startedAt' => 0.0];
+        $state = $this->live[$class] ?? ['done' => 0, 'failed' => 0, 'skipped' => 0, 'retried' => 0, 'duration' => 0.0, 'startedAt' => 0.0];
         unset($this->live[$class]);
 
-        $permanent = $this->verbose || !$this->cursor || $state['failed'] > 0 || $state['skipped'] > 0;
+        $permanent = $this->verbose || !$this->cursor || $state['failed'] > 0 || $state['skipped'] > 0 || $state['retried'] > 0;
 
         if (!$this->cursor) {
             if ($permanent) {
@@ -334,7 +348,7 @@ final class TtyReporter implements Reporter, Ticking
     }
 
     /**
-     * @param array{done: int, failed: int, skipped: int, duration: float, startedAt: float} $state
+     * @param array{done: int, failed: int, skipped: int, retried: int, duration: float, startedAt: float} $state
      */
     private function finalLine(string $class, array $state): string
     {
@@ -350,9 +364,15 @@ final class TtyReporter implements Reporter, Ticking
                 : \sprintf(', %d skipped', $state['skipped']);
         }
 
+        if ($state['retried'] > 0) {
+            $counts .= \sprintf(', %d passed after retry', $state['retried']);
+        }
+
         $mark = $state['failed'] > 0
             ? $this->style->error('✗')
-            : ($state['done'] === $state['skipped'] && $state['done'] > 0 ? $this->style->warn('−') : $this->style->ok('✓'));
+            : ($state['done'] === $state['skipped'] && $state['done'] > 0
+                ? $this->style->warn('−')
+                : ($state['retried'] > 0 ? $this->style->warn('↻') : $this->style->ok('✓')));
 
         return \sprintf('%s %s (%s, %s)', $mark, $class, $counts, $this->style->duration($state['duration']));
     }

--- a/src/Result/RunPolicy.php
+++ b/src/Result/RunPolicy.php
@@ -11,10 +11,16 @@ namespace Greenlight\Result;
  */
 final readonly class RunPolicy
 {
-    public function __construct(public bool $failOnSkipped = false) {}
+    public function __construct(
+        public bool $failOnSkipped = false,
+        public bool $failOnRetriedPass = false,
+    ) {}
 
-    public function accepts(ResultSummary $summary): bool
+    /** @param non-negative-int $retriedPasses */
+    public function accepts(ResultSummary $summary, int $retriedPasses = 0): bool
     {
-        return $summary->isSuccessful() && (!$this->failOnSkipped || $summary->skipped === 0);
+        return $summary->isSuccessful()
+            && (!$this->failOnSkipped || $summary->skipped === 0)
+            && (!$this->failOnRetriedPass || $retriedPasses === 0);
     }
 }

--- a/tests/Acceptance/PolicyTest.php
+++ b/tests/Acceptance/PolicyTest.php
@@ -149,6 +149,83 @@ final readonly class PolicyTest
         Expect::that($repeated->output())->toContain('Repeat: failed iterations: 1, 2');
     }
 
+    #[Test]
+    public function retriedPassEvidenceAndPolicyStayConsistentAcrossConsumers(): void
+    {
+        $project = $this->writeProject();
+        $result = GreenlightCli::run($project->directory, [
+            'run',
+            '--workers=2',
+            '--shard=1/1',
+            '--bail=1',
+            '--filter=RetryProbeTest',
+            '--reporter=plain',
+            '--reporter=junit=reports/retry-junit.xml',
+            '--reporter=jsonl=reports/retry-events.jsonl',
+            '--reporter=teamcity=reports/retry-teamcity.txt',
+            '--reporter=github=reports/retry-github.txt',
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('a retried pass MUST keep the default run successful')
+            ->toBe(0);
+        Expect::that($result->output())
+            ->toContain('PASS PolicyProbe\RetryProbeTest::passesAfterRetry')
+            ->toContain('(passed after 2 attempts)')
+            ->toContain('2 tests, 2 passed, 1 passed after retry')
+            ->toContain('These results are evidence of instability.')
+            ->toContain('PolicyProbe\RetryProbeTest::stillRuns');
+
+        $junit = (string) \file_get_contents($project->path('reports/retry-junit.xml'));
+        Expect::that($junit)
+            ->because('JUnit MUST retain a passed testcase and interoperable retry metadata')
+            ->toContain('failures="0"')
+            ->toContain('<flakyFailure type="retry" message="Passed after 2 attempts.">')
+            ->toContain('[[ATTACHMENT|');
+
+        $jsonl = (string) \file_get_contents($project->path('reports/retry-events.jsonl'));
+        Expect::that($jsonl)
+            ->because('JSONL MUST use its existing result fields for retry evidence')
+            ->toContain('"outcome":"passed"')
+            ->toContain('"attempts":2')
+            ->toContain('"attempt":1');
+
+        Expect::that((string) \file_get_contents($project->path('reports/retry-teamcity.txt')))
+            ->because('TeamCity MUST receive numeric attempt metadata and failed-attempt attachments')
+            ->toContain("name='greenlight.attempts' type='number' value='2'")
+            ->toContain("name='attachment: attempt.txt'");
+
+        Expect::that((string) \file_get_contents($project->path('reports/retry-github.txt')))
+            ->because('GitHub MUST receive a warning without a failure annotation')
+            ->toContain('::warning title=Passed after retry::')
+            ->toContain('passed after 2 attempts')
+            ->not()->toContain('::error');
+
+        $strict = $this->run(
+            $project,
+            '--workers=2',
+            '--filter=RetryProbeTest',
+            '--fail-on-retried-pass',
+        );
+        Expect::that($strict->exitCode)
+            ->because('the retried-pass run policy MUST fail without changing the passed result')
+            ->toBe(1);
+        Expect::that($strict->output())
+            ->toContain('2 tests, 2 passed, 1 passed after retry')
+            ->toContain('fail-on-retried-pass policy found 1 test that passed after retry');
+
+        $repeated = $this->run(
+            $project,
+            '--filter=RetryProbeTest',
+            '--fail-on-retried-pass',
+            '--repeat=2',
+        );
+        Expect::that($repeated->exitCode)
+            ->because('each iteration with a retried pass MUST fail repeat mode')
+            ->toBe(1);
+        Expect::that($repeated->output())->toContain('Repeat: failed iterations: 1, 2');
+    }
+
     private function run(AcceptanceProject $project, string ...$flags): ProcessResult
     {
         return GreenlightCli::run($project->directory, \array_values(['run', '--reporter=plain', ...$flags]));
@@ -266,6 +343,45 @@ final readonly class PolicyTest
             }
             PHP);
 
+        $project->writeFile('tests/RetryProbeTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace PolicyProbe;
+
+            use Greenlight\Artifact\Attachments;
+            use Greenlight\Attribute\Retry;
+            use Greenlight\Attribute\Test;
+            use Greenlight\Expect\Expect;
+
+            final readonly class RetryProbeTest
+            {
+                public function __construct(private Attachments $attachments) {}
+
+                #[Test]
+                #[Retry(1)]
+                public function passesAfterRetry(): void
+                {
+                    static $attempt = 0;
+                    ++$attempt;
+                    $this->attachments->text('attempt.txt', 'attempt ' . $attempt);
+
+                    if ($attempt % 2 === 1) {
+                        throw new \RuntimeException('retry this attempt');
+                    }
+
+                    Expect::that(true)->toBeTrue();
+                }
+
+                #[Test]
+                public function stillRuns(): void
+                {
+                    Expect::that(true)->toBeTrue();
+                }
+            }
+            PHP);
+
         $project->writeFile('greenlight.php', <<<'PHP'
             <?php
 
@@ -275,6 +391,7 @@ final readonly class PolicyTest
 
             require_once __DIR__ . '/tests/DiagnosticProbeTest.php';
             require_once __DIR__ . '/tests/RiskyProbeTest.php';
+            require_once __DIR__ . '/tests/RetryProbeTest.php';
             require_once __DIR__ . '/tests/SkipProbeTest.php';
 
             return GreenlightConfig::create()

--- a/tests/Unit/Cli/Configuration/ConfigurationResolverSelectionTest.php
+++ b/tests/Unit/Cli/Configuration/ConfigurationResolverSelectionTest.php
@@ -55,7 +55,7 @@ final readonly class ConfigurationResolverSelectionTest
     }
 
     /**
-     * @param array{bool, bool, bool, bool, bool} $expected
+     * @param array{bool, bool, bool, bool, bool, bool} $expected
      */
     #[Test]
     #[DataSet('failurePolicyOverrides')]
@@ -80,32 +80,39 @@ final readonly class ConfigurationResolverSelectionTest
         Expect::that($this->resolve($overrides)->execution->runPolicy->failOnSkipped)
             ->because('the skipped-test policy flag MUST map to failOnSkipped')
             ->toBe($expected[4]);
+        Expect::that($this->resolve($overrides)->execution->runPolicy->failOnRetriedPass)
+            ->because('the retried-pass policy flag MUST map to failOnRetriedPass')
+            ->toBe($expected[5]);
     }
 
     /**
-     * @return iterable<string, array{CliOverrides, array{bool, bool, bool, bool, bool}}>
+     * @return iterable<string, array{CliOverrides, array{bool, bool, bool, bool, bool, bool}}>
      */
     public static function failurePolicyOverrides(): iterable
     {
         yield 'deprecation' => [
             new CliOverrides(execution: new ExecutionOverrides(policy: new ResultPolicy(failOnDeprecation: true))),
-            [true, false, false, false, false],
+            [true, false, false, false, false, false],
         ];
         yield 'notice' => [
             new CliOverrides(execution: new ExecutionOverrides(policy: new ResultPolicy(failOnNotice: true))),
-            [false, true, false, false, false],
+            [false, true, false, false, false, false],
         ];
         yield 'risky' => [
             new CliOverrides(execution: new ExecutionOverrides(policy: new ResultPolicy(failOnRisky: true))),
-            [false, false, true, false, false],
+            [false, false, true, false, false, false],
         ];
         yield 'warning' => [
             new CliOverrides(execution: new ExecutionOverrides(policy: new ResultPolicy(failOnWarning: true))),
-            [false, false, false, true, false],
+            [false, false, false, true, false, false],
         ];
         yield 'skipped' => [
             new CliOverrides(execution: new ExecutionOverrides(runPolicy: new RunPolicy(failOnSkipped: true))),
-            [false, false, false, false, true],
+            [false, false, false, false, true, false],
+        ];
+        yield 'retried pass' => [
+            new CliOverrides(execution: new ExecutionOverrides(runPolicy: new RunPolicy(failOnRetriedPass: true))),
+            [false, false, false, false, false, true],
         ];
     }
 

--- a/tests/Unit/Cli/Reporting/FailedTestsTapTest.php
+++ b/tests/Unit/Cli/Reporting/FailedTestsTapTest.php
@@ -38,6 +38,8 @@ final readonly class FailedTestsTapTest
             ->toBe([]);
         Expect::that($tap->classSeconds())
             ->toBe([]);
+        Expect::that($tap->retriedPasses())
+            ->toBe(0);
     }
 
     #[Test]
@@ -48,6 +50,7 @@ final readonly class FailedTestsTapTest
         $events = [
             new TestClassStarted('App\AlphaTest', 10.0, 'worker-1'),
             $this->finished('App\AlphaTest', 'passes', Outcome::Passed, 1.0),
+            $this->finished('App\AlphaTest', 'passesAfterRetry', Outcome::Passed, 1.5, attempts: 2),
             new TestClassStarted('App\BetaTest', 20.0, 'worker-2'),
             $this->finished('App\AlphaTest', 'fails', Outcome::Failed, 2.0),
             new TestClassFinished('App\AlphaTest', 14.0, 'worker-1'),
@@ -56,7 +59,7 @@ final readonly class FailedTestsTapTest
             new TestClassStarted('App\AlphaTest', 30.0, 'worker-1', isolated: true),
             $this->finished('App\AlphaTest', 'fails', Outcome::Failed, 8.0),
             new TestClassFinished('App\AlphaTest', 33.5, 'worker-1'),
-            $this->finished('App\BetaTest', 'skips', Outcome::Skipped, 16.0),
+            $this->finished('App\BetaTest', 'skips', Outcome::Skipped, 16.0, attempts: 2),
         ];
 
         foreach ($events as $event) {
@@ -78,6 +81,9 @@ final readonly class FailedTestsTapTest
         Expect::that($inner->events)
             ->because('the tap MUST forward every event unchanged')
             ->toBe($events);
+        Expect::that($tap->retriedPasses())
+            ->because('the tap MUST count only passed tests that used retry')
+            ->toBe(1);
     }
 
     #[Test]
@@ -149,9 +155,10 @@ final readonly class FailedTestsTapTest
         string $method,
         Outcome $outcome,
         float $duration,
+        int $attempts = 1,
     ): TestFinished {
         return new TestFinished(
-            new TestResult(new TestId($class, $method), $outcome, $duration, 0),
+            new TestResult(new TestId($class, $method), $outcome, $duration, 0, attempts: $attempts),
             1.0,
         );
     }

--- a/tests/Unit/Config/GreenlightConfigApiTest.php
+++ b/tests/Unit/Config/GreenlightConfigApiTest.php
@@ -34,6 +34,7 @@ final class GreenlightConfigApiTest
             'failFast',
             'failOnDeprecation',
             'failOnNotice',
+            'failOnRetriedPass',
             'failOnRisky',
             'failOnSkipped',
             'failOnWarning',

--- a/tests/Unit/Config/ResultPolicyConfigurationTest.php
+++ b/tests/Unit/Config/ResultPolicyConfigurationTest.php
@@ -109,6 +109,20 @@ final class ResultPolicyConfigurationTest
     }
 
     #[Test]
+    public function retriedPassPolicyFlowsIntoTheBuiltConfiguration(): void
+    {
+        $policy = GreenlightConfig::create()
+            ->failOnRetriedPass()
+            ->build()
+            ->execution
+            ->runPolicy;
+
+        Expect::that($policy->failOnRetriedPass)
+            ->because('the public configuration flag MUST reach the run policy')
+            ->toBeTrue();
+    }
+
+    #[Test]
     public function ignoredDeprecationPatternsAccumulateInCallOrder(): void
     {
         $policy = GreenlightConfig::create()

--- a/tests/Unit/Reporting/GithubReporterTest.php
+++ b/tests/Unit/Reporting/GithubReporterTest.php
@@ -21,7 +21,7 @@ use Greenlight\Test\TestId;
 final class GithubReporterTest
 {
     #[Test]
-    public function cannedStreamRendersOnlyFailureAndErrorCommands(): void
+    public function cannedStreamRendersProblemsAndRetriedPassWarnings(): void
     {
         $output = new BufferOutput();
         CannedStream::feed(new GithubReporter($output));
@@ -29,9 +29,10 @@ final class GithubReporterTest
         $expected = <<<'TXT'
             ::error file=/project/tests/CalculatorTest.php,line=42::Acme\CalculatorTest::subtractsIntegers: Failed asserting that two values are equal.%0Aexpected: 2%0Aactual: 3
             ::error file=/project/tests/NetworkTest.php,line=17::Acme\NetworkTest::connects: RuntimeException: Connection refused.
+            ::warning title=Passed after retry::Acme\NetworkTest::retriesFlakyEndpoint passed after 3 attempts. This result is evidence of instability.
             TXT;
 
-        Expect::that($output->buffer())->because('canned stream renders only failure and error commands')->toBe($expected . "\n");
+        Expect::that($output->buffer())->because('canned stream renders problems and retried-pass warnings')->toBe($expected . "\n");
     }
 
     #[Test]

--- a/tests/Unit/Reporting/JUnitReporterTest.php
+++ b/tests/Unit/Reporting/JUnitReporterTest.php
@@ -47,7 +47,9 @@ final class JUnitReporterTest
                 <testcase name="pings" classname="Acme\NetworkTest" assertions="0" time="0.000000">
                   <skipped message="Requires ext-redis.">Requires ext-redis.</skipped>
                 </testcase>
-                <testcase name="retriesFlakyEndpoint" classname="Acme\NetworkTest" assertions="3" time="0.150000"/>
+                <testcase name="retriesFlakyEndpoint" classname="Acme\NetworkTest" assertions="3" time="0.150000">
+                  <flakyFailure type="retry" message="Passed after 3 attempts.">Greenlight recorded a successful terminal result after retry.</flakyFailure>
+                </testcase>
               </testsuite>
             </testsuites>
             TXT;
@@ -74,6 +76,7 @@ final class JUnitReporterTest
         Expect::that(SimpleXml::xpath($document, '//failure'))->toHaveCount(1);
         Expect::that(SimpleXml::xpath($document, '//error'))->toHaveCount(1);
         Expect::that(SimpleXml::xpath($document, '//skipped'))->toHaveCount(1);
+        Expect::that(SimpleXml::xpath($document, '//flakyFailure'))->toHaveCount(1);
     }
 
     #[Test]

--- a/tests/Unit/Reporting/JsonLinesReporterTest.php
+++ b/tests/Unit/Reporting/JsonLinesReporterTest.php
@@ -87,6 +87,25 @@ final class JsonLinesReporterTest
     }
 
     #[Test]
+    public function aRetriedPassUsesTheExistingAttemptsField(): void
+    {
+        $output = new BufferOutput();
+        CannedStream::feed(new JsonLinesReporter($output));
+
+        $retried = \array_values(\array_filter(
+            \explode("\n", \rtrim($output->buffer(), "\n")),
+            static fn(string $line): bool => \str_contains($line, 'retriesFlakyEndpoint'),
+        ));
+
+        Expect::that($retried)
+            ->because('JSONL MUST retain retry evidence without a schema change')
+            ->toHaveCount(2);
+        Expect::that($retried[1])
+            ->toContain('"outcome":"passed"')
+            ->toContain('"attempts":3');
+    }
+
+    #[Test]
     public function anUnmappedEventIsRejected(): void
     {
         $reporter = new JsonLinesReporter(new BufferOutput());

--- a/tests/Unit/Reporting/PlainReporterFirstRetryTest.php
+++ b/tests/Unit/Reporting/PlainReporterFirstRetryTest.php
@@ -32,6 +32,6 @@ final readonly class PlainReporterFirstRetryTest
 
         Expect::that($output->buffer())
             ->because('the first retry MUST report both attempts')
-            ->toBe("PASS Acme\\RetryTest::passesOnFirstRetry (0.010s) (attempts: 2)\n");
+            ->toBe("PASS Acme\\RetryTest::passesOnFirstRetry (0.010s) (passed after 2 attempts)\n");
     }
 }

--- a/tests/Unit/Reporting/PlainReporterTest.php
+++ b/tests/Unit/Reporting/PlainReporterTest.php
@@ -29,7 +29,7 @@ final class PlainReporterTest
             PASS Acme\CalculatorTest::multipliesIntegers[large numbers] (0.340s)
             ERROR Acme\NetworkTest::connects (0.005s)
             SKIP Acme\NetworkTest::pings (0.000s)
-            PASS Acme\NetworkTest::retriesFlakyEndpoint (0.150s) (attempts: 3)
+            PASS Acme\NetworkTest::retriesFlakyEndpoint (0.150s) (passed after 3 attempts)
 
             FAIL Acme\CalculatorTest::subtractsIntegers
               Failed asserting that two values are equal.
@@ -42,12 +42,16 @@ final class PlainReporterTest
                 Acme\NetworkTest::connect at /project/tests/NetworkTest.php:17
               at /project/tests/NetworkTest.php:17
 
-            6 tests, 3 passed, 1 failed, 1 errored, 1 skipped, 11 expectations
+            6 tests, 3 passed, 1 failed, 1 errored, 1 skipped, 1 passed after retry, 11 expectations
             Time: 1.234s
             Workers: 2 spawned
 
             Skipped:
               Acme\NetworkTest::pings (Requires ext-redis.)
+
+            Passed after retry:
+              Acme\NetworkTest::retriesFlakyEndpoint (3 attempts)
+            These results are evidence of instability.
             TXT;
 
         Expect::that($output->buffer())->because('canned stream renders the golden output')->toBe($expected . "\n");

--- a/tests/Unit/Reporting/SummaryFormatTest.php
+++ b/tests/Unit/Reporting/SummaryFormatTest.php
@@ -22,13 +22,14 @@ final class SummaryFormatTest
             new ResultSummary(passed: 2, failed: 1, errored: 1, skipped: 1),
             7,
             new Style(ansi: false),
+            retriedPasses: 1,
         );
 
         Expect::that($line)
             ->because(
                 'the final summary shows each test outcome and the expectation count',
             )
-            ->toBe('5 tests, 2 passed, 1 failed, 1 errored, 1 skipped, 7 expectations');
+            ->toBe('5 tests, 2 passed, 1 failed, 1 errored, 1 skipped, 1 passed after retry, 7 expectations');
     }
 
     #[Test]
@@ -61,6 +62,28 @@ final class SummaryFormatTest
             . "\n"
             . "  App\BetaTest::two (no reason given)\n",
         );
+    }
+
+    #[Test]
+    public function retriedPassesListAttemptsAndInstabilityEvidence(): void
+    {
+        $block = SummaryFormat::retriedPasses([
+            new TestResult(
+                new TestId('App\RetryTest', 'passes'),
+                Outcome::Passed,
+                0.1,
+                0,
+                attempts: 2,
+            ),
+        ], new Style(ansi: false));
+
+        Expect::that($block)
+            ->because('retried passes MUST retain their test IDs and attempt counts')
+            ->toBe(
+                "\nPassed after retry:\n"
+                . "  App\\RetryTest::passes (2 attempts)\n"
+                . "These results are evidence of instability.\n",
+            );
     }
 
     #[Test]

--- a/tests/Unit/Reporting/TeamCityReporterTest.php
+++ b/tests/Unit/Reporting/TeamCityReporterTest.php
@@ -47,6 +47,7 @@ final readonly class TeamCityReporterTest
             ##teamcity[testIgnored name='Acme\NetworkTest::pings' message='Requires ext-redis.' flowId='Acme\NetworkTest']
             ##teamcity[testFinished name='Acme\NetworkTest::pings' duration='0' flowId='Acme\NetworkTest']
             ##teamcity[testStarted name='Acme\NetworkTest::retriesFlakyEndpoint' flowId='Acme\NetworkTest']
+            ##teamcity[testMetadata testName='Acme\NetworkTest::retriesFlakyEndpoint' name='greenlight.attempts' type='number' value='3' flowId='Acme\NetworkTest']
             ##teamcity[testFinished name='Acme\NetworkTest::retriesFlakyEndpoint' duration='150' flowId='Acme\NetworkTest']
             ##teamcity[testSuiteFinished name='Acme\NetworkTest' flowId='Acme\NetworkTest']
             TXT;

--- a/tests/Unit/Reporting/TtyReporterTest.php
+++ b/tests/Unit/Reporting/TtyReporterTest.php
@@ -74,6 +74,37 @@ final class TtyReporterTest
     }
 
     #[Test]
+    public function retriedPassesRemainVisibleInTheWindowAndFinalSummary(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new TtyReporter($output, color: false, cursor: true);
+
+        $reporter->onEvent(new RunStarted('run-1', 1, 1, 1.0));
+        $reporter->onEvent(new TestClassStarted('App\RetryTest', 1.0));
+        $reporter->onEvent(new TestFinished(new TestResult(
+            new TestId('App\RetryTest', 'passes'),
+            Outcome::Passed,
+            0.01,
+            0,
+            attempts: 2,
+        ), 1.1));
+        $reporter->onEvent(new TestClassFinished('App\RetryTest', 1.2));
+        $reporter->onEvent(new RunFinished('run-1', new ResultSummary(passed: 1), 0.1, 1.3));
+        $reporter->finish();
+
+        $terminal = new TerminalEmulator();
+        $terminal->write($output->buffer());
+        $screen = $terminal->screen();
+
+        Expect::that($screen)
+            ->because('interactive output MUST retain retried-pass evidence after the live window closes')
+            ->toContain('↻ App\RetryTest (1 test, 1 passed after retry, 0.010s)')
+            ->toContain('1 test, 1 passed, 1 passed after retry, 0 expectations')
+            ->toContain("Passed after retry:\n  App\\RetryTest::passes (2 attempts)")
+            ->toContain('These results are evidence of instability.');
+    }
+
+    #[Test]
     public function concurrentAssignmentsForOneClassShareOneLiveEntry(): void
     {
         $output = new BufferOutput();

--- a/tests/Unit/Result/RunPolicyTest.php
+++ b/tests/Unit/Result/RunPolicyTest.php
@@ -13,29 +13,30 @@ use Greenlight\Result\RunPolicy;
 final readonly class RunPolicyTest
 {
     /**
-     * @param array{bool, int, int, int} $case
+     * @param array{bool, bool, non-negative-int, non-negative-int, non-negative-int, non-negative-int} $case
      */
     #[Test]
     #[DataSet('summaries')]
     public function skippedPolicyEvaluatesTheFinalSummaryWithoutChangingIt(array $case, bool $expected): void
     {
-        [$failOnSkipped, $failed, $errored, $skipped] = $case;
+        [$failOnSkipped, $failOnRetriedPass, $failed, $errored, $skipped, $retriedPasses] = $case;
         $summary = new ResultSummary(failed: $failed, errored: $errored, skipped: $skipped);
 
-        Expect::that(new RunPolicy($failOnSkipped)->accepts($summary))
+        Expect::that(new RunPolicy($failOnSkipped, $failOnRetriedPass)->accepts($summary, $retriedPasses))
             ->because('the run policy MUST evaluate the final summary without changing test outcomes')
             ->toBe($expected);
     }
 
     /**
-     * @return iterable<string, array{array{bool, int, int, int}, bool}>
+     * @return iterable<string, array{array{bool, bool, non-negative-int, non-negative-int, non-negative-int, non-negative-int}, bool}>
      */
     public static function summaries(): iterable
     {
-        yield 'default accepts skipped tests' => [[false, 0, 0, 1], true];
-        yield 'enabled accepts a clean summary' => [[true, 0, 0, 0], true];
-        yield 'enabled rejects skipped tests' => [[true, 0, 0, 1], false];
-        yield 'enabled rejects failed tests' => [[true, 1, 0, 0], false];
-        yield 'enabled rejects errored tests' => [[true, 0, 1, 0], false];
+        yield 'default accepts skipped tests and retried passes' => [[false, false, 0, 0, 1, 2], true];
+        yield 'enabled accepts a clean summary' => [[true, true, 0, 0, 0, 0], true];
+        yield 'enabled rejects skipped tests' => [[true, false, 0, 0, 1, 0], false];
+        yield 'enabled rejects retried passes' => [[false, true, 0, 0, 0, 1], false];
+        yield 'enabled rejects failed tests' => [[true, true, 1, 0, 0, 0], false];
+        yield 'enabled rejects errored tests' => [[true, true, 0, 1, 0, 0], false];
     }
 }


### PR DESCRIPTION
Summary:

- Report passed-after-retry evidence in TTY, plain, JUnit, JSONL, GitHub, and TeamCity output.
- Add failOnRetriedPass() and --fail-on-retried-pass as a run-level policy that preserves passed outcomes.
- Cover retries across process workers, sharding, bail, repeat mode, attachments, and reporter contracts.

This pull request is stacked on #1611.