### PR TITLE
docs: add GitLab CI guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ for the complete model.
 * [Start with Greenlight](docs/getting-started.md)
 * [Configuration reference](docs/configuration.md)
 * [Use Greenlight in GitHub Actions](docs/github-actions.md)
+* [Use Greenlight in GitLab CI/CD](docs/gitlab-ci.md)
 * [Attribute reference](docs/attributes.md)
 * [Expectations](docs/expectations.md)
 * [Test doubles](docs/test-doubles.md)

--- a/docs/gitlab-ci.md
+++ b/docs/gitlab-ci.md
@@ -1,0 +1,128 @@
+# GitLab CI/CD
+
+GitLab reads Greenlight JUnit output through `artifacts:reports:junit`.
+Greenlight does not need a GitLab-specific reporter.
+
+## Configure attachment storage
+
+Configure a project-relative parent directory for Greenlight run directories.
+Add this configuration to `greenlight.php`:
+
+<!-- php-example {"mode":"display","reason":"Shows one method in an existing Greenlight configuration chain."} -->
+```php
+->artifacts(fn ($artifacts) => $artifacts
+    ->directory('build/gitlab/greenlight-runs'))
+```
+
+Greenlight creates a unique run directory below this parent directory. Retained
+attachments stay in that run directory. Upload the parent directory to keep
+attachments after the job ends.
+
+## Publish test results
+
+Add a test job to `.gitlab-ci.yml`. This example assumes that the runner has
+PHP and Composer:
+
+```yaml
+tests:
+  stage: test
+  before_script:
+    - composer install --no-interaction --prefer-dist
+  script:
+    - vendor/bin/greenlight run --reporter=plain --reporter=junit=build/test-results/greenlight.xml
+  artifacts:
+    when: always
+    expire_in: 1 week
+    paths:
+      - build/test-results/greenlight.xml
+      - build/gitlab/greenlight-runs/
+    reports:
+      junit: build/test-results/greenlight.xml
+```
+
+The `plain` reporter keeps human-readable output in the job log. The `junit`
+reporter writes the project-relative XML file that GitLab reads.
+
+GitLab uploads report artifacts after successful and failed jobs. The
+`when: always` value also uploads the browsable XML file and retained
+attachments after a failed job. A job timeout can prevent this upload.
+
+The `expire_in` value controls artifact retention. Select a period that
+agrees with your project policy.
+
+JUnit reports do not determine the job status. The Greenlight command returns
+a nonzero exit code for a failed run. Do not discard that exit code.
+
+See the GitLab documentation for [unit test
+reports](https://docs.gitlab.com/ci/testing/unit_test_reports/) and [job
+artifacts](https://docs.gitlab.com/ci/jobs/job_artifacts/).
+
+## Use parallel shards
+
+Use GitLab parallel jobs for a large suite. Pass the GitLab job index and total
+to Greenlight:
+
+```yaml
+tests:
+  stage: test
+  parallel: 4
+  before_script:
+    - composer install --no-interaction --prefer-dist
+  script:
+    - vendor/bin/greenlight run --shard="$CI_NODE_INDEX/$CI_NODE_TOTAL" --reporter=plain --reporter="junit=build/test-results/greenlight-$CI_NODE_INDEX.xml"
+  artifacts:
+    when: always
+    expire_in: 1 week
+    paths:
+      - build/test-results/greenlight-*.xml
+      - build/gitlab/greenlight-runs/
+    reports:
+      junit: build/test-results/greenlight-*.xml
+```
+
+Each parallel job has a separate workspace and artifact archive. Greenlight
+uses one-based shard numbers, which agree with `CI_NODE_INDEX`.
+
+For multiple XML files in one job, `junit` accepts a filename pattern or an
+array of paths. It does not accept a directory. See the GitLab
+[`junit` report reference](https://docs.gitlab.com/ci/yaml/artifacts_reports/#artifactsreportsjunit)
+and [parallel job variables](https://docs.gitlab.com/ci/variables/predefined_variables/).
+
+## Add coverage annotations
+
+Greenlight can write the Cobertura report that GitLab uses for merge request
+diff annotations. Add this configuration to `greenlight.php`:
+
+<!-- php-example {"mode":"display","reason":"Shows one method in an existing Greenlight configuration chain."} -->
+```php
+->coverage(fn ($coverage) => $coverage
+    ->include('src')
+    ->export('cobertura', 'build/coverage/cobertura.xml'))
+```
+
+Add the coverage file to the test job artifacts:
+
+```yaml
+  artifacts:
+    when: always
+    expire_in: 1 week
+    paths:
+      - build/test-results/greenlight.xml
+      - build/coverage/cobertura.xml
+      - build/gitlab/greenlight-runs/
+    reports:
+      junit: build/test-results/greenlight.xml
+      coverage_report:
+        coverage_format: cobertura
+        path: build/coverage/cobertura.xml
+```
+
+GitLab uses `coverage_report` for line annotations in a merge request diff. It
+does not add a coverage percentage to the merge request widget.
+
+A Cobertura export from one Greenlight shard contains only that shard's
+coverage. For complete project coverage, use a separate unsharded coverage
+job. In one job, GitLab can merge the Cobertura files that one pattern selects.
+
+See the GitLab documentation for [coverage
+visualization](https://docs.gitlab.com/ci/testing/code_coverage/coverage_visualization/).

--- a/website/src/lib/docs.ts
+++ b/website/src/lib/docs.ts
@@ -32,6 +32,11 @@ export const docSections = [
         description: 'This guide explains how to reuse Greenlight run state between GitHub Actions runs.',
       },
       {
+        id: 'gitlab-ci',
+        title: 'GitLab CI/CD',
+        description: 'This guide explains how to publish Greenlight test results, attachments, and coverage in GitLab.',
+      },
+      {
         id: 'attributes',
         title: 'Attributes',
         description: 'This reference explains attributes for tests, hooks, data sets, and execution.',


### PR DESCRIPTION
## Summary

- document GitLab JUnit report ingestion with readable Greenlight output
- explain project-relative attachment storage, failed-job uploads, and retention
- cover parallel shards, report patterns, and Cobertura merge-request annotations