### PR TITLE
fix: improve portable JUnit compatibility

### DIFF
--- a/src/Reporting/JUnitReporter.php
+++ b/src/Reporting/JUnitReporter.php
@@ -44,6 +44,11 @@ final class JUnitReporter implements Reporter
      */
     private array $countsByClass = [];
 
+    /**
+     * @var array<string, array<string, ?string>> source files per test method
+     */
+    private array $sourceFilesByClassAndMethod = [];
+
     private ?float $runDurationSeconds = null;
 
     private readonly XmlWriterRuntime $xmlWriter;
@@ -172,11 +177,18 @@ final class JUnitReporter implements Reporter
         $writer->writeAttribute('assertions', (string) $result->expectations);
         $writer->writeAttribute('time', $this->time($result->durationSeconds));
 
+        $sourceFile = $this->sourceFile($result->id->class, $result->id->method);
+
+        if ($sourceFile !== null) {
+            $writer->writeAttribute('file', $this->xml($sourceFile));
+        }
+
         if ($result->outcome === Outcome::Failed) {
             if ($result->failures === []) {
                 $writer->startElement('failure');
                 $writer->writeAttribute('type', 'failure');
                 $writer->writeAttribute('message', 'failed');
+                $writer->text('failed');
                 $writer->endElement();
             }
 
@@ -185,7 +197,7 @@ final class JUnitReporter implements Reporter
                 $writer->writeAttribute('type', 'failure');
                 $writer->writeAttribute('message', $this->xml($failure->message));
 
-                $body = [];
+                $body = [$failure->message];
 
                 if ($failure->expected !== null) {
                     $body[] = 'expected: ' . $failure->expected;
@@ -199,9 +211,7 @@ final class JUnitReporter implements Reporter
                     $body[] = 'at ' . $failure->location;
                 }
 
-                if ($body !== []) {
-                    $writer->text($this->xml(\implode("\n", $body)));
-                }
+                $writer->text($this->xml(\implode("\n", $body)));
 
                 $writer->endElement();
             }
@@ -216,12 +226,13 @@ final class JUnitReporter implements Reporter
                 $writer->writeAttribute('type', $this->xml($error->class));
                 $writer->writeAttribute('message', $this->xml($error->message));
 
-                $body = $error->stackFrames;
+                $body = [$error->message, ...$error->stackFrames];
                 $body[] = 'at ' . $error->file . ':' . $error->line;
                 $writer->text($this->xml(\implode("\n", $body)));
             } else {
                 $writer->writeAttribute('type', 'error');
                 $writer->writeAttribute('message', 'errored');
+                $writer->text('errored');
             }
 
             $writer->endElement();
@@ -232,6 +243,7 @@ final class JUnitReporter implements Reporter
 
             if ($result->skipReason !== null) {
                 $writer->writeAttribute('message', $this->xml($result->skipReason));
+                $writer->text($this->xml($result->skipReason));
             }
 
             $writer->endElement();
@@ -254,6 +266,33 @@ final class JUnitReporter implements Reporter
         $lines = \array_slice($lines, 2, -2);
 
         return \implode("\n", $lines) . "\n";
+    }
+
+    /**
+     * @param non-empty-string $class
+     * @param non-empty-string $method
+     */
+    private function sourceFile(string $class, string $method): ?string
+    {
+        $classFiles = $this->sourceFilesByClassAndMethod[$class] ?? [];
+
+        if (\array_key_exists($method, $classFiles)) {
+            return $classFiles[$method];
+        }
+
+        $file = null;
+
+        try {
+            $reflected = new \ReflectionMethod($class, $method)->getFileName();
+
+            if ($reflected !== false) {
+                $file = $reflected;
+            }
+        } catch (\Throwable) {
+            // An autoloader error MUST NOT stop report generation.
+        }
+
+        return $this->sourceFilesByClassAndMethod[$class][$method] = $file;
     }
 
     private function xml(string $value): string

--- a/tests/Acceptance/PolicyTest.php
+++ b/tests/Acceptance/PolicyTest.php
@@ -100,7 +100,10 @@ final readonly class PolicyTest
             ->because('JUnit MUST retain the skipped testcase')
             ->toContain('failures="0"')
             ->toContain('skipped="1"')
-            ->toContain('<skipped message="integration service is unavailable"/>');
+            ->toContain(
+                '<skipped message="integration service is unavailable">'
+                . 'integration service is unavailable</skipped>',
+            );
 
         $jsonl = (string) \file_get_contents($project->path('reports/events.jsonl'));
         Expect::that($jsonl)

--- a/tests/Unit/Reporting/JUnitErrorFallbackTest.php
+++ b/tests/Unit/Reporting/JUnitErrorFallbackTest.php
@@ -35,7 +35,7 @@ final class JUnitErrorFallbackTest
                 . "<testsuites name=\"greenlight\" tests=\"1\" failures=\"0\" errors=\"1\" skipped=\"0\" time=\"0.002000\">\n"
                 . "  <testsuite name=\"Acme\\PartialResultTest\" tests=\"1\" failures=\"0\" errors=\"1\" skipped=\"0\" assertions=\"0\" time=\"0.002000\">\n"
                 . "    <testcase name=\"missingErrorDetail\" classname=\"Acme\\PartialResultTest\" assertions=\"0\" time=\"0.002000\">\n"
-                . "      <error type=\"error\" message=\"errored\"/>\n"
+                . "      <error type=\"error\" message=\"errored\">errored</error>\n"
                 . "    </testcase>\n"
                 . "  </testsuite>\n"
                 . "</testsuites>\n",

--- a/tests/Unit/Reporting/JUnitFailureFallbackTest.php
+++ b/tests/Unit/Reporting/JUnitFailureFallbackTest.php
@@ -35,7 +35,7 @@ final class JUnitFailureFallbackTest
                 . "<testsuites name=\"greenlight\" tests=\"1\" failures=\"1\" errors=\"0\" skipped=\"0\" time=\"0.002000\">\n"
                 . "  <testsuite name=\"Acme\\PartialResultTest\" tests=\"1\" failures=\"1\" errors=\"0\" skipped=\"0\" assertions=\"0\" time=\"0.002000\">\n"
                 . "    <testcase name=\"missingFailureDetail\" classname=\"Acme\\PartialResultTest\" assertions=\"0\" time=\"0.002000\">\n"
-                . "      <failure type=\"failure\" message=\"failed\"/>\n"
+                . "      <failure type=\"failure\" message=\"failed\">failed</failure>\n"
                 . "    </testcase>\n"
                 . "  </testsuite>\n"
                 . "</testsuites>\n",

--- a/tests/Unit/Reporting/JUnitPartialDiffTest.php
+++ b/tests/Unit/Reporting/JUnitPartialDiffTest.php
@@ -39,8 +39,10 @@ final class JUnitPartialDiffTest
             <testsuites name="greenlight" tests="1" failures="1" errors="0" skipped="0" time="0.001000">
               <testsuite name="Acme\PartialDiffTest" tests="1" failures="1" errors="0" skipped="0" assertions="0" time="0.001000">
                 <testcase name="reports" classname="Acme\PartialDiffTest" assertions="0" time="0.001000">
-                  <failure type="failure" message="expected only">expected: </failure>
-                  <failure type="failure" message="actual only">actual: </failure>
+                  <failure type="failure" message="expected only">expected only
+            expected: </failure>
+                  <failure type="failure" message="actual only">actual only
+            actual: </failure>
                 </testcase>
               </testsuite>
             </testsuites>

--- a/tests/Unit/Reporting/JUnitReporterAutoloadTest.php
+++ b/tests/Unit/Reporting/JUnitReporterAutoloadTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Event\TestFinished;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\JUnitReporter;
+use Greenlight\Result\Outcome;
+use Greenlight\Result\TestResult;
+use Greenlight\Sandbox\Autoloaders;
+use Greenlight\Test\TestId;
+
+final readonly class JUnitReporterAutoloadTest
+{
+    public function __construct(private Autoloaders $autoloaders) {}
+
+    #[Test]
+    public function autoloaderFailuresDoNotStopReportGeneration(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new JUnitReporter($output);
+        $class = 'Acme\BrokenJUnitAutoloaderTest';
+        $autoloadCalls = 0;
+        $autoload = static function (string $requested) use ($class, &$autoloadCalls): void {
+            if ($requested === $class) {
+                ++$autoloadCalls;
+
+                throw new \RuntimeException('autoload failed');
+            }
+        };
+        $this->autoloaders->register($autoload);
+
+        foreach ([null, 'second data set'] as $dataSetKey) {
+            $reporter->onEvent(new TestFinished(new TestResult(
+                new TestId($class, 'runs', $dataSetKey),
+                Outcome::Passed,
+                0.001,
+                0,
+            ), 1.0));
+        }
+
+        $reporter->finish();
+
+        Expect::that($autoloadCalls)
+            ->because('a failed source lookup MUST not rerun the autoloader for the same method')
+            ->toBe(1);
+        Expect::that(\simplexml_load_string($output->buffer()))
+            ->because('an autoloader failure MUST preserve valid JUnit XML')
+            ->toBeInstanceOf(\SimpleXMLElement::class);
+        Expect::that($output->buffer())
+            ->because('an autoloader failure MUST omit the optional source file')
+            ->not()
+            ->toContain(' file=');
+    }
+}

--- a/tests/Unit/Reporting/JUnitReporterTest.php
+++ b/tests/Unit/Reporting/JUnitReporterTest.php
@@ -31,7 +31,8 @@ final class JUnitReporterTest
               <testsuite name="Acme\CalculatorTest" tests="3" failures="1" errors="0" skipped="0" assertions="7" time="0.372000">
                 <testcase name="addsIntegers" classname="Acme\CalculatorTest" assertions="2" time="0.012000"/>
                 <testcase name="subtractsIntegers" classname="Acme\CalculatorTest" assertions="1" time="0.020000">
-                  <failure type="failure" message="Failed asserting that two values are equal.">expected: 2
+                  <failure type="failure" message="Failed asserting that two values are equal.">Failed asserting that two values are equal.
+            expected: 2
             actual: 3
             at /project/tests/CalculatorTest.php:42</failure>
                 </testcase>
@@ -39,11 +40,12 @@ final class JUnitReporterTest
               </testsuite>
               <testsuite name="Acme\NetworkTest" tests="3" failures="0" errors="1" skipped="1" assertions="4" time="0.155000">
                 <testcase name="connects" classname="Acme\NetworkTest" assertions="1" time="0.005000">
-                  <error type="RuntimeException" message="Connection refused.">Acme\NetworkTest::connect at /project/tests/NetworkTest.php:17
+                  <error type="RuntimeException" message="Connection refused.">Connection refused.
+            Acme\NetworkTest::connect at /project/tests/NetworkTest.php:17
             at /project/tests/NetworkTest.php:17</error>
                 </testcase>
                 <testcase name="pings" classname="Acme\NetworkTest" assertions="0" time="0.000000">
-                  <skipped message="Requires ext-redis."/>
+                  <skipped message="Requires ext-redis.">Requires ext-redis.</skipped>
                 </testcase>
                 <testcase name="retriesFlakyEndpoint" classname="Acme\NetworkTest" assertions="3" time="0.150000"/>
               </testsuite>
@@ -112,6 +114,74 @@ final class JUnitReporterTest
             ->toBe('first failure');
         Expect::that((string) $failures[1]['message'])
             ->toBe('second failure');
+        Expect::that((string) $failures[0])
+            ->because('each failure element contains its primary diagnostic')
+            ->toBe('first failure');
+        Expect::that((string) $failures[1])
+            ->toBe('second failure');
+    }
+
+    #[Test]
+    public function loadableTestMethodsIncludeTheirSourceFile(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new JUnitReporter($output);
+        $reporter->onEvent(new TestFinished(new TestResult(
+            new TestId(self::class, __FUNCTION__),
+            Outcome::Passed,
+            0.001,
+            1,
+        ), 1.0));
+
+        $reporter->finish();
+        $document = \simplexml_load_string($output->buffer());
+
+        Expect::that($document)
+            ->because('the source-file attribute MUST preserve valid JUnit XML')
+            ->toBeInstanceOf(\SimpleXMLElement::class);
+
+        $case = SimpleXml::xpath($document, '/testsuites/testsuite/testcase')[0];
+
+        Expect::that((string) $case['file'])
+            ->because('a loadable test method MUST identify its source file')
+            ->toBe(__FILE__);
+    }
+
+    #[Test]
+    public function unavailableSourceMetadataDoesNotStopReportGeneration(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new JUnitReporter($output);
+        $reporter->onEvent(new TestFinished(new TestResult(
+            new TestId('Acme\\UnavailableSourceTest', 'runs'),
+            Outcome::Passed,
+            0.001,
+            0,
+        ), 1.0));
+        $reporter->onEvent(new TestFinished(new TestResult(
+            new TestId(self::class, 'unavailableMethod'),
+            Outcome::Passed,
+            0.001,
+            0,
+        ), 1.1));
+
+        $reporter->finish();
+        $document = \simplexml_load_string($output->buffer());
+
+        Expect::that($document)
+            ->because('unavailable source metadata MUST preserve valid JUnit XML')
+            ->toBeInstanceOf(\SimpleXMLElement::class);
+
+        $cases = SimpleXml::xpath($document, '/testsuites/testsuite/testcase');
+
+        Expect::that(SimpleXml::attributes($cases[0]))
+            ->because('an unavailable test class MUST omit the optional source file')
+            ->not()
+            ->toHaveKey('file');
+        Expect::that(SimpleXml::attributes($cases[1]))
+            ->because('an unavailable test method MUST omit the optional source file')
+            ->not()
+            ->toHaveKey('file');
     }
 
     #[Test]
@@ -169,21 +239,21 @@ final class JUnitReporterTest
     }
 
     #[Test]
-    public function forbiddenXmlCharactersAreReplacedInNamesAndDiagnostics(): void
+    public function invalidTextIsReplacedInNamesAndDiagnostics(): void
     {
         $output = new BufferOutput();
         $reporter = new JUnitReporter($output);
         $result = new TestResult(
-            new TestId('Acme\XmlTest', 'fails', "case\x01"),
+            new TestId('Acme\XmlTest', 'fails', "case\x01\xFF"),
             Outcome::Failed,
             0.001,
             0,
             failures: [
                 new FailureDetail(
-                    "message\x02",
-                    "expected\x03",
-                    "actual\x04",
-                    new SourceLocation("/project/tests/\x05Test.php", 12),
+                    "message\x02\xFF",
+                    "expected\x03\xFF",
+                    "actual\x04\xFF",
+                    new SourceLocation("/project/tests/\x05\xFFTest.php", 12),
                 ),
             ],
         );
@@ -200,17 +270,18 @@ final class JUnitReporterTest
         $failure = SimpleXml::xpath($case, 'failure')[0];
 
         Expect::that((string) $case['name'])
-            ->because('forbidden characters in test names are replaced')
-            ->toBe("fails[case\u{FFFD}]");
+            ->because('invalid text in test names is replaced')
+            ->toBe("fails[case\u{FFFD}\u{FFFD}]");
         Expect::that((string) $failure['message'])
-            ->because('forbidden characters in diagnostic attributes are replaced')
-            ->toBe("message\u{FFFD}");
+            ->because('invalid text in diagnostic attributes is replaced')
+            ->toBe("message\u{FFFD}\u{FFFD}");
         Expect::that((string) $failure)
-            ->because('forbidden characters in diagnostic text are replaced')
+            ->because('invalid text in diagnostic content is replaced')
             ->toBe(
-                "expected: expected\u{FFFD}\n"
-                . "actual: actual\u{FFFD}\n"
-                . "at /project/tests/\u{FFFD}Test.php:12",
+                "message\u{FFFD}\u{FFFD}\n"
+                . "expected: expected\u{FFFD}\u{FFFD}\n"
+                . "actual: actual\u{FFFD}\u{FFFD}\n"
+                . "at /project/tests/\u{FFFD}\u{FFFD}Test.php:12",
             );
     }
 }

--- a/tests/Unit/Reporting/JUnitZeroSkipReasonTest.php
+++ b/tests/Unit/Reporting/JUnitZeroSkipReasonTest.php
@@ -32,6 +32,6 @@ final class JUnitZeroSkipReasonTest
 
         Expect::that($output->buffer())
             ->because('JUnit MUST preserve the skip reason "0"')
-            ->toContain('<skipped message="0"/>');
+            ->toContain('<skipped message="0">0</skipped>');
     }
 }


### PR DESCRIPTION
## Summary

- add portable JUnit testcase source-file attributes through failure-safe method reflection
- include primary failure, error, and skip diagnostics in element content while retaining conventional attributes and detail
- preserve fallbacks, multiple failures, XML scrubbing, and bounded lookup behavior with focused regression coverage