### PR TITLE
feat(cli): add test discovery manifest

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -346,7 +346,7 @@ deptrac:
     Cli: [CliCommand, CliOutput, Coverage, CoverageRelay, ExecutionProcessProtocol, ExecutionProcessWorker, InternalWire, Reporting]
     CliInput: []
     CliConfiguration: [CliInput, Config, InternalPhp, InternalText, Result, Test]
-    CliDiscovery: [CliConfiguration, Config, Discovery, DiscoveryPlan]
+    CliDiscovery: [CliConfiguration, CliInput, CliState, Config, Discovery, DiscoveryPlan, Test]
     CliOutput: [InternalPhp, InternalText, Reporting]
     CliReporting: [CliInput, CliOutput, Event, InternalPhp, Plugin, Reporting, ReportingProfile]
     CliCoverage: [CliConfiguration, CliOutput, Config, Coverage, CoverageCollection, CoverageExport, CoverageRelay, InternalFilesystem, InternalPhp, Reporting]

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -144,9 +144,9 @@ implementation classes.
 
 ### Output
 
-Human reporters control presentation. Each JSONL and coverage JSON format has
-a version. The worker protocol is internal. Before you change an output shape,
-read [compatibility](compatibility.md).
+Human reporters control presentation. JSONL, coverage JSON, and the test
+manifest have versions. The worker protocol is internal. Before you change an
+output shape, read [compatibility](compatibility.md).
 
 The internal event codec owns event tags, tagged payload validation, and event
 construction. It also owns JSONL encoding and decoding. The worker protocol,
@@ -175,6 +175,7 @@ JSONL reporter, and `profile:report` use this codec through their own seams.
 - [Orchestrator-owned integration fixtures](orchestrator-integration-fixtures.md)
 - [Artifact storage](artifacts.md)
 - [JSONL reporter schema](jsonl.md)
+- [Test discovery manifest](test-manifest.md)
 - [Coverage JSON schema](coverage-json.md)
 - [Temporal expectations](temporal-expectations.md)
 - [Infection support decision](mutation-testing.md)

--- a/docs/architecture/compatibility.md
+++ b/docs/architecture/compatibility.md
@@ -11,6 +11,7 @@ Only documented interfaces and versioned formats have compatibility promises.
 | Documented attributes, configuration builders, expectations, fixtures, doubles, attachments, conditions, and plugin interfaces | Public PHP interface |
 | Documented CLI commands, options, exit meanings, and configuration-file shape | Public command interface |
 | JSONL reporter | Public, versioned data interface |
+| Test discovery manifest | Public, versioned data interface |
 | Coverage JSON export | Public, versioned data interface |
 | JUnit, TeamCity, and GitHub output | External integration interfaces |
 | Classes or members marked `@internal` | Internal implementation |
@@ -169,6 +170,7 @@ These public formats intentionally report absolute paths:
 
 - Coverage JSON keys
 - Failure and diagnostic source locations in JSONL
+- Test discovery manifest source locations
 - Published attachment paths and the run artifact directory
 
 Absolute paths help users find files on the source machine. These paths also

--- a/docs/architecture/test-manifest.md
+++ b/docs/architecture/test-manifest.md
@@ -1,0 +1,70 @@
+# Test discovery manifest
+
+`list-tests --format=json` writes one versioned JSON test discovery manifest.
+It discovers the selected tests and does not execute them.
+
+The version 1 JSON Schema is at
+[resources/schema/test-manifest-v1.schema.json](../../resources/schema/test-manifest-v1.schema.json).
+
+## Selection and order
+
+The command accepts the normal test selectors. These selectors include suite,
+group, test ID, exclusion, seed, previous-failure, and shard selectors.
+
+The `tests` array is in plan order. The `order.tests` value is `plan`.
+The manifest does not contain completion order because no test executes.
+Thus, `order.completion` is `not-applicable`.
+
+The `order.seed` value contains the resolved seed. Its value is `null` for an
+unseeded plan. The `shard` value contains the selected shard or `null`.
+
+## Test entries
+
+Each test entry has these identity and source fields:
+
+- `id`: The complete stable test ID.
+- `class`: The test class.
+- `method`: The test method.
+- `dataSetKey`: The normalized data-set key, or `null`.
+- `source.file`: The absolute declaring file.
+- `source.line`: The test method declaration line.
+- `groups`: The selected test groups.
+- `suites`: Each configured suite whose path contains the test class file.
+
+A labeled data row or provider key keeps its printable label in `dataSetKey`.
+An integer key uses `#<value>`. Greenlight hashes an empty or nonprintable key.
+
+Each entry also contains this execution metadata:
+
+- `skip.present` and `skip.condition`
+- `retry.additionalAttempts` and `retry.onlyOn`
+- `timeoutSeconds`
+- `captureOutput` and `noExpectations`
+- `resources`
+- `isolated` and `allowParallel`
+
+The manifest does not contain skip reasons or condition arguments. It also
+does not contain closures, plugin instances, or internal wire payloads.
+
+## Streams and exit codes
+
+Standard output contains only the JSON document and its final newline.
+Greenlight writes warnings and diagnostics to standard error.
+
+The command uses these exit codes:
+
+- `0`: Discovery succeeded. The `tests` array can be empty.
+- `1`: Configuration or discovery failed. Standard output is empty.
+- `64`: Command-line use is invalid. Standard output is empty.
+
+## Compatibility
+
+The top-level `version` value selects the complete manifest schema.
+Consumers **SHOULD** validate the document against the schema for that version.
+
+Greenlight **MAY** add optional fields in one version. Consumers **MUST** ignore
+unknown fields.
+
+A removed field, renamed field, new required field, changed type, or changed
+meaning requires a new version and schema file. A closed enum extension also
+requires a new version.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -670,6 +670,16 @@ Greenlight resolves relative prefixes from the current directory. Repeatable.
 
 Prints the selected test IDs. It does not run them.
 
+Use `--format=json` to write the version 1 test discovery manifest. The
+[manifest reference](architecture/test-manifest.md) defines its schema, order,
+metadata, compatibility rules, and exit codes.
+
+### `--format=<format>`
+
+Sets `list-tests` output to `text` or `json`. The default is `text`.
+
+Use this option only with `list-tests` or `run --list-tests`.
+
 ### `--list-groups`
 
 Prints each selected group and its test count. It does not run tests.

--- a/resources/schema/test-manifest-v1.schema.json
+++ b/resources/schema/test-manifest-v1.schema.json
@@ -1,0 +1,138 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://raw.githubusercontent.com/ben-challis/greenlight/main/resources/schema/test-manifest-v1.schema.json",
+    "title": "Greenlight test discovery manifest (version 1)",
+    "description": "One selected test plan from list-tests --format=json. Prose reference: docs/architecture/test-manifest.md.",
+    "type": "object",
+    "required": ["version", "order", "shard", "tests"],
+    "properties": {
+        "version": {
+            "enum": [1]
+        },
+        "order": {
+            "$ref": "#/definitions/order"
+        },
+        "shard": {
+            "oneOf": [
+                {"type": "null"},
+                {"$ref": "#/definitions/shard"}
+            ]
+        },
+        "tests": {
+            "type": "array",
+            "items": {"$ref": "#/definitions/test"}
+        }
+    },
+    "definitions": {
+        "order": {
+            "type": "object",
+            "required": ["tests", "completion", "seed"],
+            "properties": {
+                "tests": {
+                    "enum": ["plan"]
+                },
+                "completion": {
+                    "enum": ["not-applicable"]
+                },
+                "seed": {
+                    "type": ["integer", "null"],
+                    "minimum": 0
+                }
+            }
+        },
+        "shard": {
+            "type": "object",
+            "required": ["index", "count"],
+            "properties": {
+                "index": {"type": "integer", "minimum": 1},
+                "count": {"type": "integer", "minimum": 1}
+            }
+        },
+        "test": {
+            "type": "object",
+            "required": [
+                "id",
+                "class",
+                "method",
+                "dataSetKey",
+                "source",
+                "groups",
+                "suites",
+                "skip",
+                "retry",
+                "timeoutSeconds",
+                "captureOutput",
+                "noExpectations",
+                "resources",
+                "isolated",
+                "allowParallel"
+            ],
+            "properties": {
+                "id": {"type": "string", "minLength": 1},
+                "class": {"type": "string", "minLength": 1},
+                "method": {"type": "string", "minLength": 1},
+                "dataSetKey": {"type": ["string", "null"]},
+                "source": {"$ref": "#/definitions/source"},
+                "groups": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {"type": "string", "minLength": 1}
+                },
+                "suites": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {"type": "string", "minLength": 1}
+                },
+                "skip": {"$ref": "#/definitions/skip"},
+                "retry": {"$ref": "#/definitions/retry"},
+                "timeoutSeconds": {
+                    "oneOf": [
+                        {"type": "null"},
+                        {"type": "number", "minimum": 0, "exclusiveMinimum": true}
+                    ]
+                },
+                "captureOutput": {"type": "boolean"},
+                "noExpectations": {"type": "boolean"},
+                "resources": {
+                    "type": "array",
+                    "uniqueItems": true,
+                    "items": {"type": "string", "minLength": 1}
+                },
+                "isolated": {"type": "boolean"},
+                "allowParallel": {"type": "boolean"}
+            }
+        },
+        "source": {
+            "type": "object",
+            "required": ["file", "line"],
+            "properties": {
+                "file": {
+                    "description": "The absolute path of the file that declares the test method.",
+                    "type": "string",
+                    "minLength": 1
+                },
+                "line": {
+                    "description": "The source line of the test method declaration.",
+                    "type": "integer",
+                    "minimum": 1
+                }
+            }
+        },
+        "skip": {
+            "type": "object",
+            "required": ["present", "condition"],
+            "properties": {
+                "present": {"type": "boolean"},
+                "condition": {"type": ["string", "null"]}
+            }
+        },
+        "retry": {
+            "type": "object",
+            "required": ["additionalAttempts", "onlyOn"],
+            "properties": {
+                "additionalAttempts": {"type": "integer", "minimum": 0},
+                "onlyOn": {"type": ["string", "null"]}
+            }
+        }
+    }
+}

--- a/src/Cli/Command/CommandDispatcher.php
+++ b/src/Cli/Command/CommandDispatcher.php
@@ -48,6 +48,13 @@ final readonly class CommandDispatcher
             return 0;
         }
         $command = $arguments->command ?? 'run';
+        if ($arguments->has('format')
+            && $command !== 'list-tests'
+            && ($command !== 'run' || !$arguments->has('list-tests'))
+        ) {
+            $this->console->error(CliError::formatRequiresTestListing()->getMessage(), $arguments->has('no-ansi'));
+            return 64;
+        }
         if ($command === 'list-tests' || ($command === 'run' && !$arguments->has('dry-run') && ($arguments->has('list-tests') || $arguments->has('list-groups') || $arguments->has('list-suites')))) {
             return new ListCommand($this->console)->run($arguments, $workingDirectory);
         }

--- a/src/Cli/Command/ListCommand.php
+++ b/src/Cli/Command/ListCommand.php
@@ -6,6 +6,7 @@ namespace Greenlight\Cli\Command;
 
 use Greenlight\Cli\Configuration\ConfigurationLoader;
 use Greenlight\Cli\Discovery\SelectionDiscovery;
+use Greenlight\Cli\Discovery\SelectionPlan;
 use Greenlight\Cli\Input\CliError;
 use Greenlight\Cli\Input\ParsedArguments;
 use Greenlight\Cli\Output\Console;
@@ -27,6 +28,39 @@ final readonly class ListCommand
 
     public function run(ParsedArguments $arguments, string $workingDirectory): int
     {
+        $format = $arguments->value('format') ?? 'text';
+
+        if (!\in_array($format, ['text', 'json'], true)) {
+            $this->console->error(CliError::unknownTestListFormat($format)->getMessage(), $arguments->has('no-ansi'));
+            return 64;
+        }
+
+        $manifest = $format === 'json';
+
+        if ($manifest && ($arguments->has('list-groups') || $arguments->has('list-suites'))) {
+            $this->console->error(CliError::formatRequiresTestListing()->getMessage(), $arguments->has('no-ansi'));
+            return 64;
+        }
+
+        if (!$manifest) {
+            return $this->execute($arguments, $workingDirectory, false);
+        }
+
+        \ob_start();
+
+        try {
+            return $this->execute($arguments, $workingDirectory, true);
+        } finally {
+            $diagnostics = \ob_get_clean();
+
+            if (\is_string($diagnostics) && $diagnostics !== '') {
+                $this->console->err($diagnostics);
+            }
+        }
+    }
+
+    private function execute(ParsedArguments $arguments, string $workingDirectory, bool $manifest): int
+    {
         try {
             $loaded = new ConfigurationLoader()->load($arguments, $workingDirectory);
         } catch (CliError $error) {
@@ -43,11 +77,30 @@ final readonly class ListCommand
         $discovery = new SelectionDiscovery($loaded, $workingDirectory);
         $this->warnWhenExcludePathsMatchNothing($discovery, $arguments->has('no-ansi'));
         try {
-            $plan = $discovery->plan();
+            $plan = SelectionPlan::resolve($loaded, $workingDirectory, $arguments->has('failed'));
+        } catch (CliError $error) {
+            $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
+            return 64;
         } catch (DiscoveryError $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
             return 1;
         }
+
+        if ($manifest) {
+            $document = TestManifest::document(
+                $plan,
+                $loaded->resolved->discovery->suites,
+                $loaded->resolved->selection->shard,
+                $workingDirectory,
+            );
+            $this->console->out(\json_encode(
+                $document,
+                \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_INVALID_UTF8_SUBSTITUTE | \JSON_THROW_ON_ERROR,
+            ) . "\n");
+
+            return 0;
+        }
+
         return !$standalone && $arguments->has('list-groups') ? $this->groups($plan) : $this->tests($plan);
     }
 

--- a/src/Cli/Command/TestManifest.php
+++ b/src/Cli/Command/TestManifest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli\Command;
+
+use Greenlight\Cli\Configuration\ConfigurationLoader;
+use Greenlight\Config\SuiteConfiguration;
+use Greenlight\Discovery\Plan\ExecutionPlan;
+use Greenlight\Discovery\Plan\PlanEntry;
+
+/**
+ * Makes the public test discovery manifest without internal wire payloads.
+ *
+ * @internal
+ */
+final class TestManifest
+{
+    private function __construct() {}
+
+    /**
+     * @param list<SuiteConfiguration> $suites
+     * @param array{int, int}|null $shard
+     *
+     * @return array<string, mixed>
+     */
+    public static function document(
+        ExecutionPlan $plan,
+        array $suites,
+        ?array $shard,
+        string $workingDirectory,
+    ): array {
+        $suitePaths = self::suitePaths($suites, $workingDirectory);
+
+        return [
+            'version' => 1,
+            'order' => [
+                'tests' => 'plan',
+                'completion' => 'not-applicable',
+                'seed' => $plan->seed,
+            ],
+            'shard' => $shard === null ? null : [
+                'index' => $shard[0],
+                'count' => $shard[1],
+            ],
+            'tests' => \array_map(
+                static fn(PlanEntry $entry): array => self::test($entry, $suitePaths),
+                $plan->entries,
+            ),
+        ];
+    }
+
+    /**
+     * @param array<non-empty-string, list<string>> $suitePaths
+     * @return array<string, mixed>
+     */
+    private static function test(PlanEntry $entry, array $suitePaths): array
+    {
+        $definition = $entry->definition;
+        $method = new \ReflectionMethod($definition->class, $definition->method);
+        $file = $method->getFileName();
+        $line = $method->getStartLine();
+        $classFile = \class_exists($definition->class)
+            ? new \ReflectionClass($definition->class)->getFileName()
+            : false;
+
+        if (!\is_string($file) || $file === '' || !\is_int($line) || $line < 1) {
+            throw new \LogicException(\sprintf(
+                'Test method %s::%s() does not have a source location.',
+                $definition->class,
+                $definition->method,
+            ));
+        }
+
+        $groups = $definition->groups;
+        $resources = $definition->scheduling->resources;
+        \sort($groups, \SORT_STRING);
+        \sort($resources, \SORT_STRING);
+
+        return [
+            'id' => (string) $entry->id,
+            'class' => $definition->class,
+            'method' => $definition->method,
+            'dataSetKey' => $entry->dataSetKey,
+            'source' => [
+                'file' => $file,
+                'line' => $line,
+            ],
+            'groups' => $groups,
+            'suites' => \is_string($classFile) ? self::memberships($classFile, $suitePaths) : [],
+            'skip' => [
+                'present' => $definition->skip->reason !== null || $definition->skip->condition !== null,
+                'condition' => $definition->skip->condition,
+            ],
+            'retry' => [
+                'additionalAttempts' => $definition->retry->times ?? 0,
+                'onlyOn' => $definition->retry->onlyOn,
+            ],
+            'timeoutSeconds' => $definition->execution->timeoutSeconds,
+            'captureOutput' => $definition->execution->capture,
+            'noExpectations' => $definition->execution->noExpectations,
+            'resources' => $resources,
+            'isolated' => $definition->scheduling->isolated,
+            'allowParallel' => $definition->scheduling->allowParallel,
+        ];
+    }
+
+    /**
+     * @param list<SuiteConfiguration> $suites
+     * @return array<non-empty-string, list<string>>
+     */
+    private static function suitePaths(array $suites, string $workingDirectory): array
+    {
+        $resolved = [];
+
+        foreach ($suites as $suite) {
+            foreach ($suite->paths as $path) {
+                $absolute = ConfigurationLoader::absolutePath($path, $workingDirectory);
+                $real = \realpath($absolute);
+                $resolved[$suite->name][] = $real === false ? $absolute : $real;
+            }
+        }
+
+        return $resolved;
+    }
+
+    /**
+     * @param array<non-empty-string, list<string>> $suitePaths
+     * @return list<non-empty-string>
+     */
+    private static function memberships(string $file, array $suitePaths): array
+    {
+        $memberships = [];
+
+        foreach ($suitePaths as $suite => $directories) {
+            foreach ($directories as $directory) {
+                if (self::isBelow($file, $directory)) {
+                    $memberships[] = $suite;
+                    break;
+                }
+            }
+        }
+
+        \sort($memberships, \SORT_STRING);
+
+        return $memberships;
+    }
+
+    private static function isBelow(string $file, string $directory): bool
+    {
+        return \str_starts_with($file, \rtrim($directory, '/\\') . \DIRECTORY_SEPARATOR);
+    }
+}

--- a/src/Cli/Discovery/SelectionDiscovery.php
+++ b/src/Cli/Discovery/SelectionDiscovery.php
@@ -11,6 +11,7 @@ use Greenlight\Discovery\DiscoveryError;
 use Greenlight\Discovery\Plan\ExecutionPlan;
 use Greenlight\Discovery\Plan\PlanShard;
 use Greenlight\Discovery\TestDiscoverer;
+use Greenlight\Test\TestSelection;
 
 /**
  * Discovers one selected plan and diagnoses unmatched excluded paths.
@@ -24,20 +25,25 @@ final readonly class SelectionDiscovery
     /**
      * @throws DiscoveryError
      */
-    public function plan(): ExecutionPlan
+    public function plan(?TestSelection $selection = null): ExecutionPlan
     {
         $resolved = $this->configuration->resolved;
-        $storage = StorageLayout::resolve($resolved->storage, $this->workingDirectory);
+        $selection ??= $resolved->selection;
+        $storage = StorageLayout::resolve(
+            $resolved->storage,
+            $this->workingDirectory,
+            $resolved->suiteSelection->stateIdentity(),
+        );
         $plan = new TestDiscoverer()->discover(
             $this->configuration->directories,
-            $resolved->selection,
+            $selection,
             $resolved->order->seed,
             DiscoveryCache::forDirectories($this->configuration->directories, $storage->cacheDirectory),
         );
 
-        return $resolved->selection->shard === null
+        return $selection->shard === null
             ? $plan
-            : PlanShard::select($plan, \max(1, $resolved->selection->shard[0]), \max(1, $resolved->selection->shard[1]));
+            : PlanShard::select($plan, \max(1, $selection->shard[0]), \max(1, $selection->shard[1]));
     }
 
     /** @return list<non-empty-string> */

--- a/src/Cli/Discovery/SelectionPlan.php
+++ b/src/Cli/Discovery/SelectionPlan.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli\Discovery;
+
+use Greenlight\Cli\Configuration\LoadedConfiguration;
+use Greenlight\Cli\Input\CliError;
+use Greenlight\Cli\State\RunState;
+use Greenlight\Config\StorageLayout;
+use Greenlight\Discovery\DiscoveryError;
+use Greenlight\Discovery\Plan\ExecutionPlan;
+use Greenlight\Discovery\Plan\PlanOrder;
+
+/**
+ * Makes the selected plan that listing interfaces expose.
+ *
+ * @internal
+ */
+final class SelectionPlan
+{
+    private function __construct() {}
+
+    /**
+     * @throws CliError
+     * @throws DiscoveryError
+     */
+    public static function resolve(
+        LoadedConfiguration $configuration,
+        string $workingDirectory,
+        bool $failed,
+    ): ExecutionPlan {
+        $resolved = $configuration->resolved;
+        $storage = StorageLayout::resolve(
+            $resolved->storage,
+            $workingDirectory,
+            $resolved->suiteSelection->stateIdentity(),
+        );
+        $state = RunState::forFile($storage->runStateFile);
+        $previousFailures = $state->failedTests();
+
+        if ($failed && $previousFailures === null) {
+            throw CliError::failedRequiresState();
+        }
+
+        if ($failed && $previousFailures === []) {
+            return new ExecutionPlan([], $resolved->order->seed);
+        }
+
+        $selection = $failed && \is_array($previousFailures)
+            ? $resolved->selection->withExactIds($previousFailures)
+            : $resolved->selection;
+        $priorityClasses = [];
+
+        if (!$resolved->order->isRandomized() && \is_array($previousFailures)) {
+            foreach ($previousFailures as $id) {
+                $class = \strstr($id, '::', true);
+
+                if (\is_string($class) && $class !== '' && !\in_array($class, $priorityClasses, true)) {
+                    $priorityClasses[] = $class;
+                }
+            }
+        }
+
+        $classSeconds = $resolved->order->isRandomized() ? [] : $state->classSeconds();
+        $plan = new SelectionDiscovery($configuration, $workingDirectory)->plan($selection);
+
+        return PlanOrder::schedule($plan, $priorityClasses, $classSeconds);
+    }
+}

--- a/src/Cli/Input/CliError.php
+++ b/src/Cli/Input/CliError.php
@@ -61,6 +61,24 @@ final class CliError extends \RuntimeException
         return new self('--filter requires a pattern.');
     }
 
+    public static function unknownTestListFormat(string $format): self
+    {
+        return new self(\sprintf(
+            'Unknown list-tests format "%s". Select text or json.',
+            $format,
+        ));
+    }
+
+    public static function formatRequiresTestListing(): self
+    {
+        return new self('Use --format only with list-tests or run --list-tests.');
+    }
+
+    public static function failedRequiresState(): self
+    {
+        return new self('--failed requires state from a previous run. Run Greenlight once without --failed.');
+    }
+
     /** @param non-empty-list<non-empty-string> $names */
     public static function unknownSuites(array $names): self
     {

--- a/src/Cli/Input/Definition.php
+++ b/src/Cli/Input/Definition.php
@@ -28,6 +28,7 @@ final readonly class Definition
 
     /** @var array<non-empty-string, list<non-empty-string>> */
     public const array COMPLETION_VALUES = [
+        'format' => ['text', 'json'],
         'reporter' => self::BUILT_IN_REPORTERS,
         'workers' => ['auto'],
     ];
@@ -75,6 +76,7 @@ final readonly class Definition
                              working directory. You can repeat this option.
           --failed           Run only tests that failed or had an error in the previous run
           --list-tests       Print the selected test IDs. Do not run the tests.
+          --format=<format>  Set list-tests output to text or json (default text)
           --list-groups      Print each selected group and its test count
           --list-suites      Print the configured suites
           --repeat=<n>       Run the selected tests n times in separate runs.
@@ -138,6 +140,7 @@ final readonly class Definition
             new OptionSpec('exclude-method', OptionValue::Required, repeatable: true),
             new OptionSpec('exclude-path', OptionValue::Required, repeatable: true),
             new OptionSpec('list-tests'), new OptionSpec('list-groups'), new OptionSpec('list-suites'),
+            new OptionSpec('format', OptionValue::Required),
             new OptionSpec('repeat', OptionValue::Required), new OptionSpec('repeat-until-failure'),
             new OptionSpec('failed'), new OptionSpec('shard', OptionValue::Required),
             new OptionSpec('fail-on-deprecation'), new OptionSpec('fail-on-notice'), new OptionSpec('fail-on-warning'),

--- a/src/Cli/Run/RunCommand.php
+++ b/src/Cli/Run/RunCommand.php
@@ -162,7 +162,7 @@ final readonly class RunCommand
 
             if ($arguments->has('failed')) {
                 if ($previousFailures === null) {
-                    $this->printError('--failed requires state from a previous run. Run Greenlight once without --failed.', $arguments->has('no-ansi'));
+                    $this->printError(CliError::failedRequiresState()->getMessage(), $arguments->has('no-ansi'));
 
                     return self::EXIT_USAGE;
                 }

--- a/tests/Acceptance/TestManifestTest.php
+++ b/tests/Acceptance/TestManifestTest.php
@@ -1,0 +1,308 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Condition\EnvironmentVariableEquals;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\GreenlightCli;
+use JsonSchema\Validator;
+
+final readonly class TestManifestTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function jsonFormatWritesTheSelectedVersionedPlanWithoutExecution(): void
+    {
+        $project = $this->writeRichProject();
+        $arguments = [
+            'list-tests',
+            '--format=json',
+            '--suite=unit',
+            '--group=manifest',
+            '--exclude-group=excluded',
+            '--test-id=ManifestProbe\\RichTest::describes[card]',
+            '--test-id=ManifestProbe\\ParallelTest::describes',
+            '--seed=7',
+            '--shard=1/1',
+        ];
+        $first = GreenlightCli::run($project->directory, $arguments);
+        $second = GreenlightCli::run($project->directory, $arguments);
+
+        Expect::that($first->exitCode)->toBe(0);
+        Expect::that($second->stdout)
+            ->because('the same selected plan MUST produce the same manifest')
+            ->toBe($first->stdout);
+        Expect::that($first->stderr)
+            ->because('configuration and provider output MUST stay off standard output')
+            ->toContain('configuration diagnostic')
+            ->toContain('provider diagnostic');
+        Expect::that(\is_file($project->path('executed')))
+            ->because('manifest discovery MUST NOT execute a test')
+            ->toBeFalse();
+
+        $decoded = $this->decode($first->stdout);
+        Expect::that($decoded['version'] ?? null)->toBe(1);
+        Expect::that($decoded['order'] ?? null)->toBe([
+            'tests' => 'plan',
+            'completion' => 'not-applicable',
+            'seed' => 7,
+        ]);
+        Expect::that($decoded['shard'] ?? null)->toBe(['index' => 1, 'count' => 1]);
+        $tests = $decoded['tests'] ?? null;
+
+        if (!\is_array($tests)) {
+            throw new \RuntimeException('Manifest tests must be an array.');
+        }
+
+        Expect::that($tests)->toHaveCount(2);
+        $byId = $this->testsById($tests);
+
+        $rich = $byId['ManifestProbe\\RichTest::describes[card]'] ?? null;
+
+        if (!\is_array($rich)) {
+            throw new \RuntimeException('The rich manifest test is missing.');
+        }
+
+        $source = $rich['source'] ?? null;
+
+        if (!\is_array($source)) {
+            throw new \RuntimeException('The rich manifest source is missing.');
+        }
+
+        Expect::that($rich['dataSetKey'] ?? null)->toBe('card');
+        Expect::that($source['file'] ?? null)->toBe($project->path('tests/Unit/RichTest.php'));
+        Expect::that($source['line'] ?? null)->toBeInt()->toBeGreaterThan(0);
+        Expect::that($rich['groups'] ?? null)->toBe(['manifest']);
+        Expect::that($rich['suites'] ?? null)->toBe(['all', 'unit']);
+        Expect::that($rich['skip'] ?? null)->toBe([
+            'present' => true,
+            'condition' => EnvironmentVariableEquals::class,
+        ]);
+        Expect::that($rich['retry'] ?? null)->toBe([
+            'additionalAttempts' => 2,
+            'onlyOn' => 'RuntimeException',
+        ]);
+        Expect::that($rich['timeoutSeconds'] ?? null)->toBe(1.5);
+        Expect::that($rich['captureOutput'] ?? null)->toBeFalse();
+        Expect::that($rich['noExpectations'] ?? null)->toBeTrue();
+        Expect::that($rich['resources'] ?? null)->toBe(['database']);
+        Expect::that($rich['isolated'] ?? null)->toBeTrue();
+        Expect::that($rich['allowParallel'] ?? null)->toBeFalse();
+        $parallel = $byId['ManifestProbe\\ParallelTest::describes'] ?? null;
+
+        if (!\is_array($parallel)) {
+            throw new \RuntimeException('The parallel manifest test is missing.');
+        }
+
+        Expect::that($parallel['allowParallel'] ?? null)->toBeTrue();
+        Expect::that($first->stdout)
+            ->because('the manifest MUST omit private skip metadata')
+            ->not()
+            ->toContain('skip-secret')
+            ->not()
+            ->toContain('condition-secret');
+
+        $validator = new Validator();
+        $schemaDocument = \json_decode($first->stdout, flags: \JSON_THROW_ON_ERROR);
+        $validator->validate(
+            $schemaDocument,
+            (object) ['$ref' => 'file://' . \dirname(__DIR__, 2) . '/resources/schema/test-manifest-v1.schema.json'],
+        );
+        Expect::that($validator->isValid())
+            ->because('the emitted manifest MUST match the shipped schema')
+            ->toBeTrue();
+    }
+
+    #[Test]
+    public function jsonFormatUsesAValidEmptyDocumentForZeroTests(): void
+    {
+        $project = AcceptanceProject::createWithOnePassingTest($this->tempDirectory, 'manifest-empty');
+        $result = GreenlightCli::run($project->directory, [
+            'list-tests',
+            '--format=json',
+            '--filter=does-not-exist',
+        ]);
+        $decoded = $this->decode($result->stdout);
+
+        Expect::that($result->exitCode)
+            ->because('an empty manifest MUST be a successful discovery result')
+            ->toBe(0);
+        Expect::that($decoded['tests'] ?? null)->toBe([]);
+    }
+
+    #[Test]
+    public function jsonFormatKeepsDiscoveryErrorsOffStandardOutput(): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'manifest-error');
+        $project->writeFile('tests/NoClassTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace ManifestDiscoveryError;
+
+            function helper(): void {}
+            PHP);
+        $project->configureWithTestFiles(['tests/NoClassTest.php']);
+        $result = GreenlightCli::run($project->directory, [
+            'list-tests',
+            '--format=json',
+            '--no-ansi',
+        ]);
+
+        Expect::that($result->exitCode)->toBe(1);
+        Expect::that($result->stdout)
+            ->because('a discovery error MUST NOT write a partial JSON document')
+            ->toBe('');
+        Expect::that($result->stderr)
+            ->toContain('does not declare a class, interface, trait, or enum.');
+    }
+
+    private function writeRichProject(): AcceptanceProject
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'manifest-rich');
+        $project->writeFile('tests/Unit/RichTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace ManifestProbe;
+
+            use Greenlight\Attribute\DataSet;
+            use Greenlight\Attribute\Group;
+            use Greenlight\Attribute\Isolated;
+            use Greenlight\Attribute\NoExpectations;
+            use Greenlight\Attribute\RequiresResource;
+            use Greenlight\Attribute\Retry;
+            use Greenlight\Attribute\Skip;
+            use Greenlight\Attribute\SkipUnless;
+            use Greenlight\Attribute\Test;
+            use Greenlight\Attribute\Timeout;
+            use Greenlight\Condition\EnvironmentVariableEquals;
+
+            final class RichTest
+            {
+                #[Test(capture: false)]
+                #[Group('manifest')]
+                #[DataSet('rows')]
+                #[Skip('skip-secret')]
+                #[SkipUnless(EnvironmentVariableEquals::class, 'MANIFEST_NAME', 'condition-secret')]
+                #[Retry(2, \RuntimeException::class)]
+                #[Timeout(1.5)]
+                #[NoExpectations]
+                #[RequiresResource('database')]
+                #[Isolated]
+                public function describes(): void
+                {
+                    file_put_contents(__DIR__ . '/../../executed', 'yes');
+                }
+
+                public static function rows(): iterable
+                {
+                    echo "provider diagnostic\n";
+                    yield 'card' => [];
+                }
+            }
+            PHP);
+        $project->writeFile('tests/Unit/ParallelTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace ManifestProbe;
+
+            use Greenlight\Attribute\AllowParallel;
+            use Greenlight\Attribute\Group;
+            use Greenlight\Attribute\Test;
+
+            #[AllowParallel]
+            final class ParallelTest
+            {
+                #[Test]
+                #[Group('manifest')]
+                public function describes(): void
+                {
+                    file_put_contents(__DIR__ . '/../../executed', 'yes');
+                }
+            }
+            PHP);
+        $project->writeFile('tests/Unit/ExcludedTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace ManifestProbe;
+
+            use Greenlight\Attribute\Group;
+            use Greenlight\Attribute\Test;
+
+            final class ExcludedTest
+            {
+                #[Test]
+                #[Group('excluded')]
+                public function excluded(): void {}
+            }
+            PHP);
+        $project->writeFile('greenlight.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Config\GreenlightConfig;
+            use Greenlight\Config\SuiteBuilder;
+
+            echo "configuration diagnostic\n";
+
+            require_once __DIR__ . '/tests/Unit/RichTest.php';
+            require_once __DIR__ . '/tests/Unit/ParallelTest.php';
+            require_once __DIR__ . '/tests/Unit/ExcludedTest.php';
+
+            return GreenlightConfig::create()
+                ->suite('unit', static fn(SuiteBuilder $suite) => $suite->in('tests/Unit')->tag('fast'))
+                ->suite('all', static fn(SuiteBuilder $suite) => $suite->in('tests')->tag('broad'));
+            PHP);
+
+        return $project;
+    }
+
+    /** @return array<string, mixed> */
+    private function decode(string $json): array
+    {
+        $decoded = \json_decode($json, true, flags: \JSON_THROW_ON_ERROR);
+
+        if (!\is_array($decoded)) {
+            throw new \RuntimeException('Manifest JSON must decode to an object.');
+        }
+
+        $document = [];
+
+        foreach ($decoded as $key => $value) {
+            $document[(string) $key] = $value;
+        }
+
+        return $document;
+    }
+
+    /**
+     * @param array<mixed> $tests
+     * @return array<string, array<mixed>>
+     */
+    private function testsById(array $tests): array
+    {
+        $byId = [];
+
+        foreach ($tests as $test) {
+            if (\is_array($test) && \is_string($test['id'] ?? null)) {
+                $byId[$test['id']] = $test;
+            }
+        }
+
+        return $byId;
+    }
+}

--- a/tests/Unit/Cli/Command/TestManifestTest.php
+++ b/tests/Unit/Cli/Command/TestManifestTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli\Command;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\Command\TestManifest;
+use Greenlight\Condition\EnvironmentVariableEquals;
+use Greenlight\Config\SuiteConfiguration;
+use Greenlight\Discovery\Plan\ExecutionPlan;
+use Greenlight\Discovery\Plan\PlanEntry;
+use Greenlight\Expect\Expect;
+use Greenlight\Test\ExecutionPolicy;
+use Greenlight\Test\RetryPolicy;
+use Greenlight\Test\SchedulingPolicy;
+use Greenlight\Test\SkipPolicy;
+use Greenlight\Test\TestDefinition;
+
+final class TestManifestTest
+{
+    #[Test]
+    public function documentKeepsThePublicContractSmallAndDeterministic(): void
+    {
+        $root = \dirname(__DIR__, 4);
+        $definition = new TestDefinition(
+            self::class,
+            __FUNCTION__,
+            ['zeta', 'alpha'],
+            new SkipPolicy('private skip reason', EnvironmentVariableEquals::class, ['PRIVATE_NAME', 'private value']),
+            new RetryPolicy(2, \RuntimeException::class),
+            execution: new ExecutionPolicy(1.25, false, true),
+            scheduling: new SchedulingPolicy(true, ['zeta-resource', 'alpha-resource']),
+        );
+        $document = TestManifest::document(
+            new ExecutionPlan([new PlanEntry($definition, 'labeled row')], 17),
+            [
+                new SuiteConfiguration('unit', ['tests/Unit'], []),
+                new SuiteConfiguration('all', ['tests'], []),
+            ],
+            [2, 3],
+            $root,
+        );
+        $method = new \ReflectionMethod(self::class, __FUNCTION__);
+
+        Expect::that($document)->toBe([
+            'version' => 1,
+            'order' => [
+                'tests' => 'plan',
+                'completion' => 'not-applicable',
+                'seed' => 17,
+            ],
+            'shard' => [
+                'index' => 2,
+                'count' => 3,
+            ],
+            'tests' => [[
+                'id' => self::class . '::' . __FUNCTION__ . '[labeled row]',
+                'class' => self::class,
+                'method' => __FUNCTION__,
+                'dataSetKey' => 'labeled row',
+                'source' => [
+                    'file' => __FILE__,
+                    'line' => $method->getStartLine(),
+                ],
+                'groups' => ['alpha', 'zeta'],
+                'suites' => ['all', 'unit'],
+                'skip' => [
+                    'present' => true,
+                    'condition' => EnvironmentVariableEquals::class,
+                ],
+                'retry' => [
+                    'additionalAttempts' => 2,
+                    'onlyOn' => \RuntimeException::class,
+                ],
+                'timeoutSeconds' => 1.25,
+                'captureOutput' => false,
+                'noExpectations' => true,
+                'resources' => ['alpha-resource', 'zeta-resource'],
+                'isolated' => true,
+                'allowParallel' => false,
+            ]],
+        ]);
+
+        $json = \json_encode($document, \JSON_THROW_ON_ERROR);
+        Expect::that($json)
+            ->because('the public manifest MUST omit skip reasons and condition arguments')
+            ->not()
+            ->toContain('private skip reason')
+            ->not()
+            ->toContain('PRIVATE_NAME')
+            ->not()
+            ->toContain('private value');
+    }
+}


### PR DESCRIPTION
## Summary

- add a versioned JSON format to list-tests for deterministic discovery plans
- expose stable identities, source locations, suite membership, and safe execution metadata
- apply normal selectors, previous-failure selection, plan ordering, and sharding without test execution
- ship a version 1 JSON Schema and document compatibility and exit rules