### PR TITLE
feat(coverage): merge shard coverage reports

### DIFF
--- a/docs/architecture/compatibility.md
+++ b/docs/architecture/compatibility.md
@@ -182,6 +182,10 @@ As an alternative, use `coverage:diff` with `--baseline-root` and
 `--current-root`. This command option normalizes paths for one comparison. It
 does not change the coverage JSON version 1 contract.
 
+For coverage from multiple roots, use `coverage:merge` with one `--input-root`
+for each input and one `--project-root`. This operation writes version 1
+absolute paths below the selected output root.
+
 Paths can disclose the workspace layout. Give machine-readable reports the same
 access controls as logs and test evidence.
 

--- a/docs/architecture/compatibility.md
+++ b/docs/architecture/compatibility.md
@@ -183,8 +183,8 @@ As an alternative, use `coverage:diff` with `--baseline-root` and
 does not change the coverage JSON version 1 contract.
 
 For coverage from multiple roots, use `coverage:merge` with one `--input-root`
-for each input and one `--project-root`. This operation writes version 1
-absolute paths below the selected output root.
+for each input and one `--project-root`. This operation writes absolute paths
+below the selected output root.
 
 Paths can disclose the workspace layout. Give machine-readable reports the same
 access controls as logs and test evidence.

--- a/docs/architecture/coverage-json.md
+++ b/docs/architecture/coverage-json.md
@@ -117,6 +117,43 @@ Greenlight rounds the value to two decimal places.
 An empty report has `100.0` coverage because there are no executable lines to
 miss.
 
+## Merge behavior
+
+The coverage merge command reads two or more version 1 documents:
+
+```sh id="merge-coverage-json"
+greenlight coverage:merge \
+    --input=shard-1.json \
+    --input=shard-2.json \
+    --export=json=coverage.json
+```
+
+The result contains the union of the file paths and executable line sets. A
+line has coverage if any input identifies it as covered. Thus, an uncovered
+line has no covered occurrence in any input.
+
+The merge operation is commutative, associative, and idempotent. Input order,
+duplicate inputs, and empty maps do not change the result.
+
+A file can be absent from an input. The result contains that file if a different
+input contains it.
+
+The command rejects malformed documents and unsupported versions. Without root
+options, each file path must be an absolute version 1 path.
+
+For different roots, give one `--input-root` for each input. Give one
+`--project-root` for the output. Greenlight removes each applicable input root
+and adds the output root.
+
+The command rejects these root errors:
+
+* The number of input roots differs from the number of inputs.
+* A path is outside its applicable input root.
+* The same input has different input roots.
+
+Root relocation does not change the schema. The JSON output remains version 1
+and contains absolute file paths.
+
 ## Semantics
 
 The format stores covered and uncovered line sets, not hit counts.

--- a/docs/architecture/coverage-json.md
+++ b/docs/architecture/coverage-json.md
@@ -119,7 +119,7 @@ miss.
 
 ## Merge behavior
 
-The coverage merge command reads two or more version 1 documents:
+The coverage merge command reads two or more coverage documents:
 
 ```sh id="merge-coverage-json"
 greenlight coverage:merge \
@@ -139,7 +139,7 @@ A file can be absent from an input. The result contains that file if a different
 input contains it.
 
 The command rejects malformed documents and unsupported versions. Without root
-options, each file path must be an absolute version 1 path.
+options, each file path must be absolute.
 
 For different roots, give one `--input-root` for each input. Give one
 `--project-root` for the output. Greenlight removes each applicable input root
@@ -151,8 +151,8 @@ The command rejects these root errors:
 * A path is outside its applicable input root.
 * The same input has different input roots.
 
-Root relocation does not change the schema. The JSON output remains version 1
-and contains absolute file paths.
+Root relocation does not change the schema. The JSON output contains absolute
+file paths.
 
 ## Semantics
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1085,10 +1085,6 @@ artifact later with:
 greenlight profile:report --input=<file>
 ```
 
-### `--input=<path>`
-
-Sets the JSONL input file for `profile:report`.
-
 ### `--output=<path>`
 
 Changes the file written by `ide-helper`.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -565,6 +565,56 @@ This is the default command if you do not give a command.
 
 Prints each discovered test ID on a separate line. It then prints the count.
 
+### `coverage:merge`
+
+Merges two or more Greenlight coverage JSON exports.
+
+Repeat `--input` for each source. Repeat `--export` for each required output:
+
+```sh
+greenlight coverage:merge \
+    --input=coverage-shard-1.json \
+    --input=coverage-shard-2.json \
+    --export=json=coverage.json \
+    --export=lcov=coverage.lcov \
+    --export=html=coverage-html
+```
+
+The command supports `json`, `lcov`, `clover`, `cobertura`, and `html`.
+
+The merged map contains the union of all executable lines. A line has coverage
+if one or more inputs identify it as covered. Input order does not change the
+result.
+
+Duplicate inputs and empty maps do not change the result. A file that is absent
+from one input remains in the result if another input contains it.
+
+By default, version 1 absolute paths identify files. For different checkout
+roots, repeat `--input-root` once for each input. Also set `--project-root`:
+
+```sh
+greenlight coverage:merge \
+    --input=one.json \
+    --input=two.json \
+    --input-root=/old/checkout-one \
+    --input-root=/old/checkout-two \
+    --project-root=/current/checkout \
+    --export=json=coverage.json
+```
+
+Greenlight maps each input path to the selected project root. It rejects a path
+outside its applicable input root. It also rejects one input that has different
+input roots.
+
+The command rejects malformed documents and unsupported schema versions. It
+also rejects relative version 1 file paths.
+
+Each output file uses an atomic replacement. Output files and HTML pages have
+deterministic content and order.
+
+The command accepts `--minimum-coverage` and `--maximum-uncovered-lines`. These
+gates apply to the merged map after Greenlight writes the outputs.
+
 ### `coverage:diff`
 
 Compares two coverage JSON exports.
@@ -899,7 +949,8 @@ machine-readable output.
 
 Overrides `CoverageBuilder::minimumPercentage()` for a run. The option also
 enables coverage when the configuration file does not configure it. With
-`coverage:diff`, the option checks the current export.
+`coverage:diff`, the option checks the current export. With `coverage:merge`,
+the option checks the merged map.
 
 The value must be from `0` through `100`. It can have two decimal places.
 
@@ -907,7 +958,8 @@ The value must be from `0` through `100`. It can have two decimal places.
 
 Overrides `CoverageBuilder::maximumUncoveredLines()` for a run. The option also
 enables coverage when the configuration file does not configure it. With
-`coverage:diff`, the option checks the current export.
+`coverage:diff`, the option checks the current export. With `coverage:merge`,
+the option checks the merged map.
 
 The value must be a nonnegative integer.
 
@@ -933,6 +985,29 @@ Sets the project root for baseline path normalization. Use this option with
 
 Sets the project root for current path normalization. Use this option with
 `--baseline-root`.
+
+### `--input=<path>`
+
+Sets the input stream for `profile:report`.
+
+With `coverage:merge`, the option sets one coverage JSON input. Repeat the
+option for each input.
+
+### `--export=<format>=<path>`
+
+Sets one output for `coverage:merge`. Repeat the option for each output.
+
+Supported formats are `json`, `lcov`, `clover`, `cobertura`, and `html`.
+
+### `--input-root=<path>`
+
+Sets the source project root for one `coverage:merge` input. Repeat the option
+once for each input. Use this option with `--project-root`.
+
+### `--project-root=<path>`
+
+Sets the target project root for `coverage:merge` path relocation. Use this
+option with `--input-root`.
 
 ### `--watch`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -589,8 +589,8 @@ result.
 Duplicate inputs and empty maps do not change the result. A file that is absent
 from one input remains in the result if another input contains it.
 
-By default, version 1 absolute paths identify files. For different checkout
-roots, repeat `--input-root` once for each input. Also set `--project-root`:
+By default, absolute paths identify files. For different checkout roots, repeat
+`--input-root` once for each input. Also set `--project-root`:
 
 ```sh
 greenlight coverage:merge \
@@ -607,7 +607,7 @@ outside its applicable input root. It also rejects one input that has different
 input roots.
 
 The command rejects malformed documents and unsupported schema versions. It
-also rejects relative version 1 file paths.
+also rejects relative file paths.
 
 Each output file uses an atomic replacement. Output files and HTML pages have
 deterministic content and order.

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -204,7 +204,7 @@ jobs:
 ```
 
 GitHub-hosted matrix jobs use the same workspace path for one repository. Thus,
-their version 1 absolute paths match.
+their absolute paths match.
 
 For runners with different checkout roots, add one `--input-root` for each
 input. Also add `--project-root` for the merge job checkout.

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -87,3 +87,127 @@ default.
 
 Cache package downloads and static analysis data separately. Their invalidation
 rules differ from the Greenlight run-state rules.
+
+## Merge coverage from shards
+
+Each shard must write a Greenlight JSON coverage export. A later job can merge
+these exports and apply gates to the complete suite.
+
+First, make the export target configurable in `greenlight.php`:
+
+<!-- php-example {"mode":"display","reason":"Shows environment selection inside an existing Greenlight configuration file."} -->
+```php
+$coverageOutput = getenv('GREENLIGHT_COVERAGE_OUTPUT')
+    ?: 'build/coverage/coverage.json';
+
+return GreenlightConfig::create()
+    ->paths(['tests'])
+    ->coverage(fn ($coverage) => $coverage
+        ->include('src')
+        ->requireDriver()
+        ->export('json', $coverageOutput));
+```
+
+This workflow runs four shards. Each shard uses a unique artifact name and file
+name. The merge job downloads all files into one directory.
+
+```yaml
+name: Sharded coverage
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  coverage-shard:
+    name: Coverage shard ${{ matrix.shard }}/4
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: pcntl, sockets
+          coverage: xdebug
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Run coverage shard
+        run: >-
+          vendor/bin/greenlight run
+          --shard=${{ matrix.shard }}/4
+          --require-coverage-driver
+        env:
+          GREENLIGHT_COVERAGE_OUTPUT: build/coverage/shard-${{ matrix.shard }}.json
+
+      - name: Upload shard coverage
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-shard-${{ matrix.shard }}
+          path: build/coverage/shard-${{ matrix.shard }}.json
+          if-no-files-found: error
+
+  coverage-merge:
+    name: Whole-suite coverage gate
+    needs: coverage-shard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: pcntl, sockets
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Download shard coverage
+        uses: actions/download-artifact@v8
+        with:
+          pattern: coverage-shard-*
+          path: build/coverage/shards
+          merge-multiple: true
+
+      - name: Merge coverage and apply gates
+        shell: bash
+        run: |
+          inputs=()
+          for path in build/coverage/shards/shard-*.json; do
+            inputs+=("--input=${path}")
+          done
+
+          vendor/bin/greenlight coverage:merge \
+            "${inputs[@]}" \
+            --export=json=build/coverage/coverage.json \
+            --export=lcov=build/coverage/lcov.info \
+            --minimum-coverage=90.00 \
+            --maximum-uncovered-lines=100
+
+      - name: Upload whole-suite coverage
+        uses: actions/upload-artifact@v7
+        with:
+          name: whole-suite-coverage
+          path: build/coverage
+          if-no-files-found: error
+```
+
+GitHub-hosted matrix jobs use the same workspace path for one repository. Thus,
+their version 1 absolute paths match.
+
+For runners with different checkout roots, add one `--input-root` for each
+input. Also add `--project-root` for the merge job checkout.
+
+To compare with a saved baseline, omit the merge gates. Then run
+`coverage:diff` with the merged JSON file as `--current`.

--- a/src/Cli/Command/CoverageMergeCommand.php
+++ b/src/Cli/Command/CoverageMergeCommand.php
@@ -202,7 +202,7 @@ final readonly class CoverageMergeCommand
         foreach ($map->files() as $path => $_coverage) {
             if (!\str_starts_with($path, '/')) {
                 throw new \InvalidArgumentException(\sprintf(
-                    'Coverage JSON version 1 requires an absolute file path. Received "%s".',
+                    'Coverage JSON requires an absolute file path. Received "%s".',
                     $path,
                 ));
             }

--- a/src/Cli/Command/CoverageMergeCommand.php
+++ b/src/Cli/Command/CoverageMergeCommand.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli\Command;
+
+use Greenlight\Cli\Configuration\ConfigurationLoader;
+use Greenlight\Cli\Configuration\CoverageOverrides;
+use Greenlight\Cli\Coverage\CoverageWriter;
+use Greenlight\Cli\Input\CliError;
+use Greenlight\Cli\Input\ParsedArguments;
+use Greenlight\Cli\Output\Console;
+use Greenlight\Config\CoverageConfiguration;
+use Greenlight\Config\CoverageExport;
+use Greenlight\Config\InvalidConfiguration;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Coverage\Diff\ProjectRootNormalizer;
+use Greenlight\Coverage\Export\JsonExporter;
+use Greenlight\Internal\Php\ErrorTrap;
+use Greenlight\Reporting\Style;
+
+/**
+ * Merges saved coverage maps and writes the selected coverage exports.
+ *
+ * @internal
+ */
+final readonly class CoverageMergeCommand
+{
+    public function __construct(private Console $console) {}
+
+    public function run(ParsedArguments $arguments, string $workingDirectory): int
+    {
+        $inputs = $arguments->values('input');
+
+        if (\count($inputs) < 2) {
+            $this->console->err("coverage:merge requires at least two --input=<path> options.\n");
+
+            return 64;
+        }
+
+        try {
+            $exports = $this->exports($arguments, $workingDirectory);
+            $coverageOverrides = CoverageOverrides::fromArguments($arguments);
+        } catch (CliError|InvalidConfiguration $error) {
+            $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
+
+            return 64;
+        }
+
+        if ($exports === []) {
+            $this->console->err("coverage:merge requires at least one --export=<format>=<path> option.\n");
+
+            return 64;
+        }
+
+        $inputRoots = $arguments->values('input-root');
+        $projectRoot = $arguments->value('project-root');
+
+        if (($inputRoots === []) !== ($projectRoot === null)) {
+            $this->console->err("Use --input-root=<path> and --project-root=<path> together.\n");
+
+            return 64;
+        }
+
+        if ($inputRoots !== [] && \count($inputRoots) !== \count($inputs)) {
+            $this->console->err("Repeat --input-root=<path> once for each --input=<path>.\n");
+
+            return 64;
+        }
+
+        $targetRoot = $projectRoot === null
+            ? null
+            : ConfigurationLoader::absolutePath($projectRoot, $workingDirectory);
+        $merged = CoverageMap::empty();
+
+        /** @var array<string, string|null> $seenInputs */
+        $seenInputs = [];
+
+        foreach ($inputs as $index => $input) {
+            if ($input === '') {
+                $this->console->err("--input requires a non-empty path.\n");
+
+                return 64;
+            }
+
+            $path = ConfigurationLoader::absolutePath($input, $workingDirectory);
+            $identity = \realpath($path) ?: $path;
+            $inputRoot = $inputRoots === []
+                ? null
+                : ConfigurationLoader::absolutePath($inputRoots[$index], $workingDirectory);
+            $rootIdentity = $inputRoot === null ? null : $this->rootIdentity($inputRoot);
+
+            if (\array_key_exists($identity, $seenInputs)) {
+                if ($seenInputs[$identity] !== $rootIdentity) {
+                    $this->console->error(\sprintf(
+                        'Coverage input "%s" cannot use more than one input root.',
+                        $input,
+                    ), $arguments->has('no-ansi'));
+
+                    return 64;
+                }
+
+                continue;
+            }
+
+            $seenInputs[$identity] = $rootIdentity;
+            $json = ErrorTrap::run(static fn() => \file_get_contents($path), $warning);
+
+            if (!\is_string($json)) {
+                $this->console->error(\sprintf(
+                    'Greenlight could not read coverage input "%s"%s.',
+                    $input,
+                    $warning === null ? '' : ': ' . $warning,
+                ), $arguments->has('no-ansi'));
+
+                return 1;
+            }
+
+            try {
+                $map = JsonExporter::import($json);
+
+                if ($inputRoot !== null && $targetRoot !== null) {
+                    $map = ProjectRootNormalizer::relocate($map, $inputRoot, $targetRoot);
+                } else {
+                    $this->requireAbsolutePaths($map);
+                }
+            } catch (\Throwable $error) {
+                $this->console->error(\sprintf(
+                    'Coverage input "%s" is not compatible: %s',
+                    $input,
+                    $error->getMessage(),
+                ), $arguments->has('no-ansi'));
+
+                return 1;
+            }
+
+            $merged = $merged->merge($map);
+        }
+
+        $configuration = new CoverageConfiguration(
+            [],
+            null,
+            $exports,
+            $coverageOverrides->minimumPercentage,
+            $coverageOverrides->maximumUncoveredLines,
+        );
+        $style = new Style($this->console->capabilities(
+            $arguments->has('no-ansi'),
+            $arguments->has('ansi'),
+        )->color);
+
+        return new CoverageWriter($this->console)->write(
+            $configuration,
+            $merged,
+            $workingDirectory,
+            $style,
+        ) ? 0 : 1;
+    }
+
+    /**
+     * @return list<CoverageExport>
+     * @throws CliError
+     * @throws InvalidConfiguration
+     */
+    private function exports(ParsedArguments $arguments, string $workingDirectory): array
+    {
+        $exports = [];
+        $targets = [];
+
+        foreach ($arguments->values('export') as $raw) {
+            $separator = \strpos($raw, '=');
+
+            if ($separator === false) {
+                throw CliError::malformedCoverageExport($raw);
+            }
+
+            $export = new CoverageExport(
+                \substr($raw, 0, $separator),
+                \substr($raw, $separator + 1),
+            );
+            $target = ConfigurationLoader::absolutePath($export->target, $workingDirectory);
+
+            if (isset($targets[$target])) {
+                throw CliError::duplicateCoverageExport($export->target);
+            }
+
+            $targets[$target] = true;
+            $exports[] = $export;
+        }
+
+        return $exports;
+    }
+
+    private function rootIdentity(string $root): string
+    {
+        return $root === '/' ? '/' : \rtrim($root, '/');
+    }
+
+    private function requireAbsolutePaths(CoverageMap $map): void
+    {
+        foreach ($map->files() as $path => $_coverage) {
+            if (!\str_starts_with($path, '/')) {
+                throw new \InvalidArgumentException(\sprintf(
+                    'Coverage JSON version 1 requires an absolute file path. Received "%s".',
+                    $path,
+                ));
+            }
+        }
+    }
+}

--- a/src/Cli/Command/CoverageMergeCommand.php
+++ b/src/Cli/Command/CoverageMergeCommand.php
@@ -84,7 +84,8 @@ final readonly class CoverageMergeCommand
             }
 
             $path = ConfigurationLoader::absolutePath($input, $workingDirectory);
-            $identity = \realpath($path) ?: $path;
+            $realPath = \realpath($path);
+            $identity = $realPath === false ? $path : $realPath;
             $inputRoot = $inputRoots === []
                 ? null
                 : ConfigurationLoader::absolutePath($inputRoots[$index], $workingDirectory);

--- a/src/Cli/Command/ProfileReportCommand.php
+++ b/src/Cli/Command/ProfileReportCommand.php
@@ -25,8 +25,9 @@ final readonly class ProfileReportCommand
 
     public function run(ParsedArguments $arguments, string $workingDirectory): int
     {
-        $input = $arguments->value('input');
-        if ($input === null || $input === '') {
+        $inputs = $arguments->values('input');
+        $input = $inputs[0] ?? null;
+        if (\count($inputs) !== 1 || $input === '') {
             $this->console->err("profile:report requires --input=<path to a JSONL stream>.\n");
             return 64;
         }

--- a/src/Cli/Command/ProfileReportCommand.php
+++ b/src/Cli/Command/ProfileReportCommand.php
@@ -27,7 +27,7 @@ final readonly class ProfileReportCommand
     {
         $inputs = $arguments->values('input');
         $input = $inputs[0] ?? null;
-        if (\count($inputs) !== 1 || $input === '') {
+        if (\count($inputs) !== 1 || $input === null || $input === '') {
             $this->console->err("profile:report requires --input=<path to a JSONL stream>.\n");
             return 64;
         }

--- a/src/Cli/Coverage/CoverageWriter.php
+++ b/src/Cli/Coverage/CoverageWriter.php
@@ -50,7 +50,17 @@ final readonly class CoverageWriter
                 $this->console->err(\sprintf("Unknown coverage export format \"%s\".\n", $export->format));
                 return false;
             }
-            $files = $exporter->export($coverage);
+            try {
+                $files = $exporter->export($coverage);
+            } catch (\Throwable $error) {
+                $this->console->err(\sprintf(
+                    "Greenlight could not create the \"%s\" coverage export: %s\n",
+                    $export->format,
+                    $error->getMessage(),
+                ));
+
+                return false;
+            }
             $target = ConfigurationLoader::absolutePath($export->target, $workingDirectory);
             if (\count($files) === 1) {
                 ErrorTrap::run(static fn() => \mkdir(\dirname($target), 0o777, true));

--- a/src/Cli/Input/CliError.php
+++ b/src/Cli/Input/CliError.php
@@ -143,6 +143,19 @@ final class CliError extends \RuntimeException
         ));
     }
 
+    public static function malformedCoverageExport(string $raw): self
+    {
+        return new self(\sprintf(
+            '--export requires <format>=<path>, such as json=coverage.json. Received "%s".',
+            $raw,
+        ));
+    }
+
+    public static function duplicateCoverageExport(string $path): self
+    {
+        return new self(\sprintf('Write coverage export target "%s" only once.', $path));
+    }
+
     public static function malformedResourceLimit(string $raw): self
     {
         return new self(\sprintf(

--- a/src/Cli/Input/Definition.php
+++ b/src/Cli/Input/Definition.php
@@ -20,6 +20,7 @@ final readonly class Definition
     public const array COMMAND_DESCRIPTIONS = [
         'run' => 'Find and run tests (default)',
         'list-tests' => 'List each found test ID, one per line',
+        'coverage:merge' => 'Merge coverage JSON exports',
         'coverage:diff' => 'Compare two coverage JSON exports',
         'profile:report' => 'Create a run profile from a saved JSONL stream',
         'artifacts:prune' => 'Apply configured artifact retention',
@@ -43,6 +44,8 @@ final readonly class Definition
         Commands:
           run            Find and run tests (default)
           list-tests     List each found test ID, one per line
+          coverage:merge Merge coverage JSON exports. Repeat --input for each
+                         source and --export for each output.
           coverage:diff  Compare two coverage JSON exports. Fail if total coverage
                          decreases or a line becomes newly uncovered.
           profile:report Create a run profile from a saved JSONL stream (--input)
@@ -121,6 +124,13 @@ final readonly class Definition
                              Fail if more than n executable lines are uncovered.
           --require-coverage-driver
                              Fail if no configured coverage driver is available.
+          --input=<path>     Read an input file. Repeat for coverage:merge.
+          --export=<format>=<path>
+                             Write merged coverage. Repeat for more formats.
+          --input-root=<path>
+                             Set one source root. Repeat once for each input.
+          --project-root=<path>
+                             Set the project root for merged coverage paths.
           --baseline-root=<path>
                              Set the baseline project root for coverage:diff.
           --current-root=<path>
@@ -168,9 +178,12 @@ final readonly class Definition
             new OptionSpec('require-coverage-driver'),
             new OptionSpec('baseline', OptionValue::Required), new OptionSpec('current', OptionValue::Required),
             new OptionSpec('baseline-root', OptionValue::Required), new OptionSpec('current-root', OptionValue::Required),
+            new OptionSpec('input-root', OptionValue::Required, repeatable: true),
+            new OptionSpec('project-root', OptionValue::Required),
+            new OptionSpec('export', OptionValue::Required, repeatable: true),
             new OptionSpec('watch'), new OptionSpec('detect-leaks'), new OptionSpec('dry-run'),
             new OptionSpec('ansi'), new OptionSpec('no-ansi'), new OptionSpec('verbose'), new OptionSpec('profile'),
-            new OptionSpec('input', OptionValue::Required), new OptionSpec('output', OptionValue::Required),
+            new OptionSpec('input', OptionValue::Required, repeatable: true), new OptionSpec('output', OptionValue::Required),
             new OptionSpec('help', short: 'h'), new OptionSpec('version', short: 'V'),
         ];
     }

--- a/src/Cli/Plugin/BundledCommands.php
+++ b/src/Cli/Plugin/BundledCommands.php
@@ -6,6 +6,7 @@ namespace Greenlight\Cli\Plugin;
 
 use Greenlight\Cli\Command\CompletionCommand;
 use Greenlight\Cli\Command\CoverageDiffCommand;
+use Greenlight\Cli\Command\CoverageMergeCommand;
 use Greenlight\Cli\Command\IdeHelperCommand;
 use Greenlight\Cli\Command\ListCommand;
 use Greenlight\Cli\Command\ProfileReportCommand;
@@ -112,6 +113,7 @@ final readonly class BundledCommands implements CommandProvider
                 $invocation->workingDirectory,
                 $invocation->binaryPath,
             ),
+            'coverage:merge' => new CoverageMergeCommand($this->console)->run($arguments, $invocation->workingDirectory),
             'coverage:diff' => new CoverageDiffCommand($this->console)->run($arguments, $invocation->workingDirectory),
             'profile:report' => new ProfileReportCommand($this->console)->run($arguments, $invocation->workingDirectory),
             'artifacts:prune' => new ArtifactsPruneCommand($this->console)->run($arguments, $invocation->workingDirectory),

--- a/src/Coverage/Diff/ProjectRootNormalizer.php
+++ b/src/Coverage/Diff/ProjectRootNormalizer.php
@@ -7,7 +7,7 @@ namespace Greenlight\Coverage\Diff;
 use Greenlight\Coverage\CoverageMap;
 use Greenlight\Coverage\FileCoverage;
 
-/** Changes absolute coverage paths below one explicit root to relative paths.
+/** Normalizes absolute coverage paths against explicit project roots.
  *
  * @internal
  */
@@ -39,6 +39,28 @@ final class ProjectRootNormalizer
 
             $files[] = new FileCoverage(
                 $relative,
+                $coverage->coveredLines,
+                $coverage->uncoveredLines,
+            );
+        }
+
+        return new CoverageMap($files);
+    }
+
+    /** Changes paths below one source root to paths below one target root. */
+    public static function relocate(CoverageMap $map, string $sourceRoot, string $targetRoot): CoverageMap
+    {
+        if (!\str_starts_with($targetRoot, '/')) {
+            throw new \InvalidArgumentException('The target project root must be an absolute path.');
+        }
+
+        $relative = self::normalize($map, $sourceRoot);
+        $root = $targetRoot === '/' ? '' : \rtrim($targetRoot, '/');
+        $files = [];
+
+        foreach ($relative->files() as $path => $coverage) {
+            $files[] = new FileCoverage(
+                $root . '/' . $path,
                 $coverage->coveredLines,
                 $coverage->uncoveredLines,
             );

--- a/tests/Acceptance/CompletionTest.php
+++ b/tests/Acceptance/CompletionTest.php
@@ -21,6 +21,7 @@ final readonly class CompletionTest
         $result = $this->run('bash');
         Expect::that($result->exitCode)->because('prints a script per shell and rejects unknown shells')->toBe(0);
         Expect::that($result->stdout)->toContain('_greenlight_completions')
+            ->toContain('coverage:merge')
             ->toContain('coverage:diff')
             ->toContain('artifacts:prune')
             ->toContain('--detect-leaks')

--- a/tests/Acceptance/CoverageMergeErrorTest.php
+++ b/tests/Acceptance/CoverageMergeErrorTest.php
@@ -1,0 +1,219 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Coverage\FileCoverage;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\CoverageJson;
+use Greenlight\Tests\Support\GreenlightCli;
+
+final readonly class CoverageMergeErrorTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function requiresMultipleInputsAndOneOutput(): void
+    {
+        $directory = $this->tempDirectory->subdirectory('coverage-merge-required');
+        CoverageJson::write($directory . '/one.json', CoverageMap::empty());
+
+        $oneInput = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=one.json',
+            '--export=json=merged.json',
+        ]);
+        Expect::that($oneInput->exitCode)->toBe(64);
+        Expect::that($oneInput->output())
+            ->toContain('coverage:merge requires at least two --input=<path> options.');
+
+        $noOutput = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=one.json',
+            '--input=one.json',
+        ]);
+        Expect::that($noOutput->exitCode)->toBe(64);
+        Expect::that($noOutput->output())
+            ->toContain('coverage:merge requires at least one --export=<format>=<path> option.');
+    }
+
+    #[Test]
+    public function rejectsMalformedAndConflictingOutputs(): void
+    {
+        $directory = $this->tempDirectory->subdirectory('coverage-merge-output-options');
+        CoverageJson::write($directory . '/one.json', CoverageMap::empty());
+
+        $malformed = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=one.json',
+            '--input=one.json',
+            '--export=json',
+        ]);
+        Expect::that($malformed->exitCode)->toBe(64);
+        Expect::that($malformed->output())
+            ->toContain('--export requires <format>=<path>');
+
+        $unknown = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=one.json',
+            '--input=one.json',
+            '--export=unknown=merged.out',
+        ]);
+        Expect::that($unknown->exitCode)->toBe(64);
+        Expect::that($unknown->output())
+            ->toContain('Unknown coverage export format "unknown"');
+
+        $duplicate = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=one.json',
+            '--input=one.json',
+            '--export=json=merged.out',
+            '--export=lcov=merged.out',
+        ]);
+        Expect::that($duplicate->exitCode)->toBe(64);
+        Expect::that($duplicate->output())
+            ->toContain('Write coverage export target "merged.out" only once.');
+    }
+
+    #[Test]
+    public function namesUnreadableMalformedAndUnsupportedInputs(): void
+    {
+        $directory = $this->tempDirectory->subdirectory('coverage-merge-input-errors');
+        CoverageJson::write($directory . '/valid.json', CoverageMap::empty());
+        \file_put_contents($directory . '/malformed.json', '{');
+        \file_put_contents($directory . '/version.json', '{"v":2,"files":{}}');
+
+        $missing = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=missing.json',
+            '--input=valid.json',
+            '--export=json=merged.json',
+        ]);
+        Expect::that($missing->exitCode)->toBe(1);
+        Expect::that($missing->output())
+            ->toContain('Greenlight could not read coverage input "missing.json"');
+
+        $malformed = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=malformed.json',
+            '--input=valid.json',
+            '--export=json=merged.json',
+        ]);
+        Expect::that($malformed->exitCode)->toBe(1);
+        Expect::that($malformed->output())
+            ->toContain('Coverage input "malformed.json" is not compatible')
+            ->toContain('Coverage JSON document is invalid');
+
+        $version = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=version.json',
+            '--input=valid.json',
+            '--export=json=merged.json',
+        ]);
+        Expect::that($version->exitCode)->toBe(1);
+        Expect::that($version->output())
+            ->toContain('Coverage input "version.json" is not compatible')
+            ->toContain('unsupported or missing schema version');
+    }
+
+    #[Test]
+    public function rejectsRelativeVersionOnePathsWithoutExplicitRootMapping(): void
+    {
+        $directory = $this->tempDirectory->subdirectory('coverage-merge-relative-path');
+        \file_put_contents(
+            $directory . '/relative.json',
+            '{"v":1,"files":{"src/A.php":{"covered":[1],"uncovered":[]}}}',
+        );
+        CoverageJson::write($directory . '/valid.json', CoverageMap::empty());
+
+        $result = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=relative.json',
+            '--input=valid.json',
+            '--export=json=merged.json',
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('coverage JSON version 1 MUST keep absolute file paths')
+            ->toBe(1);
+        Expect::that($result->output())
+            ->toContain('Coverage JSON version 1 requires an absolute file path. Received "src/A.php".');
+    }
+
+    #[Test]
+    public function requiresCompleteCompatibleRootMetadata(): void
+    {
+        $directory = $this->tempDirectory->subdirectory('coverage-merge-root-errors');
+        CoverageJson::write(
+            $directory . '/one.json',
+            new CoverageMap([new FileCoverage('/old/one/A.php', [1], [])]),
+        );
+        CoverageJson::write($directory . '/two.json', CoverageMap::empty());
+
+        $partial = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=one.json',
+            '--input=two.json',
+            '--input-root=/old/one',
+            '--project-root=/current',
+            '--export=json=merged.json',
+        ]);
+        Expect::that($partial->exitCode)->toBe(64);
+        Expect::that($partial->output())
+            ->toContain('Repeat --input-root=<path> once for each --input=<path>.');
+
+        $outside = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=one.json',
+            '--input=two.json',
+            '--input-root=/wrong',
+            '--input-root=/old/two',
+            '--project-root=/current',
+            '--export=json=merged.json',
+        ]);
+        Expect::that($outside->exitCode)->toBe(1);
+        Expect::that($outside->output())
+            ->toContain('Coverage path "/old/one/A.php" is not below project root "/wrong".');
+
+        $conflict = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=one.json',
+            '--input=one.json',
+            '--input-root=/old/one',
+            '--input-root=/other',
+            '--project-root=/current',
+            '--export=json=merged.json',
+        ]);
+        Expect::that($conflict->exitCode)->toBe(64);
+        Expect::that($conflict->output())
+            ->toContain('Coverage input "one.json" cannot use more than one input root.');
+    }
+
+    #[Test]
+    public function anUnreadableDestinationDoesNotReplaceIt(): void
+    {
+        $directory = $this->tempDirectory->subdirectory('coverage-merge-output-error');
+        CoverageJson::write($directory . '/one.json', CoverageMap::empty());
+        CoverageJson::write($directory . '/two.json', CoverageMap::empty());
+        \mkdir($directory . '/coverage.json');
+
+        $result = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=one.json',
+            '--input=two.json',
+            '--export=json=coverage.json',
+            '--no-ansi',
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('an invalid output destination MUST fail without replacing it')
+            ->toBe(1);
+        Expect::that($result->output())
+            ->toContain('Greenlight could not write the coverage export');
+        Expect::that(\is_dir($directory . '/coverage.json'))->toBeTrue();
+    }
+}

--- a/tests/Acceptance/CoverageMergeErrorTest.php
+++ b/tests/Acceptance/CoverageMergeErrorTest.php
@@ -22,6 +22,16 @@ final readonly class CoverageMergeErrorTest
         $directory = $this->tempDirectory->subdirectory('coverage-merge-required');
         CoverageJson::write($directory . '/one.json', CoverageMap::empty());
 
+        $emptyInput = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=',
+            '--input=one.json',
+            '--export=json=merged.json',
+        ]);
+        Expect::that($emptyInput->exitCode)->toBe(64);
+        Expect::that($emptyInput->output())
+            ->toContain('--input requires a non-empty path.');
+
         $oneInput = GreenlightCli::run($directory, [
             'coverage:merge',
             '--input=one.json',
@@ -154,6 +164,29 @@ final readonly class CoverageMergeErrorTest
         );
         CoverageJson::write($directory . '/two.json', CoverageMap::empty());
 
+        $missingInputRoots = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=one.json',
+            '--input=two.json',
+            '--project-root=/current',
+            '--export=json=merged.json',
+        ]);
+        Expect::that($missingInputRoots->exitCode)->toBe(64);
+        Expect::that($missingInputRoots->output())
+            ->toContain('Use --input-root=<path> and --project-root=<path> together.');
+
+        $missingProjectRoot = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=one.json',
+            '--input=two.json',
+            '--input-root=/old/one',
+            '--input-root=/old/two',
+            '--export=json=merged.json',
+        ]);
+        Expect::that($missingProjectRoot->exitCode)->toBe(64);
+        Expect::that($missingProjectRoot->output())
+            ->toContain('Use --input-root=<path> and --project-root=<path> together.');
+
         $partial = GreenlightCli::run($directory, [
             'coverage:merge',
             '--input=one.json',
@@ -215,5 +248,30 @@ final readonly class CoverageMergeErrorTest
         Expect::that($result->output())
             ->toContain('Greenlight could not write the coverage export');
         Expect::that(\is_dir($directory . '/coverage.json'))->toBeTrue();
+    }
+
+    #[Test]
+    public function anUnsupportedExportPathFailsCleanly(): void
+    {
+        $directory = $this->tempDirectory->subdirectory('coverage-merge-export-error');
+        \file_put_contents(
+            $directory . '/invalid-path.json',
+            '{"v":1,"files":{"/project/A\\nB.php":{"covered":[1],"uncovered":[]}}}',
+        );
+        CoverageJson::write($directory . '/valid.json', CoverageMap::empty());
+
+        $result = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=invalid-path.json',
+            '--input=valid.json',
+            '--export=lcov=coverage.lcov',
+            '--no-ansi',
+        ]);
+
+        Expect::that($result->exitCode)->toBe(1);
+        Expect::that($result->output())
+            ->toContain('Greenlight could not create the "lcov" coverage export')
+            ->toContain('LCOV file paths MUST NOT contain line breaks.');
+        Expect::that(\file_exists($directory . '/coverage.lcov'))->toBeFalse();
     }
 }

--- a/tests/Acceptance/CoverageMergeErrorTest.php
+++ b/tests/Acceptance/CoverageMergeErrorTest.php
@@ -131,7 +131,7 @@ final readonly class CoverageMergeErrorTest
     }
 
     #[Test]
-    public function rejectsRelativeVersionOnePathsWithoutExplicitRootMapping(): void
+    public function rejectsRelativePathsWithoutExplicitRootMapping(): void
     {
         $directory = $this->tempDirectory->subdirectory('coverage-merge-relative-path');
         \file_put_contents(
@@ -148,10 +148,10 @@ final readonly class CoverageMergeErrorTest
         ]);
 
         Expect::that($result->exitCode)
-            ->because('coverage JSON version 1 MUST keep absolute file paths')
+            ->because('coverage JSON MUST use absolute file paths')
             ->toBe(1);
         Expect::that($result->output())
-            ->toContain('Coverage JSON version 1 requires an absolute file path. Received "src/A.php".');
+            ->toContain('Coverage JSON requires an absolute file path. Received "src/A.php".');
     }
 
     #[Test]

--- a/tests/Acceptance/CoverageMergeTest.php
+++ b/tests/Acceptance/CoverageMergeTest.php
@@ -87,7 +87,7 @@ final readonly class CoverageMergeTest
     }
 
     #[Test]
-    public function explicitRootsCreateOnePortableVersionOneMap(): void
+    public function explicitRootsCreateOnePortableCoverageMap(): void
     {
         $directory = $this->tempDirectory->subdirectory('coverage-merge-roots');
         CoverageJson::write(

--- a/tests/Acceptance/CoverageMergeTest.php
+++ b/tests/Acceptance/CoverageMergeTest.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Coverage\FileCoverage;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\CoverageJson;
+use Greenlight\Tests\Support\GreenlightCli;
+
+final readonly class CoverageMergeTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function mergesLineSetsAndWritesEachDeterministicExport(): void
+    {
+        $directory = $this->tempDirectory->subdirectory('coverage-merge-exports');
+        CoverageJson::write(
+            $directory . '/shard-1.json',
+            new CoverageMap([
+                new FileCoverage('/project/src/B.php', [4], []),
+                new FileCoverage('/project/src/A.php', [1], [2, 3]),
+            ]),
+        );
+        CoverageJson::write(
+            $directory . '/shard-2.json',
+            new CoverageMap([
+                new FileCoverage('/project/src/A.php', [2], [1, 3]),
+            ]),
+        );
+
+        $result = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=shard-1.json',
+            '--input=shard-2.json',
+            '--export=json=out/coverage.json',
+            '--export=lcov=out/lcov.info',
+            '--export=clover=out/clover.xml',
+            '--export=cobertura=out/cobertura.xml',
+            '--export=html=out/html',
+            '--no-ansi',
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('compatible coverage inputs MUST produce all selected exports')
+            ->toBe(0);
+        Expect::that($result->output())
+            ->toContain('Coverage: 75.00% (3 of 4 lines)')
+            ->toContain('json → out/coverage.json')
+            ->toContain('html → out/html');
+        Expect::that(CoverageJson::read($directory . '/out/coverage.json')->toWire())
+            ->toBe([
+                'files' => [
+                    '/project/src/A.php' => [[1, 2], [3]],
+                    '/project/src/B.php' => [[4], []],
+                ],
+            ]);
+        Expect::that((string) \file_get_contents($directory . '/out/lcov.info'))
+            ->toContain("SF:/project/src/A.php\n")
+            ->toContain("DA:3,0\n")
+            ->toContain("SF:/project/src/B.php\n");
+        Expect::that((string) \file_get_contents($directory . '/out/clover.xml'))
+            ->toContain('<file name="/project/src/A.php">');
+        Expect::that((string) \file_get_contents($directory . '/out/cobertura.xml'))
+            ->toContain('filename="project/src/A.php"');
+        Expect::that((string) \file_get_contents($directory . '/out/html/index.html'))
+            ->toContain('src/A.php')
+            ->toContain('src/B.php');
+
+        $reverse = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=shard-2.json',
+            '--input=shard-1.json',
+            '--export=json=reverse.json',
+            '--no-ansi',
+        ]);
+
+        Expect::that($reverse->exitCode)->toBe(0);
+        Expect::that((string) \file_get_contents($directory . '/reverse.json'))
+            ->because('input order MUST NOT change serialized coverage')
+            ->toBe((string) \file_get_contents($directory . '/out/coverage.json'));
+    }
+
+    #[Test]
+    public function explicitRootsCreateOnePortableVersionOneMap(): void
+    {
+        $directory = $this->tempDirectory->subdirectory('coverage-merge-roots');
+        CoverageJson::write(
+            $directory . '/one.json',
+            new CoverageMap([new FileCoverage('/old/one/src/A.php', [1], [2])]),
+        );
+        CoverageJson::write(
+            $directory . '/two.json',
+            new CoverageMap([new FileCoverage('/old/two/src/A.php', [2], [1])]),
+        );
+
+        $result = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=one.json',
+            '--input=two.json',
+            '--input-root=/old/one',
+            '--input-root=/old/two',
+            '--project-root=/current/project',
+            '--export=json=merged.json',
+            '--no-ansi',
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('explicit roots MUST map each shard to the selected project root')
+            ->toBe(0);
+        Expect::that(CoverageJson::read($directory . '/merged.json')->toWire())
+            ->toBe([
+                'files' => [
+                    '/current/project/src/A.php' => [[1, 2], []],
+                ],
+            ]);
+    }
+
+    #[Test]
+    public function duplicateInputsAndEmptyMapsDoNotChangeTheResult(): void
+    {
+        $directory = $this->tempDirectory->subdirectory('coverage-merge-duplicates');
+        CoverageJson::write($directory . '/empty.json', CoverageMap::empty());
+        CoverageJson::write(
+            $directory . '/coverage.json',
+            new CoverageMap([new FileCoverage('/project/A.php', [1], [2])]),
+        );
+
+        $result = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=coverage.json',
+            '--input=coverage.json',
+            '--input=empty.json',
+            '--export=json=merged.json',
+            '--no-ansi',
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('duplicate and empty inputs MUST be idempotent')
+            ->toBe(0);
+        Expect::that(CoverageJson::read($directory . '/merged.json')->toWire())
+            ->toBe([
+                'files' => [
+                    '/project/A.php' => [[1], [2]],
+                ],
+            ]);
+    }
+
+    #[Test]
+    public function mergesEmptyMapsIntoOneDeterministicEmptyDocument(): void
+    {
+        $directory = $this->tempDirectory->subdirectory('coverage-merge-empty');
+        CoverageJson::write($directory . '/one.json', CoverageMap::empty());
+        CoverageJson::write($directory . '/two.json', CoverageMap::empty());
+
+        $result = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=one.json',
+            '--input=two.json',
+            '--export=json=merged.json',
+            '--no-ansi',
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('empty shard maps MUST produce one valid empty map')
+            ->toBe(0);
+        Expect::that((string) \file_get_contents($directory . '/merged.json'))
+            ->toBe('{"v":1,"files":{},"totals":{"files":0,"coveredLines":0,"executableLines":0,"percentage":100}}' . "\n");
+    }
+
+    #[Test]
+    public function appliesCoverageGatesToTheMergedMapAfterItWritesExports(): void
+    {
+        $directory = $this->tempDirectory->subdirectory('coverage-merge-gates');
+        CoverageJson::write(
+            $directory . '/one.json',
+            new CoverageMap([new FileCoverage('/project/A.php', [1], [2])]),
+        );
+        CoverageJson::write($directory . '/two.json', CoverageMap::empty());
+
+        $result = GreenlightCli::run($directory, [
+            'coverage:merge',
+            '--input=one.json',
+            '--input=two.json',
+            '--export=json=merged.json',
+            '--minimum-coverage=50.01',
+            '--maximum-uncovered-lines=0',
+            '--no-ansi',
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('a failed merged coverage gate MUST fail the command')
+            ->toBe(1);
+        Expect::that($result->output())
+            ->toContain('Coverage gate failed: 50.00% is less than the minimum 50.01%.')
+            ->toContain('Coverage gate failed: 1 uncovered line exceeds the maximum 0.');
+        Expect::that(\is_file($directory . '/merged.json'))
+            ->because('a failed gate MUST keep the merged coverage export')
+            ->toBeTrue();
+    }
+}

--- a/tests/Unit/Cli/Input/CompletionScriptsTest.php
+++ b/tests/Unit/Cli/Input/CompletionScriptsTest.php
@@ -19,7 +19,7 @@ final class CompletionScriptsTest
     {
         $script = (string) $this->scripts()->render($shell);
 
-        foreach (['run', 'list-tests', 'coverage:diff', 'profile:report', 'artifacts:prune', 'ide-helper', 'completion'] as $command) {
+        foreach (['run', 'list-tests', 'coverage:merge', 'coverage:diff', 'profile:report', 'artifacts:prune', 'ide-helper', 'completion'] as $command) {
             // The zsh _describe entries use an escape before the colon in a
             // command name.
             Expect::that($script)->toContain($shell === 'zsh' ? \str_replace(':', '\:', $command) : $command);
@@ -35,6 +35,7 @@ final class CompletionScriptsTest
         Expect::that($script)
             ->toContain('Find and run tests (default)')
             ->toContain('List each found test ID, one per line')
+            ->toContain('Merge coverage JSON exports')
             ->toContain('Compare two coverage JSON exports')
             ->toContain('Create a run profile from a saved JSONL stream')
             ->toContain('Apply configured artifact retention')

--- a/tests/Unit/Coverage/Diff/ProjectRootNormalizerTest.php
+++ b/tests/Unit/Coverage/Diff/ProjectRootNormalizerTest.php
@@ -56,4 +56,22 @@ final class ProjectRootNormalizerTest
                 message: 'The project root must be an absolute path.',
             );
     }
+
+    #[Test]
+    public function relocationUsesTheTargetRootAndKeepsLineSets(): void
+    {
+        $relocated = ProjectRootNormalizer::relocate(
+            new CoverageMap([new FileCoverage('/old/worktree/src/A.php', [2], [3])]),
+            '/old/worktree',
+            '/new/worktree/',
+        );
+
+        Expect::that($relocated->toWire())
+            ->because('relocation MUST change only the project root')
+            ->toBe([
+                'files' => [
+                    '/new/worktree/src/A.php' => [[2], [3]],
+                ],
+            ]);
+    }
 }

--- a/tests/Unit/Coverage/Diff/ProjectRootNormalizerTest.php
+++ b/tests/Unit/Coverage/Diff/ProjectRootNormalizerTest.php
@@ -74,4 +74,19 @@ final class ProjectRootNormalizerTest
                 ],
             ]);
     }
+
+    #[Test]
+    public function relocationRejectsARelativeTargetRoot(): void
+    {
+        Expect::that(static fn(): CoverageMap => ProjectRootNormalizer::relocate(
+            CoverageMap::empty(),
+            '/old/worktree',
+            'new/worktree',
+        ))
+            ->because('relocation requires an explicit absolute target root')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'The target project root must be an absolute path.',
+            );
+    }
 }


### PR DESCRIPTION
## Summary

- Add `coverage:merge` for deterministic whole-suite aggregation of Greenlight JSON v1 shard reports.
- Reuse the existing JSON, LCOV, Clover, Cobertura, and HTML exporters, with atomic file replacement and merged coverage gates.
- Relocate coverage from explicit input roots to one project root for shards from different checkouts.
- Register the command through the existing `CommandProvider` plugin seam without a new extension interface.
- Document a complete GitHub Actions shard, artifact, merge, gate, and diff workflow.

## Stack

- Base: #1612 (`ben-challis/coverage-ci-gates`).
