### PR TITLE
feat: add safe artifact run retention

### DIFF
--- a/docs/api-configuration.md
+++ b/docs/api-configuration.md
@@ -29,7 +29,7 @@ PHPDoc:
 - `@param non-empty-string $directory`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L35)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L44)
 
 ### `maxAttachmentsPerTest()`
 
@@ -42,7 +42,7 @@ PHPDoc:
 - `@param positive-int $count`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L55)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L64)
 
 ### `maxAttachmentSize()`
 
@@ -55,7 +55,7 @@ PHPDoc:
 - `@param non-empty-string $size`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L71)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L80)
 
 ### `maxTestSize()`
 
@@ -68,7 +68,7 @@ PHPDoc:
 - `@param non-empty-string $size`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L83)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L92)
 
 ### `maxRunAttachments()`
 
@@ -81,7 +81,7 @@ PHPDoc:
 - `@param positive-int $count`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L95)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L104)
 
 ### `maxRunSize()`
 
@@ -94,7 +94,46 @@ PHPDoc:
 - `@param non-empty-string $size`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L111)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L120)
+
+### `maxCompletedRuns()`
+
+```php
+public function maxCompletedRuns(int $count): self
+```
+
+PHPDoc:
+
+- `@param positive-int $count`
+- `@throws InvalidConfiguration`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L132)
+
+### `maxCompletedRunAge()`
+
+```php
+public function maxCompletedRunAge(int $seconds): self
+```
+
+PHPDoc:
+
+- `@param positive-int $seconds`
+- `@throws InvalidConfiguration`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L148)
+
+### `maxRetainedSize()`
+
+```php
+public function maxRetainedSize(string $size): self
+```
+
+PHPDoc:
+
+- `@param non-empty-string $size`
+- `@throws InvalidConfiguration`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/ArtifactBuilder.php#L164)
 
 ## `CoverageBuilder`
 

--- a/docs/architecture/artifacts.md
+++ b/docs/architecture/artifacts.md
@@ -37,8 +37,32 @@ changes include retries, teardown, plugin transformations, and result policy.
 When the process discards an attachment, it deletes the staged content and
 releases its run quota.
 
-Greenlight leaves completed output in place. Cleanup and retention belong to
-the user or CI system.
+Greenlight leaves completed output in place unless configuration enables run
+retention. Automatic retention runs after normal run completion. The
+`artifacts:prune` command supports explicit maintenance and dry-run output.
+
+Each public run directory contains versioned ownership metadata and a lifecycle
+lock. Active processes hold the lock. An unlocked active record identifies an
+incomplete run that can be recovered.
+
+A completed record contains the completion time and an exact file manifest.
+The manifest has each relative path, byte count, and SHA-256 digest. Greenlight
+does not prune a directory when its content does not match the manifest.
+
+Pruning uses one lock in the canonical artifact parent. It claims a selected
+run with an atomic rename before deletion. Concurrent Greenlight processes can
+safely apply the same policy.
+
+Age has first precedence, then count, then total bytes. Each limit selects the
+oldest eligible completed run first. Completion time and run ID give the stable
+order. A future completion time is not old for the age policy.
+
+The current automatic run is not eligible. Unknown, active, incomplete,
+changed, malformed, and future-version directories are not eligible. A
+directory with a symbolic link is not eligible.
+
+Retention failures are advisory. They do not change a test result or run exit
+code. A failure that prevents publication of the current run remains fatal.
 
 ## Crash recovery
 
@@ -76,6 +100,9 @@ Destination and recovery paths **MUST** stay below their configured roots.
 Attachment files and internal metadata use private permissions on platforms
 that support these permissions.
 
+Pruning **MUST** keep the configured parent. It **MUST NOT** follow a symbolic
+link or delete content outside the canonical parent.
+
 The storage layer does not redact content. Tests and plugins **MUST** remove
 secrets before they add data as an attachment.
 
@@ -88,3 +115,6 @@ staging, publication, and recovery are also internal.
 JSONL versions 2 and 3 require `attachments` on `TestResult` and
 `artifactsDirectory` on `RunStarted`. The worker protocol is internal and
 versioned separately.
+
+CI platform retention remains authoritative after artifact upload. Local
+Greenlight retention only controls files on the runner filesystem.

--- a/docs/architecture/technical-writing.md
+++ b/docs/architecture/technical-writing.md
@@ -177,7 +177,7 @@ and meaning. Use the singular form unless the context requires a plural.
 | resource lease | Technical noun | A temporary grant of resource capacity to one scheduling unit |
 | resource limit | Technical noun | A limit on concurrent access to a named resource |
 | result policy | Technical noun | A rule that can change a test result after execution |
-| retention | Technical noun | The rule that determines if Greenlight publishes an attachment |
+| retention | Technical noun | A rule that determines if Greenlight publishes an attachment or keeps a completed run directory |
 | retried pass | Technical noun | A successful terminal result that used more than one test attempt |
 | run acceptance policy | Technical noun | A command-side plugin that can reject an otherwise successful run without changing test outcomes |
 | retry decider | Technical noun | A plugin that determines if Greenlight starts another test attempt |

--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -85,8 +85,25 @@ Use `--artifacts-dir` to override it for one run:
 vendor/bin/greenlight run --artifacts-dir=build/ci-evidence
 ```
 
-Greenlight does not delete completed run directories. For local runs, remove
-these directories. In CI, use the artifact retention settings.
+Completed run retention is disabled by default. Configure one or more limits
+to remove old Greenlight run directories after a run completes:
+
+<!-- php-example {"example":"attachments-example-04","file":"snippet.php","mode":"file","tools":["rector"]} -->
+```php
+use Greenlight\Config\ArtifactBuilder;
+
+return GreenlightConfig::create()
+    ->artifacts(fn (ArtifactBuilder $artifacts) => $artifacts
+        ->maxCompletedRuns(20)
+        ->maxCompletedRunAge(7 * 24 * 60 * 60)
+        ->maxRetainedSize('2G'));
+```
+
+The age value is in seconds. Greenlight applies age, count, and byte limits in
+that order. Each limit removes the oldest eligible completed run first.
+
+Use `greenlight artifacts:prune --dry-run` to examine the configured policy.
+Use the command without `--dry-run` to apply the policy.
 
 ## Metadata and names
 
@@ -107,6 +124,11 @@ Source files must be regular files, not symlinks. Greenlight verifies that a
 source does not change during the copy operation. Published paths stay in the
 configured run directory. Greenlight creates artifact files with private
 permissions on supported platforms.
+
+Each run directory contains versioned ownership metadata and a lifecycle lock.
+Greenlight prunes only completed directories with an exact content manifest.
+It does not prune active, incomplete, changed, unknown, or symbolic-link
+directories. Cleanup claims use atomic directory renames and a parent lock.
 
 Greenlight does not inspect or redact attachment content. Before you attach a
 value or file, remove secrets and personal data.
@@ -133,6 +155,9 @@ apply across parallel workers. Per-test limits include all attempts, even when
 Greenlight discards some attachments later. Greenlight releases run quota when
 it discards an attachment.
 
+Completed run limits are independent of attachment limits. The completed run
+defaults are unbounded. Retention failures do not fail a test run.
+
 ## Plugins
 
 `$context->attachments` gives the same attempt-owned object to
@@ -157,3 +182,6 @@ schema](architecture/jsonl.md).
 
 For other CI systems, use a post-test step that always runs. Upload the reported
 run directory from this step.
+
+CI platform retention remains authoritative after upload. Greenlight retention
+controls only the runner filesystem.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -368,13 +368,23 @@ the same builder.
     ->maxAttachmentSize('10M')
     ->maxTestSize('50M')
     ->maxRunAttachments(2_000)
-    ->maxRunSize('500M'))
+    ->maxRunSize('500M')
+    ->maxCompletedRuns(20)
+    ->maxCompletedRunAge(604_800)
+    ->maxRetainedSize('2G'))
 ```
 
 Defaults are 32 attachments and 100 MiB per test. Each attachment has a 25 MiB
 limit. Each run has limits of 10,000 attachments and 1 GiB. Per-test limits
 include all retry attempts, even if retention policy discards attachments
 later. Greenlight releases run quota when it discards an attachment.
+
+Completed run retention is unbounded by default. Configure a maximum count,
+age in seconds, or total size. Greenlight applies age, count, and size limits
+in that order. Each limit removes the oldest eligible completed run first.
+
+Run `greenlight artifacts:prune --dry-run` to list selected directories. The
+command without `--dry-run` applies the configured policy.
 
 See [test attachments](attachments.md) for the runtime API and security model.
 

--- a/resources/schema/worker-protocol-v3.schema.json
+++ b/resources/schema/worker-protocol-v3.schema.json
@@ -354,7 +354,10 @@
                 "maxAttachmentBytes": {"type": "integer", "minimum": 1},
                 "maxTestBytes": {"type": "integer", "minimum": 1},
                 "maxRunAttachments": {"type": "integer", "minimum": 1},
-                "maxRunBytes": {"type": "integer", "minimum": 1}
+                "maxRunBytes": {"type": "integer", "minimum": 1},
+                "maxCompletedRuns": {"type": ["integer", "null"], "minimum": 1},
+                "maxCompletedRunAgeSeconds": {"type": ["integer", "null"], "minimum": 1},
+                "maxRetainedBytes": {"type": ["integer", "null"], "minimum": 1}
             }
         },
         "attemptStarted": {

--- a/src/Cli/Input/Definition.php
+++ b/src/Cli/Input/Definition.php
@@ -22,6 +22,7 @@ final readonly class Definition
         'list-tests' => 'List each found test ID, one per line',
         'coverage:diff' => 'Compare two coverage JSON exports',
         'profile:report' => 'Create a run profile from a saved JSONL stream',
+        'artifacts:prune' => 'Apply configured artifact retention',
         'ide-helper' => 'Write the IDE autocomplete helper for extension matchers',
         'completion' => 'Print a shell completion script to standard output',
     ];
@@ -45,6 +46,8 @@ final readonly class Definition
           coverage:diff  Compare two coverage JSON exports. Fail if total coverage
                          decreases or a line becomes newly uncovered.
           profile:report Create a run profile from a saved JSONL stream (--input)
+          artifacts:prune Apply configured retention to completed artifact runs.
+                         Use --dry-run to list selected runs without deletion.
           ide-helper     Write the IDE autocomplete helper for extension matchers
                          (--output, default _greenlight_ide_helper.php)
           completion     Print a shell completion script for bash, zsh, or fish

--- a/src/Cli/Plugin/BundledCommands.php
+++ b/src/Cli/Plugin/BundledCommands.php
@@ -12,6 +12,7 @@ use Greenlight\Cli\Command\ProfileReportCommand;
 use Greenlight\Cli\Input\CliError;
 use Greenlight\Cli\Input\Definition;
 use Greenlight\Cli\Output\Console;
+use Greenlight\Cli\Run\ArtifactsPruneCommand;
 use Greenlight\Cli\Run\RunCommand;
 use Greenlight\Coverage\CoverageError;
 use Greenlight\Plugin\CommandDefinition;
@@ -113,6 +114,7 @@ final readonly class BundledCommands implements CommandProvider
             ),
             'coverage:diff' => new CoverageDiffCommand($this->console)->run($arguments, $invocation->workingDirectory),
             'profile:report' => new ProfileReportCommand($this->console)->run($arguments, $invocation->workingDirectory),
+            'artifacts:prune' => new ArtifactsPruneCommand($this->console)->run($arguments, $invocation->workingDirectory),
             'ide-helper' => new IdeHelperCommand($this->console)->run($arguments, $invocation->workingDirectory),
             default => throw new \LogicException(\sprintf('Bundled command "%s" has no handler.', $command)),
         };

--- a/src/Cli/Run/ArtifactsPruneCommand.php
+++ b/src/Cli/Run/ArtifactsPruneCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli\Run;
+
+use Greenlight\Artifact\AttachmentError;
+use Greenlight\Cli\Configuration\ConfigurationLoader;
+use Greenlight\Cli\Input\CliError;
+use Greenlight\Cli\Input\ParsedArguments;
+use Greenlight\Cli\Output\Console;
+use Greenlight\Config\ConfigFileError;
+use Greenlight\Config\InvalidConfiguration;
+use Greenlight\Execution\ArtifactMaintenance;
+
+/**
+ * Applies configured retention to completed Greenlight artifact runs.
+ *
+ * @internal
+ */
+final readonly class ArtifactsPruneCommand
+{
+    public function __construct(private Console $console) {}
+
+    public function run(ParsedArguments $arguments, string $workingDirectory): int
+    {
+        try {
+            $configuration = new ConfigurationLoader()->load($arguments, $workingDirectory)->resolved->execution->artifacts;
+            $maintenance = ArtifactMaintenance::forConfiguration($configuration, $workingDirectory);
+        } catch (CliError $error) {
+            $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
+            return 64;
+        } catch (AttachmentError|ConfigFileError|InvalidConfiguration $error) {
+            $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
+            return 1;
+        }
+
+        if (!$configuration->hasRetentionPolicy()) {
+            $this->console->out("No artifact retention policy is configured.\n");
+            return 0;
+        }
+
+        $report = $maintenance->prune($arguments->has('dry-run'));
+        foreach ($report->items as $item) {
+            $action = $report->dryRun ? 'Would prune' : 'Pruned';
+            $this->console->out(\sprintf(
+                "%s %s (%d bytes, %s limit).\n",
+                $action,
+                $item->directory,
+                $item->bytes,
+                \implode(', ', $item->reasons),
+            ));
+        }
+        if ($report->items === []) {
+            $this->console->out($report->dryRun
+                ? "No completed artifact runs would be pruned.\n"
+                : "No completed artifact runs were pruned.\n");
+        }
+        foreach ($report->warnings as $warning) {
+            $this->console->err($warning . "\n");
+        }
+
+        return 0;
+    }
+}

--- a/src/Config/ArtifactBuilder.php
+++ b/src/Config/ArtifactBuilder.php
@@ -27,6 +27,15 @@ final class ArtifactBuilder
     /** @var positive-int */
     private int $maxRunBytes = ArtifactConfiguration::DEFAULT_MAX_RUN_BYTES;
 
+    /** @var positive-int|null */
+    private ?int $maxCompletedRuns = null;
+
+    /** @var positive-int|null */
+    private ?int $maxCompletedRunAgeSeconds = null;
+
+    /** @var positive-int|null */
+    private ?int $maxRetainedBytes = null;
+
     /**
      * @param non-empty-string $directory
      *
@@ -116,6 +125,50 @@ final class ArtifactBuilder
     }
 
     /**
+     * @param positive-int $count
+     *
+     * @throws InvalidConfiguration
+     */
+    public function maxCompletedRuns(int $count): self
+    {
+        if ($count < 1) {
+            throw new InvalidConfiguration('Completed artifact run count must be at least 1.');
+        }
+
+        $this->maxCompletedRuns = $count;
+
+        return $this;
+    }
+
+    /**
+     * @param positive-int $seconds
+     *
+     * @throws InvalidConfiguration
+     */
+    public function maxCompletedRunAge(int $seconds): self
+    {
+        if ($seconds < 1) {
+            throw new InvalidConfiguration('Completed artifact run age must be at least 1 second.');
+        }
+
+        $this->maxCompletedRunAgeSeconds = $seconds;
+
+        return $this;
+    }
+
+    /**
+     * @param non-empty-string $size
+     *
+     * @throws InvalidConfiguration
+     */
+    public function maxRetainedSize(string $size): self
+    {
+        $this->maxRetainedBytes = MemorySize::parseToBytes($size);
+
+        return $this;
+    }
+
+    /**
      * @internal
      */
     public function toConfiguration(): ArtifactConfiguration
@@ -127,6 +180,9 @@ final class ArtifactBuilder
             $this->maxTestBytes,
             $this->maxRunAttachments,
             $this->maxRunBytes,
+            $this->maxCompletedRuns,
+            $this->maxCompletedRunAgeSeconds,
+            $this->maxRetainedBytes,
         );
     }
 }

--- a/src/Config/ArtifactConfiguration.php
+++ b/src/Config/ArtifactConfiguration.php
@@ -29,6 +29,9 @@ final readonly class ArtifactConfiguration
         public int $maxTestBytes = self::DEFAULT_MAX_TEST_BYTES,
         public int $maxRunAttachments = self::DEFAULT_MAX_RUN_ATTACHMENTS,
         public int $maxRunBytes = self::DEFAULT_MAX_RUN_BYTES,
+        public ?int $maxCompletedRuns = null,
+        public ?int $maxCompletedRunAgeSeconds = null,
+        public ?int $maxRetainedBytes = null,
     ) {}
 
     public function withDirectory(string $directory): self
@@ -40,7 +43,17 @@ final readonly class ArtifactConfiguration
             $this->maxTestBytes,
             $this->maxRunAttachments,
             $this->maxRunBytes,
+            $this->maxCompletedRuns,
+            $this->maxCompletedRunAgeSeconds,
+            $this->maxRetainedBytes,
         );
+    }
+
+    public function hasRetentionPolicy(): bool
+    {
+        return $this->maxCompletedRuns !== null
+            || $this->maxCompletedRunAgeSeconds !== null
+            || $this->maxRetainedBytes !== null;
     }
 
     /** @return array<string, mixed> */
@@ -53,6 +66,9 @@ final readonly class ArtifactConfiguration
             'maxTestBytes' => $this->maxTestBytes,
             'maxRunAttachments' => $this->maxRunAttachments,
             'maxRunBytes' => $this->maxRunBytes,
+            'maxCompletedRuns' => $this->maxCompletedRuns,
+            'maxCompletedRunAgeSeconds' => $this->maxCompletedRunAgeSeconds,
+            'maxRetainedBytes' => $this->maxRetainedBytes,
         ];
     }
 
@@ -79,6 +95,20 @@ final readonly class ArtifactConfiguration
             \max(1, Wire::int($payload, 'maxTestBytes')),
             \max(1, Wire::int($payload, 'maxRunAttachments')),
             \max(1, Wire::int($payload, 'maxRunBytes')),
+            self::optionalPositiveInt($payload, 'maxCompletedRuns'),
+            self::optionalPositiveInt($payload, 'maxCompletedRunAgeSeconds'),
+            self::optionalPositiveInt($payload, 'maxRetainedBytes'),
         );
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     * @throws WireCommunicationFailed
+     */
+    private static function optionalPositiveInt(array $payload, string $key): ?int
+    {
+        $value = \array_key_exists($key, $payload) ? Wire::nullableInt($payload, $key) : null;
+
+        return $value === null ? null : \max(1, $value);
     }
 }

--- a/src/Execution/Artifact/ArtifactPruneItem.php
+++ b/src/Execution/Artifact/ArtifactPruneItem.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Execution\Artifact;
+
+/**
+ * Describes one completed artifact run that a retention operation selects.
+ *
+ * @internal
+ */
+final readonly class ArtifactPruneItem
+{
+    /**
+     * @param non-empty-string $runId
+     * @param non-empty-string $directory
+     * @param non-empty-list<'age'|'count'|'size'> $reasons
+     */
+    public function __construct(
+        public string $runId,
+        public string $directory,
+        public int $bytes,
+        public array $reasons,
+    ) {}
+}

--- a/src/Execution/Artifact/ArtifactPruneReport.php
+++ b/src/Execution/Artifact/ArtifactPruneReport.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Execution\Artifact;
+
+/**
+ * Contains selected runs and advisory failures from one retention operation.
+ *
+ * @internal
+ */
+final readonly class ArtifactPruneReport
+{
+    /**
+     * @param list<ArtifactPruneItem> $items
+     * @param list<non-empty-string> $warnings
+     */
+    public function __construct(
+        public array $items = [],
+        public array $warnings = [],
+        public bool $dryRun = false,
+    ) {}
+}

--- a/src/Execution/Artifact/ArtifactRetention.php
+++ b/src/Execution/Artifact/ArtifactRetention.php
@@ -1,0 +1,666 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Execution\Artifact;
+
+use Greenlight\Artifact\AttachmentError;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Internal\Php\ErrorTrap;
+
+/**
+ * Owns run metadata and safely applies retention below one artifact parent.
+ *
+ * @internal
+ */
+final readonly class ArtifactRetention
+{
+    public const int METADATA_VERSION = 1;
+    public const string OWNER = 'greenlight';
+    public const string METADATA_FILE = '.greenlight-run.json';
+    public const string LOCK_FILE = '.greenlight-run.lock';
+
+    private const string PRUNE_LOCK_FILE = '.greenlight-prune.lock';
+    private const int MAX_METADATA_BYTES = 16 * 1024 * 1024;
+
+    /** @param non-empty-string $parent */
+    private function __construct(
+        private ArtifactConfiguration $configuration,
+        public string $parent,
+    ) {}
+
+    /** @throws AttachmentError */
+    public static function forConfiguration(ArtifactConfiguration $configuration, string $workingDirectory): self
+    {
+        $configured = \rtrim($configuration->directory, '/');
+        if ($configured === '' || \str_contains($configured, "\0")) {
+            throw AttachmentError::storage('Attachment output directory is invalid');
+        }
+        if (!\str_starts_with($configured, '/') && \in_array('..', \explode('/', $configured), true)) {
+            throw AttachmentError::storage('Keep a relative attachment output directory inside the working directory');
+        }
+
+        $workingReal = ErrorTrap::run(static fn() => \realpath($workingDirectory));
+        $workingDirectory = $workingReal === false ? $workingDirectory : $workingReal;
+        $parent = \str_starts_with($configured, '/')
+            ? $configured
+            : \rtrim($workingDirectory, '/') . '/' . $configured;
+
+        return new self($configuration, $parent);
+    }
+
+    /** @return non-empty-string */
+    public function runDirectory(string $runId): string
+    {
+        return $this->parent . '/' . $runId;
+    }
+
+    /** @throws AttachmentError */
+    public function begin(string $runId): ArtifactRunHandle
+    {
+        $validatedRunId = $this->validatedRunId($runId);
+        if ($validatedRunId === null) {
+            throw AttachmentError::storage('Artifact run ID is unsafe');
+        }
+        $runId = $validatedRunId;
+
+        $parent = $this->ensureParent();
+        $directory = $parent . '/' . $runId;
+        if (!ErrorTrap::run(static fn() => \mkdir($directory, 0o700), $warning)) {
+            throw AttachmentError::storage('Failed to create artifact run directory' . ($warning === null ? '' : ': ' . $warning));
+        }
+
+        $lockPath = $directory . '/' . self::LOCK_FILE;
+        $lock = ErrorTrap::run(static fn() => \fopen($lockPath, 'x+'), $warning);
+        if ($lock === false || !ErrorTrap::run(static fn() => \flock($lock, \LOCK_EX), $lockWarning)) {
+            if (\is_resource($lock)) {
+                ErrorTrap::run(static fn() => \fclose($lock));
+            }
+            ErrorTrap::run(static fn() => \unlink($lockPath));
+            ErrorTrap::run(static fn() => \rmdir($directory));
+            throw AttachmentError::storage('Failed to lock artifact run directory' . (($lockWarning ?? $warning) === null ? '' : ': ' . ($lockWarning ?? $warning)));
+        }
+        \chmod($lockPath, 0o600);
+
+        try {
+            self::writeMetadata($directory, [
+                'version' => self::METADATA_VERSION,
+                'owner' => self::OWNER,
+                'runId' => $runId,
+                'state' => 'active',
+                'startedAt' => \time(),
+            ]);
+        } catch (\Throwable $failure) {
+            ErrorTrap::run(static fn() => \flock($lock, \LOCK_UN));
+            ErrorTrap::run(static fn() => \fclose($lock));
+            ErrorTrap::run(static fn() => \unlink($lockPath));
+            ErrorTrap::run(static fn() => \rmdir($directory));
+            throw AttachmentError::storage($failure->getMessage());
+        }
+
+        return new ArtifactRunHandle($runId, $directory, $lock);
+    }
+
+    public function prune(bool $dryRun = false, ?string $protectedRunId = null, ?int $now = null): ArtifactPruneReport
+    {
+        try {
+            return $this->applyPolicy($dryRun, $protectedRunId, $now ?? \time());
+        } catch (\Throwable) {
+            return new ArtifactPruneReport(
+                warnings: ['Greenlight did not apply the artifact retention policy.'],
+                dryRun: $dryRun,
+            );
+        }
+    }
+
+    private function applyPolicy(bool $dryRun, ?string $protectedRunId, int $now): ArtifactPruneReport
+    {
+        if (!$this->configuration->hasRetentionPolicy() || !\is_dir($this->parent) || \is_link($this->parent)) {
+            return new ArtifactPruneReport(dryRun: $dryRun);
+        }
+
+        $canonical = ErrorTrap::run(fn() => \realpath($this->parent));
+        if ($canonical === false || $canonical !== $this->parent) {
+            return new ArtifactPruneReport(warnings: ['Greenlight did not prune artifacts because the artifact parent is not canonical.'], dryRun: $dryRun);
+        }
+
+        if ($dryRun) {
+            return $this->pruneLocked($canonical, true, $protectedRunId, $now);
+        }
+
+        $pruneLock = ErrorTrap::run(fn() => \fopen($canonical . '/' . self::PRUNE_LOCK_FILE, 'c+'));
+        if ($pruneLock === false || !ErrorTrap::run(static fn() => \flock($pruneLock, \LOCK_EX))) {
+            if (\is_resource($pruneLock)) {
+                ErrorTrap::run(static fn() => \fclose($pruneLock));
+            }
+            return new ArtifactPruneReport(warnings: ['Greenlight did not lock the artifact parent for pruning.'], dryRun: $dryRun);
+        }
+        \chmod($canonical . '/' . self::PRUNE_LOCK_FILE, 0o600);
+
+        try {
+            if (!$this->canonicalDirectory($canonical, $canonical)) {
+                return new ArtifactPruneReport(
+                    warnings: ['Greenlight did not prune artifacts because the artifact parent changed.'],
+                );
+            }
+
+            return $this->pruneLocked($canonical, $dryRun, $protectedRunId, $now);
+        } finally {
+            ErrorTrap::run(static fn() => \flock($pruneLock, \LOCK_UN));
+            ErrorTrap::run(static fn() => \fclose($pruneLock));
+        }
+    }
+
+    /**
+     * @param non-empty-string $parent
+     */
+    private function pruneLocked(string $parent, bool $dryRun, ?string $protectedRunId, int $now): ArtifactPruneReport
+    {
+        $records = [];
+        $warnings = [];
+        $iterator = ErrorTrap::run(static fn() => new \FilesystemIterator($parent, \FilesystemIterator::SKIP_DOTS));
+        foreach ($iterator as $entry) {
+            if (!$entry instanceof \SplFileInfo || $entry->isLink() || !$entry->isDir()) {
+                continue;
+            }
+            $record = $this->completedRecord($entry->getPathname(), $entry->getFilename());
+            if ($record instanceof ArtifactRunRecord) {
+                $records[] = $record;
+            }
+        }
+
+        \usort($records, static fn(ArtifactRunRecord $a, ArtifactRunRecord $b): int => [$a->completedAt, $a->runId] <=> [$b->completedAt, $b->runId]);
+        /** @var array<non-empty-string, non-empty-list<'age'|'count'|'size'>> $selected */
+        $selected = [];
+        $age = $this->configuration->maxCompletedRunAgeSeconds;
+        if ($age !== null) {
+            foreach ($records as $record) {
+                if ($record->runId !== $protectedRunId && $record->completedAt <= $now && $now - $record->completedAt >= $age) {
+                    $selected[$record->runId] = ['age'];
+                }
+            }
+        }
+
+        $remainingCount = \count($records) - \count($selected);
+        $countLimit = $this->configuration->maxCompletedRuns;
+        if ($countLimit !== null) {
+            foreach ($records as $record) {
+                if ($remainingCount <= $countLimit) {
+                    break;
+                }
+                if ($record->runId === $protectedRunId || isset($selected[$record->runId])) {
+                    continue;
+                }
+                $selected[$record->runId] = ['count'];
+                --$remainingCount;
+            }
+        }
+
+        $remainingBytes = 0;
+        foreach ($records as $record) {
+            if (!isset($selected[$record->runId])) {
+                $remainingBytes = $this->saturatingAdd($remainingBytes, $record->bytes);
+            }
+        }
+        $byteLimit = $this->configuration->maxRetainedBytes;
+        if ($byteLimit !== null) {
+            foreach ($records as $record) {
+                if ($remainingBytes <= $byteLimit) {
+                    break;
+                }
+                if ($record->runId === $protectedRunId || isset($selected[$record->runId])) {
+                    continue;
+                }
+                $selected[$record->runId] = ['size'];
+                $remainingBytes = \max(0, $remainingBytes - $record->bytes);
+            }
+        }
+
+        $items = [];
+        foreach ($records as $record) {
+            $reasons = $selected[$record->runId] ?? null;
+            if ($reasons === null) {
+                continue;
+            }
+            $directory = $parent . '/' . $record->runId;
+            if (!$dryRun && !$this->removeClaimed($parent, $directory, $record)) {
+                $warnings[] = \sprintf('Greenlight did not prune artifact run "%s".', $record->runId);
+                continue;
+            }
+            $items[] = new ArtifactPruneItem($record->runId, $directory, $record->bytes, $reasons);
+        }
+
+        return new ArtifactPruneReport($items, $warnings, $dryRun);
+    }
+
+    private function removeClaimed(string $parent, string $directory, ArtifactRunRecord $record): bool
+    {
+        if (\dirname($directory) !== $parent || !$this->canonicalDirectory($directory, $directory)) {
+            return false;
+        }
+
+        $lockPath = $directory . '/' . self::LOCK_FILE;
+        if ($this->pathIsLink($lockPath)) {
+            return false;
+        }
+        $lock = ErrorTrap::run(static fn() => \fopen($lockPath, 'r+'));
+        if ($lock === false || !ErrorTrap::run(static fn() => \flock($lock, \LOCK_EX | \LOCK_NB))) {
+            if (\is_resource($lock)) {
+                ErrorTrap::run(static fn() => \fclose($lock));
+            }
+            return false;
+        }
+
+        $claim = $parent . '/.greenlight-prune-' . \bin2hex(\random_bytes(12));
+        try {
+            if ($this->pathIsLink($lockPath)
+                || !$this->canonicalDirectory($parent, $parent)
+                || !$this->canonicalDirectory($directory, $directory)
+            ) {
+                return false;
+            }
+            if (!ErrorTrap::run(static fn() => \rename($directory, $claim))) {
+                return false;
+            }
+            $claimed = $this->canonicalDirectory($claim, $claim)
+                ? $this->recordWithoutLock($claim, $record->runId)
+                : null;
+            if (!$claimed instanceof ArtifactRunRecord
+                || $claimed->files !== $record->files
+                || !$this->treeRemovable($claim)
+            ) {
+                ErrorTrap::run(static fn() => \rename($claim, $directory));
+                return false;
+            }
+        } finally {
+            ErrorTrap::run(static fn() => \flock($lock, \LOCK_UN));
+            ErrorTrap::run(static fn() => \fclose($lock));
+        }
+
+        if ($this->removeTree($claim)) {
+            return true;
+        }
+        ErrorTrap::run(static fn() => \rename($claim, $directory));
+
+        return false;
+    }
+
+    /** @return array<non-empty-string, array{bytes: int, sha256: non-empty-string}> */
+    public static function contentManifest(string $directory): array
+    {
+        if (ErrorTrap::run(static fn() => \is_link($directory))
+            || !ErrorTrap::run(static fn() => \is_dir($directory))
+        ) {
+            throw new \RuntimeException('Artifact run root is not a directory owned by Greenlight.');
+        }
+
+        $files = [];
+        $directories = [];
+        $entries = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::SELF_FIRST,
+        );
+        foreach ($entries as $entry) {
+            if (!$entry instanceof \SplFileInfo || $entry->isLink()) {
+                if ($entry instanceof \SplFileInfo && $entry->isLink()) {
+                    throw new \RuntimeException('Artifact run content contains a symbolic link.');
+                }
+                continue;
+            }
+            if (!$entry->isFile()) {
+                if ($entry->isDir()) {
+                    $directories[] = \substr($entry->getPathname(), \strlen($directory) + 1);
+
+                    continue;
+                }
+
+                throw new \RuntimeException('Artifact run content contains an unsupported filesystem entry.');
+            }
+            $relative = self::validatedRelativePath(\substr($entry->getPathname(), \strlen($directory) + 1));
+            if ($relative === null) {
+                throw new \RuntimeException('Artifact run content contains an unsafe path.');
+            }
+            if (\in_array($relative, [self::METADATA_FILE, self::LOCK_FILE], true)) {
+                continue;
+            }
+            $size = $entry->getSize();
+            $hash = ErrorTrap::run(static fn() => \hash_file('sha256', $entry->getPathname()));
+            if (!\is_int($size) || $size < 0 || !\is_string($hash) || $hash === '') {
+                throw new \RuntimeException('Greenlight did not read artifact run content.');
+            }
+            $files[$relative] = ['bytes' => $size, 'sha256' => $hash];
+        }
+        \ksort($files);
+        $expectedDirectories = [];
+        foreach (\array_keys($files) as $file) {
+            $parent = \dirname($file);
+            while ($parent !== '.') {
+                $expectedDirectories[$parent] = true;
+                $parent = \dirname($parent);
+            }
+        }
+        \sort($directories);
+        $expected = \array_keys($expectedDirectories);
+        \sort($expected);
+        if ($directories !== $expected) {
+            throw new \RuntimeException('Artifact run content contains an unowned directory.');
+        }
+
+        return $files;
+    }
+
+    /** @param array<string, mixed> $metadata */
+    public static function writeMetadata(string $directory, array $metadata): void
+    {
+        $path = $directory . '/' . self::METADATA_FILE;
+        $part = $path . '.part-' . \bin2hex(\random_bytes(6));
+        $encoded = \json_encode($metadata, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES);
+        if (ErrorTrap::run(static fn() => \file_put_contents($part, $encoded . "\n", \LOCK_EX)) === false) {
+            ErrorTrap::run(static fn() => \unlink($part));
+            throw new \RuntimeException('Greenlight did not write artifact run metadata.');
+        }
+        \chmod($part, 0o600);
+        if (!ErrorTrap::run(static fn() => \rename($part, $path))) {
+            ErrorTrap::run(static fn() => \unlink($part));
+            throw new \RuntimeException('Greenlight did not finalize artifact run metadata.');
+        }
+    }
+
+    public static function startedAt(string $directory, string $runId): int
+    {
+        $decoded = self::metadataMap($directory);
+        if (($decoded['version'] ?? null) !== self::METADATA_VERSION
+            || ($decoded['owner'] ?? null) !== self::OWNER
+            || ($decoded['runId'] ?? null) !== $runId
+            || ($decoded['state'] ?? null) !== 'active'
+            || !\is_int($decoded['startedAt'] ?? null)
+            || $decoded['startedAt'] < 0
+        ) {
+            throw new \RuntimeException('Artifact run metadata is not an active Greenlight record.');
+        }
+
+        return $decoded['startedAt'];
+    }
+
+    private function completedRecord(string $directory, string $runId): ?ArtifactRunRecord
+    {
+        if (!$this->safeRunId($runId) || \is_link($directory)) {
+            return null;
+        }
+        $lockPath = $directory . '/' . self::LOCK_FILE;
+        if (\is_link($lockPath) || !\is_file($lockPath)) {
+            return null;
+        }
+        $lock = ErrorTrap::run(static fn() => \fopen($lockPath, 'r+'));
+        if ($lock === false || !ErrorTrap::run(static fn() => \flock($lock, \LOCK_EX | \LOCK_NB))) {
+            if (\is_resource($lock)) {
+                ErrorTrap::run(static fn() => \fclose($lock));
+            }
+            return null;
+        }
+        try {
+            return $this->recordWithoutLock($directory, $runId);
+        } catch (\Throwable) {
+            return null;
+        } finally {
+            ErrorTrap::run(static fn() => \flock($lock, \LOCK_UN));
+            ErrorTrap::run(static fn() => \fclose($lock));
+        }
+    }
+
+    private function recordWithoutLock(string $directory, string $runId): ?ArtifactRunRecord
+    {
+        if (ErrorTrap::run(static fn() => \is_link($directory))
+            || !ErrorTrap::run(static fn() => \is_dir($directory))
+        ) {
+            return null;
+        }
+
+        $validatedRunId = $this->validatedRunId($runId);
+        if ($validatedRunId === null) {
+            return null;
+        }
+        $runId = $validatedRunId;
+        $decoded = self::metadataMap($directory);
+        if (($decoded['version'] ?? null) !== self::METADATA_VERSION
+            || ($decoded['owner'] ?? null) !== self::OWNER
+            || ($decoded['runId'] ?? null) !== $runId
+            || ($decoded['state'] ?? null) !== 'completed'
+            || !\is_int($decoded['startedAt'] ?? null) || $decoded['startedAt'] < 0
+            || !\is_int($decoded['completedAt'] ?? null) || $decoded['completedAt'] < 0
+            || !\is_array($decoded['files'] ?? null)
+        ) {
+            return null;
+        }
+        $files = $this->validatedFiles($decoded['files']);
+        if ($files === null || self::contentManifest($directory) !== $files) {
+            return null;
+        }
+        $bytes = $this->manifestBytes($files);
+        foreach ([self::METADATA_FILE, self::LOCK_FILE] as $internal) {
+            $size = ErrorTrap::run(static fn() => \filesize($directory . '/' . $internal));
+            if (!\is_int($size) || $size < 0) {
+                return null;
+            }
+            $bytes = $this->saturatingAdd($bytes, $size);
+        }
+
+        return new ArtifactRunRecord($runId, $decoded['startedAt'], $decoded['completedAt'], $files, $bytes);
+    }
+
+    /** @return array<string, mixed> */
+    private static function metadataMap(string $directory): array
+    {
+        $path = $directory . '/' . self::METADATA_FILE;
+        if (\is_link($path) || !\is_file($path)) {
+            return [];
+        }
+        $size = ErrorTrap::run(static fn() => \filesize($path));
+        if (!\is_int($size) || $size < 1 || $size > self::MAX_METADATA_BYTES) {
+            return [];
+        }
+        $decoded = \json_decode((string) ErrorTrap::run(static fn() => \file_get_contents($path)), true, flags: \JSON_THROW_ON_ERROR);
+
+        if (!\is_array($decoded) || \array_is_list($decoded)) {
+            return [];
+        }
+        $map = [];
+        foreach ($decoded as $key => $value) {
+            if (!\is_string($key)) {
+                return [];
+            }
+            $map[$key] = $value;
+        }
+
+        return $map;
+    }
+
+    /**
+     * @param array<mixed> $raw
+     * @return array<non-empty-string, array{bytes: int, sha256: non-empty-string}>|null
+     */
+    private function validatedFiles(array $raw): ?array
+    {
+        $files = [];
+        foreach ($raw as $path => $metadata) {
+            $validatedPath = \is_string($path) ? self::validatedRelativePath($path) : null;
+            if ($validatedPath === null || !\is_array($metadata)
+                || !\is_int($metadata['bytes'] ?? null) || $metadata['bytes'] < 0
+                || !\is_string($metadata['sha256'] ?? null)
+                || \preg_match('/^[a-f0-9]{64}$/D', $metadata['sha256']) !== 1
+            ) {
+                return null;
+            }
+            $files[$validatedPath] = ['bytes' => $metadata['bytes'], 'sha256' => $metadata['sha256']];
+        }
+        \ksort($files);
+
+        return $files;
+    }
+
+    /** @throws AttachmentError */
+    private function ensureParent(): string
+    {
+        $this->createDirectorySafely($this->parent);
+        $canonical = ErrorTrap::run(fn() => \realpath($this->parent));
+        if ($canonical === false || $canonical !== $this->parent) {
+            throw AttachmentError::storage('Artifact parent directory is not canonical');
+        }
+
+        return $canonical;
+    }
+
+    /** @throws AttachmentError */
+    private function createDirectorySafely(string $directory): void
+    {
+        if (ErrorTrap::run(static fn() => \is_link($directory))) {
+            throw AttachmentError::storage('Attachment output directory contains a symbolic link');
+        }
+        if (ErrorTrap::run(static fn() => \is_dir($directory))) {
+            return;
+        }
+
+        $missing = [];
+        $current = $directory;
+        while (!ErrorTrap::run(static fn() => \is_dir($current))) {
+            if (ErrorTrap::run(static fn() => \is_link($current))) {
+                throw AttachmentError::storage('Attachment output directory contains a symbolic link');
+            }
+            if (ErrorTrap::run(static fn() => \file_exists($current))) {
+                throw AttachmentError::storage('Attachment output path contains a non-directory entry');
+            }
+            $missing[] = $current;
+            $parent = \dirname($current);
+            if ($parent === $current) {
+                throw AttachmentError::storage('Failed to find the artifact output parent');
+            }
+            $current = $parent;
+        }
+
+        foreach (\array_reverse($missing) as $path) {
+            if (!ErrorTrap::run(static fn() => \mkdir($path, 0o700), $warning)) {
+                throw AttachmentError::storage('Failed to create attachment output directory' . ($warning === null ? '' : ': ' . $warning));
+            }
+        }
+    }
+
+    private function safeRunId(string $runId): bool
+    {
+        return $this->validatedRunId($runId) !== null;
+    }
+
+    /**
+     * @return non-empty-string|null
+     */
+    private function validatedRunId(string $runId): ?string
+    {
+        if ($runId === '' || \in_array($runId, ['.', '..'], true)
+            || \preg_match('/^[A-Za-z0-9][A-Za-z0-9._-]*$/D', $runId) !== 1
+        ) {
+            return null;
+        }
+
+        return $runId;
+    }
+
+    /** @return non-empty-string|null */
+    private static function validatedRelativePath(string $path): ?string
+    {
+        if ($path === '' || \str_starts_with($path, '/') || \str_contains($path, '\\')
+            || !\array_all(\explode('/', $path), static fn(string $part): bool => !\in_array($part, ['', '.', '..'], true))
+        ) {
+            return null;
+        }
+
+        return $path;
+    }
+
+    /** @param array<non-empty-string, array{bytes: int, sha256: non-empty-string}> $files */
+    private function manifestBytes(array $files): int
+    {
+        $bytes = 0;
+        foreach ($files as $file) {
+            $bytes = $this->saturatingAdd($bytes, $file['bytes']);
+        }
+
+        return $bytes;
+    }
+
+    private function saturatingAdd(int $left, int $right): int
+    {
+        return $left > \PHP_INT_MAX - $right ? \PHP_INT_MAX : $left + $right;
+    }
+
+    private function removeTree(string $directory): bool
+    {
+        if (ErrorTrap::run(static fn() => \is_link($directory))
+            || !ErrorTrap::run(static fn() => \is_dir($directory))
+        ) {
+            return false;
+        }
+
+        try {
+            $entries = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::CHILD_FIRST,
+            );
+            foreach ($entries as $entry) {
+                if (!$entry instanceof \SplFileInfo) {
+                    continue;
+                }
+                $path = $entry->getPathname();
+                $removed = !$entry->isLink() && $entry->isDir()
+                    ? ErrorTrap::run(static fn() => \rmdir($path))
+                    : ErrorTrap::run(static fn() => \unlink($path));
+                if (!$removed) {
+                    return false;
+                }
+            }
+
+            return ErrorTrap::run(static fn() => \rmdir($directory));
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    private function treeRemovable(string $directory): bool
+    {
+        if (ErrorTrap::run(static fn() => \is_link($directory))
+            || !ErrorTrap::run(static fn() => \is_dir($directory))
+            || !ErrorTrap::run(static fn() => \is_writable($directory))
+        ) {
+            return false;
+        }
+        try {
+            $entries = new \RecursiveIteratorIterator(
+                new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
+                \RecursiveIteratorIterator::SELF_FIRST,
+            );
+            foreach ($entries as $entry) {
+                if ($entry instanceof \SplFileInfo && $entry->isDir() && !$entry->isLink()
+                    && !ErrorTrap::run(static fn() => \is_writable($entry->getPathname()))
+                ) {
+                    return false;
+                }
+            }
+
+            return true;
+        } catch (\Throwable) {
+            return false;
+        }
+    }
+
+    /** @phpstan-impure */
+    private function canonicalDirectory(string $directory, string $expected): bool
+    {
+        return !ErrorTrap::run(static fn() => \is_link($directory))
+            && ErrorTrap::run(static fn() => \is_dir($directory))
+            && ErrorTrap::run(static fn() => \realpath($directory)) === $expected;
+    }
+
+    /** @phpstan-impure */
+    private function pathIsLink(string $path): bool
+    {
+        return ErrorTrap::run(static fn() => \is_link($path));
+    }
+}

--- a/src/Execution/Artifact/ArtifactRetention.php
+++ b/src/Execution/Artifact/ArtifactRetention.php
@@ -466,10 +466,9 @@ final readonly class ArtifactRetention
         }
         $map = [];
         foreach ($decoded as $key => $value) {
-            if (!\is_string($key)) {
-                return [];
+            if (\is_string($key)) {
+                $map[$key] = $value;
             }
-            $map[$key] = $value;
         }
 
         return $map;
@@ -522,9 +521,12 @@ final readonly class ArtifactRetention
 
         $missing = [];
         $current = $directory;
-        while (!ErrorTrap::run(static fn() => \is_dir($current))) {
+        while (true) {
             if (ErrorTrap::run(static fn() => \is_link($current))) {
                 throw AttachmentError::storage('Attachment output directory contains a symbolic link');
+            }
+            if (ErrorTrap::run(static fn() => \is_dir($current))) {
+                break;
             }
             if (ErrorTrap::run(static fn() => \file_exists($current))) {
                 throw AttachmentError::storage('Attachment output path contains a non-directory entry');

--- a/src/Execution/Artifact/ArtifactRunHandle.php
+++ b/src/Execution/Artifact/ArtifactRunHandle.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Execution\Artifact;
+
+use Greenlight\Internal\Php\ErrorTrap;
+
+/**
+ * Holds the lifecycle lock and completes metadata for one owned run directory.
+ *
+ * @internal
+ */
+final class ArtifactRunHandle
+{
+    private bool $closed = false;
+
+    /**
+     * @param non-empty-string $runId
+     * @param non-empty-string $directory
+     * @param resource $lock
+     */
+    public function __construct(
+        public readonly string $runId,
+        public readonly string $directory,
+        private readonly mixed $lock,
+    ) {}
+
+    /** @throws \RuntimeException */
+    public function complete(): void
+    {
+        if ($this->closed) {
+            return;
+        }
+
+        $files = ArtifactRetention::contentManifest($this->directory);
+        ArtifactRetention::writeMetadata($this->directory, [
+            'version' => ArtifactRetention::METADATA_VERSION,
+            'owner' => ArtifactRetention::OWNER,
+            'runId' => $this->runId,
+            'state' => 'completed',
+            'startedAt' => ArtifactRetention::startedAt($this->directory, $this->runId),
+            'completedAt' => \time(),
+            'files' => $files,
+        ]);
+        $this->close();
+    }
+
+    public function close(): void
+    {
+        if ($this->closed) {
+            return;
+        }
+
+        $this->closed = true;
+        ErrorTrap::run(fn() => \flock($this->lock, \LOCK_UN));
+        ErrorTrap::run(fn() => \fclose($this->lock));
+    }
+
+    public function __destruct()
+    {
+        $this->close();
+    }
+}

--- a/src/Execution/Artifact/ArtifactRunRecord.php
+++ b/src/Execution/Artifact/ArtifactRunRecord.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Execution\Artifact;
+
+/**
+ * Contains validated ownership and completion metadata for one artifact run.
+ *
+ * @internal
+ */
+final readonly class ArtifactRunRecord
+{
+    /**
+     * @param non-empty-string $runId
+     * @param array<non-empty-string, array{bytes: int, sha256: non-empty-string}> $files
+     */
+    public function __construct(
+        public string $runId,
+        public int $startedAt,
+        public int $completedAt,
+        public array $files,
+        public int $bytes,
+    ) {}
+}

--- a/src/Execution/Artifact/ArtifactStore.php
+++ b/src/Execution/Artifact/ArtifactStore.php
@@ -543,13 +543,7 @@ final class ArtifactStore
             }
         }
 
-        try {
-            $report = $this->retention->prune(protectedRunId: $protectedRunId);
-        } catch (\Throwable) {
-            $warnings[] = 'Greenlight did not apply the artifact retention policy.';
-
-            return new ArtifactPruneReport(warnings: $warnings);
-        }
+        $report = $this->retention->prune(protectedRunId: $protectedRunId);
 
         return new ArtifactPruneReport($report->items, [...$warnings, ...$report->warnings]);
     }

--- a/src/Execution/Artifact/ArtifactStore.php
+++ b/src/Execution/Artifact/ArtifactStore.php
@@ -26,6 +26,8 @@ final class ArtifactStore
 
     private bool $cleaned = false;
 
+    private ?ArtifactRunHandle $runHandle = null;
+
     private function __construct(
         private readonly ArtifactSession $session,
         private readonly ArtifactConfiguration $configuration,
@@ -34,6 +36,7 @@ final class ArtifactStore
         private readonly FileCopier $fileCopier,
         /** @var (\Closure(TestResult, Attachment): bool)|null */
         private readonly ?\Closure $retainAttachment,
+        private readonly ?ArtifactRetention $retention,
     ) {}
 
     /**
@@ -48,30 +51,8 @@ final class ArtifactStore
         ?string $temporaryDirectory = null,
         ?\Closure $retainAttachment = null,
     ): self {
-        $configured = \rtrim($configuration->directory, '/');
-
-        if ($configured === '' || \str_contains($configured, "\0")) {
-            throw AttachmentError::storage('Attachment output directory is invalid');
-        }
-
-        if (!\str_starts_with($configured, '/')
-            && \in_array('..', \explode('/', $configured), true)
-        ) {
-            throw AttachmentError::storage('Keep a relative attachment output directory inside the working directory');
-        }
-
-        if (\str_starts_with($configured, '/')
-            && ($resolved = ErrorTrap::run(static fn() => \realpath($configured))) !== false
-        ) {
-            $configured = $resolved;
-        }
-
-        $public = $configured . '/' . $runId;
-        $resolvedWorkingDirectory = ErrorTrap::run(static fn() => \realpath($workingDirectory));
-        $workingDirectory = $resolvedWorkingDirectory === false ? $workingDirectory : $resolvedWorkingDirectory;
-        $output = \str_starts_with($configured, '/')
-            ? $public
-            : \rtrim($workingDirectory, '/') . '/' . $public;
+        $retention = ArtifactRetention::forConfiguration($configuration, $workingDirectory);
+        $output = $retention->runDirectory($runId);
         $temporaryDirectory ??= \sys_get_temp_dir();
         $staging = \rtrim($temporaryDirectory, '/') . '/greenlight-artifacts-'
             . \substr(\hash('sha256', $runId), 0, 16)
@@ -83,6 +64,7 @@ final class ArtifactStore
             true,
             $fileCopier ?? new NativeFileCopier(),
             $retainAttachment,
+            $retention,
         );
     }
 
@@ -97,6 +79,7 @@ final class ArtifactStore
             null,
             false,
             $fileCopier ?? new NativeFileCopier(),
+            null,
             null,
         );
     }
@@ -380,16 +363,20 @@ final class ArtifactStore
 
             $storageKey = $attachment->storageKey;
             $this->assertSafeStorageKey($storageKey);
+            $destination = $this->outputDirectory . '/' . $storageKey;
+            if ($this->pathExists($destination)) {
+                throw AttachmentError::storage('An attachment output path already exists');
+            }
+            $this->assertOutputPathSafe(\dirname($destination));
+            $this->ensureRunDirectory();
 
             $source = $this->session->stagingDirectory . '/' . $storageKey;
-            $destination = $this->outputDirectory . '/' . $storageKey;
             $parent = \dirname($destination);
             $part = $destination . '.part-' . \bin2hex(\random_bytes(4));
 
             $this->createDirectorySafely($parent);
 
-            if (\file_exists($destination) || \is_link($destination)
-                || \file_exists($part) || \is_link($part)
+            if ($this->pathExists($destination) || $this->pathExists($part)
             ) {
                 throw AttachmentError::storage('An attachment output path already exists');
             }
@@ -509,6 +496,7 @@ final class ArtifactStore
         }
 
         $this->cleaned = true;
+        $this->runHandle?->close();
         $directory = $this->session->stagingDirectory;
 
         if (!\is_dir($directory)) {
@@ -535,6 +523,35 @@ final class ArtifactStore
         }
 
         ErrorTrap::run(static fn() => \rmdir($directory));
+    }
+
+    public function complete(): ArtifactPruneReport
+    {
+        if (!$this->ownsStaging || !$this->retention instanceof ArtifactRetention) {
+            return new ArtifactPruneReport();
+        }
+
+        $warnings = [];
+        $protectedRunId = null;
+        if ($this->runHandle instanceof ArtifactRunHandle) {
+            $protectedRunId = $this->runHandle->runId;
+            try {
+                $this->runHandle->complete();
+            } catch (\Throwable) {
+                $warnings[] = 'Greenlight did not complete artifact run metadata. This run is not eligible for pruning.';
+                $this->runHandle->close();
+            }
+        }
+
+        try {
+            $report = $this->retention->prune(protectedRunId: $protectedRunId);
+        } catch (\Throwable) {
+            $warnings[] = 'Greenlight did not apply the artifact retention policy.';
+
+            return new ArtifactPruneReport(warnings: $warnings);
+        }
+
+        return new ArtifactPruneReport($report->items, [...$warnings, ...$report->warnings]);
     }
 
     /**
@@ -811,6 +828,11 @@ final class ArtifactStore
         return $this->session->stagingDirectory . '/' . $storageKey . '.meta.json';
     }
 
+    private function pathExists(string $path): bool
+    {
+        return \file_exists($path) || \is_link($path);
+    }
+
     /**
      * @throws AttachmentError
      */
@@ -833,28 +855,63 @@ final class ArtifactStore
      */
     private function createDirectorySafely(string $directory): void
     {
-        $absolute = \str_starts_with($directory, '/');
-        $current = $absolute ? '/' : '';
-
-        foreach (\explode('/', \trim($directory, '/')) as $segment) {
-            $current = $current === '/' ? '/' . $segment : ($current === '' ? $segment : $current . '/' . $segment);
-
-            if (\is_link($current)) {
+        $missing = [];
+        $current = $directory;
+        while (\str_starts_with($current . '/', $this->session->publicDirectory . '/')) {
+            if (ErrorTrap::run(static fn() => \is_link($current))) {
                 throw AttachmentError::storage('Attachment output directory contains a symbolic link');
             }
-
-            if (\is_dir($current)) {
-                continue;
-            }
-
-            if (\file_exists($current)) {
+            $isDirectory = ErrorTrap::run(static fn() => \is_dir($current));
+            if (ErrorTrap::run(static fn() => \file_exists($current)) && !$isDirectory) {
                 throw AttachmentError::storage('Attachment output path contains a non-directory entry');
             }
-            $created = ErrorTrap::run(static fn() => \mkdir($current, 0o700), $warning);
+            if (!$isDirectory) {
+                $missing[] = $current;
+            }
+            if ($current === $this->session->publicDirectory) {
+                break;
+            }
+            $current = \dirname($current);
+        }
 
-            if (!$created) {
+        foreach (\array_reverse($missing) as $path) {
+            if (!ErrorTrap::run(static fn() => \mkdir($path, 0o700), $warning)) {
                 throw AttachmentError::storage('Failed to create attachment output directory' . ($warning === null ? '' : ': ' . $warning));
             }
         }
+    }
+
+    /** @throws AttachmentError */
+    private function assertOutputPathSafe(string $directory): void
+    {
+        $current = $directory;
+        while (\str_starts_with($current . '/', $this->session->publicDirectory . '/')) {
+            if (ErrorTrap::run(static fn() => \is_link($current))) {
+                throw AttachmentError::storage('Attachment output directory contains a symbolic link');
+            }
+            if (ErrorTrap::run(static fn() => \file_exists($current))
+                && !ErrorTrap::run(static fn() => \is_dir($current))
+            ) {
+                throw AttachmentError::storage('Attachment output path contains a non-directory entry');
+            }
+            if ($current === $this->session->publicDirectory) {
+                break;
+            }
+            $current = \dirname($current);
+        }
+    }
+
+    /** @throws AttachmentError */
+    private function ensureRunDirectory(): void
+    {
+        if ($this->runHandle instanceof ArtifactRunHandle) {
+            return;
+        }
+        if (!$this->retention instanceof ArtifactRetention) {
+            throw AttachmentError::storage('A worker attempted to create an artifact run directory');
+        }
+
+        $runId = \basename($this->session->publicDirectory);
+        $this->runHandle = $this->retention->begin($runId);
     }
 }

--- a/src/Execution/ArtifactMaintenance.php
+++ b/src/Execution/ArtifactMaintenance.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Execution;
+
+use Greenlight\Artifact\AttachmentError;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Execution\Artifact\ArtifactRetention;
+
+/**
+ * Applies artifact retention without exposing run publication internals.
+ *
+ * @internal
+ */
+final readonly class ArtifactMaintenance
+{
+    private function __construct(private ArtifactRetention $retention) {}
+
+    /** @throws AttachmentError */
+    public static function forConfiguration(ArtifactConfiguration $configuration, string $workingDirectory): self
+    {
+        return new self(ArtifactRetention::forConfiguration($configuration, $workingDirectory));
+    }
+
+    public function prune(bool $dryRun): ArtifactMaintenanceReport
+    {
+        $report = $this->retention->prune($dryRun);
+        $items = [];
+        foreach ($report->items as $item) {
+            $items[] = new ArtifactMaintenanceItem($item->directory, $item->bytes, $item->reasons);
+        }
+
+        return new ArtifactMaintenanceReport($items, $report->warnings, $report->dryRun);
+    }
+}

--- a/src/Execution/ArtifactMaintenanceItem.php
+++ b/src/Execution/ArtifactMaintenanceItem.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Execution;
+
+/**
+ * Describes one completed artifact run that maintenance selects.
+ *
+ * @internal
+ */
+final readonly class ArtifactMaintenanceItem
+{
+    /**
+     * @param non-empty-string $directory
+     * @param non-empty-list<'age'|'count'|'size'> $reasons
+     */
+    public function __construct(
+        public string $directory,
+        public int $bytes,
+        public array $reasons,
+    ) {}
+}

--- a/src/Execution/ArtifactMaintenanceReport.php
+++ b/src/Execution/ArtifactMaintenanceReport.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Execution;
+
+/**
+ * Contains selected runs and advisory failures from artifact maintenance.
+ *
+ * @internal
+ */
+final readonly class ArtifactMaintenanceReport
+{
+    /**
+     * @param list<ArtifactMaintenanceItem> $items
+     * @param list<non-empty-string> $warnings
+     */
+    public function __construct(
+        public array $items = [],
+        public array $warnings = [],
+        public bool $dryRun = false,
+    ) {}
+}

--- a/src/Execution/RunCoordinator.php
+++ b/src/Execution/RunCoordinator.php
@@ -94,6 +94,8 @@ final readonly class RunCoordinator
                 $summary = new ResultSummary();
                 $sink->emit(new RunFinished($runId, $summary, $durationSeconds, \microtime(true)));
 
+                $artifacts->complete();
+
                 return new RunResult($summary, 0, $durationSeconds, $seed);
             }
 
@@ -155,6 +157,8 @@ final readonly class RunCoordinator
             if ($cleanupFailures !== []) {
                 throw IntegrationFixtureError::cleanup($cleanupFailures);
             }
+
+            $artifacts->complete();
 
             return $result;
         } finally {

--- a/tests/Acceptance/ArtifactRunRetentionTest.php
+++ b/tests/Acceptance/ArtifactRunRetentionTest.php
@@ -102,6 +102,87 @@ final readonly class ArtifactRunRetentionTest
         Expect::that(\is_dir($project->path('artifacts/run-first')))->toBeFalse();
     }
 
+    #[Test]
+    public function maintenanceCommandReportsEmptyAndInvalidConfigurations(): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'artifact-prune-empty');
+        $project->writeFile('greenlight.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Config\GreenlightConfig;
+
+            return GreenlightConfig::create();
+            PHP);
+
+        $noPolicy = GreenlightCli::run($project->directory, ['artifacts:prune', '--no-ansi']);
+        $missingConfig = GreenlightCli::run($project->directory, [
+            'artifacts:prune',
+            '--config=missing.php',
+            '--no-ansi',
+        ]);
+        $emptyDirectory = GreenlightCli::run($project->directory, [
+            'artifacts:prune',
+            '--artifacts-dir=',
+            '--no-ansi',
+        ]);
+
+        Expect::that($noPolicy->exitCode)->toBe(0);
+        Expect::that($noPolicy->stdout)->toContain('No artifact retention policy is configured.');
+        Expect::that($missingConfig->exitCode)->toBe(1);
+        Expect::that($missingConfig->output())->toContain('missing.php');
+        Expect::that($emptyDirectory->exitCode)->toBe(64);
+        Expect::that($emptyDirectory->output())->toContain('--artifacts-dir requires a value.');
+
+        $project->writeFile('greenlight.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Config\ArtifactBuilder;
+            use Greenlight\Config\GreenlightConfig;
+
+            return GreenlightConfig::create()
+                ->artifacts(static fn(ArtifactBuilder $artifacts) => $artifacts
+                    ->directory(__DIR__ . '/artifacts')
+                    ->maxCompletedRuns(1));
+            PHP);
+
+        $dryRun = GreenlightCli::run($project->directory, ['artifacts:prune', '--dry-run', '--no-ansi']);
+        $prune = GreenlightCli::run($project->directory, ['artifacts:prune', '--no-ansi']);
+
+        Expect::that($dryRun->stdout)->toContain('No completed artifact runs would be pruned.');
+        Expect::that($prune->stdout)->toContain('No completed artifact runs were pruned.');
+    }
+
+    #[Test]
+    public function maintenanceCommandReportsANoncanonicalParent(): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'artifact-prune-warning');
+        \mkdir($project->path('artifacts'));
+        $project->writeFile('greenlight.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Config\ArtifactBuilder;
+            use Greenlight\Config\GreenlightConfig;
+
+            return GreenlightConfig::create()
+                ->artifacts(static fn(ArtifactBuilder $artifacts) => $artifacts
+                    ->directory(__DIR__ . '/artifacts/.')
+                    ->maxCompletedRuns(1));
+            PHP);
+
+        $result = GreenlightCli::run($project->directory, ['artifacts:prune', '--no-ansi']);
+
+        Expect::that($result->exitCode)->toBe(0);
+        Expect::that($result->stdout)->toContain('No completed artifact runs were pruned.');
+        Expect::that($result->stderr)
+            ->toContain('Greenlight did not prune artifacts because the artifact parent is not canonical.');
+    }
+
     private function writeCompletedRun(string $parent, string $runId, int $completedAt): void
     {
         if (!\is_dir($parent)) {

--- a/tests/Acceptance/ArtifactRunRetentionTest.php
+++ b/tests/Acceptance/ArtifactRunRetentionTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\GreenlightCli;
+
+final readonly class ArtifactRunRetentionTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function completedRunsApplyTheConfiguredPolicyAutomatically(): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'automatic-artifact-retention');
+        $project->writeFile('tests/RetainedArtifactTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace AcceptanceArtifactRetention;
+
+            use Greenlight\Artifact\AttachmentRetention;
+            use Greenlight\Artifact\Attachments;
+            use Greenlight\Attribute\Test;
+
+            final readonly class RetainedArtifactTest
+            {
+                public function __construct(private Attachments $attachments) {}
+
+                #[Test]
+                public function publishesEvidence(): void
+                {
+                    $this->attachments->text('evidence.txt', 'retained', retention: AttachmentRetention::Always);
+                }
+            }
+            PHP);
+        $project->writeFile('greenlight.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Config\ArtifactBuilder;
+            use Greenlight\Config\GreenlightConfig;
+
+            require_once __DIR__ . '/tests/RetainedArtifactTest.php';
+
+            return GreenlightConfig::create()
+                ->paths([__DIR__ . '/tests'])
+                ->workers(1)
+                ->artifacts(static fn(ArtifactBuilder $artifacts) => $artifacts
+                    ->directory(__DIR__ . '/artifacts')
+                    ->maxCompletedRuns(1));
+            PHP);
+
+        $first = GreenlightCli::run($project->directory, ['run', '--no-ansi']);
+        $second = GreenlightCli::run($project->directory, ['run', '--no-ansi']);
+        $runs = \glob($project->path('artifacts/*'), \GLOB_ONLYDIR);
+        $runs = $runs === false ? [] : $runs;
+
+        Expect::that($first->exitCode)->toBe(0);
+        Expect::that($second->exitCode)->toBe(0);
+        Expect::that($runs)
+            ->because('run completion MUST apply the configured completed-run count')
+            ->toHaveCount(1);
+        Expect::that(\is_file(($runs[0] ?? '') . '/.greenlight-run.json'))->toBeTrue();
+    }
+
+    #[Test]
+    public function maintenanceCommandSupportsDryRunAndReportsDeletion(): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'artifact-prune-command');
+        $project->writeFile('greenlight.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Config\ArtifactBuilder;
+            use Greenlight\Config\GreenlightConfig;
+
+            return GreenlightConfig::create()
+                ->artifacts(static fn(ArtifactBuilder $artifacts) => $artifacts
+                    ->directory(__DIR__ . '/artifacts')
+                    ->maxCompletedRuns(1));
+            PHP);
+        $this->writeCompletedRun($project->path('artifacts'), 'run-first', 10);
+        $this->writeCompletedRun($project->path('artifacts'), 'run-second', 20);
+
+        $dryRun = GreenlightCli::run($project->directory, ['artifacts:prune', '--dry-run', '--no-ansi']);
+        $prune = GreenlightCli::run($project->directory, ['artifacts:prune', '--no-ansi']);
+
+        Expect::that($dryRun->exitCode)->toBe(0);
+        Expect::that($dryRun->stdout)->toContain('Would prune')->toContain('run-first')->toContain('count limit');
+        Expect::that(\is_dir($project->path('artifacts/run-second')))->toBeTrue();
+        Expect::that($prune->exitCode)->toBe(0);
+        Expect::that($prune->stdout)->toContain('Pruned')->toContain('run-first');
+        Expect::that(\is_dir($project->path('artifacts/run-first')))->toBeFalse();
+    }
+
+    private function writeCompletedRun(string $parent, string $runId, int $completedAt): void
+    {
+        if (!\is_dir($parent)) {
+            \mkdir($parent, 0o700, true);
+        }
+        $directory = $parent . '/' . $runId;
+        \mkdir($directory, 0o700);
+        \file_put_contents($directory . '/evidence.txt', $runId);
+        \file_put_contents($directory . '/.greenlight-run.lock', '');
+        \file_put_contents($directory . '/.greenlight-run.json', \json_encode([
+            'version' => 1,
+            'owner' => 'greenlight',
+            'runId' => $runId,
+            'state' => 'completed',
+            'startedAt' => 1,
+            'completedAt' => $completedAt,
+            'files' => [
+                'evidence.txt' => [
+                    'bytes' => \strlen($runId),
+                    'sha256' => \hash('sha256', $runId),
+                ],
+            ],
+        ], \JSON_THROW_ON_ERROR));
+    }
+}

--- a/tests/Acceptance/CompletionTest.php
+++ b/tests/Acceptance/CompletionTest.php
@@ -22,6 +22,7 @@ final readonly class CompletionTest
         Expect::that($result->exitCode)->because('prints a script per shell and rejects unknown shells')->toBe(0);
         Expect::that($result->stdout)->toContain('_greenlight_completions')
             ->toContain('coverage:diff')
+            ->toContain('artifacts:prune')
             ->toContain('--detect-leaks')
             ->toContain('teamcity');
 

--- a/tests/Unit/Cli/Configuration/ArtifactDirectoryOverrideTest.php
+++ b/tests/Unit/Cli/Configuration/ArtifactDirectoryOverrideTest.php
@@ -24,7 +24,10 @@ final class ArtifactDirectoryOverrideTest
                 ->maxAttachmentSize('11K')
                 ->maxTestSize('13K')
                 ->maxRunAttachments(17)
-                ->maxRunSize('19K'))
+                ->maxRunSize('19K')
+                ->maxCompletedRuns(23)
+                ->maxCompletedRunAge(29)
+                ->maxRetainedSize('31K'))
             ->build();
 
         $resolved = ConfigurationResolver::resolve(
@@ -41,6 +44,9 @@ final class ArtifactDirectoryOverrideTest
                 'maxTestBytes' => 13 * 1024,
                 'maxRunAttachments' => 17,
                 'maxRunBytes' => 19 * 1024,
+                'maxCompletedRuns' => 23,
+                'maxCompletedRunAgeSeconds' => 29,
+                'maxRetainedBytes' => 31 * 1024,
             ]);
     }
 }

--- a/tests/Unit/Cli/Input/CompletionScriptsTest.php
+++ b/tests/Unit/Cli/Input/CompletionScriptsTest.php
@@ -19,7 +19,7 @@ final class CompletionScriptsTest
     {
         $script = (string) $this->scripts()->render($shell);
 
-        foreach (['run', 'list-tests', 'coverage:diff', 'profile:report', 'ide-helper', 'completion'] as $command) {
+        foreach (['run', 'list-tests', 'coverage:diff', 'profile:report', 'artifacts:prune', 'ide-helper', 'completion'] as $command) {
             // The zsh _describe entries use an escape before the colon in a
             // command name.
             Expect::that($script)->toContain($shell === 'zsh' ? \str_replace(':', '\:', $command) : $command);
@@ -37,6 +37,7 @@ final class CompletionScriptsTest
             ->toContain('List each found test ID, one per line')
             ->toContain('Compare two coverage JSON exports')
             ->toContain('Create a run profile from a saved JSONL stream')
+            ->toContain('Apply configured artifact retention')
             ->toContain('Write the IDE autocomplete helper for extension matchers')
             ->toContain('Print a shell completion script to standard output');
     }

--- a/tests/Unit/Config/ArtifactBuilderTest.php
+++ b/tests/Unit/Config/ArtifactBuilderTest.php
@@ -24,6 +24,32 @@ final class ArtifactBuilderTest
             ->toBe('0');
     }
 
+    #[Test]
+    public function retentionIsUnboundedUntilAUserConfiguresIt(): void
+    {
+        $configuration = new ArtifactBuilder()->toConfiguration();
+
+        Expect::that($configuration->maxCompletedRuns)->toBe(null);
+        Expect::that($configuration->maxCompletedRunAgeSeconds)->toBe(null);
+        Expect::that($configuration->maxRetainedBytes)->toBe(null);
+        Expect::that($configuration->hasRetentionPolicy())->toBeFalse();
+    }
+
+    #[Test]
+    public function buildsEachCompletedRunRetentionLimit(): void
+    {
+        $configuration = new ArtifactBuilder()
+            ->maxCompletedRuns(4)
+            ->maxCompletedRunAge(3_600)
+            ->maxRetainedSize('2M')
+            ->toConfiguration();
+
+        Expect::that($configuration->maxCompletedRuns)->toBe(4);
+        Expect::that($configuration->maxCompletedRunAgeSeconds)->toBe(3_600);
+        Expect::that($configuration->maxRetainedBytes)->toBe(2 * 1024 * 1024);
+        Expect::that($configuration->hasRetentionPolicy())->toBeTrue();
+    }
+
     /**
      * @param \Closure(ArtifactBuilder): void $configure
      */
@@ -69,6 +95,20 @@ final class ArtifactBuilderTest
                 $builder->maxRunAttachments(-1); // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
             },
             'Artifact count per run must be at least 1.',
+        ];
+
+        yield 'zero completed runs' => [
+            static function (ArtifactBuilder $builder): void {
+                $builder->maxCompletedRuns(0); // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
+            },
+            'Completed artifact run count must be at least 1.',
+        ];
+
+        yield 'zero completed run age' => [
+            static function (ArtifactBuilder $builder): void {
+                $builder->maxCompletedRunAge(0); // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
+            },
+            'Completed artifact run age must be at least 1 second.',
         ];
     }
 }

--- a/tests/Unit/Config/ArtifactConfigurationWireTest.php
+++ b/tests/Unit/Config/ArtifactConfigurationWireTest.php
@@ -23,6 +23,9 @@ final class ArtifactConfigurationWireTest
             maxTestBytes: 33,
             maxRunAttachments: 44,
             maxRunBytes: 55,
+            maxCompletedRuns: 66,
+            maxCompletedRunAgeSeconds: 77,
+            maxRetainedBytes: 88,
         );
 
         $restored = ArtifactConfiguration::fromWire(
@@ -73,6 +76,9 @@ final class ArtifactConfigurationWireTest
             'max test bytes' => 'maxTestBytes',
             'max run attachments' => 'maxRunAttachments',
             'max run bytes' => 'maxRunBytes',
+            'maximum completed runs' => 'maxCompletedRuns',
+            'maximum completed run age' => 'maxCompletedRunAgeSeconds',
+            'maximum retained bytes' => 'maxRetainedBytes',
         ] as $label => $field) {
             yield $label . ': zero' => [$field, 0];
             yield $label . ': negative' => [$field, -1];

--- a/tests/Unit/Execution/Artifact/ArtifactRetentionTest.php
+++ b/tests/Unit/Execution/Artifact/ArtifactRetentionTest.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Execution\Artifact;
 
+use Greenlight\Artifact\AttachmentError;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Execution\Artifact\ArtifactRetention;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Test\Cleanup;
+use Greenlight\Test\SkipTest;
 
 final readonly class ArtifactRetentionTest
 {
@@ -265,6 +267,221 @@ final readonly class ArtifactRetentionTest
                 ['run-counted', ['count']],
                 ['run-sized', ['size']],
             ]);
+    }
+
+    #[Test]
+    public function beginRejectsUnsafeAndExistingRunDirectories(): void
+    {
+        $parent = $this->tempDirectory->subdirectory('retention-begin-errors');
+        $retention = $this->retention($parent, maxCompletedRuns: 1);
+
+        Expect::that(static fn() => $retention->begin('../outside'))
+            ->toThrow(AttachmentError::class, message: 'Artifact run ID is unsafe.');
+
+        \mkdir($parent . '/run-existing');
+        Expect::that(static fn() => $retention->begin('run-existing'))
+            ->toThrow(AttachmentError::class);
+    }
+
+    #[Test]
+    public function parentPathValidationRejectsUnsafeFilesystemShapes(): void
+    {
+        $base = $this->tempDirectory->subdirectory('retention-parent-errors');
+        $outside = $this->tempDirectory->subdirectory('retention-parent-target');
+        \symlink($outside, $base . '/linked');
+        \file_put_contents($base . '/blocked', 'file');
+
+        $linkedParent = $this->retention($base . '/linked', maxCompletedRuns: 1);
+        Expect::that(static fn() => $linkedParent->begin('run'))
+            ->toThrow(AttachmentError::class, message: 'Attachment output directory contains a symbolic link.');
+
+        $linkedAncestor = $this->retention($base . '/linked/artifacts', maxCompletedRuns: 1);
+        Expect::that(static fn() => $linkedAncestor->begin('run'))
+            ->toThrow(AttachmentError::class, message: 'Attachment output directory contains a symbolic link.');
+
+        $fileAncestor = $this->retention($base . '/blocked/artifacts', maxCompletedRuns: 1);
+        Expect::that(static fn() => $fileAncestor->begin('run'))
+            ->toThrow(AttachmentError::class, message: 'Attachment output path contains a non-directory entry.');
+
+        $noncanonical = $this->retention($base . '/.', maxCompletedRuns: 1);
+        Expect::that(static fn() => $noncanonical->begin('run'))
+            ->toThrow(AttachmentError::class, message: 'Artifact parent directory is not canonical.');
+    }
+
+    #[Test]
+    public function aBlockedPruneLockIsAdvisory(): void
+    {
+        $parent = $this->tempDirectory->subdirectory('retention-prune-lock');
+        $retention = $this->retention($parent, maxCompletedRuns: 1);
+        \mkdir($parent . '/.greenlight-prune.lock');
+
+        $report = $retention->prune();
+
+        Expect::that($report->warnings)
+            ->toBe(['Greenlight did not lock the artifact parent for pruning.']);
+    }
+
+    #[Test]
+    public function malformedRecordShapesRemainIneligible(): void
+    {
+        $parent = $this->tempDirectory->subdirectory('retention-record-shapes');
+        $retention = $this->retention($parent, maxCompletedRunAgeSeconds: 1);
+        \mkdir($parent . '/unsafe name');
+        $this->metadataDirectory($parent, 'run-missing-metadata', '');
+        \unlink($parent . '/run-missing-metadata/' . ArtifactRetention::METADATA_FILE);
+        $this->metadataDirectory($parent, 'run-empty-metadata', '');
+        $this->metadataDirectory($parent, 'run-list-metadata', '[]');
+        $this->metadataDirectory($parent, 'run-numeric-key', '{"0":"value"}');
+
+        $report = $retention->prune(now: 100);
+
+        Expect::that($report->items)->toBe([]);
+        Expect::that(\is_dir($parent . '/unsafe name'))->toBeTrue();
+        Expect::that(\is_dir($parent . '/run-missing-metadata'))->toBeTrue();
+        Expect::that(\is_dir($parent . '/run-empty-metadata'))->toBeTrue();
+        Expect::that(\is_dir($parent . '/run-list-metadata'))->toBeTrue();
+        Expect::that(\is_dir($parent . '/run-numeric-key'))->toBeTrue();
+    }
+
+    #[Test]
+    public function manifestAndMetadataFailuresAreExplicit(): void
+    {
+        $parent = $this->tempDirectory->subdirectory('retention-content-errors');
+        $unowned = $parent . '/unowned-directory';
+        \mkdir($unowned);
+        \mkdir($unowned . '/empty');
+        Expect::that(static fn() => ArtifactRetention::contentManifest($unowned))
+            ->toThrow(\RuntimeException::class, message: 'Artifact run content contains an unowned directory.');
+
+        $unsafe = $parent . '/unsafe-path';
+        \mkdir($unsafe);
+        \file_put_contents($unsafe . '/bad\\name', 'content');
+        Expect::that(static fn() => ArtifactRetention::contentManifest($unsafe))
+            ->toThrow(\RuntimeException::class, message: 'Artifact run content contains an unsafe path.');
+
+        $readFailure = $parent . '/read-failure';
+        \mkdir($readFailure);
+        \file_put_contents($readFailure . '/unreadable.txt', 'content');
+        \chmod($readFailure . '/unreadable.txt', 0o000);
+        try {
+            Expect::that(static fn() => ArtifactRetention::contentManifest($readFailure))
+                ->toThrow(\RuntimeException::class, message: 'Greenlight did not read artifact run content.');
+        } finally {
+            \chmod($readFailure . '/unreadable.txt', 0o600);
+        }
+
+        $unwritable = $parent . '/unwritable';
+        \mkdir($unwritable);
+        \chmod($unwritable, 0o500);
+        try {
+            Expect::that(static fn() => ArtifactRetention::writeMetadata($unwritable, []))
+                ->toThrow(\RuntimeException::class, message: 'Greenlight did not write artifact run metadata.');
+        } finally {
+            \chmod($unwritable, 0o700);
+        }
+
+        $blockedTarget = $parent . '/blocked-target';
+        \mkdir($blockedTarget);
+        \mkdir($blockedTarget . '/' . ArtifactRetention::METADATA_FILE);
+        Expect::that(static fn() => ArtifactRetention::writeMetadata($blockedTarget, []))
+            ->toThrow(\RuntimeException::class, message: 'Greenlight did not finalize artifact run metadata.');
+    }
+
+    #[Test]
+    public function runHandleCompletionIsIdempotentAndValidatesActiveMetadata(): void
+    {
+        $parent = $this->tempDirectory->subdirectory('retention-handle');
+        $retention = $this->retention($parent, maxCompletedRuns: 1);
+        $handle = $retention->begin('run-valid');
+        $handle->complete();
+        $handle->complete();
+
+        $invalid = $retention->begin('run-invalid');
+        ArtifactRetention::writeMetadata($invalid->directory, []);
+        Expect::that($invalid->complete(...))
+            ->toThrow(\RuntimeException::class, message: 'Artifact run metadata is not an active Greenlight record.');
+        $invalid->close();
+    }
+
+    #[Test]
+    public function aReadOnlyNestedDirectoryMakesCleanupAdvisory(): void
+    {
+        $parent = $this->tempDirectory->subdirectory('retention-nested-cleanup-failure');
+        $retention = $this->retention($parent, maxCompletedRunAgeSeconds: 1);
+        $handle = $retention->begin('run-read-only-nested');
+        \mkdir($handle->directory . '/nested');
+        \file_put_contents($handle->directory . '/nested/evidence.txt', 'owned');
+        $handle->complete();
+        \chmod($handle->directory . '/nested', 0o500);
+
+        try {
+            $report = $retention->prune(now: \PHP_INT_MAX);
+        } finally {
+            $directory = \is_dir($handle->directory)
+                ? $handle->directory
+                : $parent . '/.greenlight-prune-recovery';
+            if (\is_dir($directory . '/nested')) {
+                \chmod($directory . '/nested', 0o700);
+            }
+            $claims = \glob($parent . '/.greenlight-prune-*', \GLOB_ONLYDIR);
+            foreach ($claims === false ? [] : $claims as $claim) {
+                if (\is_dir($claim . '/nested')) {
+                    \chmod($claim . '/nested', 0o700);
+                }
+            }
+        }
+
+        Expect::that($report->items)->toBe([]);
+        Expect::that($report->warnings)->toBe([
+            'Greenlight did not prune artifact run "run-read-only-nested".',
+        ]);
+    }
+
+    #[Test]
+    public function anUnreadableParentMakesPolicyFailureAdvisory(): void
+    {
+        $parent = $this->tempDirectory->subdirectory('retention-unreadable-parent');
+        $retention = $this->retention($parent, maxCompletedRuns: 1);
+        \chmod($parent, 0o000);
+
+        try {
+            $report = $retention->prune();
+        } finally {
+            \chmod($parent, 0o700);
+        }
+
+        Expect::that($report->warnings)->toBe([
+            'Greenlight did not lock the artifact parent for pruning.',
+        ]);
+    }
+
+    #[Test]
+    public function aSatisfiedByteLimitKeepsCompletedRuns(): void
+    {
+        $parent = $this->tempDirectory->subdirectory('retention-satisfied-size');
+        $retention = $this->retention($parent, maxRetainedBytes: \PHP_INT_MAX);
+        $this->completedRun($retention, 'run-kept', 10, 'owned');
+
+        $report = $retention->prune(now: 20);
+
+        Expect::that($report->items)->toBe([]);
+        Expect::that(\is_dir($parent . '/run-kept'))->toBeTrue();
+    }
+
+    #[Test]
+    public function manifestRejectsUnsupportedFilesystemEntries(): void
+    {
+        if (!\function_exists('posix_mkfifo')) {
+            throw new SkipTest('The posix extension is not available.');
+        }
+
+        $directory = $this->tempDirectory->subdirectory('retention-unsupported-entry');
+        if (!\posix_mkfifo($directory . '/pipe', 0o600)) {
+            throw new SkipTest('The filesystem did not create a named pipe.');
+        }
+
+        Expect::that(static fn() => ArtifactRetention::contentManifest($directory))
+            ->toThrow(\RuntimeException::class, message: 'Artifact run content contains an unsupported filesystem entry.');
     }
 
     private function retention(

--- a/tests/Unit/Execution/Artifact/ArtifactRetentionTest.php
+++ b/tests/Unit/Execution/Artifact/ArtifactRetentionTest.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Execution\Artifact;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Execution\Artifact\ArtifactRetention;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Test\Cleanup;
+
+final readonly class ArtifactRetentionTest
+{
+    public function __construct(
+        private TemporaryDirectory $tempDirectory,
+        private Cleanup $cleanup,
+    ) {}
+
+    #[Test]
+    public function countPolicyPrunesTheOldestCompletedRunFirst(): void
+    {
+        $parent = $this->tempDirectory->subdirectory('retention-count');
+        $retention = $this->retention($parent, maxCompletedRuns: 2);
+        $this->completedRun($retention, 'run-oldest', 10, 'one');
+        $this->completedRun($retention, 'run-middle', 20, 'two');
+        $this->completedRun($retention, 'run-newest', 30, 'three');
+
+        $report = $retention->prune(now: 40);
+
+        Expect::that(\array_map(static fn($item): string => $item->runId, $report->items))
+            ->because('the count policy MUST select completed runs in deterministic oldest-first order')
+            ->toBe(['run-oldest']);
+        Expect::that($report->items[0]->reasons)->toBe(['count']);
+        Expect::that(\is_dir($parent . '/run-oldest'))->toBeFalse();
+        Expect::that(\is_dir($parent . '/run-middle'))->toBeTrue();
+        Expect::that(\is_dir($parent . '/run-newest'))->toBeTrue();
+    }
+
+    #[Test]
+    public function agePolicyDoesNotTreatFutureCompletionAsOld(): void
+    {
+        $parent = $this->tempDirectory->subdirectory('retention-age');
+        $retention = $this->retention($parent, maxCompletedRunAgeSeconds: 10);
+        $this->completedRun($retention, 'run-past', 80, 'past');
+        $this->completedRun($retention, 'run-future', 110, 'future');
+
+        $report = $retention->prune(now: 100);
+
+        Expect::that(\array_map(static fn($item): string => $item->runId, $report->items))->toBe(['run-past']);
+        Expect::that(\is_dir($parent . '/run-future'))
+            ->because('a clock change MUST NOT make a future completion eligible for age pruning')
+            ->toBeTrue();
+    }
+
+    #[Test]
+    public function dryRunReportsSelectionWithoutDeletingContent(): void
+    {
+        $parent = $this->tempDirectory->subdirectory('retention-dry-run');
+        $retention = $this->retention($parent, maxCompletedRuns: 1);
+        $this->completedRun($retention, 'run-first', 10, 'first');
+        $this->completedRun($retention, 'run-second', 20, 'second');
+
+        $report = $retention->prune(dryRun: true, now: 30);
+
+        Expect::that($report->dryRun)->toBeTrue();
+        Expect::that(\array_map(static fn($item): string => $item->runId, $report->items))->toBe(['run-first']);
+        Expect::that(\is_file($parent . '/run-first/evidence.txt'))->toBeTrue();
+        Expect::that(\is_file($parent . '/.greenlight-prune.lock'))
+            ->because('dry-run maintenance MUST NOT change the artifact parent')
+            ->toBeFalse();
+    }
+
+    #[Test]
+    public function activeAndIncompleteRunsAreNeverEligible(): void
+    {
+        $parent = $this->tempDirectory->subdirectory('retention-active');
+        $retention = $this->retention($parent, maxCompletedRunAgeSeconds: 1);
+        $active = $retention->begin('run-active');
+        $this->cleanup->defer($active->close(...));
+
+        $report = $retention->prune(now: \PHP_INT_MAX);
+        $active->close();
+        $secondReport = $retention->prune(now: \PHP_INT_MAX);
+
+        Expect::that($report->items)->toBe([]);
+        Expect::that($secondReport->items)
+            ->because('an unlocked active marker identifies an incomplete recoverable run')
+            ->toBe([]);
+        Expect::that(\is_dir($parent . '/run-active'))->toBeTrue();
+    }
+
+    #[Test]
+    public function unknownMalformedFutureAndChangedRunsRemainUntouched(): void
+    {
+        $parent = $this->tempDirectory->subdirectory('retention-unknown');
+        $retention = $this->retention($parent, maxCompletedRunAgeSeconds: 1);
+        \mkdir($parent . '/user-content');
+        \file_put_contents($parent . '/user-content/keep.txt', 'keep');
+        $this->metadataDirectory($parent, 'run-malformed', '{');
+        $this->metadataDirectory($parent, 'run-future-version', \json_encode([
+            'version' => ArtifactRetention::METADATA_VERSION + 1,
+            'owner' => ArtifactRetention::OWNER,
+            'runId' => 'run-future-version',
+            'state' => 'completed',
+            'startedAt' => 1,
+            'completedAt' => 2,
+            'files' => [],
+        ], \JSON_THROW_ON_ERROR));
+        $this->completedRun($retention, 'run-changed', 2, 'owned');
+        \file_put_contents($parent . '/run-changed/user.txt', 'user');
+
+        $report = $retention->prune(now: 100);
+
+        Expect::that($report->items)->toBe([]);
+        Expect::that(\file_get_contents($parent . '/user-content/keep.txt'))->toBe('keep');
+        Expect::that(\is_dir($parent . '/run-malformed'))->toBeTrue();
+        Expect::that(\is_dir($parent . '/run-future-version'))->toBeTrue();
+        Expect::that(\file_get_contents($parent . '/run-changed/user.txt'))
+            ->because('content that is absent from the completion manifest MUST NOT be deleted')
+            ->toBe('user');
+    }
+
+    #[Test]
+    public function symbolicLinksAndTheirTargetsRemainUntouched(): void
+    {
+        $parent = $this->tempDirectory->subdirectory('retention-symlink');
+        $outside = $this->tempDirectory->subdirectory('retention-symlink-target');
+        $sentinel = $outside . '/sentinel.txt';
+        \file_put_contents($sentinel, 'keep');
+        $retention = $this->retention($parent, maxCompletedRunAgeSeconds: 1);
+        $this->completedRun($retention, 'run-link', 2, 'owned');
+        \symlink($outside, $parent . '/run-link/external');
+        \symlink($outside, $parent . '/linked-run');
+
+        $report = $retention->prune(now: 100);
+
+        Expect::that($report->items)->toBe([]);
+        Expect::that(\file_get_contents($sentinel))
+            ->because('retention MUST NOT follow or remove a symbolic link target')
+            ->toBe('keep');
+        Expect::that(\is_link($parent . '/run-link/external'))->toBeTrue();
+        Expect::that(\is_link($parent . '/linked-run'))->toBeTrue();
+        Expect::that(static fn() => ArtifactRetention::contentManifest($parent . '/linked-run'))
+            ->because('manifest inspection MUST NOT follow a symbolic run root')
+            ->toThrow(\RuntimeException::class);
+    }
+
+    #[Test]
+    public function aConcurrentRunClaimMakesCleanupAdvisory(): void
+    {
+        $parent = $this->tempDirectory->subdirectory('retention-concurrent');
+        $retention = $this->retention($parent, maxCompletedRunAgeSeconds: 1);
+        $this->completedRun($retention, 'run-claimed', 2, 'owned');
+        $lock = \fopen($parent . '/run-claimed/' . ArtifactRetention::LOCK_FILE, 'r+');
+        if ($lock === false || !\flock($lock, \LOCK_EX | \LOCK_NB)) {
+            throw new \RuntimeException('The test did not claim the artifact run lock.');
+        }
+
+        try {
+            $report = $retention->prune(now: 100);
+        } finally {
+            \flock($lock, \LOCK_UN);
+            \fclose($lock);
+        }
+
+        Expect::that($report->items)->toBe([]);
+        Expect::that(\is_dir($parent . '/run-claimed'))
+            ->because('a concurrent claim MUST make the run ineligible for this prune operation')
+            ->toBeTrue();
+    }
+
+    #[Test]
+    public function sizePolicyUsesSaturatingOldestFirstAccounting(): void
+    {
+        $parent = $this->tempDirectory->subdirectory('retention-size');
+        $retention = $this->retention($parent, maxRetainedBytes: 1);
+        $this->completedRun($retention, 'run-one', 10, 'one');
+        $this->completedRun($retention, 'run-two', 20, 'two');
+
+        $report = $retention->prune(now: 30);
+
+        Expect::that(\array_map(static fn($item): string => $item->runId, $report->items))
+            ->because('the byte policy MUST select each required run in oldest-first order')
+            ->toBe(['run-one', 'run-two']);
+        Expect::that($report->items[0]->reasons)->toBe(['size']);
+        Expect::that($report->items[1]->reasons)->toBe(['size']);
+    }
+
+    #[Test]
+    public function traversalAndOverflowMetadataCannotClaimUserContent(): void
+    {
+        $parent = $this->tempDirectory->subdirectory('retention-malicious-metadata');
+        $outside = $this->tempDirectory->path() . '/outside.txt';
+        \file_put_contents($outside, 'keep');
+        $runId = 'run-malicious';
+        $this->metadataDirectory($parent, $runId, \json_encode([
+            'version' => ArtifactRetention::METADATA_VERSION,
+            'owner' => ArtifactRetention::OWNER,
+            'runId' => $runId,
+            'state' => 'completed',
+            'startedAt' => 1,
+            'completedAt' => 2,
+            'files' => [
+                '../outside.txt' => ['bytes' => \PHP_INT_MAX, 'sha256' => \str_repeat('0', 64)],
+            ],
+        ], \JSON_THROW_ON_ERROR));
+        $retention = $this->retention($parent, maxCompletedRunAgeSeconds: 1);
+
+        $report = $retention->prune(now: \PHP_INT_MAX);
+
+        Expect::that($report->items)->toBe([]);
+        Expect::that(\file_get_contents($outside))
+            ->because('traversal and oversized metadata MUST NOT select content outside the artifact parent')
+            ->toBe('keep');
+    }
+
+    #[Test]
+    public function cleanupFailureIsAdvisory(): void
+    {
+        $parent = $this->tempDirectory->subdirectory('retention-cleanup-failure');
+        $retention = $this->retention($parent, maxCompletedRunAgeSeconds: 1);
+        $this->completedRun($retention, 'run-read-only', 2, 'owned');
+        \chmod($parent . '/run-read-only', 0o500);
+
+        try {
+            $report = $retention->prune(now: 100);
+        } finally {
+            if (\is_dir($parent . '/run-read-only')) {
+                \chmod($parent . '/run-read-only', 0o700);
+            }
+            $claims = \glob($parent . '/.greenlight-prune-*', \GLOB_ONLYDIR);
+            foreach ($claims === false ? [] : $claims as $claim) {
+                \chmod($claim, 0o700);
+            }
+        }
+
+        Expect::that($report->items)->toBe([]);
+        Expect::that($report->warnings)
+            ->because('a cleanup failure MUST remain an advisory retention result')
+            ->toBe(['Greenlight did not prune artifact run "run-read-only".']);
+    }
+
+    #[Test]
+    public function combinedLimitsUseAgeThenCountThenSize(): void
+    {
+        $parent = $this->tempDirectory->subdirectory('retention-precedence');
+        $retention = $this->retention(
+            $parent,
+            maxCompletedRuns: 1,
+            maxCompletedRunAgeSeconds: 50,
+            maxRetainedBytes: 1,
+        );
+        $this->completedRun($retention, 'run-aged', 10, 'one');
+        $this->completedRun($retention, 'run-counted', 60, 'two');
+        $this->completedRun($retention, 'run-sized', 70, 'three');
+
+        $report = $retention->prune(dryRun: true, now: 100);
+
+        Expect::that(\array_map(static fn($item): array => [$item->runId, $item->reasons], $report->items))
+            ->because('combined retention MUST use the documented policy precedence')
+            ->toBe([
+                ['run-aged', ['age']],
+                ['run-counted', ['count']],
+                ['run-sized', ['size']],
+            ]);
+    }
+
+    private function retention(
+        string $parent,
+        ?int $maxCompletedRuns = null,
+        ?int $maxCompletedRunAgeSeconds = null,
+        ?int $maxRetainedBytes = null,
+    ): ArtifactRetention {
+        return ArtifactRetention::forConfiguration(new ArtifactConfiguration(
+            directory: $parent,
+            maxCompletedRuns: $maxCompletedRuns,
+            maxCompletedRunAgeSeconds: $maxCompletedRunAgeSeconds,
+            maxRetainedBytes: $maxRetainedBytes,
+        ), $parent);
+    }
+
+    private function completedRun(ArtifactRetention $retention, string $runId, int $completedAt, string $content): void
+    {
+        $handle = $retention->begin($runId);
+        \file_put_contents($handle->directory . '/evidence.txt', $content);
+        $handle->complete();
+        $metadataPath = $handle->directory . '/' . ArtifactRetention::METADATA_FILE;
+        $metadata = \json_decode((string) \file_get_contents($metadataPath), true, flags: \JSON_THROW_ON_ERROR);
+        if (!\is_array($metadata)) {
+            throw new \RuntimeException('The test did not decode artifact metadata.');
+        }
+        $map = [];
+        foreach ($metadata as $key => $value) {
+            $map[(string) $key] = $value;
+        }
+        $map['completedAt'] = $completedAt;
+        ArtifactRetention::writeMetadata($handle->directory, $map);
+    }
+
+    private function metadataDirectory(string $parent, string $runId, string $metadata): void
+    {
+        $directory = $parent . '/' . $runId;
+        \mkdir($directory);
+        \file_put_contents($directory . '/' . ArtifactRetention::LOCK_FILE, '');
+        \file_put_contents($directory . '/' . ArtifactRetention::METADATA_FILE, $metadata);
+    }
+}

--- a/tests/Unit/Execution/Artifact/ArtifactStoreIntegrityTest.php
+++ b/tests/Unit/Execution/Artifact/ArtifactStoreIntegrityTest.php
@@ -73,6 +73,50 @@ final readonly class ArtifactStoreIntegrityTest
     }
 
     #[Test]
+    public function workerSideCompletionDoesNotOwnRunRetention(): void
+    {
+        $root = $this->tempDirectory->subdirectory('worker-completion');
+        $configuration = new ArtifactConfiguration($root);
+        $owner = ArtifactStore::open($configuration, $root, 'run-worker-completion');
+        $this->cleanup->defer($owner->cleanup(...));
+        $worker = ArtifactStore::fromSession($owner->session(), $configuration);
+
+        $report = $worker->complete();
+
+        Expect::that($report->items)->toBe([]);
+        Expect::that($report->warnings)->toBe([]);
+    }
+
+    #[Test]
+    public function invalidCompletionMetadataMakesRetentionAdvisory(): void
+    {
+        $root = $this->tempDirectory->subdirectory('invalid-completion-metadata');
+        $configuration = new ArtifactConfiguration($root, maxCompletedRuns: 1);
+        $store = ArtifactStore::open($configuration, $root, 'run-invalid-completion');
+        $this->cleanup->defer($store->cleanup(...));
+        $id = new TestId('Example\\EvidenceTest', 'fails');
+        $attachments = $store->forAttempt($id, 1, new TestArtifactBudget());
+        $attachments->text('evidence.txt', 'body');
+        $store->publish(new TestResult(
+            $id,
+            Outcome::Failed,
+            0.1,
+            0,
+            attachments: $attachments->seal(),
+        ));
+        \file_put_contents($store->publicDirectory() . '/.greenlight-run.json', '{}');
+
+        $report = $store->complete();
+
+        Expect::that($report->warnings)->toBe([
+            'Greenlight did not complete artifact run metadata. This run is not eligible for pruning.',
+        ]);
+        Expect::that(\is_dir($store->publicDirectory()))
+            ->because('an incomplete ownership record MUST keep the current run directory')
+            ->toBeTrue();
+    }
+
+    #[Test]
     public function unsafeStorageKeysCannotEscapeThePublicationDirectory(): void
     {
         $root = $this->tempDirectory->subdirectory('unsafe-storage-key');


### PR DESCRIPTION
## Summary

- add opt-in completed-run limits for age, count, and total retained bytes with deterministic oldest-first precedence
- record versioned ownership, lifecycle locks, completion timestamps, and exact manifests before a run becomes eligible
- serialize pruning with parent and run locks, canonical-path checks, atomic claims, and advisory cleanup failures
- reject existing symlink ancestors before creating artifact directories
- add automatic completion-time retention plus an `artifacts:prune` maintenance command through the existing command-provider plugin seam
- keep the retention policy internal because there is only one real implementation
- document local retention and CI platform retention authority after upload