### PR TITLE
feat: add impacted-test watch mode

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -357,7 +357,7 @@ deptrac:
     CliCoverage: [CliConfiguration, CliOutput, Config, Coverage, CoverageCollection, CoverageExport, CoverageRelay, InternalFilesystem, InternalPhp, Reporting]
     CliSignal: [InternalProcess]
     CliState: [InternalFilesystem, InternalPhp]
-    CliWatch: [CliOutput, Event, InternalPhp, InternalProcess]
+    CliWatch: [CliOutput, CoverageAttribution, Discovery, DiscoveryPlan, Event, InternalPhp, InternalProcess, Test]
     CliWorkerCapacity: [Attribute, CpuCoreCounter, InternalPhp, InternalText]
     CliCommand: [CliConfiguration, CliDiscovery, CliInput, CliOutput, CliRun, Config, Coverage, CoverageDiff, CoverageExport, Discovery, DiscoveryPlan, Event, InternalEvent, InternalFilesystem, InternalPhp, InternalWire, PhpStan, Reporting, ReportingProfile]
     CliRun: [Artifact, CliConfiguration, CliCoverage, CliDiscovery, CliInput, CliOutput, CliReporting, CliSignal, CliState, CliWatch, CliWorkerCapacity, Config, Coverage, CoverageAttribution, CoverageCollection, CoverageIgnore, CoverageRelay, Discovery, Event, Execution, ExecutionAdapter, ExecutionWorker, IntegrationFixture, InternalPhp, InternalProcess, Reporting, Test]

--- a/docs/architecture/mutation-testing.md
+++ b/docs/architecture/mutation-testing.md
@@ -113,5 +113,7 @@ converts it to Infection's PHPUnit coverage XML format.
 
 ## Watch mode
 
-Per-test coverage is not available in watch mode. CI should continue to run the
-complete suite.
+Standard watch mode does not collect per-test coverage. Impacted watch can use
+the same JSONL map, but it does not replace a complete mutation-testing run.
+
+CI should continue to run the complete mutation-testing workflow.

--- a/docs/architecture/test-coverage-jsonl.md
+++ b/docs/architecture/test-coverage-jsonl.md
@@ -125,3 +125,19 @@ metadata and test table appearing before coverage records.
 
 A per-test map can be much larger than aggregate coverage. Greenlight and the
 Infection adapter read and write it one line at a time.
+
+## Impacted watch lifecycle
+
+Standard watch mode does not collect per-test coverage. Add
+`--watch-impacted` to use the map for impacted selection.
+
+Impacted watch publishes the map only after a successful complete selected
+run. A selective run does not replace it. The next file change uses a complete
+run to refresh the stale map.
+
+The impact reader streams the artifact for each stable change batch. It keeps
+the test table and records for changed lines in memory.
+
+The reader selects a line only when the aggregate map marks it covered and a
+completed test owns it. Uncovered, missing, or unattributed lines cause a
+complete selected run.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -845,7 +845,7 @@ explicit suite selection limits the effective test paths to selected suites.
 After a change, classes that failed in the previous watch iteration run first.
 
 Watch mode does not publish coverage totals or coverage exports.
-Per-test coverage cannot be combined with watch mode.
+Per-test coverage cannot be combined with standard watch mode.
 
 In watch mode:
 
@@ -853,6 +853,55 @@ In watch mode:
 * `q` quits with exit code 0, regardless of the last iteration result.
 
 Signals use the exit codes in the [interruption](#interruption) section.
+
+### `--watch-impacted`
+
+Use this option with `--watch`. It keeps standard watch mode unchanged when the
+option is absent.
+
+Impacted watch starts with the complete selected plan. It then runs these
+tests after a stable change batch:
+
+* exact test IDs that failed in the previous iteration
+* current selected tests from each changed test file
+* tests that covered each changed source line
+
+The selected plan still applies suites, groups, filters, exclusions, exact test
+IDs, and shards. Previous failures run first. Discovery uses the normal cache.
+
+Impacted watch requires at least one coverage include path. It also requires
+pcov or Xdebug coverage mode. Greenlight uses an internal temporary per-test
+map when no `--coverage-map` target is configured.
+
+Greenlight runs the complete selected plan for these changes:
+
+* an added, deleted, or renamed source file
+* a source edit that adds or removes lines
+* a changed line with no complete attribution
+* a deleted or renamed test file
+* the Greenlight configuration file
+* a PHP file outside the selected test and coverage roots
+* a discovery error or a stale map
+
+The complete fallback favors correctness. It also refreshes the per-test map
+after a successful run. A selective run makes the map stale, so the next
+change causes a complete run.
+
+Enter always runs the complete selected plan. A file change during a complete
+run makes its new map stale.
+
+Greenlight loads configuration once when watch mode starts. A configuration
+change causes a complete run, but the new settings require a restart.
+
+Greenlight cannot add or remove loaded test declarations in the watch process.
+Restart watch mode after a test class, method, or data set changes its identity.
+
+Impacted watch scans PHP files below the working directory. It also scans
+configured test and coverage roots outside that directory. Each stable change
+batch streams the per-test map once and keeps only relevant line records.
+
+Large projects or maps increase polling and selection time. Increase the watch
+debounce when frequent save events cause excess scans.
 
 ### `--detect-leaks`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -249,6 +249,13 @@ Watch mode combines rapid save events. The default delay is 200 ms.
 
 Use the `watch()` configuration builder to change this delay.
 
+Add `--watch-impacted` to select previous failures and tests affected by a
+change. This mode requires a coverage include path and an available coverage
+driver.
+
+Impacted watch uses exact test IDs from per-test coverage. It runs the complete
+selected plan when the map cannot give a reliable selection.
+
 ## Configure workers
 
 Tests run in parallel worker processes by default.

--- a/src/Cli/Input/Definition.php
+++ b/src/Cli/Input/Definition.php
@@ -103,6 +103,8 @@ final readonly class Definition
           --no-coverage      Disable configured coverage for this run.
           --watch            Run selected tests at startup and after file changes.
                              Enter reruns them. q quits with exit code 0.
+          --watch-impacted   With --watch, rerun previous failures and tests
+                             affected by changed test or covered source lines.
           --detect-leaks     Verify collection of each test instance. Leaks fail the run.
           --verbose          Print a permanent line per completed class in
                              interactive output
@@ -159,7 +161,7 @@ final readonly class Definition
             new OptionSpec('coverage-include', OptionValue::Required, repeatable: true),
             new OptionSpec('no-coverage'),
             new OptionSpec('baseline', OptionValue::Required), new OptionSpec('current', OptionValue::Required),
-            new OptionSpec('watch'), new OptionSpec('detect-leaks'), new OptionSpec('dry-run'),
+            new OptionSpec('watch'), new OptionSpec('watch-impacted'), new OptionSpec('detect-leaks'), new OptionSpec('dry-run'),
             new OptionSpec('ansi'), new OptionSpec('no-ansi'), new OptionSpec('verbose'), new OptionSpec('profile'),
             new OptionSpec('input', OptionValue::Required), new OptionSpec('output', OptionValue::Required),
             new OptionSpec('help', short: 'h'), new OptionSpec('version', short: 'V'),

--- a/src/Cli/Run/RunCommand.php
+++ b/src/Cli/Run/RunCommand.php
@@ -96,7 +96,22 @@ final readonly class RunCommand
             return self::EXIT_USAGE;
         }
 
-        if ($arguments->has('watch') && $resolved->coverage?->perTestTarget !== null) {
+        if ($arguments->has('watch-impacted') && !$arguments->has('watch')) {
+            $this->printError('Use --watch-impacted with --watch.', $arguments->has('no-ansi'));
+
+            return self::EXIT_USAGE;
+        }
+
+        if ($arguments->has('watch-impacted') && (!$resolved->coverage instanceof CoverageConfiguration || $resolved->coverage->includePaths === [])) {
+            $this->printError('Impacted watch requires at least one coverage include path.', $arguments->has('no-ansi'));
+
+            return self::EXIT_USAGE;
+        }
+
+        if ($arguments->has('watch')
+            && !$arguments->has('watch-impacted')
+            && $resolved->coverage?->perTestTarget !== null
+        ) {
             $this->printError('Per-test coverage is not available in watch mode.', $arguments->has('no-ansi'));
 
             return self::EXIT_USAGE;

--- a/src/Cli/Run/RunSession.php
+++ b/src/Cli/Run/RunSession.php
@@ -78,30 +78,104 @@ final readonly class RunSession
 
     /**
      * @param list<non-empty-string> $priorityClasses
-     * @return list<non-empty-string>
      * @throws CoverageError
      * @throws ReportGenerationFailed
      */
-    public function watchAttempt(Reporter $reporter, array $priorityClasses): array
-    {
+    public function watchAttempt(
+        Reporter $reporter,
+        array $priorityClasses,
+        ?TestSelection $selection = null,
+        bool $publishPerTest = false,
+    ): WatchAttemptResult {
         $tap = new ClassFailureTap($failedTap = new FailedTestsTap(new ReporterSink($reporter)));
         $classSeconds = $this->configuration->resolved->order->isRandomized() ? [] : $this->state->classSeconds();
         $workers = $this->configuration->resolved->workers->count->fixed ?? CpuCores::count();
-        $coverageSettings = CoverageSettingsResolver::resolve($this->configuration->resolved->coverage, $this->workingDirectory);
+        $resolved = $this->configuration->resolved;
+        $coverageSettings = null;
+        $coverageSession = null;
+        $testCoverageStore = null;
+        $reporterFinished = false;
 
         try {
-            $this->coordinate($reporter, $tap, $priorityClasses, $classSeconds, $workers, $coverageSettings);
-        } catch (AttachmentError|DiscoveryError|ExecutionFailed|IntegrationFixtureError $error) {
+            $coverageSettings = CoverageSettingsResolver::resolve($resolved->coverage, $this->workingDirectory);
+            if (!$publishPerTest && $coverageSettings?->perTest === true) {
+                $coverageSettings = new CoverageSettings(
+                    $coverageSettings->includePaths,
+                    $coverageSettings->driver,
+                );
+            }
+
+            $storage = StorageLayout::resolve($resolved->storage, $this->workingDirectory);
+            $testCoverageStore = $publishPerTest && $coverageSettings?->perTest === true
+                ? TestCoverageStore::open($storage->temporaryDirectory)
+                : null;
+            $coverageSession = CoverageSession::open(
+                $coverageSettings,
+                $workers !== 1 && $this->workerBin !== false && !SubprocessCoverage::requested(),
+                $storage->temporaryDirectory,
+            );
+            $run = $this->coordinate(
+                $reporter,
+                $tap,
+                $priorityClasses,
+                $classSeconds,
+                $workers,
+                $coverageSettings,
+                $testCoverageStore,
+                $selection,
+            );
+            $coverage = $coverageSession->finish($run->coverage);
+            $coverageSession->close();
+            $coverageSession = null;
+
+            if ($coverage instanceof CoverageMap) {
+                $coverage = new IgnoreFilter()->apply($coverage);
+            }
+
             $reporter->finish();
+            $reporterFinished = true;
+            $this->persist($failedTap->failedTests(), $failedTap->classSeconds());
+            $mapPublished = false;
+            $coverageConfig = $resolved->coverage;
+
+            if ($publishPerTest
+                && $testCoverageStore instanceof TestCoverageStore
+                && $coverageConfig?->perTestTarget !== null
+                && $coverage instanceof CoverageMap
+                && $run->plannedTests > 0
+                && $run->leaks === []
+                && $resolved->execution->runPolicy->accepts($run->summary)
+                && !$this->shutdown->requested()
+            ) {
+                $root = ErrorTrap::run(fn() => \realpath($this->workingDirectory));
+                $testCoverageStore->write(
+                    ConfigurationLoader::absolutePath($coverageConfig->perTestTarget, $this->workingDirectory),
+                    $root === false ? $this->workingDirectory : $root,
+                    $run->runId,
+                    $coverage,
+                );
+                $mapPublished = true;
+            }
+
+            return new WatchAttemptResult(
+                $failedTap->failedTests(),
+                $tap->failedClasses(),
+                true,
+                $mapPublished,
+                $mapPublished ? $run->runId : null,
+            );
+        } catch (AttachmentError|CoverageError|DiscoveryError|ExecutionFailed|IntegrationFixtureError $error) {
+            if (!$reporterFinished) {
+                $reporter->finish();
+            }
+
             $this->console->error($error->getMessage(), $this->arguments->has('no-ansi'));
 
-            return $priorityClasses;
+            return new WatchAttemptResult([], $priorityClasses, false, false);
+        } finally {
+            $coverageSession?->close();
+            $testCoverageStore?->close();
         }
-
-        $reporter->finish();
-        $this->persist($failedTap->failedTests(), $failedTap->classSeconds());
-
-        return $tap->failedClasses();
     }
 
     /**
@@ -240,13 +314,13 @@ final readonly class RunSession
      * @throws ExecutionFailed
      * @throws ReportGenerationFailed
      */
-    private function coordinate(Reporter $reporter, EventSink $sink, array $priorityClasses, array $classSeconds, int $workers, ?CoverageSettings $coverageSettings, ?TestCoverageStore $testCoverageStore = null): RunResult
+    private function coordinate(Reporter $reporter, EventSink $sink, array $priorityClasses, array $classSeconds, int $workers, ?CoverageSettings $coverageSettings, ?TestCoverageStore $testCoverageStore = null, ?TestSelection $selection = null): RunResult
     {
         $resolved = $this->configuration->resolved;
 
         return new RunCoordinator($this->workingDirectory)->run(
             $resolved,
-            $this->selection,
+            $selection ?? $this->selection,
             $this->configuration->directories,
             $sink,
             $this->adapter($resolved->workers, $workers, $coverageSettings, $reporter),

--- a/src/Cli/Run/WatchAttemptResult.php
+++ b/src/Cli/Run/WatchAttemptResult.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli\Run;
+
+/**
+ * Contains failure and coverage-map state from one watch attempt.
+ *
+ * @internal
+ */
+final readonly class WatchAttemptResult
+{
+    /**
+     * @param list<non-empty-string> $failedTests
+     * @param list<non-empty-string> $failedClasses
+     */
+    public function __construct(
+        public array $failedTests,
+        public array $failedClasses,
+        public bool $completed,
+        public bool $mapPublished,
+        public ?string $mapRunId = null,
+    ) {}
+}

--- a/src/Cli/Run/WatchRuns.php
+++ b/src/Cli/Run/WatchRuns.php
@@ -6,6 +6,7 @@ namespace Greenlight\Cli\Run;
 
 use Greenlight\Cli\Configuration\ConfigurationLoader;
 use Greenlight\Cli\Configuration\LoadedConfiguration;
+use Greenlight\Cli\Discovery\SelectionDiscovery;
 use Greenlight\Cli\Input\ParsedArguments;
 use Greenlight\Cli\Output\Console;
 use Greenlight\Cli\Reporting\ReporterCatalog;
@@ -14,12 +15,18 @@ use Greenlight\Cli\Reporting\ReporterOutputPlan;
 use Greenlight\Cli\Reporting\ReporterSetupFailed;
 use Greenlight\Cli\State\RunState;
 use Greenlight\Cli\Watch\Debouncer;
+use Greenlight\Cli\Watch\FileChange;
+use Greenlight\Cli\Watch\ImpactedTestSelector;
 use Greenlight\Cli\Watch\StatChangeDetector;
 use Greenlight\Cli\Watch\StdinKeyInput;
 use Greenlight\Cli\Watch\SystemWatchClock;
 use Greenlight\Cli\Watch\WatchLoop;
+use Greenlight\Cli\Watch\WatchLoopResult;
+use Greenlight\Config\CoverageConfiguration;
+use Greenlight\Config\ResolvedConfiguration;
 use Greenlight\Config\StorageLayout;
 use Greenlight\Execution\Worker\LeakDetector;
+use Greenlight\Internal\Php\ErrorTrap;
 use Greenlight\Internal\Process\GracefulShutdown;
 use Greenlight\Reporting\Reporter;
 
@@ -35,15 +42,27 @@ final readonly class WatchRuns
     /** @param non-empty-string|false $workerBin */
     public function run(ParsedArguments $arguments, string $workingDirectory, string|false $workerBin, LoadedConfiguration $configuration, GracefulShutdown $shutdown, ReporterCatalog $reporterCatalog, ReporterOutputPlan $reporterOutputs, Reporter $initialReporter): int
     {
+        $impacted = $arguments->has('watch-impacted');
+        [$configuration, $coverageMap, $internalCoverageMap] = $this->watchConfiguration(
+            $configuration,
+            $workingDirectory,
+            $impacted,
+        );
         $resolved = $configuration->resolved;
         $directories = $configuration->directories;
-        $watched = $directories;
+        $testRoots = $this->resolvedRoots($directories);
+        $sourceRoots = [];
         foreach ($resolved->coverage->includePaths ?? [] as $path) {
             $absolute = ConfigurationLoader::absolutePath($path, $workingDirectory);
-            if ($absolute !== '' && !\in_array($absolute, $watched, true)) {
-                $watched[] = $absolute;
+            $real = ErrorTrap::run(static fn() => \realpath($absolute));
+            $source = $real === false ? $absolute : $real;
+            if ($source !== '' && !\in_array($source, $sourceRoots, true)) {
+                $sourceRoots[] = $source;
             }
         }
+        $watched = $impacted
+            ? \array_values(\array_unique([$workingDirectory, ...$testRoots, ...$sourceRoots]))
+            : \array_values(\array_unique([...$testRoots, ...$sourceRoots]));
         $detectLeaks = $arguments->has('detect-leaks');
         $storage = StorageLayout::resolve(
             $resolved->storage,
@@ -56,22 +75,174 @@ final readonly class WatchRuns
         }
         $nextReporter = $initialReporter;
         $session = new RunSession($this->console, $arguments, $configuration, $workingDirectory, $workerBin, $shutdown, $resolved->selection, RunState::forFile($storage->runStateFile));
-        $runOnce = function (array $priorityClasses) use ($arguments, $reporterCatalog, $reporterOutputs, $session, &$nextReporter): array {
+        $projectRoot = ErrorTrap::run(static fn() => \realpath($workingDirectory));
+        $projectRoot = $projectRoot === false ? $workingDirectory : $projectRoot;
+        $selector = null;
+        if ($impacted && $coverageMap !== null) {
+            $discovery = new SelectionDiscovery($configuration, $workingDirectory);
+            $selector = new ImpactedTestSelector(
+                $resolved->selection,
+                $discovery->plan(...),
+                $coverageMap,
+                $testRoots,
+                $sourceRoots,
+                $projectRoot,
+                $configuration->file,
+            );
+        }
+        $failedTests = [];
+        $mapRunId = null;
+        $runOnce = function (array $priorityClasses, array $changes, bool $complete, bool $mapFresh) use ($arguments, $reporterCatalog, $reporterOutputs, $session, $selector, $impacted, &$failedTests, &$mapRunId, &$nextReporter): WatchLoopResult {
             $priorityClasses = \array_values(\array_filter($priorityClasses, static fn(mixed $class): bool => \is_string($class) && $class !== ''));
             $reporter = $nextReporter ?? new ReporterFactory($this->console)->create($arguments, $reporterCatalog, $reporterOutputs);
             $nextReporter = null;
+            $selection = null;
+            $publishMap = false;
 
-            return $session->watchAttempt($reporter, $priorityClasses);
+            if ($impacted) {
+                if ($complete) {
+                    $publishMap = true;
+                } elseif (!$mapFresh || !$selector instanceof ImpactedTestSelector) {
+                    $publishMap = true;
+                    $this->console->out("Impacted watch will run all selected tests. The per-test coverage map is stale.\n");
+                } else {
+                    $impact = $selector->select($this->fileChanges($changes), $failedTests, $mapRunId);
+                    $selection = $impact->selection;
+                    $publishMap = $impact->complete;
+                    $this->console->out($impact->diagnostic . "\n");
+                }
+            }
+
+            $attempt = $session->watchAttempt($reporter, $priorityClasses, $selection, $publishMap);
+            if ($attempt->completed) {
+                $failedTests = $attempt->failedTests;
+            }
+            if ($attempt->mapPublished) {
+                $mapRunId = $attempt->mapRunId;
+            }
+
+            return new WatchLoopResult($attempt->failedClasses, $attempt->mapPublished);
         };
         $keys = new StdinKeyInput();
         try {
-            new WatchLoop(new StatChangeDetector($watched), new Debouncer($resolved->watch->debounceMilliseconds / 1000), $keys, new SystemWatchClock(), $this->console->out(...), $shutdown)->run($runOnce);
+            new WatchLoop(
+                new StatChangeDetector(
+                    $watched,
+                    $impacted ? \array_values(\array_unique([...$testRoots, ...$sourceRoots])) : [],
+                    $impacted ? [$configuration->file] : [],
+                ),
+                new Debouncer($resolved->watch->debounceMilliseconds / 1000),
+                $keys,
+                new SystemWatchClock(),
+                $this->console->out(...),
+                $shutdown,
+                $impacted,
+            )->run($runOnce);
         } catch (ReporterSetupFailed $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
             return 1;
         } finally {
             $keys->restore();
+            if ($internalCoverageMap) {
+                ErrorTrap::run(static fn(): bool => \unlink($coverageMap ?? ''));
+            }
         }
         return $shutdown->exitCode() ?? 0;
+    }
+
+    /** @return array{LoadedConfiguration, ?non-empty-string, bool} */
+    private function watchConfiguration(LoadedConfiguration $configuration, string $workingDirectory, bool $impacted): array
+    {
+        if (!$impacted) {
+            return [$configuration, null, false];
+        }
+
+        $resolved = $configuration->resolved;
+        $coverage = $resolved->coverage;
+        if (!$coverage instanceof CoverageConfiguration) {
+            return [$configuration, null, false];
+        }
+
+        $internal = $coverage->perTestTarget === null;
+        $target = $coverage->perTestTarget;
+
+        if ($target === null) {
+            $storage = StorageLayout::resolve(
+                $resolved->storage,
+                $workingDirectory,
+                $resolved->suiteSelection->stateIdentity(),
+            );
+            $target = \rtrim($storage->temporaryDirectory, '/')
+                . '/greenlight-watch-impact-' . (int) \getmypid() . '-' . \bin2hex(\random_bytes(8)) . '.jsonl';
+        }
+
+        if ($target === '') {
+            throw new \LogicException('The impacted watch coverage-map path is empty.');
+        }
+
+        $coverage = new CoverageConfiguration(
+            $coverage->includePaths,
+            $coverage->driver,
+            $coverage->exports,
+            $target,
+        );
+        $watchResolved = new ResolvedConfiguration(
+            $resolved->discovery,
+            $resolved->suiteSelection,
+            $resolved->workers,
+            $resolved->execution,
+            $resolved->order,
+            $resolved->selection,
+            $coverage,
+            $resolved->watch,
+            $resolved->storage,
+        );
+
+        $absoluteTarget = ConfigurationLoader::absolutePath($target, $workingDirectory);
+        if ($absoluteTarget === '') {
+            throw new \LogicException('The impacted watch coverage-map path is empty.');
+        }
+
+        return [
+            new LoadedConfiguration(
+                $watchResolved,
+                $configuration->file,
+                $configuration->overrides,
+                $configuration->directories,
+            ),
+            $absoluteTarget,
+            $internal,
+        ];
+    }
+
+    /**
+     * @param array<mixed> $changes
+     * @return list<FileChange>
+     */
+    private function fileChanges(array $changes): array
+    {
+        return \array_values(\array_filter(
+            $changes,
+            static fn(mixed $change): bool => $change instanceof FileChange,
+        ));
+    }
+
+    /**
+     * @param list<string> $roots
+     * @return list<string>
+     */
+    private function resolvedRoots(array $roots): array
+    {
+        $resolved = [];
+        foreach ($roots as $root) {
+            $real = ErrorTrap::run(static fn() => \realpath($root));
+            $path = $real === false ? $root : $real;
+
+            if ($path !== '' && !\in_array($path, $resolved, true)) {
+                $resolved[] = $path;
+            }
+        }
+
+        return $resolved;
     }
 }

--- a/src/Cli/Watch/ChangeDetector.php
+++ b/src/Cli/Watch/ChangeDetector.php
@@ -8,7 +8,7 @@ namespace Greenlight\Cli\Watch;
 interface ChangeDetector
 {
     /**
-     * @return list<non-empty-string> paths changed since the previous poll
+     * @return list<FileChange> files changed since the previous poll
      */
     public function poll(): array;
 }

--- a/src/Cli/Watch/FileChange.php
+++ b/src/Cli/Watch/FileChange.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli\Watch;
+
+/**
+ * Describes one file change and optional content from both sides of the change.
+ *
+ * @internal
+ */
+final readonly class FileChange
+{
+    /** @param non-empty-string $path */
+    public function __construct(
+        public string $path,
+        public bool $existedBefore,
+        public bool $existsAfter,
+        public ?string $before = null,
+        public ?string $after = null,
+    ) {}
+
+    /** @param non-empty-string $path */
+    public static function unknown(string $path): self
+    {
+        return new self($path, true, true);
+    }
+
+    public function isAdded(): bool
+    {
+        return !$this->existedBefore && $this->existsAfter;
+    }
+
+    public function isDeleted(): bool
+    {
+        return $this->existedBefore && !$this->existsAfter;
+    }
+
+    public function hasLineCountChange(): bool
+    {
+        return $this->before === null
+            || $this->after === null
+            || \count($this->lines($this->before)) !== \count($this->lines($this->after));
+    }
+
+    /** @return list<positive-int>|null */
+    public function changedLines(): ?array
+    {
+        if ($this->before === null || $this->after === null || $this->hasLineCountChange()) {
+            return null;
+        }
+
+        $before = $this->lines($this->before);
+        $after = $this->lines($this->after);
+        $changed = [];
+
+        foreach ($before as $offset => $line) {
+            if ($line !== $after[$offset]) {
+                $changed[] = $offset + 1;
+            }
+        }
+
+        return $changed;
+    }
+
+    public function followedBy(self $later): self
+    {
+        if ($later->path !== $this->path) {
+            throw new \InvalidArgumentException('Combine file changes only when their paths are equal.');
+        }
+
+        return new self(
+            $this->path,
+            $this->existedBefore,
+            $later->existsAfter,
+            $this->before,
+            $later->after,
+        );
+    }
+
+    /** @return list<string> */
+    private function lines(string $contents): array
+    {
+        return \explode("\n", $contents);
+    }
+}

--- a/src/Cli/Watch/ImpactSelection.php
+++ b/src/Cli/Watch/ImpactSelection.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli\Watch;
+
+use Greenlight\Test\TestSelection;
+
+/**
+ * Contains one impacted selection and its selection diagnostic.
+ *
+ * @internal
+ */
+final readonly class ImpactSelection
+{
+    public function __construct(
+        public TestSelection $selection,
+        public bool $complete,
+        public string $diagnostic,
+    ) {}
+}

--- a/src/Cli/Watch/ImpactedTestSelector.php
+++ b/src/Cli/Watch/ImpactedTestSelector.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli\Watch;
+
+use Greenlight\Coverage\Attribution\TestCoverageMap;
+use Greenlight\Coverage\Attribution\TestCoverageMapError;
+use Greenlight\Discovery\DiscoveryError;
+use Greenlight\Discovery\Plan\ExecutionPlan;
+use Greenlight\Internal\Php\ErrorTrap;
+use Greenlight\Test\TestSelection;
+
+/**
+ * Selects previous failures and tests affected by one stable file-change batch.
+ *
+ * @internal
+ */
+final readonly class ImpactedTestSelector
+{
+    /**
+     * @param list<string> $testRoots
+     * @param list<string> $sourceRoots
+     * @param \Closure(): ExecutionPlan $discover
+     */
+    public function __construct(
+        private TestSelection $completeSelection,
+        private \Closure $discover,
+        private string $coverageMap,
+        private array $testRoots,
+        private array $sourceRoots,
+        private string $projectRoot,
+        private string $configurationFile,
+    ) {}
+
+    /**
+     * @param list<FileChange> $changes
+     * @param list<non-empty-string> $failedTests
+     */
+    public function select(array $changes, array $failedTests, ?string $mapRunId): ImpactSelection
+    {
+        if ($changes === []) {
+            return $this->complete('No stable file-change batch is available.');
+        }
+
+        foreach ($changes as $change) {
+            if ($change->isDeleted()) {
+                return $this->complete('A file was deleted or renamed.');
+            }
+
+            if ($this->samePath($change->path, $this->configurationFile)) {
+                return $this->complete('The Greenlight configuration changed.');
+            }
+
+            if (!$this->inRoots($change->path, [...$this->testRoots, ...$this->sourceRoots])) {
+                return $this->complete('A changed file is outside the configured test and coverage roots.');
+            }
+        }
+
+        try {
+            $plan = ($this->discover)();
+        } catch (DiscoveryError) {
+            return $this->complete('Test discovery did not produce a reliable impacted plan.');
+        }
+
+        $planIds = $this->planIds($plan);
+        $selected = [];
+        foreach ($failedTests as $id) {
+            if (!isset($planIds[$id])) {
+                return $this->complete('A previous failed test is not in the current selected plan.');
+            }
+
+            $selected[$id] = true;
+        }
+
+        /** @var array<non-empty-string, non-empty-list<positive-int>> $changedLines */
+        $changedLines = [];
+
+        foreach ($changes as $change) {
+            if ($this->inRoots($change->path, $this->testRoots)) {
+                $found = false;
+                foreach ($plan->entries as $entry) {
+                    if ($this->samePath($entry->sourceFile, $change->path)) {
+                        $selected[(string) $entry->id] = true;
+                        $found = true;
+                    }
+                }
+
+                if (!$found) {
+                    return $this->complete('A changed test file has no test in the current selected plan.');
+                }
+
+                continue;
+            }
+
+            if ($change->isAdded() || $change->hasLineCountChange()) {
+                return $this->complete('A source change has no stable line mapping.');
+            }
+
+            $lines = $change->changedLines();
+            if ($lines === null || $lines === []) {
+                return $this->complete('A source change has no stable covered line.');
+            }
+
+            $changedLines[$change->path] = $lines;
+        }
+
+        if ($changedLines !== []) {
+            if ($mapRunId === null || $mapRunId === '') {
+                return $this->complete('The per-test coverage map has no current run ID.');
+            }
+
+            try {
+                $impacted = TestCoverageMap::impactedTests(
+                    $this->coverageMap,
+                    $this->projectRoot,
+                    $mapRunId,
+                    $changedLines,
+                );
+            } catch (TestCoverageMapError) {
+                return $this->complete('The per-test coverage map is missing, stale, or incomplete.');
+            }
+
+            foreach ($impacted as $id) {
+                if (!isset($planIds[$id])) {
+                    return $this->complete('The per-test coverage map contains a stale test ID.');
+                }
+
+                $selected[$id] = true;
+            }
+        }
+
+        if ($selected === []) {
+            return $this->complete('No test has a reliable impact mapping.');
+        }
+
+        $ids = [];
+        foreach (\array_keys($selected) as $id) {
+            if ($id !== '') {
+                $ids[] = $id;
+            }
+        }
+
+        return new ImpactSelection(
+            $this->completeSelection->withOnlyExactIds($ids),
+            false,
+            \sprintf('Impacted watch selected %d %s.', \count($ids), \count($ids) === 1 ? 'test' : 'tests'),
+        );
+    }
+
+    private function complete(string $reason): ImpactSelection
+    {
+        return new ImpactSelection(
+            $this->completeSelection,
+            true,
+            'Impacted watch will run all selected tests. ' . $reason,
+        );
+    }
+
+    /** @return array<non-empty-string, true> */
+    private function planIds(ExecutionPlan $plan): array
+    {
+        $ids = [];
+        foreach ($plan->entries as $entry) {
+            $id = (string) $entry->id;
+            if ($id !== '') {
+                $ids[$id] = true;
+            }
+        }
+
+        return $ids;
+    }
+
+    /** @param list<string> $roots */
+    private function inRoots(string $path, array $roots): bool
+    {
+        return \array_any($roots, fn(string $root): bool => $this->samePath($path, $root)
+            || \str_starts_with($path, \rtrim($root, '/') . '/'));
+    }
+
+    private function samePath(string $left, string $right): bool
+    {
+        $resolvedLeft = ErrorTrap::run(static fn() => \realpath($left));
+        $resolvedRight = ErrorTrap::run(static fn() => \realpath($right));
+
+        return ($resolvedLeft === false ? $left : $resolvedLeft)
+            === ($resolvedRight === false ? $right : $resolvedRight);
+    }
+}

--- a/src/Cli/Watch/StatChangeDetector.php
+++ b/src/Cli/Watch/StatChangeDetector.php
@@ -20,14 +20,20 @@ use Greenlight\Internal\Php\ErrorTrap;
 final class StatChangeDetector implements ChangeDetector
 {
     /**
-     * @var array<string, string>|null path to fingerprint
+     * @var array<non-empty-string, array{fingerprint: non-empty-string, contents: ?string}>|null
      */
     private ?array $snapshot = null;
 
     /**
-     * @param list<non-empty-string> $directories
+     * @param list<string> $directories
+     * @param list<string> $contentRoots
+     * @param list<string> $files
      */
-    public function __construct(private readonly array $directories) {}
+    public function __construct(
+        private readonly array $directories,
+        private readonly array $contentRoots = [],
+        private readonly array $files = [],
+    ) {}
 
     #[\Override]
     public function poll(): array
@@ -42,26 +48,29 @@ final class StatChangeDetector implements ChangeDetector
 
         $changed = [];
 
-        foreach ($current as $path => $fingerprint) {
-            if (($this->snapshot[$path] ?? null) !== $fingerprint) {
-                $changed[] = $path;
+        foreach ($current as $path => $state) {
+            $previous = $this->snapshot[$path] ?? null;
+
+            if ($previous === null) {
+                $changed[] = new FileChange($path, false, true, after: $state['contents']);
+            } elseif ($previous['fingerprint'] !== $state['fingerprint']) {
+                $changed[] = new FileChange($path, true, true, $previous['contents'], $state['contents']);
             }
         }
 
         foreach (\array_keys($this->snapshot) as $path) {
             if (!isset($current[$path])) {
-                $changed[] = $path;
+                $changed[] = new FileChange($path, true, false, $this->snapshot[$path]['contents']);
             }
         }
 
         $this->snapshot = $current;
 
-        /** @var list<non-empty-string> $changed */
         return $changed;
     }
 
     /**
-     * @return array<string, string>
+     * @return array<non-empty-string, array{fingerprint: non-empty-string, contents: ?string}>
      */
     private function scan(): array
     {
@@ -74,14 +83,30 @@ final class StatChangeDetector implements ChangeDetector
                 continue;
             }
 
-            $snapshot = [...$snapshot, ...$files];
+            foreach ($files as $path => $state) {
+                if ($path !== '') {
+                    $snapshot[$path] = $state;
+                }
+            }
+        }
+
+        foreach ($this->files as $file) {
+            if ($file === '') {
+                continue;
+            }
+
+            $state = $this->fileState($file);
+
+            if ($state !== null) {
+                $snapshot[$file] = $state;
+            }
         }
 
         return $snapshot;
     }
 
     /**
-     * @return array<string, string>
+     * @return array<non-empty-string, array{fingerprint: non-empty-string, contents: ?string}>
      */
     private function scanDirectory(string $directory): array
     {
@@ -100,21 +125,22 @@ final class StatChangeDetector implements ChangeDetector
             }
 
             $path = $file->getPathname();
-            $fingerprint = $this->fingerprint($path);
+            $state = $this->fileState($path);
 
-            if ($fingerprint !== null) {
-                $snapshot[$path] = $fingerprint;
+            if ($path !== '' && $state !== null) {
+                $snapshot[$path] = $state;
             }
         }
 
         return $snapshot;
     }
 
-    private function fingerprint(string $path): ?string
+    /** @return array{fingerprint: non-empty-string, contents: ?string}|null */
+    private function fileState(string $path): ?array
     {
         \clearstatcache(true, $path);
 
-        return ErrorTrap::run(static function () use ($path) {
+        return ErrorTrap::run(function () use ($path) {
             $mtime = \filemtime($path);
             $size = \filesize($path);
             $contentHash = \sha1_file($path);
@@ -123,7 +149,28 @@ final class StatChangeDetector implements ChangeDetector
                 return null;
             }
 
-            return $mtime . ':' . $size . ':' . $contentHash;
+            $fingerprint = $mtime . ':' . $size . ':' . $contentHash;
+
+            return [
+                'fingerprint' => $fingerprint,
+                'contents' => $this->capturesContents($path) ? $this->contents($path) : null,
+            ];
         });
+    }
+
+    private function capturesContents(string $path): bool
+    {
+        return \array_any($this->contentRoots, static function (string $root) use ($path): bool {
+            $prefix = \rtrim($root, '/') . '/';
+
+            return $path === \rtrim($root, '/') || \str_starts_with($path, $prefix);
+        });
+    }
+
+    private function contents(string $path): ?string
+    {
+        $contents = ErrorTrap::run(static fn() => \file_get_contents($path));
+
+        return \is_string($contents) ? $contents : null;
     }
 }

--- a/src/Cli/Watch/WatchLoop.php
+++ b/src/Cli/Watch/WatchLoop.php
@@ -36,18 +36,33 @@ final readonly class WatchLoop
         private WatchClock $clock,
         private \Closure $out,
         private ?GracefulShutdown $shutdown = null,
+        private bool $tracksStableRuns = false,
     ) {}
 
     /**
-     * @param \Closure(array<string>): list<non-empty-string> $runOnce Runs the
-     *        suite with the specified classes first and returns failed classes
+     * @param \Closure(list<non-empty-string>, list<FileChange>, bool, bool): WatchLoopResult $runOnce
+     *        Runs one selected iteration and returns its watch state.
      * @param int<1, max>|null $maxIterations Test loop limit. A null value runs
      *        until q.
      */
     public function run(\Closure $runOnce, ?int $maxIterations = null): void
     {
         $this->detector->poll();
-        $failedClasses = $runOnce([]);
+        $result = $runOnce([], [], true, false);
+        $failedClasses = $result->failedClasses;
+        $mapFresh = $result->mapPublished;
+        $pending = [];
+
+        if ($this->tracksStableRuns) {
+            $changes = $this->detector->poll();
+            if ($changes !== []) {
+                $this->reportChanges($changes);
+                $pending = $this->mergeChanges($pending, $changes);
+                $this->debouncer->noteChange($this->clock->now());
+                $mapFresh = false;
+            }
+        }
+
         $iterations = 1;
         ($this->out)("\nWaiting for changes. Press Enter to run all tests. Press q to quit.\n");
 
@@ -66,15 +81,34 @@ final readonly class WatchLoop
             $changes = $this->detector->poll();
 
             if ($changes !== []) {
-                $count = \count($changes);
-                ($this->out)(\sprintf("Detected changes in %d %s.\n", $count, $count === 1 ? 'file' : 'files'));
+                $this->reportChanges($changes);
+                $pending = $this->mergeChanges($pending, $changes);
                 $this->debouncer->noteChange($this->clock->now());
             }
 
             if ($runNow || $this->debouncer->shouldFire($this->clock->now())) {
                 $this->debouncer->reset();
-                $failedClasses = $runOnce($runNow ? [] : $failedClasses);
+                $result = $runOnce(
+                    $runNow ? [] : $failedClasses,
+                    $runNow ? [] : \array_values($pending),
+                    $runNow,
+                    $mapFresh,
+                );
+                $failedClasses = $result->failedClasses;
+                $mapFresh = $result->mapPublished;
+                $pending = [];
                 ++$iterations;
+
+                if ($this->tracksStableRuns) {
+                    $changes = $this->detector->poll();
+                    if ($changes !== []) {
+                        $this->reportChanges($changes);
+                        $pending = $this->mergeChanges($pending, $changes);
+                        $this->debouncer->noteChange($this->clock->now());
+                        $mapFresh = false;
+                    }
+                }
+
                 ($this->out)("\nWaiting for changes. Press Enter to run all tests. Press q to quit.\n");
 
                 continue;
@@ -82,5 +116,28 @@ final readonly class WatchLoop
 
             $this->clock->sleep(self::POLL_INTERVAL_SECONDS);
         }
+    }
+
+    /** @param list<FileChange> $changes */
+    private function reportChanges(array $changes): void
+    {
+        $count = \count($changes);
+        ($this->out)(\sprintf("Detected changes in %d %s.\n", $count, $count === 1 ? 'file' : 'files'));
+    }
+
+    /**
+     * @param array<non-empty-string, FileChange> $pending
+     * @param list<FileChange> $changes
+     * @return array<non-empty-string, FileChange>
+     */
+    private function mergeChanges(array $pending, array $changes): array
+    {
+        foreach ($changes as $change) {
+            $pending[$change->path] = isset($pending[$change->path])
+                ? $pending[$change->path]->followedBy($change)
+                : $change;
+        }
+
+        return $pending;
     }
 }

--- a/src/Cli/Watch/WatchLoopResult.php
+++ b/src/Cli/Watch/WatchLoopResult.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli\Watch;
+
+/**
+ * Contains the failed classes and coverage-map state after one watch run.
+ *
+ * @internal
+ */
+final readonly class WatchLoopResult
+{
+    /** @param list<non-empty-string> $failedClasses */
+    public function __construct(
+        public array $failedClasses,
+        public bool $mapPublished = false,
+    ) {}
+}

--- a/src/Coverage/Attribution/TestCoverageMap.php
+++ b/src/Coverage/Attribution/TestCoverageMap.php
@@ -1,0 +1,268 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Coverage\Attribution;
+
+use Greenlight\Internal\Php\ErrorTrap;
+
+/**
+ * Reads the version 1 attribution stream for specified source lines.
+ *
+ * The reader keeps only the test table and records for the changed lines.
+ *
+ * @internal
+ */
+final class TestCoverageMap
+{
+    private const int VERSION = 1;
+
+    /** @codeCoverageIgnore */
+    private function __construct() {}
+
+    /**
+     * @param array<non-empty-string, non-empty-list<positive-int>> $changedLines
+     * @return list<non-empty-string>
+     * @throws TestCoverageMapError
+     */
+    public static function impactedTests(string $artifact, string $root, string $runId, array $changedLines): array
+    {
+        $stream = ErrorTrap::run(static fn() => \fopen($artifact, 'rb'), $warning);
+
+        if (!\is_resource($stream)) {
+            throw new TestCoverageMapError(\sprintf('The per-test coverage map "%s" is not readable.', $artifact));
+        }
+
+        /** @var array<non-empty-string, array<positive-int, true>> $wanted */
+        $wanted = [];
+        foreach ($changedLines as $file => $lines) {
+            foreach ($lines as $line) {
+                $wanted[$file][$line] = true;
+            }
+        }
+
+        /** @var array<non-negative-int, non-empty-string> $tests */
+        $tests = [];
+        /** @var array<non-empty-string, array<positive-int, bool>> $source */
+        $source = [];
+        /** @var array<non-empty-string, array<positive-int, true>> $attributed */
+        $attributed = [];
+        /** @var array<non-empty-string, array<positive-int, true>> $unattributed */
+        $unattributed = [];
+        /** @var array<non-empty-string, true> $impacted */
+        $impacted = [];
+        $metadata = false;
+
+        try {
+            while (($line = \fgets($stream)) !== false) {
+                $record = self::decode($line);
+
+                if (($record['v'] ?? null) !== self::VERSION || !\is_string($record['type'] ?? null)) {
+                    throw new TestCoverageMapError('The per-test coverage map contains an unsupported record.');
+                }
+
+                $type = $record['type'];
+
+                if (!$metadata) {
+                    self::validateMetadata($record, $root, $runId);
+                    $metadata = true;
+
+                    continue;
+                }
+
+                if ($type === 'meta') {
+                    throw new TestCoverageMapError('The per-test coverage map contains more than one metadata record.');
+                }
+
+                if ($type === 'test') {
+                    $ordinal = self::ordinal($record, 'test');
+                    $id = self::requiredString($record, 'renderedId');
+
+                    if (isset($tests[$ordinal])) {
+                        throw new TestCoverageMapError('The per-test coverage map contains a duplicate test ordinal.');
+                    }
+
+                    $tests[$ordinal] = $id;
+
+                    continue;
+                }
+
+                if (!\in_array($type, ['coverage', 'source', 'unattributed'], true)) {
+                    continue;
+                }
+
+                $file = self::requiredString($record, 'file');
+                $wantedLines = $wanted[$file] ?? null;
+
+                if ($wantedLines === null) {
+                    continue;
+                }
+
+                $lines = self::positiveLines($record);
+
+                if ($type === 'coverage') {
+                    $ordinal = self::ordinal($record, 'test');
+                    $id = $tests[$ordinal] ?? null;
+
+                    if ($id === null) {
+                        throw new TestCoverageMapError('The per-test coverage map references an unknown test.');
+                    }
+
+                    foreach ($lines as $coveredLine) {
+                        if (isset($wantedLines[$coveredLine])) {
+                            $attributed[$file][$coveredLine] = true;
+                            $impacted[$id] = true;
+                        }
+                    }
+
+                    continue;
+                }
+
+                if ($type === 'unattributed') {
+                    foreach ($lines as $unattributedLine) {
+                        if (isset($wantedLines[$unattributedLine])) {
+                            $unattributed[$file][$unattributedLine] = true;
+                        }
+                    }
+
+                    continue;
+                }
+
+                $covered = $record['covered'] ?? null;
+                if (!\is_bool($covered)) {
+                    throw new TestCoverageMapError('The per-test coverage map has an invalid source record.');
+                }
+
+                foreach ($lines as $sourceLine) {
+                    if (!isset($wantedLines[$sourceLine])) {
+                        continue;
+                    }
+
+                    if (isset($source[$file][$sourceLine]) && $source[$file][$sourceLine] !== $covered) {
+                        throw new TestCoverageMapError('The per-test coverage map has conflicting source records.');
+                    }
+
+                    $source[$file][$sourceLine] = $covered;
+                }
+            }
+        } finally {
+            \fclose($stream);
+        }
+
+        if (!$metadata) {
+            throw new TestCoverageMapError('The per-test coverage map has no metadata record.');
+        }
+
+        foreach ($wanted as $file => $lines) {
+            foreach (\array_keys($lines) as $line) {
+                if (($source[$file][$line] ?? null) !== true
+                    || !isset($attributed[$file][$line])
+                    || isset($unattributed[$file][$line])
+                ) {
+                    throw new TestCoverageMapError(\sprintf(
+                        'The per-test coverage map cannot attribute changed line %d in "%s".',
+                        $line,
+                        $file,
+                    ));
+                }
+            }
+        }
+
+        $ids = [];
+        foreach (\array_keys($impacted) as $id) {
+            if ($id !== '') {
+                $ids[] = $id;
+            }
+        }
+
+        return $ids;
+    }
+
+    /** @param array<string, mixed> $record */
+    private static function validateMetadata(array $record, string $root, string $runId): void
+    {
+        if (($record['type'] ?? null) !== 'meta'
+            || ($record['complete'] ?? null) !== true
+            || self::requiredString($record, 'root') !== $root
+            || self::requiredString($record, 'runId') !== $runId
+        ) {
+            throw new TestCoverageMapError('The per-test coverage map metadata is not valid for this project.');
+        }
+    }
+
+    /** @param array<string, mixed> $record */
+    private static function ordinal(array $record, string $key): int
+    {
+        $value = $record[$key] ?? null;
+
+        if (!\is_int($value) || $value < 0) {
+            throw new TestCoverageMapError('The per-test coverage map contains an invalid test ordinal.');
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $record
+     * @return non-empty-string
+     */
+    private static function requiredString(array $record, string $key): string
+    {
+        $value = $record[$key] ?? null;
+
+        if (!\is_string($value) || $value === '') {
+            throw new TestCoverageMapError(\sprintf('The per-test coverage map has an invalid "%s" field.', $key));
+        }
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, mixed> $record
+     * @return list<positive-int>
+     */
+    private static function positiveLines(array $record): array
+    {
+        $lines = $record['lines'] ?? null;
+
+        if (!\is_array($lines) || !\array_is_list($lines)) {
+            throw new TestCoverageMapError('The per-test coverage map has an invalid lines field.');
+        }
+
+        $validated = [];
+        foreach ($lines as $line) {
+            if (!\is_int($line) || $line < 1) {
+                throw new TestCoverageMapError('The per-test coverage map contains an invalid line number.');
+            }
+
+            $validated[] = $line;
+        }
+
+        return $validated;
+    }
+
+    /** @return array<string, mixed> */
+    private static function decode(string $line): array
+    {
+        try {
+            $decoded = \json_decode($line, true, flags: \JSON_THROW_ON_ERROR);
+        } catch (\JsonException $error) {
+            throw new TestCoverageMapError('The per-test coverage map contains invalid JSON.', $error->getCode(), previous: $error);
+        }
+
+        if (!\is_array($decoded)) {
+            throw new TestCoverageMapError('The per-test coverage map contains a non-object record.');
+        }
+
+        $record = [];
+        foreach ($decoded as $key => $value) {
+            if (!\is_string($key)) {
+                throw new TestCoverageMapError('The per-test coverage map contains a non-string key.');
+            }
+
+            $record[$key] = $value;
+        }
+
+        return $record;
+    }
+}

--- a/src/Coverage/Attribution/TestCoverageMapError.php
+++ b/src/Coverage/Attribution/TestCoverageMapError.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Coverage\Attribution;
+
+/**
+ * A per-test coverage map is missing, stale, or not valid for impact selection.
+ *
+ * @internal
+ */
+final class TestCoverageMapError extends \RuntimeException {}

--- a/src/Test/TestSelection.php
+++ b/src/Test/TestSelection.php
@@ -26,6 +26,22 @@ final readonly class TestSelection
         return new self($this->include->withExactIds($ids), $this->exclude, $this->shard);
     }
 
+    /** @param list<non-empty-string> $ids */
+    public function withOnlyExactIds(array $ids): self
+    {
+        return new self(
+            new TestInclusions(
+                groups: $this->include->groups,
+                classes: $this->include->classes,
+                methods: $this->include->methods,
+                paths: $this->include->paths,
+                exactIds: $ids,
+            ),
+            $this->exclude,
+            $this->shard,
+        );
+    }
+
     /** @param list<non-empty-string> $paths */
     public function withExcludedPaths(array $paths): self
     {

--- a/tests/Acceptance/CommandErrorsTest.php
+++ b/tests/Acceptance/CommandErrorsTest.php
@@ -69,6 +69,41 @@ final readonly class CommandErrorsTest
     }
 
     #[Test]
+    public function impactedWatchRequiresWatchMode(): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'impacted-watch-requires-watch');
+        $this->writeMinimalConfiguration($project);
+        $result = GreenlightCli::run($project->directory, ['run', '--watch-impacted', '--no-ansi']);
+
+        Expect::that($result->exitCode)->toBe(64);
+        Expect::that($result->stderr)->toBe('greenlight: Use --watch-impacted with --watch.');
+    }
+
+    #[Test]
+    public function impactedWatchRequiresACoverageIncludePath(): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'impacted-watch-requires-coverage');
+        $this->writeMinimalConfiguration($project);
+        $result = GreenlightCli::run($project->directory, ['run', '--watch', '--watch-impacted', '--no-ansi']);
+
+        Expect::that($result->exitCode)->toBe(64);
+        Expect::that($result->stderr)->toBe('greenlight: Impacted watch requires at least one coverage include path.');
+    }
+
+    private function writeMinimalConfiguration(AcceptanceProject $project): void
+    {
+        $project->writeFile('greenlight.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Config\GreenlightConfig;
+
+            return GreenlightConfig::create()->paths([__DIR__ . '/tests']);
+            PHP);
+    }
+
+    #[Test]
     public function coverageDiffWithoutBaselineOrCurrentIsAUsageError(): void
     {
         $result = GreenlightCli::run(\dirname(__DIR__, 2), ['coverage:diff']);

--- a/tests/Acceptance/WatchModeTest.php
+++ b/tests/Acceptance/WatchModeTest.php
@@ -142,6 +142,54 @@ final readonly class WatchModeTest
             ->toBe(0);
     }
 
+    #[Test]
+    public function impactedWatchSelectsCoveredTestsThenRefreshesAStaleMap(): void
+    {
+        $project = $this->writeImpactedProject();
+        $environment = [
+            'XDEBUG_MODE' => 'coverage',
+            'DD_TRACE_ENABLED' => 'false',
+            'DD_PROFILING_ENABLED' => 'false',
+            'DD_APPSEC_ENABLED' => 'false',
+            'DD_INSTRUMENTATION_TELEMETRY_ENABLED' => 'false',
+        ];
+        $process = GreenlightCli::start(
+            $project->directory,
+            ['run', '--watch', '--watch-impacted', '--reporter=plain', '--no-ansi'],
+            $environment,
+        );
+        $this->cleanup->defer($process->terminate(...));
+
+        $output = $process->readStdoutUntil('Waiting for changes', 30.0);
+        Expect::that($output)
+            ->because('impacted watch MUST start with the complete selected plan')
+            ->toContain('2 tests, 2 passed');
+
+        $project->writeFile('source/Observed.php', $this->observedSource(2));
+        $output = $process->readStdoutUntil('Waiting for changes', 30.0);
+        Expect::that($output)
+            ->because('a covered changed line MUST select only its mapped test')
+            ->toContain('Impacted watch selected 1 test.')
+            ->toContain('1 test, 1 passed');
+
+        $project->writeFile('source/Observed.php', $this->observedSource(3));
+        $output = $process->readStdoutUntil('Waiting for changes', 30.0);
+        Expect::that($output)
+            ->because('a selective rerun MUST make the old map stale')
+            ->toContain('The per-test coverage map is stale.')
+            ->toContain('2 tests, 2 passed');
+
+        $process->write("\n");
+        $output = $process->readStdoutUntil('Waiting for changes', 30.0);
+        Expect::that($output)
+            ->because('Enter MUST keep its complete rerun behavior')
+            ->toContain('2 tests, 2 passed');
+
+        $process->write('q');
+        $result = $process->wait(10.0);
+        Expect::that($result->exitCode)->toBe(0);
+    }
+
     private function writeProject(
         bool $watchCoverageSource = false,
         bool $failCleanup = false,
@@ -195,6 +243,62 @@ final readonly class WatchModeTest
         ));
 
         return $project;
+    }
+
+    private function writeImpactedProject(): AcceptanceProject
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'watch-impacted');
+        $project->writeFile('source/Observed.php', $this->observedSource(1));
+        $project->writeFile('tests/WatchImpactTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace WatchImpact;
+
+            use Greenlight\Attribute\Test;
+
+            require_once __DIR__ . '/../source/Observed.php';
+
+            final class WatchImpactTest
+            {
+                #[Test]
+                public function usesObservedSource(): void
+                {
+                    observed();
+                }
+
+                #[Test]
+                public function doesNotUseObservedSource(): void {}
+            }
+            PHP);
+        $project->writeFile('greenlight.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Config\GreenlightConfig;
+
+            require_once __DIR__ . '/tests/WatchImpactTest.php';
+
+            return GreenlightConfig::create()
+                ->paths([__DIR__ . '/tests'])
+                ->workers(2)
+                ->watch(fn($watch) => $watch->debounceMilliseconds(50))
+                ->coverage(fn($coverage) => $coverage
+                    ->include(__DIR__ . '/source')
+                    ->driver('xdebug'));
+            PHP);
+
+        return $project;
+    }
+
+    private function observedSource(int $value): string
+    {
+        return \sprintf(
+            "<?php\n\ndeclare(strict_types=1);\n\nnamespace WatchImpact;\n\nfunction observed(): int\n{\n    return %d;\n}\n",
+            $value,
+        );
     }
 
     /**

--- a/tests/Unit/Cli/Watch/ImpactedTestSelectorTest.php
+++ b/tests/Unit/Cli/Watch/ImpactedTestSelectorTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli\Watch;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\Watch\FileChange;
+use Greenlight\Cli\Watch\ImpactedTestSelector;
+use Greenlight\Discovery\DiscoveryError;
+use Greenlight\Discovery\Plan\ExecutionPlan;
+use Greenlight\Discovery\Plan\PlanEntry;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Test\TestDefinition;
+use Greenlight\Test\TestExclusions;
+use Greenlight\Test\TestInclusions;
+use Greenlight\Test\TestSelection;
+
+final readonly class ImpactedTestSelectorTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function combinesPreviousFailuresWithTestsForCoveredChangedLines(): void
+    {
+        [$root, $testFile, $source, $artifact, $plan] = $this->fixture();
+        $selection = new TestSelection(
+            include: new TestInclusions(groups: ['fast'], idPatterns: ['*::runs']),
+            exclude: new TestExclusions(groups: ['quarantined']),
+            shard: [1, 2],
+        );
+        $selector = $this->selector($selection, $plan, $artifact, $root, $testFile, $source);
+        $impact = $selector->select([
+            new FileChange($source, true, true, "<?php\nold\n", "<?php\nnew\n"),
+        ], ['Example\\FailedTest::runs'], 'run-one');
+
+        Expect::that($impact->complete)
+            ->because('a covered changed line has a reliable impacted selection')
+            ->toBeFalse();
+        Expect::that($impact->selection->include->exactIds)
+            ->because('the impacted selection MUST include previous failures and line coverage')
+            ->toBe(['Example\\FailedTest::runs', 'Example\\CoveredTest::runs']);
+        Expect::that($impact->selection->include->idPatterns)
+            ->because('the impacted exact IDs MUST replace broad ID patterns')
+            ->toBe([]);
+        Expect::that($impact->selection->include->groups)->toBe(['fast']);
+        Expect::that($impact->selection->exclude->groups)->toBe(['quarantined']);
+        Expect::that($impact->selection->shard)->toBe([1, 2]);
+    }
+
+    #[Test]
+    public function mapsAChangedTestFileDirectlyToItsCurrentTests(): void
+    {
+        [$root, $testFile, $source, $artifact, $plan] = $this->fixture();
+        $selector = $this->selector(new TestSelection(), $plan, $artifact, $root, $testFile, $source);
+        $impact = $selector->select([
+            new FileChange($testFile, true, true, "<?php\nold\n", "<?php\nnew\n"),
+        ], [], 'run-one');
+
+        Expect::that($impact->complete)->toBeFalse();
+        Expect::that($impact->selection->include->exactIds)
+            ->because('a changed test file MUST select each current test in that file')
+            ->toBe(['Example\\CoveredTest::runs']);
+    }
+
+    #[Test]
+    public function uncertainFileChangesRequireTheCompleteSelection(): void
+    {
+        [$root, $testFile, $source, $artifact, $plan] = $this->fixture();
+        $selection = new TestSelection(include: new TestInclusions(groups: ['fast']));
+        $selector = $this->selector($selection, $plan, $artifact, $root, $testFile, $source);
+        $config = $root . '/greenlight.php';
+        $outside = $root . '/bootstrap.php';
+
+        $changes = [
+            'deleted file' => new FileChange($source, true, false, '<?php'),
+            'added source file' => new FileChange($source, false, true, after: '<?php'),
+            'shifted source lines' => new FileChange($source, true, true, "<?php\n", "<?php\nnew\n"),
+            'configuration file' => new FileChange($config, true, true),
+            'outside configured roots' => new FileChange($outside, true, true),
+        ];
+
+        foreach ($changes as $name => $change) {
+            $impact = $selector->select([$change], [], 'run-one');
+
+            Expect::that($impact->complete)
+                ->because($name . ' MUST require the complete selected plan')
+                ->toBeTrue();
+            Expect::that($impact->selection)->toBe($selection);
+        }
+    }
+
+    #[Test]
+    public function aDiscoveryErrorRequiresTheCompleteSelection(): void
+    {
+        [$root, $testFile, $source, $artifact] = $this->fixture();
+        $selection = new TestSelection();
+        $selector = new ImpactedTestSelector(
+            $selection,
+            static fn(): ExecutionPlan => throw DiscoveryError::directoryNotFound('/missing'),
+            $artifact,
+            [\dirname($testFile)],
+            [\dirname($source)],
+            $root,
+            $root . '/greenlight.php',
+        );
+        $impact = $selector->select([
+            new FileChange($testFile, true, true, '<?php', '<?php '),
+        ], [], 'run-one');
+
+        Expect::that($impact->complete)
+            ->because('a discovery error MUST require the complete selected plan')
+            ->toBeTrue();
+        Expect::that($impact->diagnostic)->toContain('discovery');
+    }
+
+    #[Test]
+    public function aMissingCoverageMapRequiresTheCompleteSelection(): void
+    {
+        [$root, $testFile, $source, $artifact, $plan] = $this->fixture();
+        \unlink($artifact);
+        $selection = new TestSelection();
+        $selector = $this->selector($selection, $plan, $artifact, $root, $testFile, $source);
+        $impact = $selector->select([
+            new FileChange($source, true, true, "<?php\nold\n", "<?php\nnew\n"),
+        ], [], 'run-one');
+
+        Expect::that($impact->complete)
+            ->because('a missing map MUST require the complete selected plan')
+            ->toBeTrue();
+        Expect::that($impact->selection)->toBe($selection);
+        Expect::that($impact->diagnostic)->toContain('missing');
+    }
+
+    /**
+     * @return array{non-empty-string, non-empty-string, non-empty-string, non-empty-string, ExecutionPlan}
+     */
+    private function fixture(): array
+    {
+        $root = $this->tempDirectory->subdirectory('impacted-selector-' . \bin2hex(\random_bytes(4)));
+        $tests = $this->tempDirectory->subdirectory(\basename($root) . '/tests');
+        $sources = $this->tempDirectory->subdirectory(\basename($root) . '/src');
+        $testFile = $tests . '/CoveredTest.php';
+        $failedFile = $tests . '/FailedTest.php';
+        $source = $sources . '/Subject.php';
+        $artifact = $root . '/coverage.jsonl';
+        \file_put_contents($testFile, '<?php');
+        \file_put_contents($failedFile, '<?php');
+        \file_put_contents($source, "<?php\nold\n");
+        \file_put_contents($root . '/greenlight.php', '<?php');
+        $plan = new ExecutionPlan([
+            new PlanEntry(new TestDefinition('Example\\CoveredTest', 'runs', ['fast']), sourceFile: $testFile),
+            new PlanEntry(new TestDefinition('Example\\FailedTest', 'runs', ['fast']), sourceFile: $failedFile),
+        ]);
+        $records = [
+            ['v' => 1, 'type' => 'meta', 'root' => $root, 'runId' => 'run-one', 'complete' => true],
+            ['v' => 1, 'type' => 'test', 'test' => 0, 'renderedId' => 'Example\\CoveredTest::runs'],
+            ['v' => 1, 'type' => 'test', 'test' => 1, 'renderedId' => 'Example\\FailedTest::runs'],
+            ['v' => 1, 'type' => 'coverage', 'test' => 0, 'file' => $source, 'lines' => [2]],
+            ['v' => 1, 'type' => 'source', 'file' => $source, 'covered' => true, 'lines' => [2]],
+        ];
+        $lines = \array_map(
+            static fn(array $record): string => \json_encode($record, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES),
+            $records,
+        );
+        \file_put_contents($artifact, \implode("\n", $lines) . "\n");
+
+        return [$root, $testFile, $source, $artifact, $plan];
+    }
+
+    private function selector(TestSelection $selection, ExecutionPlan $plan, string $artifact, string $root, string $testFile, string $source): ImpactedTestSelector
+    {
+        return new ImpactedTestSelector(
+            $selection,
+            static fn(): ExecutionPlan => $plan,
+            $artifact,
+            [\dirname($testFile)],
+            [\dirname($source)],
+            $root,
+            $root . '/greenlight.php',
+        );
+    }
+}

--- a/tests/Unit/Cli/Watch/StatChangeDetectorContentTest.php
+++ b/tests/Unit/Cli/Watch/StatChangeDetectorContentTest.php
@@ -49,8 +49,29 @@ final readonly class StatChangeDetectorContentTest
         Expect::that(\filesize($source))
             ->because('the rewrite MUST preserve the file size in the original fingerprint')
             ->toBe(\strlen($original));
-        Expect::that($detector->poll())
+        $changes = $detector->poll();
+
+        Expect::that($changes)
             ->because('the content fingerprint MUST report an equal-size rewrite')
-            ->toBe([$source]);
+            ->toHaveCount(1);
+        Expect::that($changes[0]->path)->toBe($source);
+    }
+
+    #[Test]
+    public function configuredContentRootsKeepBothSidesOfAChange(): void
+    {
+        $directory = $this->tempDirectory->subdirectory('watch-content-details');
+        $source = $directory . '/ContentProbeTest.php';
+        \file_put_contents($source, "<?php\nold\n");
+        $detector = new StatChangeDetector([$directory], [$directory]);
+        $detector->poll();
+        \file_put_contents($source, "<?php\nnew\n");
+
+        $changes = $detector->poll();
+
+        Expect::that($changes)->toHaveCount(1);
+        Expect::that($changes[0]->before)->toBe("<?php\nold\n");
+        Expect::that($changes[0]->after)->toBe("<?php\nnew\n");
+        Expect::that($changes[0]->changedLines())->toBe([2]);
     }
 }

--- a/tests/Unit/Cli/Watch/StatChangeDetectorEmptySnapshotTest.php
+++ b/tests/Unit/Cli/Watch/StatChangeDetectorEmptySnapshotTest.php
@@ -26,8 +26,11 @@ final readonly class StatChangeDetectorEmptySnapshotTest
         $file = $directory . '/FirstTest.php';
         \file_put_contents($file, '<?php');
 
-        Expect::that($detector->poll())
+        $changes = $detector->poll();
+
+        Expect::that($changes)
             ->because('the first PHP file MUST be reported after an empty snapshot')
-            ->toBe([$file]);
+            ->toHaveCount(1);
+        Expect::that($changes[0]->path)->toBe($file);
     }
 }

--- a/tests/Unit/Cli/Watch/WatchLoopIdleTest.php
+++ b/tests/Unit/Cli/Watch/WatchLoopIdleTest.php
@@ -9,6 +9,7 @@ use Greenlight\Cli\Watch\ChangeDetector;
 use Greenlight\Cli\Watch\Debouncer;
 use Greenlight\Cli\Watch\KeyInput;
 use Greenlight\Cli\Watch\WatchLoop;
+use Greenlight\Cli\Watch\WatchLoopResult;
 use Greenlight\Doubles\Fake;
 use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\Cli\Watch\FakeWatchClock;
@@ -43,10 +44,10 @@ final class WatchLoopIdleTest
             $keys,
             $clock,
             static function (string $text): void {},
-        )->run(static function (array $priorityClasses) use (&$runs): array {
+        )->run(static function (array $priorityClasses, array $changes, bool $complete, bool $mapFresh) use (&$runs): WatchLoopResult {
             ++$runs;
 
-            return [];
+            return new WatchLoopResult([]);
         });
 
         Expect::that($clock->sleeps)

--- a/tests/Unit/Cli/Watch/WatchTest.php
+++ b/tests/Unit/Cli/Watch/WatchTest.php
@@ -7,10 +7,12 @@ namespace Greenlight\Tests\Unit\Cli\Watch;
 use Greenlight\Attribute\Test;
 use Greenlight\Cli\Watch\ChangeDetector;
 use Greenlight\Cli\Watch\Debouncer;
+use Greenlight\Cli\Watch\FileChange;
 use Greenlight\Cli\Watch\KeyInput;
 use Greenlight\Cli\Watch\StatChangeDetector;
 use Greenlight\Cli\Watch\SystemWatchClock;
 use Greenlight\Cli\Watch\WatchLoop;
+use Greenlight\Cli\Watch\WatchLoopResult;
 use Greenlight\Doubles\Fake;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
@@ -75,14 +77,14 @@ final readonly class WatchTest
         // Both changes occur in the same second. Thus, a size change shows
         // that the fingerprint operates correctly.
         \file_put_contents($directory . '/A.php', '<?php // a changed');
-        Expect::that($detector->poll())->toBe([$directory . '/A.php']);
+        Expect::that($this->paths($detector->poll()))->toBe([$directory . '/A.php']);
         Expect::that($detector->poll())->toBe([]);
 
         \file_put_contents($directory . '/B.php', '<?php // b');
-        Expect::that($detector->poll())->toBe([$directory . '/B.php']);
+        Expect::that($this->paths($detector->poll()))->toBe([$directory . '/B.php']);
 
         \unlink($directory . '/A.php');
-        Expect::that($detector->poll())->toBe([$directory . '/A.php']);
+        Expect::that($this->paths($detector->poll()))->toBe([$directory . '/A.php']);
     }
 
     #[Test]
@@ -112,7 +114,7 @@ final readonly class WatchTest
 
         \file_put_contents($watchedFile, '<?php // second and larger');
 
-        Expect::that($detector->poll())
+        Expect::that($this->paths($detector->poll()))
             ->because('nested PHP files are watched')
             ->toBe([$watchedFile]);
     }
@@ -130,7 +132,7 @@ final readonly class WatchTest
 
                 return $this->polls === 1
                     ? []
-                    : ['/tmp/FirstTest.php', '/tmp/SecondTest.php'];
+                    : [FileChange::unknown('/tmp/FirstTest.php'), FileChange::unknown('/tmp/SecondTest.php')];
             }
         };
         $keys = new class implements KeyInput, Fake {
@@ -151,7 +153,7 @@ final readonly class WatchTest
             static function (string $text) use (&$output): void {
                 $output .= $text;
             },
-        )->run(static fn(array $priorityClasses): array => [], maxIterations: 2);
+        )->run(static fn(array $priorityClasses, array $changes, bool $complete, bool $mapFresh): WatchLoopResult => new WatchLoopResult([]), maxIterations: 2);
 
         $ready = "\nWaiting for changes. Press Enter to run all tests. Press q to quit.\n";
 
@@ -204,10 +206,10 @@ final readonly class WatchTest
             static function (string $text) use ($record): void {
                 $record('ready');
             },
-        )->run(static function (array $priorityClasses) use ($record): array {
+        )->run(static function (array $priorityClasses, array $changes, bool $complete, bool $mapFresh) use ($record): WatchLoopResult {
             $record('run');
 
-            return [];
+            return new WatchLoopResult([]);
         });
 
         Expect::that($events)->toBe(['baseline', 'run', 'ready', 'key']);
@@ -244,11 +246,11 @@ final readonly class WatchTest
             new SystemWatchClock(),
             static function (string $text): void {},
             $shutdown,
-        )->run(static function (array $priorityClasses) use (&$runs, $shutdown): array {
+        )->run(static function (array $priorityClasses, array $changes, bool $complete, bool $mapFresh) use (&$runs, $shutdown): WatchLoopResult {
             ++$runs;
             $shutdown->request(15);
 
-            return [];
+            return new WatchLoopResult([]);
         });
 
         Expect::that($runs)
@@ -278,7 +280,7 @@ final readonly class WatchTest
                 ++$this->tick;
 
                 return match ($this->tick) {
-                    2, 3 => ['/tmp/file.php'],
+                    2, 3 => [FileChange::unknown('/tmp/file.php')],
                     default => [],
                 };
             }
@@ -302,10 +304,10 @@ final readonly class WatchTest
         };
 
         $runs = [];
-        $runOnce = static function (array $priorityClasses) use (&$runs): array {
+        $runOnce = static function (array $priorityClasses, array $changes, bool $complete, bool $mapFresh) use (&$runs): WatchLoopResult {
             $runs[] = $priorityClasses;
 
-            return ['App\\BrokenTest'];
+            return new WatchLoopResult(['App\\BrokenTest']);
         };
 
         $output = '';
@@ -321,5 +323,59 @@ final readonly class WatchTest
         Expect::that($runs[1])->toBe(['App\\BrokenTest']);
         Expect::that($runs[2])->toBe([]);
         Expect::that($output)->toContain('Detected changes in 1 file.');
+    }
+
+    #[Test]
+    public function changesDuringACompleteRunInvalidateItsCoverageMap(): void
+    {
+        $detector = new class implements ChangeDetector, Fake {
+            private int $polls = 0;
+
+            #[\Override]
+            public function poll(): array
+            {
+                return ++$this->polls === 2
+                    ? [new FileChange('/project/src/Subject.php', true, true, 'old', 'new')]
+                    : [];
+            }
+        };
+        $keys = new class implements KeyInput, Fake {
+            #[\Override]
+            public function poll(): ?string
+            {
+                return null;
+            }
+        };
+        $requests = [];
+
+        new WatchLoop(
+            $detector,
+            new Debouncer(0.0),
+            $keys,
+            new FakeWatchClock(),
+            static function (string $text): void {},
+            tracksStableRuns: true,
+        )->run(static function (array $priorityClasses, array $changes, bool $complete, bool $mapFresh) use (&$requests): WatchLoopResult {
+            $requests[] = [$changes, $complete, $mapFresh];
+
+            return new WatchLoopResult([], mapPublished: true);
+        }, maxIterations: 2);
+
+        Expect::that($requests)->toHaveCount(2);
+        Expect::that($requests[0][1])->toBeTrue();
+        Expect::that($requests[1][0])->toHaveCount(1);
+        Expect::that($requests[1][1])->toBeFalse();
+        Expect::that($requests[1][2])
+            ->because('a change during a complete run MUST make its coverage map stale')
+            ->toBeFalse();
+    }
+
+    /**
+     * @param list<FileChange> $changes
+     * @return list<non-empty-string>
+     */
+    private function paths(array $changes): array
+    {
+        return \array_map(static fn(FileChange $change): string => $change->path, $changes);
     }
 }

--- a/tests/Unit/Coverage/Attribution/TestCoverageMapImpactTest.php
+++ b/tests/Unit/Coverage/Attribution/TestCoverageMapImpactTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage\Attribution;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\Attribution\TestCoverageMap;
+use Greenlight\Coverage\Attribution\TestCoverageMapError;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+
+final readonly class TestCoverageMapImpactTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function returnsEachTestThatCoversAChangedLine(): void
+    {
+        $root = $this->tempDirectory->subdirectory('coverage-impact');
+        $source = $root . '/src/Subject.php';
+        $artifact = $root . '/coverage.jsonl';
+        $this->write($artifact, [
+            ['v' => 1, 'type' => 'meta', 'root' => $root, 'runId' => 'run-one', 'complete' => true],
+            ['v' => 1, 'type' => 'test', 'test' => 0, 'renderedId' => 'Example\\FirstTest::runs'],
+            ['v' => 1, 'type' => 'test', 'test' => 1, 'renderedId' => 'Example\\SecondTest::runs'],
+            ['v' => 1, 'type' => 'coverage', 'test' => 0, 'file' => $source, 'lines' => [4, 8]],
+            ['v' => 1, 'type' => 'coverage', 'test' => 1, 'file' => $source, 'lines' => [8]],
+            ['v' => 1, 'type' => 'source', 'file' => $source, 'covered' => true, 'lines' => [4, 8]],
+        ]);
+
+        Expect::that(TestCoverageMap::impactedTests($artifact, $root, 'run-one', [$source => [8]]))
+            ->because('each test that covered the changed line MUST be selected')
+            ->toBe(['Example\\FirstTest::runs', 'Example\\SecondTest::runs']);
+    }
+
+    #[Test]
+    public function rejectsAMapFromAnOlderRun(): void
+    {
+        $root = $this->tempDirectory->subdirectory('coverage-impact-stale');
+        $source = $root . '/src/Subject.php';
+        $artifact = $root . '/coverage.jsonl';
+        $this->write($artifact, [
+            ['v' => 1, 'type' => 'meta', 'root' => $root, 'runId' => 'old-run', 'complete' => true],
+        ]);
+
+        Expect::that(
+            static fn(): array => TestCoverageMap::impactedTests($artifact, $root, 'current-run', [$source => [8]]),
+        )
+            ->because('a map from an older run MUST require the complete selected plan')
+            ->toThrow(TestCoverageMapError::class);
+    }
+
+    /** @param list<array<string, mixed>> $extraRecords */
+    #[Test]
+    #[DataSet('uncertainMaps')]
+    public function rejectsAnUncertainChangedLine(array $extraRecords): void
+    {
+        $root = $this->tempDirectory->subdirectory('coverage-impact-uncertain-' . \count($extraRecords));
+        $source = $root . '/src/Subject.php';
+        $artifact = $root . '/coverage.jsonl';
+        $records = [
+            ['v' => 1, 'type' => 'meta', 'root' => $root, 'runId' => 'run-two', 'complete' => true],
+            ['v' => 1, 'type' => 'test', 'test' => 0, 'renderedId' => 'Example\\SubjectTest::runs'],
+        ];
+
+        foreach ($extraRecords as $record) {
+            $record['file'] = $source;
+            $records[] = $record;
+        }
+        $this->write($artifact, $records);
+
+        Expect::that(
+            static fn(): array => TestCoverageMap::impactedTests($artifact, $root, 'run-two', [$source => [8]]),
+        )
+            ->because('uncertain line attribution MUST require a complete selected run')
+            ->toThrow(TestCoverageMapError::class);
+    }
+
+    /** @return iterable<string, array{list<array<string, mixed>>}> */
+    public static function uncertainMaps(): iterable
+    {
+        yield 'uncovered line' => [[
+            ['v' => 1, 'type' => 'source', 'covered' => false, 'lines' => [8]],
+        ]];
+        yield 'unattributed line' => [[
+            ['v' => 1, 'type' => 'source', 'covered' => true, 'lines' => [8]],
+            ['v' => 1, 'type' => 'unattributed', 'lines' => [8]],
+        ]];
+        yield 'missing coverage record' => [[
+            ['v' => 1, 'type' => 'source', 'covered' => true, 'lines' => [8]],
+        ]];
+        yield 'missing source record' => [[
+            ['v' => 1, 'type' => 'coverage', 'test' => 0, 'lines' => [8]],
+        ]];
+    }
+
+    /** @param list<array<string, mixed>> $records */
+    private function write(string $artifact, array $records): void
+    {
+        $lines = \array_map(
+            static fn(array $record): string => \json_encode($record, \JSON_THROW_ON_ERROR | \JSON_UNESCAPED_SLASHES),
+            $records,
+        );
+        \file_put_contents($artifact, \implode("\n", $lines) . "\n");
+    }
+}

--- a/tests/Unit/Test/TestSelectionTest.php
+++ b/tests/Unit/Test/TestSelectionTest.php
@@ -30,4 +30,31 @@ final readonly class TestSelectionTest
         Expect::that($selection->acceptsId('Acme\ExactTest::only'))->toBeTrue();
         Expect::that($selection->acceptsId('Acme\FastTest::other'))->toBeFalse();
     }
+
+    #[Test]
+    public function onlyExactIdsKeepNonIdFiltersAndTheShard(): void
+    {
+        $selection = new TestSelection(
+            include: new TestInclusions(
+                groups: ['fast'],
+                classes: ['Acme'],
+                methods: ['works'],
+                paths: ['/project/tests'],
+                idPatterns: ['*::broad*'],
+            ),
+            exclude: new TestExclusions(groups: ['quarantined']),
+            shard: [2, 3],
+        );
+
+        $narrowed = $selection->withOnlyExactIds(['Acme\ExactTest::works']);
+
+        Expect::that($narrowed->include->groups)->toBe(['fast']);
+        Expect::that($narrowed->include->classes)->toBe(['Acme']);
+        Expect::that($narrowed->include->methods)->toBe(['works']);
+        Expect::that($narrowed->include->paths)->toBe(['/project/tests']);
+        Expect::that($narrowed->include->idPatterns)->toBe([]);
+        Expect::that($narrowed->include->exactIds)->toBe(['Acme\ExactTest::works']);
+        Expect::that($narrowed->exclude->groups)->toBe(['quarantined']);
+        Expect::that($narrowed->shard)->toBe([2, 3]);
+    }
 }


### PR DESCRIPTION
## Summary

- add an opt-in `--watch-impacted` mode on top of the refreshed per-test coverage map from #16
- rerun previous failures, tests from changed test files, and exact test IDs attributed to changed covered source lines
- preserve filters, exclusions, suites, sharding, failure priority, discovery caching, debounce, and complete Enter reruns
- broaden to the complete selected plan when file changes, discovery, or attribution are uncertain
- document map freshness, fallbacks, limitations, and polling performance

## Stack

This pull request targets `feat/per-test-coverage-and-infection-support` at the refreshed #16 head. Retarget it to `main` after #16 merges.