### PR TITLE
feat: capture direct test output

### DIFF
--- a/docs/api-results.md
+++ b/docs/api-results.md
@@ -13,14 +13,15 @@ Namespace: `Greenlight\Result`
 When output is too long, Greenlight keeps the first part. This part usually
 identifies the cause. The last part usually contains repeated information.
 
-Greenlight converts captured standard output to valid UTF-8 before it adds
-the output to a test result.
+Greenlight keeps at most 1 MiB from each standard stream and 1,000
+diagnostics. It converts captured stream data to valid UTF-8 before it adds
+the data to a test result.
 
 ```php
 final readonly class CapturedOutput
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/CapturedOutput.php#L18)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/CapturedOutput.php#L19)
 
 ### `$diagnostics`
 
@@ -32,7 +33,7 @@ PHPDoc:
 
 - `@var list<Diagnostic>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/CapturedOutput.php#L23)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/CapturedOutput.php#L28)
 
 ### `$stdout`
 
@@ -40,7 +41,7 @@ PHPDoc:
 public string $stdout
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/CapturedOutput.php#L31)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/CapturedOutput.php#L36)
 
 ### `$stdoutTruncated`
 
@@ -48,7 +49,7 @@ public string $stdout
 public bool $stdoutTruncated
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/CapturedOutput.php#L33)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/CapturedOutput.php#L38)
 
 ### `$diagnosticsTruncated`
 
@@ -56,7 +57,31 @@ public bool $stdoutTruncated
 public bool $diagnosticsTruncated
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/CapturedOutput.php#L34)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/CapturedOutput.php#L39)
+
+### `$stderr`
+
+```php
+public string $stderr
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/CapturedOutput.php#L40)
+
+### `$stderrTruncated`
+
+```php
+public bool $stderrTruncated
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/CapturedOutput.php#L41)
+
+### `$capability`
+
+```php
+public OutputCaptureCapability $capability
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/CapturedOutput.php#L42)
 
 ### `__construct()`
 
@@ -66,6 +91,9 @@ public function __construct(
     array $diagnostics = [],
     public bool $stdoutTruncated = false,
     public bool $diagnosticsTruncated = false,
+    public string $stderr = '',
+    public bool $stderrTruncated = false,
+    public OutputCaptureCapability $capability = OutputCaptureCapability::Buffered,
 )
 ```
 
@@ -74,7 +102,7 @@ PHPDoc:
 - `@param array<mixed> $diagnostics`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/CapturedOutput.php#L30)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/CapturedOutput.php#L35)
 
 ## `Diagnostic`
 
@@ -366,6 +394,49 @@ PHPDoc:
 - `@throws \InvalidArgumentException`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/OutcomeTransformation.php#L21)
+
+## `OutputCaptureCapability`
+
+Namespace: `Greenlight\Result`
+
+Identifies the stream writes that Greenlight could capture for a result.
+
+`Buffered` contains PHP output-buffer content and diagnostics only.
+`PhpStreams` also contains writes through the PHP `STDOUT` and `STDERR`
+resources.
+
+`ProcessDescriptors` also contains safely attributed writes from child
+processes that inherited the worker descriptors.
+
+```php
+enum OutputCaptureCapability: string
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/OutputCaptureCapability.php#L17)
+
+### `Buffered`
+
+```php
+case Buffered = 'buffered';
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/OutputCaptureCapability.php#L19)
+
+### `PhpStreams`
+
+```php
+case PhpStreams = 'php-streams';
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/OutputCaptureCapability.php#L20)
+
+### `ProcessDescriptors`
+
+```php
+case ProcessDescriptors = 'process-descriptors';
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/OutputCaptureCapability.php#L21)
 
 ## `ResultSummary`
 

--- a/docs/architecture/jsonl.md
+++ b/docs/architecture/jsonl.md
@@ -236,6 +236,7 @@ When present, it has this shape:
 ```json id="w4mt8a"
 {
     "stdout": "...",
+    "stderr": "...",
     "diagnostics": [
         {
             "severity": "warning",
@@ -245,13 +246,19 @@ When present, it has this shape:
         }
     ],
     "stdoutTruncated": false,
-    "diagnosticsTruncated": false
+    "stderrTruncated": false,
+    "diagnosticsTruncated": false,
+    "capability": "process-descriptors"
 }
 ```
 
 `severity` is one of `notice`, `warning`, or `deprecation`.
 
-The two output flags show that output capture reached its size limit.
+The three output flags show that output capture reached its size limit.
+`capability` is `buffered`, `php-streams`, or `process-descriptors`. Readers of
+version 3 MUST accept output objects that do not have `stderr`,
+`stderrTruncated`, or `capability`. These additive fields do not change the
+JSONL version.
 
 ### risky
 

--- a/docs/architecture/worker-lifecycle.md
+++ b/docs/architecture/worker-lifecycle.md
@@ -39,20 +39,31 @@ connects as a client.
 Each message is a length-prefixed JSON frame: a 4-byte big-endian length
 followed by the JSON body. Frames are capped at 8 MiB. Greenlight rejects
 oversized or malformed frames as protocol errors. The JSON envelope contains a
-protocol version (`v`, currently `3`), a type tag, and the payload. Greenlight
+protocol version (`v`, currently `4`), a type tag, and the payload. Greenlight
 also rejects unknown versions and tags.
 
-The [version 3 schema](../../resources/schema/worker-protocol-v3.schema.json)
+The [version 4 schema](../../resources/schema/worker-protocol-v4.schema.json)
 specifies each envelope and payload that Greenlight sends.
 
 The socket carries all protocol data. The native adapter closes worker stdin
-after process start. It drains stdout and stderr into a small bounded buffer.
-The orchestrator requests this output for a crash report. Test results never
-travel over stdio, so test output cannot corrupt the protocol.
+after process start. Worker standard output and standard error are data pipes,
+not protocol channels. Thus, test output cannot become a protocol frame.
+
+Before each attempt, the worker sends `attempt-started`. The orchestrator then
+starts bounded capture on both process descriptors and sends `attempt-ready`.
+The worker does not start test code before this acknowledgement. When the
+orchestrator receives `TestFinished`, it drains and closes the capture window
+before it emits the event. This handshake gives each synchronous descriptor
+write a deterministic owner.
+
+Each stream has an independent 1 MiB limit and truncation flag. The adapter
+retains raw bytes up to the limit. It converts the data to valid UTF-8 before it
+adds the data to a result. If capture is disabled, the adapter drains and
+discards both streams during the attempt.
 
 ## The messages
 
-Nine message types cross the socket:
+Ten message types cross the socket:
 
 | Tag | Direction | Payload |
 | --- | --- | --- |
@@ -61,7 +72,8 @@ Nine message types cross the socket:
 | `ready` | worker to orchestrator | bootstrap acknowledgement |
 | `assign` | orchestrator to worker | a plan slice (test classes to run), remaining failure allowance, coverage settings, leak detection flag, result policy, artifact session and limits |
 | `event` | worker to orchestrator | one test event: class started, test started, test finished, class finished |
-| `attempt-started` | worker to orchestrator | active test ID and attempt number for a crash report |
+| `attempt-started` | worker to orchestrator | active test ID, attempt number, and capture setting |
+| `attempt-ready` | orchestrator to worker | output-capture acknowledgement |
 | `done` | worker to orchestrator | result summary, peak memory, coverage, detected leaks |
 | `drain` | orchestrator to worker | no payload (request for a clean worker exit) |
 | `fatal` | worker to orchestrator | details of a throwable that the worker could not contain |
@@ -304,9 +316,27 @@ stateDiagram-v2
 ### Crashes
 
 If a worker dies mid-assignment, the orchestrator reports its in-flight test as
-errored and attaches the tail of the worker's stderr. It returns the rest of the
-assignment to the queue. It does not re-queue the crashed test because a test
-that kills its process would kill each replacement in turn.
+errored. It drains the active output window and adds its standard output and
+standard error to the result. It returns the rest of the assignment to the
+queue. It does not re-queue the crashed test because a test that kills its
+process would kill each replacement in turn.
+
+The capture window starts before constructor injection. It contains attempt
+runners, test subscribers, hooks, the test method, and cleanup. It also contains
+test-scope disposal, retry decisions, and class-scope disposal that belongs to
+the test. Output from a failed attempt remains in the result after a later
+attempt passes.
+
+Output from a child process is attributable only when the child
+inherits the worker descriptors and completes before the capture window closes.
+A background child that writes after this boundary produces worker diagnostics.
+Greenlight does not assign that output to a completed test.
+
+An in-process run cannot redirect native process descriptors without also
+redirecting reporter output. It uses PHP stream filters instead. This method
+captures `echo`, `print`, diagnostics, and writes through PHP's `STDOUT` and
+`STDERR` resources. It does not capture output from inherited child processes.
+The public `OutputCaptureCapability` value makes this limit explicit.
 
 ### Timeouts
 

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -19,20 +19,33 @@ bool $capture = true
 
 Marks a public method as a test.
 
-Greenlight enables output capture by default. It records output from PHP's
-output buffer, such as `echo` and `print`. It also records notices, warnings,
-and deprecations from the test. Reporters can associate this output with its
-test.
+Greenlight enables output capture by default. It records `echo`, `print`, PHP
+diagnostics, and direct writes to the PHP `STDOUT` and `STDERR` resources. It
+keeps standard output and standard error separate. The limit is 1 MiB for each
+stream and 1,000 diagnostics for each test. A result has a separate truncation
+flag for each limit.
 
-Direct writes to the `STDOUT` and `STDERR` stream resources bypass PHP's output
-buffer. Greenlight does not capture these writes. They can also interfere with
-terminal output. Do not use these resources for test diagnostics. Use test
-attachments to retain diagnostic content. See [test
-attachments](attachments.md).
+In a process-pool run, Greenlight captures the worker process descriptors. It
+also captures writes from a child process that inherits these descriptors and
+finishes inside the active test boundary. In an in-process run, Greenlight can
+capture only writes that use the PHP stream resources. It cannot capture writes
+from an inherited child process. The result's `capability` value identifies the
+capture method. See [Result API](api-results.md#outputcapturecapability).
+
+If PHP cannot install its required stream filters, Greenlight reports a capture
+error for the test. It does not report that direct-write capture succeeded.
+
+The capture boundary starts before constructor injection. It contains attempt
+runners, test subscribers, hooks, the test method, and cleanup callbacks. It
+also contains test-scope disposal and retry decisions. The boundary contains
+class-scope disposal that Greenlight assigns to the test. Greenlight retains
+output from a failed attempt when it retries the test.
 
 Set `capture: false` only when a test needs to control PHP's output buffer or
 error handler itself. With capture disabled, Greenlight does not record output
-or diagnostics for that test.
+or diagnostics for that test. Greenlight discards direct stream writes while
+the test is active. Thus, these writes cannot corrupt reporter or protocol
+output.
 
 <!-- php-example {"mode":"display","reason":"Uses an ellipsis to omit code that is not relevant to the example."} -->
 ```php

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -578,6 +578,11 @@ final class FlakyQuarantine implements AfterTestSubscriber
 `afterTest()` receives the finished result and must return a result, either the
 same one or a replacement.
 
+In a process-pool run, this worker-side callback sees buffered output and PHP
+diagnostics collected before the callback. Native descriptor output is not in
+the result until the orchestrator receives `TestFinished`. Orchestrator-side
+event subscribers and reporters receive the complete captured output.
+
 Use `TestResult::withOutcome()` for each outcome change. This method records the
 plugin that changed the result. If a plugin changes the outcome without a
 transformation-log entry, Greenlight reports an error and names the plugin.
@@ -639,6 +644,10 @@ contains the complete test ID.
 The result contains metadata for the attachments from that attempt. A decider
 can inspect names, kinds, sizes, and media types. It cannot read the attachment
 content.
+
+The result contains buffered output and PHP diagnostics from the attempt. In a
+process-pool run, native descriptor output is not in this worker-side result.
+The orchestrator adds it to the final result.
 
 The built-in `#[Retry]` attribute uses this interface.
 

--- a/resources/schema/jsonl-v3.schema.json
+++ b/resources/schema/jsonl-v3.schema.json
@@ -297,12 +297,15 @@
             "required": ["stdout", "diagnostics", "stdoutTruncated", "diagnosticsTruncated"],
             "properties": {
                 "stdout": {"type": "string"},
+                "stderr": {"type": "string"},
                 "diagnostics": {
                     "type": "array",
                     "items": {"$ref": "#/definitions/diagnostic"}
                 },
                 "stdoutTruncated": {"type": "boolean"},
-                "diagnosticsTruncated": {"type": "boolean"}
+                "stderrTruncated": {"type": "boolean"},
+                "diagnosticsTruncated": {"type": "boolean"},
+                "capability": {"enum": ["buffered", "php-streams", "process-descriptors"]}
             }
         },
         "diagnostic": {

--- a/resources/schema/worker-protocol-v4.schema.json
+++ b/resources/schema/worker-protocol-v4.schema.json
@@ -1,13 +1,13 @@
 {
     "$schema": "http://json-schema.org/draft-04/schema#",
-    "id": "https://raw.githubusercontent.com/ben-challis/greenlight/main/resources/schema/worker-protocol-v3.schema.json",
-    "title": "Greenlight worker protocol envelope (version 3)",
+    "id": "https://raw.githubusercontent.com/ben-challis/greenlight/main/resources/schema/worker-protocol-v4.schema.json",
+    "title": "Greenlight worker protocol envelope (version 4)",
     "description": "The JSON body of one length-prefixed worker protocol frame.",
     "type": "object",
     "additionalProperties": false,
     "required": ["v", "t", "p"],
     "properties": {
-        "v": {"enum": [3]},
+        "v": {"enum": [4]},
         "t": {"type": "string", "minLength": 1},
         "p": {"type": ["object", "array"]}
     },
@@ -52,6 +52,12 @@
             "properties": {
                 "t": {"enum": ["attempt-started"]},
                 "p": {"$ref": "#/definitions/attemptStarted"}
+            }
+        },
+        {
+            "properties": {
+                "t": {"enum": ["attempt-ready"]},
+                "p": {"$ref": "#/definitions/emptyPayload"}
             }
         },
         {
@@ -360,10 +366,11 @@
         "attemptStarted": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["id", "attempt"],
+            "required": ["id", "attempt", "capture"],
             "properties": {
                 "id": {"$ref": "#/definitions/testId"},
-                "attempt": {"type": "integer", "minimum": 1}
+                "attempt": {"type": "integer", "minimum": 1},
+                "capture": {"type": "boolean"}
             }
         },
         "done": {
@@ -702,15 +709,18 @@
         "capturedOutput": {
             "type": "object",
             "additionalProperties": false,
-            "required": ["stdout", "diagnostics", "stdoutTruncated", "diagnosticsTruncated"],
+            "required": ["stdout", "stderr", "diagnostics", "stdoutTruncated", "stderrTruncated", "diagnosticsTruncated", "capability"],
             "properties": {
                 "stdout": {"type": "string"},
+                "stderr": {"type": "string"},
                 "diagnostics": {
                     "type": "array",
                     "items": {"$ref": "#/definitions/diagnostic"}
                 },
                 "stdoutTruncated": {"type": "boolean"},
-                "diagnosticsTruncated": {"type": "boolean"}
+                "stderrTruncated": {"type": "boolean"},
+                "diagnosticsTruncated": {"type": "boolean"},
+                "capability": {"enum": ["buffered", "php-streams", "process-descriptors"]}
             }
         },
         "diagnostic": {

--- a/src/Execution/ProcessPool/Orchestrator/NativeWorkerTransport.php
+++ b/src/Execution/ProcessPool/Orchestrator/NativeWorkerTransport.php
@@ -9,6 +9,7 @@ use Greenlight\Execution\ProcessPool\Protocol\ProtocolError;
 use Greenlight\Execution\ProcessPool\Protocol\SocketChannel;
 use Greenlight\Internal\Php\ErrorTrap;
 use Greenlight\Internal\Wire\WireCommunicationFailed;
+use Greenlight\Result\CapturedOutput;
 
 /**
  * Owns native worker processes, sockets, diagnostics, poll operations, and retirement.
@@ -244,6 +245,21 @@ final class NativeWorkerTransport implements WorkerTransport
         $handle->drainPipes();
 
         return $handle->diagnostics;
+    }
+
+    #[\Override]
+    public function startOutputCapture(string $workerId, bool $enabled): void
+    {
+        $handle = $this->workers[$workerId] ?? null;
+        $handle?->startOutputCapture($enabled);
+    }
+
+    #[\Override]
+    public function finishOutputCapture(string $workerId): ?CapturedOutput
+    {
+        $handle = $this->workers[$workerId] ?? null;
+
+        return $handle?->finishOutputCapture();
     }
 
     #[\Override]

--- a/src/Execution/ProcessPool/Orchestrator/Orchestrator.php
+++ b/src/Execution/ProcessPool/Orchestrator/Orchestrator.php
@@ -17,6 +17,7 @@ use Greenlight\Event\WorkerTiming;
 use Greenlight\Execution\Artifact\ArtifactStore;
 use Greenlight\Execution\ProcessPool\Protocol\Message;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\Assign;
+use Greenlight\Execution\ProcessPool\Protocol\Messages\AttemptReady;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\AttemptStarted;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\Bootstrap;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\Done;
@@ -30,6 +31,7 @@ use Greenlight\Execution\Worker\WorkerError;
 use Greenlight\Internal\Text\Utf8;
 use Greenlight\Internal\Wire\WireCommunicationFailed;
 use Greenlight\Reporting\ReportGenerationFailed;
+use Greenlight\Result\CapturedOutput;
 use Greenlight\Result\FailureDetail;
 use Greenlight\Result\Outcome;
 use Greenlight\Result\ResultSummary;
@@ -599,6 +601,18 @@ final class Orchestrator
      */
     private function onEvent(WorkerState $handle, Event $event, EventSink $sink): void
     {
+        if ($event instanceof TestFinished) {
+            $event = new TestFinished(
+                $event->result->withOutput(CapturedOutput::merge(
+                    $event->result->output,
+                    $handle->capturedOutput,
+                    $this->transport->finishOutputCapture($handle->workerId),
+                )),
+                $event->occurredAt,
+            );
+            $handle->capturedOutput = null;
+        }
+
         if ($event instanceof TestFinished && $this->configuration->artifactStore instanceof ArtifactStore) {
             $event = new TestFinished(
                 $this->configuration->artifactStore->publish($event->result),
@@ -656,6 +670,12 @@ final class Orchestrator
         }
 
         $handle->inFlightAttempt = $message->attempt;
+        $handle->capturedOutput = CapturedOutput::merge(
+            $handle->capturedOutput,
+            $this->transport->finishOutputCapture($handle->workerId),
+        );
+        $this->transport->startOutputCapture($handle->workerId, $message->capture);
+        $this->transport->send($handle->workerId, new AttemptReady());
     }
 
     /**
@@ -843,6 +863,12 @@ final class Orchestrator
     private function recordSyntheticResult(WorkerState $handle, EventSink $sink, TestResult $result): void
     {
         $result = $result->withAttempts(\max($result->attempts, $handle->inFlightAttempt));
+        $result = $result->withOutput(CapturedOutput::merge(
+            $result->output,
+            $handle->capturedOutput,
+            $this->transport->finishOutputCapture($handle->workerId),
+        ));
+        $handle->capturedOutput = null;
 
         if ($this->configuration->artifactStore instanceof ArtifactStore) {
             $result = $this->configuration->artifactStore->recover($result);

--- a/src/Execution/ProcessPool/Orchestrator/WorkerHandle.php
+++ b/src/Execution/ProcessPool/Orchestrator/WorkerHandle.php
@@ -7,6 +7,7 @@ namespace Greenlight\Execution\ProcessPool\Orchestrator;
 use Greenlight\Execution\ProcessPool\Protocol\SocketChannel;
 use Greenlight\Internal\Php\ErrorTrap;
 use Greenlight\Internal\Text\Utf8;
+use Greenlight\Result\CapturedOutput;
 
 /**
  * Owns one native worker process, its protocol channel, and diagnostics.
@@ -16,6 +17,7 @@ use Greenlight\Internal\Text\Utf8;
 final class WorkerHandle
 {
     private const int MAX_DIAGNOSTIC_BYTES = 65_536;
+    private const int MAX_CAPTURE_BYTES = 1_048_576;
 
     public ?SocketChannel $channel = null;
 
@@ -27,6 +29,13 @@ final class WorkerHandle
 
     /** @var array{string, string} */
     private array $diagnosticCarry = ['', ''];
+
+    private bool $outputCaptureActive = false;
+    private bool $outputCaptureEnabled = false;
+    private string $capturedStdout = '';
+    private string $capturedStderr = '';
+    private bool $capturedStdoutTruncated = false;
+    private bool $capturedStderrTruncated = false;
 
     public readonly float $spawnedAt;
 
@@ -165,6 +174,14 @@ final class WorkerHandle
                     continue;
                 }
 
+                if ($this->outputCaptureActive) {
+                    if ($this->outputCaptureEnabled) {
+                        $this->appendCaptured($index, $bytes);
+                    }
+
+                    continue;
+                }
+
                 [$complete, $this->diagnosticCarry[$index]] = $this->completeUtf8Prefix(
                     $this->diagnosticCarry[$index] . $bytes,
                 );
@@ -182,6 +199,65 @@ final class WorkerHandle
                 }
             }
         });
+    }
+
+    public function startOutputCapture(bool $enabled): void
+    {
+        $this->drainPipes();
+        $this->outputCaptureActive = true;
+        $this->outputCaptureEnabled = $enabled;
+        $this->capturedStdout = '';
+        $this->capturedStderr = '';
+        $this->capturedStdoutTruncated = false;
+        $this->capturedStderrTruncated = false;
+    }
+
+    public function finishOutputCapture(): ?CapturedOutput
+    {
+        $this->drainPipes();
+
+        if (!$this->outputCaptureActive) {
+            return null;
+        }
+
+        $this->outputCaptureActive = false;
+
+        if (!$this->outputCaptureEnabled) {
+            $this->outputCaptureEnabled = false;
+
+            return null;
+        }
+
+        $this->outputCaptureEnabled = false;
+
+        return CapturedOutput::fromProcessDescriptors(
+            $this->capturedStdout,
+            $this->capturedStderr,
+            $this->capturedStdoutTruncated,
+            $this->capturedStderrTruncated,
+        );
+    }
+
+    private function appendCaptured(int $index, string $bytes): void
+    {
+        $property = $index === 0 ? 'capturedStdout' : 'capturedStderr';
+        $truncatedProperty = $index === 0 ? 'capturedStdoutTruncated' : 'capturedStderrTruncated';
+        $remaining = self::MAX_CAPTURE_BYTES - \strlen($this->{$property});
+
+        if ($remaining <= 0) {
+            $this->{$truncatedProperty} = $bytes !== '' || $this->{$truncatedProperty};
+
+            return;
+        }
+
+        if (\strlen($bytes) > $remaining) {
+            $this->{$property} .= \substr($bytes, 0, $remaining);
+            $this->{$truncatedProperty} = true;
+
+            return;
+        }
+
+        $this->{$property} .= $bytes;
     }
 
     /**

--- a/src/Execution/ProcessPool/Orchestrator/WorkerState.php
+++ b/src/Execution/ProcessPool/Orchestrator/WorkerState.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Execution\ProcessPool\Orchestrator;
 
 use Greenlight\Discovery\Plan\ExecutionPlan;
+use Greenlight\Result\CapturedOutput;
 use Greenlight\Result\ResultSummary;
 use Greenlight\Test\TestId;
 
@@ -45,6 +46,8 @@ final class WorkerState
     /** @var non-negative-int */
     public int $inFlightAttempt = 0;
 
+    public ?CapturedOutput $capturedOutput = null;
+
     public readonly WorkerTimingRecorder $timing;
 
     public float $lastProgressAt;
@@ -72,6 +75,7 @@ final class WorkerState
         $this->finished = [];
         $this->inFlight = null;
         $this->inFlightAttempt = 0;
+        $this->capturedOutput = null;
     }
 
     public function finishAssignment(): void
@@ -82,6 +86,7 @@ final class WorkerState
         $this->isolatedAssignment = false;
         $this->inFlight = null;
         $this->inFlightAttempt = 0;
+        $this->capturedOutput = null;
     }
 
     public function isFresh(): bool

--- a/src/Execution/ProcessPool/Orchestrator/WorkerTransport.php
+++ b/src/Execution/ProcessPool/Orchestrator/WorkerTransport.php
@@ -7,6 +7,7 @@ namespace Greenlight\Execution\ProcessPool\Orchestrator;
 use Greenlight\Execution\ProcessPool\Protocol\Message;
 use Greenlight\Execution\ProcessPool\Protocol\ProtocolError;
 use Greenlight\Internal\Wire\WireCommunicationFailed;
+use Greenlight\Result\CapturedOutput;
 
 /**
  * Controls worker processes and carries protocol messages for an orchestrator.
@@ -57,6 +58,12 @@ interface WorkerTransport
 
     /** @param non-empty-string $workerId */
     public function diagnostics(string $workerId): string;
+
+    /** @param non-empty-string $workerId */
+    public function startOutputCapture(string $workerId, bool $enabled): void;
+
+    /** @param non-empty-string $workerId */
+    public function finishOutputCapture(string $workerId): ?CapturedOutput;
 
     public function close(): void;
 }

--- a/src/Execution/ProcessPool/Protocol/MessageRegistry.php
+++ b/src/Execution/ProcessPool/Protocol/MessageRegistry.php
@@ -6,6 +6,7 @@ namespace Greenlight\Execution\ProcessPool\Protocol;
 
 use Greenlight\Attribute\CoverageIgnore;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\Assign;
+use Greenlight\Execution\ProcessPool\Protocol\Messages\AttemptReady;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\AttemptStarted;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\Bootstrap;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\Done;
@@ -27,7 +28,7 @@ use Greenlight\Internal\Wire\WireCommunicationFailed;
  */
 final class MessageRegistry
 {
-    private const int VERSION = 3;
+    private const int VERSION = 4;
 
     /**
      * @var array<non-empty-string, class-string<Message>>
@@ -40,6 +41,7 @@ final class MessageRegistry
         'drain' => Drain::class,
         'event' => EventEnvelope::class,
         'attempt-started' => AttemptStarted::class,
+        'attempt-ready' => AttemptReady::class,
         'done' => Done::class,
         'fatal' => Fatal::class,
     ];

--- a/src/Execution/ProcessPool/Protocol/Messages/AttemptReady.php
+++ b/src/Execution/ProcessPool/Protocol/Messages/AttemptReady.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Execution\ProcessPool\Protocol\Messages;
+
+use Greenlight\Execution\ProcessPool\Protocol\Message;
+
+/**
+ * Orchestrator to worker: the attempt output window is active.
+ *
+ * @internal
+ */
+final readonly class AttemptReady implements Message
+{
+    #[\Override]
+    public static function tag(): string
+    {
+        return 'attempt-ready';
+    }
+
+    #[\Override]
+    public function toWire(): array
+    {
+        return [];
+    }
+
+    #[\Override]
+    public static function fromWire(array $payload): static
+    {
+        return new self();
+    }
+}

--- a/src/Execution/ProcessPool/Protocol/Messages/AttemptStarted.php
+++ b/src/Execution/ProcessPool/Protocol/Messages/AttemptStarted.php
@@ -29,6 +29,7 @@ final readonly class AttemptStarted implements Message
     public function __construct(
         public TestId $id,
         int $attempt,
+        public bool $capture = true,
     ) {
         if ($attempt < 1) {
             throw new \InvalidArgumentException(\sprintf(
@@ -52,6 +53,7 @@ final readonly class AttemptStarted implements Message
         return [
             'id' => $this->id->toWire(),
             'attempt' => $this->attempt,
+            'capture' => $this->capture,
         ];
     }
 
@@ -61,6 +63,7 @@ final readonly class AttemptStarted implements Message
         return new self(
             TestId::fromWire(Wire::map($payload, 'id')),
             \max(1, Wire::int($payload, 'attempt')),
+            Wire::bool($payload, 'capture'),
         );
     }
 }

--- a/src/Execution/ProcessPool/Protocol/ProtocolError.php
+++ b/src/Execution/ProcessPool/Protocol/ProtocolError.php
@@ -119,6 +119,11 @@ final class ProtocolError extends WireCommunicationFailed
         ));
     }
 
+    public static function attemptNotAcknowledged(): self
+    {
+        return new self('Worker did not receive an output-capture acknowledgement for its test attempt.');
+    }
+
     public static function workerNeverConnected(string $workerId, float $deadlineSeconds, string $diagnostics): self
     {
         $message = \sprintf(

--- a/src/Execution/ProcessPool/Worker/WorkerProcess.php
+++ b/src/Execution/ProcessPool/Worker/WorkerProcess.php
@@ -13,6 +13,7 @@ use Greenlight\Execution\Artifact\ArtifactStore;
 use Greenlight\Execution\Plugin\WorkerPluginRuntime;
 use Greenlight\Execution\ProcessPool\Protocol\Message;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\Assign;
+use Greenlight\Execution\ProcessPool\Protocol\Messages\AttemptReady;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\AttemptStarted;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\Bootstrap;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\Done;
@@ -25,6 +26,7 @@ use Greenlight\Execution\ProcessPool\Protocol\SocketChannel;
 use Greenlight\Execution\Worker\ChannelEnvironment;
 use Greenlight\Execution\Worker\HarnessServiceDisposal;
 use Greenlight\Execution\Worker\LeakDetector;
+use Greenlight\Execution\Worker\OutputRouting;
 use Greenlight\Execution\Worker\ResultPolicyPlugin;
 use Greenlight\Execution\Worker\StandardHarnessPlugin;
 use Greenlight\Execution\Worker\Worker;
@@ -265,14 +267,21 @@ final readonly class WorkerProcess
                 $leakDetector,
                 $workerId,
                 $artifactStore,
+                OutputRouting::ForwardToProcess,
             )->run(
                 $message->slice,
                 new SocketEventSink($channel),
                 $message->stopAfterFailures,
                 static fn(): bool => $channel->poll() instanceof Drain,
                 $scopes,
-                static function (TestId $id, int $attempt) use ($channel): void {
-                    $channel->send(new AttemptStarted($id, $attempt));
+                static function (TestId $id, int $attempt, bool $capture) use ($channel): void {
+                    $channel->send(new AttemptStarted($id, $attempt, $capture));
+
+                    $ready = $channel->receive(self::RECEIVE_POLL_SECONDS);
+
+                    if (!$ready instanceof AttemptReady) {
+                        throw ProtocolError::attemptNotAcknowledged();
+                    }
                 },
             );
 

--- a/src/Execution/Worker/AttemptStartFailed.php
+++ b/src/Execution/Worker/AttemptStartFailed.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Execution\Worker;
+
+/**
+ * The worker could not complete its attempt-start coordination callback.
+ *
+ * @internal
+ */
+final class AttemptStartFailed extends \RuntimeException
+{
+    public function __construct(\Throwable $previous)
+    {
+        parent::__construct($previous->getMessage(), previous: $previous);
+    }
+}

--- a/src/Execution/Worker/CaptureError.php
+++ b/src/Execution/Worker/CaptureError.php
@@ -30,4 +30,12 @@ final class CaptureError extends \LogicException
     {
         return new self('Output capture cannot stop because a nested output buffer cannot be removed.');
     }
+
+    public static function streamFilterUnavailable(string $stream): self
+    {
+        return new self(\sprintf(
+            'Output capture cannot attach to %s. Use process-pool execution for descriptor capture.',
+            $stream,
+        ));
+    }
 }

--- a/src/Execution/Worker/CapturedStreamFilter.php
+++ b/src/Execution/Worker/CapturedStreamFilter.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Execution\Worker;
+
+/**
+ * Captures writes through one PHP stream resource without forwarding them.
+ *
+ * @internal
+ */
+final class CapturedStreamFilter extends \php_user_filter
+{
+    /**
+     * @param resource $in
+     * @param resource $out
+     * @param int $consumed
+     */
+    public function filter($in, $out, &$consumed, bool $closing): int
+    {
+        if (!$this->params instanceof OutputStreamBuffer) {
+            return \PSFS_ERR_FATAL;
+        }
+
+        while (($bucket = \stream_bucket_make_writeable($in)) instanceof \StreamBucket) {
+            $consumed += $bucket->datalen;
+            $this->params->append($bucket->data);
+        }
+
+        return \PSFS_PASS_ON;
+    }
+}

--- a/src/Execution/Worker/OutputCapture.php
+++ b/src/Execution/Worker/OutputCapture.php
@@ -10,11 +10,9 @@ use Greenlight\Internal\Text\Utf8;
 use Greenlight\Result\CapturedOutput;
 use Greenlight\Result\Diagnostic;
 use Greenlight\Result\DiagnosticSeverity;
+use Greenlight\Result\OutputCaptureCapability;
 
 /**
- * Direct writes to stream resources bypass output capture. Examples include
- * fwrite(STDERR, ...) and fwrite(STDOUT, ...).
- *
  * If output is too long, Greenlight keeps the first part. This part usually
  * contains useful error information. The final part frequently contains
  * repeated information. Greenlight removes a partial multibyte character at
@@ -25,10 +23,20 @@ use Greenlight\Result\DiagnosticSeverity;
 final class OutputCapture
 {
     private const int DEFAULT_MAX_STDOUT_BYTES = 1_048_576;
+    private const int DEFAULT_MAX_STDERR_BYTES = 1_048_576;
     private const int DEFAULT_MAX_DIAGNOSTICS = 1_000;
+    private const string STREAM_FILTER = 'greenlight.output-capture';
 
-    private string $stdout = '';
-    private bool $stdoutTruncated = false;
+    private static bool $streamFilterRegistered = false;
+
+    private OutputStreamBuffer $stdout;
+    private OutputStreamBuffer $stderr;
+
+    /** @var resource|null */
+    private mixed $stdoutFilter = null;
+
+    /** @var resource|null */
+    private mixed $stderrFilter = null;
 
     /** @var list<Diagnostic> */
     private array $diagnostics = [];
@@ -44,6 +52,8 @@ final class OutputCapture
     public function __construct(
         private readonly int $maxStdoutBytes = self::DEFAULT_MAX_STDOUT_BYTES,
         private readonly int $maxDiagnostics = self::DEFAULT_MAX_DIAGNOSTICS,
+        private readonly int $maxStderrBytes = self::DEFAULT_MAX_STDERR_BYTES,
+        private readonly OutputRouting $routing = OutputRouting::CapturePhpStreams,
     ) {
         if ($maxStdoutBytes < 1) {
             throw new \InvalidArgumentException(\sprintf('Stdout bound must be at least 1 byte, got %d.', $maxStdoutBytes));
@@ -52,6 +62,13 @@ final class OutputCapture
         if ($maxDiagnostics < 1) {
             throw new \InvalidArgumentException(\sprintf('Diagnostics bound must be at least 1 entry, got %d.', $maxDiagnostics));
         }
+
+        if ($maxStderrBytes < 1) {
+            throw new \InvalidArgumentException(\sprintf('Stderr bound must be at least 1 byte, got %d.', $maxStderrBytes));
+        }
+
+        $this->stdout = new OutputStreamBuffer($maxStdoutBytes);
+        $this->stderr = new OutputStreamBuffer($maxStderrBytes);
     }
 
     /**
@@ -66,8 +83,8 @@ final class OutputCapture
             throw CaptureError::alreadyStarted();
         }
 
-        $this->stdout = '';
-        $this->stdoutTruncated = false;
+        $this->stdout = new OutputStreamBuffer($this->maxStdoutBytes);
+        $this->stderr = new OutputStreamBuffer($this->maxStderrBytes);
         $this->diagnostics = [];
         $this->diagnosticsTruncated = false;
         $this->bufferClosed = false;
@@ -87,6 +104,10 @@ final class OutputCapture
         $this->errorHandler = $handler;
         \set_error_handler($handler);
 
+        if ($this->routing === OutputRouting::CapturePhpStreams) {
+            $this->attachStreamFilters();
+        }
+
         \ob_start($this->handleChunk(...), 1);
         $this->bufferLevel = \ob_get_level();
     }
@@ -95,6 +116,10 @@ final class OutputCapture
     {
         if (($phase & \PHP_OUTPUT_HANDLER_FINAL) !== 0) {
             $this->bufferClosed = true;
+        }
+
+        if ($this->routing === OutputRouting::ForwardToProcess) {
+            return $chunk;
         }
 
         return $this->appendChunk($chunk);
@@ -121,6 +146,7 @@ final class OutputCapture
             $removed = ErrorTrap::run(static fn() => \ob_end_flush());
 
             if (!$removed || \ob_get_level() >= $previousLevel) {
+                $this->removeStreamFilters();
                 $this->restoreErrorHandler();
 
                 throw CaptureError::nestedBufferCannotBeRemoved();
@@ -128,27 +154,53 @@ final class OutputCapture
         }
 
         if (!$this->bufferClosed && \ob_get_level() === $level) {
-            \ob_end_clean();
+            if ($this->routing === OutputRouting::ForwardToProcess) {
+                \ob_end_flush();
+            } else {
+                \ob_end_clean();
+            }
         }
 
+        $this->removeStreamFilters();
         $this->restoreErrorHandler();
 
-        $scrubbedStdout = Utf8::scrub($this->stdout);
-        $boundedStdout = Utf8::headBytes($scrubbedStdout, $this->maxStdoutBytes);
-        $this->stdoutTruncated = $this->stdoutTruncated
-            || \strlen($boundedStdout) < \strlen($scrubbedStdout);
+        $captured = $this->snapshot();
 
-        $captured = new CapturedOutput(
-            $boundedStdout,
-            $this->diagnostics,
-            $this->stdoutTruncated,
-            $this->diagnosticsTruncated,
-        );
-
-        $this->stdout = '';
+        $this->stdout = new OutputStreamBuffer($this->maxStdoutBytes);
+        $this->stderr = new OutputStreamBuffer($this->maxStderrBytes);
         $this->diagnostics = [];
 
         return $captured;
+    }
+
+    /**
+     * Returns the output recorded so far without closing the capture window.
+     *
+     * @internal
+     * @throws CaptureError when no capture window is active
+     */
+    public function snapshot(): CapturedOutput
+    {
+        if ($this->bufferLevel === null && !$this->bufferClosed) {
+            throw CaptureError::notStarted();
+        }
+
+        $scrubbedStdout = Utf8::scrub($this->stdout->bytes);
+        $scrubbedStderr = Utf8::scrub($this->stderr->bytes);
+        $boundedStdout = Utf8::headBytes($scrubbedStdout, $this->maxStdoutBytes);
+        $boundedStderr = Utf8::headBytes($scrubbedStderr, $this->maxStderrBytes);
+
+        return new CapturedOutput(
+            $boundedStdout,
+            $this->diagnostics,
+            $this->stdout->truncated || \strlen($boundedStdout) < \strlen($scrubbedStdout),
+            $this->diagnosticsTruncated,
+            $boundedStderr,
+            $this->stderr->truncated || \strlen($boundedStderr) < \strlen($scrubbedStderr),
+            $this->routing === OutputRouting::CapturePhpStreams
+                ? OutputCaptureCapability::PhpStreams
+                : OutputCaptureCapability::Buffered,
+        );
     }
 
     /**
@@ -158,20 +210,7 @@ final class OutputCapture
      */
     private function appendChunk(string $chunk): string
     {
-        if ($this->stdoutTruncated || $chunk === '') {
-            return '';
-        }
-
-        $combined = $this->stdout . $chunk;
-
-        if (\strlen($combined) <= $this->maxStdoutBytes) {
-            $this->stdout = $combined;
-
-            return '';
-        }
-
-        $this->stdout = Utf8::headBytes($combined, $this->maxStdoutBytes);
-        $this->stdoutTruncated = true;
+        $this->stdout->append($chunk);
 
         return '';
     }
@@ -197,5 +236,56 @@ final class OutputCapture
         }
 
         ErrorHandlerStack::remove($handler);
+    }
+
+    /** @throws CaptureError */
+    private function attachStreamFilters(): void
+    {
+        if (!self::$streamFilterRegistered
+            && !\stream_filter_register(self::STREAM_FILTER, CapturedStreamFilter::class)
+        ) {
+            $this->restoreErrorHandler();
+
+            throw CaptureError::streamFilterUnavailable('STDOUT and STDERR');
+        }
+
+        self::$streamFilterRegistered = true;
+
+        $stdoutFilter = ErrorTrap::run(
+            fn() => \stream_filter_append(\STDOUT, self::STREAM_FILTER, \STREAM_FILTER_WRITE, $this->stdout),
+        );
+
+        if (!\is_resource($stdoutFilter)) {
+            $this->restoreErrorHandler();
+
+            throw CaptureError::streamFilterUnavailable('STDOUT');
+        }
+
+        $this->stdoutFilter = $stdoutFilter;
+
+        $stderrFilter = ErrorTrap::run(
+            fn() => \stream_filter_append(\STDERR, self::STREAM_FILTER, \STREAM_FILTER_WRITE, $this->stderr),
+        );
+
+        if (!\is_resource($stderrFilter)) {
+            $this->removeStreamFilters();
+            $this->restoreErrorHandler();
+
+            throw CaptureError::streamFilterUnavailable('STDERR');
+        }
+
+        $this->stderrFilter = $stderrFilter;
+    }
+
+    private function removeStreamFilters(): void
+    {
+        foreach (['stderrFilter', 'stdoutFilter'] as $property) {
+            $filter = $this->{$property};
+            $this->{$property} = null;
+
+            if (\is_resource($filter)) {
+                ErrorTrap::run(static fn() => \stream_filter_remove($filter));
+            }
+        }
     }
 }

--- a/src/Execution/Worker/OutputRouting.php
+++ b/src/Execution/Worker/OutputRouting.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Execution\Worker;
+
+/** @internal */
+enum OutputRouting
+{
+    /** Capture PHP stream writes in this process. */
+    case CapturePhpStreams;
+
+    /** Forward buffered output to worker descriptors for parent capture. */
+    case ForwardToProcess;
+}

--- a/src/Execution/Worker/OutputSilencer.php
+++ b/src/Execution/Worker/OutputSilencer.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Execution\Worker;
+
+use Greenlight\Internal\Php\ErrorTrap;
+
+/**
+ * Prevents direct PHP stream writes from reaching in-process reporter streams
+ * when a test disables output capture.
+ *
+ * @internal
+ */
+final class OutputSilencer
+{
+    private const string STREAM_FILTER = 'greenlight.output-discard';
+    private static bool $registered = false;
+
+    /** @var resource|null */
+    private mixed $stdoutFilter = null;
+
+    /** @var resource|null */
+    private mixed $stderrFilter = null;
+
+    /** @throws CaptureError */
+    public function start(): void
+    {
+        if (!self::$registered
+            && !\stream_filter_register(self::STREAM_FILTER, CapturedStreamFilter::class)
+        ) {
+            throw CaptureError::streamFilterUnavailable('STDOUT and STDERR');
+        }
+
+        self::$registered = true;
+
+        $stdout = new OutputStreamBuffer(1);
+        $stderr = new OutputStreamBuffer(1);
+        $stdoutFilter = ErrorTrap::run(
+            static fn() => \stream_filter_append(\STDOUT, self::STREAM_FILTER, \STREAM_FILTER_WRITE, $stdout),
+        );
+        $stderrFilter = ErrorTrap::run(
+            static fn() => \stream_filter_append(\STDERR, self::STREAM_FILTER, \STREAM_FILTER_WRITE, $stderr),
+        );
+
+        if (!\is_resource($stdoutFilter) || !\is_resource($stderrFilter)) {
+            if (\is_resource($stdoutFilter)) {
+                ErrorTrap::run(static fn() => \stream_filter_remove($stdoutFilter));
+            }
+
+            if (\is_resource($stderrFilter)) {
+                ErrorTrap::run(static fn() => \stream_filter_remove($stderrFilter));
+            }
+
+            $this->stop();
+
+            throw CaptureError::streamFilterUnavailable('STDOUT and STDERR');
+        }
+
+        $this->stdoutFilter = $stdoutFilter;
+        $this->stderrFilter = $stderrFilter;
+    }
+
+    public function stop(): void
+    {
+        foreach (['stderrFilter', 'stdoutFilter'] as $property) {
+            $filter = $this->{$property};
+            $this->{$property} = null;
+
+            if (\is_resource($filter)) {
+                ErrorTrap::run(static fn() => \stream_filter_remove($filter));
+            }
+        }
+    }
+}

--- a/src/Execution/Worker/OutputStreamBuffer.php
+++ b/src/Execution/Worker/OutputStreamBuffer.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Execution\Worker;
+
+/** @internal */
+final class OutputStreamBuffer
+{
+    public string $bytes = '';
+    public bool $truncated = false;
+
+    public function __construct(private readonly int $maxBytes) {}
+
+    public function append(string $bytes): void
+    {
+        if ($bytes === '') {
+            return;
+        }
+
+        $remaining = $this->maxBytes - \strlen($this->bytes);
+
+        if ($remaining <= 0) {
+            $this->truncated = true;
+
+            return;
+        }
+
+        if (\strlen($bytes) > $remaining) {
+            $this->bytes .= \substr($bytes, 0, $remaining);
+            $this->truncated = true;
+
+            return;
+        }
+
+        $this->bytes .= $bytes;
+    }
+}

--- a/src/Execution/Worker/TestExecutor.php
+++ b/src/Execution/Worker/TestExecutor.php
@@ -20,6 +20,7 @@ use Greenlight\Harness\HarnessScopes;
 use Greenlight\Harness\ServiceResolutionFailed;
 use Greenlight\Harness\UnresolvableService;
 use Greenlight\Plugin\TestContext;
+use Greenlight\Result\CapturedOutput;
 use Greenlight\Result\FailureDetail;
 use Greenlight\Result\Outcome;
 use Greenlight\Result\TestResult;
@@ -57,7 +58,7 @@ use Greenlight\Test\TestId;
 final readonly class TestExecutor
 {
     /**
-     * @param \Closure(TestId, positive-int): void|null $attemptStarted
+     * @param \Closure(TestId, positive-int, bool): void|null $attemptStarted
      */
     public function __construct(
         private HarnessScopes $scopes,
@@ -66,6 +67,7 @@ final readonly class TestExecutor
         private ?LeakDetector $leakDetector = null,
         private ?ArtifactStore $artifactStore = null,
         private ?\Closure $attemptStarted = null,
+        private OutputRouting $outputRouting = OutputRouting::CapturePhpStreams,
     ) {}
 
     /**
@@ -104,58 +106,85 @@ final readonly class TestExecutor
 
         $attempt = 0;
         $retainedAttachments = [];
+        $retainedOutput = null;
         $artifactBudget = new TestArtifactBudget();
 
         do {
             ++$attempt;
 
+            $capture = $definition->execution->capture
+                ? new OutputCapture(routing: $this->outputRouting)
+                : null;
+            $silencer = !$definition->execution->capture
+                && $this->outputRouting === OutputRouting::CapturePhpStreams
+                    ? new OutputSilencer()
+                    : null;
+
             if ($this->attemptStarted instanceof \Closure) {
-                ($this->attemptStarted)($entry->id, $attempt);
+                try {
+                    ($this->attemptStarted)($entry->id, $attempt, $capture instanceof OutputCapture);
+                } catch (\Throwable $failure) {
+                    throw new AttemptStartFailed($failure);
+                }
             }
+
+            $capture?->start();
+            $silencer?->start();
+            $retry = false;
+            $retryFailed = false;
+            $attemptOutput = null;
 
             try {
-                [$result, $cause, $attachments] = $this->runTestAttempt(
-                    fn(): array => $this->attempt($entry, $attempt, $artifactBudget),
-                );
-            } catch (\Throwable $threw) {
-                $cause = $threw;
-                $attachments = null;
-                $result = new TestResult(
-                    $entry->id,
-                    Outcome::Errored,
-                    0.0,
-                    0,
-                    $attempt,
-                    error: ThrowableDetail::fromThrowable($threw),
-                );
+                try {
+                    [$result, $cause, $attachments] = $this->runTestAttempt(
+                        fn(): array => $this->attempt($entry, $attempt, $artifactBudget, $capture, $retainedOutput),
+                    );
+                } catch (\Throwable $threw) {
+                    $cause = $threw;
+                    $attachments = null;
+                    $result = new TestResult(
+                        $entry->id,
+                        Outcome::Errored,
+                        0.0,
+                        0,
+                        $attempt,
+                        error: ThrowableDetail::fromThrowable($threw),
+                    );
+                }
+
+                if ($attachments instanceof StagedAttachments) {
+                    $result = $result->withAttachments($attachments->collected());
+                }
+
+                if (!$result->outcome->isSuccessful()) {
+                    try {
+                        $retry = $this->plugins->shouldRetry($definition->retry, $result, $attempt, $cause);
+                    } catch (\Throwable $threw) {
+                        $result = $result->erroredBy(ThrowableDetail::fromThrowable($threw));
+                        $retryFailed = true;
+                    }
+                }
+            } finally {
+                try {
+                    $attemptOutput = $capture?->stop();
+                } finally {
+                    $silencer?->stop();
+                }
             }
 
-            if ($attachments instanceof StagedAttachments) {
-                $result = $result->withAttachments($attachments->collected());
-            }
-
-            if ($result->outcome->isSuccessful()) {
-                $sealed = $attachments?->seal() ?? [];
-
-                return $result->withAttachments([...$retainedAttachments, ...$sealed]);
-            }
-
-            try {
-                $retry = $this->plugins->shouldRetry($definition->retry, $result, $attempt, $cause);
-            } catch (\Throwable $threw) {
-                $result = $result->erroredBy(ThrowableDetail::fromThrowable($threw));
-                $sealed = $attachments?->seal() ?? [];
-
-                return $result->withAttachments([...$retainedAttachments, ...$sealed]);
-            }
-
+            $result = $result->withOutput(CapturedOutput::merge($retainedOutput, $attemptOutput));
             $sealed = $attachments?->seal() ?? [];
 
-            if (!$retry) {
+            if ($result->outcome->isSuccessful()) {
+                return $result->withAttachments([...$retainedAttachments, ...$sealed]);
+            }
+
+            if (!$retry || $retryFailed) {
                 return $result->withAttachments([...$retainedAttachments, ...$sealed]);
             }
 
             $retainedAttachments = [...$retainedAttachments, ...$sealed];
+            $retainedOutput = $result->output;
         } while (true);
     }
 
@@ -176,8 +205,13 @@ final readonly class TestExecutor
      * @throws CaptureError
      * @throws AttachmentError
      */
-    private function attempt(PlanEntry $entry, int $attempt, TestArtifactBudget $artifactBudget): array
-    {
+    private function attempt(
+        PlanEntry $entry,
+        int $attempt,
+        TestArtifactBudget $artifactBudget,
+        ?OutputCapture $capture,
+        ?CapturedOutput $retainedOutput,
+    ): array {
         $definition = $entry->definition;
         $execution = $definition->execution;
         ExpectationCounter::reset();
@@ -188,16 +222,13 @@ final readonly class TestExecutor
         $cause = null;
         $error = null;
         $skipReason = null;
-        $captured = null;
         $context = null;
-        $capture = $execution->capture ? new OutputCapture() : null;
         $stagedAttachments = $this->artifactStore?->forAttempt($entry->id, $attempt, $artifactBudget);
         $attachments = $stagedAttachments ?? new UnavailableAttachments();
         $cleanup = new Cleanup();
         $disposalFailures = [];
         $memoryBefore = \memory_get_usage(true);
         $startedAt = \hrtime(true);
-        $capture?->start();
         ExpectationRuntime::enterAttempt(
             $execution->timeoutSeconds === null
                 ? null
@@ -262,44 +293,40 @@ final readonly class TestExecutor
             $error = ThrowableDetail::fromThrowable($threw);
         } finally {
             try {
-                $captured = $capture?->stop();
-            } finally {
                 try {
-                    try {
-                        $cleanup->close();
-                    } catch (CleanupFailed $cleanupFailed) {
-                        foreach ($cleanupFailed->failures as $cleanupFailure) {
-                            if (!$cause instanceof \Throwable) {
-                                $cause = $cleanupFailure;
-                                $skipReason = null;
-
-                                if ($cleanupFailure instanceof ExpectationFailed) {
-                                    $failures = $cleanupFailure->details;
-                                } else {
-                                    $error = ThrowableDetail::fromThrowable($cleanupFailure);
-                                }
-
-                                continue;
-                            }
+                    $cleanup->close();
+                } catch (CleanupFailed $cleanupFailed) {
+                    foreach ($cleanupFailed->failures as $cleanupFailure) {
+                        if (!$cause instanceof \Throwable) {
+                            $cause = $cleanupFailure;
+                            $skipReason = null;
 
                             if ($cleanupFailure instanceof ExpectationFailed) {
-                                $failures = [...$failures, ...$cleanupFailure->details];
-
-                                continue;
+                                $failures = $cleanupFailure->details;
+                            } else {
+                                $error = ThrowableDetail::fromThrowable($cleanupFailure);
                             }
 
-                            $failures[] = new FailureDetail(\sprintf(
-                                'Cleanup callback caused an error: %s',
-                                $cleanupFailure->getMessage(),
-                            ));
+                            continue;
                         }
+
+                        if ($cleanupFailure instanceof ExpectationFailed) {
+                            $failures = [...$failures, ...$cleanupFailure->details];
+
+                            continue;
+                        }
+
+                        $failures[] = new FailureDetail(\sprintf(
+                            'Cleanup callback caused an error: %s',
+                            $cleanupFailure->getMessage(),
+                        ));
                     }
+                }
+            } finally {
+                try {
+                    $disposalFailures = $this->scopes->closeTest();
                 } finally {
-                    try {
-                        $disposalFailures = $this->scopes->closeTest();
-                    } finally {
-                        ExpectationRuntime::leaveAttempt();
-                    }
+                    ExpectationRuntime::leaveAttempt();
                 }
             }
         }
@@ -334,7 +361,7 @@ final readonly class TestExecutor
             $failures,
             $error,
             $skipReason,
-            output: $captured,
+            output: CapturedOutput::merge($retainedOutput, $capture?->snapshot()),
             expectations: ExpectationCounter::count(),
         );
 

--- a/src/Execution/Worker/Worker.php
+++ b/src/Execution/Worker/Worker.php
@@ -15,6 +15,7 @@ use Greenlight\Execution\Artifact\ArtifactStore;
 use Greenlight\Execution\Plugin\WorkerPluginRuntime;
 use Greenlight\Harness\HarnessScopes;
 use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Result\CapturedOutput;
 use Greenlight\Result\Outcome;
 use Greenlight\Result\ResultSummary;
 use Greenlight\Result\TestResult;
@@ -45,11 +46,12 @@ final readonly class Worker
         private ?LeakDetector $leakDetector = null,
         private string $workerId = '',
         private ?ArtifactStore $artifactStore = null,
+        private OutputRouting $outputRouting = OutputRouting::CapturePhpStreams,
     ) {}
 
     /**
      * @param \Closure(): bool|null $drainRequested polled between tests
-     * @param \Closure(TestId, positive-int): void|null $attemptStarted reports retry progress for crash containment
+     * @param \Closure(TestId, positive-int, bool): void|null $attemptStarted reports retry progress and output capture
      *
      * @throws WorkerError
      */
@@ -100,8 +102,11 @@ final readonly class Worker
                         $this->leakDetector,
                         $this->artifactStore,
                         $attemptStarted,
+                        $this->outputRouting,
                     );
                     $result = $executor->execute($entry);
+                } catch (AttemptStartFailed $failure) {
+                    throw $failure;
                 } catch (\Throwable $threw) {
                     $result = new TestResult(
                         $entry->id,
@@ -120,7 +125,7 @@ final readonly class Worker
                 $drainReached = $drainRequested instanceof \Closure && $drainRequested();
 
                 if ($index === $lastIndex || $failureLimitReached || $drainReached) {
-                    $result = HarnessServiceDisposal::applyToTest($result, $scopes->closeClass());
+                    $result = $this->closeClassScope($result, $scopes, $entry->definition->execution->capture);
                 }
 
                 $summary = $summary->add($result->outcome);
@@ -161,5 +166,48 @@ final readonly class Worker
         }
 
         return HarnessServiceDisposal::runAndClose($scopes, static fn(): WorkerRunOutcome => $outcome);
+    }
+
+    private function closeClassScope(TestResult $result, HarnessScopes $scopes, bool $captureEnabled): TestResult
+    {
+        if ($this->outputRouting === OutputRouting::ForwardToProcess) {
+            return HarnessServiceDisposal::applyToTest($result, $scopes->closeClass());
+        }
+
+        $capture = $captureEnabled ? new OutputCapture() : null;
+        $silencer = $captureEnabled ? null : new OutputSilencer();
+
+        try {
+            $capture?->start();
+            $silencer?->start();
+        } catch (\Throwable $threw) {
+            return HarnessServiceDisposal::applyToTest(
+                $result->erroredBy(ThrowableDetail::fromThrowable($threw)),
+                $scopes->closeClass(),
+            );
+        }
+
+        $output = null;
+        $stopFailure = null;
+
+        try {
+            $result = HarnessServiceDisposal::applyToTest($result, $scopes->closeClass());
+        } finally {
+            try {
+                try {
+                    $output = $capture?->stop();
+                } catch (\Throwable $threw) {
+                    $stopFailure = $threw;
+                }
+            } finally {
+                $silencer?->stop();
+            }
+        }
+
+        $result = $result->withOutput(CapturedOutput::merge($result->output, $output));
+
+        return $stopFailure instanceof \Throwable
+            ? $result->erroredBy(ThrowableDetail::fromThrowable($stopFailure))
+            : $result;
     }
 }

--- a/src/Reporting/JUnitReporter.php
+++ b/src/Reporting/JUnitReporter.php
@@ -8,6 +8,7 @@ use Greenlight\Event\Event;
 use Greenlight\Event\RunFinished;
 use Greenlight\Event\TestFinished;
 use Greenlight\Internal\Text\Utf8;
+use Greenlight\Result\CapturedOutput;
 use Greenlight\Result\Outcome;
 use Greenlight\Result\TestResult;
 use Greenlight\Result\ThrowableDetail;
@@ -257,12 +258,38 @@ final class JUnitReporter implements Reporter
             $writer->endElement();
         }
 
-        if ($result->attachments !== []) {
+        $captured = $result->output;
+        $systemOut = $captured instanceof CapturedOutput ? $captured->stdout : '';
+        $attachmentOutput = \implode("\n", \array_map(
+            static fn($attachment): string => '[[ATTACHMENT|' . $attachment->path . ']]',
+            $result->attachments,
+        ));
+
+        if ($captured?->stdoutTruncated === true) {
+            $systemOut .= ($systemOut === '' || \str_ends_with($systemOut, "\n") ? '' : "\n")
+                . '[Greenlight: standard output truncated]';
+        }
+
+        if ($attachmentOutput !== '') {
+            $systemOut .= ($systemOut === '' || \str_ends_with($systemOut, "\n") ? '' : "\n") . $attachmentOutput;
+        }
+
+        if ($systemOut !== '') {
             $writer->startElement('system-out');
-            $writer->text($this->xml(\implode("\n", \array_map(
-                static fn($attachment): string => '[[ATTACHMENT|' . $attachment->path . ']]',
-                $result->attachments,
-            ))));
+            $writer->text($this->xml($systemOut));
+            $writer->endElement();
+        }
+
+        if ($captured instanceof CapturedOutput && ($captured->stderr !== '' || $captured->stderrTruncated)) {
+            $systemErr = $captured->stderr;
+
+            if ($captured->stderrTruncated) {
+                $systemErr .= ($systemErr === '' || \str_ends_with($systemErr, "\n") ? '' : "\n")
+                    . '[Greenlight: standard error truncated]';
+            }
+
+            $writer->startElement('system-err');
+            $writer->text($this->xml($systemErr));
             $writer->endElement();
         }
 

--- a/src/Reporting/ProblemDetails.php
+++ b/src/Reporting/ProblemDetails.php
@@ -70,14 +70,30 @@ final class ProblemDetails
 
         $captured = $result->output;
 
-        if ($captured instanceof CapturedOutput && $captured->stdout !== '') {
-            $lines[] = '  captured output:';
+        if ($captured instanceof CapturedOutput && ($captured->stdout !== '' || $captured->stdoutTruncated)) {
+            $lines[] = '  captured standard output:';
 
-            foreach (\explode("\n", \rtrim($captured->stdout, "\n")) as $capturedLine) {
-                $lines[] = '    ' . $capturedLine;
+            if ($captured->stdout !== '') {
+                foreach (\explode("\n", \rtrim($captured->stdout, "\n")) as $capturedLine) {
+                    $lines[] = '    ' . $capturedLine;
+                }
             }
 
             if ($captured->stdoutTruncated) {
+                $lines[] = '    (truncated)';
+            }
+        }
+
+        if ($captured instanceof CapturedOutput && ($captured->stderr !== '' || $captured->stderrTruncated)) {
+            $lines[] = '  captured standard error:';
+
+            if ($captured->stderr !== '') {
+                foreach (\explode("\n", \rtrim($captured->stderr, "\n")) as $capturedLine) {
+                    $lines[] = '    ' . $capturedLine;
+                }
+            }
+
+            if ($captured->stderrTruncated) {
                 $lines[] = '    (truncated)';
             }
         }

--- a/src/Result/CapturedOutput.php
+++ b/src/Result/CapturedOutput.php
@@ -12,11 +12,16 @@ use Greenlight\Internal\Wire\WireCommunicationFailed;
  * When output is too long, Greenlight keeps the first part. This part usually
  * identifies the cause. The last part usually contains repeated information.
  *
- * Greenlight converts captured standard output to valid UTF-8 before it adds
- * the output to a test result.
+ * Greenlight keeps at most 1 MiB from each standard stream and 1,000
+ * diagnostics. It converts captured stream data to valid UTF-8 before it adds
+ * the data to a test result.
  */
 final readonly class CapturedOutput
 {
+    private const int MAX_STDOUT_BYTES = 1_048_576;
+    private const int MAX_STDERR_BYTES = 1_048_576;
+    private const int MAX_DIAGNOSTICS = 1_000;
+
     /**
      * @var list<Diagnostic>
      */
@@ -32,6 +37,9 @@ final readonly class CapturedOutput
         array $diagnostics = [],
         public bool $stdoutTruncated = false,
         public bool $diagnosticsTruncated = false,
+        public string $stderr = '',
+        public bool $stderrTruncated = false,
+        public OutputCaptureCapability $capability = OutputCaptureCapability::Buffered,
     ) {
         $validatedDiagnostics = [];
 
@@ -60,12 +68,15 @@ final readonly class CapturedOutput
     {
         return [
             'stdout' => Utf8::scrub($this->stdout),
+            'stderr' => Utf8::scrub($this->stderr),
             'diagnostics' => \array_map(
                 static fn(Diagnostic $diagnostic): array => $diagnostic->toWire(),
                 $this->diagnostics,
             ),
             'stdoutTruncated' => $this->stdoutTruncated,
+            'stderrTruncated' => $this->stderrTruncated,
             'diagnosticsTruncated' => $this->diagnosticsTruncated,
+            'capability' => $this->capability->value,
         ];
     }
 
@@ -88,6 +99,110 @@ final readonly class CapturedOutput
             $diagnostics,
             Wire::bool($payload, 'stdoutTruncated'),
             Wire::bool($payload, 'diagnosticsTruncated'),
+            \array_key_exists('stderr', $payload) ? Wire::string($payload, 'stderr') : '',
+            \array_key_exists('stderrTruncated', $payload) && Wire::bool($payload, 'stderrTruncated'),
+            \array_key_exists('capability', $payload)
+                ? Wire::enum($payload, 'capability', OutputCaptureCapability::class)
+                : OutputCaptureCapability::Buffered,
         );
+    }
+
+    /**
+     * Combines attempt and transport output within the per-test limits.
+     *
+     * @internal
+     */
+    public static function merge(?self ...$outputs): ?self
+    {
+        $stdout = '';
+        $stderr = '';
+        $diagnostics = [];
+        $stdoutTruncated = false;
+        $stderrTruncated = false;
+        $diagnosticsTruncated = false;
+        $capability = OutputCaptureCapability::Buffered;
+        $present = false;
+
+        foreach ($outputs as $output) {
+            if (!$output instanceof self) {
+                continue;
+            }
+
+            $present = true;
+            [$stdout, $stdoutCut] = self::appendBounded($stdout, $output->stdout, self::MAX_STDOUT_BYTES);
+            [$stderr, $stderrCut] = self::appendBounded($stderr, $output->stderr, self::MAX_STDERR_BYTES);
+            $stdoutTruncated = $stdoutTruncated || $output->stdoutTruncated || $stdoutCut;
+            $stderrTruncated = $stderrTruncated || $output->stderrTruncated || $stderrCut;
+
+            foreach ($output->diagnostics as $diagnostic) {
+                if (\count($diagnostics) >= self::MAX_DIAGNOSTICS) {
+                    $diagnosticsTruncated = true;
+
+                    break;
+                }
+
+                $diagnostics[] = $diagnostic;
+            }
+
+            $diagnosticsTruncated = $diagnosticsTruncated || $output->diagnosticsTruncated;
+            $capability = match (true) {
+                $output->capability === OutputCaptureCapability::ProcessDescriptors => OutputCaptureCapability::ProcessDescriptors,
+                $output->capability === OutputCaptureCapability::PhpStreams
+                    && $capability === OutputCaptureCapability::Buffered => OutputCaptureCapability::PhpStreams,
+                default => $capability,
+            };
+        }
+
+        if (!$present) {
+            return null;
+        }
+
+        return new self(
+            $stdout,
+            $diagnostics,
+            $stdoutTruncated,
+            $diagnosticsTruncated,
+            $stderr,
+            $stderrTruncated,
+            $capability,
+        );
+    }
+
+    /**
+     * Creates bounded text from raw descriptor bytes.
+     *
+     * @internal
+     */
+    public static function fromProcessDescriptors(
+        string $stdout,
+        string $stderr,
+        bool $stdoutTruncated = false,
+        bool $stderrTruncated = false,
+    ): self {
+        $scrubbedStdout = Utf8::scrub($stdout);
+        $scrubbedStderr = Utf8::scrub($stderr);
+        $boundedStdout = Utf8::headBytes($scrubbedStdout, self::MAX_STDOUT_BYTES);
+        $boundedStderr = Utf8::headBytes($scrubbedStderr, self::MAX_STDERR_BYTES);
+
+        return new self(
+            $boundedStdout,
+            stdoutTruncated: $stdoutTruncated || \strlen($boundedStdout) < \strlen($scrubbedStdout),
+            stderr: $boundedStderr,
+            stderrTruncated: $stderrTruncated || \strlen($boundedStderr) < \strlen($scrubbedStderr),
+            capability: OutputCaptureCapability::ProcessDescriptors,
+        );
+    }
+
+    /** @return array{string, bool} */
+    private static function appendBounded(string $current, string $addition, int $maxBytes): array
+    {
+        if (\strlen($current) >= $maxBytes) {
+            return [$current, $addition !== ''];
+        }
+
+        $combined = Utf8::scrub($current . $addition);
+        $bounded = Utf8::headBytes($combined, $maxBytes);
+
+        return [$bounded, \strlen($bounded) < \strlen($combined)];
     }
 }

--- a/src/Result/OutputCaptureCapability.php
+++ b/src/Result/OutputCaptureCapability.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Result;
+
+/**
+ * Identifies the stream writes that Greenlight could capture for a result.
+ *
+ * `Buffered` contains PHP output-buffer content and diagnostics only.
+ * `PhpStreams` also contains writes through the PHP `STDOUT` and `STDERR`
+ * resources.
+ *
+ * `ProcessDescriptors` also contains safely attributed writes from child
+ * processes that inherited the worker descriptors.
+ */
+enum OutputCaptureCapability: string
+{
+    case Buffered = 'buffered';
+    case PhpStreams = 'php-streams';
+    case ProcessDescriptors = 'process-descriptors';
+}

--- a/src/Result/TestResult.php
+++ b/src/Result/TestResult.php
@@ -122,6 +122,26 @@ final readonly class TestResult
         return $this->with(attempts: $attempts);
     }
 
+    /** @internal */
+    public function withOutput(?CapturedOutput $output): self
+    {
+        return new self(
+            $this->id,
+            $this->outcome,
+            $this->durationSeconds,
+            $this->memoryDeltaBytes,
+            $this->attempts,
+            $this->failures,
+            $this->error,
+            $this->skipReason,
+            $this->transformations,
+            $output,
+            $this->risky,
+            $this->expectations,
+            $this->attachments,
+        );
+    }
+
     /**
      * Returns the same result with an error and the specified detail.
      *

--- a/tests/Acceptance/OutputCaptureRunTest.php
+++ b/tests/Acceptance/OutputCaptureRunTest.php
@@ -1,0 +1,359 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Event\TestFinished;
+use Greenlight\Expect\Expect;
+use Greenlight\Result\Outcome;
+use Greenlight\Result\OutputCaptureCapability;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\GreenlightCli;
+use Greenlight\Tests\Support\JsonlEvents;
+use Greenlight\Tests\Support\ProcessResult;
+
+final readonly class OutputCaptureRunTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    #[DataSet('workerCounts')]
+    public function directWritesRemainWithTheirTest(int $workers, OutputCaptureCapability $capability): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'direct-output-' . $workers);
+        $project->writeFile('tests/DirectOutputTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace DirectOutput;
+
+            use Greenlight\Attribute\Test;
+
+            final class DirectOutputTest
+            {
+                #[Test]
+                public function writesToEachStream(): void
+                {
+                    \fwrite(\STDOUT, 'stdout-direct');
+                    echo '-buffered';
+                    \fwrite(\STDERR, "stderr-direct\xFF");
+                }
+            }
+            PHP);
+        $project->configureWithTestFiles(['tests/DirectOutputTest.php'], workers: $workers);
+
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=jsonl']);
+        $finished = \array_find(
+            JsonlEvents::from($result),
+            static fn($event): bool => $event instanceof TestFinished,
+        );
+
+        Expect::that($finished)
+            ->because('The run did not emit a test result. Output: ' . $result->output())
+            ->toBeInstanceOf(TestFinished::class);
+        Expect::that($result->exitCode)->toBe(0);
+        Expect::that($finished->result->output?->stdout)->toBe('stdout-direct-buffered');
+        Expect::that($finished->result->output?->stderr)->toBe("stderr-direct\u{FFFD}");
+        Expect::that($finished->result->output?->capability)->toBe($capability);
+    }
+
+    /** @return iterable<string, array{positive-int, OutputCaptureCapability}> */
+    public static function workerCounts(): iterable
+    {
+        yield 'in-process' => [1, OutputCaptureCapability::PhpStreams];
+        yield 'process pool' => [2, OutputCaptureCapability::ProcessDescriptors];
+    }
+
+    #[Test]
+    #[DataSet('workerCounts')]
+    public function failedAttemptOutputSurvivesAPassingRetry(int $workers, OutputCaptureCapability $capability): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'retry-output-' . $workers);
+        $project->writeFile('tests/RetryOutputTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace RetryOutput;
+
+            use Greenlight\Attribute\Retry;
+            use Greenlight\Attribute\Test;
+
+            final class RetryOutputTest
+            {
+                #[Test]
+                #[Retry(1)]
+                public function passesOnRetry(): void
+                {
+                    static $attempt = 0;
+                    ++$attempt;
+                    \fwrite(\STDOUT, 'stdout-' . $attempt . "\n");
+                    \fwrite(\STDERR, 'stderr-' . $attempt . "\n");
+
+                    if ($attempt === 1) {
+                        throw new \RuntimeException('retry');
+                    }
+                }
+            }
+            PHP);
+        $project->configureWithTestFiles(['tests/RetryOutputTest.php'], workers: $workers);
+
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=jsonl']);
+        $finished = $this->finished($result);
+
+        Expect::that($result->exitCode)->toBe(0);
+        Expect::that($finished->result->outcome)->toBe(Outcome::Passed);
+        Expect::that($finished->result->attempts)->toBe(2);
+        Expect::that($finished->result->output?->stdout)->toBe("stdout-1\nstdout-2\n");
+        Expect::that($finished->result->output?->stderr)->toBe("stderr-1\nstderr-2\n");
+        Expect::that($finished->result->output?->capability)->toBe($capability);
+    }
+
+    #[Test]
+    public function inheritedSubprocessWritesAreCapturedByTheProcessPool(): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'inherited-output');
+        $project->writeFile('tests/InheritedOutputTest.php', <<<'PHP_WRAP'
+        <?php
+
+        declare(strict_types=1);
+
+        namespace InheritedOutput;
+
+        use Greenlight\Attribute\Test;
+
+        final class InheritedOutputTest
+        {
+            #[Test]
+            public function startsAChildProcess(): void
+            {
+                $process = \proc_open(
+                    [\PHP_BINARY, '-r', 'fwrite(STDOUT, "child-out"); fwrite(STDERR, "child-err");'],
+                    [0 => ['pipe', 'r'], 1 => \STDOUT, 2 => \STDERR],
+                    $pipes,
+                );
+
+                if (!\is_resource($process)) {
+                    throw new \RuntimeException('The child process did not start.');
+                }
+
+                \fclose($pipes[0]);
+
+                if (\proc_close($process) !== 0) {
+                    throw new \RuntimeException('The child process failed.');
+                }
+            }
+        }
+        PHP_WRAP);
+        $project->configureWithTestFiles(['tests/InheritedOutputTest.php'], workers: 2);
+
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=jsonl']);
+        $finished = $this->finished($result);
+
+        Expect::that($result->exitCode)->toBe(0);
+        Expect::that($finished->result->output?->stdout)->toBe('child-out');
+        Expect::that($finished->result->output?->stderr)->toBe('child-err');
+        Expect::that($finished->result->output?->capability)->toBe(OutputCaptureCapability::ProcessDescriptors);
+    }
+
+    #[Test]
+    #[DataSet('workerCounts')]
+    public function lifecycleWritesStayInsideTheAttemptBoundary(
+        int $workers,
+        OutputCaptureCapability $capability,
+    ): void {
+        $project = AcceptanceProject::create($this->tempDirectory, 'lifecycle-output-' . $workers);
+        $project->writeFile('tests/LifecycleOutputTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace LifecycleOutput;
+
+            use Greenlight\Attribute\After;
+            use Greenlight\Attribute\Before;
+            use Greenlight\Attribute\Test;
+            use Greenlight\Harness\Disposable;
+            use Greenlight\Harness\Scope;
+            use Greenlight\Harness\ServiceDefinition;
+            use Greenlight\Plugin\AfterTestSubscriber;
+            use Greenlight\Plugin\BeforeTestSubscriber;
+            use Greenlight\Plugin\HarnessProvider;
+            use Greenlight\Plugin\TestAttemptRunner;
+            use Greenlight\Plugin\TestContext;
+            use Greenlight\Result\TestResult;
+            use Greenlight\Test\Cleanup;
+
+            final class LifecyclePlugin implements AfterTestSubscriber, BeforeTestSubscriber, HarnessProvider, TestAttemptRunner
+            {
+                public function services(): array
+                {
+                    return [new ServiceDefinition(
+                        ClassService::class,
+                        Scope::PerClass,
+                        static fn(): ClassService => new ClassService(),
+                    )];
+                }
+
+                public function runTestAttempt(\Closure $attempt): mixed
+                {
+                    \fwrite(\STDOUT, "runner-before\n");
+
+                    try {
+                        return $attempt();
+                    } finally {
+                        \fwrite(\STDOUT, "runner-after\n");
+                    }
+                }
+
+                public function beforeTest(TestContext $context): void
+                {
+                    \fwrite(\STDOUT, "before-subscriber\n");
+                }
+
+                public function afterTest(TestContext $context, TestResult $result): TestResult
+                {
+                    \fwrite(\STDOUT, "after-subscriber\n");
+
+                    return $result;
+                }
+            }
+
+            final class ClassService implements Disposable
+            {
+                public function touch(): void {}
+
+                public function dispose(): void
+                {
+                    \fwrite(\STDOUT, "class-scope-disposal\n");
+                }
+            }
+
+            final readonly class LifecycleOutputTest
+            {
+                public function __construct(ClassService $service, Cleanup $cleanup)
+                {
+                    $service->touch();
+                    \fwrite(\STDOUT, "constructor\n");
+                    $cleanup->defer(static fn() => \fwrite(\STDOUT, "cleanup\n"));
+                }
+
+                #[Before]
+                public function before(): void
+                {
+                    \fwrite(\STDOUT, "before-hook\n");
+                }
+
+                #[After]
+                public function after(): void
+                {
+                    \fwrite(\STDOUT, "after-hook\n");
+                }
+
+                #[Test]
+                public function writes(): void
+                {
+                    \fwrite(\STDOUT, "test-body\n");
+                }
+            }
+            PHP);
+        $project->writeFile('greenlight.php', \sprintf(
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Config\GreenlightConfig;
+            use LifecycleOutput\LifecyclePlugin;
+
+            require_once __DIR__ . '/tests/LifecycleOutputTest.php';
+
+            return GreenlightConfig::create()
+                ->paths([__DIR__ . '/tests'])
+                ->workers(%d)
+                ->plugins(static fn(): LifecyclePlugin => new LifecyclePlugin());
+            PHP,
+            $workers,
+        ));
+
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=jsonl']);
+        $finished = $this->finished($result);
+
+        Expect::that($result->exitCode)->toBe(0);
+        Expect::that($finished->result->output?->stdout)->toBe(<<<'OUTPUT'
+            runner-before
+            constructor
+            before-subscriber
+            before-hook
+            test-body
+            after-hook
+            cleanup
+            after-subscriber
+            runner-after
+            class-scope-disposal
+
+            OUTPUT);
+        Expect::that($finished->result->output?->capability)->toBe($capability);
+    }
+
+    #[Test]
+    #[DataSet('workerNumbers')]
+    public function disabledCaptureDoesNotRetainOrLeakDirectWrites(int $workers): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'disabled-output-' . $workers);
+        $project->writeFile('tests/DisabledOutputTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace DisabledOutput;
+
+            use Greenlight\Attribute\Test;
+
+            final class DisabledOutputTest
+            {
+                #[Test(capture: false)]
+                public function writesDirectly(): void
+                {
+                    \fwrite(\STDOUT, 'discarded-stdout');
+                    \fwrite(\STDERR, 'discarded-stderr');
+                }
+            }
+            PHP);
+        $project->configureWithTestFiles(['tests/DisabledOutputTest.php'], workers: $workers);
+
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=jsonl']);
+        $finished = $this->finished($result);
+
+        Expect::that($result->exitCode)->toBe(0);
+        Expect::that($finished->result->output)->toBeNull();
+        Expect::that($result->stdout)->not()->toContain('discarded-stdout');
+        Expect::that($result->stderr)->not()->toContain('discarded-stderr');
+    }
+
+    /** @return iterable<string, array{positive-int}> */
+    public static function workerNumbers(): iterable
+    {
+        yield 'in-process' => [1];
+        yield 'process pool' => [2];
+    }
+
+    private function finished(ProcessResult $result): TestFinished
+    {
+        $finished = \array_find(
+            JsonlEvents::from($result),
+            static fn($event): bool => $event instanceof TestFinished,
+        );
+
+        if (!$finished instanceof TestFinished) {
+            throw new \RuntimeException('The run did not emit a test result. Output: ' . $result->output());
+        }
+
+        return $finished;
+    }
+}

--- a/tests/Acceptance/WorkerFailureContainmentTest.php
+++ b/tests/Acceptance/WorkerFailureContainmentTest.php
@@ -8,7 +8,6 @@ use Greenlight\Attribute\Test;
 use Greenlight\Event\TestFinished;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
-use Greenlight\Result\FailureDetail;
 use Greenlight\Result\Outcome;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
@@ -54,6 +53,8 @@ final readonly class WorkerFailureContainmentTest
                 {
                     static $attempt = 0;
                     ++$attempt;
+                    \fwrite(\STDOUT, 'attempt-' . $attempt . "\n");
+                    \fwrite(\STDERR, 'error-' . $attempt . "\n");
 
                     if ($attempt === 1) {
                         throw new \RuntimeException('retry me');
@@ -78,6 +79,8 @@ final readonly class WorkerFailureContainmentTest
         Expect::that($result->exitCode)->because('a crash on a retry preserves the attempt count')->toBe(1);
         Expect::that($finished->result->outcome)->toBe(Outcome::Errored);
         Expect::that($finished->result->attempts)->toBe(2);
+        Expect::that($finished->result->output?->stdout)->toBe("attempt-1\nattempt-2\n");
+        Expect::that($finished->result->output?->stderr)->toBe("error-1\nerror-2\n");
     }
 
     #[Test]
@@ -139,18 +142,12 @@ final readonly class WorkerFailureContainmentTest
             ->because('The diagnostic hard timeout did not emit TestFinished.')
             ->toBeInstanceOf(TestFinished::class);
 
-        $failure = $finished->result->failures[0] ?? null;
-
-        Expect::that($failure)
-            ->because('The diagnostic hard timeout did not report a failure.')
-            ->toBeInstanceOf(FailureDetail::class);
-
         Expect::that($result->exitCode)
             ->because('a hard timeout MUST fail the run')
             ->toBe(1);
-        Expect::that($failure->message)
-            ->because('a hard timeout MUST preserve the worker diagnostic output')
-            ->toContain("Worker output:\nThe timed-out worker emitted diagnostics.");
+        Expect::that($finished->result->output?->stderr)
+            ->because('a hard timeout MUST retain output with its test result')
+            ->toBe("The timed-out worker emitted diagnostics.\n");
     }
 
     /**

--- a/tests/Fixture/Lifecycle/CleanupExpectationAfterError/CleanupExpectationAfterErrorTest.php
+++ b/tests/Fixture/Lifecycle/CleanupExpectationAfterError/CleanupExpectationAfterErrorTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Lifecycle\CleanupExpectationAfterError;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Test\Cleanup;
+
+final readonly class CleanupExpectationAfterErrorTest
+{
+    public function __construct(private Cleanup $cleanup) {}
+
+    #[Test]
+    public function errorsBeforeCleanupExpectationFails(): never
+    {
+        $this->cleanup->defer(static function (): void {
+            Expect::that('actual')->toBe('expected');
+        });
+
+        throw new \RuntimeException('test broke first');
+    }
+}

--- a/tests/Support/ScriptedWorkerTransport.php
+++ b/tests/Support/ScriptedWorkerTransport.php
@@ -12,6 +12,7 @@ use Greenlight\Execution\ProcessPool\Protocol\Message;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\Drain;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\Hello;
 use Greenlight\Execution\ProcessPool\Protocol\ProtocolError;
+use Greenlight\Result\CapturedOutput;
 
 /**
  * Runs deterministic worker scripts through the orchestrator transport seam.
@@ -164,6 +165,15 @@ final class ScriptedWorkerTransport implements Fake, WorkerTransport
     public function diagnostics(string $workerId): string
     {
         return '';
+    }
+
+    #[\Override]
+    public function startOutputCapture(string $workerId, bool $enabled): void {}
+
+    #[\Override]
+    public function finishOutputCapture(string $workerId): ?CapturedOutput
+    {
+        return null;
     }
 
     #[\Override]

--- a/tests/Unit/Capture/CapturedOutputTest.php
+++ b/tests/Unit/Capture/CapturedOutputTest.php
@@ -10,6 +10,7 @@ use Greenlight\Internal\Wire\InvalidWirePayload;
 use Greenlight\Result\CapturedOutput;
 use Greenlight\Result\Diagnostic;
 use Greenlight\Result\DiagnosticSeverity;
+use Greenlight\Result\OutputCaptureCapability;
 use Greenlight\Tests\Support\JsonWire;
 
 final class CapturedOutputTest
@@ -22,6 +23,9 @@ final class CapturedOutputTest
             [new Diagnostic(DiagnosticSeverity::Warning, 'careful', '/tmp/UserTest.php', 42)],
             true,
             false,
+            'standard error',
+            true,
+            OutputCaptureCapability::ProcessDescriptors,
         );
 
         $restored = CapturedOutput::fromWire(JsonWire::roundTrip($original->toWire()));
@@ -29,6 +33,9 @@ final class CapturedOutputTest
         Expect::that($restored->stdout)->because('survives a JSON round trip')->toBe('some output');
         Expect::that($restored->stdoutTruncated)->toBeTrue();
         Expect::that($restored->diagnosticsTruncated)->toBeFalse();
+        Expect::that($restored->stderr)->toBe('standard error');
+        Expect::that($restored->stderrTruncated)->toBeTrue();
+        Expect::that($restored->capability)->toBe(OutputCaptureCapability::ProcessDescriptors);
         Expect::that($restored->diagnostics)->toHaveCount(1);
         Expect::that($restored->diagnostics[0]->severity)->toBe(DiagnosticSeverity::Warning);
         Expect::that($restored->diagnostics[0]->message)->toBe('careful');
@@ -63,6 +70,49 @@ final class CapturedOutputTest
         Expect::that($restored->diagnostics)->toBe([]);
         Expect::that($restored->stdoutTruncated)->toBeFalse();
         Expect::that($restored->diagnosticsTruncated)->toBeFalse();
+    }
+
+    #[Test]
+    public function legacyOutputPayloadsUseAdditiveFieldDefaults(): void
+    {
+        $restored = CapturedOutput::fromWire([
+            'stdout' => 'legacy output',
+            'diagnostics' => [],
+            'stdoutTruncated' => false,
+            'diagnosticsTruncated' => false,
+        ]);
+
+        Expect::that($restored->stderr)->toBe('');
+        Expect::that($restored->stderrTruncated)->toBeFalse();
+        Expect::that($restored->capability)->toBe(OutputCaptureCapability::Buffered);
+    }
+
+    #[Test]
+    public function mergeBoundsEveryOutputChannelAndKeepsTheStrongestCapability(): void
+    {
+        $diagnostic = new Diagnostic(DiagnosticSeverity::Notice, 'notice', 'Test.php', 1);
+        $full = new CapturedOutput(
+            \str_repeat('o', 1_048_576),
+            \array_fill(0, 1_000, $diagnostic),
+            capability: OutputCaptureCapability::PhpStreams,
+        );
+        $overflow = new CapturedOutput(
+            'later',
+            [$diagnostic],
+            capability: OutputCaptureCapability::ProcessDescriptors,
+        );
+
+        $merged = CapturedOutput::merge($full, $overflow);
+
+        if (!$merged instanceof CapturedOutput) {
+            throw new \RuntimeException('The two output captures did not merge.');
+        }
+
+        Expect::that($merged->stdout)->toBe(\str_repeat('o', 1_048_576));
+        Expect::that($merged->stdoutTruncated)->toBeTrue();
+        Expect::that($merged->diagnostics)->toHaveCount(1_000);
+        Expect::that($merged->diagnosticsTruncated)->toBeTrue();
+        Expect::that($merged->capability)->toBe(OutputCaptureCapability::ProcessDescriptors);
     }
 
     #[Test]

--- a/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorInitialAssignmentTest.php
+++ b/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorInitialAssignmentTest.php
@@ -158,7 +158,7 @@ final readonly class OrchestratorInitialAssignmentTest
                 };
 
                 $send([
-                    'v' => 3,
+                    'v' => 4,
                     't' => 'hello',
                     'p' => ['workerId' => $workerId, 'token' => $token, 'pid' => getmypid()],
                 ]);
@@ -169,7 +169,7 @@ final readonly class OrchestratorInitialAssignmentTest
                     file_put_contents($directory . '/slow-ready', (string) microtime(true));
                 }
 
-                $send(['v' => 3, 't' => 'ready', 'p' => []]);
+                $send(['v' => 4, 't' => 'ready', 'p' => []]);
 
                 while (true) {
                     $message = $receive();
@@ -185,7 +185,7 @@ final readonly class OrchestratorInitialAssignmentTest
                         FILE_APPEND,
                     );
                     $send([
-                        'v' => 3,
+                        'v' => 4,
                         't' => 'done',
                         'p' => [
                             'summary' => ['passed' => 0, 'failed' => 0, 'errored' => 0, 'skipped' => 0],

--- a/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorTest.php
+++ b/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorTest.php
@@ -88,7 +88,7 @@ final class OrchestratorTest
                 [, , $address, $workerId, $token] = $argv;
                 $socket = stream_socket_client($address);
                 $json = json_encode([
-                    'v' => 3,
+                    'v' => 4,
                     't' => 'hello',
                     'p' => [
                         'workerId' => $workerId,
@@ -168,7 +168,7 @@ final class OrchestratorTest
         $script = <<<'PHP'
             [, , $address, $workerId, $token] = $argv;
             $socket = stream_socket_client($address);
-            $json = json_encode(['v' => 3, 't' => 'hello', 'p' => ['workerId' => $workerId, 'token' => $token, 'pid' => getmypid()]]);
+            $json = json_encode(['v' => 4, 't' => 'hello', 'p' => ['workerId' => $workerId, 'token' => $token, 'pid' => getmypid()]]);
             fwrite($socket, pack('N', strlen($json)) . $json);
             fflush($socket);
             sleep(60);
@@ -298,12 +298,11 @@ final class OrchestratorTest
         Expect::that($results)
             ->toHaveCount(1);
         Expect::that($results[0]->error?->message)
-            ->because('the synthetic error MUST preserve the worker diagnostic output')
-            ->toBe(
-                "Worker \"w-1\" crashed during this test: the worker process exited unexpectedly.\n"
-                . "Worker output:\nThe worker emitted crash diagnostics.",
-            );
+            ->toBe('Worker "w-1" crashed during this test: the worker process exited unexpectedly.');
         Expect::that($results[0]->error?->class)->toBe(WorkerError::class);
+        Expect::that($results[0]->output?->stderr)
+            ->because('the synthetic result MUST preserve worker standard error')
+            ->toBe("The worker emitted crash diagnostics.\n");
     }
 
     #[Test]
@@ -344,7 +343,7 @@ final class OrchestratorTest
 
     #[Test]
     #[Timeout(30.0)]
-    public function crashedWorkerKeepsACompleteUnicodeDiagnosticTail(): void
+    public function crashedWorkerKeepsCompleteUnicodeDiagnosticOutput(): void
     {
         $root = \dirname(__DIR__, 5);
         $sink = new CollectingEventSink();
@@ -363,12 +362,11 @@ final class OrchestratorTest
             ->because('a worker crash MUST produce one synthetic test result')
             ->toHaveCount(1);
         Expect::that($results[0]->error?->message)
-            ->because('the diagnostic tail MUST contain only complete Unicode characters within its byte limit')
-            ->toBe(
-                "Worker \"w-1\" crashed during this test: the worker process exited unexpectedly.\n"
-                . "Worker output:\n"
-                . \str_repeat('y', 2046),
-            );
+            ->toBe('Worker "w-1" crashed during this test: the worker process exited unexpectedly.');
+        Expect::that($results[0]->output?->stderr)
+            ->because('captured standard error MUST contain complete Unicode characters')
+            ->toBe('xx€' . \str_repeat('y', 2046));
+        Expect::that($results[0]->output?->stderrTruncated)->toBeFalse();
     }
 
     private function plan(): ExecutionPlan

--- a/tests/Unit/Execution/ProcessPool/Orchestrator/WorkerHandleDiagnosticStreamsTest.php
+++ b/tests/Unit/Execution/ProcessPool/Orchestrator/WorkerHandleDiagnosticStreamsTest.php
@@ -7,6 +7,8 @@ namespace Greenlight\Tests\Unit\Execution\ProcessPool\Orchestrator;
 use Greenlight\Attribute\Test;
 use Greenlight\Execution\ProcessPool\Orchestrator\WorkerHandle;
 use Greenlight\Expect\Expect;
+use Greenlight\Result\CapturedOutput;
+use Greenlight\Result\OutputCaptureCapability;
 use Greenlight\Tests\Support\MemoryStream;
 
 final readonly class WorkerHandleDiagnosticStreamsTest
@@ -46,6 +48,90 @@ final readonly class WorkerHandleDiagnosticStreamsTest
         Expect::that($handle->diagnostics)
             ->because('one pipe drain MUST retain the bounded tail of all available output')
             ->toBe($tail);
+    }
+
+    #[Test]
+    public function activeCaptureKeepsDescriptorStreamsSeparateAndScrubsBinaryBytes(): void
+    {
+        $stdout = MemoryStream::open();
+        $stderr = MemoryStream::open();
+        $handle = new WorkerHandle('worker-1', 1, MemoryStream::open(), $stdout, $stderr);
+        $handle->startOutputCapture(true);
+        \fwrite($stdout, "stdout\xFF");
+        \fwrite($stderr, "stderr\xFF");
+        \rewind($stdout);
+        \rewind($stderr);
+
+        $captured = $handle->finishOutputCapture();
+
+        Expect::that($captured?->stdout)->toBe("stdout\u{FFFD}");
+        Expect::that($captured?->stderr)->toBe("stderr\u{FFFD}");
+        Expect::that($captured?->capability)->toBe(OutputCaptureCapability::ProcessDescriptors);
+        Expect::that($handle->diagnostics)->toBe('');
+    }
+
+    #[Test]
+    public function descriptorStreamsHaveIndependentStrictByteBounds(): void
+    {
+        $stdout = MemoryStream::open();
+        $stderr = MemoryStream::open();
+        $handle = new WorkerHandle('worker-1', 1, MemoryStream::open(), $stdout, $stderr);
+        $handle->startOutputCapture(true);
+        \fwrite($stdout, \str_repeat('o', 1_048_577));
+        \fwrite($stderr, \str_repeat('e', 1_048_576));
+        \rewind($stdout);
+        \rewind($stderr);
+
+        $captured = $handle->finishOutputCapture();
+
+        if (!$captured instanceof CapturedOutput) {
+            throw new \RuntimeException('The active descriptor capture returned no output.');
+        }
+
+        Expect::that(\strlen($captured->stdout))->toBe(1_048_576);
+        Expect::that(\strlen($captured->stderr))->toBe(1_048_576);
+        Expect::that($captured->stdoutTruncated)->toBeTrue();
+        Expect::that($captured->stderrTruncated)->toBeFalse();
+    }
+
+    #[Test]
+    public function descriptorCaptureReportsBytesThatArriveAfterTheBoundIsFull(): void
+    {
+        $stdout = MemoryStream::open();
+        $handle = new WorkerHandle(
+            'worker-1',
+            1,
+            MemoryStream::open(),
+            $stdout,
+            MemoryStream::open(),
+        );
+        $handle->startOutputCapture(true);
+        \fwrite($stdout, \str_repeat('o', 1_048_576));
+        \rewind($stdout);
+        $handle->drainPipes();
+        \fwrite($stdout, 'later');
+        \fseek($stdout, 1_048_576);
+        $handle->drainPipes();
+
+        $captured = $handle->finishOutputCapture();
+
+        Expect::that($captured?->stdout)->toBe(\str_repeat('o', 1_048_576));
+        Expect::that($captured?->stdoutTruncated)
+            ->because('bytes that arrive after the descriptor bound MUST set the truncation flag')
+            ->toBeTrue();
+    }
+
+    #[Test]
+    public function disabledCaptureDiscardsAttemptBytes(): void
+    {
+        $stdout = MemoryStream::open();
+        $handle = new WorkerHandle('worker-1', 1, MemoryStream::open(), $stdout, MemoryStream::open());
+        $handle->startOutputCapture(false);
+        \fwrite($stdout, 'discarded');
+        \rewind($stdout);
+
+        Expect::that($handle->finishOutputCapture())->toBeNull();
+        Expect::that($handle->diagnostics)->toBe('');
     }
 
 }

--- a/tests/Unit/Execution/ProcessPool/Protocol/MessageTagsTest.php
+++ b/tests/Unit/Execution/ProcessPool/Protocol/MessageTagsTest.php
@@ -9,6 +9,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Execution\ProcessPool\Protocol\Message;
 use Greenlight\Execution\ProcessPool\Protocol\MessageRegistry;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\Assign;
+use Greenlight\Execution\ProcessPool\Protocol\Messages\AttemptReady;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\AttemptStarted;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\Done;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\Drain;
@@ -42,6 +43,7 @@ final class MessageTagsTest
         yield 'drain' => [Drain::class, 'drain'];
         yield 'event' => [EventEnvelope::class, 'event'];
         yield 'attempt started' => [AttemptStarted::class, 'attempt-started'];
+        yield 'attempt ready' => [AttemptReady::class, 'attempt-ready'];
         yield 'done' => [Done::class, 'done'];
         yield 'fatal' => [Fatal::class, 'fatal'];
     }
@@ -52,7 +54,7 @@ final class MessageTagsTest
         Expect::that(MessageRegistry::envelope(new Drain()))
             ->because('the published worker-protocol envelope MUST remain compatible')
             ->toBe([
-                'v' => 3,
+                'v' => 4,
                 't' => 'drain',
                 'p' => [],
             ]);

--- a/tests/Unit/Execution/ProcessPool/Protocol/ProtocolTest.php
+++ b/tests/Unit/Execution/ProcessPool/Protocol/ProtocolTest.php
@@ -226,7 +226,7 @@ final class ProtocolTest
     #[Test]
     public function unknownTagsAndVersionsAreProtocolErrors(): void
     {
-        Expect::that(static fn(): Message => MessageRegistry::open(['v' => 3, 't' => 'nonsense', 'p' => []]))->because('unknown tags and versions are protocol errors')
+        Expect::that(static fn(): Message => MessageRegistry::open(['v' => 4, 't' => 'nonsense', 'p' => []]))->because('unknown tags and versions are protocol errors')
             ->toThrow(ProtocolError::class, matching: '/Unknown message type "nonsense"/');
 
         Expect::that(static fn(): Message => MessageRegistry::open(['v' => 9, 't' => 'drain', 'p' => []]))->because('unknown tags and versions are protocol errors')

--- a/tests/Unit/Execution/ProcessPool/Protocol/WorkerMessageWireTest.php
+++ b/tests/Unit/Execution/ProcessPool/Protocol/WorkerMessageWireTest.php
@@ -37,6 +37,7 @@ final class WorkerMessageWireTest
         $attempt = AttemptStarted::fromWire([
             'id' => new TestId('App\ExampleTest', 'checksValue')->toWire(),
             'attempt' => $number,
+            'capture' => true,
         ]);
 
         Expect::that($attempt->attempt)

--- a/tests/Unit/Execution/ProcessPool/Protocol/WorkerProtocolSchemaTest.php
+++ b/tests/Unit/Execution/ProcessPool/Protocol/WorkerProtocolSchemaTest.php
@@ -19,6 +19,7 @@ use Greenlight\Execution\ProcessPool\Protocol\JsonFrameCodec;
 use Greenlight\Execution\ProcessPool\Protocol\Message;
 use Greenlight\Execution\ProcessPool\Protocol\MessageRegistry;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\Assign;
+use Greenlight\Execution\ProcessPool\Protocol\Messages\AttemptReady;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\AttemptStarted;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\Bootstrap;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\Done;
@@ -116,13 +117,13 @@ final class WorkerProtocolSchemaTest
             ['data', 'result', 'attachments'],
         ]);
 
-        Expect::that($this->validationErrors($this->asJsonObject(['v' => 3, 't' => 'bootstrap', 'p' => $bootstrapPayload])))
+        Expect::that($this->validationErrors($this->asJsonObject(['v' => 4, 't' => 'bootstrap', 'p' => $bootstrapPayload])))
             ->because('the schema MUST accept compatible bootstrap payloads')
             ->toBe([]);
-        Expect::that($this->validationErrors($this->asJsonObject(['v' => 3, 't' => 'assign', 'p' => $assignPayload])))
+        Expect::that($this->validationErrors($this->asJsonObject(['v' => 4, 't' => 'assign', 'p' => $assignPayload])))
             ->because('the schema MUST accept compatible assignment payloads')
             ->toBe([]);
-        Expect::that($this->validationErrors($this->asJsonObject(['v' => 3, 't' => 'event', 'p' => $eventPayload])))
+        Expect::that($this->validationErrors($this->asJsonObject(['v' => 4, 't' => 'event', 'p' => $eventPayload])))
             ->because('the schema MUST accept compatible test result payloads')
             ->toBe([]);
     }
@@ -133,7 +134,7 @@ final class WorkerProtocolSchemaTest
         $payload = $this->messages()['assign']->toWire();
         $payload['futureProtocolField'] = true;
 
-        Expect::that($this->validationErrors($this->asJsonObject(['v' => 3, 't' => 'assign', 'p' => $payload])))
+        Expect::that($this->validationErrors($this->asJsonObject(['v' => 4, 't' => 'assign', 'p' => $payload])))
             ->because('a protocol change MUST update the schema')
             ->not()
             ->toBe([]);
@@ -251,6 +252,7 @@ final class WorkerProtocolSchemaTest
             'drain' => new Drain(),
             'event' => new EventEnvelope(new TestFinished($result, 1_780_000_000.5)),
             'attempt-started' => new AttemptStarted($id, 2),
+            'attempt-ready' => new AttemptReady(),
             'done' => new Done(
                 new ResultSummary(passed: 2, failed: 1),
                 123_456,
@@ -403,7 +405,7 @@ final class WorkerProtocolSchemaTest
 
     private function schemaPath(): string
     {
-        return \dirname(__DIR__, 5) . '/resources/schema/worker-protocol-v3.schema.json';
+        return \dirname(__DIR__, 5) . '/resources/schema/worker-protocol-v4.schema.json';
     }
 
     /**

--- a/tests/Unit/Execution/ProcessPool/Worker/WorkerArtifactSessionTest.php
+++ b/tests/Unit/Execution/ProcessPool/Worker/WorkerArtifactSessionTest.php
@@ -104,6 +104,10 @@ final readonly class WorkerArtifactSessionTest
                     $finished = $message->event;
                 }
 
+                if ($message instanceof Greenlight\Execution\ProcessPool\Protocol\Messages\AttemptStarted) {
+                    $channel->send(new Greenlight\Execution\ProcessPool\Protocol\Messages\AttemptReady());
+                }
+
                 if ($message instanceof Greenlight\Execution\ProcessPool\Protocol\Messages\Done) {
                     $done = $message;
                 }

--- a/tests/Unit/Execution/ProcessPool/Worker/WorkerProcessTest.php
+++ b/tests/Unit/Execution/ProcessPool/Worker/WorkerProcessTest.php
@@ -236,6 +236,7 @@ final readonly class WorkerProcessTest
     {
         yield 'assignment before bootstrap' => ['assignment-before-bootstrap'];
         yield 'duplicate bootstrap' => ['duplicate-bootstrap'];
+        yield 'missing attempt acknowledgement' => ['attempt-not-acknowledged'];
     }
 
     /**
@@ -342,6 +343,36 @@ final readonly class WorkerProcessTest
                     || $fatal->detail->message !== 'Worker received bootstrap more than once.'
                 ) {
                     exit(6);
+                }
+
+                exit(0);
+            }
+
+            if ($scenario === 'attempt-not-acknowledged') {
+                $channel->send(new Greenlight\Execution\ProcessPool\Protocol\Messages\Assign(
+                    new Greenlight\Discovery\Plan\ExecutionPlan([
+                        Greenlight\Tests\Support\PlanEntryFixture::create(
+                            Greenlight\Tests\Fixture\Execution\Worker\OptionalConstructorProbe::class,
+                            'usesDeclaredDefault',
+                        ),
+                    ]),
+                ));
+
+                do {
+                    $started = $channel->receive(2.0);
+                } while ($started instanceof Greenlight\Execution\ProcessPool\Protocol\Messages\EventEnvelope);
+
+                if (!$started instanceof Greenlight\Execution\ProcessPool\Protocol\Messages\AttemptStarted) {
+                    exit(7);
+                }
+
+                $channel->send(new Greenlight\Execution\ProcessPool\Protocol\Messages\Drain());
+                $fatal = $channel->receive(2.0);
+
+                if (!$fatal instanceof Greenlight\Execution\ProcessPool\Protocol\Messages\Fatal
+                    || $fatal->detail->message !== 'Worker did not receive an output-capture acknowledgement for its test attempt.'
+                ) {
+                    exit(8);
                 }
 
                 exit(0);

--- a/tests/Unit/Execution/Worker/Capture/CapturedStreamFilterTest.php
+++ b/tests/Unit/Execution/Worker/Capture/CapturedStreamFilterTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Execution\Worker\Capture;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Execution\Worker\CapturedStreamFilter;
+use Greenlight\Expect\Expect;
+
+final readonly class CapturedStreamFilterTest
+{
+    #[Test]
+    public function missingBufferParametersRejectTheWrite(): void
+    {
+        $name = 'greenlight.test.missing-buffer';
+        \stream_filter_register($name, CapturedStreamFilter::class);
+        $stream = \fopen('php://temp', 'w+');
+
+        if (!\is_resource($stream)) {
+            throw new \RuntimeException('The test stream did not open.');
+        }
+
+        $filter = \stream_filter_append($stream, $name, \STREAM_FILTER_WRITE);
+
+        if (!\is_resource($filter)) {
+            throw new \RuntimeException('The test filter did not attach.');
+        }
+
+        try {
+            Expect::that(@\fwrite($stream, 'discarded'))
+                ->because('a capture filter without its buffer MUST reject the write')
+                ->toBeFalse();
+        } finally {
+            @\stream_filter_remove($filter);
+            \fclose($stream);
+        }
+    }
+}

--- a/tests/Unit/Execution/Worker/Capture/OutputCaptureTest.php
+++ b/tests/Unit/Execution/Worker/Capture/OutputCaptureTest.php
@@ -8,8 +8,11 @@ use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Execution\Worker\CaptureError;
 use Greenlight\Execution\Worker\OutputCapture;
+use Greenlight\Execution\Worker\OutputRouting;
 use Greenlight\Expect\Expect;
+use Greenlight\Result\CapturedOutput;
 use Greenlight\Result\DiagnosticSeverity;
+use Greenlight\Result\OutputCaptureCapability;
 use Greenlight\Test\Cleanup;
 use Greenlight\Tests\Support\PhpSubprocess;
 
@@ -36,6 +39,60 @@ final readonly class OutputCaptureTest
         Expect::that($captured->stdout)->because('echo inside the window is captured and does not reach the outer stream')->toBe('hello from the test');
         Expect::that($captured->stdoutTruncated)->toBeFalse();
         Expect::that($leaked)->toBe('');
+    }
+
+    #[Test]
+    public function directPhpStreamWritesRemainSeparateAndOrderedWithBufferedOutput(): void
+    {
+        $captured = $this->standaloneCapture(<<<'PHP_WRAP'
+            $capture = new Greenlight\Execution\Worker\OutputCapture();
+            $capture->start();
+            fwrite(STDOUT, 'stdout-a');
+            fwrite(STDERR, 'stderr-a');
+            echo '-echo';
+            fwrite(STDERR, '-stderr-b');
+            fwrite(STDOUT, '-stdout-b');
+            PHP_WRAP);
+
+        Expect::that($captured->stdout)->toBe('stdout-a-echo-stdout-b');
+        Expect::that($captured->stderr)->toBe('stderr-a-stderr-b');
+        Expect::that($captured->stdoutTruncated)->toBeFalse();
+        Expect::that($captured->stderrTruncated)->toBeFalse();
+        Expect::that($captured->capability)->toBe(OutputCaptureCapability::PhpStreams);
+    }
+
+    #[Test]
+    public function standardStreamsHaveIndependentStrictByteBounds(): void
+    {
+        $captured = $this->standaloneCapture(<<<'PHP_WRAP'
+            $capture = new Greenlight\Execution\Worker\OutputCapture(maxStdoutBytes: 4, maxStderrBytes: 3);
+            $capture->start();
+            fwrite(STDOUT, '12345');
+            fwrite(STDERR, 'abc');
+            PHP_WRAP);
+
+        Expect::that($captured->stdout)->toBe('1234');
+        Expect::that($captured->stderr)->toBe('abc');
+        Expect::that($captured->stdoutTruncated)->toBeTrue();
+        Expect::that($captured->stderrTruncated)->toBeFalse();
+    }
+
+    #[Test]
+    public function binaryBytesInDirectStreamsAreScrubbedWithoutExceedingTheBounds(): void
+    {
+        $captured = $this->standaloneCapture(<<<'PHP_WRAP'
+            $capture = new Greenlight\Execution\Worker\OutputCapture(maxStdoutBytes: 4, maxStderrBytes: 4);
+            $capture->start();
+            fwrite(STDOUT, "a\xFFb");
+            fwrite(STDERR, "c\xFFd");
+            PHP_WRAP);
+
+        Expect::that($captured->stdout)->toBe("a\u{FFFD}");
+        Expect::that($captured->stderr)->toBe("c\u{FFFD}");
+        Expect::that(\strlen($captured->stdout))->toBeLessThan(5);
+        Expect::that(\strlen($captured->stderr))->toBeLessThan(5);
+        Expect::that($captured->stdoutTruncated)->toBeTrue();
+        Expect::that($captured->stderrTruncated)->toBeTrue();
     }
 
     #[Test]
@@ -351,6 +408,38 @@ final readonly class OutputCaptureTest
     }
 
     #[Test]
+    public function snapshotWithoutStartingThrows(): void
+    {
+        Expect::that(static fn(): CapturedOutput => new OutputCapture()->snapshot())
+            ->toThrow(CaptureError::class, '/not active.*start\(\)/');
+    }
+
+    #[Test]
+    public function duplicateFilterRegistrationRestoresTheErrorHandler(): void
+    {
+        $capture = new OutputCapture();
+        $capture->start();
+        $capture->stop();
+        $registered = new \ReflectionProperty(OutputCapture::class, 'streamFilterRegistered');
+        $baselineHandler = $this->activeErrorHandler();
+        $registered->setValue(null, false);
+
+        try {
+            Expect::that(static fn() => new OutputCapture()->start())
+                ->toThrow(
+                    CaptureError::class,
+                    message: 'Output capture cannot attach to STDOUT and STDERR. '
+                        . 'Use process-pool execution for descriptor capture.',
+                );
+            Expect::that($this->activeErrorHandler())
+                ->because('a filter setup failure MUST restore the previous error handler')
+                ->toBe($baselineHandler);
+        } finally {
+            $registered->setValue(null, true);
+        }
+    }
+
+    #[Test]
     public function startingTwiceThrows(): void
     {
         $capture = new OutputCapture();
@@ -402,22 +491,60 @@ final readonly class OutputCaptureTest
     public function nonPositiveBoundsAreRejected(
         int $maxStdoutBytes,
         int $maxDiagnostics,
+        int $maxStderrBytes,
         string $message,
     ): void {
-        Expect::that(static fn(): OutputCapture => new OutputCapture($maxStdoutBytes, $maxDiagnostics))
+        Expect::that(static fn(): OutputCapture => new OutputCapture(
+            $maxStdoutBytes,
+            $maxDiagnostics,
+            $maxStderrBytes,
+            OutputRouting::CapturePhpStreams,
+        ))
             ->because('output capture bounds MUST be positive')
             ->toThrow(\InvalidArgumentException::class, message: $message);
     }
 
     /**
-     * @return iterable<string, array{int, int, non-empty-string}>
+     * @return iterable<string, array{int, int, int, non-empty-string}>
      */
     public static function nonPositiveBounds(): iterable
     {
-        yield 'zero stdout bound' => [0, 1, 'Stdout bound must be at least 1 byte, got 0.'];
-        yield 'negative stdout bound' => [-1, 1, 'Stdout bound must be at least 1 byte, got -1.'];
-        yield 'zero diagnostics bound' => [1, 0, 'Diagnostics bound must be at least 1 entry, got 0.'];
-        yield 'negative diagnostics bound' => [1, -1, 'Diagnostics bound must be at least 1 entry, got -1.'];
+        yield 'zero stdout bound' => [0, 1, 1, 'Stdout bound must be at least 1 byte, got 0.'];
+        yield 'negative stdout bound' => [-1, 1, 1, 'Stdout bound must be at least 1 byte, got -1.'];
+        yield 'zero diagnostics bound' => [1, 0, 1, 'Diagnostics bound must be at least 1 entry, got 0.'];
+        yield 'negative diagnostics bound' => [1, -1, 1, 'Diagnostics bound must be at least 1 entry, got -1.'];
+        yield 'zero stderr bound' => [1, 1, 0, 'Stderr bound must be at least 1 byte, got 0.'];
+        yield 'negative stderr bound' => [1, 1, -1, 'Stderr bound must be at least 1 byte, got -1.'];
+    }
+
+    private function standaloneCapture(string $setup): CapturedOutput
+    {
+        $root = \dirname(__DIR__, 5);
+        $process = PhpSubprocess::run($root, [
+            '-r',
+            \sprintf(
+                "require \$argv[1];\n%s\n\$captured = \$capture->stop();\necho json_encode(\$captured->toWire(), JSON_THROW_ON_ERROR);",
+                $setup,
+            ),
+            $root . '/vendor/autoload.php',
+        ]);
+        $payload = \json_decode($process->stdout, true, flags: \JSON_THROW_ON_ERROR);
+
+        if (!\is_array($payload)) {
+            throw new \RuntimeException('The capture subprocess did not return a wire payload.');
+        }
+
+        $wire = [];
+
+        foreach ($payload as $key => $value) {
+            if (!\is_string($key)) {
+                throw new \RuntimeException('The capture subprocess returned an invalid wire payload.');
+            }
+
+            $wire[$key] = $value;
+        }
+
+        return CapturedOutput::fromWire($wire);
     }
 
     /** @return (callable(int, string, string, int): bool)|null */

--- a/tests/Unit/Execution/Worker/WorkerTest.php
+++ b/tests/Unit/Execution/Worker/WorkerTest.php
@@ -9,6 +9,7 @@ use Greenlight\Discovery\Plan\ExecutionPlan;
 use Greenlight\Discovery\TestDiscoverer;
 use Greenlight\Event\TestClassStarted;
 use Greenlight\Execution\Worker\LeakDetector;
+use Greenlight\Execution\Worker\OutputSilencer;
 use Greenlight\Execution\Worker\Worker;
 use Greenlight\Expect\Expect;
 use Greenlight\Harness\Scope;
@@ -169,6 +170,47 @@ final class WorkerTest
         Expect::that(TraceLog::drain())
             ->because('a cleanup failure MUST NOT prevent later callbacks')
             ->toBe(['first cleanup', 'failing cleanup', 'last cleanup']);
+    }
+
+    #[Test]
+    public function cleanupExpectationFailuresRemainSecondaryToTheTestError(): void
+    {
+        [, $results] = $this->runFixture('CleanupExpectationAfterError');
+
+        Expect::that($results[0]->outcome)->toBe(Outcome::Errored);
+        Expect::that($results[0]->error?->message)->toBe('test broke first');
+        Expect::that($results[0]->failures)->toHaveCount(1);
+        Expect::that($results[0]->failures[0]->expected)->toBe("'expected'");
+        Expect::that($results[0]->failures[0]->actual)->toBe("'actual'");
+    }
+
+    #[Test]
+    public function outputSilencerStartupFailuresAreContainedDuringClassClose(): void
+    {
+        $silencer = new OutputSilencer();
+        $silencer->start();
+        $silencer->stop();
+        $registered = new \ReflectionProperty(OutputSilencer::class, 'registered');
+        $registered->setValue(null, false);
+
+        try {
+            [, $results] = $this->runFixture('Captured');
+        } finally {
+            $registered->setValue(null, true);
+        }
+
+        $last = \array_pop($results);
+
+        if (!$last instanceof TestResult) {
+            throw new \RuntimeException('The output-silencer fixture produced no test result.');
+        }
+
+        Expect::that($last->outcome)
+            ->because('a class-close silencer failure MUST become a contained test error')
+            ->toBe(Outcome::Errored);
+        Expect::that($last->error?->message)
+            ->toBe('Output capture cannot attach to STDOUT and STDERR. '
+                . 'Use process-pool execution for descriptor capture.');
     }
 
     #[Test]

--- a/tests/Unit/Reporting/JUnitReporterTest.php
+++ b/tests/Unit/Reporting/JUnitReporterTest.php
@@ -9,6 +9,7 @@ use Greenlight\Event\RunFinished;
 use Greenlight\Event\TestFinished;
 use Greenlight\Expect\Expect;
 use Greenlight\Reporting\JUnitReporter;
+use Greenlight\Result\CapturedOutput;
 use Greenlight\Result\FailureDetail;
 use Greenlight\Result\Outcome;
 use Greenlight\Result\ResultSummary;
@@ -286,5 +287,32 @@ final class JUnitReporterTest
                 . "actual: actual\u{FFFD}\u{FFFD}\n"
                 . "at /project/tests/\u{FFFD}\u{FFFD}Test.php:12",
             );
+    }
+
+    #[Test]
+    public function capturedStreamsUseSeparateJunitElementsWithTruncationMarkers(): void
+    {
+        $output = new BufferOutput();
+        $reporter = new JUnitReporter($output);
+        $reporter->onEvent(new TestFinished(new TestResult(
+            new TestId('Acme\OutputTest', 'fails'),
+            Outcome::Failed,
+            0.001,
+            0,
+            output: new CapturedOutput(
+                'stdout',
+                stdoutTruncated: true,
+                stderr: 'stderr',
+                stderrTruncated: true,
+            ),
+        ), 1.0));
+        $reporter->finish();
+        $document = \simplexml_load_string($output->buffer());
+
+        Expect::that($document)->toBeInstanceOf(\SimpleXMLElement::class);
+        Expect::that((string) SimpleXml::xpath($document, '//system-out')[0])
+            ->toBe("stdout\n[Greenlight: standard output truncated]");
+        Expect::that((string) SimpleXml::xpath($document, '//system-err')[0])
+            ->toBe("stderr\n[Greenlight: standard error truncated]");
     }
 }

--- a/tests/Unit/Reporting/ProblemDetailsTest.php
+++ b/tests/Unit/Reporting/ProblemDetailsTest.php
@@ -35,15 +35,23 @@ final class ProblemDetailsTest
             transformations: [
                 new OutcomeTransformation('quarantine', Outcome::Passed, Outcome::Failed),
             ],
-            output: new CapturedOutput("first line\nsecond line\n", stdoutTruncated: true),
+            output: new CapturedOutput(
+                "first line\nsecond line\n",
+                stdoutTruncated: true,
+                stderr: "error line\n",
+                stderrTruncated: true,
+            ),
         );
 
         $expected = <<<'TXT'
               after 3 attempts
               outcome changed from passed to failed by quarantine
-              captured output:
+              captured standard output:
                 first line
                 second line
+                (truncated)
+              captured standard error:
+                error line
                 (truncated)
             TXT;
 
@@ -90,7 +98,7 @@ final class ProblemDetailsTest
               expected: 42
               actual: 41
               at FailureTest.php:12
-              captured output:
+              captured standard output:
                 captured
               warning: careful at FailureTest.php:13
               attachments:
@@ -125,6 +133,25 @@ final class ProblemDetailsTest
                 "  warning: first warning at FailureTest.php:13\n"
                 . "  additional diagnostics omitted\n",
             );
+    }
+
+    #[Test]
+    public function emptyTruncatedStreamsStillReportTheirLimits(): void
+    {
+        $result = new TestResult(
+            new TestId('Acme\\FailureTest', 'reportsEmptyTruncatedStreams'),
+            Outcome::Failed,
+            0.1,
+            0,
+            output: new CapturedOutput('', stdoutTruncated: true, stderrTruncated: true),
+        );
+
+        Expect::that(ProblemDetails::render($result))->toBe(
+            "  captured standard output:\n"
+            . "    (truncated)\n"
+            . "  captured standard error:\n"
+            . "    (truncated)\n",
+        );
     }
 
     #[Test]

--- a/tests/Unit/Reporting/ProblemDetailsZeroOutputTest.php
+++ b/tests/Unit/Reporting/ProblemDetailsZeroOutputTest.php
@@ -27,6 +27,6 @@ final class ProblemDetailsZeroOutputTest
 
         Expect::that(ProblemDetails::render($result))
             ->because('captured output MUST preserve the string "0"')
-            ->toBe("  captured output:\n    0\n");
+            ->toBe("  captured standard output:\n    0\n");
     }
 }


### PR DESCRIPTION
## Summary

- capture bounded per-test standard output and standard error without using protocol streams
- retain output across retries, crashes, timeouts, cleanup, hooks, and worker plugins
- expose additive result fields, capture capability, JSONL compatibility, JUnit streams, and failure details

## Portability

Process-pool runs capture native worker descriptors, including synchronous child processes that inherit them. In-process runs use PHP stream filters and report the php-streams capability; inherited child-process writes are not attributable there. A filter setup failure produces an explicit capture error.