### PR TITLE
feat(execution): add plugin leak detectors

### DIFF
--- a/docs/api-plugins.md
+++ b/docs/api-plugins.md
@@ -288,7 +288,7 @@ Plugins implement one or more capability interfaces such as
 `WorkerRuntimeRunner`, `TestAttemptRunner`, `BeforeTestSubscriber`,
 `AfterTestSubscriber`, `RunLifecycleSubscriber`, `RetryDecider`,
 `CommandProvider`, `CoverageMapTransformer`, `HarnessProvider`, `ReporterProvider`,
-`TerminalResultTransformer`, `TestPlanTransformer`, or
+`TerminalResultTransformer`, `TestInstanceLeakDetector`, `TestPlanTransformer`, or
 `ExpectationExtension`.
 
 ```php
@@ -536,6 +536,44 @@ PHPDoc:
 - `@throws SkipTest`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L64)
+
+## `TestInstanceLeakDetector`
+
+Namespace: `Greenlight\Plugin`
+
+Detects test instances that remain reachable after their test.
+
+```php
+interface TestInstanceLeakDetector extends Plugin
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestInstanceLeakDetector.php#L10)
+
+### `watch()`
+
+Records one test instance before Greenlight releases its references.
+
+```php
+public function watch(TestId $id, object $instance): void;
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestInstanceLeakDetector.php#L13)
+
+### `sweep()`
+
+Reports leaks after Greenlight releases its references to the test.
+
+A detector MUST report each leak one time.
+
+```php
+public function sweep(): array;
+```
+
+PHPDoc:
+
+- `@return list<TestId>`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestInstanceLeakDetector.php#L22)
 
 ## `TestPlan`
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -578,6 +578,29 @@ transformers.
 
 The built-in diagnostic and risky-test policies use this interface.
 
+### TestInstanceLeakDetector
+
+Worker-side.
+
+<!-- php-example {"mode":"display","reason":"Shows the two method signatures without their interface declaration."} -->
+```php
+public function watch(TestId $id, object $instance): void;
+public function sweep(): array;
+```
+
+Greenlight calls `watch()` after the test method, hooks, cleanup callbacks,
+test-scope disposal, and after-test subscribers complete. It then releases its
+references to the test instance. Before `TestFinished`, Greenlight calls
+`sweep()`. Return the IDs of test instances that remain reachable.
+
+A detector MUST report each leak one time. Greenlight combines and
+deduplicates results from all detectors. A reported leak makes the run fail.
+
+The `--detect-leaks` option adds Greenlight's weak-reference detector through
+this capability. A configured detector runs without this option. Use a
+configured detector when an application runtime needs a different collection
+or reachability check.
+
 ### RunLifecycleSubscriber
 
 Orchestrator-side.
@@ -787,6 +810,7 @@ Priority applies to these capabilities:
 * `AfterTestSubscriber`
 * `RetryDecider`
 * `TerminalResultTransformer`
+* `TestInstanceLeakDetector`
 * `RunLifecycleSubscriber`
 * `HarnessProvider`
 * `ServiceResolver`

--- a/src/Execution/Adapter/InProcessExecution.php
+++ b/src/Execution/Adapter/InProcessExecution.php
@@ -71,6 +71,9 @@ final readonly class InProcessExecution implements ExecutionAdapter
             ),
             ...($execution->policy->isNoOp() ? [] : [new ResultPolicyPlugin($execution->policy)]),
         ]);
+        if ($this->detectLeaks) {
+            $plugins = $plugins->withBundledPlugins([new LeakDetector()]);
+        }
         $channelEnvironment = EnvironmentBackup::capture('GREENLIGHT_CHANNEL');
         \putenv('GREENLIGHT_CHANNEL=1');
 
@@ -105,7 +108,6 @@ final readonly class InProcessExecution implements ExecutionAdapter
                         fn() => new Worker(
                             [],
                             $plugins,
-                            $this->detectLeaks ? new LeakDetector() : null,
                             'in-process',
                             $context->artifacts,
                         )->run(

--- a/src/Execution/Plugin/PluginRuntime.php
+++ b/src/Execution/Plugin/PluginRuntime.php
@@ -103,4 +103,10 @@ abstract readonly class PluginRuntime
 
         return \array_column($matching, 'plugin');
     }
+
+    /** @return list<Plugin> */
+    final protected function instances(): array
+    {
+        return \array_column($this->plugins, 'plugin');
+    }
 }

--- a/src/Execution/Plugin/PluginRuntimeError.php
+++ b/src/Execution/Plugin/PluginRuntimeError.php
@@ -66,4 +66,14 @@ final class PluginRuntimeError extends \RuntimeException
             $test,
         ));
     }
+
+    /** @param class-string $plugin */
+    public static function invalidLeakedTest(string $plugin, mixed $value): self
+    {
+        return new self(\sprintf(
+            'Plugin "%s" returned %s from sweep(). It MUST return TestId instances.',
+            $plugin,
+            \get_debug_type($value),
+        ));
+    }
 }

--- a/src/Execution/Plugin/WorkerPluginRuntime.php
+++ b/src/Execution/Plugin/WorkerPluginRuntime.php
@@ -19,6 +19,7 @@ use Greenlight\Plugin\RetryDecider;
 use Greenlight\Plugin\TerminalResultTransformer;
 use Greenlight\Plugin\TestAttemptRunner;
 use Greenlight\Plugin\TestContext;
+use Greenlight\Plugin\TestInstanceLeakDetector;
 use Greenlight\Plugin\WorkerBootstrapContext;
 use Greenlight\Plugin\WorkerBootstrapSubscriber;
 use Greenlight\Plugin\WorkerRuntimeRunner;
@@ -28,6 +29,7 @@ use Greenlight\Result\ThrowableDetail;
 use Greenlight\Test\RetryPolicy;
 use Greenlight\Test\SkipTest;
 use Greenlight\Test\TestDefinition;
+use Greenlight\Test\TestId;
 
 /**
  * Executes the plugin capabilities that one physical worker owns.
@@ -48,6 +50,7 @@ final readonly class WorkerPluginRuntime extends PluginRuntime
         ServiceResolver::class,
         TerminalResultTransformer::class,
         TestAttemptRunner::class,
+        TestInstanceLeakDetector::class,
         WorkerBootstrapSubscriber::class,
         WorkerRuntimeRunner::class,
     ];
@@ -76,6 +79,18 @@ final readonly class WorkerPluginRuntime extends PluginRuntime
     public static function fromPlugins(array $plugins, array $bundledPlugins = []): self
     {
         return new self([new AttributeRetryDecider(), ...$bundledPlugins, ...$plugins]);
+    }
+
+    /**
+     * Adds capabilities that Greenlight enables for one assignment.
+     *
+     * @internal
+     *
+     * @param list<Plugin> $plugins
+     */
+    public function withBundledPlugins(array $plugins): self
+    {
+        return new self([...$this->instances(), ...$plugins]);
     }
 
     /**
@@ -211,6 +226,45 @@ final readonly class WorkerPluginRuntime extends PluginRuntime
         }
 
         return $result;
+    }
+
+    /** @throws PluginRuntimeError */
+    public function watchTestInstance(TestId $id, object $instance): void
+    {
+        foreach ($this->ordered(TestInstanceLeakDetector::class) as $detector) {
+            try {
+                $detector->watch($id, $instance);
+            } catch (\Throwable $failure) {
+                throw PluginRuntimeError::hookFailed($detector::class, 'watch', $failure);
+            }
+        }
+    }
+
+    /**
+     * @return list<TestId>
+     * @throws PluginRuntimeError
+     */
+    public function detectedLeaks(): array
+    {
+        $leaks = [];
+
+        foreach ($this->ordered(TestInstanceLeakDetector::class) as $detector) {
+            try {
+                $detected = $detector->sweep();
+            } catch (\Throwable $failure) {
+                throw PluginRuntimeError::hookFailed($detector::class, 'sweep', $failure);
+            }
+
+            foreach ($detected as $id) {
+                if (!$id instanceof TestId) {
+                    throw PluginRuntimeError::invalidLeakedTest($detector::class, $id);
+                }
+
+                $leaks[(string) $id] = $id;
+            }
+        }
+
+        return \array_values($leaks);
     }
 
     public function shouldRetry(

--- a/src/Execution/ProcessPool/Worker/WorkerProcess.php
+++ b/src/Execution/ProcessPool/Worker/WorkerProcess.php
@@ -257,12 +257,13 @@ final readonly class WorkerProcess
 
             $collector?->start();
 
-            $leakDetector = $message->detectLeaks ? new LeakDetector() : null;
+            $assignmentPlugins = $message->detectLeaks
+                ? $plugins->withBundledPlugins([new LeakDetector()])
+                : $plugins;
 
             $outcome = new Worker(
                 [],
-                $plugins,
-                $leakDetector,
+                $assignmentPlugins,
                 $workerId,
                 $artifactStore,
             )->run(

--- a/src/Execution/Worker/LeakDetector.php
+++ b/src/Execution/Worker/LeakDetector.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Greenlight\Execution\Worker;
 
+use Greenlight\Plugin\Prioritized;
+use Greenlight\Plugin\TestInstanceLeakDetector;
 use Greenlight\Test\TestId;
 
 /**
@@ -22,12 +24,18 @@ use Greenlight\Test\TestId;
  *
  * @internal
  */
-final class LeakDetector
+final class LeakDetector implements Prioritized, TestInstanceLeakDetector
 {
     /**
      * @var list<array{TestId, \WeakReference<object>}>
      */
     private array $watched = [];
+
+    #[\Override]
+    public function priority(): int
+    {
+        return \PHP_INT_MIN;
+    }
 
     /**
      * @param list<string>|null $xdebugModes Explicit mode snapshot. A null value reads the environment.
@@ -47,6 +55,7 @@ final class LeakDetector
         return 'Warning: Xdebug develop mode keeps caught exceptions in memory. Thus, leak detection reports false positives. Rerun with XDEBUG_MODE=off to get correct results.';
     }
 
+    #[\Override]
     public function watch(TestId $id, object $instance): void
     {
         $this->watched[] = [$id, \WeakReference::create($instance)];
@@ -55,6 +64,7 @@ final class LeakDetector
     /**
      * @return list<TestId> tests whose instances are still alive
      */
+    #[\Override]
     public function sweep(): array
     {
         \gc_collect_cycles();

--- a/src/Execution/Worker/TestExecutor.php
+++ b/src/Execution/Worker/TestExecutor.php
@@ -63,7 +63,6 @@ final readonly class TestExecutor
         private HarnessScopes $scopes,
         private ClassContext $context,
         private WorkerPluginRuntime $plugins,
-        private ?LeakDetector $leakDetector = null,
         private ?ArtifactStore $artifactStore = null,
         private ?\Closure $attemptStarted = null,
     ) {}
@@ -353,7 +352,7 @@ final readonly class TestExecutor
 
         if ($context instanceof TestContext) {
             $result = $this->plugins->afterTest($context, $result);
-            $this->leakDetector?->watch($entry->id, $context->instance);
+            $this->plugins->watchTestInstance($entry->id, $context->instance);
         }
 
         return [$result, $cause, $stagedAttachments];

--- a/src/Execution/Worker/Worker.php
+++ b/src/Execution/Worker/Worker.php
@@ -42,7 +42,6 @@ final readonly class Worker
     public function __construct(
         private array $definitions,
         private ?WorkerPluginRuntime $plugins = null,
-        private ?LeakDetector $leakDetector = null,
         private string $workerId = '',
         private ?ArtifactStore $artifactStore = null,
     ) {}
@@ -97,7 +96,6 @@ final readonly class Worker
                         $scopes,
                         $context,
                         $plugins,
-                        $this->leakDetector,
                         $this->artifactStore,
                         $attemptStarted,
                     );
@@ -114,6 +112,12 @@ final readonly class Worker
 
                 $result = $plugins->terminalResult($entry->definition, $result);
 
+                try {
+                    $leaks = [...$leaks, ...$plugins->detectedLeaks()];
+                } catch (\Throwable $threw) {
+                    $result = $result->erroredBy(ThrowableDetail::fromThrowable($threw));
+                }
+
                 $candidateSummary = $summary->add($result->outcome);
                 $failureLimitReached = $stopAfterFailures !== null
                     && $candidateSummary->failed + $candidateSummary->errored >= $stopAfterFailures;
@@ -125,10 +129,6 @@ final readonly class Worker
 
                 $summary = $summary->add($result->outcome);
                 $sink->emit(new TestFinished($result, \microtime(true)));
-
-                if ($this->leakDetector instanceof LeakDetector) {
-                    $leaks = [...$leaks, ...$this->leakDetector->sweep()];
-                }
 
                 $stopReached = match (true) {
                     $stopAfterFailures !== null && $summary->failed + $summary->errored >= $stopAfterFailures => 'bail',

--- a/src/Plugin/Plugin.php
+++ b/src/Plugin/Plugin.php
@@ -11,7 +11,7 @@ namespace Greenlight\Plugin;
  * `WorkerRuntimeRunner`, `TestAttemptRunner`, `BeforeTestSubscriber`,
  * `AfterTestSubscriber`, `RunLifecycleSubscriber`, `RetryDecider`,
  * `CommandProvider`, `CoverageMapTransformer`, `HarnessProvider`, `ReporterProvider`,
- * `TerminalResultTransformer`, `TestPlanTransformer`, or
+ * `TerminalResultTransformer`, `TestInstanceLeakDetector`, `TestPlanTransformer`, or
  * `ExpectationExtension`.
  */
 interface Plugin {}

--- a/src/Plugin/TestInstanceLeakDetector.php
+++ b/src/Plugin/TestInstanceLeakDetector.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Plugin;
+
+use Greenlight\Test\TestId;
+
+/** Detects test instances that remain reachable after their test. */
+interface TestInstanceLeakDetector extends Plugin
+{
+    /** Records one test instance before Greenlight releases its references. */
+    public function watch(TestId $id, object $instance): void;
+
+    /**
+     * Reports leaks after Greenlight releases its references to the test.
+     *
+     * A detector MUST report each leak one time.
+     *
+     * @return list<TestId>
+     */
+    public function sweep(): array;
+}

--- a/tests/Unit/Execution/Worker/WorkerTest.php
+++ b/tests/Unit/Execution/Worker/WorkerTest.php
@@ -7,12 +7,15 @@ namespace Greenlight\Tests\Unit\Execution\Worker;
 use Greenlight\Attribute\Test;
 use Greenlight\Discovery\Plan\ExecutionPlan;
 use Greenlight\Discovery\TestDiscoverer;
+use Greenlight\Doubles\Fake;
 use Greenlight\Event\TestClassStarted;
+use Greenlight\Execution\Plugin\WorkerPluginRuntime;
 use Greenlight\Execution\Worker\LeakDetector;
 use Greenlight\Execution\Worker\Worker;
 use Greenlight\Expect\Expect;
 use Greenlight\Harness\Scope;
 use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Plugin\TestInstanceLeakDetector;
 use Greenlight\Result\Outcome;
 use Greenlight\Result\ResultSummary;
 use Greenlight\Result\TestResult;
@@ -544,13 +547,45 @@ final class WorkerTest
         $plan = new TestDiscoverer()->discover([$directory]);
         $sink = new CollectingEventSink();
 
-        $outcome = new Worker($this->definitions(), leakDetector: new LeakDetector())
+        $outcome = new Worker(
+            $this->definitions(),
+            WorkerPluginRuntime::fromPlugins([], [new LeakDetector()]),
+        )
             ->run($plan, $sink);
 
         $leakedIds = \array_map(static fn($id): string => (string) $id, $outcome->leaks);
 
         Expect::that($outcome->leaks)->because('leak detection names the test that retained its instance')->toHaveCount(1);
         Expect::that($leakedIds[0])->toContain('LeakyTest::passesButLeaksItself');
+
+        LeakyTest::$retained = [];
+    }
+
+    #[Test]
+    public function leakDetectorFailuresErrorTheAffectedTest(): void
+    {
+        LeakyTest::$retained = [];
+        $directory = FixturePath::get('LeakSuite');
+        $plan = new TestDiscoverer()->discover([$directory]);
+        $detector = new class implements Fake, TestInstanceLeakDetector {
+            #[\Override]
+            public function watch(TestId $id, object $instance): void {}
+
+            #[\Override]
+            public function sweep(): array
+            {
+                throw new \RuntimeException('Leak sweep exploded');
+            }
+        };
+
+        $outcome = new Worker(
+            $this->definitions(),
+            WorkerPluginRuntime::fromPlugins([$detector]),
+        )->run($plan, new CollectingEventSink());
+
+        Expect::that($outcome->summary->errored)
+            ->because('a detector failure MUST become an error for each affected test')
+            ->toBe($outcome->summary->total());
 
         LeakyTest::$retained = [];
     }

--- a/tests/Unit/Plugin/WorkerPluginRuntimeTest.php
+++ b/tests/Unit/Plugin/WorkerPluginRuntimeTest.php
@@ -12,9 +12,11 @@ use Greenlight\Execution\Plugin\WorkerPluginRuntime;
 use Greenlight\Expect\Expect;
 use Greenlight\Plugin\PluginDefinition;
 use Greenlight\Plugin\Prioritized;
+use Greenlight\Plugin\TestInstanceLeakDetector;
 use Greenlight\Plugin\WorkerBootstrapContext;
 use Greenlight\Plugin\WorkerBootstrapSubscriber;
 use Greenlight\Plugin\WorkerRuntimeRunner;
+use Greenlight\Test\TestId;
 use Greenlight\Tests\Fixture\Plugins\FakeCapabilityPlugin;
 use Greenlight\Tests\Fixture\Plugins\QuarantinePlugin;
 use Greenlight\Tests\Fixture\Plugins\RecordingRunSubscriber;
@@ -159,6 +161,32 @@ final class WorkerPluginRuntimeTest
     }
 
     #[Test]
+    public function assignmentLeakDetectorsJoinTheStableCapabilityOrder(): void
+    {
+        /** @var \ArrayObject<int, string> $events */
+        $events = new \ArrayObject();
+        $id = new TestId('Example\\LeakyTest', 'retainsItself');
+        $instance = new \stdClass();
+        $configured = new RecordingLeakDetectorProbe($events, 'configured', 0, $id);
+        $bundled = new RecordingLeakDetectorProbe($events, 'bundled', -10, $id);
+        $runtime = WorkerPluginRuntime::fromPlugins([$configured])
+            ->withBundledPlugins([$bundled]);
+
+        $runtime->watchTestInstance($id, $instance);
+        $leaks = $runtime->detectedLeaks();
+
+        Expect::that($events->getArrayCopy())->toBe([
+            'bundled:watch',
+            'configured:watch',
+            'bundled:sweep',
+            'configured:sweep',
+        ]);
+        Expect::that($leaks)
+            ->because('multiple detectors MUST NOT duplicate one leaked test')
+            ->toBe([$id]);
+    }
+
+    #[Test]
     public function bootstrapCapabilityRequiresTheInitialBarrierWithoutConstruction(): void
     {
         $constructions = 0;
@@ -208,5 +236,36 @@ final class MutablePriorityRunnerProbe implements Fake, Prioritized, WorkerRunti
         } finally {
             $this->events->append($this->name . ':exit');
         }
+    }
+}
+
+final readonly class RecordingLeakDetectorProbe implements Fake, Prioritized, TestInstanceLeakDetector
+{
+    /** @param \ArrayObject<int, string> $events */
+    public function __construct(
+        private \ArrayObject $events,
+        private string $name,
+        private int $priority,
+        private TestId $leak,
+    ) {}
+
+    #[\Override]
+    public function priority(): int
+    {
+        return $this->priority;
+    }
+
+    #[\Override]
+    public function watch(TestId $id, object $instance): void
+    {
+        $this->events->append($this->name . ':watch');
+    }
+
+    #[\Override]
+    public function sweep(): array
+    {
+        $this->events->append($this->name . ':sweep');
+
+        return [$this->leak];
     }
 }


### PR DESCRIPTION
Adds a worker-owned TestInstanceLeakDetector capability with stable priority and duplicate suppression. Routes the built-in weak-reference detector used by --detect-leaks through the same runtime, and contains detector failures as errors on affected tests. Documents the lifecycle and publishes the capability in the plugin API.