### PR TITLE
feat(watch): add configurable inputs

### DIFF
--- a/docs/api-configuration.md
+++ b/docs/api-configuration.md
@@ -651,4 +651,64 @@ PHPDoc:
 - `@param positive-int $milliseconds`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/WatchBuilder.php#L22)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/WatchBuilder.php#L36)
+
+### `paths()`
+
+Adds file or directory inputs. Relative paths use the command working
+directory. Multiple calls add paths.
+
+```php
+public function paths(string ...$paths): self
+```
+
+PHPDoc:
+
+- `@throws InvalidConfiguration`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/WatchBuilder.php#L53)
+
+### `include()`
+
+Selects files below additional directory inputs. Multiple calls add
+patterns. Exact file inputs do not require an include pattern.
+
+```php
+public function include(string ...$patterns): self
+```
+
+PHPDoc:
+
+- `@throws InvalidConfiguration`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/WatchBuilder.php#L66)
+
+### `exclude()`
+
+Removes from all watch inputs each file that matches. Exclusion has
+precedence over an explicit path or include pattern. Multiple calls add
+patterns.
+
+```php
+public function exclude(string ...$patterns): self
+```
+
+PHPDoc:
+
+- `@throws InvalidConfiguration`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/WatchBuilder.php#L80)
+
+### `maximumFiles()`
+
+Sets the maximum number of files that one poll can track.
+
+```php
+public function maximumFiles(int $maximumFiles): self
+```
+
+PHPDoc:
+
+- `@throws InvalidConfiguration`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/WatchBuilder.php#L92)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -235,22 +235,66 @@ paths filter coverage from all processes.
 
 ### `watch(callable $configurator): self`
 
-Default: 200 ms debounce.
+Defaults: 200 ms debounce and a 100,000-file poll limit.
 
 The configurator receives a `WatchBuilder`.
 
-`WatchBuilder` has one method:
+`WatchBuilder` has these methods:
 
 * `debounceMilliseconds(int $milliseconds): self` sets the quiet period before a
   rerun starts. The value must be at least 1.
+* `paths(string ...$paths): self` adds file or directory inputs.
+* `include(string ...$patterns): self` selects files below additional directory
+  inputs.
+* `exclude(string ...$patterns): self` removes from all watch inputs each file
+  that matches.
+* `maximumFiles(int $maximumFiles): self` sets the file limit for one poll.
+
+Relative paths use the command working directory. An input that does not exist
+stays in the configuration and can appear later.
+
+An additional file input does not need an include pattern. An additional
+directory includes all its regular files when there are no include patterns.
+When include patterns exist, the directory includes only files that match.
+
+Patterns match the complete path. Paths below the working directory use a
+relative path. Paths outside it use an absolute path.
+
+Pattern syntax is as follows:
+
+* `/` separates path segments.
+* `*` matches zero or more characters except `/`.
+* `?` matches one character except `/`.
+* `**` matches characters across path segments.
+
+Pattern comparison is case-sensitive. Patterns do not use negation. Use
+`exclude()` for an exclusion. An exclusion has precedence over each path and
+include pattern.
+
+The effective test and coverage roots keep their default PHP-only behavior.
+Exclusion patterns also apply to those roots.
 
 A rerun starts after the configured period has no file changes. Thus, a group
 of save operations starts only one run.
 
 <!-- php-example {"example":"configuration-example-06","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
-->watch(fn ($w) => $w->debounceMilliseconds(500))
+->watch(fn ($w) => $w
+    ->debounceMilliseconds(500)
+    ->paths('templates', 'config/app.yaml', 'migrations')
+    ->include('**/*.twig', '**/*.yaml', '**/*.sql')
+    ->exclude(
+        'build/**',
+        'coverage/**',
+        'var/greenlight/**',
+    )
+    ->maximumFiles(25_000))
 ```
+
+Use exclusions for files that the run writes. Examples include build output,
+Greenlight storage, coverage output, and configured report or artifact targets.
+Greenlight does not add broad default exclusions because those exclusions can
+hide source inputs.
 
 ### `failOnDeprecation(bool $enabled = true): self`
 
@@ -1017,6 +1061,9 @@ Greenlight watches the effective test paths and all coverage include paths. An
 explicit suite selection limits the effective test paths to selected suites.
 After a change, classes that failed in the previous watch iteration run first.
 
+The `watch()` builder can add templates, YAML, JSON, SQL migrations, fixtures,
+and other inputs. It can also exclude generated output from every watched root.
+
 Watch mode does not publish coverage totals or coverage exports.
 
 In watch mode:
@@ -1025,6 +1072,29 @@ In watch mode:
 * `q` quits with exit code 0, regardless of the last iteration result.
 
 Signals use the exit codes in the [interruption](#interruption) section.
+
+### Configure watch inputs
+
+Use `WatchBuilder::paths()` to add files or directories. Relative paths use the
+command working directory. Include patterns select files in additional
+directories. Exact file inputs do not require an include pattern. Exclude
+patterns apply to all watch inputs and have precedence over include patterns.
+
+Each poll visits directory entries in a stable lexical order. It does not hash
+an excluded or unmatched file. A poll stops with an error when it exceeds the
+configured file limit.
+
+Greenlight does not follow symlinks in watched trees.
+
+A created file reports an addition. A removed file reports a deletion. A
+rename reports one deletion and one addition.
+
+An unreadable or temporarily absent file is not in that poll. If it was in the
+prior poll, Greenlight reports a deletion. It reports an addition when the file
+becomes readable again.
+
+Large projects increase poll time. Increase the watch debounce when frequent
+save events cause excess scans.
 
 ### `--detect-leaks`
 
@@ -1094,7 +1164,8 @@ Default: `_greenlight_ide_helper.php`.
 ### `--dry-run`
 
 Prints a summary of the resolved run settings without test discovery or
-execution.
+execution. The summary includes additional watch paths, patterns, debounce, and
+the file limit.
 
 ### `--verbose`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -249,6 +249,19 @@ Watch mode combines rapid save events. The default delay is 200 ms.
 
 Use the `watch()` configuration builder to change this delay.
 
+The builder can also watch non-PHP inputs:
+
+<!-- php-example {"example":"getting-started-example-04","file":"snippet.php","mode":"statements","tools":["rector"]} -->
+```php
+->watch(fn ($watch) => $watch
+    ->paths('templates', 'config')
+    ->include('**/*.twig', '**/*.yaml')
+    ->exclude('build/**', 'coverage/**'))
+```
+
+Relative paths and patterns use the command working directory. Exclusions have
+precedence and can prevent runs that generated artifacts would cause.
+
 ## Configure workers
 
 Tests run in parallel worker processes by default.

--- a/src/Cli/Configuration/PlanFormatter.php
+++ b/src/Cli/Configuration/PlanFormatter.php
@@ -86,6 +86,11 @@ final class PlanFormatter
         $lines[] = '  storage cache: ' . $storage->cacheDirectory;
         $lines[] = '  storage generated code: ' . $storage->generatedCodeDirectory;
         $lines[] = '  storage temporary: ' . $storage->temporaryDirectory;
+        $lines[] = '  watch debounce: ' . $configuration->watch->debounceMilliseconds . ' ms';
+        $lines[] = '  additional watch paths: ' . ($configuration->watch->paths === [] ? '(none)' : \implode(', ', $configuration->watch->paths));
+        $lines[] = '  watch include patterns: ' . ($configuration->watch->includePatterns === [] ? '(all additional directory files)' : \implode(', ', $configuration->watch->includePatterns));
+        $lines[] = '  watch exclude patterns: ' . ($configuration->watch->excludePatterns === [] ? '(none)' : \implode(', ', $configuration->watch->excludePatterns));
+        $lines[] = '  watch file limit: ' . $configuration->watch->maximumFiles;
 
         if (!$configuration->coverage instanceof CoverageConfiguration) {
             $lines[] = '  coverage: (off)';

--- a/src/Cli/Run/WatchRuns.php
+++ b/src/Cli/Run/WatchRuns.php
@@ -18,6 +18,7 @@ use Greenlight\Cli\Watch\StatChangeDetector;
 use Greenlight\Cli\Watch\StdinKeyInput;
 use Greenlight\Cli\Watch\SystemWatchClock;
 use Greenlight\Cli\Watch\WatchLoop;
+use Greenlight\Cli\Watch\WatchPathMatcher;
 use Greenlight\Cli\Watch\WatchSourceFailed;
 use Greenlight\Cli\Watch\WatchSourceRuntime;
 use Greenlight\Config\StorageLayout;
@@ -47,6 +48,13 @@ final readonly class WatchRuns
                 $watched[] = $absolute;
             }
         }
+        $additionalPaths = [];
+        foreach ($resolved->watch->paths as $path) {
+            $absolute = ConfigurationLoader::absolutePath($path, $workingDirectory);
+            if ($absolute !== '' && !\in_array($absolute, $additionalPaths, true)) {
+                $additionalPaths[] = $absolute;
+            }
+        }
         $detectLeaks = $arguments->has('detect-leaks');
         $storage = StorageLayout::resolve(
             $resolved->storage,
@@ -70,7 +78,16 @@ final readonly class WatchRuns
         try {
             $sources = WatchSourceRuntime::fromDefinitions(
                 $resolved->execution->plugins,
-                [new StatChangeDetector($watched)],
+                [new StatChangeDetector(
+                    directories: $watched,
+                    additionalPaths: $additionalPaths,
+                    matcher: new WatchPathMatcher(
+                        $workingDirectory,
+                        $resolved->watch->includePatterns,
+                        $resolved->watch->excludePatterns,
+                    ),
+                    maximumFiles: $resolved->watch->maximumFiles,
+                )],
             );
             new WatchLoop($sources, new Debouncer($resolved->watch->debounceMilliseconds / 1000), $keys, new SystemWatchClock(), $this->console->out(...), $shutdown)->run($runOnce);
         } catch (ReporterSetupFailed|RunPolicyError|WatchSourceFailed $error) {

--- a/src/Cli/Watch/StatChangeDetector.php
+++ b/src/Cli/Watch/StatChangeDetector.php
@@ -10,9 +10,8 @@ use Greenlight\Plugin\WatchSource;
 /**
  * A portable file change detector.
  *
- * poll() records the modification time, size, and content hash for each PHP
- * file in the specified directories. It reports a path when its fingerprint
- * changes. It also reports new and removed paths.
+ * poll() records the modification time, size, and content hash for each
+ * selected file. It reports changed, new, and removed paths.
  *
  * The first poll creates the initial record and reports no changes.
  *
@@ -20,15 +19,24 @@ use Greenlight\Plugin\WatchSource;
  */
 final class StatChangeDetector implements WatchSource
 {
-    /**
-     * @var array<string, string>|null path to fingerprint
-     */
+    /** @var array<string, string>|null path to fingerprint */
     private ?array $snapshot = null;
+
+    private readonly WatchPathMatcher $matcher;
 
     /**
      * @param list<non-empty-string> $directories
+     * @param list<non-empty-string> $additionalPaths
+     * @param positive-int $maximumFiles
      */
-    public function __construct(private readonly array $directories) {}
+    public function __construct(
+        private readonly array $directories,
+        private readonly array $additionalPaths = [],
+        ?WatchPathMatcher $matcher = null,
+        private readonly int $maximumFiles = 100_000,
+    ) {
+        $this->matcher = $matcher ?? new WatchPathMatcher('', [], []);
+    }
 
     #[\Override]
     public function poll(): array
@@ -61,46 +69,28 @@ final class StatChangeDetector implements WatchSource
         return $changed;
     }
 
-    /**
-     * @return array<string, string>
-     */
+    /** @return array<string, string> */
     private function scan(): array
     {
-        $snapshot = [];
+        /** @var array<non-empty-string, true> $candidates */
+        $candidates = [];
 
         foreach ($this->directories as $directory) {
-            try {
-                $files = ErrorTrap::run(fn() => $this->scanDirectory($directory));
-            } catch (\UnexpectedValueException) {
-                continue;
+            $this->collectDirectory($directory, false, $candidates);
+        }
+
+        foreach ($this->additionalPaths as $path) {
+            if ($this->isDirectory($path)) {
+                $this->collectDirectory($path, true, $candidates);
+            } else {
+                $this->collectFile($path, true, true, $candidates);
             }
-
-            $snapshot = [...$snapshot, ...$files];
         }
 
-        return $snapshot;
-    }
-
-    /**
-     * @return array<string, string>
-     */
-    private function scanDirectory(string $directory): array
-    {
-        if (!\is_dir($directory)) {
-            return [];
-        }
-
+        \ksort($candidates, \SORT_STRING);
         $snapshot = [];
-        $iterator = new \RecursiveIteratorIterator(
-            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
-        );
 
-        foreach ($iterator as $file) {
-            if (!$file instanceof \SplFileInfo || $file->getExtension() !== 'php') {
-                continue;
-            }
-
-            $path = $file->getPathname();
+        foreach (\array_keys($candidates) as $path) {
             $fingerprint = $this->fingerprint($path);
 
             if ($fingerprint !== null) {
@@ -111,9 +101,88 @@ final class StatChangeDetector implements WatchSource
         return $snapshot;
     }
 
+    /** @param array<non-empty-string, true> $candidates */
+    private function collectDirectory(string $directory, bool $additional, array &$candidates): void
+    {
+        if ($directory === '' || $this->isLink($directory) || !$this->isDirectory($directory)) {
+            return;
+        }
+
+        /** @var list<non-empty-string> $pending */
+        $pending = [$directory];
+
+        while (($current = \array_pop($pending)) !== null) {
+            if ($this->matcher->excludesDirectory($current)) {
+                continue;
+            }
+
+            $entries = ErrorTrap::run(static fn() => \scandir($current));
+
+            if (!\is_array($entries)) {
+                continue;
+            }
+
+            /** @var list<non-empty-string> $childDirectories */
+            $childDirectories = [];
+
+            foreach ($entries as $entry) {
+                if ($entry === '.' || $entry === '..') {
+                    continue;
+                }
+
+                $path = \rtrim($current, '/') . '/' . $entry;
+
+                if ($this->isLink($path)) {
+                    continue;
+                }
+
+                if ($this->isDirectory($path)) {
+                    $childDirectories[] = $path;
+
+                    continue;
+                }
+
+                $this->collectFile($path, $additional, false, $candidates);
+            }
+
+            for ($offset = \count($childDirectories) - 1; $offset >= 0; --$offset) {
+                $pending[] = $childDirectories[$offset];
+            }
+        }
+    }
+
+    /** @param array<non-empty-string, true> $candidates */
+    private function collectFile(string $path, bool $additional, bool $explicit, array &$candidates): void
+    {
+        if ($path === '' || $this->isLink($path) || !$this->isFile($path)) {
+            return;
+        }
+
+        $included = $additional
+            ? $this->matcher->includesAdditionalFile($path, $explicit)
+            : $this->matcher->includesDefaultPhpFile($path);
+
+        if (!$included || isset($candidates[$path])) {
+            return;
+        }
+
+        $candidates[$path] = true;
+
+        if (\count($candidates) > $this->maximumFiles) {
+            throw new WatchScanFailed(\sprintf(
+                'Watch mode matched more files than the limit of %d. Narrow the watch paths or patterns, or increase maximumFiles().',
+                $this->maximumFiles,
+            ));
+        }
+    }
+
     private function fingerprint(string $path): ?string
     {
         \clearstatcache(true, $path);
+
+        if ($this->isLink($path) || !$this->isFile($path)) {
+            return null;
+        }
 
         return ErrorTrap::run(static function () use ($path) {
             $mtime = \filemtime($path);
@@ -126,5 +195,20 @@ final class StatChangeDetector implements WatchSource
 
             return $mtime . ':' . $size . ':' . $contentHash;
         });
+    }
+
+    private function isLink(string $path): bool
+    {
+        return ErrorTrap::run(static fn(): bool => \is_link($path));
+    }
+
+    private function isDirectory(string $path): bool
+    {
+        return ErrorTrap::run(static fn(): bool => \is_dir($path));
+    }
+
+    private function isFile(string $path): bool
+    {
+        return ErrorTrap::run(static fn(): bool => \is_file($path));
     }
 }

--- a/src/Cli/Watch/WatchPathMatcher.php
+++ b/src/Cli/Watch/WatchPathMatcher.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli\Watch;
+
+/**
+ * Matches watch paths with case-sensitive, slash-separated glob patterns.
+ *
+ * @internal
+ */
+final readonly class WatchPathMatcher
+{
+    /** @var list<array{regex: non-empty-string, absolute: bool}> */
+    private array $includes;
+
+    /** @var list<array{regex: non-empty-string, absolute: bool}> */
+    private array $excludes;
+
+    /** @var list<array{regex: non-empty-string, absolute: bool}> */
+    private array $excludedDirectories;
+
+    /**
+     * @param list<non-empty-string> $includePatterns
+     * @param list<non-empty-string> $excludePatterns
+     */
+    public function __construct(
+        private string $workingDirectory,
+        array $includePatterns,
+        array $excludePatterns,
+    ) {
+        $this->includes = $this->compile($includePatterns);
+        $this->excludes = $this->compile($excludePatterns);
+        /** @var list<non-empty-string> $directoryPatterns */
+        $directoryPatterns = [];
+
+        foreach ($excludePatterns as $pattern) {
+            $normalized = $this->normalize($pattern);
+
+            if (\str_ends_with($normalized, '/**')) {
+                $prefix = \substr($normalized, 0, -3);
+                $directoryPatterns[] = $prefix === '' ? '/' : $prefix;
+            }
+        }
+
+        $this->excludedDirectories = $this->compile($directoryPatterns);
+    }
+
+    public function includesAdditionalFile(string $path, bool $explicit): bool
+    {
+        if ($this->isExcluded($path)) {
+            return false;
+        }
+
+        return $explicit || $this->includes === [] || $this->matches($path, $this->includes);
+    }
+
+    public function includesDefaultPhpFile(string $path): bool
+    {
+        return \pathinfo($path, \PATHINFO_EXTENSION) === 'php'
+            && !$this->isExcluded($path);
+    }
+
+    public function isExcluded(string $path): bool
+    {
+        return $this->matches($path, $this->excludes);
+    }
+
+    public function excludesDirectory(string $path): bool
+    {
+        return $this->matches($path, $this->excludedDirectories);
+    }
+
+    /**
+     * @param list<non-empty-string> $patterns
+     * @return list<array{regex: non-empty-string, absolute: bool}>
+     */
+    private function compile(array $patterns): array
+    {
+        $compiled = [];
+
+        foreach ($patterns as $pattern) {
+            $normalized = $this->normalize($pattern);
+            $regex = '';
+            $length = \strlen($normalized);
+
+            for ($offset = 0; $offset < $length; ++$offset) {
+                $character = $normalized[$offset];
+
+                if ($character === '*' && ($normalized[$offset + 1] ?? '') === '*') {
+                    ++$offset;
+
+                    if (($normalized[$offset + 1] ?? '') === '/') {
+                        ++$offset;
+                        $regex .= '(?:.*/)?';
+                    } else {
+                        $regex .= '.*';
+                    }
+
+                    continue;
+                }
+
+                $regex .= match ($character) {
+                    '*' => '[^/]*',
+                    '?' => '[^/]',
+                    default => \preg_quote($character, '~'),
+                };
+            }
+
+            $absolute = $this->isAbsolute($normalized);
+            $compiled[] = [
+                'regex' => '~\\A' . $regex . '\\z~D',
+                'absolute' => $absolute,
+            ];
+        }
+
+        return $compiled;
+    }
+
+    /**
+     * @param list<array{regex: non-empty-string, absolute: bool}> $patterns
+     */
+    private function matches(string $path, array $patterns): bool
+    {
+        $absolute = $this->normalize($path);
+        $relative = $this->relative($absolute);
+
+        return \array_any(
+            $patterns,
+            static fn(array $pattern): bool => \preg_match(
+                $pattern['regex'],
+                $pattern['absolute'] ? $absolute : $relative,
+            ) === 1,
+        );
+    }
+
+    private function relative(string $path): string
+    {
+        $root = \rtrim($this->normalize($this->workingDirectory), '/');
+
+        if ($path === $root) {
+            return '';
+        }
+
+        $prefix = $root . '/';
+
+        return \str_starts_with($path, $prefix) ? \substr($path, \strlen($prefix)) : $path;
+    }
+
+    private function normalize(string $path): string
+    {
+        $normalized = \str_replace('\\', '/', $path);
+
+        while (\str_starts_with($normalized, './')) {
+            $normalized = \substr($normalized, 2);
+        }
+
+        return $normalized;
+    }
+
+    private function isAbsolute(string $path): bool
+    {
+        return \str_starts_with($path, '/')
+            || \preg_match('~\\A[A-Za-z]:/~D', $path) === 1;
+    }
+}

--- a/src/Cli/Watch/WatchScanFailed.php
+++ b/src/Cli/Watch/WatchScanFailed.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli\Watch;
+
+/**
+ * Indicates that a watch poll matched more files than its configured limit.
+ *
+ * @internal
+ */
+final class WatchScanFailed extends \RuntimeException {}

--- a/src/Config/WatchBuilder.php
+++ b/src/Config/WatchBuilder.php
@@ -6,10 +6,24 @@ namespace Greenlight\Config;
 
 final class WatchBuilder
 {
+    private const int DEFAULT_MAXIMUM_FILES = 100_000;
+
     /**
      * @var positive-int
      */
     private int $debounceMilliseconds = 200;
+
+    /** @var list<non-empty-string> */
+    private array $paths = [];
+
+    /** @var list<non-empty-string> */
+    private array $includePatterns = [];
+
+    /** @var list<non-empty-string> */
+    private array $excludePatterns = [];
+
+    /** @var positive-int */
+    private int $maximumFiles = self::DEFAULT_MAXIMUM_FILES;
 
     /**
      * Sets the quiet period before a new run. The period restarts after each
@@ -31,11 +45,93 @@ final class WatchBuilder
     }
 
     /**
+     * Adds file or directory inputs. Relative paths use the command working
+     * directory. Multiple calls add paths.
+     *
+     * @throws InvalidConfiguration
+     */
+    public function paths(string ...$paths): self
+    {
+        $this->paths = [...$this->paths, ...$this->validate(\array_values($paths), 'Watch paths')];
+
+        return $this;
+    }
+
+    /**
+     * Selects files below additional directory inputs. Multiple calls add
+     * patterns. Exact file inputs do not require an include pattern.
+     *
+     * @throws InvalidConfiguration
+     */
+    public function include(string ...$patterns): self
+    {
+        $this->includePatterns = [...$this->includePatterns, ...$this->validate(\array_values($patterns), 'Watch include patterns')];
+
+        return $this;
+    }
+
+    /**
+     * Removes from all watch inputs each file that matches. Exclusion has
+     * precedence over an explicit path or include pattern. Multiple calls add
+     * patterns.
+     *
+     * @throws InvalidConfiguration
+     */
+    public function exclude(string ...$patterns): self
+    {
+        $this->excludePatterns = [...$this->excludePatterns, ...$this->validate(\array_values($patterns), 'Watch exclude patterns')];
+
+        return $this;
+    }
+
+    /**
+     * Sets the maximum number of files that one poll can track.
+     *
+     * @throws InvalidConfiguration
+     */
+    public function maximumFiles(int $maximumFiles): self
+    {
+        if ($maximumFiles < 1) {
+            throw new InvalidConfiguration(\sprintf('The watch file limit must be at least 1, got %d.', $maximumFiles));
+        }
+
+        $this->maximumFiles = $maximumFiles;
+
+        return $this;
+    }
+
+    /**
      * @internal
      * @throws InvalidConfiguration
      */
     public function toConfiguration(): WatchConfiguration
     {
-        return new WatchConfiguration($this->debounceMilliseconds);
+        return new WatchConfiguration(
+            $this->debounceMilliseconds,
+            $this->paths,
+            $this->includePatterns,
+            $this->excludePatterns,
+            $this->maximumFiles,
+        );
+    }
+
+    /**
+     * @param list<string> $values
+     * @return list<non-empty-string>
+     * @throws InvalidConfiguration
+     */
+    private function validate(array $values, string $name): array
+    {
+        foreach ($values as $value) {
+            if ($value === '') {
+                throw new InvalidConfiguration($name . ' cannot contain an empty string.');
+            }
+
+            if (\str_contains($value, "\0")) {
+                throw new InvalidConfiguration($name . ' cannot contain a null byte.');
+            }
+        }
+
+        return $values;
     }
 }

--- a/src/Config/WatchConfiguration.php
+++ b/src/Config/WatchConfiguration.php
@@ -12,11 +12,32 @@ final readonly class WatchConfiguration
      */
     public int $debounceMilliseconds;
 
+    /** @var list<non-empty-string> */
+    public array $paths;
+
+    /** @var list<non-empty-string> */
+    public array $includePatterns;
+
+    /** @var list<non-empty-string> */
+    public array $excludePatterns;
+
+    /** @var positive-int */
+    public int $maximumFiles;
+
     /**
+     * @param array<mixed> $paths
+     * @param array<mixed> $includePatterns
+     * @param array<mixed> $excludePatterns
+     *
      * @throws InvalidConfiguration
      */
-    public function __construct(int $debounceMilliseconds = 200)
-    {
+    public function __construct(
+        int $debounceMilliseconds = 200,
+        array $paths = [],
+        array $includePatterns = [],
+        array $excludePatterns = [],
+        int $maximumFiles = 100_000,
+    ) {
         if ($debounceMilliseconds < 1) {
             throw new InvalidConfiguration(\sprintf(
                 'The watch debounce must be at least 1 millisecond, got %d.',
@@ -24,6 +45,41 @@ final readonly class WatchConfiguration
             ));
         }
 
+        if ($maximumFiles < 1) {
+            throw new InvalidConfiguration(\sprintf('The watch file limit must be at least 1, got %d.', $maximumFiles));
+        }
+
         $this->debounceMilliseconds = $debounceMilliseconds;
+        $this->paths = $this->validate($paths, 'Watch paths');
+        $this->includePatterns = $this->validate($includePatterns, 'Watch include patterns');
+        $this->excludePatterns = $this->validate($excludePatterns, 'Watch exclude patterns');
+        $this->maximumFiles = $maximumFiles;
+    }
+
+    /**
+     * @param array<mixed> $values
+     * @return list<non-empty-string>
+     * @throws InvalidConfiguration
+     */
+    private function validate(array $values, string $name): array
+    {
+        if (!\array_is_list($values)) {
+            throw new InvalidConfiguration($name . ' must be a list.');
+        }
+
+        $validated = [];
+        foreach ($values as $value) {
+            if (!\is_string($value) || $value === '') {
+                throw new InvalidConfiguration($name . ' must contain non-empty strings.');
+            }
+
+            if (\str_contains($value, "\0")) {
+                throw new InvalidConfiguration($name . ' cannot contain a null byte.');
+            }
+
+            $validated[] = $value;
+        }
+
+        return $validated;
     }
 }

--- a/tests/Acceptance/WatchModeTest.php
+++ b/tests/Acceptance/WatchModeTest.php
@@ -142,9 +142,46 @@ final readonly class WatchModeTest
             ->toBe(0);
     }
 
+    #[Test]
+    public function configuredNonPhpInputsTriggerRunsAndExclusionsPreventArtifactLoops(): void
+    {
+        $project = $this->writeProject(additionalWatchInputs: true);
+        $process = GreenlightCli::start(
+            $project->directory,
+            ['run', '--watch', '--reporter=plain', '--no-ansi'],
+        );
+        $this->cleanup->defer($process->terminate(...));
+        $process->readStdoutUntil('Waiting for changes', 20.0);
+
+        $project->writeFile('templates/page.twig', 'changed template');
+        $templateOutput = $process->readStdoutUntil('Waiting for changes', 20.0);
+
+        Expect::that($templateOutput)
+            ->because('a configured template input MUST trigger a watch run')
+            ->toContain('Detected changes in 1 file.')
+            ->toContain('1 test, 1 passed');
+
+        $project->writeFile('build/report.json', '{"changed":true}');
+        \usleep(300_000);
+        $project->writeFile('config/settings.yaml', 'changed: true');
+        $configurationOutput = $process->readStdoutUntil('Waiting for changes', 20.0);
+
+        Expect::that($configurationOutput)
+            ->because('an excluded artifact MUST not enter the next change batch')
+            ->toContain('Detected changes in 1 file.')
+            ->toContain('1 test, 1 passed');
+
+        $process->write('q');
+        Expect::that($process->wait(10.0)->exitCode)->toBe(0);
+        $provisioned = \file($project->path('markers/provisioned.log'), \FILE_IGNORE_NEW_LINES);
+        Expect::that(\is_array($provisioned) ? $provisioned : [])
+            ->because('the excluded artifact MUST not start a watch run')
+            ->toHaveCount(3);
+    }
     private function writeProject(
         bool $watchCoverageSource = false,
         bool $failCleanup = false,
+        bool $additionalWatchInputs = false,
     ): AcceptanceProject {
         $project = AcceptanceProject::create($this->tempDirectory, 'watch');
         $project->writeFile('markers/.gitkeep', '');
@@ -170,6 +207,11 @@ final readonly class WatchModeTest
             : '';
         $markerDirectory = \var_export($project->path('markers'), true);
         $failCleanupValue = $failCleanup ? 'true' : 'false';
+        $watchInputs = $additionalWatchInputs
+            ? "\n        ->paths('templates', 'config/settings.yaml', 'build')"
+                . "\n        ->include('**/*.twig', '**/*.yaml', '**/*.json')"
+                . "\n        ->exclude('build/**')"
+            : '';
         $project->writeFile('greenlight.php', \sprintf(
             <<<'PHP'
             <?php
@@ -184,15 +226,22 @@ final readonly class WatchModeTest
             return GreenlightConfig::create()
                 ->paths([__DIR__ . '/tests'])
                 ->workers(1)%s
-                ->watch(fn($watch) => $watch->debounceMilliseconds(50))
+                ->watch(fn($watch) => $watch->debounceMilliseconds(50)%s)
                 ->plugins(
                     static fn(): IntegrationProbePlugin => new IntegrationProbePlugin(%s, failCleanup: %s),
                 );
             PHP,
             $coverage,
+            $watchInputs,
             $markerDirectory,
             $failCleanupValue,
         ));
+
+        if ($additionalWatchInputs) {
+            $project->writeFile('templates/page.twig', 'initial template');
+            $project->writeFile('config/settings.yaml', 'initial: true');
+            $project->writeFile('build/report.json', '{"initial":true}');
+        }
 
         return $project;
     }

--- a/tests/Unit/Cli/Configuration/PlanFormatterTest.php
+++ b/tests/Unit/Cli/Configuration/PlanFormatterTest.php
@@ -13,6 +13,7 @@ use Greenlight\Cli\Configuration\PlanFormatter;
 use Greenlight\Config\CoverageBuilder;
 use Greenlight\Config\GreenlightConfig;
 use Greenlight\Config\SuiteBuilder;
+use Greenlight\Config\WatchBuilder;
 use Greenlight\Expect\Expect;
 use Greenlight\Test\TestInclusions;
 use Greenlight\Test\TestSelection;
@@ -56,6 +57,11 @@ final class PlanFormatterTest
                   storage cache: {$temporary}
                   storage generated code: {$temporary}/greenlight-proxies-{$projectKey}
                   storage temporary: {$temporary}
+                  watch debounce: 200 ms
+                  additional watch paths: (none)
+                  watch include patterns: (all additional directory files)
+                  watch exclude patterns: (none)
+                  watch file limit: 100000
                   coverage include paths: src
                   coverage driver: xdebug
                   coverage driver required: yes
@@ -133,10 +139,38 @@ final class PlanFormatterTest
                       storage cache: {$temporary}
                       storage generated code: {$temporary}/greenlight-proxies-{$projectKey}
                       storage temporary: {$temporary}
+                      watch debounce: 200 ms
+                      additional watch paths: (none)
+                      watch include patterns: (all additional directory files)
+                      watch exclude patterns: (none)
+                      watch file limit: 100000
                       coverage: (off)
 
                     PLAN,
             );
+    }
+
+    #[Test]
+    public function formatsConfiguredWatchInputs(): void
+    {
+        $configuration = ConfigurationResolver::resolve(
+            GreenlightConfig::create()
+                ->watch(static fn(WatchBuilder $watch) => $watch
+                    ->debounceMilliseconds(350)
+                    ->paths('templates', 'config/app.yaml')
+                    ->include('**/*.twig', '**/*.yaml')
+                    ->exclude('build/**')
+                    ->maximumFiles(2_000))
+                ->build(),
+            new CliOverrides(),
+        );
+
+        Expect::that(PlanFormatter::format($configuration, '/project/greenlight.php', '/project'))
+            ->toContain('  watch debounce: 350 ms')
+            ->toContain('  additional watch paths: templates, config/app.yaml')
+            ->toContain('  watch include patterns: **/*.twig, **/*.yaml')
+            ->toContain('  watch exclude patterns: build/**')
+            ->toContain('  watch file limit: 2000');
     }
 
     /**

--- a/tests/Unit/Cli/Watch/StatChangeDetectorTest.php
+++ b/tests/Unit/Cli/Watch/StatChangeDetectorTest.php
@@ -7,6 +7,8 @@ namespace Greenlight\Tests\Unit\Cli\Watch;
 use Greenlight\Attribute\Isolated;
 use Greenlight\Attribute\Test;
 use Greenlight\Cli\Watch\StatChangeDetector;
+use Greenlight\Cli\Watch\WatchPathMatcher;
+use Greenlight\Cli\Watch\WatchScanFailed;
 use Greenlight\Expect\Expect;
 use Greenlight\Internal\Php\ErrorTrap;
 use Greenlight\Sandbox\TemporaryDirectory;
@@ -38,6 +40,125 @@ final readonly class StatChangeDetectorTest
         Expect::that($detector->poll())
             ->because('missing directories and non-PHP changes MUST be ignored')
             ->toBe([]);
+    }
+
+    #[Test]
+    public function additionalDirectoriesUseIncludesAndExcludePrecedence(): void
+    {
+        $root = $this->tempDirectory->subdirectory('watch-additional');
+        $templates = $this->tempDirectory->subdirectory('watch-additional/templates');
+        $cache = $this->tempDirectory->subdirectory('watch-additional/templates/cache');
+        $included = $templates . '/page.twig';
+        $excluded = $cache . '/page.twig';
+        $unmatched = $templates . '/notes.txt';
+        \file_put_contents($included, 'first');
+        \file_put_contents($excluded, 'first');
+        \file_put_contents($unmatched, 'first');
+        $detector = new StatChangeDetector(
+            [],
+            additionalPaths: [$templates],
+            matcher: new WatchPathMatcher($root, ['**/*.twig'], ['templates/cache/**']),
+        );
+        $detector->poll();
+
+        \file_put_contents($included, 'second');
+        \file_put_contents($excluded, 'second');
+        \file_put_contents($unmatched, 'second');
+
+        Expect::that($detector->poll())
+            ->because('exclusions MUST have precedence and unmatched files MUST not be hashed')
+            ->toHaveCount(1);
+        Expect::that($detector->poll())->toBe([]);
+    }
+
+    #[Test]
+    public function exactAdditionalFilesNeedNoIncludePattern(): void
+    {
+        $root = $this->tempDirectory->subdirectory('watch-exact-input');
+        $file = $root . '/settings.json';
+        \file_put_contents($file, 'first');
+        $detector = new StatChangeDetector(
+            [],
+            additionalPaths: [$file],
+            matcher: new WatchPathMatcher($root, ['**/*.yaml'], []),
+        );
+        $detector->poll();
+        \file_put_contents($file, 'second');
+
+        Expect::that($detector->poll())->toBe([$file]);
+    }
+
+    #[Test]
+    public function missingAdditionalInputsCanAppearDisappearAndReappear(): void
+    {
+        $root = $this->tempDirectory->subdirectory('watch-missing-input');
+        $file = $root . '/settings.yaml';
+        $detector = new StatChangeDetector([], additionalPaths: [$file]);
+        $detector->poll();
+
+        \file_put_contents($file, 'first');
+        $created = $detector->poll();
+        \unlink($file);
+        $removed = $detector->poll();
+        \file_put_contents($file, 'second');
+        $recreated = $detector->poll();
+
+        Expect::that($created)->toBe([$file]);
+        Expect::that($removed)->toBe([$file]);
+        Expect::that($recreated)->toBe([$file]);
+    }
+
+    #[Test]
+    public function aRenameReportsOneCreatedPathAndOneRemovedPath(): void
+    {
+        $root = $this->tempDirectory->subdirectory('watch-rename');
+        $old = $root . '/old.yaml';
+        $new = $root . '/new.yaml';
+        \file_put_contents($old, 'contents');
+        $detector = new StatChangeDetector([], additionalPaths: [$root]);
+        $detector->poll();
+        \rename($old, $new);
+
+        $changes = $detector->poll();
+
+        Expect::that($changes)->toBe([$new, $old]);
+    }
+
+    #[Test]
+    public function directorySymlinksAreNotFollowed(): void
+    {
+        $root = $this->tempDirectory->subdirectory('watch-symlink');
+        $target = $this->tempDirectory->subdirectory('watch-symlink-target');
+        $link = $root . '/linked';
+        $file = $target . '/settings.yaml';
+        \file_put_contents($file, 'first');
+
+        if (!\symlink($target, $link)) {
+            throw new \RuntimeException('Could not create the watch symlink fixture.');
+        }
+
+        $detector = new StatChangeDetector([], additionalPaths: [$root]);
+        $detector->poll();
+        \file_put_contents($file, 'second');
+
+        Expect::that($detector->poll())
+            ->because('watch polling MUST not follow directory symlinks')
+            ->toBe([]);
+    }
+
+    #[Test]
+    public function stopsDeterministicallyAtTheConfiguredFileLimit(): void
+    {
+        $root = $this->tempDirectory->subdirectory('watch-limit');
+        \file_put_contents($root . '/a.yaml', 'a');
+        \file_put_contents($root . '/b.yaml', 'b');
+        $detector = new StatChangeDetector([], additionalPaths: [$root], maximumFiles: 1);
+
+        Expect::that($detector->poll(...))
+            ->toThrow(
+                WatchScanFailed::class,
+                message: 'Watch mode matched more files than the limit of 1. Narrow the watch paths or patterns, or increase maximumFiles().',
+            );
     }
 
     #[Test]

--- a/tests/Unit/Cli/Watch/WatchPathMatcherTest.php
+++ b/tests/Unit/Cli/Watch/WatchPathMatcherTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli\Watch;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\Watch\WatchPathMatcher;
+use Greenlight\Expect\Expect;
+
+final class WatchPathMatcherTest
+{
+    #[Test]
+    public function matchesSlashSeparatedPatternsRelativeToTheWorkingDirectory(): void
+    {
+        $matcher = new WatchPathMatcher(
+            '/project',
+            ['**/*.twig', 'config/?.yaml'],
+            ['templates/cache/**'],
+        );
+
+        Expect::that($matcher->includesAdditionalFile('/project/templates/page.twig', false))->toBeTrue();
+        Expect::that($matcher->includesAdditionalFile('/project/config/a.yaml', false))->toBeTrue();
+        Expect::that($matcher->includesAdditionalFile('/project/config/app.yaml', false))->toBeFalse();
+        Expect::that($matcher->includesAdditionalFile('/project/templates/cache/page.twig', false))
+            ->because('an exclude pattern MUST have precedence over an include pattern')
+            ->toBeFalse();
+    }
+
+    #[Test]
+    public function exactInputsNeedNoIncludePatternButStillUseExclusions(): void
+    {
+        $matcher = new WatchPathMatcher('/project', ['**/*.yaml'], ['secrets/**']);
+
+        Expect::that($matcher->includesAdditionalFile('/project/config/settings.json', true))->toBeTrue();
+        Expect::that($matcher->includesAdditionalFile('/project/secrets/settings.json', true))->toBeFalse();
+    }
+
+    #[Test]
+    public function absolutePatternsMatchInputsOutsideTheWorkingDirectory(): void
+    {
+        $matcher = new WatchPathMatcher('/project', ['/shared/**/*.sql'], []);
+
+        Expect::that($matcher->includesAdditionalFile('/shared/migrations/one.sql', false))->toBeTrue();
+        Expect::that($matcher->includesAdditionalFile('/other/migrations/one.sql', false))->toBeFalse();
+    }
+
+    #[Test]
+    public function defaultInputsRemainPhpOnlyAndUseConfiguredExclusions(): void
+    {
+        $matcher = new WatchPathMatcher('/project', [], ['build/**']);
+
+        Expect::that($matcher->includesDefaultPhpFile('/project/src/Example.php'))->toBeTrue();
+        Expect::that($matcher->includesDefaultPhpFile('/project/src/template.twig'))->toBeFalse();
+        Expect::that($matcher->includesDefaultPhpFile('/project/build/Example.php'))->toBeFalse();
+    }
+
+    #[Test]
+    public function prunesOnlyPatternsThatExcludeACompleteDirectoryTree(): void
+    {
+        $matcher = new WatchPathMatcher('/project', [], ['templates/*', '**/cache/**']);
+
+        Expect::that($matcher->excludesDirectory('/project/templates'))
+            ->because('a single-star file pattern MUST not prune nested files')
+            ->toBeFalse();
+        Expect::that($matcher->excludesDirectory('/project/templates/cache'))
+            ->because('a double-star directory suffix excludes the complete tree')
+            ->toBeTrue();
+    }
+}

--- a/tests/Unit/Config/WatchBuilderTest.php
+++ b/tests/Unit/Config/WatchBuilderTest.php
@@ -28,6 +28,59 @@ final class WatchBuilderTest
     }
 
     #[Test]
+    public function accumulatesWatchInputsPatternsAndAFileLimit(): void
+    {
+        $configuration = new WatchBuilder()
+            ->paths('templates', 'config/app.yaml')
+            ->paths('migrations')
+            ->include('**/*.twig', '**/*.yaml')
+            ->include('**/*.sql')
+            ->exclude('build/**', 'var/greenlight/**')
+            ->maximumFiles(500)
+            ->toConfiguration();
+
+        Expect::that($configuration->paths)->toBe(['templates', 'config/app.yaml', 'migrations']);
+        Expect::that($configuration->includePatterns)->toBe(['**/*.twig', '**/*.yaml', '**/*.sql']);
+        Expect::that($configuration->excludePatterns)->toBe(['build/**', 'var/greenlight/**']);
+        Expect::that($configuration->maximumFiles)->toBe(500);
+    }
+
+    #[Test]
+    public function rejectsAnEmptyWatchPath(): void
+    {
+        Expect::that(static fn(): WatchBuilder => new WatchBuilder()->paths(''))
+            ->toThrow(InvalidConfiguration::class, message: 'Watch paths cannot contain an empty string.');
+    }
+
+    #[Test]
+    public function rejectsAnEmptyIncludePattern(): void
+    {
+        Expect::that(static fn(): WatchBuilder => new WatchBuilder()->include(''))
+            ->toThrow(InvalidConfiguration::class, message: 'Watch include patterns cannot contain an empty string.');
+    }
+
+    #[Test]
+    public function rejectsAnEmptyExcludePattern(): void
+    {
+        Expect::that(static fn(): WatchBuilder => new WatchBuilder()->exclude(''))
+            ->toThrow(InvalidConfiguration::class, message: 'Watch exclude patterns cannot contain an empty string.');
+    }
+
+    #[Test]
+    public function rejectsANullByteInAWatchPath(): void
+    {
+        Expect::that(static fn(): WatchBuilder => new WatchBuilder()->paths("templates\0private"))
+            ->toThrow(InvalidConfiguration::class, message: 'Watch paths cannot contain a null byte.');
+    }
+
+    #[Test]
+    public function rejectsANonPositiveFileLimit(): void
+    {
+        Expect::that(static fn(): WatchBuilder => new WatchBuilder()->maximumFiles(0))
+            ->toThrow(InvalidConfiguration::class, message: 'The watch file limit must be at least 1, got 0.');
+    }
+
+    #[Test]
     #[DataSet('nonPositiveDebounces')]
     public function theDebounceMustBePositive(int $milliseconds): void
     {

--- a/tests/Unit/Config/WatchConfigurationTest.php
+++ b/tests/Unit/Config/WatchConfigurationTest.php
@@ -13,6 +13,18 @@ use Greenlight\Expect\Expect;
 final readonly class WatchConfigurationTest
 {
     #[Test]
+    public function keepsStableDefaults(): void
+    {
+        $configuration = new WatchConfiguration();
+
+        Expect::that($configuration->debounceMilliseconds)->toBe(200);
+        Expect::that($configuration->paths)->toBe([]);
+        Expect::that($configuration->includePatterns)->toBe([]);
+        Expect::that($configuration->excludePatterns)->toBe([]);
+        Expect::that($configuration->maximumFiles)->toBe(100_000);
+    }
+
+    #[Test]
     #[DataSet('nonPositiveDebounces')]
     public function rejectsANonPositiveDebounce(int $milliseconds): void
     {
@@ -35,5 +47,22 @@ final readonly class WatchConfigurationTest
         yield 'zero' => [0];
 
         yield 'negative' => [-1];
+    }
+
+    #[Test]
+    public function rejectsMalformedInternalLists(): void
+    {
+        Expect::that(static fn(): WatchConfiguration => new WatchConfiguration(paths: ['valid', 7]))
+            ->toThrow(InvalidConfiguration::class, message: 'Watch paths must contain non-empty strings.');
+
+        Expect::that(static fn(): WatchConfiguration => new WatchConfiguration(includePatterns: ['key' => '*.yaml']))
+            ->toThrow(InvalidConfiguration::class, message: 'Watch include patterns must be a list.');
+    }
+
+    #[Test]
+    public function rejectsANonPositiveFileLimit(): void
+    {
+        Expect::that(static fn(): WatchConfiguration => new WatchConfiguration(maximumFiles: 0))
+            ->toThrow(InvalidConfiguration::class, message: 'The watch file limit must be at least 1, got 0.');
     }
 }


### PR DESCRIPTION
## Summary

- add explicit watch paths, include and exclude globs, and a deterministic file limit
- keep default PHP watch inputs unchanged and filter candidates before hashing
- send non-PHP changes through impacted watch complete-plan fallback
- document path resolution, matching, lifecycle, symlink, and feedback-loop behavior