### PR TITLE
feat(watch): add plugin change sources

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -357,7 +357,7 @@ deptrac:
     CliCoverage: [CliConfiguration, CliOutput, Config, Coverage, CoverageCollection, CoverageExport, CoverageIgnore, CoverageRelay, InternalFilesystem, InternalPhp, Plugin, Reporting]
     CliSignal: [InternalProcess]
     CliState: [InternalFilesystem, InternalPhp]
-    CliWatch: [CliOutput, Event, InternalPhp, InternalProcess]
+    CliWatch: [CliOutput, Event, InternalPhp, InternalProcess, Plugin]
     CliWorkerCapacity: [Attribute, CpuCoreCounter, InternalPhp, InternalText]
     CliCommand: [CliConfiguration, CliDiscovery, CliInput, CliOutput, CliRun, Config, Coverage, CoverageDiff, CoverageExport, Discovery, DiscoveryPlan, Event, InternalEvent, InternalFilesystem, InternalPhp, InternalWire, PhpStan, Reporting, ReportingProfile]
     CliRun: [Artifact, CliConfiguration, CliCoverage, CliDiscovery, CliInput, CliOutput, CliReporting, CliSignal, CliState, CliWatch, CliWorkerCapacity, Config, Coverage, CoverageCollection, CoverageIgnore, CoverageRelay, Discovery, Event, Execution, ExecutionAdapter, ExecutionWorker, IntegrationFixture, InternalPhp, InternalProcess, Reporting, Test]

--- a/docs/api-plugins.md
+++ b/docs/api-plugins.md
@@ -288,7 +288,7 @@ Plugins implement one or more capability interfaces such as
 `WorkerRuntimeRunner`, `TestAttemptRunner`, `BeforeTestSubscriber`,
 `AfterTestSubscriber`, `RunLifecycleSubscriber`, `RetryDecider`,
 `CommandProvider`, `CoverageMapTransformer`, `HarnessProvider`, `ReporterProvider`,
-`TerminalResultTransformer`, `TestPlanTransformer`, or
+`TerminalResultTransformer`, `TestPlanTransformer`, `WatchSource`, or
 `ExpectationExtension`.
 
 ```php
@@ -591,6 +591,30 @@ public function transformTestPlan(TestPlan $plan): TestPlan;
 ```
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestPlanTransformer.php#L10)
+
+## `WatchSource`
+
+Namespace: `Greenlight\Plugin`
+
+Reports changes that cause a watch-mode rerun.
+
+```php
+interface WatchSource extends Plugin
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/WatchSource.php#L8)
+
+### `poll()`
+
+```php
+public function poll(): array;
+```
+
+PHPDoc:
+
+- `@return list<non-empty-string> changed paths or trigger labels since the previous poll`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/WatchSource.php#L13)
 
 ## `WorkerBootstrapContext`
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -22,10 +22,11 @@ return GreenlightConfig::create()
 
 Greenlight creates plugin instances only for an owner that uses one of their
 capabilities. It creates one command-owned instance for each factory that
-has `CommandProvider` or `ReporterProvider`. Command dispatch and reporter
-setup own separate instances. It creates one run-owned orchestrator instance
-for each factory that has a run capability. It creates one worker instance for
-each factory that has a worker capability and for each physical worker.
+has `CommandProvider`, `ReporterProvider`, or `WatchSource`. Command dispatch,
+reporter setup, and watch polling own separate instances. It creates one
+run-owned orchestrator instance for each factory that has a run capability. It
+creates one worker instance for each factory that has a worker capability and
+for each physical worker.
 
 A plugin that has capabilities on both sides gets one instance on each side.
 The instances are separate with one in-process worker and with parallel
@@ -100,6 +101,28 @@ Built-in and configured names share one registry. A duplicate name stops
 command dispatch. Greenlight creates the provider only when it resolves a
 configured command. Configured commands do not change the bundled help text or
 completion scripts.
+
+### WatchSource
+
+Command-side.
+
+<!-- php-example {"mode":"display","reason":"Shows one method signature without its interface declaration."} -->
+```php
+public function poll(): array;
+```
+
+A `WatchSource` reports changed paths or trigger labels that cause a watch-mode
+rerun. Greenlight polls configured sources with its built-in PHP file source.
+Return an empty list when no change occurred. Greenlight removes duplicate
+strings before it notifies the watch loop.
+
+The source instance belongs to one `--watch` command. It can keep a snapshot or
+cursor between polls. Its first poll SHOULD establish the initial state and
+return an empty list. A source can poll an external change feed, a generated
+file index, or another application-specific signal.
+
+If source creation or polling fails, Greenlight names the plugin, stops watch
+mode, restores terminal input, and returns exit code 1.
 
 ### ReporterProvider
 
@@ -787,6 +810,7 @@ Priority applies to these capabilities:
 * `AfterTestSubscriber`
 * `RetryDecider`
 * `TerminalResultTransformer`
+* `WatchSource`
 * `RunLifecycleSubscriber`
 * `HarnessProvider`
 * `ServiceResolver`
@@ -807,6 +831,6 @@ implement both capabilities run their callbacks in the exact reverse order.
 Greenlight runs all after-test subscribers. It also runs them when a
 before-test subscriber stops the attempt.
 
-Greenlight reports all plugin failures. A worker-side failure causes an error
-for the affected test and names the plugin. An orchestrator-side failure causes
-the run to fail.
+Greenlight reports all plugin failures. A command-side failure stops the
+command. A worker-side failure causes an error for the affected test and names
+the plugin. An orchestrator-side failure causes the run to fail.

--- a/src/Cli/Run/WatchRuns.php
+++ b/src/Cli/Run/WatchRuns.php
@@ -18,6 +18,8 @@ use Greenlight\Cli\Watch\StatChangeDetector;
 use Greenlight\Cli\Watch\StdinKeyInput;
 use Greenlight\Cli\Watch\SystemWatchClock;
 use Greenlight\Cli\Watch\WatchLoop;
+use Greenlight\Cli\Watch\WatchSourceFailed;
+use Greenlight\Cli\Watch\WatchSourceRuntime;
 use Greenlight\Config\StorageLayout;
 use Greenlight\Execution\Worker\LeakDetector;
 use Greenlight\Internal\Process\GracefulShutdown;
@@ -65,8 +67,12 @@ final readonly class WatchRuns
         };
         $keys = new StdinKeyInput();
         try {
-            new WatchLoop(new StatChangeDetector($watched), new Debouncer($resolved->watch->debounceMilliseconds / 1000), $keys, new SystemWatchClock(), $this->console->out(...), $shutdown)->run($runOnce);
-        } catch (ReporterSetupFailed $error) {
+            $sources = WatchSourceRuntime::fromDefinitions(
+                $resolved->execution->plugins,
+                [new StatChangeDetector($watched)],
+            );
+            new WatchLoop($sources, new Debouncer($resolved->watch->debounceMilliseconds / 1000), $keys, new SystemWatchClock(), $this->console->out(...), $shutdown)->run($runOnce);
+        } catch (ReporterSetupFailed|WatchSourceFailed $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
             return 1;
         } finally {

--- a/src/Cli/Watch/StatChangeDetector.php
+++ b/src/Cli/Watch/StatChangeDetector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Cli\Watch;
 
 use Greenlight\Internal\Php\ErrorTrap;
+use Greenlight\Plugin\WatchSource;
 
 /**
  * A portable file change detector.
@@ -17,7 +18,7 @@ use Greenlight\Internal\Php\ErrorTrap;
  *
  * @internal
  */
-final class StatChangeDetector implements ChangeDetector
+final class StatChangeDetector implements WatchSource
 {
     /**
      * @var array<string, string>|null path to fingerprint

--- a/src/Cli/Watch/WatchSourceFailed.php
+++ b/src/Cli/Watch/WatchSourceFailed.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli\Watch;
+
+/**
+ * A configured watch source cannot complete an operation.
+ *
+ * @internal
+ */
+final class WatchSourceFailed extends \RuntimeException
+{
+    private function __construct(string $message, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, previous: $previous);
+    }
+
+    /** @param class-string $plugin */
+    public static function operation(string $plugin, string $operation, \Throwable $cause): self
+    {
+        return new self(\sprintf(
+            'Watch source plugin "%s" caused an error during %s: %s',
+            $plugin,
+            $operation,
+            $cause->getMessage(),
+        ), $cause);
+    }
+
+    /** @param class-string $plugin */
+    public static function invalidChange(string $plugin, mixed $change): self
+    {
+        return new self(\sprintf(
+            'Watch source plugin "%s" returned %s. It MUST return non-empty string paths or labels.',
+            $plugin,
+            \get_debug_type($change),
+        ));
+    }
+}

--- a/src/Cli/Watch/WatchSourceRuntime.php
+++ b/src/Cli/Watch/WatchSourceRuntime.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli\Watch;
+
+use Greenlight\Plugin\PluginDefinition;
+use Greenlight\Plugin\Prioritized;
+use Greenlight\Plugin\WatchSource;
+
+/**
+ * Polls the watch sources for one watch command.
+ *
+ * @internal
+ */
+final readonly class WatchSourceRuntime implements ChangeDetector
+{
+    /** @var list<WatchSource> */
+    private array $sources;
+
+    /**
+     * @param list<PluginDefinition> $definitions
+     * @param list<WatchSource> $bundledSources
+     * @throws WatchSourceFailed
+     */
+    public static function fromDefinitions(array $definitions, array $bundledSources = []): self
+    {
+        $sources = $bundledSources;
+
+        foreach ($definitions as $definition) {
+            if (!$definition->supports(WatchSource::class)) {
+                continue;
+            }
+
+            try {
+                $source = $definition->create();
+            } catch (\Throwable $failure) {
+                throw WatchSourceFailed::operation($definition->pluginClass, 'creation', $failure);
+            }
+
+            if ($source instanceof WatchSource) {
+                $sources[] = $source;
+            }
+        }
+
+        return new self($sources);
+    }
+
+    /** @param list<WatchSource> $sources */
+    public static function fromSources(array $sources): self
+    {
+        return new self($sources);
+    }
+
+    /** @param list<WatchSource> $sources */
+    private function __construct(array $sources)
+    {
+        $indexed = [];
+
+        foreach ($sources as $registration => $source) {
+            $indexed[] = [
+                'source' => $source,
+                'priority' => $source instanceof Prioritized ? $source->priority() : 0,
+                'registration' => $registration,
+            ];
+        }
+
+        \usort(
+            $indexed,
+            static fn(array $a, array $b): int => [$a['priority'], $a['registration']]
+                <=> [$b['priority'], $b['registration']],
+        );
+
+        $this->sources = \array_column($indexed, 'source');
+    }
+
+    /**
+     * @return list<non-empty-string>
+     * @throws WatchSourceFailed
+     */
+    #[\Override]
+    public function poll(): array
+    {
+        $changes = [];
+
+        foreach ($this->sources as $source) {
+            try {
+                $polled = $source->poll();
+            } catch (\Throwable $failure) {
+                throw WatchSourceFailed::operation($source::class, 'poll()', $failure);
+            }
+
+            foreach ($polled as $change) {
+                if (!\is_string($change) || $change === '') {
+                    throw WatchSourceFailed::invalidChange($source::class, $change);
+                }
+
+                $changes[$change] = true;
+            }
+        }
+
+        return \array_keys($changes);
+    }
+}

--- a/src/Plugin/Plugin.php
+++ b/src/Plugin/Plugin.php
@@ -11,7 +11,7 @@ namespace Greenlight\Plugin;
  * `WorkerRuntimeRunner`, `TestAttemptRunner`, `BeforeTestSubscriber`,
  * `AfterTestSubscriber`, `RunLifecycleSubscriber`, `RetryDecider`,
  * `CommandProvider`, `CoverageMapTransformer`, `HarnessProvider`, `ReporterProvider`,
- * `TerminalResultTransformer`, `TestPlanTransformer`, or
+ * `TerminalResultTransformer`, `TestPlanTransformer`, `WatchSource`, or
  * `ExpectationExtension`.
  */
 interface Plugin {}

--- a/src/Plugin/WatchSource.php
+++ b/src/Plugin/WatchSource.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Plugin;
+
+/** Reports changes that cause a watch-mode rerun. */
+interface WatchSource extends Plugin
+{
+    /**
+     * @return list<non-empty-string> changed paths or trigger labels since the previous poll
+     */
+    public function poll(): array;
+}

--- a/tests/Unit/Cli/Watch/WatchSourceRuntimeTest.php
+++ b/tests/Unit/Cli/Watch/WatchSourceRuntimeTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli\Watch;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\Watch\WatchSourceFailed;
+use Greenlight\Cli\Watch\WatchSourceRuntime;
+use Greenlight\Doubles\Fake;
+use Greenlight\Expect\Expect;
+use Greenlight\Plugin\Prioritized;
+use Greenlight\Plugin\WatchSource;
+
+final readonly class WatchSourceRuntimeTest
+{
+    #[Test]
+    public function sourcesUseStablePriorityOrderAndDeduplicateChanges(): void
+    {
+        /** @var \ArrayObject<int, string> $events */
+        $events = new \ArrayObject();
+        $runtime = WatchSourceRuntime::fromSources([
+            new RecordingWatchSource($events, 'late', 10, ['shared', 'late']),
+            new RecordingWatchSource($events, 'default', 0, ['default', 'shared']),
+            new RecordingWatchSource($events, 'same-priority', 0, []),
+            new RecordingWatchSource($events, 'early', -10, ['early']),
+        ]);
+
+        $changes = $runtime->poll();
+
+        Expect::that($events->getArrayCopy())->toBe([
+            'early',
+            'default',
+            'same-priority',
+            'late',
+        ]);
+        Expect::that($changes)->toBe(['early', 'default', 'shared', 'late']);
+    }
+
+    #[Test]
+    public function sourceFailuresKeepThePluginAndCause(): void
+    {
+        $failure = new \RuntimeException('Watch poll exploded');
+        $runtime = WatchSourceRuntime::fromSources([
+            new FailingWatchSource($failure),
+        ]);
+
+        Expect::that($runtime->poll(...))
+            ->toThrow(static function (WatchSourceFailed $error) use ($failure): void {
+                Expect::that($error->getMessage())->toBe(
+                    'Watch source plugin "Greenlight\\Tests\\Unit\\Cli\\Watch\\FailingWatchSource" caused an error during poll(): Watch poll exploded',
+                );
+                Expect::that($error->getPrevious())->toBe($failure);
+            });
+    }
+}
+
+final readonly class RecordingWatchSource implements Fake, Prioritized, WatchSource
+{
+    /**
+     * @param \ArrayObject<int, string> $events
+     * @param list<non-empty-string> $changes
+     */
+    public function __construct(
+        private \ArrayObject $events,
+        private string $name,
+        private int $priorityValue,
+        private array $changes,
+    ) {}
+
+    #[\Override]
+    public function priority(): int
+    {
+        return $this->priorityValue;
+    }
+
+    #[\Override]
+    public function poll(): array
+    {
+        $this->events->append($this->name);
+
+        return $this->changes;
+    }
+}
+
+final readonly class FailingWatchSource implements Fake, WatchSource
+{
+    public function __construct(private \RuntimeException $failure) {}
+
+    #[\Override]
+    public function poll(): array
+    {
+        throw $this->failure;
+    }
+}


### PR DESCRIPTION
Adds a command-owned WatchSource capability for paths or external trigger labels. Routes the built-in PHP filesystem scanner through the same stable, prioritized polling runtime, deduplicates changes, and contains source creation or polling failures with plugin-specific diagnostics.