### PR TITLE
feat(artifacts): add plugin retention decisions

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -342,7 +342,7 @@ deptrac:
     Execution: [Artifact, Config, Coverage, Discovery, DiscoveryPlan, Event, ExecutionArtifact, ExecutionPlugin, IntegrationFixture, InternalWire, Reporting, Result, Test]
     ExecutionAdapter: [Artifact, Config, CoverageCollection, DiscoveryPlan, Event, Execution, ExecutionArtifact, ExecutionPlugin, ExecutionProcessOrchestrator, ExecutionWorker, InternalProcess, InternalWire, Plugin, Reporting, Result, Test]
     ExecutionArtifact: [Artifact, Attribute, Config, Event, InternalPhp, InternalText, InternalWire, Result, Test]
-    ExecutionPlugin: [DiscoveryPlan, Event, Expect, Harness, IntegrationFixture, Plugin, Result, Test]
+    ExecutionPlugin: [Artifact, DiscoveryPlan, Event, Expect, Harness, IntegrationFixture, Plugin, Result, Test]
     ExecutionWorker: [Artifact, Attribute, Condition, DiscoveryPlan, Doubles, Event, ExecutionArtifact, ExecutionPlugin, Expect, Harness, IntegrationFixture, InternalPhp, InternalText, Plugin, Result, Sandbox, Test, TestDataSet]
     ExecutionProcessProtocol: [Attribute, Config, Coverage, DiscoveryPlan, Event, ExecutionArtifact, IntegrationFixture, InternalEvent, InternalPhp, InternalWire, Result, Test]
     ExecutionProcessWorker: [Config, CoverageCollection, Event, ExecutionArtifact, ExecutionPlugin, ExecutionProcessProtocol, ExecutionWorker, Harness, InternalPhp, InternalWire, Plugin, Result, Test]

--- a/docs/api-plugins.md
+++ b/docs/api-plugins.md
@@ -35,6 +35,30 @@ public function afterTest(TestContext $context, TestResult $result): TestResult;
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/AfterTestSubscriber.php#L23)
 
+## `AttachmentRetentionDecider`
+
+Namespace: `Greenlight\Plugin`
+
+Changes the publication decision for one completed test attachment.
+
+```php
+interface AttachmentRetentionDecider extends Plugin
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/AttachmentRetentionDecider.php#L11)
+
+### `retainAttachment()`
+
+```php
+public function retainAttachment(
+    TestResult $result,
+    Attachment $attachment,
+    bool $retain,
+): bool;
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/AttachmentRetentionDecider.php#L13)
+
 ## `BeforeTestSubscriber`
 
 Namespace: `Greenlight\Plugin`
@@ -284,18 +308,14 @@ Namespace: `Greenlight\Plugin`
 
 Identifies an object as a Greenlight plugin.
 
-Plugins implement one or more capability interfaces such as
-`WorkerRuntimeRunner`, `TestAttemptRunner`, `BeforeTestSubscriber`,
-`AfterTestSubscriber`, `RunLifecycleSubscriber`, `RetryDecider`,
-`CommandProvider`, `CoverageMapTransformer`, `HarnessProvider`, `ReporterProvider`,
-`TerminalResultTransformer`, `TestPlanTransformer`, `WatchSource`, or
-`ExpectationExtension`.
+Plugins implement one or more capability interfaces. The plugin guide lists
+each command, orchestrator, and worker capability.
 
 ```php
 interface Plugin
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/Plugin.php#L17)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/Plugin.php#L13)
 
 This type does not declare public members.
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -273,6 +273,30 @@ It MUST return a `CoverageMap`. A transformer or plugin-factory error stops
 coverage finishing and the command fails. Watch reruns do not write coverage
 and do not apply these transformers.
 
+### AttachmentRetentionDecider
+
+Orchestrator-side.
+
+<!-- php-example {"mode":"display","reason":"Shows one method signature without its interface declaration."} -->
+```php
+public function retainAttachment(TestResult $result, Attachment $attachment, bool $retain): bool;
+```
+
+An `AttachmentRetentionDecider` changes whether Greenlight publishes one
+completed test attachment. Greenlight first applies the retention selected by
+the test. `Always` retains the attachment. `OnFailure` retains it for an
+unsuccessful result, a transformed failure, or an earlier failed attempt.
+
+Each configured decider receives that current decision and returns the next
+decision. Thus, a decider can retain evidence that the built-in rule would
+discard, or discard evidence that the built-in rule would retain. The final
+decision applies before Greenlight publishes the file and emits
+`TestFinished`.
+
+The decider receives attachment metadata. It does not receive attachment
+content. If it throws, Greenlight names the plugin, fails the run, and retains
+the error as the cause.
+
 ### IntegrationFixtureProvider
 
 Orchestrator-side.
@@ -802,6 +826,7 @@ reads the priority one time for each owner-local plugin instance.
 
 Priority applies to these capabilities:
 
+* `AttachmentRetentionDecider`
 * `IntegrationFixtureProvider`
 * `WorkerBootstrapSubscriber`
 * `WorkerRuntimeRunner`

--- a/src/Artifact/AttachmentError.php
+++ b/src/Artifact/AttachmentError.php
@@ -48,4 +48,10 @@ final class AttachmentError extends \RuntimeException
     {
         return new self($message . '.');
     }
+
+    /** @internal */
+    public static function plugin(\Throwable $cause): self
+    {
+        return new self($cause->getMessage(), previous: $cause);
+    }
 }

--- a/src/Execution/Artifact/ArtifactStore.php
+++ b/src/Execution/Artifact/ArtifactStore.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Execution\Artifact;
 
+use Greenlight\Artifact\Attachment;
 use Greenlight\Artifact\AttachmentError;
 use Greenlight\Artifact\AttachmentKind;
 use Greenlight\Artifact\AttachmentRetention;
@@ -31,9 +32,12 @@ final class ArtifactStore
         private readonly ?string $outputDirectory,
         private readonly bool $ownsStaging,
         private readonly FileCopier $fileCopier,
+        /** @var (\Closure(TestResult, Attachment): bool)|null */
+        private readonly ?\Closure $retainAttachment,
     ) {}
 
     /**
+     * @param (\Closure(TestResult, Attachment): bool)|null $retainAttachment
      * @throws AttachmentError
      */
     public static function open(
@@ -42,6 +46,7 @@ final class ArtifactStore
         string $runId,
         ?FileCopier $fileCopier = null,
         ?string $temporaryDirectory = null,
+        ?\Closure $retainAttachment = null,
     ): self {
         $configured = \rtrim($configuration->directory, '/');
 
@@ -77,6 +82,7 @@ final class ArtifactStore
             $output,
             true,
             $fileCopier ?? new NativeFileCopier(),
+            $retainAttachment,
         );
     }
 
@@ -91,6 +97,7 @@ final class ArtifactStore
             null,
             false,
             $fileCopier ?? new NativeFileCopier(),
+            null,
         );
     }
 
@@ -351,20 +358,21 @@ final class ArtifactStore
         }
 
         $published = [];
-        $problematic = !$result->outcome->isSuccessful() || \array_any(
-            $result->transformations,
-            static fn($transformation): bool => !$transformation->from->isSuccessful(),
-        );
 
         foreach ($result->attachments as $attachment) {
             if (!$attachment instanceof StagedAttachment) {
                 throw AttachmentError::storage('Attachment metadata does not contain a staging coordinate');
             }
 
-            if (!$problematic
-                && $attachment->attempt >= $result->attempts
-                && $attachment->retention === AttachmentRetention::OnFailure
-            ) {
+            try {
+                $retain = $this->retainAttachment instanceof \Closure
+                    ? ($this->retainAttachment)($result, $attachment)
+                    : $this->defaultRetention($result, $attachment);
+            } catch (\Throwable $failure) {
+                throw AttachmentError::plugin($failure);
+            }
+
+            if (!$retain) {
                 $this->discard($attachment);
 
                 continue;
@@ -414,6 +422,18 @@ final class ArtifactStore
         }
 
         return $result->withAttachments($published);
+    }
+
+    private function defaultRetention(TestResult $result, Attachment $attachment): bool
+    {
+        $problematic = !$result->outcome->isSuccessful() || \array_any(
+            $result->transformations,
+            static fn($transformation): bool => !$transformation->from->isSuccessful(),
+        );
+
+        return $problematic
+            || $attachment->attempt < $result->attempts
+            || $attachment->retention !== AttachmentRetention::OnFailure;
     }
 
     /**

--- a/src/Execution/Plugin/DefaultAttachmentRetention.php
+++ b/src/Execution/Plugin/DefaultAttachmentRetention.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Execution\Plugin;
+
+use Greenlight\Artifact\Attachment;
+use Greenlight\Artifact\AttachmentRetention;
+use Greenlight\Plugin\AttachmentRetentionDecider;
+use Greenlight\Plugin\Prioritized;
+use Greenlight\Result\TestResult;
+
+/**
+ * Applies the retention selected when the test created an attachment.
+ *
+ * @internal
+ */
+final readonly class DefaultAttachmentRetention implements AttachmentRetentionDecider, Prioritized
+{
+    #[\Override]
+    public function priority(): int
+    {
+        return \PHP_INT_MIN;
+    }
+
+    #[\Override]
+    public function retainAttachment(
+        TestResult $result,
+        Attachment $attachment,
+        bool $retain,
+    ): bool {
+        $problematic = !$result->outcome->isSuccessful() || \array_any(
+            $result->transformations,
+            static fn($transformation): bool => !$transformation->from->isSuccessful(),
+        );
+
+        return $problematic
+            || $attachment->attempt < $result->attempts
+            || $attachment->retention !== AttachmentRetention::OnFailure;
+    }
+}

--- a/src/Execution/Plugin/OrchestratorPluginRuntime.php
+++ b/src/Execution/Plugin/OrchestratorPluginRuntime.php
@@ -4,18 +4,21 @@ declare(strict_types=1);
 
 namespace Greenlight\Execution\Plugin;
 
+use Greenlight\Artifact\Attachment;
 use Greenlight\Discovery\Plan\ExecutionPlan;
 use Greenlight\Discovery\Plan\PlanEntry;
 use Greenlight\Event\Event;
 use Greenlight\Event\EventSink;
 use Greenlight\IntegrationFixture\IntegrationFixtureDefinition;
 use Greenlight\IntegrationFixture\IntegrationFixtureError;
+use Greenlight\Plugin\AttachmentRetentionDecider;
 use Greenlight\Plugin\IntegrationFixtureProvider;
 use Greenlight\Plugin\Plugin;
 use Greenlight\Plugin\PluginDefinition;
 use Greenlight\Plugin\RunLifecycleSubscriber;
 use Greenlight\Plugin\TestPlan;
 use Greenlight\Plugin\TestPlanTransformer;
+use Greenlight\Result\TestResult;
 
 /**
  * Executes the plugin capabilities that one orchestrated run owns.
@@ -28,6 +31,7 @@ final readonly class OrchestratorPluginRuntime extends PluginRuntime implements 
      * @var non-empty-list<class-string>
      */
     private const array CAPABILITIES = [
+        AttachmentRetentionDecider::class,
         IntegrationFixtureProvider::class,
         RunLifecycleSubscriber::class,
         TestPlanTransformer::class,
@@ -48,6 +52,7 @@ final readonly class OrchestratorPluginRuntime extends PluginRuntime implements 
     public static function fromDefinitions(array $definitions, EventSink $inner, array $bundledPlugins = []): self
     {
         return new self([
+            new DefaultAttachmentRetention(),
             ...$bundledPlugins,
             ...self::createOwned($definitions, self::CAPABILITIES),
         ], $inner);
@@ -62,7 +67,23 @@ final readonly class OrchestratorPluginRuntime extends PluginRuntime implements 
      */
     public static function fromPlugins(array $plugins, EventSink $inner): self
     {
-        return new self($plugins, $inner);
+        return new self([new DefaultAttachmentRetention(), ...$plugins], $inner);
+    }
+
+    /** @throws PluginRuntimeError */
+    public function retainAttachment(TestResult $result, Attachment $attachment): bool
+    {
+        $retain = true;
+
+        foreach ($this->ordered(AttachmentRetentionDecider::class) as $decider) {
+            try {
+                $retain = $decider->retainAttachment($result, $attachment, $retain);
+            } catch (\Throwable $failure) {
+                throw PluginRuntimeError::hookFailed($decider::class, 'retainAttachment', $failure);
+            }
+        }
+
+        return $retain;
     }
 
     /**

--- a/src/Execution/RunCoordinator.php
+++ b/src/Execution/RunCoordinator.php
@@ -76,6 +76,7 @@ final readonly class RunCoordinator
             $this->workingDirectory,
             $runId,
             temporaryDirectory: $storage->temporaryDirectory,
+            retainAttachment: $orchestratorPlugins->retainAttachment(...),
         );
 
         try {

--- a/src/Plugin/AttachmentRetentionDecider.php
+++ b/src/Plugin/AttachmentRetentionDecider.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Plugin;
+
+use Greenlight\Artifact\Attachment;
+use Greenlight\Result\TestResult;
+
+/** Changes the publication decision for one completed test attachment. */
+interface AttachmentRetentionDecider extends Plugin
+{
+    public function retainAttachment(
+        TestResult $result,
+        Attachment $attachment,
+        bool $retain,
+    ): bool;
+}

--- a/src/Plugin/Plugin.php
+++ b/src/Plugin/Plugin.php
@@ -7,11 +7,7 @@ namespace Greenlight\Plugin;
 /**
  * Identifies an object as a Greenlight plugin.
  *
- * Plugins implement one or more capability interfaces such as
- * `WorkerRuntimeRunner`, `TestAttemptRunner`, `BeforeTestSubscriber`,
- * `AfterTestSubscriber`, `RunLifecycleSubscriber`, `RetryDecider`,
- * `CommandProvider`, `CoverageMapTransformer`, `HarnessProvider`, `ReporterProvider`,
- * `TerminalResultTransformer`, `TestPlanTransformer`, `WatchSource`, or
- * `ExpectationExtension`.
+ * Plugins implement one or more capability interfaces. The plugin guide lists
+ * each command, orchestrator, and worker capability.
  */
 interface Plugin {}

--- a/tests/Unit/Execution/Artifact/ArtifactStorePublicationTest.php
+++ b/tests/Unit/Execution/Artifact/ArtifactStorePublicationTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Execution\Artifact;
 
+use Greenlight\Artifact\Attachment;
 use Greenlight\Artifact\AttachmentError;
 use Greenlight\Attribute\Test;
 use Greenlight\Config\ArtifactConfiguration;
@@ -80,5 +81,66 @@ final readonly class ArtifactStorePublicationTest
         Expect::that($published->attachments)
             ->because('a rejected worker publication leaves the evidence intact')
             ->toHaveCount(1);
+    }
+
+    #[Test]
+    public function aRetentionCallbackControlsFinalPublication(): void
+    {
+        $root = $this->tempDirectory->subdirectory('plugin-retention');
+        $store = ArtifactStore::open(
+            new ArtifactConfiguration($root),
+            $root,
+            'run-plugin-retention',
+            retainAttachment: static fn(TestResult $result, Attachment $attachment): bool => false,
+        );
+        $this->cleanup->defer($store->cleanup(...));
+        $id = new TestId('Example\\EvidenceTest', 'fails');
+        $attempt = $store->forAttempt($id, 1, new TestArtifactBudget());
+        $attempt->text('evidence.txt', 'evidence');
+        $result = new TestResult(
+            $id,
+            Outcome::Failed,
+            0.1,
+            0,
+            attachments: $attempt->seal(),
+        );
+
+        $published = $store->publish($result);
+
+        Expect::that($published->attachments)->toBe([]);
+        Expect::that(\file_exists($store->publicDirectory()))->toBeFalse();
+    }
+
+    #[Test]
+    public function aRetentionCallbackFailureKeepsItsCause(): void
+    {
+        $root = $this->tempDirectory->subdirectory('plugin-retention-failure');
+        $failure = new \RuntimeException('Retention decision failed');
+        $store = ArtifactStore::open(
+            new ArtifactConfiguration($root),
+            $root,
+            'run-plugin-retention-failure',
+            retainAttachment: static fn(TestResult $result, Attachment $attachment): bool => throw $failure,
+        );
+        $this->cleanup->defer($store->cleanup(...));
+        $id = new TestId('Example\\EvidenceTest', 'fails');
+        $attempt = $store->forAttempt($id, 1, new TestArtifactBudget());
+        $attempt->text('evidence.txt', 'evidence');
+        $result = new TestResult(
+            $id,
+            Outcome::Failed,
+            0.1,
+            0,
+            attachments: $attempt->seal(),
+        );
+
+        Expect::that(static fn(): TestResult => $store->publish($result))
+            ->because('attachment publication MUST contain a retention callback failure')
+            ->toThrow(
+                static function (AttachmentError $error) use ($failure): void {
+                    Expect::that($error->getMessage())->toBe('Retention decision failed');
+                    Expect::that($error->getPrevious())->toBe($failure);
+                },
+            );
     }
 }

--- a/tests/Unit/Plugin/OrchestratorPluginRuntimePriorityTest.php
+++ b/tests/Unit/Plugin/OrchestratorPluginRuntimePriorityTest.php
@@ -4,13 +4,21 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Plugin;
 
+use Greenlight\Artifact\Attachment;
+use Greenlight\Artifact\AttachmentKind;
+use Greenlight\Artifact\AttachmentRetention;
 use Greenlight\Attribute\Test;
 use Greenlight\Doubles\Fake;
 use Greenlight\Execution\Plugin\OrchestratorPluginRuntime;
+use Greenlight\Execution\Plugin\PluginRuntimeError;
 use Greenlight\Expect\Expect;
 use Greenlight\IntegrationFixture\IntegrationFixtureDefinition;
+use Greenlight\Plugin\AttachmentRetentionDecider;
 use Greenlight\Plugin\IntegrationFixtureProvider;
 use Greenlight\Plugin\Prioritized;
+use Greenlight\Result\Outcome;
+use Greenlight\Result\TestResult;
+use Greenlight\Test\TestId;
 use Greenlight\Tests\Support\CollectingEventSink;
 
 final readonly class OrchestratorPluginRuntimePriorityTest
@@ -44,6 +52,91 @@ final readonly class OrchestratorPluginRuntimePriorityTest
             ]);
     }
 
+    #[Test]
+    public function attachmentDecidersRefineTheBundledDecisionInStablePriorityOrder(): void
+    {
+        /** @var \ArrayObject<int, string> $events */
+        $events = new \ArrayObject();
+        $result = new TestResult(
+            new TestId('Example\\EvidenceTest', 'passes'),
+            Outcome::Passed,
+            0.1,
+            1,
+        );
+        $attachment = new Attachment(
+            'evidence.txt',
+            AttachmentKind::Text,
+            'text/plain',
+            8,
+            \str_repeat('a', 64),
+            1,
+            '/tmp/evidence.txt',
+            AttachmentRetention::OnFailure,
+        );
+        $runtime = OrchestratorPluginRuntime::fromPlugins([
+            $this->retentionDecider($events, 'late', 10, false),
+            $this->retentionDecider($events, 'default', 0, true),
+            $this->retentionDecider($events, 'early', -10, true),
+        ], new CollectingEventSink());
+
+        $retain = $runtime->retainAttachment($result, $attachment);
+
+        Expect::that($events->getArrayCopy())->toBe([
+            'early:discard',
+            'default:retain',
+            'late:retain',
+        ]);
+        Expect::that($retain)->toBeFalse();
+    }
+
+    #[Test]
+    public function attachmentDeciderFailuresKeepThePluginAndCause(): void
+    {
+        $failure = new \RuntimeException('Retention decision failed');
+        $decider = new readonly class ($failure) implements AttachmentRetentionDecider, Fake {
+            public function __construct(private \Throwable $failure) {}
+
+            #[\Override]
+            public function retainAttachment(
+                TestResult $result,
+                Attachment $attachment,
+                bool $retain,
+            ): bool {
+                throw $this->failure;
+            }
+        };
+        $runtime = OrchestratorPluginRuntime::fromPlugins([$decider], new CollectingEventSink());
+        $result = new TestResult(
+            new TestId('Example\\EvidenceTest', 'passes'),
+            Outcome::Passed,
+            0.1,
+            1,
+        );
+        $attachment = new Attachment(
+            'evidence.txt',
+            AttachmentKind::Text,
+            'text/plain',
+            8,
+            \str_repeat('a', 64),
+            1,
+            '/tmp/evidence.txt',
+            AttachmentRetention::OnFailure,
+        );
+        $message = \sprintf(
+            'Plugin "%s" caused an error during retainAttachment(): Retention decision failed',
+            $decider::class,
+        );
+
+        Expect::that(static fn(): bool => $runtime->retainAttachment($result, $attachment))
+            ->because('the runtime MUST identify the failing attachment decider')
+            ->toThrow(
+                static function (PluginRuntimeError $error) use ($failure, $message): void {
+                    Expect::that($error->getMessage())->toBe($message);
+                    Expect::that($error->getPrevious())->toBe($failure);
+                },
+            );
+    }
+
     private function provider(string $id): IntegrationFixtureProvider
     {
         return new readonly class ($id) implements Fake, IntegrationFixtureProvider {
@@ -72,6 +165,41 @@ final readonly class OrchestratorPluginRuntimePriorityTest
             public function priority(): int
             {
                 return $this->priority;
+            }
+        };
+    }
+
+    /** @param \ArrayObject<int, string> $events */
+    private function retentionDecider(
+        \ArrayObject $events,
+        string $name,
+        int $priority,
+        bool $decision,
+    ): AttachmentRetentionDecider {
+        return new readonly class ($events, $name, $priority, $decision) implements AttachmentRetentionDecider, Fake, Prioritized {
+            /** @param \ArrayObject<int, string> $events */
+            public function __construct(
+                private \ArrayObject $events,
+                private string $name,
+                private int $priority,
+                private bool $decision,
+            ) {}
+
+            #[\Override]
+            public function priority(): int
+            {
+                return $this->priority;
+            }
+
+            #[\Override]
+            public function retainAttachment(
+                TestResult $result,
+                Attachment $attachment,
+                bool $retain,
+            ): bool {
+                $this->events->append($this->name . ':' . ($retain ? 'retain' : 'discard'));
+
+                return $this->decision;
             }
         };
     }


### PR DESCRIPTION
Adds an orchestrator-owned AttachmentRetentionDecider capability that refines the current decision for each completed attachment. Routes the built-in Always and OnFailure policy through the same minimum-priority plugin chain, applies the final decision before publication, and preserves plugin failure causality.