### PR TITLE
feat(execution): add plugin run acceptance policies

### DIFF
--- a/docs/api-plugins.md
+++ b/docs/api-plugins.md
@@ -400,6 +400,35 @@ public function shouldRetry(RetryPolicy $policy, TestResult $result, int $attemp
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/RetryDecider.php#L22)
 
+## `RunAcceptancePolicy`
+
+Namespace: `Greenlight\Plugin`
+
+Evaluates an otherwise successful run without changing test outcomes.
+
+Greenlight calls each policy one time after reporters finish. It runs lower
+priorities first and uses registration order for equal priorities. Return
+null to accept the run. Return a non-empty failure message to reject it.
+Greenlight runs all policies and reports all rejection messages.
+
+```php
+interface RunAcceptancePolicy extends Plugin
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/RunAcceptancePolicy.php#L17)
+
+### `failureMessage()`
+
+```php
+public function failureMessage(ResultSummary $summary, int $retriedPasses): ?string;
+```
+
+PHPDoc:
+
+- `@param non-negative-int $retriedPasses`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/RunAcceptancePolicy.php#L20)
+
 ## `RunLifecycleSubscriber`
 
 Namespace: `Greenlight\Plugin`

--- a/docs/architecture/technical-writing.md
+++ b/docs/architecture/technical-writing.md
@@ -179,6 +179,7 @@ and meaning. Use the singular form unless the context requires a plural.
 | result policy | Technical noun | A rule that can change a test result after execution |
 | retention | Technical noun | The rule that determines if Greenlight publishes an attachment |
 | retried pass | Technical noun | A successful terminal result that used more than one test attempt |
+| run acceptance policy | Technical noun | A command-side plugin that can reject an otherwise successful run without changing test outcomes |
 | retry decider | Technical noun | A plugin that determines if Greenlight starts another test attempt |
 | risky test | Technical noun | A passed test that verifies no expectations and has no `#[NoExpectations]` attribute |
 | run | Technical noun | One execution of a selected test suite |

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -22,8 +22,10 @@ return GreenlightConfig::create()
 
 Greenlight creates plugin instances only for an owner that uses one of their
 capabilities. It creates one command-owned instance for each factory that
-has `CommandProvider`, `ReporterProvider`, or `WatchSource`. Command dispatch,
-reporter setup, and watch polling own separate instances. It creates one
+has `CommandProvider`, `ReporterProvider`, `WatchSource`,
+`CoverageMapTransformer`, or `RunAcceptancePolicy`. Command dispatch,
+reporter setup, watch polling, coverage finishing, and run policy evaluation
+own separate instances. It creates one
 run-owned orchestrator instance for each factory that has a run capability. It
 creates one worker instance for each factory that has a worker capability and
 for each physical worker.
@@ -296,6 +298,44 @@ decision applies before Greenlight publishes the file and emits
 The decider receives attachment metadata. It does not receive attachment
 content. If it throws, Greenlight names the plugin, fails the run, and retains
 the error as the cause.
+
+### RunAcceptancePolicy
+
+Command-side, once for each completed standard, repeat, or watch run.
+
+A `RunAcceptancePolicy` can reject a run that has no failed or errored test
+outcomes. It receives the final `ResultSummary` and the number of tests that
+passed after a retry. Return `null` to accept the run. Return a non-empty
+failure message to reject it. The policy does not change test outcomes or
+reporter data.
+
+<!-- php-example {"example":"plugins-example-run-acceptance-policy","file":"snippet.php","mode":"file","tools":["rector"]} -->
+```php
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Plugin\RunAcceptancePolicy;
+use Greenlight\Result\ResultSummary;
+
+final readonly class RequireNoSkippedTests implements RunAcceptancePolicy
+{
+    public function failureMessage(ResultSummary $summary, int $retriedPasses): ?string
+    {
+        return $summary->skipped > 0
+            ? sprintf('The run skipped %d tests.', $summary->skipped)
+            : null;
+    }
+}
+
+return GreenlightConfig::create()
+    ->plugins(static fn(): RequireNoSkippedTests => new RequireNoSkippedTests());
+```
+
+Greenlight runs the bundled `failOnSkipped()` and `failOnRetriedPass()` policy
+first. It then runs configured policies in plugin priority and configuration
+order. Greenlight runs all policies and reports all rejection messages. It
+does not call acceptance policies when a test outcome already failed the run.
+
+If policy creation or evaluation fails, or a policy returns an empty message,
+Greenlight names the plugin and stops the command.
 
 ### IntegrationFixtureProvider
 
@@ -835,6 +875,7 @@ Priority applies to these capabilities:
 * `AfterTestSubscriber`
 * `RetryDecider`
 * `TerminalResultTransformer`
+* `RunAcceptancePolicy`
 * `WatchSource`
 * `RunLifecycleSubscriber`
 * `HarnessProvider`

--- a/src/Cli/Run/RunSession.php
+++ b/src/Cli/Run/RunSession.php
@@ -30,7 +30,9 @@ use Greenlight\Execution\Adapter\InProcessExecution;
 use Greenlight\Execution\Adapter\ProcessPoolExecution;
 use Greenlight\Execution\ExecutionAdapter;
 use Greenlight\Execution\ExecutionFailed;
+use Greenlight\Execution\RunAcceptance;
 use Greenlight\Execution\RunCoordinator;
+use Greenlight\Execution\RunPolicyError;
 use Greenlight\Execution\RunResult;
 use Greenlight\IntegrationFixture\IntegrationFixtureError;
 use Greenlight\Internal\Process\GracefulShutdown;
@@ -96,7 +98,7 @@ final readonly class RunSession
 
         $reporter->finish();
         $this->persist($failedTap->failedTests(), $failedTap->classSeconds());
-        $this->reportRunPolicyFailure($run, $failedTap);
+        $this->reportRunPolicyFailures($run, $failedTap);
 
         return $tap->failedClasses();
     }
@@ -178,38 +180,40 @@ final readonly class RunSession
             return 1;
         }
 
-        if (!$resolved->execution->runPolicy->accepts($run->summary, $failedTap->retriedPasses())) {
-            $this->reportRunPolicyFailure($run, $failedTap);
+        if (!$run->summary->isSuccessful()) {
+            return 1;
+        }
 
+        try {
+            $policyFailed = $this->reportRunPolicyFailures($run, $failedTap);
+        } catch (RunPolicyError $error) {
+            $this->console->error($error->getMessage(), $this->arguments->has('no-ansi'));
+
+            return 1;
+        }
+
+        if ($policyFailed) {
             return 1;
         }
 
         return 0;
     }
 
-    private function reportRunPolicyFailure(RunResult $run, FailedTestsTap $tap): void
+    /** @throws RunPolicyError */
+    private function reportRunPolicyFailures(RunResult $run, FailedTestsTap $tap): bool
     {
-        if (!$run->summary->isSuccessful()) {
-            return;
+        $resolved = $this->configuration->resolved;
+        $messages = RunAcceptance::failureMessages(
+            $resolved->execution,
+            $run->summary,
+            $tap->retriedPasses(),
+        );
+
+        foreach ($messages as $message) {
+            $this->console->err($message . "\n");
         }
 
-        $policy = $this->configuration->resolved->execution->runPolicy;
-
-        if ($policy->failOnSkipped && $run->summary->skipped > 0) {
-            $this->console->err(\sprintf(
-                "Greenlight failed because the fail-on-skipped policy found %d skipped %s.\n",
-                $run->summary->skipped,
-                $run->summary->skipped === 1 ? 'test' : 'tests',
-            ));
-        }
-
-        if ($policy->failOnRetriedPass && $tap->retriedPasses() > 0) {
-            $this->console->err(\sprintf(
-                "Greenlight failed because the fail-on-retried-pass policy found %d %s that passed after retry.\n",
-                $tap->retriedPasses(),
-                $tap->retriedPasses() === 1 ? 'test' : 'tests',
-            ));
-        }
+        return $messages !== [];
     }
 
     /**

--- a/src/Cli/Run/WatchRuns.php
+++ b/src/Cli/Run/WatchRuns.php
@@ -21,6 +21,7 @@ use Greenlight\Cli\Watch\WatchLoop;
 use Greenlight\Cli\Watch\WatchSourceFailed;
 use Greenlight\Cli\Watch\WatchSourceRuntime;
 use Greenlight\Config\StorageLayout;
+use Greenlight\Execution\RunPolicyError;
 use Greenlight\Execution\Worker\LeakDetector;
 use Greenlight\Internal\Process\GracefulShutdown;
 use Greenlight\Reporting\Reporter;
@@ -72,7 +73,7 @@ final readonly class WatchRuns
                 [new StatChangeDetector($watched)],
             );
             new WatchLoop($sources, new Debouncer($resolved->watch->debounceMilliseconds / 1000), $keys, new SystemWatchClock(), $this->console->out(...), $shutdown)->run($runOnce);
-        } catch (ReporterSetupFailed|WatchSourceFailed $error) {
+        } catch (ReporterSetupFailed|RunPolicyError|WatchSourceFailed $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
             return 1;
         } finally {

--- a/src/Execution/Plugin/ConfiguredRunAcceptance.php
+++ b/src/Execution/Plugin/ConfiguredRunAcceptance.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Execution\Plugin;
+
+use Greenlight\Plugin\Prioritized;
+use Greenlight\Plugin\RunAcceptancePolicy;
+use Greenlight\Result\ResultSummary;
+use Greenlight\Result\RunPolicy;
+
+/**
+ * Applies the configured skipped-test and retried-pass run rules.
+ *
+ * @internal
+ */
+final readonly class ConfiguredRunAcceptance implements Prioritized, RunAcceptancePolicy
+{
+    public function __construct(private RunPolicy $policy) {}
+
+    #[\Override]
+    public function priority(): int
+    {
+        return \PHP_INT_MIN;
+    }
+
+    /** @param non-negative-int $retriedPasses */
+    #[\Override]
+    public function failureMessage(ResultSummary $summary, int $retriedPasses): ?string
+    {
+        if (!$summary->isSuccessful()) {
+            return null;
+        }
+
+        $messages = [];
+
+        if ($this->policy->failOnSkipped && $summary->skipped > 0) {
+            $messages[] = \sprintf(
+                'Greenlight failed because the fail-on-skipped policy found %d skipped %s.',
+                $summary->skipped,
+                $summary->skipped === 1 ? 'test' : 'tests',
+            );
+        }
+
+        if ($this->policy->failOnRetriedPass && $retriedPasses > 0) {
+            $messages[] = \sprintf(
+                'Greenlight failed because the fail-on-retried-pass policy found %d %s that passed after retry.',
+                $retriedPasses,
+                $retriedPasses === 1 ? 'test' : 'tests',
+            );
+        }
+
+        return $messages === [] ? null : \implode("\n", $messages);
+    }
+}

--- a/src/Execution/Plugin/PluginRuntimeError.php
+++ b/src/Execution/Plugin/PluginRuntimeError.php
@@ -31,6 +31,25 @@ final class PluginRuntimeError extends \RuntimeException
     }
 
     /** @param class-string $plugin */
+    public static function creationFailed(string $plugin, \Throwable $cause): self
+    {
+        return new self(\sprintf(
+            'Plugin "%s" caused an error during creation: %s',
+            $plugin,
+            $cause->getMessage(),
+        ), $cause);
+    }
+
+    /** @param class-string $plugin */
+    public static function emptyRunPolicyFailure(string $plugin): self
+    {
+        return new self(\sprintf(
+            'Plugin "%s" returned an empty failure message from failureMessage().',
+            $plugin,
+        ));
+    }
+
+    /** @param class-string $plugin */
     public static function changedTestIdentity(
         string $plugin,
         TestId $before,

--- a/src/Execution/Plugin/RunPolicyRuntime.php
+++ b/src/Execution/Plugin/RunPolicyRuntime.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Execution\Plugin;
+
+use Greenlight\Plugin\Plugin;
+use Greenlight\Plugin\PluginDefinition;
+use Greenlight\Plugin\RunAcceptancePolicy;
+use Greenlight\Result\ResultSummary;
+use Greenlight\Result\RunPolicy;
+
+/**
+ * Applies command-side run acceptance policies for one completed run.
+ *
+ * @internal
+ */
+final readonly class RunPolicyRuntime extends PluginRuntime
+{
+    /**
+     * @param list<PluginDefinition> $definitions
+     * @throws PluginRuntimeError
+     */
+    public static function fromDefinitions(array $definitions, RunPolicy $builtIn): self
+    {
+        $plugins = [new ConfiguredRunAcceptance($builtIn)];
+
+        foreach ($definitions as $definition) {
+            if (!$definition->supports(RunAcceptancePolicy::class)) {
+                continue;
+            }
+
+            try {
+                $plugins[] = $definition->create();
+            } catch (\Throwable $failure) {
+                throw PluginRuntimeError::creationFailed($definition->pluginClass, $failure);
+            }
+        }
+
+        return new self($plugins);
+    }
+
+    /** @param list<Plugin> $plugins */
+    public static function fromPlugins(array $plugins): self
+    {
+        return new self($plugins);
+    }
+
+    /** @param list<Plugin> $plugins */
+    private function __construct(array $plugins)
+    {
+        parent::__construct($plugins);
+    }
+
+    /**
+     * @param non-negative-int $retriedPasses
+     * @return list<non-empty-string>
+     * @throws PluginRuntimeError
+     */
+    public function failureMessages(ResultSummary $summary, int $retriedPasses): array
+    {
+        if (!$summary->isSuccessful()) {
+            return [];
+        }
+
+        $messages = [];
+
+        foreach ($this->ordered(RunAcceptancePolicy::class) as $policy) {
+            try {
+                $message = $policy->failureMessage($summary, $retriedPasses);
+            } catch (\Throwable $failure) {
+                throw PluginRuntimeError::hookFailed($policy::class, 'failureMessage', $failure);
+            }
+
+            if ($message === null) {
+                continue;
+            }
+
+            $message = \trim($message);
+
+            if ($message === '') {
+                throw PluginRuntimeError::emptyRunPolicyFailure($policy::class);
+            }
+
+            $messages[] = $message;
+        }
+
+        return $messages;
+    }
+}

--- a/src/Execution/RunAcceptance.php
+++ b/src/Execution/RunAcceptance.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Execution;
+
+use Greenlight\Config\ExecutionConfiguration;
+use Greenlight\Execution\Plugin\PluginRuntimeError;
+use Greenlight\Execution\Plugin\RunPolicyRuntime;
+use Greenlight\Result\ResultSummary;
+
+/**
+ * Evaluates run acceptance through the execution plugin seam.
+ *
+ * @internal
+ */
+final class RunAcceptance
+{
+    /** @codeCoverageIgnore */
+    private function __construct() {}
+
+    /**
+     * @param non-negative-int $retriedPasses
+     * @return list<non-empty-string>
+     * @throws RunPolicyError
+     */
+    public static function failureMessages(
+        ExecutionConfiguration $execution,
+        ResultSummary $summary,
+        int $retriedPasses,
+    ): array {
+        try {
+            return RunPolicyRuntime::fromDefinitions(
+                $execution->plugins,
+                $execution->runPolicy,
+            )->failureMessages($summary, $retriedPasses);
+        } catch (PluginRuntimeError $error) {
+            throw RunPolicyError::fromRuntime($error);
+        }
+    }
+}

--- a/src/Execution/RunPolicyError.php
+++ b/src/Execution/RunPolicyError.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Execution;
+
+use Greenlight\Execution\Plugin\PluginRuntimeError;
+
+/**
+ * A run acceptance policy cannot complete its command-side operation.
+ *
+ * @internal
+ */
+final class RunPolicyError extends \RuntimeException
+{
+    public static function fromRuntime(PluginRuntimeError $cause): self
+    {
+        return new self($cause->getMessage(), previous: $cause);
+    }
+}

--- a/src/Plugin/RunAcceptancePolicy.php
+++ b/src/Plugin/RunAcceptancePolicy.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Plugin;
+
+use Greenlight\Result\ResultSummary;
+
+/**
+ * Evaluates an otherwise successful run without changing test outcomes.
+ *
+ * Greenlight calls each policy one time after reporters finish. It runs lower
+ * priorities first and uses registration order for equal priorities. Return
+ * null to accept the run. Return a non-empty failure message to reject it.
+ * Greenlight runs all policies and reports all rejection messages.
+ */
+interface RunAcceptancePolicy extends Plugin
+{
+    /** @param non-negative-int $retriedPasses */
+    public function failureMessage(ResultSummary $summary, int $retriedPasses): ?string;
+}

--- a/tests/Acceptance/CustomRunPolicyTest.php
+++ b/tests/Acceptance/CustomRunPolicyTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\GreenlightCli;
+
+final readonly class CustomRunPolicyTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function configuredPolicyCanRejectAnOtherwiseSuccessfulRun(): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'custom-run-policy');
+        $project->writeFile('tests/PassingTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace CustomRunPolicy;
+
+            use Greenlight\Attribute\Test;
+
+            final readonly class PassingTest
+            {
+                #[Test]
+                public function passes(): void {}
+            }
+
+            PHP);
+        $project->writeFile('greenlight.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Config\GreenlightConfig;
+            use Greenlight\Plugin\RunAcceptancePolicy;
+            use Greenlight\Result\ResultSummary;
+
+            require_once __DIR__ . '/tests/PassingTest.php';
+
+            final readonly class RequireNoPassedTests implements RunAcceptancePolicy
+            {
+                public function failureMessage(ResultSummary $summary, int $retriedPasses): ?string
+                {
+                    return $summary->passed > 0
+                        ? sprintf(
+                            'Project policy rejected %d passed test and %d retried passes.',
+                            $summary->passed,
+                            $retriedPasses,
+                        )
+                        : null;
+                }
+            }
+
+            return GreenlightConfig::create()
+                ->paths([__DIR__ . '/tests'])
+                ->workers(1)
+                ->plugins(static fn(): RequireNoPassedTests => new RequireNoPassedTests());
+
+            PHP);
+
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=plain']);
+
+        Expect::that($result->exitCode)
+            ->because('the configured run policy MUST reject an otherwise successful run')
+            ->toBe(1);
+        Expect::that($result->output())
+            ->toContain('1 test, 1 passed')
+            ->toContain('Project policy rejected 1 passed test and 0 retried passes.');
+    }
+}

--- a/tests/Unit/Execution/RunPolicyRuntimeTest.php
+++ b/tests/Unit/Execution/RunPolicyRuntimeTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Execution;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Fake;
+use Greenlight\Execution\Plugin\PluginRuntimeError;
+use Greenlight\Execution\Plugin\RunPolicyRuntime;
+use Greenlight\Expect\Expect;
+use Greenlight\Plugin\PluginDefinition;
+use Greenlight\Plugin\Prioritized;
+use Greenlight\Plugin\RunAcceptancePolicy;
+use Greenlight\Result\ResultSummary;
+use Greenlight\Result\RunPolicy;
+
+final readonly class RunPolicyRuntimeTest
+{
+    #[Test]
+    public function policiesReportAllFailuresInStablePriorityOrder(): void
+    {
+        /** @var \ArrayObject<int, string> $events */
+        $events = new \ArrayObject();
+        $runtime = RunPolicyRuntime::fromPlugins([
+            new RecordingRunPolicy($events, 'late', 10, 'late failure'),
+            new RecordingRunPolicy($events, 'default', 0, 'default failure'),
+            new RecordingRunPolicy($events, 'accepted', 0, null),
+            new RecordingRunPolicy($events, 'early', -10, 'early failure'),
+        ]);
+
+        $messages = $runtime->failureMessages(new ResultSummary(passed: 2), 1);
+
+        Expect::that($events->getArrayCopy())->toBe([
+            'early:2:1',
+            'default:2:1',
+            'accepted:2:1',
+            'late:2:1',
+        ]);
+        Expect::that($messages)->toBe([
+            'early failure',
+            'default failure',
+            'late failure',
+        ]);
+    }
+
+    #[Test]
+    public function failedTestOutcomesBypassRunAcceptancePolicies(): void
+    {
+        /** @var \ArrayObject<int, string> $events */
+        $events = new \ArrayObject();
+        $runtime = RunPolicyRuntime::fromPlugins([
+            new RecordingRunPolicy($events, 'policy', 0, 'must not run'),
+        ]);
+
+        Expect::that($runtime->failureMessages(new ResultSummary(failed: 1), 0))->toBe([]);
+        Expect::that($events->getArrayCopy())->toBe([]);
+    }
+
+    #[Test]
+    public function policyFailuresKeepThePluginAndCause(): void
+    {
+        $failure = new \RuntimeException('Policy exploded');
+        $runtime = RunPolicyRuntime::fromPlugins([new FailingRunPolicy($failure)]);
+
+        Expect::that(static fn(): array => $runtime->failureMessages(new ResultSummary(passed: 1), 0))
+            ->toThrow(static function (PluginRuntimeError $error) use ($failure): void {
+                Expect::that($error->getMessage())->toBe(
+                    'Plugin "Greenlight\\Tests\\Unit\\Execution\\FailingRunPolicy" caused an error during failureMessage(): Policy exploded',
+                );
+                Expect::that($error->getPrevious())->toBe($failure);
+            });
+    }
+
+    #[Test]
+    public function emptyFailureMessagesAreInvalid(): void
+    {
+        /** @var \ArrayObject<int, string> $events */
+        $events = new \ArrayObject();
+        $runtime = RunPolicyRuntime::fromPlugins([
+            new RecordingRunPolicy($events, 'empty', 0, "\n"),
+        ]);
+
+        Expect::that(static fn(): array => $runtime->failureMessages(new ResultSummary(passed: 1), 0))
+            ->toThrow(
+                PluginRuntimeError::class,
+                message: 'Plugin "Greenlight\\Tests\\Unit\\Execution\\RecordingRunPolicy" returned an empty failure message from failureMessage().',
+            );
+    }
+
+    #[Test]
+    public function factoryFailuresStopPolicySetup(): void
+    {
+        $definition = PluginDefinition::fromFactory(
+            static fn(): FailingPolicyCreation => new FailingPolicyCreation(),
+        );
+
+        Expect::that(static fn(): RunPolicyRuntime => RunPolicyRuntime::fromDefinitions(
+            [$definition],
+            new RunPolicy(),
+        ))->toThrow(
+            PluginRuntimeError::class,
+            message: 'Plugin "Greenlight\\Tests\\Unit\\Execution\\FailingPolicyCreation" caused an error during creation: Policy construction exploded',
+        );
+    }
+
+    #[Test]
+    public function configuredRulesUseTheBundledPluginAdapter(): void
+    {
+        $runtime = RunPolicyRuntime::fromDefinitions(
+            [],
+            new RunPolicy(failOnSkipped: true, failOnRetriedPass: true),
+        );
+
+        Expect::that($runtime->failureMessages(new ResultSummary(skipped: 2), 1))->toBe([
+            "Greenlight failed because the fail-on-skipped policy found 2 skipped tests.\n"
+            . 'Greenlight failed because the fail-on-retried-pass policy found 1 test that passed after retry.',
+        ]);
+    }
+}
+
+final readonly class RecordingRunPolicy implements Fake, Prioritized, RunAcceptancePolicy
+{
+    /** @param \ArrayObject<int, string> $events */
+    public function __construct(
+        private \ArrayObject $events,
+        private string $name,
+        private int $priorityValue,
+        private ?string $message,
+    ) {}
+
+    #[\Override]
+    public function priority(): int
+    {
+        return $this->priorityValue;
+    }
+
+    #[\Override]
+    public function failureMessage(ResultSummary $summary, int $retriedPasses): ?string
+    {
+        $this->events->append(\sprintf('%s:%d:%d', $this->name, $summary->passed, $retriedPasses));
+
+        return $this->message;
+    }
+}
+
+final readonly class FailingRunPolicy implements Fake, RunAcceptancePolicy
+{
+    public function __construct(private \RuntimeException $failure) {}
+
+    #[\Override]
+    public function failureMessage(ResultSummary $summary, int $retriedPasses): ?string
+    {
+        throw $this->failure;
+    }
+}
+
+final readonly class FailingPolicyCreation implements Fake, RunAcceptancePolicy
+{
+    public function __construct()
+    {
+        throw new \RuntimeException('Policy construction exploded');
+    }
+
+    #[\Override]
+    public function failureMessage(ResultSummary $summary, int $retriedPasses): ?string
+    {
+        return null;
+    }
+}


### PR DESCRIPTION
Adds a public RunAcceptancePolicy capability for aggregate rules that can reject an otherwise successful run without changing test outcomes or reporter data.

Routes the built-in skipped-test and retried-pass rules through a minimum-priority bundled adapter, then runs configured policies in stable plugin order. Policy creation, evaluation, and invalid messages are contained and attributed to the plugin.

Documents command-side ownership, lifecycle, ordering, and the generated public interface.