### PR TITLE
feat(doubles): validate predicate argument types

### DIFF
--- a/docs/api-doubles.md
+++ b/docs/api-doubles.md
@@ -77,6 +77,7 @@ PHPDoc:
 ### `predicate()`
 
 This matcher accepts the value when the closure returns true.
+A declared parameter type rejects incompatible values before the closure runs.
 The description identifies the constraint in failure messages.
 
 ```php
@@ -88,8 +89,9 @@ PHPDoc:
 - `@template T`
 - `@param \Closure(T): mixed $predicate`
 - `@return ArgumentMatcher<T>`
+- `@throws InvalidDoubleUsage`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L96)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L98)
 
 ### `equals()`
 
@@ -106,7 +108,7 @@ PHPDoc:
 - `@param T $value`
 - `@return ArgumentMatcher<T>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L111)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L113)
 
 ### `allOf()`
 
@@ -130,7 +132,7 @@ PHPDoc:
 - `@return ArgumentMatcher<T>`
 - `@throws InvalidDoubleUsage`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L129)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L131)
 
 ### `captor()`
 
@@ -141,7 +143,7 @@ selects the related expectation for the call.
 public static function captor(): ArgumentCaptor
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L147)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Argument.php#L149)
 
 ## `ArgumentCaptor`
 
@@ -673,6 +675,26 @@ PHPDoc:
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L220)
 
+### `incompatiblePlannedArgumentMatcher()`
+
+```php
+public static function incompatiblePlannedArgumentMatcher(
+    string $selector,
+    string $type,
+    string $method,
+    int $position,
+    string $matcherType,
+    string $parameter,
+    string $parameterType,
+): self
+```
+
+PHPDoc:
+
+- `@param class-string $type`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L240)
+
 ### `tooFewCallArguments()`
 
 ```php
@@ -683,7 +705,7 @@ PHPDoc:
 
 - `@param class-string $type`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L240)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L264)
 
 ### `tooManyCallArguments()`
 
@@ -695,7 +717,7 @@ PHPDoc:
 
 - `@param class-string $type`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L254)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L278)
 
 ### `conflictingAnswers()`
 
@@ -703,7 +725,7 @@ PHPDoc:
 public static function conflictingAnswers(string $method): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L265)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L289)
 
 ### `emptySequence()`
 
@@ -711,7 +733,7 @@ public static function conflictingAnswers(string $method): self
 public static function emptySequence(string $method): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L274)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L298)
 
 ### `sequenceExhausted()`
 
@@ -719,7 +741,7 @@ public static function emptySequence(string $method): self
 public static function sequenceExhausted(string $method, int $count): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L279)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L303)
 
 ### `nothingCaptured()`
 
@@ -727,7 +749,7 @@ public static function sequenceExhausted(string $method, int $count): self
 public static function nothingCaptured(): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L288)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L312)
 
 ### `invalidCaptorPosition()`
 
@@ -735,7 +757,7 @@ public static function nothingCaptured(): self
 public static function invalidCaptorPosition(int $position): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L293)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L317)
 
 ### `invalidArgumentType()`
 
@@ -743,7 +765,7 @@ public static function invalidCaptorPosition(int $position): self
 public static function invalidArgumentType(): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L298)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L322)
 
 ### `invalidArgumentTypeCombination()`
 
@@ -751,7 +773,7 @@ public static function invalidArgumentType(): self
 public static function invalidArgumentTypeCombination(string $factory): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L303)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L327)
 
 ### `compositeArgumentCaptor()`
 
@@ -759,7 +781,7 @@ public static function invalidArgumentTypeCombination(string $factory): self
 public static function compositeArgumentCaptor(): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L311)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L335)
 
 ## `MethodExpectation`
 

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -170,23 +170,24 @@ The bundled PHPStan extension preserves the combined value type in each
 cannot match the selected method parameter. Other type names use `mixed`, as
 they do for `Argument::type()`.
 
-Use `Argument::allOf()` to apply two or more constraints to one argument:
+Use a typed predicate to apply a type constraint and a value constraint:
 
 <!-- php-example {"example":"test-doubles-example-07","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Doubles\Argument;
 
-$plan->expects('save')->with(Argument::allOf(
-    Argument::type(Order::class),
-    Argument::predicate(
-        fn (Order $order): bool => $order->isReady(),
-        'a ready order',
-    ),
+$plan->expects('save')->with(Argument::predicate(
+    fn (Order $order): bool => $order->isReady(),
+    'a ready order',
 ));
 ```
 
-Greenlight checks the matchers from left to right. Put a type matcher before a
-predicate that has a parameter of that type. `allOf()` does not accept a captor.
+The parameter type rejects an incompatible value before the predicate runs.
+Greenlight rejects the plan if this type cannot match the method parameter.
+
+Use `Argument::allOf()` to apply two or more constraints to one argument.
+Greenlight checks the matchers from left to right. `allOf()` does not accept a
+captor.
 
 ## Argument capture
 

--- a/src/Doubles/AllOf.php
+++ b/src/Doubles/AllOf.php
@@ -9,16 +9,33 @@ namespace Greenlight\Doubles;
  *
  * @template-covariant TValue
  *
- * @implements ArgumentMatcher<TValue>
+ * @implements TypedArgumentMatcher<TValue>
  *
  * @internal
  */
-final readonly class AllOf implements ArgumentMatcher
+final readonly class AllOf implements TypedArgumentMatcher
 {
+    private ?ArgumentType $argumentType;
+
     /**
      * @param non-empty-list<ArgumentMatcher<TValue>> $matchers
      */
-    public function __construct(private array $matchers) {}
+    public function __construct(private array $matchers)
+    {
+        $types = \array_values(\array_filter(\array_map(
+            static fn(ArgumentMatcher $matcher): ?ArgumentType => $matcher instanceof TypedArgumentMatcher
+                ? $matcher->argumentType()
+                : null,
+            $matchers,
+        )));
+        $this->argumentType = $types === []
+            ? null
+            : \array_reduce(
+                \array_slice($types, 1),
+                static fn(ArgumentType $combined, ArgumentType $type): ArgumentType => $combined->intersect($type),
+                $types[0],
+            );
+    }
 
     public function matches(mixed $value): bool
     {
@@ -31,5 +48,10 @@ final readonly class AllOf implements ArgumentMatcher
             static fn(ArgumentMatcher $matcher): string => $matcher->describe(),
             $this->matchers,
         )) . ')';
+    }
+
+    public function argumentType(): ?ArgumentType
+    {
+        return $this->argumentType;
     }
 }

--- a/src/Doubles/Argument.php
+++ b/src/Doubles/Argument.php
@@ -85,6 +85,7 @@ final class Argument
 
     /**
      * This matcher accepts the value when the closure returns true.
+     * A declared parameter type rejects incompatible values before the closure runs.
      * The description identifies the constraint in failure messages.
      *
      * @template T
@@ -92,6 +93,7 @@ final class Argument
      * @param \Closure(T): mixed $predicate
      *
      * @return ArgumentMatcher<T>
+     * @throws InvalidDoubleUsage
      */
     public static function predicate(\Closure $predicate, string $description = 'predicate'): ArgumentMatcher
     {

--- a/src/Doubles/ArgumentType.php
+++ b/src/Doubles/ArgumentType.php
@@ -1,0 +1,372 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Doubles;
+
+/**
+ * Represents the values that a typed argument matcher can accept.
+ *
+ * The alternatives use disjunctive normal form. Each inner list is an
+ * intersection. The outer list is a union.
+ *
+ * @internal
+ */
+final readonly class ArgumentType
+{
+    /**
+     * @param non-empty-list<non-empty-list<non-empty-string>> $alternatives
+     */
+    private function __construct(private array $alternatives) {}
+
+    /**
+     * @param \ReflectionClass<object>|null $context
+     * @throws InvalidDoubleUsage
+     */
+    public static function fromReflection(\ReflectionType $type, ?\ReflectionClass $context = null): self
+    {
+        if ($type instanceof \ReflectionNamedType) {
+            $name = self::reflectionName($type, $context);
+            $result = new self([[$name]]);
+
+            return $type->allowsNull() && !\in_array($name, ['mixed', 'null'], true)
+                ? $result->union(new self([['null']]))
+                : $result;
+        }
+
+        if ($type instanceof \ReflectionUnionType) {
+            $members = \array_map(
+                static fn(\ReflectionType $member): self => self::fromReflection($member, $context),
+                $type->getTypes(),
+            );
+
+            return \array_reduce(
+                \array_slice($members, 1),
+                static fn(self $combined, self $member): self => $combined->union($member),
+                $members[0],
+            );
+        }
+
+        if ($type instanceof \ReflectionIntersectionType) {
+            $members = \array_map(
+                static fn(\ReflectionType $member): self => self::fromReflection($member, $context),
+                $type->getTypes(),
+            );
+
+            return \array_reduce(
+                \array_slice($members, 1),
+                static fn(self $combined, self $member): self => $combined->intersect($member),
+                $members[0],
+            );
+        }
+
+        throw InvalidDoubleUsage::unsupportedReflectionType($type::class);
+    }
+
+    public static function fromTypeName(string $type): ?self
+    {
+        $type = \ltrim($type, '\\');
+
+        if (\in_array($type, ['array', 'bool', 'float', 'int', 'null', 'string'], true)
+            || \class_exists($type)
+            || \interface_exists($type)
+            || \enum_exists($type)
+        ) {
+            return new self([[$type]]);
+        }
+
+        return null;
+    }
+
+    /**
+     * Gets a known upper bound for values that have all the specified types.
+     *
+     * @param non-empty-list<string> $types
+     */
+    public static function fromIntersectionTypeNames(array $types): ?self
+    {
+        $known = \array_values(\array_filter(\array_map(self::fromTypeName(...), $types)));
+
+        if ($known === []) {
+            return null;
+        }
+
+        return \array_reduce(
+            \array_slice($known, 1),
+            static fn(self $combined, self $member): self => $combined->intersect($member),
+            $known[0],
+        );
+    }
+
+    /**
+     * Gets the values that have one or more of the specified known types.
+     *
+     * @param non-empty-list<string> $types
+     */
+    public static function fromUnionTypeNames(array $types): ?self
+    {
+        $known = \array_map(self::fromTypeName(...), $types);
+
+        if (\in_array(null, $known, true)) {
+            return null;
+        }
+
+        /** @var non-empty-list<self> $known */
+        return \array_reduce(
+            \array_slice($known, 1),
+            static fn(self $combined, self $member): self => $combined->union($member),
+            $known[0],
+        );
+    }
+
+    public function intersect(self $other): self
+    {
+        $alternatives = [];
+
+        foreach ($this->alternatives as $left) {
+            foreach ($other->alternatives as $right) {
+                $alternatives[] = \array_values(\array_unique([...$left, ...$right]));
+            }
+        }
+
+        return new self($alternatives);
+    }
+
+    public function accepts(mixed $value): bool
+    {
+        return \array_any(
+            $this->alternatives,
+            static fn(array $alternative): bool => \array_all(
+                $alternative,
+                static fn(string $type): bool => self::acceptsNamed($value, $type),
+            ),
+        );
+    }
+
+    public function overlaps(self $other): bool
+    {
+        foreach ($this->alternatives as $left) {
+            foreach ($other->alternatives as $right) {
+                if ($this->possible([...$left, ...$right])) {
+                    return true;
+                }
+            }
+        }
+
+        return false;
+    }
+
+    public function describe(): string
+    {
+        $union = \count($this->alternatives) > 1;
+
+        return \implode('|', \array_map(
+            static function (array $alternative) use ($union): string {
+                $intersection = \implode('&', $alternative);
+
+                return $union && \count($alternative) > 1 ? '(' . $intersection . ')' : $intersection;
+            },
+            $this->alternatives,
+        ));
+    }
+
+    private function union(self $other): self
+    {
+        return new self([...$this->alternatives, ...$other->alternatives]);
+    }
+
+    /**
+     * @param \ReflectionClass<object>|null $context
+     * @return non-empty-string
+     * @throws InvalidDoubleUsage
+     */
+    private static function reflectionName(\ReflectionNamedType $type, ?\ReflectionClass $context): string
+    {
+        $name = $type->getName();
+
+        if ($name === '') {
+            throw InvalidDoubleUsage::unsupportedReflectionType($type::class);
+        }
+
+        if ($type->isBuiltin()) {
+            return $name;
+        }
+
+        if ($name === 'self' || $name === 'static') {
+            return !$context instanceof \ReflectionClass ? $name : $context->name;
+        }
+
+        if ($name !== 'parent') {
+            return $name;
+        }
+
+        if (!$context instanceof \ReflectionClass) {
+            throw InvalidDoubleUsage::parentTypeWithoutParent('Closure');
+        }
+
+        $parent = $context->getParentClass();
+
+        if ($parent === false) {
+            throw InvalidDoubleUsage::parentTypeWithoutParent($context->name);
+        }
+
+        return $parent->name;
+    }
+
+    private static function acceptsNamed(mixed $value, string $type): bool
+    {
+        return match ($type) {
+            'mixed' => true,
+            'null' => $value === null,
+            'true' => $value === true,
+            'false' => $value === false,
+            'bool' => \is_bool($value),
+            'int' => \is_int($value),
+            'float' => \is_float($value),
+            'string' => \is_string($value),
+            'array' => \is_array($value),
+            'object' => \is_object($value),
+            'callable' => \is_callable($value),
+            'iterable' => \is_iterable($value),
+            default => $value instanceof $type,
+        };
+    }
+
+    /** @param non-empty-list<non-empty-string> $types */
+    private function possible(array $types): bool
+    {
+        foreach ($types as $leftIndex => $left) {
+            foreach (\array_slice($types, $leftIndex + 1) as $right) {
+                if (!$this->namedTypesOverlap($left, $right)) {
+                    return false;
+                }
+            }
+        }
+
+        return true;
+    }
+
+    private function namedTypesOverlap(string $left, string $right): bool
+    {
+        if ($left === $right || $left === 'mixed' || $right === 'mixed') {
+            return true;
+        }
+
+        if (($left === 'bool' && \in_array($right, ['true', 'false'], true))
+            || ($right === 'bool' && \in_array($left, ['true', 'false'], true))
+        ) {
+            return true;
+        }
+
+        if ($this->isClassType($left) && $this->isClassType($right)) {
+            return $this->classTypesOverlap($left, $right);
+        }
+
+        if (($left === 'object' && $this->isClassType($right))
+            || ($right === 'object' && $this->isClassType($left))
+        ) {
+            return true;
+        }
+
+        if ($left === 'callable' && $this->isClassType($right)) {
+            return $this->classCanBeCallable($right);
+        }
+
+        if ($right === 'callable' && $this->isClassType($left)) {
+            return $this->classCanBeCallable($left);
+        }
+
+        if ($left === 'iterable' && $this->isClassType($right)) {
+            return $this->classCanBeIterable($right);
+        }
+
+        if ($right === 'iterable' && $this->isClassType($left)) {
+            return $this->classCanBeIterable($left);
+        }
+
+        $pair = [$left, $right];
+
+        return (\in_array('callable', $pair, true)
+                && \array_any(['string', 'array', 'object', 'iterable'], static fn(string $type): bool => \in_array($type, $pair, true)))
+            || (\in_array('iterable', $pair, true)
+                && \array_any(['array', 'object', 'callable'], static fn(string $type): bool => \in_array($type, $pair, true)));
+    }
+
+    private function isClassType(string $type): bool
+    {
+        return !\in_array($type, [
+            'mixed',
+            'null',
+            'true',
+            'false',
+            'bool',
+            'int',
+            'float',
+            'string',
+            'array',
+            'object',
+            'callable',
+            'iterable',
+        ], true);
+    }
+
+    private function classTypesOverlap(string $left, string $right): bool
+    {
+        $leftReflection = $this->classReflection($left);
+        $rightReflection = $this->classReflection($right);
+
+        if (!$leftReflection instanceof \ReflectionClass || !$rightReflection instanceof \ReflectionClass) {
+            return true;
+        }
+
+        if ($leftReflection->isSubclassOf($right) || $rightReflection->isSubclassOf($left)) {
+            return true;
+        }
+
+        if ($leftReflection->isInterface() && $rightReflection->isInterface()) {
+            return true;
+        }
+
+        if ($leftReflection->isInterface()) {
+            return !$rightReflection->isFinal();
+        }
+
+        if ($rightReflection->isInterface()) {
+            return !$leftReflection->isFinal();
+        }
+
+        return false;
+    }
+
+    private function classCanBeCallable(string $type): bool
+    {
+        $reflection = $this->classReflection($type);
+
+        if (!$reflection instanceof \ReflectionClass || $reflection->isInterface()) {
+            return true;
+        }
+
+        return $reflection->hasMethod('__invoke') || !$reflection->isFinal();
+    }
+
+    private function classCanBeIterable(string $type): bool
+    {
+        $reflection = $this->classReflection($type);
+
+        if (!$reflection instanceof \ReflectionClass || $reflection->isInterface()) {
+            return true;
+        }
+
+        return $reflection->isSubclassOf(\Traversable::class) || !$reflection->isFinal();
+    }
+
+    /** @return \ReflectionClass<object>|null */
+    private function classReflection(string $type): ?\ReflectionClass
+    {
+        if (!\class_exists($type) && !\interface_exists($type) && !\enum_exists($type)) {
+            return null;
+        }
+
+        return new \ReflectionClass($type);
+    }
+}

--- a/src/Doubles/ArgumentType.php
+++ b/src/Doubles/ArgumentType.php
@@ -193,7 +193,7 @@ final readonly class ArgumentType
         }
 
         if ($name === 'self' || $name === 'static') {
-            return !$context instanceof \ReflectionClass ? $name : $context->name;
+            return $context instanceof \ReflectionClass ? $context->name : $name;
         }
 
         if ($name !== 'parent') {

--- a/src/Doubles/IntersectionTypeMatcher.php
+++ b/src/Doubles/IntersectionTypeMatcher.php
@@ -5,10 +5,15 @@ declare(strict_types=1);
 namespace Greenlight\Doubles;
 
 /** @internal */
-final readonly class IntersectionTypeMatcher implements ArgumentMatcher
+final readonly class IntersectionTypeMatcher implements TypedArgumentMatcher
 {
+    private ?ArgumentType $argumentType;
+
     /** @param non-empty-list<string> $types */
-    public function __construct(private array $types) {}
+    public function __construct(private array $types)
+    {
+        $this->argumentType = ArgumentType::fromIntersectionTypeNames($types);
+    }
 
     public function matches(mixed $value): bool
     {
@@ -21,5 +26,10 @@ final readonly class IntersectionTypeMatcher implements ArgumentMatcher
     public function describe(): string
     {
         return 'intersection(' . \implode(', ', $this->types) . ')';
+    }
+
+    public function argumentType(): ?ArgumentType
+    {
+        return $this->argumentType;
     }
 }

--- a/src/Doubles/InvalidDoubleUsage.php
+++ b/src/Doubles/InvalidDoubleUsage.php
@@ -237,6 +237,30 @@ final class InvalidDoubleUsage extends \LogicException
     /**
      * @param class-string $type
      */
+    public static function incompatiblePlannedArgumentMatcher(
+        string $selector,
+        string $type,
+        string $method,
+        int $position,
+        string $matcherType,
+        string $parameter,
+        string $parameterType,
+    ): self {
+        return new self(\sprintf(
+            'The matcher in %s() argument %d accepts "%s", but parameter "$%s" of "%s::%s()" requires "%s".',
+            $selector,
+            $position,
+            $matcherType,
+            $parameter,
+            $type,
+            $method,
+            $parameterType,
+        ));
+    }
+
+    /**
+     * @param class-string $type
+     */
     public static function tooFewCallArguments(string $type, string $method, int $actual, int $required): self
     {
         return new self(\sprintf(

--- a/src/Doubles/MethodCallContract.php
+++ b/src/Doubles/MethodCallContract.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Doubles;
 
 /**
- * Defines the permitted argument count for one doubled method.
+ * Defines the permitted arguments for one doubled method.
  *
  * @internal
  *
@@ -17,12 +17,14 @@ final readonly class MethodCallContract
     /**
      * @param class-string<TTarget> $type
      * @param TMethod $requestedMethod
+     * @param list<\ReflectionParameter> $parameters
      */
     private function __construct(
         public string $type,
         public string $method,
         private int $requiredArguments,
         private ?int $maximumArguments,
+        private array $parameters,
         public string $requestedMethod,
     ) {}
 
@@ -56,6 +58,7 @@ final readonly class MethodCallContract
             $reflection->getName(),
             $reflection->getNumberOfRequiredParameters(),
             $reflection->isVariadic() ? null : $reflection->getNumberOfParameters(),
+            \array_values($reflection->getParameters()),
             $method,
         );
     }
@@ -82,6 +85,46 @@ final readonly class MethodCallContract
                 $this->requestedMethod,
                 $count,
                 $this->maximumArguments,
+            );
+        }
+    }
+
+    /**
+     * @param list<mixed> $arguments
+     * @throws InvalidDoubleUsage
+     */
+    public function assertPlannedArguments(string $selector, array $arguments): void
+    {
+        $this->assertPlannedArgumentCount($selector, \count($arguments));
+
+        foreach ($arguments as $position => $argument) {
+            if (!$argument instanceof TypedArgumentMatcher) {
+                continue;
+            }
+
+            $argumentType = $argument->argumentType();
+
+            $parameter = $this->parameters[\min($position, \count($this->parameters) - 1)];
+            $reflectionType = $parameter->getType();
+
+            if ($reflectionType === null) {
+                continue;
+            }
+
+            $parameterType = ArgumentType::fromReflection($reflectionType, $parameter->getDeclaringClass());
+
+            if ($argumentType?->overlaps($parameterType) !== false) {
+                continue;
+            }
+
+            throw InvalidDoubleUsage::incompatiblePlannedArgumentMatcher(
+                $selector,
+                $this->type,
+                $this->requestedMethod,
+                $position + 1,
+                $argumentType->describe(),
+                $parameter->getName(),
+                $parameterType->describe(),
             );
         }
     }

--- a/src/Doubles/MethodExpectation.php
+++ b/src/Doubles/MethodExpectation.php
@@ -90,7 +90,7 @@ final class MethodExpectation
      */
     private function withArguments(array $arguments, string $selector): self
     {
-        $this->contract->assertPlannedArgumentCount($selector, \count($arguments));
+        $this->contract->assertPlannedArguments($selector, $arguments);
         $this->arguments = $arguments;
 
         return $this;

--- a/src/Doubles/PredicateMatcher.php
+++ b/src/Doubles/PredicateMatcher.php
@@ -5,21 +5,42 @@ declare(strict_types=1);
 namespace Greenlight\Doubles;
 
 /** @internal */
-final readonly class PredicateMatcher implements ArgumentMatcher
+final readonly class PredicateMatcher implements TypedArgumentMatcher
 {
-    /** @param \Closure(mixed): mixed $predicate */
+    private ?ArgumentType $argumentType;
+
+    /**
+     * @param \Closure(mixed): mixed $predicate
+     * @throws InvalidDoubleUsage
+     */
     public function __construct(
         private \Closure $predicate,
         private string $description,
-    ) {}
+    ) {
+        $reflection = new \ReflectionFunction($predicate);
+        $parameter = $reflection->getParameters()[0] ?? null;
+        $type = $parameter?->getType();
+        $this->argumentType = $type === null
+            ? null
+            : ArgumentType::fromReflection($type, $reflection->getClosureScopeClass());
+    }
 
     public function matches(mixed $value): bool
     {
+        if ($this->argumentType?->accepts($value) === false) {
+            return false;
+        }
+
         return ($this->predicate)($value) === true;
     }
 
     public function describe(): string
     {
         return \sprintf('predicate(%s)', $this->description);
+    }
+
+    public function argumentType(): ?ArgumentType
+    {
+        return $this->argumentType;
     }
 }

--- a/src/Doubles/TypeMatcher.php
+++ b/src/Doubles/TypeMatcher.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Greenlight\Doubles;
 
 /** @internal */
-final readonly class TypeMatcher implements ArgumentMatcher
+final readonly class TypeMatcher implements TypedArgumentMatcher
 {
+    private ?ArgumentType $argumentType;
+
     /**
      * @throws InvalidDoubleUsage
      */
@@ -15,6 +17,8 @@ final readonly class TypeMatcher implements ArgumentMatcher
         if (\trim($type) === '') {
             throw InvalidDoubleUsage::invalidArgumentType();
         }
+
+        $this->argumentType = ArgumentType::fromTypeName($type);
     }
 
     public function matches(mixed $value): bool
@@ -25,6 +29,11 @@ final readonly class TypeMatcher implements ArgumentMatcher
     public function describe(): string
     {
         return \sprintf('type(%s)', $this->type);
+    }
+
+    public function argumentType(): ?ArgumentType
+    {
+        return $this->argumentType;
     }
 
     public static function matchesType(mixed $value, string $type): bool

--- a/src/Doubles/TypedArgumentMatcher.php
+++ b/src/Doubles/TypedArgumentMatcher.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Doubles;
+
+/**
+ * Supplies a known accepted type for argument-plan validation.
+ *
+ * @template-covariant TValue = mixed
+ * @extends ArgumentMatcher<TValue>
+ *
+ * @internal
+ */
+interface TypedArgumentMatcher extends ArgumentMatcher
+{
+    public function argumentType(): ?ArgumentType;
+}

--- a/src/Doubles/UnionTypeMatcher.php
+++ b/src/Doubles/UnionTypeMatcher.php
@@ -5,10 +5,15 @@ declare(strict_types=1);
 namespace Greenlight\Doubles;
 
 /** @internal */
-final readonly class UnionTypeMatcher implements ArgumentMatcher
+final readonly class UnionTypeMatcher implements TypedArgumentMatcher
 {
+    private ?ArgumentType $argumentType;
+
     /** @param non-empty-list<string> $types */
-    public function __construct(private array $types) {}
+    public function __construct(private array $types)
+    {
+        $this->argumentType = ArgumentType::fromUnionTypeNames($types);
+    }
 
     public function matches(mixed $value): bool
     {
@@ -21,5 +26,10 @@ final readonly class UnionTypeMatcher implements ArgumentMatcher
     public function describe(): string
     {
         return 'union(' . \implode(', ', $this->types) . ')';
+    }
+
+    public function argumentType(): ?ArgumentType
+    {
+        return $this->argumentType;
     }
 }

--- a/tests/Unit/Doubles/ArgumentMatchingTest.php
+++ b/tests/Unit/Doubles/ArgumentMatchingTest.php
@@ -197,6 +197,53 @@ final readonly class ArgumentMatchingTest
     }
 
     #[Test]
+    public function typedPredicateRejectsIncompatibleValuesBeforeTheClosureRuns(): void
+    {
+        $predicateCalled = false;
+        $matcher = Argument::predicate(static function (\DateTimeInterface|string $value) use (&$predicateCalled): bool {
+            $predicateCalled = true;
+
+            return $value !== '';
+        });
+
+        Expect::that($matcher->matches(1))
+            ->because('a typed predicate MUST reject an incompatible value')
+            ->toBeFalse();
+        Expect::that($predicateCalled)
+            ->because('a typed predicate MUST NOT receive an incompatible value')
+            ->toBeFalse();
+        Expect::that($matcher->matches('value'))
+            ->because('a typed predicate MUST receive a compatible value')
+            ->toBeTrue();
+        Expect::that($predicateCalled)->toBeTrue();
+    }
+
+    #[Test]
+    public function typedPredicateSupportsNullableUnionAndIntersectionTypes(): void
+    {
+        $matcher = Argument::predicate(
+            static fn((\IteratorAggregate&\Countable)|string|null $value): bool => true,
+        );
+
+        Expect::that($matcher->matches(new \ArrayObject()))->toBeTrue();
+        Expect::that($matcher->matches('value'))->toBeTrue();
+        Expect::that($matcher->matches(null))->toBeTrue();
+        Expect::that($matcher->matches(new \stdClass()))->toBeFalse();
+    }
+
+    #[Test]
+    public function typedPredicateDoesNotHideErrorsFromTheClosureBody(): void
+    {
+        $matcher = Argument::predicate(static function (\DateTimeInterface $value): bool {
+            throw new \TypeError('predicate body failed');
+        });
+
+        Expect::that(static fn(): bool => $matcher->matches(new \DateTimeImmutable()))
+            ->because('a typed predicate MUST preserve errors from its closure body')
+            ->toThrow(\TypeError::class, message: 'predicate body failed');
+    }
+
+    #[Test]
     public function equalsUsesDeepEquality(): void
     {
         $expected = ['a' => (object) ['values' => [1, 2]]];

--- a/tests/Unit/Doubles/ArgumentTypeTest.php
+++ b/tests/Unit/Doubles/ArgumentTypeTest.php
@@ -153,10 +153,8 @@ final class ArgumentTypeTest
     #[Test]
     public function parentTypeRequiresItsDeclaringClassContext(): void
     {
-        $reflection = new \ReflectionMethod(ArgumentTypeChild::class, 'parentType');
-        $type = $reflection->getParameters()[0]->getType();
+        $type = new ArgumentTypeParentNamedType();
 
-        Expect::that($type)->toBeInstanceOf(\ReflectionType::class);
         Expect::that(static fn(): ArgumentType => ArgumentType::fromReflection($type))
             ->toThrow(
                 InvalidDoubleUsage::class,
@@ -464,5 +462,28 @@ final class ArgumentTypeUnresolvedNamedType extends \ReflectionNamedType
     public function __toString(): string
     {
         return 'UnresolvedClass';
+    }
+}
+
+final class ArgumentTypeParentNamedType extends \ReflectionNamedType
+{
+    public function getName(): string
+    {
+        return 'parent';
+    }
+
+    public function isBuiltin(): bool
+    {
+        return false;
+    }
+
+    public function allowsNull(): bool
+    {
+        return false;
+    }
+
+    public function __toString(): string
+    {
+        return 'parent';
     }
 }

--- a/tests/Unit/Doubles/ArgumentTypeTest.php
+++ b/tests/Unit/Doubles/ArgumentTypeTest.php
@@ -1,0 +1,468 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\AllOf;
+use Greenlight\Doubles\Argument;
+use Greenlight\Doubles\ArgumentType;
+use Greenlight\Doubles\IntersectionTypeMatcher;
+use Greenlight\Doubles\InvalidDoubleUsage;
+use Greenlight\Doubles\UnionTypeMatcher;
+use Greenlight\Expect\Expect;
+
+final class ArgumentTypeTest
+{
+    #[Test]
+    #[DataSet('nativeTypes')]
+    public function reflectedTypesAcceptTheirNativeValues(
+        string $method,
+        mixed $accepted,
+        mixed $rejected,
+        bool $mustReject,
+    ): void {
+        $type = $this->parameterType($method);
+
+        Expect::that($type->accepts($accepted))
+            ->because($method . ' MUST accept its compatible value')
+            ->toBeTrue();
+
+        if ($mustReject) {
+            Expect::that($type->accepts($rejected))
+                ->because($method . ' MUST reject its incompatible value')
+                ->toBeFalse();
+        }
+    }
+
+    /** @return iterable<string, array{string, mixed, mixed, bool}> */
+    public static function nativeTypes(): iterable
+    {
+        yield 'mixed' => ['mixedType', 1, null, false];
+        yield 'null' => ['nullType', null, false, true];
+        yield 'true' => ['trueType', true, false, true];
+        yield 'false' => ['falseType', false, true, true];
+        yield 'bool' => ['boolType', true, 1, true];
+        yield 'int' => ['intType', 1, 1.0, true];
+        yield 'float' => ['floatType', 1.0, 1, true];
+        yield 'string' => ['stringType', 'value', 1, true];
+        yield 'array' => ['arrayType', [], new \stdClass(), true];
+        yield 'object' => ['objectType', new \stdClass(), [], true];
+        yield 'callable' => ['callableType', static fn(): null => null, 1, true];
+        yield 'iterable' => ['iterableType', [], 1, true];
+        yield 'class' => ['classType', new \DateTimeImmutable(), new \stdClass(), true];
+        yield 'enum' => ['enumType', ArgumentTypeEnum::Value, 'value', true];
+    }
+
+    #[Test]
+    public function reflectedTypesPreserveNullableUnionIntersectionAndRelativeTypes(): void
+    {
+        $nullable = $this->parameterType('nullableType');
+        $combined = $this->parameterType('combinedType');
+        $self = $this->parameterType('selfType');
+        $parent = $this->parameterType('parentType', ArgumentTypeChild::class);
+        $static = $this->returnType('staticType', ArgumentTypeChild::class);
+
+        Expect::that($nullable->accepts(null))->toBeTrue();
+        Expect::that($nullable->describe())->toBe('string|null');
+        Expect::that($combined->accepts(new \ArrayObject()))->toBeTrue();
+        Expect::that($combined->accepts('value'))->toBeTrue();
+        Expect::that($combined->accepts(null))->toBeTrue();
+        Expect::that($combined->accepts(new \stdClass()))->toBeFalse();
+        Expect::that($combined->describe())->toBe('(IteratorAggregate&Countable)|string|null');
+        Expect::that($self->accepts(new ArgumentTypeFixture()))->toBeTrue();
+        Expect::that($self->describe())->toBe(ArgumentTypeFixture::class);
+        Expect::that($parent->accepts(new ArgumentTypeParent()))->toBeTrue();
+        Expect::that($parent->describe())->toBe(ArgumentTypeParent::class);
+        Expect::that($static->describe())->toBe(ArgumentTypeChild::class);
+    }
+
+    #[Test]
+    public function namedTypeFactoriesKeepOnlySoundKnownBounds(): void
+    {
+        Expect::that(ArgumentType::fromTypeName('\\' . \DateTimeInterface::class)?->describe())
+            ->toBe(\DateTimeInterface::class);
+        Expect::that(ArgumentType::fromTypeName(ArgumentTypeEnum::class)?->describe())
+            ->toBe(ArgumentTypeEnum::class);
+        Expect::that(ArgumentType::fromTypeName('unknown type'))->toBeNull();
+        Expect::that(ArgumentType::fromIntersectionTypeNames(['unknown type']))->toBeNull();
+        Expect::that(ArgumentType::fromIntersectionTypeNames(['int', 'unknown type'])?->describe())
+            ->toBe('int');
+        Expect::that(ArgumentType::fromUnionTypeNames(['int', 'unknown type']))->toBeNull();
+        Expect::that(ArgumentType::fromUnionTypeNames(['int', 'string'])?->describe())
+            ->toBe('int|string');
+    }
+
+    #[Test]
+    #[DataSet('typeOverlaps')]
+    public function overlapDetectsPossibleSharedValues(string $left, string $right, bool $expected): void
+    {
+        Expect::that($this->parameterType($left)->overlaps($this->parameterType($right)))
+            ->because($left . ' and ' . $right . ' MUST have the specified overlap')
+            ->toBe($expected);
+    }
+
+    /** @return iterable<string, array{string, string, bool}> */
+    public static function typeOverlaps(): iterable
+    {
+        yield 'same type' => ['intType', 'intType', true];
+        yield 'mixed and scalar' => ['mixedType', 'intType', true];
+        yield 'bool and true' => ['boolType', 'trueType', true];
+        yield 'class hierarchy' => ['childClassType', 'parentClassType', true];
+        yield 'implemented interface' => ['implementerType', 'firstInterfaceType', true];
+        yield 'two interfaces' => ['firstInterfaceType', 'secondInterfaceType', true];
+        yield 'interface and open class' => ['firstInterfaceType', 'openClassType', true];
+        yield 'open class and interface' => ['openClassType', 'firstInterfaceType', true];
+        yield 'interface and closed class' => ['firstInterfaceType', 'closedClassType', false];
+        yield 'closed class and interface' => ['closedClassType', 'firstInterfaceType', false];
+        yield 'unrelated classes' => ['openClassType', 'parentClassType', false];
+        yield 'object and class' => ['objectType', 'closedClassType', true];
+        yield 'class and object' => ['closedClassType', 'objectType', true];
+        yield 'callable and invokable class' => ['callableType', 'invokableType', true];
+        yield 'invokable class and callable' => ['invokableType', 'callableType', true];
+        yield 'callable and open class' => ['callableType', 'openClassType', true];
+        yield 'callable and closed class' => ['callableType', 'closedClassType', false];
+        yield 'iterable and iterable class' => ['iterableType', 'iterableClassType', true];
+        yield 'iterable class and iterable' => ['iterableClassType', 'iterableType', true];
+        yield 'iterable and open class' => ['iterableType', 'openClassType', true];
+        yield 'iterable and closed class' => ['iterableType', 'closedClassType', false];
+        yield 'callable and string' => ['callableType', 'stringType', true];
+        yield 'iterable and array' => ['iterableType', 'arrayType', true];
+        yield 'callable and iterable' => ['callableType', 'iterableType', true];
+        yield 'disjoint scalars' => ['intType', 'stringType', false];
+    }
+
+    #[Test]
+    public function matcherCompositionsExposeTheirKnownAcceptedTypes(): void
+    {
+        $untyped = new AllOf([Argument::any(), Argument::any()]);
+        $intersection = new IntersectionTypeMatcher(['int', 'unknown type']);
+        $unknownIntersection = new IntersectionTypeMatcher(['first unknown', 'second unknown']);
+        $union = new UnionTypeMatcher(['int', 'string']);
+        $unknownUnion = new UnionTypeMatcher(['int', 'unknown type']);
+
+        Expect::that($untyped->argumentType())->toBeNull();
+        Expect::that($intersection->argumentType()?->describe())->toBe('int');
+        Expect::that($unknownIntersection->argumentType())->toBeNull();
+        Expect::that($union->argumentType()?->describe())->toBe('int|string');
+        Expect::that($unknownUnion->argumentType())->toBeNull();
+    }
+
+    #[Test]
+    public function parentTypeRequiresItsDeclaringClassContext(): void
+    {
+        $reflection = new \ReflectionMethod(ArgumentTypeChild::class, 'parentType');
+        $type = $reflection->getParameters()[0]->getType();
+
+        Expect::that($type)->toBeInstanceOf(\ReflectionType::class);
+        Expect::that(static fn(): ArgumentType => ArgumentType::fromReflection($type))
+            ->toThrow(
+                InvalidDoubleUsage::class,
+                message: 'Closure uses the parent type but has no parent class.',
+            );
+        Expect::that(static fn(): ArgumentType => ArgumentType::fromReflection(
+            $type,
+            self::reflectionClass(\stdClass::class),
+        ))->toThrow(
+            InvalidDoubleUsage::class,
+            message: 'stdClass uses the parent type but has no parent class.',
+        );
+    }
+
+    #[Test]
+    public function unsupportedReflectionTypesAreRejected(): void
+    {
+        Expect::that(static fn(): ArgumentType => ArgumentType::fromReflection(
+            new ArgumentTypeUnsupportedReflectionType(),
+        ))->toThrow(
+            InvalidDoubleUsage::class,
+            message: 'Unsupported reflection type ' . ArgumentTypeUnsupportedReflectionType::class . '.',
+        );
+        Expect::that(static fn(): ArgumentType => ArgumentType::fromReflection(
+            new ArgumentTypeEmptyNamedType(),
+        ))->toThrow(
+            InvalidDoubleUsage::class,
+            message: 'Unsupported reflection type ' . ArgumentTypeEmptyNamedType::class . '.',
+        );
+    }
+
+    #[Test]
+    public function unresolvedClassTypesRemainConservative(): void
+    {
+        $unresolved = ArgumentType::fromReflection(new ArgumentTypeUnresolvedNamedType());
+
+        Expect::that($unresolved->overlaps($this->parameterType('closedClassType')))->toBeTrue();
+        Expect::that($this->parameterType('callableType')->overlaps($unresolved))->toBeTrue();
+        Expect::that($this->parameterType('iterableType')->overlaps($unresolved))->toBeTrue();
+    }
+
+    /**
+     * @param class-string $class
+     * @throws InvalidDoubleUsage
+     */
+    private function parameterType(string $method, string $class = ArgumentTypeFixture::class): ArgumentType
+    {
+        $reflection = new \ReflectionMethod($class, $method);
+        $type = $reflection->getParameters()[0]->getType();
+
+        if (!$type instanceof \ReflectionType) {
+            throw new \LogicException('The test type parameter must have a type.');
+        }
+
+        return ArgumentType::fromReflection($type, $reflection->getDeclaringClass());
+    }
+
+    /**
+     * @param class-string $class
+     * @throws InvalidDoubleUsage
+     */
+    private function returnType(string $method, string $class): ArgumentType
+    {
+        $reflection = new \ReflectionMethod($class, $method);
+        $type = $reflection->getReturnType();
+
+        if (!$type instanceof \ReflectionType) {
+            throw new \LogicException('The test method must have a return type.');
+        }
+
+        return ArgumentType::fromReflection($type, $reflection->getDeclaringClass());
+    }
+
+    /**
+     * @param class-string<object> $class
+     * @return \ReflectionClass<object>
+     */
+    private static function reflectionClass(string $class): \ReflectionClass
+    {
+        return new \ReflectionClass($class);
+    }
+}
+
+final class ArgumentTypeFixture
+{
+    public static function mixedType(mixed $value): void
+    {
+        unset($value);
+    }
+
+    public static function nullType(null $value): void
+    {
+        unset($value);
+    }
+
+    public static function trueType(true $value): void
+    {
+        unset($value);
+    }
+
+    public static function falseType(false $value): void
+    {
+        unset($value);
+    }
+
+    public static function boolType(bool $value): void
+    {
+        unset($value);
+    }
+
+    public static function intType(int $value): void
+    {
+        unset($value);
+    }
+
+    public static function floatType(float $value): void
+    {
+        unset($value);
+    }
+
+    public static function stringType(string $value): void
+    {
+        unset($value);
+    }
+
+    /** @param array<array-key, mixed> $value */
+    public static function arrayType(array $value): void
+    {
+        unset($value);
+    }
+
+    public static function objectType(object $value): void
+    {
+        unset($value);
+    }
+
+    /** @param callable(): mixed $value */
+    public static function callableType(callable $value): void
+    {
+        unset($value);
+    }
+
+    /** @param iterable<mixed, mixed> $value */
+    public static function iterableType(iterable $value): void
+    {
+        unset($value);
+    }
+
+    public static function classType(\DateTimeInterface $value): void
+    {
+        unset($value);
+    }
+
+    public static function enumType(ArgumentTypeEnum $value): void
+    {
+        unset($value);
+    }
+
+    public static function nullableType(?string $value): void
+    {
+        unset($value);
+    }
+
+    /** @param (\IteratorAggregate<mixed, mixed>&\Countable)|string|null $value */
+    public static function combinedType((\IteratorAggregate&\Countable)|string|null $value): void
+    {
+        unset($value);
+    }
+
+    public static function selfType(self $value): void
+    {
+        unset($value);
+    }
+
+    public static function firstInterfaceType(ArgumentTypeFirstInterface $value): void
+    {
+        unset($value);
+    }
+
+    public static function secondInterfaceType(ArgumentTypeSecondInterface $value): void
+    {
+        unset($value);
+    }
+
+    public static function openClassType(ArgumentTypeOpenClass $value): void
+    {
+        unset($value);
+    }
+
+    public static function closedClassType(ArgumentTypeClosedClass $value): void
+    {
+        unset($value);
+    }
+
+    public static function parentClassType(ArgumentTypeParent $value): void
+    {
+        unset($value);
+    }
+
+    public static function childClassType(ArgumentTypeChild $value): void
+    {
+        unset($value);
+    }
+
+    public static function implementerType(ArgumentTypeImplementer $value): void
+    {
+        unset($value);
+    }
+
+    public static function invokableType(ArgumentTypeInvokable $value): void
+    {
+        unset($value);
+    }
+
+    public static function iterableClassType(ArgumentTypeIterable $value): void
+    {
+        unset($value);
+    }
+}
+
+interface ArgumentTypeFirstInterface {}
+
+interface ArgumentTypeSecondInterface {}
+
+class ArgumentTypeOpenClass {}
+
+final class ArgumentTypeClosedClass {}
+
+class ArgumentTypeParent {}
+
+final class ArgumentTypeChild extends ArgumentTypeParent
+{
+    public static function parentType(parent $value): void {}
+
+    public static function staticType(): static
+    {
+        return new self();
+    }
+}
+
+final class ArgumentTypeImplementer implements ArgumentTypeFirstInterface {}
+
+final class ArgumentTypeInvokable
+{
+    public function __invoke(): void {}
+}
+
+/** @implements \IteratorAggregate<never, never> */
+final class ArgumentTypeIterable implements \IteratorAggregate
+{
+    /** @return \Traversable<never, never> */
+    public function getIterator(): \Traversable
+    {
+        yield from [];
+    }
+}
+
+enum ArgumentTypeEnum
+{
+    case Value;
+}
+
+final class ArgumentTypeUnsupportedReflectionType extends \ReflectionType {}
+
+final class ArgumentTypeEmptyNamedType extends \ReflectionNamedType
+{
+    public function getName(): string
+    {
+        return '';
+    }
+
+    public function isBuiltin(): bool
+    {
+        return false;
+    }
+
+    public function allowsNull(): bool
+    {
+        return false;
+    }
+
+    public function __toString(): string
+    {
+        return '';
+    }
+}
+
+final class ArgumentTypeUnresolvedNamedType extends \ReflectionNamedType
+{
+    public function getName(): string
+    {
+        return 'UnresolvedClass';
+    }
+
+    public function isBuiltin(): bool
+    {
+        return false;
+    }
+
+    public function allowsNull(): bool
+    {
+        return false;
+    }
+
+    public function __toString(): string
+    {
+        return 'UnresolvedClass';
+    }
+}

--- a/tests/Unit/Doubles/MethodArgumentContractTest.php
+++ b/tests/Unit/Doubles/MethodArgumentContractTest.php
@@ -64,6 +64,14 @@ final readonly class MethodArgumentContractTest
     }
 
     #[Test]
+    public function typedMatcherCanTargetAnUntypedMethodParameter(): void
+    {
+        $this->doubles->mock(PredicateTarget::class, static function (MockPlan $plan): void {
+            $plan->expects('acceptUntyped')->with(Argument::type('int'))->never();
+        });
+    }
+
+    #[Test]
     public function aDoubleRejectsArgumentsThatTheMethodDoesNotDeclare(): void
     {
         $wide = $this->doubles->mock(Wide::class, static function (MockPlan $plan): void {
@@ -111,6 +119,9 @@ final readonly class MethodArgumentContractTest
 interface PredicateTarget
 {
     public function accept(PredicateBar $value): void;
+
+    /** @param mixed $value */
+    public function acceptUntyped($value): void;
 }
 
 class PredicateBar {}

--- a/tests/Unit/Doubles/MethodArgumentContractTest.php
+++ b/tests/Unit/Doubles/MethodArgumentContractTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tests\Unit\Doubles;
 
 use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Argument;
 use Greenlight\Doubles\Doubles;
 use Greenlight\Doubles\InvalidDoubleUsage;
 use Greenlight\Doubles\MethodCallContract;
@@ -32,6 +33,34 @@ final readonly class MethodArgumentContractTest
             InvalidDoubleUsage::class,
             '/with\(\) supplies 1 argument .* but the method accepts at most 0 arguments/',
         );
+    }
+
+    #[Test]
+    public function plannedPredicateTypeMustOverlapTheMethodParameterType(): void
+    {
+        Expect::that(fn(): PredicateTarget => $this->doubles->mock(
+            PredicateTarget::class,
+            static function (MockPlan $plan): void {
+                $plan->expects(self::predicateMethod())->with(Argument::predicate(
+                    static fn(PredicateBaz $value): bool => true,
+                    'a baz',
+                ));
+            },
+        ))->toThrow(
+            InvalidDoubleUsage::class,
+            '/matcher in with\(\) argument 1 accepts .*PredicateBaz.*parameter "\$value".*requires .*PredicateBar/',
+        );
+    }
+
+    #[Test]
+    public function plannedPredicateCanNarrowTheMethodParameterType(): void
+    {
+        $this->doubles->mock(PredicateTarget::class, static function (MockPlan $plan): void {
+            $plan->expects('accept')->with(Argument::predicate(
+                static fn(PredicateBarChild $value): bool => true,
+                'a bar child',
+            ))->never();
+        });
     }
 
     #[Test]
@@ -71,4 +100,21 @@ final readonly class MethodArgumentContractTest
     {
         return 'returnsVoid';
     }
+
+    /** @return non-empty-string */
+    private static function predicateMethod(): string
+    {
+        return 'accept';
+    }
 }
+
+interface PredicateTarget
+{
+    public function accept(PredicateBar $value): void;
+}
+
+class PredicateBar {}
+
+final class PredicateBarChild extends PredicateBar {}
+
+final class PredicateBaz {}


### PR DESCRIPTION
## Summary

- infer accepted types from predicate closure parameters and reject incompatible values before invocation
- reject mock plans when a typed matcher cannot overlap the doubled method parameter
- document typed predicates as the replacement for redundant type and predicate composition