### PR TITLE
docs: normalize multiline type PHPDoc

### DIFF
--- a/src/Cli/Configuration/CoverageOverrides.php
+++ b/src/Cli/Configuration/CoverageOverrides.php
@@ -8,7 +8,8 @@ use Greenlight\Cli\Input\CliError;
 use Greenlight\Cli\Input\ParsedArguments;
 use Greenlight\Internal\Text\DecimalInteger;
 
-/** Contains validated command-line coverage overrides.
+/**
+ * Contains validated command-line coverage overrides.
  *
  * @internal
  */

--- a/src/Cli/Coverage/CoverageGate.php
+++ b/src/Cli/Coverage/CoverageGate.php
@@ -7,7 +7,8 @@ namespace Greenlight\Cli\Coverage;
 use Greenlight\Config\CoverageConfiguration;
 use Greenlight\Coverage\CoverageMap;
 
-/** Evaluates total coverage against the configured CI limits.
+/**
+ * Evaluates total coverage against the configured CI limits.
  *
  * @internal
  */

--- a/src/Cli/Coverage/CoverageSettingsResolver.php
+++ b/src/Cli/Coverage/CoverageSettingsResolver.php
@@ -8,7 +8,8 @@ use Greenlight\Config\CoverageConfiguration;
 use Greenlight\Coverage\Collection\CoverageSettings;
 use Greenlight\Internal\Php\ErrorTrap;
 
-/** Resolves CLI coverage configuration into runner settings.
+/**
+ * Resolves CLI coverage configuration into runner settings.
  *
  * @internal
  */

--- a/src/Coverage/Diff/ProjectRootNormalizer.php
+++ b/src/Coverage/Diff/ProjectRootNormalizer.php
@@ -7,7 +7,8 @@ namespace Greenlight\Coverage\Diff;
 use Greenlight\Coverage\CoverageMap;
 use Greenlight\Coverage\FileCoverage;
 
-/** Normalizes absolute coverage paths against explicit project roots.
+/**
+ * Normalizes absolute coverage paths against explicit project roots.
  *
  * @internal
  */


### PR DESCRIPTION
## Summary

- Put each affected multiline PHPDoc opening delimiter on a separate line.
- Preserve the existing type summaries and internal annotations.