### PR TITLE
fix(config): reject negative run order seeds

### DIFF
--- a/docs/api-configuration.md
+++ b/docs/api-configuration.md
@@ -244,7 +244,7 @@ final class GreenlightConfig
 public static function create(): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L80)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L81)
 
 ### `paths()`
 
@@ -260,7 +260,7 @@ PHPDoc:
 - `@param non-empty-list<non-empty-string> $tests`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L93)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L94)
 
 ### `suite()`
 
@@ -281,7 +281,7 @@ PHPDoc:
 - `@param callable(SuiteBuilder): mixed $configurator`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L151)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L152)
 
 ### `workers()`
 
@@ -296,7 +296,7 @@ PHPDoc:
 - `@param positive-int|'auto' $count`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L175)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L176)
 
 ### `resourceLimit()`
 
@@ -315,7 +315,7 @@ PHPDoc:
 - `@param positive-int $limit`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L193)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L194)
 
 ### `coverage()`
 
@@ -327,7 +327,7 @@ PHPDoc:
 
 - `@param callable(CoverageBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L221)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L222)
 
 ### `watch()`
 
@@ -339,7 +339,7 @@ PHPDoc:
 
 - `@param callable(WatchBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L234)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L235)
 
 ### `artifacts()`
 
@@ -351,7 +351,7 @@ PHPDoc:
 
 - `@param callable(ArtifactBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L246)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L247)
 
 ### `storage()`
 
@@ -366,7 +366,7 @@ PHPDoc:
 
 - `@param callable(StorageBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L261)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L262)
 
 ### `failOnDeprecation()`
 
@@ -382,7 +382,7 @@ PHPDoc:
 
 - `@see self::ignoreDeprecationsMatching()`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L277)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L278)
 
 ### `failOnNotice()`
 
@@ -392,7 +392,7 @@ Fails an otherwise passed test if captured output contains a notice.
 public function failOnNotice(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L285)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L286)
 
 ### `failOnWarning()`
 
@@ -402,7 +402,7 @@ Fails an otherwise passed test if captured output contains a warning.
 public function failOnWarning(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L293)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L294)
 
 ### `failOnRisky()`
 
@@ -414,7 +414,7 @@ expectations.
 public function failOnRisky(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L305)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L306)
 
 ### `failOnSkipped()`
 
@@ -425,7 +425,7 @@ keeps its skipped outcome and reason.
 public function failOnSkipped(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L316)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L317)
 
 ### `failOnRetriedPass()`
 
@@ -436,7 +436,7 @@ outcome and attempt count.
 public function failOnRetriedPass(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L327)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L328)
 
 ### `ignoreDeprecationsMatching()`
 
@@ -453,7 +453,7 @@ PHPDoc:
 - `@param non-empty-string ...$patterns`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L343)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L344)
 
 ### `plugins()`
 
@@ -466,7 +466,7 @@ PHPDoc:
 - `@param \Closure(): Plugin ...$plugins`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L364)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L365)
 
 ### `failFast()`
 
@@ -474,7 +474,7 @@ PHPDoc:
 public function failFast(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L381)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L382)
 
 ### `randomizeOrder()`
 
@@ -484,7 +484,12 @@ If the seed is null, Greenlight selects and prints a seed when it resolves the c
 public function randomizeOrder(?int $seed = null): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L389)
+PHPDoc:
+
+- `@param int<0, max>|null $seed`
+- `@throws InvalidConfiguration`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L395)
 
 ## `InvalidConfiguration`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -525,6 +525,8 @@ Default: declared order, no seed.
 
 Randomizes class order.
 
+The seed MUST be a nonnegative integer. Zero is a valid seed.
+
 If `$seed` is `null`, Greenlight selects one seed when it resolves the command.
 Discovery and execution use this seed. Greenlight prints the seed. Use `--seed`
 with that value to reproduce the same order.

--- a/src/Config/GreenlightConfig.php
+++ b/src/Config/GreenlightConfig.php
@@ -61,6 +61,7 @@ final class GreenlightConfig
 
     private bool $randomizeOrder = false;
 
+    /** @var int<0, max>|null */
     private ?int $randomSeed = null;
 
     /**
@@ -385,9 +386,21 @@ final class GreenlightConfig
         return $this;
     }
 
-    /** If the seed is null, Greenlight selects and prints a seed when it resolves the command. */
+    /**
+     * If the seed is null, Greenlight selects and prints a seed when it resolves the command.
+     *
+     * @param int<0, max>|null $seed
+     * @throws InvalidConfiguration
+     */
     public function randomizeOrder(?int $seed = null): self
     {
+        if ($seed !== null && $seed < 0) {
+            throw new InvalidConfiguration(\sprintf(
+                'Random order seed must be a nonnegative integer. Actual value: %d.',
+                $seed,
+            ));
+        }
+
         $this->randomizeOrder = true;
         $this->randomSeed = $seed;
 

--- a/src/Config/OrderConfiguration.php
+++ b/src/Config/OrderConfiguration.php
@@ -11,6 +11,7 @@ namespace Greenlight\Config;
  */
 final readonly class OrderConfiguration
 {
+    /** @param int<0, max>|null $seed */
     public function __construct(
         public bool $randomized = false,
         public ?int $seed = null,

--- a/src/Config/RunOrder.php
+++ b/src/Config/RunOrder.php
@@ -11,9 +11,13 @@ namespace Greenlight\Config;
  */
 final readonly class RunOrder
 {
-    /** @param int|null $seed A null value keeps declared order. */
+    /** @param int<0, max>|null $seed A null value keeps declared order. */
     public function __construct(public ?int $seed = null) {}
 
+    /**
+     * @phpstan-assert-if-true int<0, max> $this->seed
+     * @phpstan-assert-if-false null $this->seed
+     */
     public function isRandomized(): bool
     {
         return $this->seed !== null;

--- a/tests/Acceptance/PhpStanConfigurationBuilderTypeTest.php
+++ b/tests/Acceptance/PhpStanConfigurationBuilderTypeTest.php
@@ -39,6 +39,7 @@ final readonly class PhpStanConfigurationBuilderTypeTest
                     ->suite('unit', static fn(SuiteBuilder $suite) => $suite->in('tests')->tag('fast'))
                     ->workers(count: 2)
                     ->resourceLimit('database', 1)
+                    ->randomizeOrder(seed: 0)
                     ->ignoreDeprecationsMatching('vendor *')
                     ->coverage(static fn(CoverageBuilder $coverage) => $coverage
                         ->include('src')
@@ -79,6 +80,7 @@ final readonly class PhpStanConfigurationBuilderTypeTest
                 GreenlightConfig::create()->workers(count: 0);
                 GreenlightConfig::create()->resourceLimit('', 1);
                 GreenlightConfig::create()->resourceLimit('database', 0);
+                GreenlightConfig::create()->randomizeOrder(seed: -1);
                 GreenlightConfig::create()->ignoreDeprecationsMatching('');
 
                 new SuiteBuilder('unit')->in('')->tag('');
@@ -106,8 +108,9 @@ final readonly class PhpStanConfigurationBuilderTypeTest
             ->because('PHPStan rejects configuration values that cannot pass runtime validation')
             ->toBe(1);
         Expect::that($probe->goodPassed)->toBeTrue();
-        Expect::that(\count($probe->errors))->toBe(24);
+        Expect::that(\count($probe->errors))->toBe(25);
         Expect::that($probe->messages())->toContain('Greenlight\Config\GreenlightConfig::workers() expects');
+        Expect::that($probe->messages())->toContain('Greenlight\Config\GreenlightConfig::randomizeOrder() expects');
         Expect::that($probe->messages())->toContain('Greenlight\Config\ArtifactBuilder::maxRunAttachments() expects');
         Expect::that($probe->messages())->toContain('Greenlight\Config\StorageBuilder::temporaryDirectory() expects');
     }

--- a/tests/Unit/Config/GreenlightConfigTest.php
+++ b/tests/Unit/Config/GreenlightConfigTest.php
@@ -130,6 +130,36 @@ final class GreenlightConfigTest
     }
 
     #[Test]
+    public function zeroIsAValidConfiguredSeed(): void
+    {
+        $configuration = GreenlightConfig::create()->randomizeOrder(seed: 0)->build();
+
+        Expect::that($configuration->order->randomized)
+            ->because('zero MUST enable random order')
+            ->toBeTrue();
+        Expect::that($configuration->order->seed)
+            ->because('zero MUST remain the configured seed')
+            ->toBe(0);
+    }
+
+    #[Test]
+    public function aNegativeSeedDoesNotPartiallyChangeTheBuilder(): void
+    {
+        $builder = GreenlightConfig::create()->randomizeOrder(seed: 7);
+
+        Expect::that(static fn(): GreenlightConfig => $builder->randomizeOrder(seed: -1)) // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
+            ->because('a negative seed MUST be rejected')
+            ->toThrow(
+                InvalidConfiguration::class,
+                message: 'Random order seed must be a nonnegative integer. Actual value: -1.',
+            );
+
+        Expect::that($builder->build()->order->seed)
+            ->because('a rejected seed MUST retain the prior seed')
+            ->toBe(7);
+    }
+
+    #[Test]
     public function rejectedWorkerConfigurationsDoNotPartiallyChangeTheBuilder(): void
     {
         $builder = GreenlightConfig::create()->workers(count: 2);


### PR DESCRIPTION
## What

Reject negative run-order seeds in the PHP configuration API. Keep zero as a valid, active seed.

Constrain configured and resolved seed types to the PHPStan integer range from zero through the platform maximum. The resolved seed also narrows to that range after the random-order predicate returns true, and to null when it returns false.

Document the seed range and cover zero, negative values, PHPStan validation, and unchanged builder state after rejection.

## Why

The command-line interface already accepts zero and rejects negative seeds. The PHP configuration API and PHPStan types allowed negative integers, which gave the two configuration entry points different contracts. They now use the same nonnegative seed contract.