### PR TITLE
refactor(cli): name command exit codes

### DIFF
--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Cli;
 
 use Greenlight\Cli\Output\Console;
+use Greenlight\Cli\Output\ExitCode;
 use Greenlight\Cli\Plugin\CommandDispatcher;
 use Greenlight\Coverage\CoverageError;
 use Greenlight\Coverage\Relay\SubprocessCoverage;
@@ -23,8 +24,6 @@ use Greenlight\Reporting\StreamOutput;
 final readonly class Application
 {
     public const string VERSION = '0.0.0'; // x-release-please-version
-
-    private const int EXIT_USAGE = 64;
 
     private function __construct(private Console $console) {}
 
@@ -67,7 +66,7 @@ final readonly class Application
             if (\count($argv) !== 4 || $argv[1] === '' || $argv[2] === '' || $argv[3] === '') {
                 $this->console->err("__worker requires <address> <workerId> <token>.\n");
 
-                return self::EXIT_USAGE;
+                return ExitCode::USAGE;
             }
 
             return new WorkerProcess(isolateProcessGroup: true)->run($argv[1], $argv[2], $argv[3]);

--- a/src/Cli/Command/CompletionCommand.php
+++ b/src/Cli/Command/CompletionCommand.php
@@ -7,6 +7,7 @@ namespace Greenlight\Cli\Command;
 use Greenlight\Cli\Input\CompletionScripts;
 use Greenlight\Cli\Input\Definition;
 use Greenlight\Cli\Output\Console;
+use Greenlight\Cli\Output\ExitCode;
 
 /**
  * Prints a completion script for a supported shell.
@@ -23,14 +24,14 @@ final readonly class CompletionCommand
         $shell = $arguments[0] ?? null;
         if ($shell === null) {
             $this->console->err(\sprintf("completion requires a shell argument: %s.\n", \implode(', ', Definition::COMPLETION_SHELLS)));
-            return 64;
+            return ExitCode::USAGE;
         }
         $script = new CompletionScripts($this->definition->options())->render($shell);
         if ($script === null) {
             $this->console->err(\sprintf("Unknown shell \"%s\". Select one of: %s.\n", $shell, \implode(', ', Definition::COMPLETION_SHELLS)));
-            return 64;
+            return ExitCode::USAGE;
         }
         $this->console->out($script);
-        return 0;
+        return ExitCode::SUCCESS;
     }
 }

--- a/src/Cli/Command/CoverageDiffCommand.php
+++ b/src/Cli/Command/CoverageDiffCommand.php
@@ -10,6 +10,7 @@ use Greenlight\Cli\Coverage\CoverageGate;
 use Greenlight\Cli\Input\CliError;
 use Greenlight\Cli\Input\ParsedArguments;
 use Greenlight\Cli\Output\Console;
+use Greenlight\Cli\Output\ExitCode;
 use Greenlight\Config\CoverageConfiguration;
 use Greenlight\Coverage\Diff\BaselineDiff;
 use Greenlight\Coverage\Diff\ProjectRootNormalizer;
@@ -32,20 +33,20 @@ final readonly class CoverageDiffCommand
         } catch (CliError $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
 
-            return 64;
+            return ExitCode::USAGE;
         }
 
         $baselinePath = $arguments->value('baseline');
         $currentPath = $arguments->value('current');
         if ($baselinePath === null || $currentPath === null) {
             $this->console->err("coverage:diff requires --baseline=<path> and --current=<path>.\n");
-            return 64;
+            return ExitCode::USAGE;
         }
         $baselineRoot = $arguments->value('baseline-root');
         $currentRoot = $arguments->value('current-root');
         if (($baselineRoot === null) !== ($currentRoot === null)) {
             $this->console->err("Use --baseline-root=<path> and --current-root=<path> together.\n");
-            return 64;
+            return ExitCode::USAGE;
         }
         $maps = [];
         foreach (['baseline' => $baselinePath, 'current' => $currentPath] as $label => $path) {
@@ -53,13 +54,13 @@ final readonly class CoverageDiffCommand
             $json = ErrorTrap::run(static fn() => \file_get_contents($absolute), $warning);
             if ($json === false) {
                 $this->console->error(\sprintf('Greenlight could not read the %s coverage export at "%s"%s.', $label, $path, $warning === null ? '' : ': ' . $warning), $arguments->has('no-ansi'));
-                return 1;
+                return ExitCode::FAILURE;
             }
             try {
                 $maps[$label] = JsonExporter::import($json);
             } catch (\Throwable $error) {
                 $this->console->error(\sprintf('The %s file is not a valid coverage export: %s', $label, $error->getMessage()), $arguments->has('no-ansi'));
-                return 1;
+                return ExitCode::FAILURE;
             }
         }
 
@@ -78,7 +79,7 @@ final readonly class CoverageDiffCommand
                         $error->getMessage(),
                     ), $arguments->has('no-ansi'));
 
-                    return 1;
+                    return ExitCode::FAILURE;
                 }
             }
         }
@@ -114,6 +115,8 @@ final readonly class CoverageDiffCommand
             $this->console->err("Coverage regressed against the baseline.\n");
         }
 
-        return $report->hasRegressions() || $gateFailures !== [] ? 1 : 0;
+        return $report->hasRegressions() || $gateFailures !== []
+            ? ExitCode::FAILURE
+            : ExitCode::SUCCESS;
     }
 }

--- a/src/Cli/Command/CoverageMergeCommand.php
+++ b/src/Cli/Command/CoverageMergeCommand.php
@@ -10,6 +10,7 @@ use Greenlight\Cli\Coverage\CoverageWriter;
 use Greenlight\Cli\Input\CliError;
 use Greenlight\Cli\Input\ParsedArguments;
 use Greenlight\Cli\Output\Console;
+use Greenlight\Cli\Output\ExitCode;
 use Greenlight\Config\CoverageConfiguration;
 use Greenlight\Config\CoverageExport;
 use Greenlight\Config\InvalidConfiguration;
@@ -35,7 +36,7 @@ final readonly class CoverageMergeCommand
         if (\count($inputs) < 2) {
             $this->console->err("coverage:merge requires at least two --input=<path> options.\n");
 
-            return 64;
+            return ExitCode::USAGE;
         }
 
         try {
@@ -44,13 +45,13 @@ final readonly class CoverageMergeCommand
         } catch (CliError|InvalidConfiguration $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
 
-            return 64;
+            return ExitCode::USAGE;
         }
 
         if ($exports === []) {
             $this->console->err("coverage:merge requires at least one --export=<format>=<path> option.\n");
 
-            return 64;
+            return ExitCode::USAGE;
         }
 
         $inputRoots = $arguments->values('input-root');
@@ -59,13 +60,13 @@ final readonly class CoverageMergeCommand
         if (($inputRoots === []) !== ($projectRoot === null)) {
             $this->console->err("Use --input-root=<path> and --project-root=<path> together.\n");
 
-            return 64;
+            return ExitCode::USAGE;
         }
 
         if ($inputRoots !== [] && \count($inputRoots) !== \count($inputs)) {
             $this->console->err("Repeat --input-root=<path> once for each --input=<path>.\n");
 
-            return 64;
+            return ExitCode::USAGE;
         }
 
         $targetRoot = $projectRoot === null
@@ -80,7 +81,7 @@ final readonly class CoverageMergeCommand
             if ($input === '') {
                 $this->console->err("--input requires a non-empty path.\n");
 
-                return 64;
+                return ExitCode::USAGE;
             }
 
             $path = ConfigurationLoader::absolutePath($input, $workingDirectory);
@@ -98,7 +99,7 @@ final readonly class CoverageMergeCommand
                         $input,
                     ), $arguments->has('no-ansi'));
 
-                    return 64;
+                    return ExitCode::USAGE;
                 }
 
                 continue;
@@ -114,7 +115,7 @@ final readonly class CoverageMergeCommand
                     $warning === null ? '' : ': ' . $warning,
                 ), $arguments->has('no-ansi'));
 
-                return 1;
+                return ExitCode::FAILURE;
             }
 
             try {
@@ -132,7 +133,7 @@ final readonly class CoverageMergeCommand
                     $error->getMessage(),
                 ), $arguments->has('no-ansi'));
 
-                return 1;
+                return ExitCode::FAILURE;
             }
 
             $merged = $merged->merge($map);
@@ -155,7 +156,7 @@ final readonly class CoverageMergeCommand
             $merged,
             $workingDirectory,
             $style,
-        ) ? 0 : 1;
+        ) ? ExitCode::SUCCESS : ExitCode::FAILURE;
     }
 
     /**

--- a/src/Cli/Command/IdeHelperCommand.php
+++ b/src/Cli/Command/IdeHelperCommand.php
@@ -7,6 +7,7 @@ namespace Greenlight\Cli\Command;
 use Greenlight\Cli\Configuration\ConfigurationLoader;
 use Greenlight\Cli\Input\ParsedArguments;
 use Greenlight\Cli\Output\Console;
+use Greenlight\Cli\Output\ExitCode;
 use Greenlight\Config\ConfigFileError;
 use Greenlight\Config\ConfigLoader;
 use Greenlight\Config\InvalidConfiguration;
@@ -32,11 +33,11 @@ final readonly class IdeHelperCommand
             $map = MatcherMap::fromConfigFiles([ConfigurationLoader::absolutePath($configFile, $workingDirectory)]);
         } catch (ConfigFileError|InvalidConfiguration|MatcherMapError $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return 1;
+            return ExitCode::FAILURE;
         }
         if ($map->names() === []) {
             $this->console->out("The configuration has no extension matchers. There is no helper to generate.\n");
-            return 0;
+            return ExitCode::SUCCESS;
         }
         $output = $arguments->value('output') ?? '_greenlight_ide_helper.php';
         $path = ConfigurationLoader::absolutePath($output, $workingDirectory);
@@ -44,9 +45,9 @@ final readonly class IdeHelperCommand
             AtomicFile::write($path, IdeHelper::render($map));
         } catch (AtomicFileError $error) {
             $this->console->err(\sprintf("Greenlight could not write \"%s\": %s\n", $path, $error->getMessage()));
-            return 1;
+            return ExitCode::FAILURE;
         }
         $this->console->out(\sprintf("Wrote %s with %d matchers. Add it to .gitignore. Generate it again after matcher changes.\n", $path, \count($map->names())));
-        return 0;
+        return ExitCode::SUCCESS;
     }
 }

--- a/src/Cli/Command/ListCommand.php
+++ b/src/Cli/Command/ListCommand.php
@@ -10,6 +10,7 @@ use Greenlight\Cli\Discovery\SelectionPlan;
 use Greenlight\Cli\Input\CliError;
 use Greenlight\Cli\Input\ParsedArguments;
 use Greenlight\Cli\Output\Console;
+use Greenlight\Cli\Output\ExitCode;
 use Greenlight\Config\ConfigFileError;
 use Greenlight\Config\InvalidConfiguration;
 use Greenlight\Config\ResolvedConfiguration;
@@ -32,14 +33,14 @@ final readonly class ListCommand
 
         if (!\in_array($format, ['text', 'json'], true)) {
             $this->console->error(CliError::unknownTestListFormat($format)->getMessage(), $arguments->has('no-ansi'));
-            return 64;
+            return ExitCode::USAGE;
         }
 
         $manifest = $format === 'json';
 
         if ($manifest && ($arguments->has('list-groups') || $arguments->has('list-suites'))) {
             $this->console->error(CliError::formatRequiresTestListing()->getMessage(), $arguments->has('no-ansi'));
-            return 64;
+            return ExitCode::USAGE;
         }
 
         if (!$manifest) {
@@ -65,10 +66,10 @@ final readonly class ListCommand
             $loaded = new ConfigurationLoader()->load($arguments, $workingDirectory);
         } catch (CliError $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return 64;
+            return ExitCode::USAGE;
         } catch (ConfigFileError|InvalidConfiguration $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return 1;
+            return ExitCode::FAILURE;
         }
         $standalone = $arguments->command === 'list-tests';
         if (!$standalone && $arguments->has('list-suites')) {
@@ -80,10 +81,10 @@ final readonly class ListCommand
             $plan = SelectionPlan::resolve($loaded, $workingDirectory, $arguments->has('failed'));
         } catch (CliError $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return 64;
+            return ExitCode::USAGE;
         } catch (DiscoveryError $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return 1;
+            return ExitCode::FAILURE;
         }
 
         if ($manifest) {
@@ -98,7 +99,7 @@ final readonly class ListCommand
                 \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_INVALID_UTF8_SUBSTITUTE | \JSON_THROW_ON_ERROR,
             ) . "\n");
 
-            return 0;
+            return ExitCode::SUCCESS;
         }
 
         return !$standalone && $arguments->has('list-groups') ? $this->groups($plan) : $this->tests($plan);
@@ -110,7 +111,7 @@ final readonly class ListCommand
             $this->console->out($entry->id . "\n");
         }
         $this->console->out(\sprintf("\n%d tests\n", \count($plan->entries)));
-        return 0;
+        return ExitCode::SUCCESS;
     }
 
     private function groups(ExecutionPlan $plan): int
@@ -126,7 +127,7 @@ final readonly class ListCommand
             $this->console->out(\sprintf("%s (%d tests)\n", $group, $count));
         }
         $this->console->out(\sprintf("\n%d groups\n", \count($counts)));
-        return 0;
+        return ExitCode::SUCCESS;
     }
 
     private function suites(ResolvedConfiguration $resolved): int
@@ -141,7 +142,7 @@ final readonly class ListCommand
             $this->console->out($line . "\n");
         }
         $this->console->out(\sprintf("\n%d suites\n", \count($suites)));
-        return 0;
+        return ExitCode::SUCCESS;
     }
 
     private function warnWhenExcludePathsMatchNothing(SelectionDiscovery $discovery, bool $noAnsi): void

--- a/src/Cli/Command/ProfileReportCommand.php
+++ b/src/Cli/Command/ProfileReportCommand.php
@@ -7,6 +7,7 @@ namespace Greenlight\Cli\Command;
 use Greenlight\Cli\Configuration\ConfigurationLoader;
 use Greenlight\Cli\Input\ParsedArguments;
 use Greenlight\Cli\Output\Console;
+use Greenlight\Cli\Output\ExitCode;
 use Greenlight\Internal\Event\EventCodec;
 use Greenlight\Internal\Event\EventCodecFailed;
 use Greenlight\Internal\Event\EventCodecFailureKind;
@@ -29,13 +30,13 @@ final readonly class ProfileReportCommand
         $input = $inputs[0] ?? null;
         if (\count($inputs) !== 1 || $input === null || $input === '') {
             $this->console->err("profile:report requires --input=<path to a JSONL stream>.\n");
-            return 64;
+            return ExitCode::USAGE;
         }
         $path = ConfigurationLoader::absolutePath($input, $workingDirectory);
         $raw = ErrorTrap::run(static fn() => \file_get_contents($path), $warning);
         if (!\is_string($raw)) {
             $this->console->err(\sprintf("Greenlight could not read \"%s\"%s.\n", $path, $warning === null ? '' : ': ' . $warning));
-            return 1;
+            return ExitCode::FAILURE;
         }
         $aggregator = new ProfileAggregator();
         foreach (\explode("\n", $raw) as $line) {
@@ -58,10 +59,10 @@ final readonly class ProfileReportCommand
         $report = $aggregator->render(new Style($this->console->capabilities($arguments->has('no-ansi'), $arguments->has('ansi'))->color));
         if ($report === '') {
             $this->console->err("The stream has no finished run to profile.\n");
-            return 1;
+            return ExitCode::FAILURE;
         }
         $this->console->out(\ltrim($report, "\n"));
-        return 0;
+        return ExitCode::SUCCESS;
     }
 
     private function handleCodecFailure(EventCodecFailed $failure, bool $noAnsi): ?int
@@ -98,13 +99,13 @@ final readonly class ProfileReportCommand
             $failure->getMessage(),
         ), $noAnsi);
 
-        return 1;
+        return ExitCode::FAILURE;
     }
 
     private function writeInputError(string $message): int
     {
         $this->console->err($message . "\n");
 
-        return 1;
+        return ExitCode::FAILURE;
     }
 }

--- a/src/Cli/Output/ExitCode.php
+++ b/src/Cli/Output/ExitCode.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli\Output;
+
+/**
+ * Defines the process exit codes that Greenlight commands return.
+ *
+ * @internal
+ */
+final class ExitCode
+{
+    public const int SUCCESS = 0;
+    public const int FAILURE = 1;
+    public const int USAGE = 64;
+
+    private function __construct() {}
+}

--- a/src/Cli/Plugin/BundledCommands.php
+++ b/src/Cli/Plugin/BundledCommands.php
@@ -13,6 +13,7 @@ use Greenlight\Cli\Command\ProfileReportCommand;
 use Greenlight\Cli\Input\CliError;
 use Greenlight\Cli\Input\Definition;
 use Greenlight\Cli\Output\Console;
+use Greenlight\Cli\Output\ExitCode;
 use Greenlight\Cli\Run\ArtifactsPruneCommand;
 use Greenlight\Cli\Run\RunCommand;
 use Greenlight\Coverage\CoverageError;
@@ -70,19 +71,19 @@ final readonly class BundledCommands implements CommandProvider
         } catch (CliError $error) {
             $this->console->error($error->getMessage(), \in_array('--no-ansi', $invocation->argv(), true));
 
-            return 64;
+            return ExitCode::USAGE;
         }
 
         if ($arguments->has('help')) {
             $this->console->out(Definition::HELP . "\n");
 
-            return 0;
+            return ExitCode::SUCCESS;
         }
 
         if ($arguments->has('version')) {
             $this->console->out('Greenlight ' . $this->version . "\n");
 
-            return 0;
+            return ExitCode::SUCCESS;
         }
 
         $command = $arguments->command ?? 'run';
@@ -96,7 +97,7 @@ final readonly class BundledCommands implements CommandProvider
                 $arguments->has('no-ansi'),
             );
 
-            return 64;
+            return ExitCode::USAGE;
         }
 
         if ($command === 'list-tests'

--- a/src/Cli/Plugin/CommandDispatcher.php
+++ b/src/Cli/Plugin/CommandDispatcher.php
@@ -7,6 +7,7 @@ namespace Greenlight\Cli\Plugin;
 use Greenlight\Cli\Configuration\ConfigurationLoader;
 use Greenlight\Cli\Input\Definition;
 use Greenlight\Cli\Output\Console;
+use Greenlight\Cli\Output\ExitCode;
 use Greenlight\Config\ConfigFileError;
 use Greenlight\Config\ConfigLoader;
 use Greenlight\Config\InvalidConfiguration;
@@ -56,7 +57,7 @@ final readonly class CommandDispatcher
         } catch (ConfigFileError|InvalidConfiguration|CommandSetupFailed $error) {
             $this->console->error($error->getMessage(), \in_array('--no-ansi', $argv, true));
 
-            return 1;
+            return ExitCode::FAILURE;
         }
 
         $definition = $catalog->get($command);
@@ -67,7 +68,7 @@ final readonly class CommandDispatcher
                 \in_array('--no-ansi', $argv, true),
             );
 
-            return 64;
+            return ExitCode::USAGE;
         }
 
         $arguments = $argv;
@@ -95,7 +96,7 @@ final readonly class CommandDispatcher
                 $error->getMessage(),
             ), \in_array('--no-ansi', $argv, true));
 
-            return 1;
+            return ExitCode::FAILURE;
         }
 
         if ($exitCode < 0 || $exitCode > 255) {
@@ -105,7 +106,7 @@ final readonly class CommandDispatcher
                 $exitCode,
             ), \in_array('--no-ansi', $argv, true));
 
-            return 1;
+            return ExitCode::FAILURE;
         }
 
         return $exitCode;

--- a/src/Cli/Run/ArtifactsPruneCommand.php
+++ b/src/Cli/Run/ArtifactsPruneCommand.php
@@ -9,6 +9,7 @@ use Greenlight\Cli\Configuration\ConfigurationLoader;
 use Greenlight\Cli\Input\CliError;
 use Greenlight\Cli\Input\ParsedArguments;
 use Greenlight\Cli\Output\Console;
+use Greenlight\Cli\Output\ExitCode;
 use Greenlight\Config\ConfigFileError;
 use Greenlight\Config\InvalidConfiguration;
 use Greenlight\Execution\ArtifactMaintenance;
@@ -29,15 +30,15 @@ final readonly class ArtifactsPruneCommand
             $maintenance = ArtifactMaintenance::forConfiguration($configuration, $workingDirectory);
         } catch (CliError $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return 64;
+            return ExitCode::USAGE;
         } catch (AttachmentError|ConfigFileError|InvalidConfiguration $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return 1;
+            return ExitCode::FAILURE;
         }
 
         if (!$configuration->hasRetentionPolicy()) {
             $this->console->out("No artifact retention policy is configured.\n");
-            return 0;
+            return ExitCode::SUCCESS;
         }
 
         $report = $maintenance->prune($arguments->has('dry-run'));
@@ -60,6 +61,6 @@ final readonly class ArtifactsPruneCommand
             $this->console->err($warning . "\n");
         }
 
-        return 0;
+        return ExitCode::SUCCESS;
     }
 }

--- a/src/Cli/Run/RunCommand.php
+++ b/src/Cli/Run/RunCommand.php
@@ -11,6 +11,7 @@ use Greenlight\Cli\Discovery\SelectionDiscovery;
 use Greenlight\Cli\Input\CliError;
 use Greenlight\Cli\Input\ParsedArguments;
 use Greenlight\Cli\Output\Console;
+use Greenlight\Cli\Output\ExitCode;
 use Greenlight\Cli\Output\Terminal;
 use Greenlight\Cli\Output\TerminalCapabilities;
 use Greenlight\Cli\Reporting\ReporterFactory;
@@ -39,10 +40,6 @@ use Greenlight\Reporting\Style;
  */
 final readonly class RunCommand
 {
-    private const int EXIT_OK = 0;
-    private const int EXIT_FAILURE = 1;
-    private const int EXIT_USAGE = 64;
-
     /** @var resource */
     private mixed $stderr;
 
@@ -80,11 +77,11 @@ final readonly class RunCommand
         } catch (CliError $error) {
             $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-            return self::EXIT_USAGE;
+            return ExitCode::USAGE;
         } catch (ConfigFileError|InvalidConfiguration $error) {
             $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-            return self::EXIT_FAILURE;
+            return ExitCode::FAILURE;
         }
         $resolved = $configuration->resolved;
         $configFile = $configuration->file;
@@ -93,13 +90,13 @@ final readonly class RunCommand
         if ($arguments->has('watch') && ($overrides->repeat->count !== null || $overrides->repeat->untilFailure)) {
             $this->printError('Do not use --watch with --repeat or --repeat-until-failure.', $arguments->has('no-ansi'));
 
-            return self::EXIT_USAGE;
+            return ExitCode::USAGE;
         }
 
         if ($arguments->has('dry-run')) {
             ($this->out)(PlanFormatter::format($resolved, $configFile, $workingDirectory));
 
-            return self::EXIT_OK;
+            return ExitCode::SUCCESS;
         }
 
         $this->warnWhenExcludePathsMatchNothing(new SelectionDiscovery($configuration, $workingDirectory), $arguments->has('no-ansi'));
@@ -123,11 +120,11 @@ final readonly class RunCommand
         } catch (CliError $error) {
             $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-            return self::EXIT_USAGE;
+            return ExitCode::USAGE;
         } catch (ReporterSetupFailed $error) {
             $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-            return self::EXIT_FAILURE;
+            return ExitCode::FAILURE;
         }
 
         try {
@@ -136,12 +133,12 @@ final readonly class RunCommand
             $reporterOutputs->close();
             $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-            return self::EXIT_USAGE;
+            return ExitCode::USAGE;
         } catch (ReporterSetupFailed $error) {
             $reporterOutputs->close();
             $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-            return self::EXIT_FAILURE;
+            return ExitCode::FAILURE;
         }
 
         try {
@@ -164,13 +161,13 @@ final readonly class RunCommand
                 if ($previousFailures === null) {
                     $this->printError(CliError::failedRequiresState()->getMessage(), $arguments->has('no-ansi'));
 
-                    return self::EXIT_USAGE;
+                    return ExitCode::USAGE;
                 }
 
                 if ($previousFailures === []) {
                     ($this->out)("No tests failed in the previous run. There are no tests to run again.\n");
 
-                    return self::EXIT_OK;
+                    return ExitCode::SUCCESS;
                 }
 
                 $selection = $resolved->selection->withExactIds($previousFailures);
@@ -235,11 +232,11 @@ final readonly class RunCommand
                     } catch (CliError $error) {
                         $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-                        return self::EXIT_USAGE;
+                        return ExitCode::USAGE;
                     } catch (ReporterSetupFailed $error) {
                         $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-                        return self::EXIT_FAILURE;
+                        return ExitCode::FAILURE;
                     }
                 }
 
@@ -260,7 +257,7 @@ final readonly class RunCommand
                     return $interruptExit;
                 }
 
-                if ($attempt->exitCode !== self::EXIT_OK) {
+                if ($attempt->exitCode !== ExitCode::SUCCESS) {
                     $failedIterations[] = $iteration;
 
                     if ($overrides->repeat->untilFailure) {
@@ -272,7 +269,7 @@ final readonly class RunCommand
             if ($failedIterations === []) {
                 $repeatOutput(\sprintf("Repeat: %d iterations, all passed\n", $limit));
 
-                return self::EXIT_OK;
+                return ExitCode::SUCCESS;
             }
 
             // Record each test that fails in an iteration. Thus, a later --failed
@@ -281,7 +278,7 @@ final readonly class RunCommand
 
             $repeatOutput(\sprintf("Repeat: failed iterations: %s\n", \implode(', ', $failedIterations)));
 
-            return self::EXIT_FAILURE;
+            return ExitCode::FAILURE;
         } finally {
             $reporterOutputs->close();
         }

--- a/src/Cli/Run/RunSession.php
+++ b/src/Cli/Run/RunSession.php
@@ -12,6 +12,7 @@ use Greenlight\Cli\Coverage\CoverageSettingsResolver;
 use Greenlight\Cli\Coverage\CoverageWriter;
 use Greenlight\Cli\Input\ParsedArguments;
 use Greenlight\Cli\Output\Console;
+use Greenlight\Cli\Output\ExitCode;
 use Greenlight\Cli\Reporting\FailedTestsTap;
 use Greenlight\Cli\Reporting\ReporterSink;
 use Greenlight\Cli\State\RunState;
@@ -143,7 +144,7 @@ final readonly class RunSession
                     $this->console->err("Interrupted. Integration fixture teardown was attempted before exit.\n");
                 }
 
-                return $interruptExit ?? 1;
+                return $interruptExit ?? ExitCode::FAILURE;
             }
             $coverage = $coverageSession->finish($run->coverage);
         } finally {
@@ -165,7 +166,7 @@ final readonly class RunSession
         if ($run->plannedTests === 0) {
             $this->console->err("Greenlight found no tests. Check the configuration, test paths, and filters.\n");
 
-            return 1;
+            return ExitCode::FAILURE;
         }
         $coverageConfig = $resolved->coverage;
         if ($coverageConfig instanceof CoverageConfiguration
@@ -178,16 +179,16 @@ final readonly class RunSession
                     : $this->console->stdoutStyle($this->arguments->has('no-ansi')),
             )
         ) {
-            return 1;
+            return ExitCode::FAILURE;
         }
         if ($run->leaks !== []) {
             $this->console->err(SummaryFormat::leaks($run->leaks, $this->console->stderrStyle($this->arguments->has('no-ansi'))));
 
-            return 1;
+            return ExitCode::FAILURE;
         }
 
         if (!$run->summary->isSuccessful()) {
-            return 1;
+            return ExitCode::FAILURE;
         }
 
         try {
@@ -195,14 +196,14 @@ final readonly class RunSession
         } catch (RunPolicyError $error) {
             $this->console->error($error->getMessage(), $this->arguments->has('no-ansi'));
 
-            return 1;
+            return ExitCode::FAILURE;
         }
 
         if ($policyFailed) {
-            return 1;
+            return ExitCode::FAILURE;
         }
 
-        return 0;
+        return ExitCode::SUCCESS;
     }
 
     /** @throws RunPolicyError */

--- a/src/Cli/Run/WatchRuns.php
+++ b/src/Cli/Run/WatchRuns.php
@@ -8,6 +8,7 @@ use Greenlight\Cli\Configuration\ConfigurationLoader;
 use Greenlight\Cli\Configuration\LoadedConfiguration;
 use Greenlight\Cli\Input\ParsedArguments;
 use Greenlight\Cli\Output\Console;
+use Greenlight\Cli\Output\ExitCode;
 use Greenlight\Cli\Reporting\ReporterCatalog;
 use Greenlight\Cli\Reporting\ReporterFactory;
 use Greenlight\Cli\Reporting\ReporterOutputPlan;
@@ -75,10 +76,10 @@ final readonly class WatchRuns
             new WatchLoop($sources, new Debouncer($resolved->watch->debounceMilliseconds / 1000), $keys, new SystemWatchClock(), $this->console->out(...), $shutdown)->run($runOnce);
         } catch (ReporterSetupFailed|RunPolicyError|WatchSourceFailed $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return 1;
+            return ExitCode::FAILURE;
         } finally {
             $keys->restore();
         }
-        return $shutdown->exitCode() ?? 0;
+        return $shutdown->exitCode() ?? ExitCode::SUCCESS;
     }
 }

--- a/tests/Unit/Cli/ExitCodeTest.php
+++ b/tests/Unit/Cli/ExitCodeTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\Output\ExitCode;
+use Greenlight\Expect\Expect;
+
+final readonly class ExitCodeTest
+{
+    #[Test]
+    public function namesCommandExitCodes(): void
+    {
+        Expect::that(ExitCode::SUCCESS)->toBe(0);
+        Expect::that(ExitCode::FAILURE)->toBe(1);
+        Expect::that(ExitCode::USAGE)->toBe(64);
+    }
+}


### PR DESCRIPTION
Adds a shared ExitCode holder for successful, failed, and invalid-usage command results.

Replaces numeric command exit codes throughout the CLI flow so each return states its meaning at the call site.