### PR TITLE
test(coverage): ignore static-only constructors

### DIFF
--- a/src/Cli/Command/TestManifest.php
+++ b/src/Cli/Command/TestManifest.php
@@ -16,6 +16,7 @@ use Greenlight\Discovery\Plan\PlanEntry;
  */
 final class TestManifest
 {
+    /** @codeCoverageIgnore */
     private function __construct() {}
 
     /**

--- a/src/Cli/Discovery/SelectionPlan.php
+++ b/src/Cli/Discovery/SelectionPlan.php
@@ -19,6 +19,7 @@ use Greenlight\Discovery\Plan\PlanOrder;
  */
 final class SelectionPlan
 {
+    /** @codeCoverageIgnore */
     private function __construct() {}
 
     /**

--- a/src/Cli/Run/WorkerExecutable.php
+++ b/src/Cli/Run/WorkerExecutable.php
@@ -20,6 +20,7 @@ final class WorkerExecutable
         'stream_socket_client', 'stream_select', 'stream_set_blocking',
     ];
 
+    /** @codeCoverageIgnore */
     private function __construct() {}
 
     /** @return non-empty-string|false */

--- a/src/Execution/Worker/HarnessServiceDisposal.php
+++ b/src/Execution/Worker/HarnessServiceDisposal.php
@@ -17,6 +17,7 @@ use Greenlight\Result\ThrowableDetail;
  */
 final readonly class HarnessServiceDisposal
 {
+    /** @codeCoverageIgnore */
     private function __construct() {}
 
     /**

--- a/src/Rector/AssertionMap.php
+++ b/src/Rector/AssertionMap.php
@@ -75,6 +75,7 @@ final class AssertionMap
      */
     private static ?array $entries = null;
 
+    /** @codeCoverageIgnore */
     private function __construct() {}
 
     public static function lookup(string $method): ?AssertionConversion

--- a/src/Rector/PhpUnitAttributes.php
+++ b/src/Rector/PhpUnitAttributes.php
@@ -95,5 +95,6 @@ final class PhpUnitAttributes
 
     public const string TEST_WITH = 'TestWith';
 
+    /** @codeCoverageIgnore */
     private function __construct() {}
 }


### PR DESCRIPTION
Adds the coverage-ignore docblock to six private constructors that prevent instantiation of static-only classes. Constructors reached through named constructors remain covered.