### PR TITLE
fix(config): type exact worker counts as positive

### DIFF
--- a/src/Config/GreenlightConfig.php
+++ b/src/Config/GreenlightConfig.php
@@ -402,7 +402,7 @@ final class GreenlightConfig
     private function workerCount(int|string $count): WorkerCount
     {
         if (\is_int($count)) {
-            return WorkerCount::exactly($count);
+            return WorkerCount::exactly($count); // @phpstan-ignore argument.type (This method deliberately accepts wider runtime input.)
         }
 
         if ($count === 'auto') {

--- a/src/Config/GreenlightConfig.php
+++ b/src/Config/GreenlightConfig.php
@@ -397,12 +397,15 @@ final class GreenlightConfig
     /**
      * Uses a wider parameter type than the public contract. This gives callers
      * without static analysis a clear runtime error for invalid strings.
+     *
+     * @param positive-int|'auto' $count
+     *
      * @throws InvalidConfiguration
      */
     private function workerCount(int|string $count): WorkerCount
     {
         if (\is_int($count)) {
-            return WorkerCount::exactly($count); // @phpstan-ignore argument.type (This method deliberately accepts wider runtime input.)
+            return WorkerCount::exactly($count);
         }
 
         if ($count === 'auto') {

--- a/src/Config/WorkerCount.php
+++ b/src/Config/WorkerCount.php
@@ -24,6 +24,8 @@ final readonly class WorkerCount
     }
 
     /**
+     * @param positive-int $count
+     *
      * @throws InvalidConfiguration
      */
     public static function exactly(int $count): self

--- a/tests/Unit/Config/WorkerCountTest.php
+++ b/tests/Unit/Config/WorkerCountTest.php
@@ -42,7 +42,7 @@ final class WorkerCountTest
     #[DataSet('nonpositiveCounts')]
     public function nonpositiveCountsGiveExactGuidance(int $count, string $message): void
     {
-        Expect::that(static fn(): WorkerCount => WorkerCount::exactly($count))
+        Expect::that(static fn(): WorkerCount => WorkerCount::exactly($count)) // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
             ->because('a worker count must be positive')
             ->toThrow(InvalidConfiguration::class, message: $message);
     }


### PR DESCRIPTION
## Summary

- preserve the positive worker count type through the configuration hierarchy
- declare exact worker counts as positive integers
- retain runtime validation for callers without static analysis