### PR TITLE
fix(attribute): type provider class as class-string

### DIFF
--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -156,7 +156,7 @@ public ?string $providerClass;
 
 PHPDoc:
 
-- `@var non-empty-string|null`
+- `@var class-string|null`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataSet.php#L22)
 

--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -172,9 +172,11 @@ public function __construct(string $provider, ?string $method = null)
 
 PHPDoc:
 
+- `@param ($method is null ? non-empty-string : class-string) $provider`
+- `@param non-empty-string|null $method`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataSet.php#L31)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataSet.php#L34)
 
 ## `Group`
 

--- a/src/Attribute/DataSet.php
+++ b/src/Attribute/DataSet.php
@@ -26,6 +26,9 @@ final readonly class DataSet
      * arguments, it names the provider class and `$method` names the provider
      * method.
      *
+     * @param ($method is null ? non-empty-string : class-string) $provider
+     * @param non-empty-string|null $method
+     *
      * @throws \InvalidArgumentException
      */
     public function __construct(string $provider, ?string $method = null)
@@ -43,9 +46,6 @@ final readonly class DataSet
         }
 
         $this->provider = $method ?? $provider;
-
-        /** @var class-string|null $providerClass */
-        $providerClass = $method === null ? null : $provider;
-        $this->providerClass = $providerClass;
+        $this->providerClass = $method === null ? null : $provider;
     }
 }

--- a/src/Attribute/DataSet.php
+++ b/src/Attribute/DataSet.php
@@ -17,7 +17,7 @@ final readonly class DataSet
     public string $provider;
 
     /**
-     * @var non-empty-string|null
+     * @var class-string|null
      */
     public ?string $providerClass;
 
@@ -43,6 +43,9 @@ final readonly class DataSet
         }
 
         $this->provider = $method ?? $provider;
-        $this->providerClass = $method === null ? null : $provider;
+
+        /** @var class-string|null $providerClass */
+        $providerClass = $method === null ? null : $provider;
+        $this->providerClass = $providerClass;
     }
 }

--- a/tests/Acceptance/PhpStanDataSetTypeTest.php
+++ b/tests/Acceptance/PhpStanDataSetTypeTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\PhpStanProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class PhpStanDataSetTypeTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function providerClassPreservesTheClassStringType(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Attribute\DataSet;
+
+            /** @param class-string|null $providerClass */
+            function greenlightAcceptProviderClass(?string $providerClass): void {}
+
+            $dataSet = new DataSet(DateTimeImmutable::class, 'rows');
+            greenlightAcceptProviderClass($dataSet->providerClass);
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Attribute\DataSet;
+
+            /** @param class-string|null $providerClass */
+            function greenlightRejectProviderMethod(?string $providerClass): void {}
+
+            $dataSet = new DataSet('rows');
+            greenlightRejectProviderMethod($dataSet->provider);
+            PHP,
+        );
+
+        Expect::that($probe->exitCode)
+            ->because('DataSet providerClass MUST preserve the class-string type')
+            ->toBe(1);
+        Expect::that($probe->goodPassed)->because('PHPStan messages: ' . $probe->messages())->toBeTrue();
+        Expect::that(\count($probe->errors))->toBe(1);
+        Expect::that($probe->messages())->toContain('expects class-string|null, string given');
+    }
+}

--- a/tests/Acceptance/PhpStanDataSetTypeTest.php
+++ b/tests/Acceptance/PhpStanDataSetTypeTest.php
@@ -16,7 +16,7 @@ final readonly class PhpStanDataSetTypeTest
     public function __construct(private TemporaryDirectory $tempDirectory) {}
 
     #[Test]
-    public function providerClassPreservesTheClassStringType(): void
+    public function externalProviderTypesPreserveClassStrings(): void
     {
         $probe = PhpStanProbe::analyze(
             $this->tempDirectory,
@@ -27,11 +27,18 @@ final readonly class PhpStanDataSetTypeTest
 
             use Greenlight\Attribute\DataSet;
 
+            /** @param non-empty-string $provider */
+            function greenlightAcceptLocalProvider(string $provider): DataSet
+            {
+                return new DataSet($provider);
+            }
+
             /** @param class-string|null $providerClass */
             function greenlightAcceptProviderClass(?string $providerClass): void {}
 
             $dataSet = new DataSet(DateTimeImmutable::class, 'rows');
             greenlightAcceptProviderClass($dataSet->providerClass);
+            greenlightAcceptLocalProvider('rows');
             PHP,
             <<<'PHP'
             <?php
@@ -40,19 +47,27 @@ final readonly class PhpStanDataSetTypeTest
 
             use Greenlight\Attribute\DataSet;
 
+            /** @param non-empty-string $provider */
+            function greenlightRejectExternalProvider(string $provider): DataSet
+            {
+                return new DataSet($provider, 'rows');
+            }
+
             /** @param class-string|null $providerClass */
             function greenlightRejectProviderMethod(?string $providerClass): void {}
 
             $dataSet = new DataSet('rows');
             greenlightRejectProviderMethod($dataSet->provider);
+            greenlightRejectExternalProvider('NotAClass');
             PHP,
         );
 
         Expect::that($probe->exitCode)
-            ->because('DataSet providerClass MUST preserve the class-string type')
+            ->because('DataSet external provider types MUST preserve class-strings')
             ->toBe(1);
         Expect::that($probe->goodPassed)->because('PHPStan messages: ' . $probe->messages())->toBeTrue();
-        Expect::that(\count($probe->errors))->toBe(1);
+        Expect::that(\count($probe->errors))->toBe(2);
+        Expect::that($probe->messages())->toContain('expects class-string, string given');
         Expect::that($probe->messages())->toContain('expects class-string|null, string given');
     }
 }

--- a/tests/Unit/Attribute/DataSetTest.php
+++ b/tests/Unit/Attribute/DataSetTest.php
@@ -18,7 +18,7 @@ final class DataSetTest
         string $message,
     ): void {
         Expect::that(
-            static fn(): DataSet => new DataSet($provider, $method),
+            static fn(): object => new \ReflectionClass(DataSet::class)->newInstance($provider, $method),
         )
             ->because('data set provider identifiers MUST be non-empty')
             ->toThrow(\InvalidArgumentException::class, message: $message);


### PR DESCRIPTION
## Summary

- Type `DataSet::$providerClass` as `class-string|null`.
- Preserve runtime handling for missing provider classes.
- Add a PHPStan acceptance test for the public property type.