### PR TITLE
test: cover attachment media type validator

### DIFF
--- a/tests/Unit/Artifact/AttachmentMediaTypeContractTest.php
+++ b/tests/Unit/Artifact/AttachmentMediaTypeContractTest.php
@@ -6,12 +6,21 @@ namespace Greenlight\Tests\Unit\Artifact;
 
 use Greenlight\Artifact\Attachment;
 use Greenlight\Artifact\AttachmentKind;
+use Greenlight\Artifact\AttachmentMediaType;
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 
 final class AttachmentMediaTypeContractTest
 {
+    #[Test]
+    #[DataSet('invalidMediaTypes')]
+    public function validatorRejectsInvalidMediaTypes(string $mediaType): void
+    {
+        Expect::that(AttachmentMediaType::isValid($mediaType))
+            ->toBeFalse();
+    }
+
     #[Test]
     #[DataSet('invalidMediaTypes')]
     public function constructionAndWireDecodingRejectInvalidMediaTypes(string $mediaType): void

--- a/tests/Unit/Artifact/AttachmentValidMediaTypeTest.php
+++ b/tests/Unit/Artifact/AttachmentValidMediaTypeTest.php
@@ -6,12 +6,21 @@ namespace Greenlight\Tests\Unit\Artifact;
 
 use Greenlight\Artifact\Attachment;
 use Greenlight\Artifact\AttachmentKind;
+use Greenlight\Artifact\AttachmentMediaType;
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 
 final readonly class AttachmentValidMediaTypeTest
 {
+    #[Test]
+    #[DataSet('validMediaTypes')]
+    public function validatorAcceptsValidMediaTypes(string $mediaType): void
+    {
+        Expect::that(AttachmentMediaType::isValid($mediaType))
+            ->toBeTrue();
+    }
+
     #[Test]
     #[DataSet('validMediaTypes')]
     public function validMediaTypesSurviveConstructionAndTheWire(string $mediaType): void


### PR DESCRIPTION
Add direct unit coverage for AttachmentMediaType::isValid() over the existing valid and invalid media-type data sets. Keep the existing acceptance coverage for the fileinfo fallback.