### PR TITLE
refactor: let exception factories render value types

### DIFF
--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -368,7 +368,7 @@ public static function factoryFailed(\Throwable $cause): self
 ### `invalidHandler()`
 
 ```php
-public static function invalidHandler(string $type): self
+public static function invalidHandler(mixed $handler): self
 ```
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/Psr15Error.php#L20)
@@ -379,7 +379,7 @@ public static function invalidHandler(string $type): self
 public static function requestFailed(
     string $method,
     string $path,
-    string $handler,
+    mixed $handler,
     \Throwable $cause,
 ): self
 ```
@@ -389,7 +389,7 @@ public static function requestFailed(
 ### `releaseFailed()`
 
 ```php
-public static function releaseFailed(string $handler, \Throwable $cause): self
+public static function releaseFailed(mixed $handler, \Throwable $cause): self
 ```
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/Psr15Error.php#L42)

--- a/src/Execution/Worker/ClassContext.php
+++ b/src/Execution/Worker/ClassContext.php
@@ -119,7 +119,7 @@ final class ClassContext
                 $key,
                 $this->reflection->getName(),
                 $testMethod,
-                \get_debug_type($value),
+                $value,
             );
         }
 

--- a/src/Execution/Worker/WorkerError.php
+++ b/src/Execution/Worker/WorkerError.php
@@ -46,14 +46,14 @@ final class WorkerError extends \RuntimeException
      * @param class-string $class
      * @param non-empty-string $method
      */
-    public static function invalidDataSet(string $key, string $class, string $method, string $actualType): self
+    public static function invalidDataSet(string $key, string $class, string $method, mixed $actual): self
     {
         return new self(\sprintf(
             'Data set "%s" of "%s::%s()" requires an argument array. Actual type: %s.',
             $key,
             $class,
             $method,
-            $actualType,
+            \get_debug_type($actual),
         ));
     }
 

--- a/src/Harness/HarnessScopes.php
+++ b/src/Harness/HarnessScopes.php
@@ -84,7 +84,7 @@ final class HarnessScopes
             $service = $this->containerFor($definition->scope)->get($definition);
 
             if (!$service instanceof $type) {
-                throw UnresolvableService::factoryTypeMismatch($type, $service::class);
+                throw UnresolvableService::factoryTypeMismatch($type, $service);
             }
 
             return $service;
@@ -105,7 +105,7 @@ final class HarnessScopes
             }
 
             if (!$service instanceof $type) {
-                throw UnresolvableService::resolverTypeMismatch($type, $consumer, $resolver::class, $service::class);
+                throw UnresolvableService::resolverTypeMismatch($type, $consumer, $resolver::class, $service);
             }
 
             return $service;

--- a/src/Harness/ScopeContainer.php
+++ b/src/Harness/ScopeContainer.php
@@ -84,7 +84,7 @@ final class ScopeContainer
             if (!$service instanceof $definition->type) {
                 throw UnresolvableService::factoryTypeMismatch(
                     $definition->type,
-                    \get_debug_type($service),
+                    $service,
                 );
             }
 

--- a/src/Harness/UnresolvableService.php
+++ b/src/Harness/UnresolvableService.php
@@ -36,7 +36,7 @@ final class UnresolvableService extends ServiceResolutionFailed
         ));
     }
 
-    public static function resolverTypeMismatch(string $type, string $consumer, string $resolver, string $actual): self
+    public static function resolverTypeMismatch(string $type, string $consumer, string $resolver, mixed $actual): self
     {
         return new self(\sprintf(
             'Resolver "%s" answered the request for "%s" (required by "%s") with an instance of "%s", '
@@ -44,16 +44,16 @@ final class UnresolvableService extends ServiceResolutionFailed
             $resolver,
             $type,
             $consumer,
-            $actual,
+            \get_debug_type($actual),
         ));
     }
 
-    public static function factoryTypeMismatch(string $type, string $actual): self
+    public static function factoryTypeMismatch(string $type, mixed $actual): self
     {
         return new self(\sprintf(
             'Service definition for type "%s" created "%s". Its factory MUST return an instance of "%s".',
             $type,
-            $actual,
+            \get_debug_type($actual),
             $type,
         ));
     }

--- a/src/Hyperf/HyperfBridgeError.php
+++ b/src/Hyperf/HyperfBridgeError.php
@@ -26,12 +26,12 @@ final class HyperfBridgeError extends ServiceResolutionFailed
         ));
     }
 
-    public static function basePathConflict(string $configured, string $defined): self
+    public static function basePathConflict(string $configured, mixed $defined): self
     {
         return new self(\sprintf(
             'HyperfPlugin uses base path "%s", but BASE_PATH is already "%s". Use one Hyperf application in each worker.',
             $configured,
-            $defined,
+            \is_string($defined) ? $defined : \get_debug_type($defined),
         ));
     }
 
@@ -96,12 +96,12 @@ final class HyperfBridgeError extends ServiceResolutionFailed
         ));
     }
 
-    public static function notAContainer(string $path, string $actual): self
+    public static function notAContainer(string $path, mixed $actual): self
     {
         return new self(\sprintf(
             'The Hyperf container file "%s" returned "%s". It must return a Psr\\Container\\ContainerInterface instance.',
             $path,
-            $actual,
+            \get_debug_type($actual),
         ));
     }
 
@@ -112,11 +112,11 @@ final class HyperfBridgeError extends ServiceResolutionFailed
         );
     }
 
-    public static function applicationUnavailable(string $actual): self
+    public static function applicationUnavailable(mixed $actual): self
     {
         return new self(\sprintf(
             'The Hyperf application binding returned "%s". The binding must return an application object.',
-            $actual,
+            \get_debug_type($actual),
         ));
     }
 
@@ -155,12 +155,12 @@ final class HyperfBridgeError extends ServiceResolutionFailed
         ));
     }
 
-    public static function serviceTypeMismatch(string $id, string $type, string $actual): self
+    public static function serviceTypeMismatch(string $id, string $type, mixed $actual): self
     {
         return new self(\sprintf(
             'The Hyperf service "%s" has type "%s". The parameter requires type "%s".',
             $id,
-            $actual,
+            \get_debug_type($actual),
             $type,
         ));
     }

--- a/src/Hyperf/HyperfPlugin.php
+++ b/src/Hyperf/HyperfPlugin.php
@@ -110,7 +110,7 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemp
             $service = $container->get($id);
 
             if (!$service instanceof $type) {
-                throw HyperfBridgeError::serviceTypeMismatch($id, $type, \get_debug_type($service));
+                throw HyperfBridgeError::serviceTypeMismatch($id, $type, $service);
             }
 
             return $service;
@@ -148,7 +148,7 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemp
             $defined = \constant('BASE_PATH');
 
             if (!\is_string($defined)) {
-                throw HyperfBridgeError::basePathConflict($basePath, \get_debug_type($defined));
+                throw HyperfBridgeError::basePathConflict($basePath, $defined);
             }
 
             $definedPath = ErrorTrap::run(static fn() => \realpath($defined));
@@ -372,7 +372,7 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemp
         $container = $loader($this->containerFile);
 
         if (!$container instanceof ContainerInterface) {
-            throw HyperfBridgeError::notAContainer($this->containerFile, \get_debug_type($container));
+            throw HyperfBridgeError::notAContainer($this->containerFile, $container);
         }
 
         return $container;
@@ -394,7 +394,7 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemp
         $application = $container->get(ApplicationInterface::class);
 
         if (!\is_object($application)) {
-            throw HyperfBridgeError::applicationUnavailable(\get_debug_type($application));
+            throw HyperfBridgeError::applicationUnavailable($application);
         }
     }
 

--- a/src/Laravel/LaravelBridgeError.php
+++ b/src/Laravel/LaravelBridgeError.php
@@ -46,14 +46,14 @@ final class LaravelBridgeError extends ServiceResolutionFailed
         ));
     }
 
-    public static function notAnApplication(string $actual): self
+    public static function notAnApplication(mixed $actual): self
     {
         return new self(\sprintf(
             'The Laravel bootstrap returned "%s" instead of an '
             . 'Illuminate\Contracts\Foundation\Application instance, so LaravelPlugin cannot '
             . 'boot it. Return the application from the bootstrap file or the closure, '
             . 'usually the result of Application::configure(...)->create().',
-            $actual,
+            \get_debug_type($actual),
         ));
     }
 
@@ -66,12 +66,12 @@ final class LaravelBridgeError extends ServiceResolutionFailed
         );
     }
 
-    public static function consoleKernelTypeMismatch(string $actual): self
+    public static function consoleKernelTypeMismatch(mixed $actual): self
     {
         return new self(\sprintf(
             'The Laravel console kernel binding contains "%s" instead of an '
             . 'Illuminate\Contracts\Console\Kernel instance, so LaravelPlugin cannot boot it.',
-            $actual,
+            \get_debug_type($actual),
         ));
     }
 
@@ -85,12 +85,12 @@ final class LaravelBridgeError extends ServiceResolutionFailed
         ));
     }
 
-    public static function serviceTypeMismatch(string $id, string $type, string $actual): self
+    public static function serviceTypeMismatch(string $id, string $type, mixed $actual): self
     {
         return new self(\sprintf(
             'The Laravel service "%s" is an instance of "%s", but the parameter declares "%s".',
             $id,
-            $actual,
+            \get_debug_type($actual),
             $type,
         ));
     }

--- a/src/Laravel/LaravelPlugin.php
+++ b/src/Laravel/LaravelPlugin.php
@@ -61,7 +61,7 @@ final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, Servi
                 $app = require $application;
 
                 if (!$app instanceof Application) {
-                    throw LaravelBridgeError::notAnApplication(\get_debug_type($app));
+                    throw LaravelBridgeError::notAnApplication($app);
                 }
 
                 return $app;
@@ -113,7 +113,7 @@ final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, Servi
             $service = $app->make($id);
 
             if (!$service instanceof $type) {
-                throw LaravelBridgeError::serviceTypeMismatch($id, $type, \get_debug_type($service));
+                throw LaravelBridgeError::serviceTypeMismatch($id, $type, $service);
             }
 
             return $service;
@@ -153,7 +153,7 @@ final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, Servi
             $app = ($this->factory)();
 
             if (!$app instanceof Application) {
-                throw LaravelBridgeError::notAnApplication(\get_debug_type($app));
+                throw LaravelBridgeError::notAnApplication($app);
             }
 
             $this->app = $app;
@@ -165,7 +165,7 @@ final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, Servi
             $kernel = $this->containerEntry($app, Kernel::class);
 
             if (!$kernel instanceof Kernel) {
-                throw LaravelBridgeError::consoleKernelTypeMismatch(\get_debug_type($kernel));
+                throw LaravelBridgeError::consoleKernelTypeMismatch($kernel);
             }
 
             $this->preserveDiagnosticHandlers($app);

--- a/src/Psr11/Psr11BridgeError.php
+++ b/src/Psr11/Psr11BridgeError.php
@@ -26,11 +26,11 @@ final class Psr11BridgeError extends ServiceResolutionFailed
         );
     }
 
-    public static function notAContainer(string $actual): self
+    public static function notAContainer(mixed $actual): self
     {
         return new self(\sprintf(
             'The PSR-11 container factory returned "%s". Return an instance of Psr\\Container\\ContainerInterface.',
-            $actual,
+            \get_debug_type($actual),
         ));
     }
 
@@ -59,12 +59,12 @@ final class Psr11BridgeError extends ServiceResolutionFailed
         ));
     }
 
-    public static function serviceTypeMismatch(string $id, string $type, string $actual): self
+    public static function serviceTypeMismatch(string $id, string $type, mixed $actual): self
     {
         return new self(\sprintf(
             'PSR-11 service "%s" has type "%s". The parameter requires type "%s".',
             $id,
-            $actual,
+            \get_debug_type($actual),
             $type,
         ));
     }

--- a/src/Psr11/Psr11Plugin.php
+++ b/src/Psr11/Psr11Plugin.php
@@ -72,7 +72,7 @@ final class Psr11Plugin implements AfterTestSubscriber, HarnessProvider, Service
         }
 
         if (!$container instanceof ContainerInterface) {
-            throw Psr11BridgeError::notAContainer(\get_debug_type($container));
+            throw Psr11BridgeError::notAContainer($container);
         }
 
         $this->activeContainer = $container;
@@ -128,7 +128,7 @@ final class Psr11Plugin implements AfterTestSubscriber, HarnessProvider, Service
         }
 
         if (!$service instanceof $type) {
-            throw Psr11BridgeError::serviceTypeMismatch($id, $type, \get_debug_type($service));
+            throw Psr11BridgeError::serviceTypeMismatch($id, $type, $service);
         }
 
         return $service;

--- a/src/Psr15/HttpHarness.php
+++ b/src/Psr15/HttpHarness.php
@@ -59,7 +59,7 @@ final class HttpHarness implements Disposable
             throw Psr15Error::requestFailed(
                 $method === '' ? '<empty>' : $method,
                 $path === '' ? '/' : $path,
-                \get_debug_type($handler),
+                $handler,
                 $threw,
             );
         }
@@ -86,7 +86,7 @@ final class HttpHarness implements Disposable
         try {
             ($this->release)($handler);
         } catch (\Throwable $threw) {
-            throw Psr15Error::releaseFailed(\get_debug_type($handler), $threw);
+            throw Psr15Error::releaseFailed($handler, $threw);
         }
     }
 
@@ -109,7 +109,7 @@ final class HttpHarness implements Disposable
         }
 
         if (!$handler instanceof RequestHandlerInterface) {
-            throw Psr15Error::invalidHandler(\get_debug_type($handler));
+            throw Psr15Error::invalidHandler($handler);
         }
 
         $this->handler = $handler;

--- a/src/Psr15/Psr15Error.php
+++ b/src/Psr15/Psr15Error.php
@@ -12,33 +12,33 @@ final class Psr15Error extends \RuntimeException
         return new self('The PSR-15 handler factory failed.', 0, $cause);
     }
 
-    public static function invalidHandler(string $type): self
+    public static function invalidHandler(mixed $handler): self
     {
         return new self(\sprintf(
             'The PSR-15 handler factory returned "%s". It MUST return an instance of "Psr\\Http\\Server\\RequestHandlerInterface".',
-            $type,
+            \get_debug_type($handler),
         ));
     }
 
     public static function requestFailed(
         string $method,
         string $path,
-        string $handler,
+        mixed $handler,
         \Throwable $cause,
     ): self {
         return new self(\sprintf(
             'PSR-15 handler "%s" failed for request "%s %s".',
-            $handler,
+            \get_debug_type($handler),
             $method,
             $path,
         ), 0, $cause);
     }
 
-    public static function releaseFailed(string $handler, \Throwable $cause): self
+    public static function releaseFailed(mixed $handler, \Throwable $cause): self
     {
         return new self(\sprintf(
             'The release callback failed for PSR-15 handler "%s".',
-            $handler,
+            \get_debug_type($handler),
         ), 0, $cause);
     }
 

--- a/src/Symfony/SymfonyBridgeError.php
+++ b/src/Symfony/SymfonyBridgeError.php
@@ -51,12 +51,12 @@ final class SymfonyBridgeError extends ServiceResolutionFailed
         ));
     }
 
-    public static function serviceTypeMismatch(string $id, string $type, string $actual): self
+    public static function serviceTypeMismatch(string $id, string $type, mixed $actual): self
     {
         return new self(\sprintf(
             'Symfony service "%s" has type "%s". The parameter requires type "%s".',
             $id,
-            $actual,
+            \get_debug_type($actual),
             $type,
         ));
     }
@@ -70,11 +70,11 @@ final class SymfonyBridgeError extends ServiceResolutionFailed
         ));
     }
 
-    public static function notAKernelFromFactory(string $actual): self
+    public static function notAKernelFromFactory(mixed $actual): self
     {
         return new self(\sprintf(
             'The Symfony kernel factory returned "%s". Return an instance of Symfony\Component\HttpKernel\KernelInterface.',
-            $actual,
+            \get_debug_type($actual),
         ));
     }
 

--- a/src/Symfony/SymfonyPlugin.php
+++ b/src/Symfony/SymfonyPlugin.php
@@ -109,7 +109,7 @@ final class SymfonyPlugin implements AfterTestSubscriber, HarnessProvider, Servi
             $service = $container->get($id);
 
             if (!$service instanceof $type) {
-                throw SymfonyBridgeError::serviceTypeMismatch($id, $type, \get_debug_type($service));
+                throw SymfonyBridgeError::serviceTypeMismatch($id, $type, $service);
             }
 
             return $service;
@@ -144,7 +144,7 @@ final class SymfonyPlugin implements AfterTestSubscriber, HarnessProvider, Servi
         $kernel = ($this->factory)();
 
         if (!$kernel instanceof KernelInterface) {
-            throw SymfonyBridgeError::notAKernelFromFactory(\get_debug_type($kernel));
+            throw SymfonyBridgeError::notAKernelFromFactory($kernel);
         }
 
         $kernel->boot();

--- a/src/Tempest/TempestBridgeError.php
+++ b/src/Tempest/TempestBridgeError.php
@@ -63,11 +63,11 @@ final class TempestBridgeError extends ServiceResolutionFailed
         ), $cause);
     }
 
-    public static function serviceTypeMismatch(string $type, string $actual): self
+    public static function serviceTypeMismatch(string $type, mixed $actual): self
     {
         return new self(\sprintf(
             'The Tempest container returned "%s" for the parameter type "%s".',
-            $actual,
+            \get_debug_type($actual),
             $type,
         ));
     }

--- a/src/Tempest/TempestPlugin.php
+++ b/src/Tempest/TempestPlugin.php
@@ -104,7 +104,7 @@ final class TempestPlugin implements AfterTestSubscriber, BeforeTestSubscriber, 
         }
 
         if (!$service instanceof $type) {
-            throw TempestBridgeError::serviceTypeMismatch($type, \get_debug_type($service));
+            throw TempestBridgeError::serviceTypeMismatch($type, $service);
         }
 
         return $service;

--- a/src/Test/DataSet/DataSetError.php
+++ b/src/Test/DataSet/DataSetError.php
@@ -60,13 +60,13 @@ final class DataSetError extends \RuntimeException
         ));
     }
 
-    public static function providerNotIterable(string $class, string $provider, string $actualType): self
+    public static function providerNotIterable(string $class, string $provider, mixed $actual): self
     {
         return new self(\sprintf(
             'Data-set provider %s::%s() returned %s. Return an iterable from the provider.',
             $class,
             $provider,
-            $actualType,
+            \get_debug_type($actual),
         ));
     }
 
@@ -103,13 +103,13 @@ final class DataSetError extends \RuntimeException
         ));
     }
 
-    public static function providerKeyInvalid(string $class, string $provider, string $keyType): self
+    public static function providerKeyInvalid(string $class, string $provider, mixed $key): self
     {
         return new self(\sprintf(
             'Data-set provider %s::%s() produced a key of type %s. Use string or integer keys.',
             $class,
             $provider,
-            $keyType,
+            \get_debug_type($key),
         ));
     }
 

--- a/src/Test/DataSet/DataSetExpander.php
+++ b/src/Test/DataSet/DataSetExpander.php
@@ -157,7 +157,7 @@ final readonly class DataSetExpander
         }
 
         if (!\is_iterable($result)) {
-            throw DataSetError::providerNotIterable($providerClassName, $provider, \get_debug_type($result));
+            throw DataSetError::providerNotIterable($providerClassName, $provider, $result);
         }
 
         $dataSets = [];
@@ -215,7 +215,7 @@ final readonly class DataSetExpander
         }
 
         if (!\is_string($key)) {
-            throw DataSetError::providerKeyInvalid($class, $provider, \get_debug_type($key));
+            throw DataSetError::providerKeyInvalid($class, $provider, $key);
         }
 
         if ($key !== '' && \preg_match('/^\P{C}+\z/u', $key) === 1) {

--- a/tests/Unit/Hyperf/HyperfBridgeErrorTest.php
+++ b/tests/Unit/Hyperf/HyperfBridgeErrorTest.php
@@ -30,6 +30,10 @@ final readonly class HyperfBridgeErrorTest
             static fn(): HyperfBridgeError => HyperfBridgeError::basePathConflict('/app', '/other'),
             'HyperfPlugin uses base path "/app", but BASE_PATH is already "/other". Use one Hyperf application in each worker.',
         ];
+        yield 'invalid base path type' => [
+            static fn(): HyperfBridgeError => HyperfBridgeError::basePathConflict('/app', null),
+            'HyperfPlugin uses base path "/app", but BASE_PATH is already "null". Use one Hyperf application in each worker.',
+        ];
         yield 'missing container file' => [
             static fn(): HyperfBridgeError => HyperfBridgeError::containerFileMissing('/app/config/container.php'),
             'The Hyperf container file "/app/config/container.php" does not exist. Add the standard config/container.php file.',
@@ -63,15 +67,15 @@ final readonly class HyperfBridgeErrorTest
             'HyperfPlugin cannot lock "/app/runtime/container/greenlight.scan.lock" for the class scan.',
         ];
         yield 'invalid container' => [
-            static fn(): HyperfBridgeError => HyperfBridgeError::notAContainer('/app/config/container.php', 'string'),
-            'The Hyperf container file "/app/config/container.php" returned "string". It must return a Psr\\Container\\ContainerInterface instance.',
+            static fn(): HyperfBridgeError => HyperfBridgeError::notAContainer('/app/config/container.php', false),
+            'The Hyperf container file "/app/config/container.php" returned "bool". It must return a Psr\\Container\\ContainerInterface instance.',
         ];
         yield 'reused container' => [
             HyperfBridgeError::reusedContainer(...),
             'The Hyperf container file returned the previous test container. It must create a new container for each test.',
         ];
         yield 'invalid application' => [
-            static fn(): HyperfBridgeError => HyperfBridgeError::applicationUnavailable('null'),
+            static fn(): HyperfBridgeError => HyperfBridgeError::applicationUnavailable(null),
             'The Hyperf application binding returned "null". The binding must return an application object.',
         ];
         yield 'coroutine start failure' => [
@@ -95,7 +99,7 @@ final readonly class HyperfBridgeErrorTest
             'The Hyperf container has no service "clock" for type "DateTimeInterface". Check the service ID.',
         ];
         yield 'service type mismatch' => [
-            static fn(): HyperfBridgeError => HyperfBridgeError::serviceTypeMismatch('clock', \DateTimeInterface::class, 'stdClass'),
+            static fn(): HyperfBridgeError => HyperfBridgeError::serviceTypeMismatch('clock', \DateTimeInterface::class, new \stdClass()),
             'The Hyperf service "clock" has type "stdClass". The parameter requires type "DateTimeInterface".',
         ];
     }

--- a/tests/Unit/Tempest/TempestBridgeErrorTest.php
+++ b/tests/Unit/Tempest/TempestBridgeErrorTest.php
@@ -62,7 +62,7 @@ final readonly class TempestBridgeErrorTest
     #[Test]
     public function reportsAServiceTypeMismatch(): void
     {
-        $error = TempestBridgeError::serviceTypeMismatch(ProbeService::class, \stdClass::class);
+        $error = TempestBridgeError::serviceTypeMismatch(ProbeService::class, new \stdClass());
 
         Expect::that($error->getMessage())->toBe(
             'The Tempest container returned "stdClass" for the parameter type "'

--- a/tests/Unit/Test/DataSet/DataSetErrorTest.php
+++ b/tests/Unit/Test/DataSet/DataSetErrorTest.php
@@ -20,11 +20,11 @@ final class DataSetErrorTest
             DataSetError::providerClassMissing('App\ExampleTest', 'checksValue', 'App\Rows')->getMessage(),
             DataSetError::providerMissing('App\ExampleTest', 'checksValue', 'App\Rows', 'values')->getMessage(),
             DataSetError::providerNotPublicStatic('App\ExampleTest', 'checksValue', 'App\Rows', 'values')->getMessage(),
-            DataSetError::providerNotIterable('App\Rows', 'values', 'string')->getMessage(),
+            DataSetError::providerNotIterable('App\Rows', 'values', 'not iterable')->getMessage(),
             $providerError->getMessage(),
             DataSetError::providerTooSlow('App\Rows', 'values', 0.125)->getMessage(),
             DataSetError::providerYieldedNothing('App\Rows', 'values')->getMessage(),
-            DataSetError::providerKeyInvalid('App\Rows', 'values', 'float')->getMessage(),
+            DataSetError::providerKeyInvalid('App\Rows', 'values', 1.5)->getMessage(),
             DataSetError::duplicateDataSetKey('App\ExampleTest', 'checksValue', 'same')->getMessage(),
         ];
 


### PR DESCRIPTION
## Summary

- Pass rejected runtime values to exception factories.
- Render value types inside each factory.
- Preserve path diagnostics for a string Hyperf BASE_PATH value.