### PR TITLE
refactor(cli): type bundled command results

### DIFF
--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -76,14 +76,14 @@ final readonly class Application
         // process. A CLI process that inherits them reports its coverage
         // through the shared directory.
         $dump = SubprocessCoverage::begin();
-        $dispatch = fn(): int => new CommandDispatcher($this->console, self::VERSION)->dispatch($argv, $workingDirectory, $binPath);
+        $dispatch = fn(): ExitCode => new CommandDispatcher($this->console, self::VERSION)->dispatch($argv, $workingDirectory, $binPath);
 
         if (!$dump instanceof SubprocessCoverage) {
-            return $dispatch();
+            return $dispatch()->toInt();
         }
 
         try {
-            return $dispatch();
+            return $dispatch()->toInt();
         } finally {
             $dump->write();
         }

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -66,7 +66,7 @@ final readonly class Application
             if (\count($argv) !== 4 || $argv[1] === '' || $argv[2] === '' || $argv[3] === '') {
                 $this->console->err("__worker requires <address> <workerId> <token>.\n");
 
-                return ExitCode::USAGE;
+                return ExitCode::Usage->toInt();
             }
 
             return new WorkerProcess(isolateProcessGroup: true)->run($argv[1], $argv[2], $argv[3]);

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -66,7 +66,7 @@ final readonly class Application
             if (\count($argv) !== 4 || $argv[1] === '' || $argv[2] === '' || $argv[3] === '') {
                 $this->console->err("__worker requires <address> <workerId> <token>.\n");
 
-                return ExitCode::Usage->toInt();
+                return ExitCode::usage()->toInt();
             }
 
             return new WorkerProcess(isolateProcessGroup: true)->run($argv[1], $argv[2], $argv[3]);

--- a/src/Cli/Command/CompletionCommand.php
+++ b/src/Cli/Command/CompletionCommand.php
@@ -19,19 +19,19 @@ final readonly class CompletionCommand
     public function __construct(private Console $console, private Definition $definition) {}
 
     /** @param list<string> $arguments */
-    public function run(array $arguments): int
+    public function run(array $arguments): ExitCode
     {
         $shell = $arguments[0] ?? null;
         if ($shell === null) {
             $this->console->err(\sprintf("completion requires a shell argument: %s.\n", \implode(', ', Definition::COMPLETION_SHELLS)));
-            return ExitCode::USAGE;
+            return ExitCode::Usage;
         }
         $script = new CompletionScripts($this->definition->options())->render($shell);
         if ($script === null) {
             $this->console->err(\sprintf("Unknown shell \"%s\". Select one of: %s.\n", $shell, \implode(', ', Definition::COMPLETION_SHELLS)));
-            return ExitCode::USAGE;
+            return ExitCode::Usage;
         }
         $this->console->out($script);
-        return ExitCode::SUCCESS;
+        return ExitCode::Success;
     }
 }

--- a/src/Cli/Command/CompletionCommand.php
+++ b/src/Cli/Command/CompletionCommand.php
@@ -24,14 +24,14 @@ final readonly class CompletionCommand
         $shell = $arguments[0] ?? null;
         if ($shell === null) {
             $this->console->err(\sprintf("completion requires a shell argument: %s.\n", \implode(', ', Definition::COMPLETION_SHELLS)));
-            return ExitCode::Usage;
+            return ExitCode::usage();
         }
         $script = new CompletionScripts($this->definition->options())->render($shell);
         if ($script === null) {
             $this->console->err(\sprintf("Unknown shell \"%s\". Select one of: %s.\n", $shell, \implode(', ', Definition::COMPLETION_SHELLS)));
-            return ExitCode::Usage;
+            return ExitCode::usage();
         }
         $this->console->out($script);
-        return ExitCode::Success;
+        return ExitCode::success();
     }
 }

--- a/src/Cli/Command/CoverageDiffCommand.php
+++ b/src/Cli/Command/CoverageDiffCommand.php
@@ -33,20 +33,20 @@ final readonly class CoverageDiffCommand
         } catch (CliError $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
 
-            return ExitCode::Usage;
+            return ExitCode::usage();
         }
 
         $baselinePath = $arguments->value('baseline');
         $currentPath = $arguments->value('current');
         if ($baselinePath === null || $currentPath === null) {
             $this->console->err("coverage:diff requires --baseline=<path> and --current=<path>.\n");
-            return ExitCode::Usage;
+            return ExitCode::usage();
         }
         $baselineRoot = $arguments->value('baseline-root');
         $currentRoot = $arguments->value('current-root');
         if (($baselineRoot === null) !== ($currentRoot === null)) {
             $this->console->err("Use --baseline-root=<path> and --current-root=<path> together.\n");
-            return ExitCode::Usage;
+            return ExitCode::usage();
         }
         $maps = [];
         foreach (['baseline' => $baselinePath, 'current' => $currentPath] as $label => $path) {
@@ -63,7 +63,7 @@ final readonly class CoverageDiffCommand
                     $arguments->has('no-ansi'),
                 );
 
-                return ExitCode::Failure;
+                return ExitCode::failure();
             }
             try {
                 $maps[$label] = JsonExporter::import($json);
@@ -77,7 +77,7 @@ final readonly class CoverageDiffCommand
                     $arguments->has('no-ansi'),
                 );
 
-                return ExitCode::Failure;
+                return ExitCode::failure();
             }
         }
 
@@ -96,7 +96,7 @@ final readonly class CoverageDiffCommand
                         $error->getMessage(),
                     ), $arguments->has('no-ansi'));
 
-                    return ExitCode::Failure;
+                    return ExitCode::failure();
                 }
             }
         }
@@ -146,7 +146,7 @@ final readonly class CoverageDiffCommand
         }
 
         return $report->hasRegressions() || $gateFailures !== []
-            ? ExitCode::Failure
-            : ExitCode::Success;
+            ? ExitCode::failure()
+            : ExitCode::success();
     }
 }

--- a/src/Cli/Command/CoverageDiffCommand.php
+++ b/src/Cli/Command/CoverageDiffCommand.php
@@ -26,27 +26,27 @@ final readonly class CoverageDiffCommand
 {
     public function __construct(private Console $console) {}
 
-    public function run(ParsedArguments $arguments, string $workingDirectory): int
+    public function run(ParsedArguments $arguments, string $workingDirectory): ExitCode
     {
         try {
             $coverageOverrides = CoverageOverrides::fromArguments($arguments);
         } catch (CliError $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
 
-            return ExitCode::USAGE;
+            return ExitCode::Usage;
         }
 
         $baselinePath = $arguments->value('baseline');
         $currentPath = $arguments->value('current');
         if ($baselinePath === null || $currentPath === null) {
             $this->console->err("coverage:diff requires --baseline=<path> and --current=<path>.\n");
-            return ExitCode::USAGE;
+            return ExitCode::Usage;
         }
         $baselineRoot = $arguments->value('baseline-root');
         $currentRoot = $arguments->value('current-root');
         if (($baselineRoot === null) !== ($currentRoot === null)) {
             $this->console->err("Use --baseline-root=<path> and --current-root=<path> together.\n");
-            return ExitCode::USAGE;
+            return ExitCode::Usage;
         }
         $maps = [];
         foreach (['baseline' => $baselinePath, 'current' => $currentPath] as $label => $path) {
@@ -63,7 +63,7 @@ final readonly class CoverageDiffCommand
                     $arguments->has('no-ansi'),
                 );
 
-                return ExitCode::FAILURE;
+                return ExitCode::Failure;
             }
             try {
                 $maps[$label] = JsonExporter::import($json);
@@ -77,7 +77,7 @@ final readonly class CoverageDiffCommand
                     $arguments->has('no-ansi'),
                 );
 
-                return ExitCode::FAILURE;
+                return ExitCode::Failure;
             }
         }
 
@@ -96,7 +96,7 @@ final readonly class CoverageDiffCommand
                         $error->getMessage(),
                     ), $arguments->has('no-ansi'));
 
-                    return ExitCode::FAILURE;
+                    return ExitCode::Failure;
                 }
             }
         }
@@ -146,7 +146,7 @@ final readonly class CoverageDiffCommand
         }
 
         return $report->hasRegressions() || $gateFailures !== []
-            ? ExitCode::FAILURE
-            : ExitCode::SUCCESS;
+            ? ExitCode::Failure
+            : ExitCode::Success;
     }
 }

--- a/src/Cli/Command/CoverageMergeCommand.php
+++ b/src/Cli/Command/CoverageMergeCommand.php
@@ -29,14 +29,14 @@ final readonly class CoverageMergeCommand
 {
     public function __construct(private Console $console) {}
 
-    public function run(ParsedArguments $arguments, string $workingDirectory): int
+    public function run(ParsedArguments $arguments, string $workingDirectory): ExitCode
     {
         $inputs = $arguments->values('input');
 
         if (\count($inputs) < 2) {
             $this->console->err("coverage:merge requires at least two --input=<path> options.\n");
 
-            return ExitCode::USAGE;
+            return ExitCode::Usage;
         }
 
         try {
@@ -45,13 +45,13 @@ final readonly class CoverageMergeCommand
         } catch (CliError|InvalidConfiguration $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
 
-            return ExitCode::USAGE;
+            return ExitCode::Usage;
         }
 
         if ($exports === []) {
             $this->console->err("coverage:merge requires at least one --export=<format>=<path> option.\n");
 
-            return ExitCode::USAGE;
+            return ExitCode::Usage;
         }
 
         $inputRoots = $arguments->values('input-root');
@@ -60,13 +60,13 @@ final readonly class CoverageMergeCommand
         if (($inputRoots === []) !== ($projectRoot === null)) {
             $this->console->err("Use --input-root=<path> and --project-root=<path> together.\n");
 
-            return ExitCode::USAGE;
+            return ExitCode::Usage;
         }
 
         if ($inputRoots !== [] && \count($inputRoots) !== \count($inputs)) {
             $this->console->err("Repeat --input-root=<path> once for each --input=<path>.\n");
 
-            return ExitCode::USAGE;
+            return ExitCode::Usage;
         }
 
         $targetRoot = $projectRoot === null
@@ -81,7 +81,7 @@ final readonly class CoverageMergeCommand
             if ($input === '') {
                 $this->console->err("--input requires a non-empty path.\n");
 
-                return ExitCode::USAGE;
+                return ExitCode::Usage;
             }
 
             $path = ConfigurationLoader::absolutePath($input, $workingDirectory);
@@ -99,7 +99,7 @@ final readonly class CoverageMergeCommand
                         $input,
                     ), $arguments->has('no-ansi'));
 
-                    return ExitCode::USAGE;
+                    return ExitCode::Usage;
                 }
 
                 continue;
@@ -115,7 +115,7 @@ final readonly class CoverageMergeCommand
                     $warning === null ? '' : ': ' . $warning,
                 ), $arguments->has('no-ansi'));
 
-                return ExitCode::FAILURE;
+                return ExitCode::Failure;
             }
 
             try {
@@ -133,7 +133,7 @@ final readonly class CoverageMergeCommand
                     $error->getMessage(),
                 ), $arguments->has('no-ansi'));
 
-                return ExitCode::FAILURE;
+                return ExitCode::Failure;
             }
 
             $merged = $merged->merge($map);
@@ -156,7 +156,7 @@ final readonly class CoverageMergeCommand
             $merged,
             $workingDirectory,
             $style,
-        ) ? ExitCode::SUCCESS : ExitCode::FAILURE;
+        ) ? ExitCode::Success : ExitCode::Failure;
     }
 
     /**

--- a/src/Cli/Command/CoverageMergeCommand.php
+++ b/src/Cli/Command/CoverageMergeCommand.php
@@ -36,7 +36,7 @@ final readonly class CoverageMergeCommand
         if (\count($inputs) < 2) {
             $this->console->err("coverage:merge requires at least two --input=<path> options.\n");
 
-            return ExitCode::Usage;
+            return ExitCode::usage();
         }
 
         try {
@@ -45,13 +45,13 @@ final readonly class CoverageMergeCommand
         } catch (CliError|InvalidConfiguration $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
 
-            return ExitCode::Usage;
+            return ExitCode::usage();
         }
 
         if ($exports === []) {
             $this->console->err("coverage:merge requires at least one --export=<format>=<path> option.\n");
 
-            return ExitCode::Usage;
+            return ExitCode::usage();
         }
 
         $inputRoots = $arguments->values('input-root');
@@ -60,13 +60,13 @@ final readonly class CoverageMergeCommand
         if (($inputRoots === []) !== ($projectRoot === null)) {
             $this->console->err("Use --input-root=<path> and --project-root=<path> together.\n");
 
-            return ExitCode::Usage;
+            return ExitCode::usage();
         }
 
         if ($inputRoots !== [] && \count($inputRoots) !== \count($inputs)) {
             $this->console->err("Repeat --input-root=<path> once for each --input=<path>.\n");
 
-            return ExitCode::Usage;
+            return ExitCode::usage();
         }
 
         $targetRoot = $projectRoot === null
@@ -81,7 +81,7 @@ final readonly class CoverageMergeCommand
             if ($input === '') {
                 $this->console->err("--input requires a non-empty path.\n");
 
-                return ExitCode::Usage;
+                return ExitCode::usage();
             }
 
             $path = ConfigurationLoader::absolutePath($input, $workingDirectory);
@@ -99,7 +99,7 @@ final readonly class CoverageMergeCommand
                         $input,
                     ), $arguments->has('no-ansi'));
 
-                    return ExitCode::Usage;
+                    return ExitCode::usage();
                 }
 
                 continue;
@@ -115,7 +115,7 @@ final readonly class CoverageMergeCommand
                     $warning === null ? '' : ': ' . $warning,
                 ), $arguments->has('no-ansi'));
 
-                return ExitCode::Failure;
+                return ExitCode::failure();
             }
 
             try {
@@ -133,7 +133,7 @@ final readonly class CoverageMergeCommand
                     $error->getMessage(),
                 ), $arguments->has('no-ansi'));
 
-                return ExitCode::Failure;
+                return ExitCode::failure();
             }
 
             $merged = $merged->merge($map);
@@ -156,7 +156,7 @@ final readonly class CoverageMergeCommand
             $merged,
             $workingDirectory,
             $style,
-        ) ? ExitCode::Success : ExitCode::Failure;
+        ) ? ExitCode::success() : ExitCode::failure();
     }
 
     /**

--- a/src/Cli/Command/IdeHelperCommand.php
+++ b/src/Cli/Command/IdeHelperCommand.php
@@ -33,11 +33,11 @@ final readonly class IdeHelperCommand
             $map = MatcherMap::fromConfigFiles([ConfigurationLoader::absolutePath($configFile, $workingDirectory)]);
         } catch (ConfigFileError|InvalidConfiguration|MatcherMapError $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return ExitCode::Failure;
+            return ExitCode::failure();
         }
         if ($map->names() === []) {
             $this->console->out("The configuration has no extension matchers. There is no helper to generate.\n");
-            return ExitCode::Success;
+            return ExitCode::success();
         }
         $output = $arguments->value('output') ?? '_greenlight_ide_helper.php';
         $path = ConfigurationLoader::absolutePath($output, $workingDirectory);
@@ -45,12 +45,12 @@ final readonly class IdeHelperCommand
             AtomicFile::write($path, IdeHelper::render($map));
         } catch (AtomicFileError $error) {
             $this->console->err(\sprintf("Greenlight could not write \"%s\": %s\n", $path, $error->getMessage()));
-            return ExitCode::Failure;
+            return ExitCode::failure();
         }
         $this->console->out(
             \sprintf("Wrote %s with %d matchers. Add it to .gitignore. Generate it again after matcher changes.\n", $path, \count($map->names())),
         );
 
-        return ExitCode::Success;
+        return ExitCode::success();
     }
 }

--- a/src/Cli/Command/IdeHelperCommand.php
+++ b/src/Cli/Command/IdeHelperCommand.php
@@ -26,18 +26,18 @@ final readonly class IdeHelperCommand
 {
     public function __construct(private Console $console) {}
 
-    public function run(ParsedArguments $arguments, string $workingDirectory): int
+    public function run(ParsedArguments $arguments, string $workingDirectory): ExitCode
     {
         try {
             $configFile = $arguments->value('config') ?? \rtrim($workingDirectory, '/') . '/' . ConfigLoader::FILE_NAME;
             $map = MatcherMap::fromConfigFiles([ConfigurationLoader::absolutePath($configFile, $workingDirectory)]);
         } catch (ConfigFileError|InvalidConfiguration|MatcherMapError $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return ExitCode::FAILURE;
+            return ExitCode::Failure;
         }
         if ($map->names() === []) {
             $this->console->out("The configuration has no extension matchers. There is no helper to generate.\n");
-            return ExitCode::SUCCESS;
+            return ExitCode::Success;
         }
         $output = $arguments->value('output') ?? '_greenlight_ide_helper.php';
         $path = ConfigurationLoader::absolutePath($output, $workingDirectory);
@@ -45,12 +45,12 @@ final readonly class IdeHelperCommand
             AtomicFile::write($path, IdeHelper::render($map));
         } catch (AtomicFileError $error) {
             $this->console->err(\sprintf("Greenlight could not write \"%s\": %s\n", $path, $error->getMessage()));
-            return ExitCode::FAILURE;
+            return ExitCode::Failure;
         }
         $this->console->out(
             \sprintf("Wrote %s with %d matchers. Add it to .gitignore. Generate it again after matcher changes.\n", $path, \count($map->names())),
         );
 
-        return ExitCode::SUCCESS;
+        return ExitCode::Success;
     }
 }

--- a/src/Cli/Command/ListCommand.php
+++ b/src/Cli/Command/ListCommand.php
@@ -33,14 +33,14 @@ final readonly class ListCommand
 
         if (!\in_array($format, ['text', 'json'], true)) {
             $this->console->error(CliError::unknownTestListFormat($format)->getMessage(), $arguments->has('no-ansi'));
-            return ExitCode::Usage;
+            return ExitCode::usage();
         }
 
         $manifest = $format === 'json';
 
         if ($manifest && ($arguments->has('list-groups') || $arguments->has('list-suites'))) {
             $this->console->error(CliError::formatRequiresTestListing()->getMessage(), $arguments->has('no-ansi'));
-            return ExitCode::Usage;
+            return ExitCode::usage();
         }
 
         if (!$manifest) {
@@ -66,10 +66,10 @@ final readonly class ListCommand
             $loaded = new ConfigurationLoader()->load($arguments, $workingDirectory);
         } catch (CliError $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return ExitCode::Usage;
+            return ExitCode::usage();
         } catch (ConfigFileError|InvalidConfiguration $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return ExitCode::Failure;
+            return ExitCode::failure();
         }
         $standalone = $arguments->command === 'list-tests';
         if (!$standalone && $arguments->has('list-suites')) {
@@ -81,10 +81,10 @@ final readonly class ListCommand
             $plan = SelectionPlan::resolve($loaded, $workingDirectory, $arguments->has('failed'));
         } catch (CliError $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return ExitCode::Usage;
+            return ExitCode::usage();
         } catch (DiscoveryError $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return ExitCode::Failure;
+            return ExitCode::failure();
         }
 
         if ($manifest) {
@@ -99,7 +99,7 @@ final readonly class ListCommand
                 \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_INVALID_UTF8_SUBSTITUTE | \JSON_THROW_ON_ERROR,
             ) . "\n");
 
-            return ExitCode::Success;
+            return ExitCode::success();
         }
 
         return !$standalone && $arguments->has('list-groups') ? $this->groups($plan) : $this->tests($plan);
@@ -111,7 +111,7 @@ final readonly class ListCommand
             $this->console->out($entry->id . "\n");
         }
         $this->console->out(\sprintf("\n%d tests\n", \count($plan->entries)));
-        return ExitCode::Success;
+        return ExitCode::success();
     }
 
     private function groups(ExecutionPlan $plan): ExitCode
@@ -127,7 +127,7 @@ final readonly class ListCommand
             $this->console->out(\sprintf("%s (%d tests)\n", $group, $count));
         }
         $this->console->out(\sprintf("\n%d groups\n", \count($counts)));
-        return ExitCode::Success;
+        return ExitCode::success();
     }
 
     private function suites(ResolvedConfiguration $resolved): ExitCode
@@ -142,7 +142,7 @@ final readonly class ListCommand
             $this->console->out($line . "\n");
         }
         $this->console->out(\sprintf("\n%d suites\n", \count($suites)));
-        return ExitCode::Success;
+        return ExitCode::success();
     }
 
     private function warnWhenExcludePathsMatchNothing(SelectionDiscovery $discovery, bool $noAnsi): void

--- a/src/Cli/Command/ListCommand.php
+++ b/src/Cli/Command/ListCommand.php
@@ -27,20 +27,20 @@ final readonly class ListCommand
 {
     public function __construct(private Console $console) {}
 
-    public function run(ParsedArguments $arguments, string $workingDirectory): int
+    public function run(ParsedArguments $arguments, string $workingDirectory): ExitCode
     {
         $format = $arguments->value('format') ?? 'text';
 
         if (!\in_array($format, ['text', 'json'], true)) {
             $this->console->error(CliError::unknownTestListFormat($format)->getMessage(), $arguments->has('no-ansi'));
-            return ExitCode::USAGE;
+            return ExitCode::Usage;
         }
 
         $manifest = $format === 'json';
 
         if ($manifest && ($arguments->has('list-groups') || $arguments->has('list-suites'))) {
             $this->console->error(CliError::formatRequiresTestListing()->getMessage(), $arguments->has('no-ansi'));
-            return ExitCode::USAGE;
+            return ExitCode::Usage;
         }
 
         if (!$manifest) {
@@ -60,16 +60,16 @@ final readonly class ListCommand
         }
     }
 
-    private function execute(ParsedArguments $arguments, string $workingDirectory, bool $manifest): int
+    private function execute(ParsedArguments $arguments, string $workingDirectory, bool $manifest): ExitCode
     {
         try {
             $loaded = new ConfigurationLoader()->load($arguments, $workingDirectory);
         } catch (CliError $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return ExitCode::USAGE;
+            return ExitCode::Usage;
         } catch (ConfigFileError|InvalidConfiguration $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return ExitCode::FAILURE;
+            return ExitCode::Failure;
         }
         $standalone = $arguments->command === 'list-tests';
         if (!$standalone && $arguments->has('list-suites')) {
@@ -81,10 +81,10 @@ final readonly class ListCommand
             $plan = SelectionPlan::resolve($loaded, $workingDirectory, $arguments->has('failed'));
         } catch (CliError $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return ExitCode::USAGE;
+            return ExitCode::Usage;
         } catch (DiscoveryError $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return ExitCode::FAILURE;
+            return ExitCode::Failure;
         }
 
         if ($manifest) {
@@ -99,22 +99,22 @@ final readonly class ListCommand
                 \JSON_PRETTY_PRINT | \JSON_UNESCAPED_SLASHES | \JSON_INVALID_UTF8_SUBSTITUTE | \JSON_THROW_ON_ERROR,
             ) . "\n");
 
-            return ExitCode::SUCCESS;
+            return ExitCode::Success;
         }
 
         return !$standalone && $arguments->has('list-groups') ? $this->groups($plan) : $this->tests($plan);
     }
 
-    private function tests(ExecutionPlan $plan): int
+    private function tests(ExecutionPlan $plan): ExitCode
     {
         foreach ($plan->entries as $entry) {
             $this->console->out($entry->id . "\n");
         }
         $this->console->out(\sprintf("\n%d tests\n", \count($plan->entries)));
-        return ExitCode::SUCCESS;
+        return ExitCode::Success;
     }
 
-    private function groups(ExecutionPlan $plan): int
+    private function groups(ExecutionPlan $plan): ExitCode
     {
         $counts = [];
         foreach ($plan->entries as $entry) {
@@ -127,10 +127,10 @@ final readonly class ListCommand
             $this->console->out(\sprintf("%s (%d tests)\n", $group, $count));
         }
         $this->console->out(\sprintf("\n%d groups\n", \count($counts)));
-        return ExitCode::SUCCESS;
+        return ExitCode::Success;
     }
 
-    private function suites(ResolvedConfiguration $resolved): int
+    private function suites(ResolvedConfiguration $resolved): ExitCode
     {
         $suites = $resolved->discovery->suites;
         \usort($suites, static fn(SuiteConfiguration $a, SuiteConfiguration $b): int => \strcmp($a->name, $b->name));
@@ -142,7 +142,7 @@ final readonly class ListCommand
             $this->console->out($line . "\n");
         }
         $this->console->out(\sprintf("\n%d suites\n", \count($suites)));
-        return ExitCode::SUCCESS;
+        return ExitCode::Success;
     }
 
     private function warnWhenExcludePathsMatchNothing(SelectionDiscovery $discovery, bool $noAnsi): void

--- a/src/Cli/Command/ProfileReportCommand.php
+++ b/src/Cli/Command/ProfileReportCommand.php
@@ -24,19 +24,19 @@ final readonly class ProfileReportCommand
 {
     public function __construct(private Console $console) {}
 
-    public function run(ParsedArguments $arguments, string $workingDirectory): int
+    public function run(ParsedArguments $arguments, string $workingDirectory): ExitCode
     {
         $inputs = $arguments->values('input');
         $input = $inputs[0] ?? null;
         if (\count($inputs) !== 1 || $input === null || $input === '') {
             $this->console->err("profile:report requires --input=<path to a JSONL stream>.\n");
-            return ExitCode::USAGE;
+            return ExitCode::Usage;
         }
         $path = ConfigurationLoader::absolutePath($input, $workingDirectory);
         $raw = ErrorTrap::run(static fn() => \file_get_contents($path), $warning);
         if (!\is_string($raw)) {
             $this->console->err(\sprintf("Greenlight could not read \"%s\"%s.\n", $path, $warning === null ? '' : ': ' . $warning));
-            return ExitCode::FAILURE;
+            return ExitCode::Failure;
         }
         $aggregator = new ProfileAggregator();
         foreach (\explode("\n", $raw) as $line) {
@@ -49,7 +49,7 @@ final readonly class ProfileReportCommand
             } catch (EventCodecFailed $failure) {
                 $exitCode = $this->handleCodecFailure($failure, $arguments->has('no-ansi'));
 
-                if ($exitCode === null) {
+                if (!$exitCode instanceof ExitCode) {
                     continue;
                 }
 
@@ -59,13 +59,13 @@ final readonly class ProfileReportCommand
         $report = $aggregator->render(new Style($this->console->capabilities($arguments->has('no-ansi'), $arguments->has('ansi'))->color));
         if ($report === '') {
             $this->console->err("The stream has no finished run to profile.\n");
-            return ExitCode::FAILURE;
+            return ExitCode::Failure;
         }
         $this->console->out(\ltrim($report, "\n"));
-        return ExitCode::SUCCESS;
+        return ExitCode::Success;
     }
 
-    private function handleCodecFailure(EventCodecFailed $failure, bool $noAnsi): ?int
+    private function handleCodecFailure(EventCodecFailed $failure, bool $noAnsi): ?ExitCode
     {
         return match ($failure->kind) {
             EventCodecFailureKind::UnknownEvent => null,
@@ -83,7 +83,7 @@ final readonly class ProfileReportCommand
         };
     }
 
-    private function writeUnsupportedVersion(EventCodecFailed $failure): int
+    private function writeUnsupportedVersion(EventCodecFailed $failure): ExitCode
     {
         return $this->writeInputError(\sprintf(
             'The input uses unsupported JSONL version %d.',
@@ -91,7 +91,7 @@ final readonly class ProfileReportCommand
         ));
     }
 
-    private function writeInvalidEvent(EventCodecFailed $failure, bool $noAnsi): int
+    private function writeInvalidEvent(EventCodecFailed $failure, bool $noAnsi): ExitCode
     {
         $this->console->error(\sprintf(
             'Greenlight could not decode a "%s" event: %s',
@@ -99,13 +99,13 @@ final readonly class ProfileReportCommand
             $failure->getMessage(),
         ), $noAnsi);
 
-        return ExitCode::FAILURE;
+        return ExitCode::Failure;
     }
 
-    private function writeInputError(string $message): int
+    private function writeInputError(string $message): ExitCode
     {
         $this->console->err($message . "\n");
 
-        return ExitCode::FAILURE;
+        return ExitCode::Failure;
     }
 }

--- a/src/Cli/Command/ProfileReportCommand.php
+++ b/src/Cli/Command/ProfileReportCommand.php
@@ -30,13 +30,13 @@ final readonly class ProfileReportCommand
         $input = $inputs[0] ?? null;
         if (\count($inputs) !== 1 || $input === null || $input === '') {
             $this->console->err("profile:report requires --input=<path to a JSONL stream>.\n");
-            return ExitCode::Usage;
+            return ExitCode::usage();
         }
         $path = ConfigurationLoader::absolutePath($input, $workingDirectory);
         $raw = ErrorTrap::run(static fn() => \file_get_contents($path), $warning);
         if (!\is_string($raw)) {
             $this->console->err(\sprintf("Greenlight could not read \"%s\"%s.\n", $path, $warning === null ? '' : ': ' . $warning));
-            return ExitCode::Failure;
+            return ExitCode::failure();
         }
         $aggregator = new ProfileAggregator();
         foreach (\explode("\n", $raw) as $line) {
@@ -59,10 +59,10 @@ final readonly class ProfileReportCommand
         $report = $aggregator->render(new Style($this->console->capabilities($arguments->has('no-ansi'), $arguments->has('ansi'))->color));
         if ($report === '') {
             $this->console->err("The stream has no finished run to profile.\n");
-            return ExitCode::Failure;
+            return ExitCode::failure();
         }
         $this->console->out(\ltrim($report, "\n"));
-        return ExitCode::Success;
+        return ExitCode::success();
     }
 
     private function handleCodecFailure(EventCodecFailed $failure, bool $noAnsi): ?ExitCode
@@ -99,13 +99,13 @@ final readonly class ProfileReportCommand
             $failure->getMessage(),
         ), $noAnsi);
 
-        return ExitCode::Failure;
+        return ExitCode::failure();
     }
 
     private function writeInputError(string $message): ExitCode
     {
         $this->console->err($message . "\n");
 
-        return ExitCode::Failure;
+        return ExitCode::failure();
     }
 }

--- a/src/Cli/Output/ExitCode.php
+++ b/src/Cli/Output/ExitCode.php
@@ -5,15 +5,41 @@ declare(strict_types=1);
 namespace Greenlight\Cli\Output;
 
 /**
- * Defines the process exit codes that Greenlight commands return.
+ * Identifies one result that a Greenlight command returns. Converts the result
+ * to an integer at a process or plugin seam.
  *
  * @internal
  */
-final class ExitCode
+enum ExitCode
 {
-    public const int SUCCESS = 0;
-    public const int FAILURE = 1;
-    public const int USAGE = 64;
+    case Success;
+    case Failure;
+    case Usage;
+    case Interrupted;
+    case Terminated;
 
-    private function __construct() {}
+    public function toInt(): int
+    {
+        return match ($this) {
+            self::Success => 0,
+            self::Failure => 1,
+            self::Usage => 64,
+            self::Interrupted => 130,
+            self::Terminated => 143,
+        };
+    }
+
+    public static function fromInt(int $value): self
+    {
+        foreach (self::cases() as $exitCode) {
+            if ($exitCode->toInt() === $value) {
+                return $exitCode;
+            }
+        }
+
+        throw new \InvalidArgumentException(\sprintf(
+            'Exit code %d does not identify a Greenlight command result.',
+            $value,
+        ));
+    }
 }

--- a/src/Cli/Output/ExitCode.php
+++ b/src/Cli/Output/ExitCode.php
@@ -5,42 +5,42 @@ declare(strict_types=1);
 namespace Greenlight\Cli\Output;
 
 /**
- * Identifies one result that a Greenlight command returns. Converts the result
- * to an integer at a process or plugin seam.
+ * Contains the integer result that a Greenlight command returns. Converts the
+ * result to an integer at a process or plugin seam.
  *
  * @internal
  */
-enum ExitCode
+final readonly class ExitCode
 {
-    case Success;
-    case Failure;
-    case Usage;
-    case Interrupted;
-    case Terminated;
+    private function __construct(private int $value) {}
 
-    /** @return 0|1|64|130|143 */
-    public function toInt(): int
+    public static function success(): self
     {
-        return match ($this) {
-            self::Success => 0,
-            self::Failure => 1,
-            self::Usage => 64,
-            self::Interrupted => 130,
-            self::Terminated => 143,
-        };
+        return new self(0);
+    }
+
+    public static function failure(): self
+    {
+        return new self(1);
+    }
+
+    public static function usage(): self
+    {
+        return new self(64);
     }
 
     public static function fromInt(int $value): self
     {
-        foreach (self::cases() as $exitCode) {
-            if ($exitCode->toInt() === $value) {
-                return $exitCode;
-            }
-        }
+        return new self($value);
+    }
 
-        throw new \InvalidArgumentException(\sprintf(
-            'Exit code %d does not identify a Greenlight command result.',
-            $value,
-        ));
+    public function isSuccess(): bool
+    {
+        return $this->value === 0;
+    }
+
+    public function toInt(): int
+    {
+        return $this->value;
     }
 }

--- a/src/Cli/Output/ExitCode.php
+++ b/src/Cli/Output/ExitCode.php
@@ -18,6 +18,7 @@ enum ExitCode
     case Interrupted;
     case Terminated;
 
+    /** @return 0|1|64|130|143 */
     public function toInt(): int
     {
         return match ($this) {

--- a/src/Cli/Output/ExitCode.php
+++ b/src/Cli/Output/ExitCode.php
@@ -29,6 +29,15 @@ final readonly class ExitCode
         return new self(64);
     }
 
+    public static function signal(int $signal): self
+    {
+        if ($signal < 1 || $signal > 127) {
+            throw new \InvalidArgumentException('Signal number MUST be from 1 through 127.');
+        }
+
+        return new self(128 + $signal);
+    }
+
     public static function fromInt(int $value): self
     {
         return new self($value);

--- a/src/Cli/Plugin/BundledCommands.php
+++ b/src/Cli/Plugin/BundledCommands.php
@@ -71,19 +71,19 @@ final readonly class BundledCommands implements CommandProvider
         } catch (CliError $error) {
             $this->console->error($error->getMessage(), \in_array('--no-ansi', $invocation->argv(), true));
 
-            return ExitCode::Usage;
+            return ExitCode::usage();
         }
 
         if ($arguments->has('help')) {
             $this->console->out(Definition::HELP . "\n");
 
-            return ExitCode::Success;
+            return ExitCode::success();
         }
 
         if ($arguments->has('version')) {
             $this->console->out('Greenlight ' . $this->version . "\n");
 
-            return ExitCode::Success;
+            return ExitCode::success();
         }
 
         $command = $arguments->command ?? 'run';
@@ -97,7 +97,7 @@ final readonly class BundledCommands implements CommandProvider
                 $arguments->has('no-ansi'),
             );
 
-            return ExitCode::Usage;
+            return ExitCode::usage();
         }
 
         if ($command === 'list-tests'

--- a/src/Cli/Plugin/BundledCommands.php
+++ b/src/Cli/Plugin/BundledCommands.php
@@ -47,15 +47,15 @@ final readonly class BundledCommands implements CommandProvider
                 $name,
                 $description,
                 $name === 'completion'
-                    ? $this->completion(...)
-                    : $this->parsedCommand(...),
+                    ? fn(CommandInvocation $invocation): int => $this->completion($invocation)->toInt()
+                    : fn(CommandInvocation $invocation): int => $this->parsedCommand($invocation)->toInt(),
             );
         }
 
         return $definitions;
     }
 
-    private function completion(CommandInvocation $invocation): int
+    private function completion(CommandInvocation $invocation): ExitCode
     {
         return new CompletionCommand($this->console, $this->definition)->run($invocation->arguments);
     }
@@ -64,26 +64,26 @@ final readonly class BundledCommands implements CommandProvider
      * @throws CoverageError
      * @throws ReportGenerationFailed
      */
-    private function parsedCommand(CommandInvocation $invocation): int
+    private function parsedCommand(CommandInvocation $invocation): ExitCode
     {
         try {
             $arguments = $this->definition->parser()->parse($invocation->argv());
         } catch (CliError $error) {
             $this->console->error($error->getMessage(), \in_array('--no-ansi', $invocation->argv(), true));
 
-            return ExitCode::USAGE;
+            return ExitCode::Usage;
         }
 
         if ($arguments->has('help')) {
             $this->console->out(Definition::HELP . "\n");
 
-            return ExitCode::SUCCESS;
+            return ExitCode::Success;
         }
 
         if ($arguments->has('version')) {
             $this->console->out('Greenlight ' . $this->version . "\n");
 
-            return ExitCode::SUCCESS;
+            return ExitCode::Success;
         }
 
         $command = $arguments->command ?? 'run';
@@ -97,7 +97,7 @@ final readonly class BundledCommands implements CommandProvider
                 $arguments->has('no-ansi'),
             );
 
-            return ExitCode::USAGE;
+            return ExitCode::Usage;
         }
 
         if ($command === 'list-tests'

--- a/src/Cli/Plugin/CommandDispatcher.php
+++ b/src/Cli/Plugin/CommandDispatcher.php
@@ -57,7 +57,7 @@ final readonly class CommandDispatcher
         } catch (ConfigFileError|InvalidConfiguration|CommandSetupFailed $error) {
             $this->console->error($error->getMessage(), \in_array('--no-ansi', $argv, true));
 
-            return ExitCode::FAILURE;
+            return ExitCode::Failure->toInt();
         }
 
         $definition = $catalog->get($command);
@@ -68,7 +68,7 @@ final readonly class CommandDispatcher
                 \in_array('--no-ansi', $argv, true),
             );
 
-            return ExitCode::USAGE;
+            return ExitCode::Usage->toInt();
         }
 
         $arguments = $argv;
@@ -96,7 +96,7 @@ final readonly class CommandDispatcher
                 $error->getMessage(),
             ), \in_array('--no-ansi', $argv, true));
 
-            return ExitCode::FAILURE;
+            return ExitCode::Failure->toInt();
         }
 
         if ($exitCode < 0 || $exitCode > 255) {
@@ -106,7 +106,7 @@ final readonly class CommandDispatcher
                 $exitCode,
             ), \in_array('--no-ansi', $argv, true));
 
-            return ExitCode::FAILURE;
+            return ExitCode::Failure->toInt();
         }
 
         return $exitCode;

--- a/src/Cli/Plugin/CommandDispatcher.php
+++ b/src/Cli/Plugin/CommandDispatcher.php
@@ -57,7 +57,7 @@ final readonly class CommandDispatcher
         } catch (ConfigFileError|InvalidConfiguration|CommandSetupFailed $error) {
             $this->console->error($error->getMessage(), \in_array('--no-ansi', $argv, true));
 
-            return ExitCode::Failure->toInt();
+            return ExitCode::failure()->toInt();
         }
 
         $definition = $catalog->get($command);
@@ -68,7 +68,7 @@ final readonly class CommandDispatcher
                 \in_array('--no-ansi', $argv, true),
             );
 
-            return ExitCode::Usage->toInt();
+            return ExitCode::usage()->toInt();
         }
 
         $arguments = $argv;
@@ -96,7 +96,7 @@ final readonly class CommandDispatcher
                 $error->getMessage(),
             ), \in_array('--no-ansi', $argv, true));
 
-            return ExitCode::Failure->toInt();
+            return ExitCode::failure()->toInt();
         }
 
         if ($exitCode < 0 || $exitCode > 255) {
@@ -106,7 +106,7 @@ final readonly class CommandDispatcher
                 $exitCode,
             ), \in_array('--no-ansi', $argv, true));
 
-            return ExitCode::Failure->toInt();
+            return ExitCode::failure()->toInt();
         }
 
         return $exitCode;

--- a/src/Cli/Plugin/CommandDispatcher.php
+++ b/src/Cli/Plugin/CommandDispatcher.php
@@ -40,7 +40,7 @@ final readonly class CommandDispatcher
      * @throws ReportGenerationFailed
      * @throws WireCommunicationFailed
      */
-    public function dispatch(array $argv, string $workingDirectory, ?string $binPath): int
+    public function dispatch(array $argv, string $workingDirectory, ?string $binPath): ExitCode
     {
         [$command, $commandIndex] = $this->selectedCommand($argv);
         $command ??= 'run';
@@ -57,7 +57,7 @@ final readonly class CommandDispatcher
         } catch (ConfigFileError|InvalidConfiguration|CommandSetupFailed $error) {
             $this->console->error($error->getMessage(), \in_array('--no-ansi', $argv, true));
 
-            return ExitCode::failure()->toInt();
+            return ExitCode::failure();
         }
 
         $definition = $catalog->get($command);
@@ -68,7 +68,7 @@ final readonly class CommandDispatcher
                 \in_array('--no-ansi', $argv, true),
             );
 
-            return ExitCode::usage()->toInt();
+            return ExitCode::usage();
         }
 
         $arguments = $argv;
@@ -96,7 +96,7 @@ final readonly class CommandDispatcher
                 $error->getMessage(),
             ), \in_array('--no-ansi', $argv, true));
 
-            return ExitCode::failure()->toInt();
+            return ExitCode::failure();
         }
 
         if ($exitCode < 0 || $exitCode > 255) {
@@ -106,10 +106,10 @@ final readonly class CommandDispatcher
                 $exitCode,
             ), \in_array('--no-ansi', $argv, true));
 
-            return ExitCode::failure()->toInt();
+            return ExitCode::failure();
         }
 
-        return $exitCode;
+        return ExitCode::fromInt($exitCode);
     }
 
     /**

--- a/src/Cli/Run/ArtifactsPruneCommand.php
+++ b/src/Cli/Run/ArtifactsPruneCommand.php
@@ -23,22 +23,22 @@ final readonly class ArtifactsPruneCommand
 {
     public function __construct(private Console $console) {}
 
-    public function run(ParsedArguments $arguments, string $workingDirectory): int
+    public function run(ParsedArguments $arguments, string $workingDirectory): ExitCode
     {
         try {
             $configuration = new ConfigurationLoader()->load($arguments, $workingDirectory)->resolved->execution->artifacts;
             $maintenance = ArtifactMaintenance::forConfiguration($configuration, $workingDirectory);
         } catch (CliError $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return ExitCode::USAGE;
+            return ExitCode::Usage;
         } catch (AttachmentError|ConfigFileError|InvalidConfiguration $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return ExitCode::FAILURE;
+            return ExitCode::Failure;
         }
 
         if (!$configuration->hasRetentionPolicy()) {
             $this->console->out("No artifact retention policy is configured.\n");
-            return ExitCode::SUCCESS;
+            return ExitCode::Success;
         }
 
         $report = $maintenance->prune($arguments->has('dry-run'));
@@ -61,6 +61,6 @@ final readonly class ArtifactsPruneCommand
             $this->console->err($warning . "\n");
         }
 
-        return ExitCode::SUCCESS;
+        return ExitCode::Success;
     }
 }

--- a/src/Cli/Run/ArtifactsPruneCommand.php
+++ b/src/Cli/Run/ArtifactsPruneCommand.php
@@ -30,15 +30,15 @@ final readonly class ArtifactsPruneCommand
             $maintenance = ArtifactMaintenance::forConfiguration($configuration, $workingDirectory);
         } catch (CliError $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return ExitCode::Usage;
+            return ExitCode::usage();
         } catch (AttachmentError|ConfigFileError|InvalidConfiguration $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return ExitCode::Failure;
+            return ExitCode::failure();
         }
 
         if (!$configuration->hasRetentionPolicy()) {
             $this->console->out("No artifact retention policy is configured.\n");
-            return ExitCode::Success;
+            return ExitCode::success();
         }
 
         $report = $maintenance->prune($arguments->has('dry-run'));
@@ -61,6 +61,6 @@ final readonly class ArtifactsPruneCommand
             $this->console->err($warning . "\n");
         }
 
-        return ExitCode::Success;
+        return ExitCode::success();
     }
 }

--- a/src/Cli/Run/RunAttemptResult.php
+++ b/src/Cli/Run/RunAttemptResult.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Greenlight\Cli\Run;
 
+use Greenlight\Cli\Output\ExitCode;
+
 /**
  * Contains the observable result and saved scheduling data for one run attempt.
  *
@@ -16,7 +18,7 @@ final readonly class RunAttemptResult
      * @param array<non-empty-string, float> $classSeconds
      */
     public function __construct(
-        public int $exitCode,
+        public ExitCode $exitCode,
         public array $failedTests,
         public array $classSeconds,
     ) {}

--- a/src/Cli/Run/RunCommand.php
+++ b/src/Cli/Run/RunCommand.php
@@ -77,11 +77,11 @@ final readonly class RunCommand
         } catch (CliError $error) {
             $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-            return ExitCode::Usage;
+            return ExitCode::usage();
         } catch (ConfigFileError|InvalidConfiguration $error) {
             $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-            return ExitCode::Failure;
+            return ExitCode::failure();
         }
         $resolved = $configuration->resolved;
         $configFile = $configuration->file;
@@ -90,13 +90,13 @@ final readonly class RunCommand
         if ($arguments->has('watch') && ($overrides->repeat->count !== null || $overrides->repeat->untilFailure)) {
             $this->printError('Do not use --watch with --repeat or --repeat-until-failure.', $arguments->has('no-ansi'));
 
-            return ExitCode::Usage;
+            return ExitCode::usage();
         }
 
         if ($arguments->has('dry-run')) {
             ($this->out)(PlanFormatter::format($resolved, $configFile, $workingDirectory));
 
-            return ExitCode::Success;
+            return ExitCode::success();
         }
 
         $this->warnWhenExcludePathsMatchNothing(new SelectionDiscovery($configuration, $workingDirectory), $arguments->has('no-ansi'));
@@ -120,11 +120,11 @@ final readonly class RunCommand
         } catch (CliError $error) {
             $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-            return ExitCode::Usage;
+            return ExitCode::usage();
         } catch (ReporterSetupFailed $error) {
             $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-            return ExitCode::Failure;
+            return ExitCode::failure();
         }
 
         try {
@@ -133,12 +133,12 @@ final readonly class RunCommand
             $reporterOutputs->close();
             $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-            return ExitCode::Usage;
+            return ExitCode::usage();
         } catch (ReporterSetupFailed $error) {
             $reporterOutputs->close();
             $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-            return ExitCode::Failure;
+            return ExitCode::failure();
         }
 
         try {
@@ -161,13 +161,13 @@ final readonly class RunCommand
                 if ($previousFailures === null) {
                     $this->printError(CliError::failedRequiresState()->getMessage(), $arguments->has('no-ansi'));
 
-                    return ExitCode::Usage;
+                    return ExitCode::usage();
                 }
 
                 if ($previousFailures === []) {
                     ($this->out)("No tests failed in the previous run. There are no tests to run again.\n");
 
-                    return ExitCode::Success;
+                    return ExitCode::success();
                 }
 
                 $selection = $resolved->selection->withExactIds($previousFailures);
@@ -232,11 +232,11 @@ final readonly class RunCommand
                     } catch (CliError $error) {
                         $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-                        return ExitCode::Usage;
+                        return ExitCode::usage();
                     } catch (ReporterSetupFailed $error) {
                         $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-                        return ExitCode::Failure;
+                        return ExitCode::failure();
                     }
                 }
 
@@ -257,7 +257,7 @@ final readonly class RunCommand
                     return ExitCode::fromInt($interruptExit);
                 }
 
-                if ($attempt->exitCode !== ExitCode::Success) {
+                if (!$attempt->exitCode->isSuccess()) {
                     $failedIterations[] = $iteration;
 
                     if ($overrides->repeat->untilFailure) {
@@ -269,7 +269,7 @@ final readonly class RunCommand
             if ($failedIterations === []) {
                 $repeatOutput(\sprintf("Repeat: %d iterations, all passed\n", $limit));
 
-                return ExitCode::Success;
+                return ExitCode::success();
             }
 
             // Record each test that fails in an iteration. Thus, a later --failed
@@ -278,7 +278,7 @@ final readonly class RunCommand
 
             $repeatOutput(\sprintf("Repeat: failed iterations: %s\n", \implode(', ', $failedIterations)));
 
-            return ExitCode::Failure;
+            return ExitCode::failure();
         } finally {
             $reporterOutputs->close();
         }

--- a/src/Cli/Run/RunCommand.php
+++ b/src/Cli/Run/RunCommand.php
@@ -251,10 +251,10 @@ final readonly class RunCommand
 
                 $lastClassSeconds = $attempt->classSeconds;
 
-                $interruptExit = $shutdown->exitCode();
+                $interruptSignal = $shutdown->signal();
 
-                if ($interruptExit !== null) {
-                    return ExitCode::fromInt($interruptExit);
+                if ($interruptSignal !== null) {
+                    return ExitCode::signal($interruptSignal);
                 }
 
                 if (!$attempt->exitCode->isSuccess()) {

--- a/src/Cli/Run/RunCommand.php
+++ b/src/Cli/Run/RunCommand.php
@@ -61,7 +61,7 @@ final readonly class RunCommand
      * @throws CoverageError
      * @throws ReportGenerationFailed
      */
-    public function run(ParsedArguments $arguments, string $workingDirectory, ?string $binPath): int
+    public function run(ParsedArguments $arguments, string $workingDirectory, ?string $binPath): ExitCode
     {
         return $this->runCommand($arguments, $workingDirectory, $binPath);
     }
@@ -70,18 +70,18 @@ final readonly class RunCommand
      * @throws CoverageError
      * @throws ReportGenerationFailed
      */
-    private function runCommand(ParsedArguments $arguments, string $workingDirectory, ?string $binPath = null): int
+    private function runCommand(ParsedArguments $arguments, string $workingDirectory, ?string $binPath = null): ExitCode
     {
         try {
             $configuration = new ConfigurationLoader()->load($arguments, $workingDirectory);
         } catch (CliError $error) {
             $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-            return ExitCode::USAGE;
+            return ExitCode::Usage;
         } catch (ConfigFileError|InvalidConfiguration $error) {
             $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-            return ExitCode::FAILURE;
+            return ExitCode::Failure;
         }
         $resolved = $configuration->resolved;
         $configFile = $configuration->file;
@@ -90,13 +90,13 @@ final readonly class RunCommand
         if ($arguments->has('watch') && ($overrides->repeat->count !== null || $overrides->repeat->untilFailure)) {
             $this->printError('Do not use --watch with --repeat or --repeat-until-failure.', $arguments->has('no-ansi'));
 
-            return ExitCode::USAGE;
+            return ExitCode::Usage;
         }
 
         if ($arguments->has('dry-run')) {
             ($this->out)(PlanFormatter::format($resolved, $configFile, $workingDirectory));
 
-            return ExitCode::SUCCESS;
+            return ExitCode::Success;
         }
 
         $this->warnWhenExcludePathsMatchNothing(new SelectionDiscovery($configuration, $workingDirectory), $arguments->has('no-ansi'));
@@ -120,11 +120,11 @@ final readonly class RunCommand
         } catch (CliError $error) {
             $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-            return ExitCode::USAGE;
+            return ExitCode::Usage;
         } catch (ReporterSetupFailed $error) {
             $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-            return ExitCode::FAILURE;
+            return ExitCode::Failure;
         }
 
         try {
@@ -133,12 +133,12 @@ final readonly class RunCommand
             $reporterOutputs->close();
             $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-            return ExitCode::USAGE;
+            return ExitCode::Usage;
         } catch (ReporterSetupFailed $error) {
             $reporterOutputs->close();
             $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-            return ExitCode::FAILURE;
+            return ExitCode::Failure;
         }
 
         try {
@@ -161,13 +161,13 @@ final readonly class RunCommand
                 if ($previousFailures === null) {
                     $this->printError(CliError::failedRequiresState()->getMessage(), $arguments->has('no-ansi'));
 
-                    return ExitCode::USAGE;
+                    return ExitCode::Usage;
                 }
 
                 if ($previousFailures === []) {
                     ($this->out)("No tests failed in the previous run. There are no tests to run again.\n");
 
-                    return ExitCode::SUCCESS;
+                    return ExitCode::Success;
                 }
 
                 $selection = $resolved->selection->withExactIds($previousFailures);
@@ -232,11 +232,11 @@ final readonly class RunCommand
                     } catch (CliError $error) {
                         $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-                        return ExitCode::USAGE;
+                        return ExitCode::Usage;
                     } catch (ReporterSetupFailed $error) {
                         $this->printError($error->getMessage(), $arguments->has('no-ansi'));
 
-                        return ExitCode::FAILURE;
+                        return ExitCode::Failure;
                     }
                 }
 
@@ -254,10 +254,10 @@ final readonly class RunCommand
                 $interruptExit = $shutdown->exitCode();
 
                 if ($interruptExit !== null) {
-                    return $interruptExit;
+                    return ExitCode::fromInt($interruptExit);
                 }
 
-                if ($attempt->exitCode !== ExitCode::SUCCESS) {
+                if ($attempt->exitCode !== ExitCode::Success) {
                     $failedIterations[] = $iteration;
 
                     if ($overrides->repeat->untilFailure) {
@@ -269,7 +269,7 @@ final readonly class RunCommand
             if ($failedIterations === []) {
                 $repeatOutput(\sprintf("Repeat: %d iterations, all passed\n", $limit));
 
-                return ExitCode::SUCCESS;
+                return ExitCode::Success;
             }
 
             // Record each test that fails in an iteration. Thus, a later --failed
@@ -278,7 +278,7 @@ final readonly class RunCommand
 
             $repeatOutput(\sprintf("Repeat: failed iterations: %s\n", \implode(', ', $failedIterations)));
 
-            return ExitCode::FAILURE;
+            return ExitCode::Failure;
         } finally {
             $reporterOutputs->close();
         }

--- a/src/Cli/Run/RunSession.php
+++ b/src/Cli/Run/RunSession.php
@@ -122,7 +122,7 @@ final readonly class RunSession
      * @throws CoverageError
      * @throws ReportGenerationFailed
      */
-    private function execute(Reporter $reporter, FailedTestsTap $failedTap, array $priorityClasses, array $classSeconds): int
+    private function execute(Reporter $reporter, FailedTestsTap $failedTap, array $priorityClasses, array $classSeconds): ExitCode
     {
         $resolved = $this->configuration->resolved;
         $workers = $resolved->workers->count->fixed ?? CpuCores::count();
@@ -144,7 +144,9 @@ final readonly class RunSession
                     $this->console->err("Interrupted. Integration fixture teardown was attempted before exit.\n");
                 }
 
-                return $interruptExit ?? ExitCode::FAILURE;
+                return $interruptExit === null
+                    ? ExitCode::Failure
+                    : ExitCode::fromInt($interruptExit);
             }
             $coverage = $coverageSession->finish($run->coverage);
         } finally {
@@ -161,12 +163,12 @@ final readonly class RunSession
         if ($interruptExit !== null) {
             $this->console->err("Interrupted. The summary includes only tests that finished before shutdown.\n");
 
-            return $interruptExit;
+            return ExitCode::fromInt($interruptExit);
         }
         if ($run->plannedTests === 0) {
             $this->console->err("Greenlight found no tests. Check the configuration, test paths, and filters.\n");
 
-            return ExitCode::FAILURE;
+            return ExitCode::Failure;
         }
         $coverageConfig = $resolved->coverage;
         if ($coverageConfig instanceof CoverageConfiguration
@@ -179,16 +181,16 @@ final readonly class RunSession
                     : $this->console->stdoutStyle($this->arguments->has('no-ansi')),
             )
         ) {
-            return ExitCode::FAILURE;
+            return ExitCode::Failure;
         }
         if ($run->leaks !== []) {
             $this->console->err(SummaryFormat::leaks($run->leaks, $this->console->stderrStyle($this->arguments->has('no-ansi'))));
 
-            return ExitCode::FAILURE;
+            return ExitCode::Failure;
         }
 
         if (!$run->summary->isSuccessful()) {
-            return ExitCode::FAILURE;
+            return ExitCode::Failure;
         }
 
         try {
@@ -196,14 +198,14 @@ final readonly class RunSession
         } catch (RunPolicyError $error) {
             $this->console->error($error->getMessage(), $this->arguments->has('no-ansi'));
 
-            return ExitCode::FAILURE;
+            return ExitCode::Failure;
         }
 
         if ($policyFailed) {
-            return ExitCode::FAILURE;
+            return ExitCode::Failure;
         }
 
-        return ExitCode::SUCCESS;
+        return ExitCode::Success;
     }
 
     /** @throws RunPolicyError */

--- a/src/Cli/Run/RunSession.php
+++ b/src/Cli/Run/RunSession.php
@@ -139,14 +139,14 @@ final readonly class RunSession
             } catch (AttachmentError|DiscoveryError|ExecutionFailed|IntegrationFixtureError $error) {
                 $reporter->finish();
                 $this->console->error($error->getMessage(), $this->arguments->has('no-ansi'));
-                $interruptExit = $this->shutdown->exitCode();
-                if ($interruptExit !== null) {
+                $interruptSignal = $this->shutdown->signal();
+                if ($interruptSignal !== null) {
                     $this->console->err("Interrupted. Integration fixture teardown was attempted before exit.\n");
                 }
 
-                return $interruptExit === null
+                return $interruptSignal === null
                     ? ExitCode::failure()
-                    : ExitCode::fromInt($interruptExit);
+                    : ExitCode::signal($interruptSignal);
             }
             $coverage = $coverageSession->finish($run->coverage);
         } finally {
@@ -159,11 +159,11 @@ final readonly class RunSession
             $coverage = CoveragePluginRuntime::fromDefinitions($resolved->execution->plugins)
                 ->transform($coverage);
         }
-        $interruptExit = $this->shutdown->exitCode();
-        if ($interruptExit !== null) {
+        $interruptSignal = $this->shutdown->signal();
+        if ($interruptSignal !== null) {
             $this->console->err("Interrupted. The summary includes only tests that finished before shutdown.\n");
 
-            return ExitCode::fromInt($interruptExit);
+            return ExitCode::signal($interruptSignal);
         }
         if ($run->plannedTests === 0) {
             $this->console->err("Greenlight found no tests. Check the configuration, test paths, and filters.\n");

--- a/src/Cli/Run/RunSession.php
+++ b/src/Cli/Run/RunSession.php
@@ -145,7 +145,7 @@ final readonly class RunSession
                 }
 
                 return $interruptExit === null
-                    ? ExitCode::Failure
+                    ? ExitCode::failure()
                     : ExitCode::fromInt($interruptExit);
             }
             $coverage = $coverageSession->finish($run->coverage);
@@ -168,7 +168,7 @@ final readonly class RunSession
         if ($run->plannedTests === 0) {
             $this->console->err("Greenlight found no tests. Check the configuration, test paths, and filters.\n");
 
-            return ExitCode::Failure;
+            return ExitCode::failure();
         }
         $coverageConfig = $resolved->coverage;
         if ($coverageConfig instanceof CoverageConfiguration
@@ -181,16 +181,16 @@ final readonly class RunSession
                     : $this->console->stdoutStyle($this->arguments->has('no-ansi')),
             )
         ) {
-            return ExitCode::Failure;
+            return ExitCode::failure();
         }
         if ($run->leaks !== []) {
             $this->console->err(SummaryFormat::leaks($run->leaks, $this->console->stderrStyle($this->arguments->has('no-ansi'))));
 
-            return ExitCode::Failure;
+            return ExitCode::failure();
         }
 
         if (!$run->summary->isSuccessful()) {
-            return ExitCode::Failure;
+            return ExitCode::failure();
         }
 
         try {
@@ -198,14 +198,14 @@ final readonly class RunSession
         } catch (RunPolicyError $error) {
             $this->console->error($error->getMessage(), $this->arguments->has('no-ansi'));
 
-            return ExitCode::Failure;
+            return ExitCode::failure();
         }
 
         if ($policyFailed) {
-            return ExitCode::Failure;
+            return ExitCode::failure();
         }
 
-        return ExitCode::Success;
+        return ExitCode::success();
     }
 
     /** @throws RunPolicyError */

--- a/src/Cli/Run/WatchRuns.php
+++ b/src/Cli/Run/WatchRuns.php
@@ -97,10 +97,10 @@ final readonly class WatchRuns
         } finally {
             $keys->restore();
         }
-        $interruptExit = $shutdown->exitCode();
+        $interruptSignal = $shutdown->signal();
 
-        return $interruptExit === null
+        return $interruptSignal === null
             ? ExitCode::success()
-            : ExitCode::fromInt($interruptExit);
+            : ExitCode::signal($interruptSignal);
     }
 }

--- a/src/Cli/Run/WatchRuns.php
+++ b/src/Cli/Run/WatchRuns.php
@@ -38,7 +38,7 @@ final readonly class WatchRuns
     public function __construct(private Console $console) {}
 
     /** @param non-empty-string|false $workerBin */
-    public function run(ParsedArguments $arguments, string $workingDirectory, string|false $workerBin, LoadedConfiguration $configuration, GracefulShutdown $shutdown, ReporterCatalog $reporterCatalog, ReporterOutputPlan $reporterOutputs, Reporter $initialReporter): int
+    public function run(ParsedArguments $arguments, string $workingDirectory, string|false $workerBin, LoadedConfiguration $configuration, GracefulShutdown $shutdown, ReporterCatalog $reporterCatalog, ReporterOutputPlan $reporterOutputs, Reporter $initialReporter): ExitCode
     {
         $resolved = $configuration->resolved;
         $directories = $configuration->directories;
@@ -93,10 +93,14 @@ final readonly class WatchRuns
             new WatchLoop($sources, new Debouncer($resolved->watch->debounceMilliseconds / 1000), $keys, new SystemWatchClock(), $this->console->out(...), $shutdown)->run($runOnce);
         } catch (ReporterSetupFailed|RunPolicyError|WatchSourceFailed $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return ExitCode::FAILURE;
+            return ExitCode::Failure;
         } finally {
             $keys->restore();
         }
-        return $shutdown->exitCode() ?? ExitCode::SUCCESS;
+        $interruptExit = $shutdown->exitCode();
+
+        return $interruptExit === null
+            ? ExitCode::Success
+            : ExitCode::fromInt($interruptExit);
     }
 }

--- a/src/Cli/Run/WatchRuns.php
+++ b/src/Cli/Run/WatchRuns.php
@@ -93,14 +93,14 @@ final readonly class WatchRuns
             new WatchLoop($sources, new Debouncer($resolved->watch->debounceMilliseconds / 1000), $keys, new SystemWatchClock(), $this->console->out(...), $shutdown)->run($runOnce);
         } catch (ReporterSetupFailed|RunPolicyError|WatchSourceFailed $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
-            return ExitCode::Failure;
+            return ExitCode::failure();
         } finally {
             $keys->restore();
         }
         $interruptExit = $shutdown->exitCode();
 
         return $interruptExit === null
-            ? ExitCode::Success
+            ? ExitCode::success()
             : ExitCode::fromInt($interruptExit);
     }
 }

--- a/src/Internal/Process/GracefulShutdown.php
+++ b/src/Internal/Process/GracefulShutdown.php
@@ -6,7 +6,6 @@ namespace Greenlight\Internal\Process;
 
 /**
  * Records only the first signal. The asynchronous handler does no other work.
- * An exit code is 128 plus the signal number.
  *
  * @internal
  */
@@ -24,8 +23,8 @@ final class GracefulShutdown
         return $this->signal !== null;
     }
 
-    public function exitCode(): ?int
+    public function signal(): ?int
     {
-        return $this->signal === null ? null : 128 + $this->signal;
+        return $this->signal;
     }
 }

--- a/tests/Unit/Cli/ExitCodeTest.php
+++ b/tests/Unit/Cli/ExitCodeTest.php
@@ -28,17 +28,23 @@ final readonly class ExitCodeTest
     }
 
     #[Test]
-    #[DataSet('dynamicProcessCodes')]
-    public function preservesDynamicProcessCodes(int $processCode): void
+    #[DataSet('signals')]
+    public function convertsSignalsToProcessCodes(int $signal): void
     {
-        Expect::that(ExitCode::fromInt($processCode)->toInt())->toBe($processCode);
+        Expect::that(ExitCode::signal($signal)->toInt())->toBe(128 + $signal);
     }
 
     /** @return iterable<string, array{int}> */
-    public static function dynamicProcessCodes(): iterable
+    public static function signals(): iterable
     {
-        yield 'interrupt signal' => [128 + \SIGINT];
-        yield 'quit signal' => [128 + \SIGQUIT];
-        yield 'termination signal' => [128 + \SIGTERM];
+        yield 'interrupt signal' => [\SIGINT];
+        yield 'quit signal' => [\SIGQUIT];
+        yield 'termination signal' => [\SIGTERM];
+    }
+
+    #[Test]
+    public function preservesAPluginProcessCode(): void
+    {
+        Expect::that(ExitCode::fromInt(7)->toInt())->toBe(7);
     }
 }

--- a/tests/Unit/Cli/ExitCodeTest.php
+++ b/tests/Unit/Cli/ExitCodeTest.php
@@ -13,29 +13,32 @@ final readonly class ExitCodeTest
 {
     #[Test]
     #[DataSet('processCodes')]
-    public function convertsCommandResultsAtTheProcessSeam(ExitCode $exitCode, int $processCode): void
+    public function convertsNamedCommandResultsAtTheProcessSeam(ExitCode $exitCode, int $processCode, bool $successful): void
     {
         Expect::that($exitCode->toInt())->toBe($processCode);
-        Expect::that(ExitCode::fromInt($processCode))->toBe($exitCode);
+        Expect::that($exitCode->isSuccess())->toBe($successful);
     }
 
-    /** @return iterable<string, array{ExitCode, int}> */
+    /** @return iterable<string, array{ExitCode, int, bool}> */
     public static function processCodes(): iterable
     {
-        yield 'success' => [ExitCode::Success, 0];
-        yield 'failure' => [ExitCode::Failure, 1];
-        yield 'usage' => [ExitCode::Usage, 64];
-        yield 'interrupted' => [ExitCode::Interrupted, 130];
-        yield 'terminated' => [ExitCode::Terminated, 143];
+        yield 'success' => [ExitCode::success(), 0, true];
+        yield 'failure' => [ExitCode::failure(), 1, false];
+        yield 'usage' => [ExitCode::usage(), 64, false];
     }
 
     #[Test]
-    public function rejectsAnUnknownProcessCode(): void
+    #[DataSet('dynamicProcessCodes')]
+    public function preservesDynamicProcessCodes(int $processCode): void
     {
-        Expect::that(static fn(): ExitCode => ExitCode::fromInt(7))
-            ->toThrow(
-                \InvalidArgumentException::class,
-                message: 'Exit code 7 does not identify a Greenlight command result.',
-            );
+        Expect::that(ExitCode::fromInt($processCode)->toInt())->toBe($processCode);
+    }
+
+    /** @return iterable<string, array{int}> */
+    public static function dynamicProcessCodes(): iterable
+    {
+        yield 'interrupt signal' => [128 + \SIGINT];
+        yield 'quit signal' => [128 + \SIGQUIT];
+        yield 'termination signal' => [128 + \SIGTERM];
     }
 }

--- a/tests/Unit/Cli/ExitCodeTest.php
+++ b/tests/Unit/Cli/ExitCodeTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Cli;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Cli\Output\ExitCode;
 use Greenlight\Expect\Expect;
@@ -11,10 +12,30 @@ use Greenlight\Expect\Expect;
 final readonly class ExitCodeTest
 {
     #[Test]
-    public function namesCommandExitCodes(): void
+    #[DataSet('processCodes')]
+    public function convertsCommandResultsAtTheProcessSeam(ExitCode $exitCode, int $processCode): void
     {
-        Expect::that(ExitCode::SUCCESS)->toBe(0);
-        Expect::that(ExitCode::FAILURE)->toBe(1);
-        Expect::that(ExitCode::USAGE)->toBe(64);
+        Expect::that($exitCode->toInt())->toBe($processCode);
+        Expect::that(ExitCode::fromInt($processCode))->toBe($exitCode);
+    }
+
+    /** @return iterable<string, array{ExitCode, int}> */
+    public static function processCodes(): iterable
+    {
+        yield 'success' => [ExitCode::Success, 0];
+        yield 'failure' => [ExitCode::Failure, 1];
+        yield 'usage' => [ExitCode::Usage, 64];
+        yield 'interrupted' => [ExitCode::Interrupted, 130];
+        yield 'terminated' => [ExitCode::Terminated, 143];
+    }
+
+    #[Test]
+    public function rejectsAnUnknownProcessCode(): void
+    {
+        Expect::that(static fn(): ExitCode => ExitCode::fromInt(7))
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Exit code 7 does not identify a Greenlight command result.',
+            );
     }
 }

--- a/tests/Unit/Cli/Signal/SignalHandlersTest.php
+++ b/tests/Unit/Cli/Signal/SignalHandlersTest.php
@@ -33,8 +33,7 @@ final class SignalHandlersTest
         Expect::that($shutdown->requested())
             ->because('each supported signal MUST request graceful shutdown on first delivery')
             ->toBeTrue();
-        Expect::that($shutdown->exitCode())
-            ->toBe(128 + $signal);
+        Expect::that($shutdown->signal())->toBe($signal);
     }
 
     #[Test]
@@ -80,7 +79,7 @@ final class SignalHandlersTest
         Expect::that($shutdown->requested())
             ->because('the first signal requests graceful shutdown')
             ->toBeTrue();
-        Expect::that($shutdown->exitCode())->toBe(128 + \SIGTERM);
+        Expect::that($shutdown->signal())->toBe(\SIGTERM);
         Expect::that($operations->registrations[2] ?? null)
             ->because('the first signal restores the default SIGINT handler')
             ->toBe(['signal' => \SIGINT, 'handler' => \SIG_DFL]);

--- a/tests/Unit/Cli/Watch/WatchTest.php
+++ b/tests/Unit/Cli/Watch/WatchTest.php
@@ -257,9 +257,9 @@ final readonly class WatchTest
         Expect::that($detector->polls)
             ->because('watch mode does not poll again after a shutdown request')
             ->toBe(1);
-        Expect::that($shutdown->exitCode())
-            ->because('watch mode converts the requested signal to a shell exit status')
-            ->toBe(143);
+        Expect::that($shutdown->signal())
+            ->because('watch mode keeps the signal that requested shutdown')
+            ->toBe(15);
     }
 
     #[Test]

--- a/tests/Unit/Internal/Process/GracefulShutdownTest.php
+++ b/tests/Unit/Internal/Process/GracefulShutdownTest.php
@@ -16,22 +16,22 @@ final class GracefulShutdownTest
         $shutdown = new GracefulShutdown();
 
         Expect::that($shutdown->requested())->because('starts with nothing requested')->toBeFalse();
-        Expect::that($shutdown->exitCode())->because('starts with nothing requested')->toBe(null);
+        Expect::that($shutdown->signal())->because('starts with nothing requested')->toBe(null);
     }
 
     #[Test]
-    public function mapsSignalsToConventionalExitCodes(): void
+    public function keepsTheRequestedSignal(): void
     {
         $sigint = new GracefulShutdown();
         $sigint->request(2);
 
-        Expect::that($sigint->requested())->because('maps signals to conventional exit codes')->toBeTrue();
-        Expect::that($sigint->exitCode())->because('maps signals to conventional exit codes')->toBe(130);
+        Expect::that($sigint->requested())->because('has a requested signal')->toBeTrue();
+        Expect::that($sigint->signal())->because('keeps the requested signal')->toBe(2);
 
         $sigterm = new GracefulShutdown();
         $sigterm->request(15);
 
-        Expect::that($sigterm->exitCode())->because('maps signals to conventional exit codes')->toBe(143);
+        Expect::that($sigterm->signal())->because('keeps the requested signal')->toBe(15);
     }
 
     #[Test]
@@ -41,6 +41,6 @@ final class GracefulShutdownTest
         $shutdown->request(15);
         $shutdown->request(2);
 
-        Expect::that($shutdown->exitCode())->because('keeps the first signal')->toBe(143);
+        Expect::that($shutdown->signal())->because('keeps the first signal')->toBe(15);
     }
 }


### PR DESCRIPTION
Changes ExitCode from a constant holder to a typed value object that owns process-code conversion.

Bundled commands now return ExitCode values. Named factories make success, failure, and usage results clear at each return site. The bundled-command adapter converts results to integers only for the public CommandDefinition handler contract. CommandDispatcher validates and wraps handler results, and Application performs the final process conversion. Custom plugin commands can still return any valid process code.

GracefulShutdown retains the raw signal. ExitCode::signal() owns the conventional 128 + signal conversion, including signals such as SIGQUIT.