### PR TITLE
fix(condition): require non-empty constructor strings

### DIFF
--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -510,9 +510,10 @@ public function __construct(string $class)
 
 PHPDoc:
 
+- `@param non-empty-string $class`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ClassAvailable.php#L20)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ClassAvailable.php#L22)
 
 ### `isSatisfied()`
 
@@ -521,7 +522,7 @@ PHPDoc:
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ClassAvailable.php#L29)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ClassAvailable.php#L31)
 
 ## `Condition`
 
@@ -565,9 +566,10 @@ public function __construct(string $name, private string $value)
 
 PHPDoc:
 
+- `@param non-empty-string $name`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableEquals.php#L19)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableEquals.php#L21)
 
 ### `isSatisfied()`
 
@@ -576,7 +578,7 @@ PHPDoc:
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableEquals.php#L26)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableEquals.php#L28)
 
 ## `EnvironmentVariableSet`
 
@@ -596,9 +598,10 @@ public function __construct(string $name)
 
 PHPDoc:
 
+- `@param non-empty-string $name`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableSet.php#L19)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableSet.php#L21)
 
 ### `isSatisfied()`
 
@@ -607,7 +610,7 @@ PHPDoc:
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableSet.php#L26)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableSet.php#L28)
 
 ## `ExtensionLoaded`
 
@@ -627,9 +630,10 @@ public function __construct(string $extension)
 
 PHPDoc:
 
+- `@param non-empty-string $extension`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ExtensionLoaded.php#L17)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ExtensionLoaded.php#L19)
 
 ### `isSatisfied()`
 
@@ -638,7 +642,7 @@ PHPDoc:
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ExtensionLoaded.php#L26)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ExtensionLoaded.php#L28)
 
 ## `ExtensionMissing`
 
@@ -658,9 +662,10 @@ public function __construct(string $extension)
 
 PHPDoc:
 
+- `@param non-empty-string $extension`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ExtensionMissing.php#L17)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ExtensionMissing.php#L19)
 
 ### `isSatisfied()`
 
@@ -669,7 +674,7 @@ PHPDoc:
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ExtensionMissing.php#L26)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ExtensionMissing.php#L28)
 
 ## `FunctionAvailable`
 
@@ -689,9 +694,10 @@ public function __construct(string $function)
 
 PHPDoc:
 
+- `@param non-empty-string $function`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/FunctionAvailable.php#L17)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/FunctionAvailable.php#L19)
 
 ### `isSatisfied()`
 
@@ -700,7 +706,7 @@ PHPDoc:
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/FunctionAvailable.php#L26)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/FunctionAvailable.php#L28)
 
 ## `OperatingSystemFamily`
 
@@ -722,9 +728,10 @@ public function __construct(string $family)
 
 PHPDoc:
 
+- `@param non-empty-string $family`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/OperatingSystemFamily.php#L18)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/OperatingSystemFamily.php#L20)
 
 ### `isSatisfied()`
 
@@ -733,7 +740,7 @@ PHPDoc:
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/OperatingSystemFamily.php#L27)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/OperatingSystemFamily.php#L29)
 
 ## `PhpVersionAtLeast`
 
@@ -753,9 +760,10 @@ public function __construct(string $version)
 
 PHPDoc:
 
+- `@param non-empty-string $version`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/PhpVersionAtLeast.php#L17)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/PhpVersionAtLeast.php#L19)
 
 ### `isSatisfied()`
 
@@ -764,7 +772,7 @@ PHPDoc:
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/PhpVersionAtLeast.php#L26)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/PhpVersionAtLeast.php#L28)
 
 ## `PhpVersionLessThan`
 
@@ -784,9 +792,10 @@ public function __construct(string $version)
 
 PHPDoc:
 
+- `@param non-empty-string $version`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/PhpVersionLessThan.php#L17)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/PhpVersionLessThan.php#L19)
 
 ### `isSatisfied()`
 
@@ -795,4 +804,4 @@ PHPDoc:
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/PhpVersionLessThan.php#L26)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/PhpVersionLessThan.php#L28)

--- a/src/Condition/ClassAvailable.php
+++ b/src/Condition/ClassAvailable.php
@@ -15,6 +15,8 @@ final readonly class ClassAvailable implements Condition
     private string $class;
 
     /**
+     * @param non-empty-string $class
+     *
      * @throws \InvalidArgumentException
      */
     public function __construct(string $class)

--- a/src/Condition/EnvironmentVariableEquals.php
+++ b/src/Condition/EnvironmentVariableEquals.php
@@ -14,6 +14,8 @@ final readonly class EnvironmentVariableEquals implements Condition
     private string $name;
 
     /**
+     * @param non-empty-string $name
+     *
      * @throws \InvalidArgumentException
      */
     public function __construct(string $name, private string $value)

--- a/src/Condition/EnvironmentVariableSet.php
+++ b/src/Condition/EnvironmentVariableSet.php
@@ -14,6 +14,8 @@ final readonly class EnvironmentVariableSet implements Condition
     private string $name;
 
     /**
+     * @param non-empty-string $name
+     *
      * @throws \InvalidArgumentException
      */
     public function __construct(string $name)

--- a/src/Condition/ExtensionLoaded.php
+++ b/src/Condition/ExtensionLoaded.php
@@ -12,6 +12,8 @@ final readonly class ExtensionLoaded implements Condition
     private string $extension;
 
     /**
+     * @param non-empty-string $extension
+     *
      * @throws \InvalidArgumentException
      */
     public function __construct(string $extension)

--- a/src/Condition/ExtensionMissing.php
+++ b/src/Condition/ExtensionMissing.php
@@ -12,6 +12,8 @@ final readonly class ExtensionMissing implements Condition
     private string $extension;
 
     /**
+     * @param non-empty-string $extension
+     *
      * @throws \InvalidArgumentException
      */
     public function __construct(string $extension)

--- a/src/Condition/FunctionAvailable.php
+++ b/src/Condition/FunctionAvailable.php
@@ -12,6 +12,8 @@ final readonly class FunctionAvailable implements Condition
     private string $function;
 
     /**
+     * @param non-empty-string $function
+     *
      * @throws \InvalidArgumentException
      */
     public function __construct(string $function)

--- a/src/Condition/OperatingSystemFamily.php
+++ b/src/Condition/OperatingSystemFamily.php
@@ -13,6 +13,8 @@ final readonly class OperatingSystemFamily implements Condition
     private string $family;
 
     /**
+     * @param non-empty-string $family
+     *
      * @throws \InvalidArgumentException
      */
     public function __construct(string $family)

--- a/src/Condition/PhpVersionAtLeast.php
+++ b/src/Condition/PhpVersionAtLeast.php
@@ -12,6 +12,8 @@ final readonly class PhpVersionAtLeast implements Condition
     private string $version;
 
     /**
+     * @param non-empty-string $version
+     *
      * @throws \InvalidArgumentException
      */
     public function __construct(string $version)

--- a/src/Condition/PhpVersionLessThan.php
+++ b/src/Condition/PhpVersionLessThan.php
@@ -12,6 +12,8 @@ final readonly class PhpVersionLessThan implements Condition
     private string $version;
 
     /**
+     * @param non-empty-string $version
+     *
      * @throws \InvalidArgumentException
      */
     public function __construct(string $version)

--- a/tests/Unit/Condition/ConditionsTest.php
+++ b/tests/Unit/Condition/ConditionsTest.php
@@ -22,6 +22,7 @@ final readonly class ConditionsTest
 {
     public function __construct(private EnvironmentVariables $environment) {}
 
+    /** @param non-empty-string $extension */
     #[Test]
     #[DataSet('extensionLoadedStates')]
     public function extensionLoadedChecksTheLoadedExtensionList(string $extension, bool $expected): void
@@ -40,6 +41,7 @@ final readonly class ConditionsTest
         yield 'missing extension' => ['greenlight_no_such_extension', false];
     }
 
+    /** @param non-empty-string $extension */
     #[Test]
     #[DataSet('extensionMissingStates')]
     public function extensionMissingIsTheInverseOfExtensionLoaded(string $extension, bool $expected): void
@@ -95,6 +97,7 @@ final readonly class ConditionsTest
             ->toBeFalse();
     }
 
+    /** @param non-empty-string $family */
     #[Test]
     #[DataSet('operatingSystemFamilies')]
     public function operatingSystemFamilyComparesCaseInsensitively(string $family, bool $expected): void
@@ -114,6 +117,7 @@ final readonly class ConditionsTest
         yield 'unknown family' => ['NotAnOperatingSystem', false];
     }
 
+    /** @param non-empty-string $version */
     #[Test]
     #[DataSet('minimumPhpVersions')]
     public function phpVersionAtLeastComparesAgainstTheRunningVersion(string $version, bool $expected): void
@@ -133,6 +137,7 @@ final readonly class ConditionsTest
         yield 'newer version' => ['99.0', false];
     }
 
+    /** @param non-empty-string $version */
     #[Test]
     #[DataSet('maximumPhpVersions')]
     public function phpVersionLessThanComparesAgainstTheRunningVersion(string $version, bool $expected): void
@@ -152,6 +157,7 @@ final readonly class ConditionsTest
         yield 'current version' => [\PHP_VERSION, false];
     }
 
+    /** @param non-empty-string $function */
     #[Test]
     #[DataSet('functionAvailability')]
     public function functionAvailableChecksCallableFunctions(string $function, bool $expected): void
@@ -170,6 +176,7 @@ final readonly class ConditionsTest
         yield 'missing function' => ['greenlight_no_such_function', false];
     }
 
+    /** @param non-empty-string $class */
     #[Test]
     #[DataSet('classAvailability')]
     public function classAvailableChecksAutoloadableClasses(string $class, bool $expected): void
@@ -191,7 +198,7 @@ final readonly class ConditionsTest
     #[Test]
     public function classAvailableRejectsAnEmptyClassName(): void
     {
-        Expect::that(static fn(): ClassAvailable => new ClassAvailable(''))
+        Expect::that(static fn(): ClassAvailable => new ClassAvailable('')) // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
             ->because('a class availability condition MUST identify the class')
             ->toThrow(
                 \InvalidArgumentException::class,

--- a/tests/Unit/Condition/EnvironmentVariableConditionValidationTest.php
+++ b/tests/Unit/Condition/EnvironmentVariableConditionValidationTest.php
@@ -16,13 +16,13 @@ final readonly class EnvironmentVariableConditionValidationTest
     #[DataSet('invalidNames')]
     public function rejectsAnInvalidEnvironmentVariableName(string $name): void
     {
-        Expect::that(static fn(): EnvironmentVariableSet => new EnvironmentVariableSet($name))
+        Expect::that(static fn(): EnvironmentVariableSet => new EnvironmentVariableSet($name)) // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
             ->because('a presence condition MUST reject a name that getenv() cannot safely read')
             ->toThrow(
                 \InvalidArgumentException::class,
                 message: 'Environment variable names cannot be empty or contain "=" or a null byte.',
             );
-        Expect::that(static fn(): EnvironmentVariableEquals => new EnvironmentVariableEquals($name, 'value'))
+        Expect::that(static fn(): EnvironmentVariableEquals => new EnvironmentVariableEquals($name, 'value')) // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
             ->because('an equality condition MUST reject a name that getenv() cannot safely read')
             ->toThrow(
                 \InvalidArgumentException::class,

--- a/tests/Unit/Condition/ExtensionConditionValidationTest.php
+++ b/tests/Unit/Condition/ExtensionConditionValidationTest.php
@@ -12,14 +12,12 @@ use Greenlight\Expect\Expect;
 
 final readonly class ExtensionConditionValidationTest
 {
-    /**
-     * @param class-string<ExtensionLoaded|ExtensionMissing> $conditionClass
-     */
+    /** @param \Closure(): (ExtensionLoaded|ExtensionMissing) $create */
     #[Test]
     #[DataSet('extensionConditions')]
-    public function rejectsAnEmptyExtensionName(string $conditionClass): void
+    public function rejectsAnEmptyExtensionName(\Closure $create): void
     {
-        Expect::that(static fn(): ExtensionLoaded|ExtensionMissing => new $conditionClass(''))
+        Expect::that($create)
             ->because('an extension availability condition MUST identify the extension')
             ->toThrow(
                 \InvalidArgumentException::class,
@@ -28,12 +26,12 @@ final readonly class ExtensionConditionValidationTest
     }
 
     /**
-     * @return iterable<string, array{class-string<ExtensionLoaded|ExtensionMissing>}>
+     * @return iterable<string, array{\Closure(): (ExtensionLoaded|ExtensionMissing)}>
      */
     public static function extensionConditions(): iterable
     {
-        yield 'loaded' => [ExtensionLoaded::class];
+        yield 'loaded' => [static fn(): ExtensionLoaded => new ExtensionLoaded('')]; // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
 
-        yield 'missing' => [ExtensionMissing::class];
+        yield 'missing' => [static fn(): ExtensionMissing => new ExtensionMissing('')]; // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
     }
 }

--- a/tests/Unit/Condition/FunctionAvailableTest.php
+++ b/tests/Unit/Condition/FunctionAvailableTest.php
@@ -13,7 +13,7 @@ final readonly class FunctionAvailableTest
     #[Test]
     public function rejectsAnEmptyFunctionName(): void
     {
-        Expect::that(static fn(): FunctionAvailable => new FunctionAvailable(''))
+        Expect::that(static fn(): FunctionAvailable => new FunctionAvailable('')) // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
             ->because('a function availability condition MUST identify the function')
             ->toThrow(
                 \InvalidArgumentException::class,

--- a/tests/Unit/Condition/OperatingSystemFamilyValidationTest.php
+++ b/tests/Unit/Condition/OperatingSystemFamilyValidationTest.php
@@ -13,7 +13,7 @@ final readonly class OperatingSystemFamilyValidationTest
     #[Test]
     public function rejectsAnEmptyFamily(): void
     {
-        Expect::that(static fn(): OperatingSystemFamily => new OperatingSystemFamily(''))
+        Expect::that(static fn(): OperatingSystemFamily => new OperatingSystemFamily('')) // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
             ->because('an operating-system condition MUST identify the family')
             ->toThrow(
                 \InvalidArgumentException::class,

--- a/tests/Unit/Condition/PhpVersionConditionValidationTest.php
+++ b/tests/Unit/Condition/PhpVersionConditionValidationTest.php
@@ -33,8 +33,8 @@ final readonly class PhpVersionConditionValidationTest
      */
     public static function emptyVersionConditions(): iterable
     {
-        yield 'at least' => [static fn(): PhpVersionAtLeast => new PhpVersionAtLeast('')];
-        yield 'less than' => [static fn(): PhpVersionLessThan => new PhpVersionLessThan('')];
+        yield 'at least' => [static fn(): PhpVersionAtLeast => new PhpVersionAtLeast('')]; // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
+        yield 'less than' => [static fn(): PhpVersionLessThan => new PhpVersionLessThan('')]; // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
     }
 
     /**


### PR DESCRIPTION
Declare every condition constructor argument that rejects an empty string as non-empty-string. Preserve runtime validation coverage with targeted PHPStan ignores for deliberately invalid test inputs.