### PR TITLE
fix(docs): remove partial API attributes

### DIFF
--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -518,11 +518,10 @@ PHPDoc:
 ### `isSatisfied()`
 
 ```php
-[\Override]
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ClassAvailable.php#L31)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ClassAvailable.php#L32)
 
 ## `Condition`
 
@@ -574,11 +573,10 @@ PHPDoc:
 ### `isSatisfied()`
 
 ```php
-[\Override]
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableEquals.php#L28)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableEquals.php#L29)
 
 ## `EnvironmentVariableSet`
 
@@ -606,11 +604,10 @@ PHPDoc:
 ### `isSatisfied()`
 
 ```php
-[\Override]
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableSet.php#L28)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/EnvironmentVariableSet.php#L29)
 
 ## `ExtensionLoaded`
 
@@ -638,11 +635,10 @@ PHPDoc:
 ### `isSatisfied()`
 
 ```php
-[\Override]
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ExtensionLoaded.php#L28)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ExtensionLoaded.php#L29)
 
 ## `ExtensionMissing`
 
@@ -670,11 +666,10 @@ PHPDoc:
 ### `isSatisfied()`
 
 ```php
-[\Override]
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ExtensionMissing.php#L28)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/ExtensionMissing.php#L29)
 
 ## `FunctionAvailable`
 
@@ -702,11 +697,10 @@ PHPDoc:
 ### `isSatisfied()`
 
 ```php
-[\Override]
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/FunctionAvailable.php#L28)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/FunctionAvailable.php#L29)
 
 ## `OperatingSystemFamily`
 
@@ -736,11 +730,10 @@ PHPDoc:
 ### `isSatisfied()`
 
 ```php
-[\Override]
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/OperatingSystemFamily.php#L29)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/OperatingSystemFamily.php#L30)
 
 ## `PhpVersionAtLeast`
 
@@ -768,11 +761,10 @@ PHPDoc:
 ### `isSatisfied()`
 
 ```php
-[\Override]
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/PhpVersionAtLeast.php#L28)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/PhpVersionAtLeast.php#L29)
 
 ## `PhpVersionLessThan`
 
@@ -800,8 +792,7 @@ PHPDoc:
 ### `isSatisfied()`
 
 ```php
-[\Override]
 public function isSatisfied(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/PhpVersionLessThan.php#L28)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Condition/PhpVersionLessThan.php#L29)

--- a/docs/api-doubles.md
+++ b/docs/api-doubles.md
@@ -361,7 +361,6 @@ Verifies mocks and clears their state when the test scope closes.
 One `ExpectationFailed` contains the details for all unmet expectations.
 
 ```php
-[\Override]
 public function dispose(): void
 ```
 
@@ -369,7 +368,7 @@ PHPDoc:
 
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L160)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L161)
 
 ## `Fake`
 

--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -77,7 +77,6 @@ PHPDoc:
 ### `services()`
 
 ```php
-[\Override]
 public function services(): array
 ```
 
@@ -85,12 +84,11 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L75)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L76)
 
 ### `resolve()`
 
 ```php
-[\Override]
 public function resolve(string $type, array $attributes): ?object
 ```
 
@@ -100,12 +98,11 @@ PHPDoc:
 - `@param list<object> $attributes`
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L88)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L89)
 
 ### `onWorkerBootstrap()`
 
 ```php
-[\Override]
 public function onWorkerBootstrap(WorkerBootstrapContext $context): void
 ```
 
@@ -113,12 +110,11 @@ PHPDoc:
 
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L125)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L126)
 
 ### `runWorker()`
 
 ```php
-[\Override]
 public function runWorker(\Closure $worker): mixed
 ```
 
@@ -129,12 +125,11 @@ PHPDoc:
 - `@return T`
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L182)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L183)
 
 ### `runTestAttempt()`
 
 ```php
-[\Override]
 public function runTestAttempt(\Closure $attempt): mixed
 ```
 
@@ -145,7 +140,7 @@ PHPDoc:
 - `@return T`
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L226)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L227)
 
 ## `LaravelPlugin`
 
@@ -182,7 +177,6 @@ PHPDoc:
 ### `services()`
 
 ```php
-[\Override]
 public function services(): array
 ```
 
@@ -190,12 +184,11 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L74)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L75)
 
 ### `resolve()`
 
 ```php
-[\Override]
 public function resolve(string $type, array $attributes): ?object
 ```
 
@@ -205,16 +198,15 @@ PHPDoc:
 - `@param list<object> $attributes`
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L91)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L92)
 
 ### `afterTest()`
 
 ```php
-[\Override]
 public function afterTest(TestContext $context, TestResult $result): TestResult
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L127)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L128)
 
 ## `Psr11Plugin`
 
@@ -253,7 +245,6 @@ PHPDoc:
 ### `services()`
 
 ```php
-[\Override]
 public function services(): array
 ```
 
@@ -261,12 +252,11 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr11/Psr11Plugin.php#L47)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr11/Psr11Plugin.php#L48)
 
 ### `resolve()`
 
 ```php
-[\Override]
 public function resolve(string $type, array $attributes): ?object
 ```
 
@@ -276,12 +266,11 @@ PHPDoc:
 - `@param list<object> $attributes`
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr11/Psr11Plugin.php#L93)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr11/Psr11Plugin.php#L94)
 
 ### `afterTest()`
 
 ```php
-[\Override]
 public function afterTest(TestContext $context, TestResult $result): TestResult
 ```
 
@@ -289,7 +278,7 @@ PHPDoc:
 
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr11/Psr11Plugin.php#L140)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr11/Psr11Plugin.php#L141)
 
 ## `HttpHarness`
 
@@ -335,7 +324,6 @@ PHPDoc:
 ### `dispose()`
 
 ```php
-[\Override]
 public function dispose(): void
 ```
 
@@ -343,7 +331,7 @@ PHPDoc:
 
 - `@throws Psr15Error`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/HttpHarness.php#L71)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/HttpHarness.php#L72)
 
 ## `Psr15Error`
 
@@ -435,7 +423,6 @@ PHPDoc:
 ### `services()`
 
 ```php
-[\Override]
 public function services(): array
 ```
 
@@ -443,7 +430,7 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/Psr15Plugin.php#L40)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/Psr15Plugin.php#L41)
 
 ## `PhpUnitToGreenlightRector`
 
@@ -554,7 +541,6 @@ PHPDoc:
 ### `services()`
 
 ```php
-[\Override]
 public function services(): array
 ```
 
@@ -562,12 +548,11 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L74)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L75)
 
 ### `resolve()`
 
 ```php
-[\Override]
 public function resolve(string $type, array $attributes): ?object
 ```
 
@@ -577,16 +562,15 @@ PHPDoc:
 - `@param list<object> $attributes`
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L87)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L88)
 
 ### `afterTest()`
 
 ```php
-[\Override]
 public function afterTest(TestContext $context, TestResult $result): TestResult
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L123)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L124)
 
 ## `TempestPlugin`
 
@@ -627,16 +611,14 @@ PHPDoc:
 ### `onWorkerBootstrap()`
 
 ```php
-[\Override]
 public function onWorkerBootstrap(WorkerBootstrapContext $context): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L64)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L65)
 
 ### `services()`
 
 ```php
-[\Override]
 public function services(): array
 ```
 
@@ -644,12 +626,11 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L73)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L74)
 
 ### `resolve()`
 
 ```php
-[\Override]
 public function resolve(string $type, array $attributes): object
 ```
 
@@ -659,21 +640,19 @@ PHPDoc:
 - `@param list<object> $attributes`
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L87)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L88)
 
 ### `beforeTest()`
 
 ```php
-[\Override]
 public function beforeTest(TestContext $context): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L113)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L114)
 
 ### `afterTest()`
 
 ```php
-[\Override]
 public function afterTest(TestContext $context, TestResult $result): TestResult
 ```
 
@@ -681,4 +660,4 @@ PHPDoc:
 
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L126)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L127)

--- a/docs/api-results.md
+++ b/docs/api-results.md
@@ -521,11 +521,10 @@ PHPDoc:
 ### `__toString()`
 
 ```php
-[\Override]
 public function __toString(): string
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/SourceLocation.php#L39)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/SourceLocation.php#L40)
 
 ## `TestResult`
 

--- a/docs/api-sandboxes.md
+++ b/docs/api-sandboxes.md
@@ -33,11 +33,10 @@ PHPDoc:
 ### `dispose()`
 
 ```php
-[\Override]
 public function dispose(): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/Autoloaders.php#L24)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/Autoloaders.php#L25)
 
 ## `EnvironmentVariables`
 
@@ -79,11 +78,10 @@ PHPDoc:
 ### `dispose()`
 
 ```php
-[\Override]
 public function dispose(): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/EnvironmentVariables.php#L37)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/EnvironmentVariables.php#L38)
 
 ## `StreamWrapperError`
 
@@ -149,7 +147,6 @@ PHPDoc:
 ### `dispose()`
 
 ```php
-[\Override]
 public function dispose(): void
 ```
 
@@ -157,7 +154,7 @@ PHPDoc:
 
 - `@throws StreamWrapperError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/StreamWrappers.php#L44)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/StreamWrappers.php#L45)
 
 ## `TemporaryDirectory`
 
@@ -215,7 +212,6 @@ PHPDoc:
 ### `dispose()`
 
 ```php
-[\Override]
 public function dispose(): void
 ```
 
@@ -223,7 +219,7 @@ PHPDoc:
 
 - `@throws TemporaryDirectoryError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/TemporaryDirectory.php#L107)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/TemporaryDirectory.php#L108)
 
 ## `TemporaryDirectoryError`
 

--- a/docs/api-test-contracts.md
+++ b/docs/api-test-contracts.md
@@ -576,8 +576,7 @@ public function equals(self $other): bool
 ### `__toString()`
 
 ```php
-[\Override]
 public function __toString(): string
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Test/TestId.php#L52)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Test/TestId.php#L53)

--- a/website/scripts/generate-api-reference.mjs
+++ b/website/scripts/generate-api-reference.mjs
@@ -614,6 +614,7 @@ function memberTokens(tokens) {
   }
 
   while (tokens[index]?.value === '#' && tokens[index + 1]?.value === '[') {
+    index += 1;
     let attributeDepth = 0;
 
     do {

--- a/website/scripts/generate-api-reference.test.mjs
+++ b/website/scripts/generate-api-reference.test.mjs
@@ -42,6 +42,40 @@ final class SecondEvent {}
   }
 });
 
+test('member attributes do not leave partial signatures', async () => {
+  const sourceRoot = await mkdtemp(resolve(tmpdir(), 'greenlight-api-reference-source-'));
+  const documentationRoot = await mkdtemp(resolve(tmpdir(), 'greenlight-api-reference-docs-'));
+
+  try {
+    await writeFile(resolve(sourceRoot, 'Event.php'), `<?php
+
+namespace Greenlight\\Event;
+
+final class Event
+{
+    #[\\Override]
+    public function name(): string {}
+}
+`);
+
+    const result = spawnSync(process.execPath, [
+      script,
+      `--source-root=${sourceRoot}`,
+      `--documentation-root=${documentationRoot}`,
+    ], { encoding: 'utf8' });
+
+    assert.equal(result.status, 0, result.stderr);
+
+    const reference = await readFile(resolve(documentationRoot, 'api-events.md'), 'utf8');
+
+    assert.match(reference, /```php\npublic function name\(\): string\n```/);
+    assert.doesNotMatch(reference, /\\Override/);
+  } finally {
+    await rm(sourceRoot, { recursive: true, force: true });
+    await rm(documentationRoot, { recursive: true, force: true });
+  }
+});
+
 test('a secondary internal declaration cannot leak through a public type', async () => {
   const sourceRoot = await mkdtemp(resolve(tmpdir(), 'greenlight-api-reference-'));
 


### PR DESCRIPTION
The API generator stopped attribute parsing after the # token and left invalid [\Override] fragments in 37 public method signatures. Consume the complete attribute, add a regression fixture, and regenerate the affected API pages with source links on the declarations.