### PR TITLE
docs(attributes): document in-process isolation limit

### DIFF
--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -485,11 +485,16 @@ Target: method or class.
 
 No parameters.
 
-Runs the test method, or each test in the class, in a dedicated new worker.
-Greenlight discards that worker after the test.
+With process-pool execution, runs the test method, or each test in the class,
+in a dedicated new worker. Greenlight discards that worker after the test.
 
 Use this for tests that modify process-global state, such as ini settings,
 environment variables, or static caches.
+
+In-process execution cannot provide this isolation. `--workers=1` and the
+automatic fallback for unavailable process functions run the complete plan in
+one process. Do not use either mode when a test depends on `#[Isolated]` for
+process-global state cleanup.
 
 ## CoverageIgnore
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,6 +15,8 @@ The parallel runner uses core stream sockets and `proc_open`. Coverage requires
 If PHP disables a process or stream function that the parallel runner requires,
 Greenlight uses an in-process sequential run.
 
+An in-process run cannot give `#[Isolated]` tests a dedicated process.
+
 Install Greenlight as a development dependency:
 
 ```sh
@@ -270,6 +272,9 @@ Tests run in parallel worker processes by default.
 
 `--workers=4` specifies four workers. `--workers=1` uses one in-process runner.
 The last mode is usually the simplest choice for debug work.
+
+Do not use `--workers=1` when a test depends on `#[Isolated]` for process-global
+state cleanup.
 
 A worker remains active until it has no more tests or the worker fails.
 This behavior makes memory growth and state leaks visible in the suite.

--- a/docs/migrating-from-phpunit.md
+++ b/docs/migrating-from-phpunit.md
@@ -83,13 +83,18 @@ Some attribute conversions are less direct:
 | `#[RequiresPhpExtension]` | `#[SkipUnless]` with `ExtensionLoaded` |
 | `#[RequiresOperatingSystemFamily]` | `#[SkipUnless]` with `OperatingSystemFamily` |
 
+This separate-process conversion applies only to process-pool execution.
+`--workers=1` and automatic in-process fallback cannot give `#[Isolated]`
+tests a dedicated process.
+
 The rule removes coverage metadata attributes, for example `#[CoversClass]`,
 because coverage configuration belongs in `greenlight.php`. It also removes
 use metadata, `#[TestDox]`, and `#[DisableReturnValueGenerationForTestDoubles]`.
 
 Rector's printer also reflows each converted class. Run your code-style fixer
-after the conversion. Then run the suite one time with `--workers=1` before you
-enable parallel workers.
+after the conversion. If no test depends on `#[Isolated]`, run the suite one
+time with `--workers=1` before you enable parallel workers. Otherwise, start
+with two process-pool workers.
 
 ## Map the concepts
 
@@ -347,7 +352,8 @@ These differences are intentional:
 * Put expensive shared state in a class-scoped or worker-scoped harness service.
 * Tests run in parallel worker processes by default.
 * Tests in one class stay together unless the class has `#[AllowParallel]`.
-* Use `#[Isolated]` for a test that must own its process.
+* With process-pool execution, use `#[Isolated]` for a test that must own its
+  process.
 * External dependencies require an explicit parallel strategy.
 * Use a channel for one resource for each worker.
 * Use `#[RequiresResource]` to limit access to a shared dependency.
@@ -367,6 +373,7 @@ These differences are intentional:
 9. Keep the provider body when only the attribute must change.
 10. Convert mocks after the other test code.
 11. Use strict-double failures to find loose assumptions in the old tests.
-12. Run with `--workers=1` to exclude parallel execution from the first runs.
-13. Remove `--workers=1`.
+12. If no test depends on `#[Isolated]`, run with `--workers=1` to exclude
+    parallel execution from the first runs. Otherwise, start with two workers.
+13. Remove `--workers=1` when you used it.
 14. Correct failures that occur only with parallel workers.


### PR DESCRIPTION
The Isolated guide promised a dedicated process in every run mode, but the single-worker runner and automatic capability fallback execute the complete plan in one process. This correction states the process-pool requirement in the attribute, setup, and migration guides. It also prevents the migration sequence from recommending single-worker execution when converted separate-process tests depend on isolation.