### PR TITLE
docs(architecture): correct worker lifecycle details

### DIFF
--- a/docs/architecture/worker-lifecycle.md
+++ b/docs/architecture/worker-lifecycle.md
@@ -57,7 +57,7 @@ Nine message types cross the socket:
 | Tag | Direction | Payload |
 | --- | --- | --- |
 | `hello` | worker to orchestrator | worker ID, shared token, process ID |
-| `bootstrap` | orchestrator to worker | stable channel, config file path, that channel's integration resources |
+| `bootstrap` | orchestrator to worker | stable channel, optional configuration file path, channel resources, optional generated code directory, optional temporary directory, optional result policy |
 | `ready` | worker to orchestrator | bootstrap acknowledgement |
 | `assign` | orchestrator to worker | a plan slice (test classes to run), remaining failure allowance, coverage settings, leak detection flag, result policy, artifact session and limits |
 | `event` | worker to orchestrator | one test event: class started, test started, test finished, class finished |
@@ -96,7 +96,7 @@ sequenceDiagram
 
     O->>W: proc_open(address, workerId, token)<br/>env: GREENLIGHT_CHANNEL=n
     W->>O: hello (workerId, token, pid)
-    O->>W: bootstrap (channel, config, resources)
+    O->>W: bootstrap (channel, configuration path, resources,<br/>generated code path, temporary path, policy)
     W->>W: load plugins, run worker bootstrap,<br/>build harness service scopes
     W->>O: ready
     Note over O,W: assignment can begin after ready;<br/>subscriber mode waits for all initial workers
@@ -106,10 +106,17 @@ sequenceDiagram
             Note over O,W: worker stays connected; no frame is sent
         end
         O->>W: assign (plan slice, budgets, coverage)
-        loop each test in the slice
+        loop each test class in the plan slice
             W->>O: event (TestClassStarted)
-            W->>O: event (TestStarted)
-            W->>O: event (TestFinished)
+            loop each selected test or data set in the class
+                W->>O: event (TestStarted)
+                opt test execution starts
+                    loop each attempt
+                        W->>O: attempt-started (test ID, attempt number)
+                    end
+                end
+                W->>O: event (TestFinished)
+            end
             W->>O: event (TestClassFinished)
         end
         W->>O: done (summary, peak memory, coverage, leaks)
@@ -150,10 +157,11 @@ mode, the initial ready barrier prevents tests from starting while another
 initial worker is still bootstrapping. A replacement worker created after a
 crash needs to complete only its own bootstrap in both modes.
 
-The initial pool does not exceed the configured worker count. Greenlight also
-uses a safe resource-capacity bound. It starts fewer initial workers when the
-queued scheduling units and their resource limits prove that more workers
-cannot run concurrently. This bound does not remove achievable concurrency.
+The initial worker target does not exceed the configured worker count.
+Greenlight also uses a safe resource-capacity bound. It starts fewer initial
+workers when the queued scheduling units and their resource limits prove that
+more workers cannot run concurrently. This bound does not remove achievable
+concurrency.
 
 Workers build their plugin instances and harness registries during `bootstrap`.
 They reuse them for later assignments. One physical worker constructs each
@@ -191,11 +199,14 @@ their lifecycle does not change for a split class.
 A split class cannot use a per-class harness service. A service request causes
 a contained test error with corrective guidance.
 
-Data providers run during discovery. A worker also runs the applicable
-provider when it resolves arguments for a split entry.
+Data providers run during discovery. When a worker resolves data-set arguments,
+it expands the applicable provider for the first entry of that test method. It
+caches the expanded rows in the class context. This behavior applies to split
+and non-split entries.
 
-The provider MUST be pure and deterministic. The execution-plan keys detect a
-provider result that changes between discovery and execution.
+The provider MUST be pure and deterministic. The planned key selects one
+argument list. Greenlight reports an error if that key is absent. It does not
+compare argument values or reject additional keys.
 
 When a previous run supplies class durations, the orchestrator can put adjacent
 small classes in one assignment. Each batch has a maximum predicted duration of
@@ -374,14 +385,21 @@ always uses worker processes. Greenlight does not use Fibers for this feature.
 ## Channel numbers
 
 Every worker receives a channel number in the `GREENLIGHT_CHANNEL` environment
-variable. The channel pool runs from `1` to the configured worker count. The
-allocator gives out the lowest free number and returns it to the pool when a
-worker retires, so a replacement inherits a released slot.
+variable. The channel pool runs from `1` through the initial worker target.
+Queue size and resource capacity can reduce this target below the configured
+worker count.
 
-At most `workerCount` channels are live at once, and concurrent tests never
-share one. Per-channel databases, port ranges, and temporary directories can
-therefore use the number safely. The [README](../../README.md) describes the
-user-facing contract.
+`IntegrationFixtureContext::configuredWorkers()` returns the configured worker
+count. `IntegrationFixtureContext::channels()` returns the channel numbers that
+this run can use.
+
+The allocator gives out the lowest free number and returns it when a worker
+retires. A replacement can use a released channel.
+
+At most the initial worker target channels are live at once. Concurrent tests
+never share a channel. Per-channel databases, port ranges, and temporary
+directories can therefore use the number safely. The
+[README](../../README.md) describes the user-facing contract.
 
 Integration fixtures use the same channel pool. Greenlight merges shared values
 with the allocated channel overlay before bootstrap, so a worker never receives


### PR DESCRIPTION
The worker-lifecycle reference omitted bootstrap fields and placed class events inside the per-test loop. It also overstated data-provider drift detection and treated configured workers as the provisioned channel count. This change aligns the protocol table, sequence diagram, assignment rules, and channel contract with the current worker, scheduler, and integration-fixture implementations.