### PR TITLE
docs(plugins): complete priority capability list

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -871,6 +871,7 @@ Priority applies to these capabilities:
 
 * `AttachmentRetentionDecider`
 * `IntegrationFixtureProvider`
+* `TestPlanTransformer`
 * `WorkerBootstrapSubscriber`
 * `WorkerRuntimeRunner`
 * `TestAttemptRunner`
@@ -878,6 +879,7 @@ Priority applies to these capabilities:
 * `AfterTestSubscriber`
 * `RetryDecider`
 * `TerminalResultTransformer`
+* `CoverageMapTransformer`
 * `RunAcceptancePolicy`
 * `WatchSource`
 * `RunLifecycleSubscriber`


### PR DESCRIPTION
The definitive plugin priority list omitted two capabilities that the detailed sections and runtimes already treat as priority-aware. This adds TestPlanTransformer and CoverageMapTransformer to the summary list.