### PR TITLE
docs(architecture): correct runtime ownership map

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -21,13 +21,16 @@ flowchart LR
     coordinator --> orchestrator["Process-pool adapter"]
     orchestrator --> workers["Worker processes"]
     fixtures -. "shared and per-channel resources" .-> workers
-    fixtures -. "shared resources" .-> inprocess
+    fixtures -. "shared and channel 1 resources" .-> inprocess
     workers --> events["Typed events and results"]
     inprocess --> events
     events --> reporters["TTY, plain, JSONL, JUnit,<br/>GitHub and TeamCity reporters"]
     workers --> staging["Private artifact staging"]
     staging --> orchestrator
-    orchestrator --> coverage["Coverage merge and export"]
+    orchestrator --> adaptercoverage["Adapter coverage map"]
+    inprocess --> adaptercoverage
+    cli --> coverage["CLI coverage session<br/>final merge, transforms, gates, and exports"]
+    adaptercoverage --> coverage
 ```
 
 The CLI resolves the configuration once and selects one execution adapter.
@@ -37,14 +40,21 @@ adapter executes the plan and returns one outcome. Reporters consume the events
 and do not access coordinator state.
 
 For a nonempty plan, the coordinator provisions integration fixtures before
-`RunStarted`. The fixture graph supplies resources to both adapters. The
-coordinator closes the graph after `RunFinished` or after a run failure.
+`RunStarted`. The fixture graph supplies resources to both adapters.
+`InProcessExecution` uses channel `1`. It receives shared fixture resources plus
+the overlay for that channel. The coordinator closes the graph after
+`RunFinished` or after a run failure.
 
 The orchestrator makes decisions that apply to more than one worker. It
 controls assignments, resource capacity, bail, hard timeouts, crash
-containment, summary totals, artifact publication, and the final coverage
-merge. Workers execute their plan sections in sequence and send each result
-immediately.
+containment, summary totals, artifact publication, and worker coverage
+aggregation. Workers execute their plan sections in sequence and send each
+result immediately.
+
+Each adapter returns a coverage map in its execution outcome. The CLI coverage
+session can merge this map with command-process and relayed subprocess
+coverage. Command-side coverage plugins transform the merged map. The CLI
+writes exports and evaluates coverage gates.
 
 ## Module map
 
@@ -62,12 +72,13 @@ public.
 | `Condition` | Conditions that control test execution | `Internal/Process` |
 | `Result` | Test outcomes, diagnostics, and result values | `Artifact`, `Test`, `Internal/Wire`, `Internal/Text` |
 | `Event` | Events that describe the run lifecycle | `Result`, `Test`, `Internal/Wire` |
+| `Internal/Event` | Event tags, tagged payload validation, and the JSONL codec | `Event`, `Internal/Wire` |
 | `Attribute` | User test metadata | `Condition`, `Test` |
 | `Config` | Public builders and focused immutable configuration values | Public contracts, internal utilities, `Plugin` |
 | `Expect` | Immediate and temporal expectations | Public contracts, internal PHP utilities, `Plugin` |
 | `Harness` | Harness service scopes and resolution | Nothing |
 | `IntegrationFixture` | Fixture definitions, resources, provisioning, and cleanup | `Internal/Wire` |
-| `Plugin` | Extension interfaces and plugin capability groups | Public contracts, `IntegrationFixture`, and `Reporting` |
+| `Plugin` | Public capability interfaces and immutable plugin factory definitions | Artifact, coverage, event, harness, fixture, reporting, result, and test contracts |
 | `Doubles`, `Sandbox` | Test-author tools that use harness scopes | Lower test-author modules |
 | `Discovery` | PHP declaration discovery, metadata, and caching | Public contracts, `Discovery/Plan`, `Test/DataSet`, internal utilities, and `Attribute` |
 | `Discovery/Plan` | Immutable execution plans, ordering, and sharding | `Attribute`, `Test`, and `Internal/Wire` |
@@ -80,7 +91,7 @@ public.
 | `Reporting` | Event consumers and output formats | Public contracts and internal PHP utilities |
 | `Reporting/Profile` | Profile event aggregation and profile output | `Event` and `Reporting` |
 | `Execution/Artifact` | Private attachment staging, publication, recovery, quotas, and cleanup | Artifact, configuration, event, result, test, wire, and internal utilities |
-| `Execution/Plugin` | Orchestrator and worker plugin instances and event delivery | Plugin capability modules |
+| `Execution/Plugin` | Run-owned orchestrator, worker-owned, and command-side run-policy plugin runtimes | Artifacts, plans, events, expectations, harnesses, fixtures, plugin contracts, results, and tests |
 | `Execution/Worker` | In-process test execution, bounded output capture, and worker-owned lifecycle | Test execution modules and execution artifacts |
 | `Execution/ProcessPool/Protocol` | Internal worker messages, frames, and socket channels | Wire values and message payload modules |
 | `Execution/ProcessPool/Worker` | Hidden worker command and protocol event delivery | Worker, protocol, plugin, and coverage modules |
@@ -89,9 +100,11 @@ public.
 | `Cli` | Public command entry point and hidden worker routing | `Cli/Command`, `Cli/Output`, coverage relay, and worker execution |
 | `Cli/Input`, `Cli/Configuration` | Argument definition and configuration loading | Configuration values and focused internal utilities |
 | `Cli/Discovery` | Selection-plan discovery, sharding, and unmatched exclude-path diagnostics | `Cli/Configuration`, configuration values, and `Discovery` |
-| `Cli/Output`, `Cli/Reporting`, `Cli/Coverage` | Console output, reporter construction and destinations, and coverage sessions and exports | Their engine modules and focused CLI values |
+| `Cli/Output`, `Cli/Reporting` | Console output, reporter construction, and reporter destinations | Their engine modules and focused CLI values |
+| `Cli/Coverage` | Final coverage merge, plugin transformations, gates, and exports | Configuration and output CLI modules, coverage modules, plugin and reporting contracts, and internal utilities |
 | `Cli/Signal`, `Cli/State`, `Cli/Watch`, `Cli/WorkerCapacity` | Local runtime adapters and persisted run policy | Focused internal utilities |
 | `Cli/Command`, `Cli/Run` | Closed command dispatch and run lifecycle orchestration | Lower CLI modules and engine modules |
+| `Cli/Plugin` | Command-owned plugin catalog and dispatch | `Cli/Command`, `Cli/Configuration`, `Cli/Input`, `Cli/Output`, `Cli/Run`, `Config`, `Coverage`, `Plugin`, `Reporting`, and internal utilities |
 | `Documentation` | Build-time validation of documentation examples | Nothing |
 | `PhpStan`, `Rector`, `Symfony`, `Laravel`, `Hyperf`, `Psr11`, `Psr15`, `Tempest` | Optional adapters for external tools and frameworks | Their Greenlight interfaces and development-only frameworks |
 
@@ -135,12 +148,17 @@ again.
 
 ### Extensions
 
-Plugins use capability interfaces to add lifecycle subscribers, integration
-fixtures, retry decisions, harness providers, and expectation extensions.
-Orchestrator-side capabilities control run-wide work. Greenlight creates
-separate orchestrator-side and worker-side instances from immutable plugin
-definitions. Plugins **SHOULD NOT** depend on orchestrator classes or protocol
-implementation classes.
+Plugins use capability interfaces to add command, run, and worker behavior.
+Greenlight creates an instance only at a seam that uses one of its capabilities.
+
+Command dispatch, reporter setup, watch-source polls, coverage completion, and
+run-policy evaluation own separate command-side instances. Greenlight creates
+one run-owned orchestrator instance for each applicable factory. It creates one
+worker-owned instance for each applicable factory and physical worker.
+
+Immutable plugin definitions cross process seams. Plugin instances do not.
+Plugins **SHOULD NOT** depend on orchestrator classes or protocol implementation
+classes.
 
 ### Output
 


### PR DESCRIPTION
Correct the architecture overview where it assigned in-process fixture resources and final coverage work to the wrong owners. Add the omitted Internal/Event and Cli/Plugin layers, and align plugin lifetime prose with the owner-local runtime seams.