### PR TITLE
fix(cli): describe bail error counting

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -379,9 +379,10 @@ create an error annotation for a skipped test.
 The policy evaluates terminal results after plugins and retries. A plugin that
 changes the terminal outcome changes the run-policy input.
 
-A skipped test does not count toward `--bail` because its outcome is not a test
-failure. The policy fails the completed iteration instead. Thus, repeat mode
-records that iteration as failed. `--repeat-until-failure` stops after it.
+A skipped test does not count toward `--bail` because its outcome is neither
+`failed` nor `errored`. The policy fails the completed iteration instead. Thus,
+repeat mode records that iteration as failed. `--repeat-until-failure` stops
+after it.
 
 Also available as `--fail-on-skipped`.
 
@@ -517,7 +518,7 @@ directories that it creates and owns.
 
 Default: off.
 
-Stops the run after the first failure.
+Stops the run after the first failed or errored test.
 
 ### `randomizeOrder(?int $seed = null): self`
 
@@ -782,7 +783,7 @@ time.
 
 ### `--bail[=<n>]`
 
-Stops after `<n>` failures.
+Stops after `<n>` failed or errored tests.
 
 Bare `--bail` means `--bail=1`.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -161,7 +161,7 @@ Use these commands for common tasks:
 * `vendor/bin/greenlight run --group=slow` selects tests with `#[Group('slow')]`.
 * `vendor/bin/greenlight run --exclude-group=slow` excludes that group.
 * `vendor/bin/greenlight run --list-tests` prints the selected tests.
-* `vendor/bin/greenlight run --bail` stops after the first failure.
+* `vendor/bin/greenlight run --bail` stops after the first failed or errored test.
 
 The `--exclude-class`, `--exclude-method`, and `--exclude-path` flags also
 exclude tests. Exclusion rules take priority over inclusion rules.

--- a/src/Cli/Configuration/PlanFormatter.php
+++ b/src/Cli/Configuration/PlanFormatter.php
@@ -55,8 +55,8 @@ final class PlanFormatter
         $lines[] = '  resource limits: ' . ($resourceLimits === [] ? '(default 1 per required resource)' : \implode(', ', $resourceLimits));
         $lines[] = '  stop after: ' . match (true) {
             $configuration->execution->stopAfterFailures === null => 'never',
-            $configuration->execution->stopAfterFailures === 1 => '1 failure',
-            default => $configuration->execution->stopAfterFailures . ' failures',
+            $configuration->execution->stopAfterFailures === 1 => '1 failed or errored test',
+            default => $configuration->execution->stopAfterFailures . ' failed or errored tests',
         };
 
         $seed = $configuration->order->seed;

--- a/src/Cli/Input/Definition.php
+++ b/src/Cli/Input/Definition.php
@@ -62,7 +62,7 @@ final readonly class Definition
           --workers=<n|auto> Set the worker process count
           --resource-limit=<name>=<n>
                              Set a named resource limit. You can repeat this option.
-          --bail[=<n>]       Stop after <n> failures (default 1)
+          --bail[=<n>]       Stop after <n> failed or errored tests (default 1)
           --suite=<name>     Select a named suite. You can repeat this option.
           --suite-tag=<tag>  Select suites with this tag. You can repeat this option.
           --group=<name>     Run only this group. You can repeat this option.

--- a/src/Config/ExecutionConfiguration.php
+++ b/src/Config/ExecutionConfiguration.php
@@ -17,7 +17,7 @@ final readonly class ExecutionConfiguration
 {
     /**
      * @param list<PluginDefinition> $plugins
-     * @param positive-int|null $stopAfterFailures A null value runs all tests regardless of failures.
+     * @param positive-int|null $stopAfterFailures A null value does not stop the run for failed or errored tests.
      */
     public function __construct(
         public array $plugins,

--- a/src/Execution/ProcessPool/Protocol/Messages/Assign.php
+++ b/src/Execution/ProcessPool/Protocol/Messages/Assign.php
@@ -21,7 +21,7 @@ final readonly class Assign implements Message
     /**
      * @param list<non-empty-string>|null $coverageInclude Null disables coverage.
      * @param non-empty-string|null $coverageDriver
-     * @param positive-int|null $stopAfterFailures Remaining assignment failure allowance.
+     * @param positive-int|null $stopAfterFailures Remaining assignment allowance for failed or errored tests.
      */
     public function __construct(
         public ExecutionPlan $slice,

--- a/src/Execution/Worker/Worker.php
+++ b/src/Execution/Worker/Worker.php
@@ -27,7 +27,7 @@ use Greenlight\Test\TestId;
  *
  * run() stops early in these conditions:
  *
- * - The run reaches the failure limit.
+ * - The run reaches the failed-or-errored test limit.
  * - The orchestrator requests a drain between tests.
  *
  * run() reports incomplete entries in plan order.

--- a/tests/Acceptance/BailRunTest.php
+++ b/tests/Acceptance/BailRunTest.php
@@ -16,27 +16,26 @@ final readonly class BailRunTest
     public function __construct(private TemporaryDirectory $tempDirectory) {}
 
     #[Test]
-    public function bailWithNoValueStopsAfterOneFailure(): void
+    public function bailWithNoValueStopsAfterOneFailedTest(): void
     {
         $project = $this->writeProject();
         $result = $this->run($project, '--bail');
-        Expect::that($result->exitCode)->because('bail with no value stops after one failure')->toBe(1);
+        Expect::that($result->exitCode)->because('bail with no value stops after one failed test')->toBe(1);
         Expect::that($result->output())->toContain('6 tests, 1 worker')
-            ->toContain('1 test, 0 passed, 1 errored')
+            ->toContain('1 test, 0 passed, 1 failed')
             ->not()->toContain('BProbe')
             ->not()->toContain('CProbe');
     }
 
     #[Test]
-    public function bailWithAnExplicitCountStopsAfterThatManyFailures(): void
+    public function bailWithAnExplicitCountCountsFailedAndErroredTests(): void
     {
         $project = $this->writeProject();
         $result = $this->run($project, '--bail=2');
-        // Class A causes both counted failures. Thus, later classes do not
-        // start.
-        Expect::that($result->exitCode)->because('bail with an explicit count stops after that many failures')->toBe(1);
+        // Class A causes both counted outcomes. Thus, later classes do not start.
+        Expect::that($result->exitCode)->because('bail with an explicit count counts failed and errored tests')->toBe(1);
         Expect::that($result->output())->toContain('6 tests, 1 worker')
-            ->toContain('2 tests, 0 passed, 2 errored')
+            ->toContain('2 tests, 0 passed, 1 failed, 1 errored')
             ->not()->toContain('BProbe')
             ->not()->toContain('CProbe');
     }
@@ -47,7 +46,7 @@ final readonly class BailRunTest
         $project = $this->writeProject();
         $result = $this->run($project);
         Expect::that($result->exitCode)->because('without bail the whole plan runs')->toBe(1);
-        Expect::that($result->output())->toContain('6 tests, 3 passed, 3 errored');
+        Expect::that($result->output())->toContain('6 tests, 3 passed, 1 failed, 2 errored');
     }
 
     private function run(AcceptanceProject $project, string ...$flags): ProcessResult
@@ -67,13 +66,16 @@ final readonly class BailRunTest
             namespace BailProbe;
 
             use Greenlight\Attribute\Test;
+            use Greenlight\Expect\Expect;
 
             final class BailAProbeTest
             {
                 #[Test]
-                public function one(): never
+                public function one(): void
                 {
-                    throw new \RuntimeException('bail probe failure a1');
+                    Expect::that('actual')
+                        ->because('the bail probe MUST fail its first test')
+                        ->toBe('expected');
                 }
 
                 #[Test]

--- a/tests/Acceptance/CliTest.php
+++ b/tests/Acceptance/CliTest.php
@@ -30,7 +30,7 @@ final readonly class CliTest
             ->toContain('  suite integration: tests/Integration [tags: io]')
             ->toContain('  workers: 4')
             ->toContain('  resource limits: postgres=3')
-            ->toContain('  stop after: 1 failure')
+            ->toContain('  stop after: 1 failed or errored test')
             ->toContain('  order: random (seed 4242)')
             ->toContain('  groups: (all)');
     }
@@ -52,7 +52,7 @@ final readonly class CliTest
         Expect::that($result->exitCode)->because('command line flags override the configuration file')->toBe(0);
         Expect::that($output)->because('command line flags override the configuration file')
             ->toContain('  workers: 2')
-            ->toContain('  stop after: 7 failures')
+            ->toContain('  stop after: 7 failed or errored tests')
             ->toContain('  order: random (seed 9)')
             ->toContain('  groups: slow');
         Expect::that($output)->because('command line flags override the configuration file')->toContain('  resource limits: postgres=2');

--- a/tests/Unit/Cli/Configuration/CliOverridesTest.php
+++ b/tests/Unit/Cli/Configuration/CliOverridesTest.php
@@ -166,11 +166,11 @@ final class CliOverridesTest
     }
 
     #[Test]
-    public function bailWithoutAValueMeansStopAfterTheFirstFailure(): void
+    public function bailWithoutAValueMeansStopAfterTheFirstFailedOrErroredTest(): void
     {
         $overrides = CliOverrides::fromArguments(new ParsedArguments(null, ['bail' => [null]]));
 
-        Expect::that($overrides->execution->stopAfterFailures)->because('bail without a value means stop after the first failure')->toBe(1);
+        Expect::that($overrides->execution->stopAfterFailures)->because('bail without a value means stop after the first failed or errored test')->toBe(1);
     }
 
     #[Test]

--- a/tests/Unit/Cli/Configuration/PlanFormatterTest.php
+++ b/tests/Unit/Cli/Configuration/PlanFormatterTest.php
@@ -178,8 +178,8 @@ final class PlanFormatterTest
      */
     public static function failureLimits(): iterable
     {
-        yield 'singular' => [1, '1 failure'];
+        yield 'singular' => [1, '1 failed or errored test'];
 
-        yield 'plural' => [3, '3 failures'];
+        yield 'plural' => [3, '3 failed or errored tests'];
     }
 }

--- a/tests/Unit/Cli/Configuration/PrecedenceMatrixTest.php
+++ b/tests/Unit/Cli/Configuration/PrecedenceMatrixTest.php
@@ -41,14 +41,14 @@ final class PrecedenceMatrixTest
     #[Test]
     public function stopAfterFailuresPrecedence(): void
     {
-        Expect::that($this->resolve()->execution->stopAfterFailures)->because('failure limit options use the required precedence')->toBe(null);
+        Expect::that($this->resolve()->execution->stopAfterFailures)->because('stop-limit options use the required precedence')->toBe(null);
         Expect::that(
             $this->resolve(config: static fn(GreenlightConfig $c) => $c->failFast())->execution->stopAfterFailures,
-        )->because('failure limit options use the required precedence')->toBe(1);
-        Expect::that($this->resolve(cli: new CliOverrides(execution: new ExecutionOverrides(stopAfterFailures: 3)))->execution->stopAfterFailures)->because('failure limit options use the required precedence')->toBe(3);
+        )->because('stop-limit options use the required precedence')->toBe(1);
+        Expect::that($this->resolve(cli: new CliOverrides(execution: new ExecutionOverrides(stopAfterFailures: 3)))->execution->stopAfterFailures)->because('stop-limit options use the required precedence')->toBe(3);
         Expect::that(
             $this->resolve(config: static fn(GreenlightConfig $c) => $c->failFast(), cli: new CliOverrides(execution: new ExecutionOverrides(stopAfterFailures: 3)))->execution->stopAfterFailures,
-        )->because('failure limit options use the required precedence')->toBe(3);
+        )->because('stop-limit options use the required precedence')->toBe(3);
     }
 
     #[Test]

--- a/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorTest.php
+++ b/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorTest.php
@@ -246,7 +246,7 @@ final class OrchestratorTest
 
     #[Test]
     #[Timeout(30.0)]
-    public function failureLimitDrainsRemainingBatchedClasses(): void
+    public function failedOrErroredTestLimitDrainsRemainingBatchedClasses(): void
     {
         $root = \dirname(__DIR__, 5);
         $sink = new CollectingEventSink();
@@ -268,7 +268,7 @@ final class OrchestratorTest
         $results = $sink->results();
 
         Expect::that($summary->total())
-            ->because('the failure limit MUST stop before the remaining batched class runs')
+            ->because('the failed-or-errored test limit MUST stop before the remaining batched class runs')
             ->toBe(1);
         Expect::that($summary->errored)
             ->toBe(1);

--- a/tests/Unit/Execution/ProcessPool/Protocol/ProtocolTest.php
+++ b/tests/Unit/Execution/ProcessPool/Protocol/ProtocolTest.php
@@ -162,7 +162,7 @@ final class ProtocolTest
             ->because('legacy assignments have no artifact configuration')
             ->toBeNull();
         Expect::that($assign->stopAfterFailures)
-            ->because('legacy assignments have no local failure allowance')
+            ->because('legacy assignments have no local failed-or-errored test allowance')
             ->toBeNull();
     }
 


### PR DESCRIPTION
Correct the bail contract across the guides, help output, plan summary, and internal prose: the limit counts failed and errored terminal tests. Strengthen the acceptance fixture so one threshold counts both outcome types.