### PR TITLE
fix(docs): exclude API signature comments

### DIFF
--- a/docs/api-doubles.md
+++ b/docs/api-doubles.md
@@ -912,7 +912,7 @@ The closure receives the call arguments. The call returns the value
 from the closure.
 
 ```php
-public function andReturnsUsing(\Closure $answer): self // @phpstan-ignore missingType.callable (The doubled method determines the answer signature.)
+public function andReturnsUsing(\Closure $answer): self
 ```
 
 PHPDoc:

--- a/website/scripts/generate-api-reference.mjs
+++ b/website/scripts/generate-api-reference.mjs
@@ -578,7 +578,14 @@ function parseMembers(source, tokens, openIndex, closeIndex, typeKind) {
 
       if (isMethod(significant)) {
         addPromotedProperties(members, source, significant);
-        addMember(members, source, significant, token.start, 'method', typeKind);
+        addMember(
+          members,
+          source,
+          significant,
+          significant.findLast((candidate) => candidate.kind !== 'doc').end,
+          'method',
+          typeKind,
+        );
       } else if (isPublicProperty(significant)) {
         const propertyTokens = [...significant, ...tokens.slice(index, endIndex + 1)];
         addMember(members, source, propertyTokens, tokens[endIndex].end, 'property', typeKind);

--- a/website/scripts/generate-api-reference.test.mjs
+++ b/website/scripts/generate-api-reference.test.mjs
@@ -76,6 +76,48 @@ final class Event
   }
 });
 
+test('method comments before braces do not enter signatures', async () => {
+  const sourceRoot = await mkdtemp(resolve(tmpdir(), 'greenlight-api-reference-source-'));
+  const documentationRoot = await mkdtemp(resolve(tmpdir(), 'greenlight-api-reference-docs-'));
+
+  try {
+    await writeFile(resolve(sourceRoot, 'Event.php'), `<?php
+
+namespace Greenlight\\Event;
+
+final class Event
+{
+    public function lineComment(): string // The implementation has a line comment.
+    {
+        return '';
+    }
+
+    public function blockComment(): string /* The implementation has a block comment. */
+    {
+        return '';
+    }
+}
+`);
+
+    const result = spawnSync(process.execPath, [
+      script,
+      `--source-root=${sourceRoot}`,
+      `--documentation-root=${documentationRoot}`,
+    ], { encoding: 'utf8' });
+
+    assert.equal(result.status, 0, result.stderr);
+
+    const reference = await readFile(resolve(documentationRoot, 'api-events.md'), 'utf8');
+
+    assert.match(reference, /```php\npublic function lineComment\(\): string\n```/);
+    assert.match(reference, /```php\npublic function blockComment\(\): string\n```/);
+    assert.doesNotMatch(reference, /implementation has/);
+  } finally {
+    await rm(sourceRoot, { recursive: true, force: true });
+    await rm(documentationRoot, { recursive: true, force: true });
+  }
+});
+
 test('a secondary internal declaration cannot leak through a public type', async () => {
   const sourceRoot = await mkdtemp(resolve(tmpdir(), 'greenlight-api-reference-'));
 


### PR DESCRIPTION
Bound braced method signatures at their last parsed signature token so implementation comments cannot enter generated API fences. Add line-comment and block-comment regression cases and regenerate the affected doubles reference.