### PR TITLE
docs(laravel): qualify application refresh default

### DIFF
--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -3,10 +3,10 @@
 The [Laravel](https://laravel.com/) bridge supplies Laravel container services
 and built-in Greenlight harness services to test constructors.
 
-The bridge boots a fresh application for each test that uses it. Register the
-plugin to activate the bridge. The bridge uses the Laravel package that the
-application provides. Greenlight does not declare a runtime dependency on
-Laravel.
+By default, the bridge boots a fresh application for each test attempt that
+uses it. Register the plugin to activate the bridge. The bridge uses the
+Laravel package that the application provides. Greenlight does not declare a
+runtime dependency on Laravel.
 
 ## Setup
 
@@ -112,9 +112,9 @@ application in its own container.
 
 ## State between tests
 
-The bridge discards the application after each test. Configuration changes,
-facade roots, singleton state, and container registrations cannot reach the
-next test.
+By default, the bridge discards the application after each test attempt.
+Configuration changes, facade roots, singleton state, and container
+registrations cannot reach the next attempt.
 
 This scope is smaller than the isolation in Laravel's `TestCase`. Laravel's
 test harness resets framework static state for its helpers and fakes. The

--- a/website/src/lib/docs.ts
+++ b/website/src/lib/docs.ts
@@ -69,7 +69,7 @@ export const docSections = [
       {
         id: 'laravel',
         title: 'Laravel',
-        description: 'This guide explains how tests receive container services from a fresh Laravel application.',
+        description: 'This guide explains how tests receive Laravel container services and configure application refresh.',
       },
       {
         id: 'hyperf',


### PR DESCRIPTION
Qualify fresh Laravel applications as the default per-attempt lifecycle. Keep the guide and website summary accurate for the supported refreshBetweenTests: false per-worker mode.