### PR TITLE
docs(psr11): clarify shared reset lifecycle

### DIFF
--- a/docs/psr11.md
+++ b/docs/psr11.md
@@ -107,8 +107,8 @@ new Psr11Plugin(
 );
 ```
 
-The callback runs only if a test creates the container. The bridge discards the
-container even if the callback throws.
+With the default refresh, the callback runs only after an attempt that creates
+the container. The bridge discards the container even if the callback throws.
 
 If services keep no test state or `reset:` removes all state, set
 `refreshBetweenTests` to `false`. The worker then keeps one container:
@@ -125,6 +125,9 @@ new Psr11Plugin(
 ```
 
 Tests on the same worker receive the same service instances.
+
+When the shared container is active, the callback runs after each test attempt.
+This includes an attempt that does not request the container.
 
 The bridge controls only container state. It does not isolate databases,
 caches, queues, files, or other external resources.

--- a/tests/Unit/Psr11/Psr11PluginTest.php
+++ b/tests/Unit/Psr11/Psr11PluginTest.php
@@ -184,6 +184,27 @@ final readonly class Psr11PluginTest
     }
 
     #[Test]
+    public function anActiveSharedContainerResetsAfterAnAttemptThatDoesNotRequestIt(): void
+    {
+        $resets = 0;
+        $plugin = new Psr11Plugin(
+            static fn(): ContainerInterface => new ArrayContainer([]),
+            refreshBetweenTests: false,
+            reset: static function (ContainerInterface $container) use (&$resets): void {
+                ++$resets;
+            },
+        );
+        $this->containerFrom($plugin);
+
+        $plugin->afterTest($this->context(), $this->result());
+        $plugin->afterTest($this->context(), $this->result());
+
+        Expect::that($resets)
+            ->because('an active shared container MUST reset after each test attempt')
+            ->toBe(2);
+    }
+
+    #[Test]
     public function aFailedResetStillDiscardsAPerTestContainer(): void
     {
         $failure = new \RuntimeException('Reset failed.');


### PR DESCRIPTION
Separate the default per-attempt reset behavior from shared-container behavior. Prove that an active shared container resets after a later test attempt even when that attempt does not request the container.