### PR TITLE
docs(architecture): clarify fixture channel capacity

### DIFF
--- a/docs/architecture/orchestrator-integration-fixtures.md
+++ b/docs/architecture/orchestrator-integration-fixtures.md
@@ -32,6 +32,12 @@ before it provisions anything, then provisions dependencies first.
 Fixture IDs are non-empty UTF-8 strings. They cannot use integer strings
 because PHP converts those map keys to integers.
 
+`IntegrationFixtureContext::configuredWorkers()` returns the configured worker
+ceiling. `IntegrationFixtureContext::channels()` returns the consecutive channel
+numbers that the selected plan can use. Selected work and resource capacity can
+reduce the number of channels below the ceiling. Providers MUST create overlays
+only for these numbers. Replacement workers reuse released numbers.
+
 Call `IntegrationFixtureContext::defer()` as soon as the provisioner acquires a
 resource. The callback will then run even if the rest of the provisioner fails.
 Greenlight runs cleanup callbacks in reverse registration order.

--- a/docs/architecture/worker-lifecycle.md
+++ b/docs/architecture/worker-lifecycle.md
@@ -390,8 +390,8 @@ Queue size and resource capacity can reduce this target below the configured
 worker count.
 
 `IntegrationFixtureContext::configuredWorkers()` returns the configured worker
-count. `IntegrationFixtureContext::channels()` returns the channel numbers that
-this run can use.
+ceiling. `IntegrationFixtureContext::channels()` returns the consecutive channel
+numbers that this selected plan can use.
 
 The allocator gives out the lowest free number and returns it when a worker
 retires. A replacement can use a released channel.


### PR DESCRIPTION
Distinguish the configured worker ceiling from the dense channel set available to a selected plan. Document that resource capacity can reduce this set and fixture providers must create overlays only for returned channels.