### PR TITLE
fix(coverage): reject relative JSON paths consistently

### DIFF
--- a/docs/architecture/coverage-json.md
+++ b/docs/architecture/coverage-json.md
@@ -9,6 +9,8 @@ The coverage difference command also uses this format:
 greenlight coverage:diff --baseline=baseline.json --current=current.json
 ```
 
+Without root options, both input documents **MUST** use absolute file-path keys.
+
 The schema has a version. The fields and meanings in version 1 are stable. See
 [compatibility](compatibility.md) for the change rules.
 
@@ -138,8 +140,8 @@ duplicate inputs, and empty maps do not change the result.
 A file can be absent from an input. The result contains that file if a different
 input contains it.
 
-The command rejects malformed documents and unsupported versions. Without root
-options, each file path must be absolute.
+The command rejects malformed documents and unsupported versions. Each file
+path must be absolute.
 
 For different roots, give one `--input-root` for each input. Give one
 `--project-root` for the output. Greenlight removes each applicable input root

--- a/src/Cli/Command/CoverageDiffCommand.php
+++ b/src/Cli/Command/CoverageDiffCommand.php
@@ -67,6 +67,10 @@ final readonly class CoverageDiffCommand
             }
             try {
                 $maps[$label] = JsonExporter::import($json);
+
+                if ($baselineRoot === null && $currentRoot === null) {
+                    ProjectRootNormalizer::requireAbsolutePaths($maps[$label]);
+                }
             } catch (\Throwable $error) {
                 $this->console->error(
                     \sprintf(

--- a/src/Cli/Command/CoverageMergeCommand.php
+++ b/src/Cli/Command/CoverageMergeCommand.php
@@ -124,7 +124,7 @@ final readonly class CoverageMergeCommand
                 if ($inputRoot !== null && $targetRoot !== null) {
                     $map = ProjectRootNormalizer::relocate($map, $inputRoot, $targetRoot);
                 } else {
-                    $this->requireAbsolutePaths($map);
+                    ProjectRootNormalizer::requireAbsolutePaths($map);
                 }
             } catch (\Throwable $error) {
                 $this->console->error(\sprintf(
@@ -196,17 +196,5 @@ final readonly class CoverageMergeCommand
     private function rootIdentity(string $root): string
     {
         return $root === '/' ? '/' : \rtrim($root, '/');
-    }
-
-    private function requireAbsolutePaths(CoverageMap $map): void
-    {
-        foreach ($map->files() as $path => $_coverage) {
-            if (!\str_starts_with($path, '/')) {
-                throw new \InvalidArgumentException(\sprintf(
-                    'Coverage JSON requires an absolute file path. Received "%s".',
-                    $path,
-                ));
-            }
-        }
     }
 }

--- a/src/Coverage/Diff/ProjectRootNormalizer.php
+++ b/src/Coverage/Diff/ProjectRootNormalizer.php
@@ -69,4 +69,25 @@ final class ProjectRootNormalizer
 
         return new CoverageMap($files);
     }
+
+    public static function requireAbsolutePaths(CoverageMap $map): void
+    {
+        foreach ($map->files() as $path => $_coverage) {
+            if (self::isAbsolute($path)) {
+                continue;
+            }
+
+            throw new \InvalidArgumentException(\sprintf(
+                'Coverage JSON requires an absolute file path. Received "%s".',
+                $path,
+            ));
+        }
+    }
+
+    private static function isAbsolute(string $path): bool
+    {
+        return \str_starts_with($path, '/')
+            || \str_starts_with($path, '\\\\')
+            || \preg_match('~\A[A-Za-z]:[\\\\/]~D', $path) === 1;
+    }
 }

--- a/tests/Acceptance/CoverageDiffErrorTest.php
+++ b/tests/Acceptance/CoverageDiffErrorTest.php
@@ -111,6 +111,35 @@ final readonly class CoverageDiffErrorTest
     }
 
     #[Test]
+    #[DataSet('invalidExportLabels')]
+    public function relativeCoveragePathsNameTheirRole(string $invalidLabel): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'coverage-diff-relative-' . $invalidLabel);
+        $valid = '{"v":1,"files":{}}';
+        $invalid = '{"v":1,"files":{"src/A.php":{"covered":[1],"uncovered":[]}}}';
+
+        foreach (['baseline', 'current'] as $label) {
+            $project->writeFile($label . '.json', $label === $invalidLabel ? $invalid : $valid);
+        }
+
+        $result = GreenlightCli::run($project->directory, [
+            'coverage:diff',
+            '--baseline=baseline.json',
+            '--current=current.json',
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('relative coverage paths name their role')
+            ->toBe(1);
+        Expect::that($result->output())
+            ->toContain(\sprintf(
+                'The %s file is not a valid coverage export: '
+                . 'Coverage JSON requires an absolute file path. Received "src/A.php".',
+                $invalidLabel,
+            ));
+    }
+
+    #[Test]
     public function projectRootOptionsMustBeUsedTogether(): void
     {
         $project = AcceptanceProject::create($this->tempDirectory, 'coverage-diff-one-root');

--- a/tests/Unit/Coverage/Diff/ProjectRootNormalizerTest.php
+++ b/tests/Unit/Coverage/Diff/ProjectRootNormalizerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Coverage\Diff;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Coverage\CoverageMap;
 use Greenlight\Coverage\Diff\BaselineDiff;
@@ -88,5 +89,57 @@ final class ProjectRootNormalizerTest
                 \InvalidArgumentException::class,
                 message: 'The target project root must be an absolute path.',
             );
+    }
+
+    #[Test]
+    #[DataSet('absolutePaths')]
+    public function absoluteCoveragePathsAreAccepted(string $path): void
+    {
+        $map = new CoverageMap([new FileCoverage($path, [1], [])]);
+
+        Expect::that(static function () use ($map): void {
+            ProjectRootNormalizer::requireAbsolutePaths($map);
+        })
+            ->because('fully qualified coverage paths MUST be accepted')
+            ->not()->toThrow(\InvalidArgumentException::class);
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function absolutePaths(): iterable
+    {
+        yield 'POSIX' => ['/project/src/A.php'];
+        yield 'Windows drive with slashes' => ['C:/project/src/A.php'];
+        yield 'Windows drive with backslashes' => ['C:\project\src\A.php'];
+        yield 'Windows UNC' => ['\\\\server\share\src\A.php'];
+        yield 'Windows device' => ['\\\\?\C:\project\src\A.php'];
+    }
+
+    #[Test]
+    #[DataSet('relativePaths')]
+    public function relativeCoveragePathsAreRejected(string $path): void
+    {
+        $map = new CoverageMap([new FileCoverage($path, [1], [])]);
+
+        Expect::that(static function () use ($map): void {
+            ProjectRootNormalizer::requireAbsolutePaths($map);
+        })
+            ->because('coverage JSON MUST reject relative file paths')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: \sprintf('Coverage JSON requires an absolute file path. Received "%s".', $path),
+            );
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function relativePaths(): iterable
+    {
+        yield 'plain' => ['src/A.php'];
+        yield 'dot prefix' => ['./src/A.php'];
+        yield 'Windows drive-relative' => ['C:src\A.php'];
+        yield 'Windows current drive root' => ['\src\A.php'];
     }
 }


### PR DESCRIPTION
Apply the documented absolute-path rule to both coverage comparison commands.

Share one validator between coverage:diff and coverage:merge. Accept POSIX, drive-rooted Windows, UNC, and Windows device paths without normalizing their public identifiers.