### PR TITLE
docs(cli): document interruption exit codes

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -460,11 +460,15 @@ primary.
 
 ## Exit codes
 
-Greenlight uses three exit codes:
+Greenlight uses these exit codes:
 
 * `0` means that the run succeeded.
 * `1` means that the run failed or found no tests.
 * `64` means that the command has a usage error.
+* `128 + signal number` means that a signal interrupted the run.
+
+For example, SIGINT returns `130` and SIGTERM returns `143`. See
+[interruption](configuration.md#interruption) for the graceful shutdown rules.
 
 Exit code `1` includes test failures, test errors, invalid configuration,
 discovery errors, coverage gate failures, coverage export errors, and detected

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -16,8 +16,8 @@ use Greenlight\Reporting\ReportGenerationFailed;
 use Greenlight\Reporting\StreamOutput;
 
 /**
- * Uses exit code 0 for success. Uses 1 for a test or run failure. Uses 64 for
- * invalid command-line use.
+ * Uses exit code 0 for success. Uses 1 for a test or run failure.
+ * Uses 64 for invalid command-line use. Interruption uses 128 plus the signal.
  *
  * @internal
  */

--- a/src/Cli/Run/RunCommand.php
+++ b/src/Cli/Run/RunCommand.php
@@ -34,8 +34,8 @@ use Greenlight\Reporting\Style;
 /**
  * Orchestrates one ordinary run command and its repeat policy.
  *
- * Uses exit code 0 for success. Uses 1 for a test or run failure. Uses 64 for
- * invalid command-line use.
+ * Uses exit code 0 for success. Uses 1 for a test or run failure.
+ * Uses 64 for invalid command-line use. Interruption uses 128 plus the signal.
  *
  * @internal
  */


### PR DESCRIPTION
Add the interrupted command outcome to the getting-started exit-code list.

Document the 128-plus-signal mapping, including SIGINT 130 and SIGTERM 143, and link to the graceful shutdown rules.