### PR TITLE
docs(ci): show complete configuration chains

### DIFF
--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -11,10 +11,12 @@ reporter keeps a human-readable test log.
 
 Configure a project-relative parent directory for retained attachments:
 
-<!-- php-example {"mode":"display","reason":"Shows one method in an existing Greenlight configuration chain."} -->
+<!-- php-example {"mode":"display","reason":"Shows a configuration call after omitted calls."} -->
 ```php
-->artifacts(fn ($artifacts) => $artifacts
-    ->directory('build/github/greenlight-runs'))
+return GreenlightConfig::create()
+    // ...
+    ->artifacts(fn ($artifacts) => $artifacts
+        ->directory('build/github/greenlight-runs'));
 ```
 
 Greenlight creates a unique run directory below this parent. A run without
@@ -95,10 +97,12 @@ save it after the step.
 
 For example, add this configuration to `greenlight.php`:
 
-<!-- php-example {"mode":"display","reason":"Shows one method in an existing Greenlight configuration chain."} -->
+<!-- php-example {"mode":"display","reason":"Shows a configuration call after omitted calls."} -->
 ```php
-->storage(fn ($storage) => $storage
-    ->stateDirectory('build/greenlight-state'))
+return GreenlightConfig::create()
+    // ...
+    ->storage(fn ($storage) => $storage
+        ->stateDirectory('build/greenlight-state'));
 ```
 
 This example keeps separate state for each operating system and PHP version:

--- a/docs/gitlab-ci.md
+++ b/docs/gitlab-ci.md
@@ -8,10 +8,12 @@ Greenlight does not need a GitLab-specific reporter.
 Configure a project-relative parent directory for Greenlight run directories.
 Add this configuration to `greenlight.php`:
 
-<!-- php-example {"mode":"display","reason":"Shows one method in an existing Greenlight configuration chain."} -->
+<!-- php-example {"mode":"display","reason":"Shows a configuration call after omitted calls."} -->
 ```php
-->artifacts(fn ($artifacts) => $artifacts
-    ->directory('build/gitlab/greenlight-runs'))
+return GreenlightConfig::create()
+    // ...
+    ->artifacts(fn ($artifacts) => $artifacts
+        ->directory('build/gitlab/greenlight-runs'));
 ```
 
 Greenlight creates a unique run directory below this parent directory. Retained
@@ -93,11 +95,13 @@ and [parallel job variables](https://docs.gitlab.com/ci/variables/predefined_var
 Greenlight can write the Cobertura report that GitLab uses for merge request
 diff annotations. Add this configuration to `greenlight.php`:
 
-<!-- php-example {"mode":"display","reason":"Shows one method in an existing Greenlight configuration chain."} -->
+<!-- php-example {"mode":"display","reason":"Shows a configuration call after omitted calls."} -->
 ```php
-->coverage(fn ($coverage) => $coverage
-    ->include('src')
-    ->export('cobertura', 'build/coverage/cobertura.xml'))
+return GreenlightConfig::create()
+    // ...
+    ->coverage(fn ($coverage) => $coverage
+        ->include('src')
+        ->export('cobertura', 'build/coverage/cobertura.xml'));
 ```
 
 Add the coverage file to the test job artifacts:


### PR DESCRIPTION
Replace bare fluent-call fragments in the GitHub Actions and GitLab CI guides with complete GreenlightConfig return chains. Use an omission comment to show where existing project configuration remains.