### PR TITLE
docs(coverage): publish the version 1 JSON schema

### DIFF
--- a/docs/architecture/coverage-json.md
+++ b/docs/architecture/coverage-json.md
@@ -14,6 +14,14 @@ Without root options, both input documents **MUST** use absolute file-path keys.
 The schema has a version. The fields and meanings in version 1 are stable. See
 [compatibility](compatibility.md) for the change rules.
 
+The version 1 producer schema is at
+[resources/schema/coverage-v1.schema.json](../../resources/schema/coverage-v1.schema.json).
+It defines documents from `export()`. The importer also accepts documents that
+omit derived percentages and totals because it calculates these values again.
+
+The prose below defines path, sorting, and relationship rules that the JSON
+Schema does not express.
+
 ## Document shape
 
 ```json id="b2emxw"

--- a/resources/schema/coverage-v1.schema.json
+++ b/resources/schema/coverage-v1.schema.json
@@ -1,0 +1,57 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "https://raw.githubusercontent.com/ben-challis/greenlight/main/resources/schema/coverage-v1.schema.json",
+    "title": "Greenlight JSON coverage document (version 1)",
+    "description": "One document produced by the Greenlight JSON coverage exporter. Prose reference: docs/architecture/coverage-json.md.",
+    "type": "object",
+    "required": ["v", "files", "totals"],
+    "properties": {
+        "v": {
+            "enum": [1]
+        },
+        "files": {
+            "type": "object",
+            "patternProperties": {
+                "^.+$": {"$ref": "#/definitions/file"}
+            },
+            "additionalProperties": false
+        },
+        "totals": {
+            "$ref": "#/definitions/totals"
+        }
+    },
+    "definitions": {
+        "lineList": {
+            "type": "array",
+            "uniqueItems": true,
+            "items": {
+                "type": "integer",
+                "minimum": 1
+            }
+        },
+        "percentage": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 100
+        },
+        "file": {
+            "type": "object",
+            "required": ["covered", "uncovered", "percentage"],
+            "properties": {
+                "covered": {"$ref": "#/definitions/lineList"},
+                "uncovered": {"$ref": "#/definitions/lineList"},
+                "percentage": {"$ref": "#/definitions/percentage"}
+            }
+        },
+        "totals": {
+            "type": "object",
+            "required": ["files", "coveredLines", "executableLines", "percentage"],
+            "properties": {
+                "files": {"type": "integer", "minimum": 0},
+                "coveredLines": {"type": "integer", "minimum": 0},
+                "executableLines": {"type": "integer", "minimum": 0},
+                "percentage": {"$ref": "#/definitions/percentage"}
+            }
+        }
+    }
+}

--- a/tests/Unit/Coverage/Export/JsonExporterJsonSchemaTest.php
+++ b/tests/Unit/Coverage/Export/JsonExporterJsonSchemaTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage\Export;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Coverage\Export\JsonExporter;
+use Greenlight\Coverage\FileCoverage;
+use Greenlight\Expect\Expect;
+use JsonSchema\Validator;
+
+final readonly class JsonExporterJsonSchemaTest
+{
+    #[Test]
+    public function exportedDocumentsMatchTheShippedSchema(): void
+    {
+        $exporter = new JsonExporter();
+        $documents = [
+            'populated map' => $exporter->export(new CoverageMap([
+                new FileCoverage('/project/src/A.php', [3, 7], [5]),
+            ]))[JsonExporter::FILE_NAME],
+            'empty map' => $exporter->export(CoverageMap::empty())[JsonExporter::FILE_NAME],
+        ];
+
+        foreach ($documents as $case => $json) {
+            Expect::that($this->isValid($json))
+                ->because($case . ' MUST match the shipped coverage schema')
+                ->toBeTrue();
+        }
+    }
+
+    #[Test]
+    #[DataSet('invalidDocuments')]
+    public function invalidProducerDocumentsDoNotMatchTheSchema(string $json): void
+    {
+        Expect::that($this->isValid($json))
+            ->because('an invalid producer document MUST NOT match the coverage schema')
+            ->toBeFalse();
+    }
+
+    #[Test]
+    public function additiveFieldsMatchTheVersionOneSchema(): void
+    {
+        $json = <<<'JSON'
+            {
+                "v": 1,
+                "files": {
+                    "/project/src/A.php": {
+                        "covered": [1],
+                        "uncovered": [],
+                        "percentage": 100,
+                        "branchCoverage": 100
+                    }
+                },
+                "totals": {
+                    "files": 1,
+                    "coveredLines": 1,
+                    "executableLines": 1,
+                    "percentage": 100,
+                    "coveredBranches": 1
+                },
+                "producer": "future-greenlight"
+            }
+            JSON;
+
+        Expect::that($this->isValid($json))
+            ->because('version 1 MUST permit additive fields')
+            ->toBeTrue();
+    }
+
+    /**
+     * @return iterable<string, array{non-empty-string}>
+     */
+    public static function invalidDocuments(): iterable
+    {
+        yield 'unsupported version' => [
+            '{"v":2,"files":{},"totals":{"files":0,"coveredLines":0,"executableLines":0,"percentage":100}}',
+        ];
+        yield 'missing totals' => [
+            '{"v":1,"files":{}}',
+        ];
+        yield 'zero line number' => [
+            '{"v":1,"files":{"/a.php":{"covered":[0],"uncovered":[],"percentage":100}},"totals":{"files":1,"coveredLines":1,"executableLines":1,"percentage":100}}',
+        ];
+        yield 'duplicate line number' => [
+            '{"v":1,"files":{"/a.php":{"covered":[1,1],"uncovered":[],"percentage":100}},"totals":{"files":1,"coveredLines":2,"executableLines":2,"percentage":100}}',
+        ];
+    }
+
+    private function isValid(string $json): bool
+    {
+        $document = \json_decode($json, flags: \JSON_THROW_ON_ERROR);
+        $validator = new Validator();
+        $validator->validate($document, $this->schema());
+
+        return $validator->isValid();
+    }
+
+    private function schema(): object
+    {
+        return (object) ['$ref' => 'file://' . \dirname(__DIR__, 4) . '/resources/schema/coverage-v1.schema.json'];
+    }
+}


### PR DESCRIPTION
Publish a Draft 4 JSON Schema for version 1 coverage documents and link it from the architecture reference. Validate populated and empty exporter output, required producer fields, line constraints, and additive-field compatibility with focused tests.