### PR TITLE
docs(architecture): qualify graceful signal handling

### DIFF
--- a/docs/architecture/orchestrator-integration-fixtures.md
+++ b/docs/architecture/orchestrator-integration-fixtures.md
@@ -90,7 +90,9 @@ Provisioning, bootstrap, worker, protocol, reporter, and test failures also
 trigger teardown. Greenlight runs every registered callback even if one throws.
 A teardown failure fails the run but does not replace an earlier failure.
 
-When the orchestrator receives its first SIGINT or SIGTERM, it drains workers
-before teardown. SIGKILL, a second signal, process loss, and machine loss cannot
-run process-local callbacks. Protect resources from those cases with leases,
-expiry times, or an external reaper.
+With `ext-pcntl` available, the orchestrator drains workers before teardown
+after its first SIGINT or SIGTERM. Without PCNTL, the operating system's
+default immediate termination behavior can prevent teardown callbacks. SIGKILL,
+a second signal, process loss, and machine loss also cannot run process-local
+callbacks. Protect resources from these cases with leases, expiry times, or an
+external reaper.

--- a/docs/architecture/temporal-expectations.md
+++ b/docs/architecture/temporal-expectations.md
@@ -64,9 +64,11 @@ If the test deadline comes first, the failure includes the requested poll
 duration. Greenlight cannot interrupt a blocked probe. Therefore, the
 orchestrator process timeout remains the hard limit.
 
-Each test retry has a new instance, scope, deadline, and observation log. The
-first interrupt signal still lets active tests finish. This rule includes tests
-that use a temporal expectation.
+Each test retry has a new instance, scope, deadline, and observation log. With
+`ext-pcntl` available, the first interrupt signal still lets active tests
+finish. This rule includes tests that use a temporal expectation. Without
+PCNTL, the operating system's default immediate termination behavior can stop
+the active test.
 
 `retryOnException()` accepts only `Exception` subclasses, which excludes
 `Error`, `Throwable`, and other broader types.

--- a/docs/architecture/worker-lifecycle.md
+++ b/docs/architecture/worker-lifecycle.md
@@ -353,11 +353,16 @@ exceeds that budget, the orchestrator fails the run with a diagnostic.
 
 ### Signals
 
-When the orchestrator receives its first SIGINT or SIGTERM, it drains workers,
-emits the partial result, and then tears down integration fixtures. Workers
-ignore terminal SIGINT so the orchestrator controls that sequence. A test that
-is polling can finish like any other test in flight. A second signal restores
-the operating system's default immediate termination behavior.
+With `ext-pcntl` available, the orchestrator drains workers after its first
+SIGINT or SIGTERM. It emits the partial result and then tears down integration
+fixtures. Workers ignore terminal SIGINT so the orchestrator controls that
+sequence. A test that is polling can finish like any other test in flight. A
+second signal restores the operating system's default immediate termination
+behavior.
+
+Without PCNTL, Greenlight cannot install these signal handlers. The operating
+system's default immediate termination behavior can prevent partial results
+and teardown callbacks.
 
 ## Isolated tests
 


### PR DESCRIPTION
Qualify first-signal draining, active-test completion, and integration-fixture teardown with the ext-pcntl requirement. Explain that default immediate termination can prevent partial results and process-local cleanup when PCNTL is unavailable.