### PR TITLE
docs(api): complete stream wrapper exceptions

### DIFF
--- a/docs/api-sandboxes.md
+++ b/docs/api-sandboxes.md
@@ -139,10 +139,12 @@ public function register(string $scheme, string $wrapper): void
 
 PHPDoc:
 
+- `@param non-empty-string $scheme`
 - `@param class-string $wrapper`
+- `@throws \InvalidArgumentException if the scheme is empty`
 - `@throws StreamWrapperError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/StreamWrappers.php#L23)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/StreamWrappers.php#L25)
 
 ### `dispose()`
 
@@ -154,7 +156,7 @@ PHPDoc:
 
 - `@throws StreamWrapperError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/StreamWrappers.php#L45)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/StreamWrappers.php#L47)
 
 ## `TemporaryDirectory`
 

--- a/src/Sandbox/StreamWrappers.php
+++ b/src/Sandbox/StreamWrappers.php
@@ -16,8 +16,10 @@ final class StreamWrappers implements Disposable
     private array $schemes = [];
 
     /**
+     * @param non-empty-string $scheme
      * @param class-string $wrapper
      *
+     * @throws \InvalidArgumentException if the scheme is empty
      * @throws StreamWrapperError
      */
     public function register(string $scheme, string $wrapper): void

--- a/tests/Unit/Sandbox/StreamWrappersTest.php
+++ b/tests/Unit/Sandbox/StreamWrappersTest.php
@@ -17,7 +17,7 @@ final readonly class StreamWrappersTest
     public function registrationRejectsAnEmptyScheme(): void
     {
         Expect::that(static function (): void {
-            new StreamWrappers()->register('', UnselectableStream::class);
+            new StreamWrappers()->register('', UnselectableStream::class); // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
         })->toThrow(
             \InvalidArgumentException::class,
             message: 'Stream wrapper scheme cannot be empty.',


### PR DESCRIPTION
Document the non-empty stream-wrapper scheme contract and the InvalidArgumentException raised for an empty scheme. Regenerate the sandbox API reference from the source PHPDoc.