### PR TITLE
docs(api): complete file coverage exceptions

### DIFF
--- a/docs/api-coverage.md
+++ b/docs/api-coverage.md
@@ -184,10 +184,12 @@ public function __construct(
 
 PHPDoc:
 
+- `@param non-empty-string $file`
 - `@param list<int> $coveredLines`
 - `@param list<int> $uncoveredLines`
+- `@throws \InvalidArgumentException if the file path is empty or a line number is not positive`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/FileCoverage.php#L34)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/FileCoverage.php#L37)
 
 ### `executableLineCount()`
 
@@ -199,7 +201,7 @@ PHPDoc:
 
 - `@return int<0, max>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/FileCoverage.php#L59)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/FileCoverage.php#L62)
 
 ### `coveredLineCount()`
 
@@ -211,7 +213,7 @@ PHPDoc:
 
 - `@return int<0, max>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/FileCoverage.php#L65)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/FileCoverage.php#L68)
 
 ### `lineHits()`
 
@@ -225,7 +227,7 @@ PHPDoc:
 
 - `@return array<positive-int, 0|1>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/FileCoverage.php#L75)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/FileCoverage.php#L78)
 
 ### `percentage()`
 
@@ -237,12 +239,18 @@ A file with no executable lines has full coverage.
 public function percentage(): float
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/FileCoverage.php#L93)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/FileCoverage.php#L96)
 
 ### `merge()`
+
+Merges coverage for the same file.
 
 ```php
 public function merge(self $other): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/FileCoverage.php#L104)
+PHPDoc:
+
+- `@throws \LogicException if the file paths differ`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/FileCoverage.php#L112)

--- a/src/Coverage/Diff/ProjectRootNormalizer.php
+++ b/src/Coverage/Diff/ProjectRootNormalizer.php
@@ -37,6 +37,7 @@ final class ProjectRootNormalizer
             }
 
             $relative = \substr($path, \strlen($prefix));
+            \assert($relative !== '');
 
             $files[] = new FileCoverage(
                 $relative,

--- a/src/Coverage/FileCoverage.php
+++ b/src/Coverage/FileCoverage.php
@@ -28,8 +28,11 @@ final readonly class FileCoverage
     public array $uncoveredLines;
 
     /**
+     * @param non-empty-string $file
      * @param list<int> $coveredLines
      * @param list<int> $uncoveredLines
+     *
+     * @throws \InvalidArgumentException if the file path is empty or a line number is not positive
      */
     public function __construct(
         string $file,
@@ -101,6 +104,11 @@ final readonly class FileCoverage
         return \count($this->coveredLines) / $executable * 100.0;
     }
 
+    /**
+     * Merges coverage for the same file.
+     *
+     * @throws \LogicException if the file paths differ
+     */
     public function merge(self $other): self
     {
         if ($other->file !== $this->file) {

--- a/tests/Unit/Coverage/Diff/ProjectRootNormalizerTest.php
+++ b/tests/Unit/Coverage/Diff/ProjectRootNormalizerTest.php
@@ -91,6 +91,7 @@ final class ProjectRootNormalizerTest
             );
     }
 
+    /** @param non-empty-string $path */
     #[Test]
     #[DataSet('absolutePaths')]
     public function absoluteCoveragePathsAreAccepted(string $path): void
@@ -116,6 +117,7 @@ final class ProjectRootNormalizerTest
         yield 'Windows device' => ['\\\\?\C:\project\src\A.php'];
     }
 
+    /** @param non-empty-string $path */
     #[Test]
     #[DataSet('relativePaths')]
     public function relativeCoveragePathsAreRejected(string $path): void

--- a/tests/Unit/Coverage/Export/XmlExporterPathTest.php
+++ b/tests/Unit/Coverage/Export/XmlExporterPathTest.php
@@ -35,6 +35,7 @@ final readonly class XmlExporterPathTest
             ->toBe(\ltrim($path, '/'));
     }
 
+    /** @param non-empty-string $path */
     #[Test]
     #[DataSet('unsafePaths')]
     public function unsafePathBytesAreNormalized(string $path, string $expected): void
@@ -69,6 +70,8 @@ final readonly class XmlExporterPathTest
     }
 
     /**
+     * @param non-empty-string $path
+     *
      * @return array{
      *     cloverDocument: string,
      *     cloverPath: string,

--- a/tests/Unit/Coverage/FileCoverageTest.php
+++ b/tests/Unit/Coverage/FileCoverageTest.php
@@ -13,6 +13,7 @@ final class FileCoverageTest
     #[Test]
     public function emptyFilePathsAreRejected(): void
     {
+        // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
         Expect::that(static fn(): FileCoverage => new FileCoverage('', [], []))
             ->because('coverage entries MUST identify a file')
             ->toThrow(


### PR DESCRIPTION
Document FileCoverage constructor validation for empty paths and non-positive line numbers. Document the incompatible-file merge failure and regenerate the coverage API reference.