### PR TITLE
docs(cli): list required coverage diff inputs

### DIFF
--- a/src/Cli/Input/Definition.php
+++ b/src/Cli/Input/Definition.php
@@ -131,6 +131,8 @@ final readonly class Definition
                              Set one source root. Repeat once for each input.
           --project-root=<path>
                              Set the project root for merged coverage paths.
+          --baseline=<path>  Read the baseline coverage JSON for coverage:diff.
+          --current=<path>   Read the current coverage JSON for coverage:diff.
           --baseline-root=<path>
                              Set the baseline project root for coverage:diff.
           --current-root=<path>

--- a/tests/Acceptance/CliTest.php
+++ b/tests/Acceptance/CliTest.php
@@ -63,7 +63,11 @@ final readonly class CliTest
     {
         $result = $this->runCli(['--help']);
         Expect::that($result->exitCode)->because('help and version exit zero')->toBe(0);
-        Expect::that($result->output())->because('help and version exit zero')->toContain('Usage:');
+        Expect::that($result->output())
+            ->because('help and version exit zero and lists required coverage diff inputs')
+            ->toContain('Usage:')
+            ->toContain('--baseline=<path>')
+            ->toContain('--current=<path>');
 
         $result = $this->runCli(['--version']);
         Expect::that($result->exitCode)->because('help and version exit zero')->toBe(0);


### PR DESCRIPTION
Add the required baseline and current coverage JSON inputs to built-in help for coverage:diff. Extend the help acceptance test so these prerequisites cannot disappear again.