### PR TITLE
docs(protocol): constrain external data providers

### DIFF
--- a/resources/schema/worker-protocol-v1.schema.json
+++ b/resources/schema/worker-protocol-v1.schema.json
@@ -285,6 +285,13 @@
             "type": "object",
             "additionalProperties": false,
             "required": ["method", "class"],
+            "not": {
+                "properties": {
+                    "method": {"type": "null"},
+                    "class": {"type": "string"}
+                },
+                "required": ["method", "class"]
+            },
             "properties": {
                 "method": {"type": ["string", "null"], "minLength": 1},
                 "class": {"type": ["string", "null"], "minLength": 1}

--- a/tests/Unit/Execution/ProcessPool/Protocol/WorkerProtocolSchemaTest.php
+++ b/tests/Unit/Execution/ProcessPool/Protocol/WorkerProtocolSchemaTest.php
@@ -139,6 +139,22 @@ final class WorkerProtocolSchemaTest
             ->toBe([]);
     }
 
+    #[Test]
+    public function anExternalDataProviderWithoutAMethodIsRejected(): void
+    {
+        /** @var array{slice: array{entries: non-empty-list<array{definition: array{dataProvider: mixed}}>}} $payload */
+        $payload = $this->messages()['assign']->toWire();
+        $payload['slice']['entries'][0]['definition']['dataProvider'] = [
+            'method' => null,
+            'class' => 'App\SharedRows',
+        ];
+
+        Expect::that($this->validationErrors($this->asJsonObject(['v' => 1, 't' => 'assign', 'p' => $payload])))
+            ->because('the schema MUST match the data-provider decoder contract')
+            ->not()
+            ->toBe([]);
+    }
+
     /**
      * @return array<non-empty-string, Message>
      */


### PR DESCRIPTION
Align the version 1 worker-protocol schema with the data-provider decoder: an external provider class cannot be present when its method is null. Add a complete invalid assign-envelope case to the schema test.