### PR TITLE
docs(api): complete test event exceptions

### DIFF
--- a/docs/api-events.md
+++ b/docs/api-events.md
@@ -316,7 +316,7 @@ final readonly class TestFinished implements Event
 public TestResult $result
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Event/TestFinished.php#L12)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Event/TestFinished.php#L15)
 
 ### `$occurredAt`
 
@@ -324,7 +324,7 @@ public TestResult $result
 public float $occurredAt
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Event/TestFinished.php#L12)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Event/TestFinished.php#L15)
 
 ### `__construct()`
 
@@ -332,7 +332,11 @@ public float $occurredAt
 public function __construct(public TestResult $result, public float $occurredAt)
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Event/TestFinished.php#L12)
+PHPDoc:
+
+- `@throws \InvalidArgumentException if $occurredAt is not finite`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Event/TestFinished.php#L15)
 
 ## `TestStarted`
 
@@ -350,7 +354,7 @@ final readonly class TestStarted implements Event
 public TestId $id
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Event/TestStarted.php#L12)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Event/TestStarted.php#L15)
 
 ### `$occurredAt`
 
@@ -358,7 +362,7 @@ public TestId $id
 public float $occurredAt
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Event/TestStarted.php#L12)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Event/TestStarted.php#L15)
 
 ### `__construct()`
 
@@ -366,7 +370,11 @@ public float $occurredAt
 public function __construct(public TestId $id, public float $occurredAt)
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Event/TestStarted.php#L12)
+PHPDoc:
+
+- `@throws \InvalidArgumentException if $occurredAt is not finite`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Event/TestStarted.php#L15)
 
 ## `WorkerSpawned`
 

--- a/src/Event/TestFinished.php
+++ b/src/Event/TestFinished.php
@@ -9,6 +9,9 @@ use Greenlight\Result\TestResult;
 
 final readonly class TestFinished implements WireEvent
 {
+    /**
+     * @throws \InvalidArgumentException if $occurredAt is not finite
+     */
     public function __construct(public TestResult $result, public float $occurredAt)
     {
         if (!\is_finite($occurredAt)) {

--- a/src/Event/TestStarted.php
+++ b/src/Event/TestStarted.php
@@ -9,6 +9,9 @@ use Greenlight\Test\TestId;
 
 final readonly class TestStarted implements WireEvent
 {
+    /**
+     * @throws \InvalidArgumentException if $occurredAt is not finite
+     */
     public function __construct(public TestId $id, public float $occurredAt)
     {
         if (!\is_finite($occurredAt)) {


### PR DESCRIPTION
Document the finite timestamp exception contract for TestStarted and TestFinished. Regenerate the event API reference so both constructors publish the invariant.