### PR TITLE
test(sandbox): accept PHP 8.6 traversal message

### DIFF
--- a/tests/Unit/Sandbox/TemporaryDirectoryNestedRestrictionTest.php
+++ b/tests/Unit/Sandbox/TemporaryDirectoryNestedRestrictionTest.php
@@ -42,7 +42,7 @@ final readonly class TemporaryDirectoryNestedRestrictionTest
                 ->toThrow(
                     TemporaryDirectoryError::class,
                     matching: \sprintf(
-                        '/^Failed to remove temp directory "%s": .*%s.*Permission denied\.$/',
+                        '/^Failed to remove temp directory "%s": RecursiveDirectoryIterator::__construct\((?:%s)?\): Failed to open directory: Permission denied\.$/',
                         \preg_quote($root, '/'),
                         \preg_quote($nested, '/'),
                     ),


### PR DESCRIPTION
PHP 8.6 omits the restricted directory path from the RecursiveDirectoryIterator constructor diagnostic.

Accept the PHP 8.4, PHP 8.5, and PHP 8.6 message formats. Keep exact checks for the translated cleanup error and permission failure.