### PR TITLE
test: remove redundant attachment validator tests

### DIFF
--- a/tests/Unit/Artifact/AttachmentMediaTypeContractTest.php
+++ b/tests/Unit/Artifact/AttachmentMediaTypeContractTest.php
@@ -6,21 +6,12 @@ namespace Greenlight\Tests\Unit\Artifact;
 
 use Greenlight\Artifact\Attachment;
 use Greenlight\Artifact\AttachmentKind;
-use Greenlight\Artifact\AttachmentMediaType;
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 
 final class AttachmentMediaTypeContractTest
 {
-    #[Test]
-    #[DataSet('invalidMediaTypes')]
-    public function validatorRejectsInvalidMediaTypes(string $mediaType): void
-    {
-        Expect::that(AttachmentMediaType::isValid($mediaType))
-            ->toBeFalse();
-    }
-
     #[Test]
     #[DataSet('invalidMediaTypes')]
     public function constructionAndWireDecodingRejectInvalidMediaTypes(string $mediaType): void

--- a/tests/Unit/Artifact/AttachmentValidMediaTypeTest.php
+++ b/tests/Unit/Artifact/AttachmentValidMediaTypeTest.php
@@ -6,21 +6,12 @@ namespace Greenlight\Tests\Unit\Artifact;
 
 use Greenlight\Artifact\Attachment;
 use Greenlight\Artifact\AttachmentKind;
-use Greenlight\Artifact\AttachmentMediaType;
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 
 final readonly class AttachmentValidMediaTypeTest
 {
-    #[Test]
-    #[DataSet('validMediaTypes')]
-    public function validatorAcceptsValidMediaTypes(string $mediaType): void
-    {
-        Expect::that(AttachmentMediaType::isValid($mediaType))
-            ->toBeTrue();
-    }
-
     #[Test]
     #[DataSet('validMediaTypes')]
     public function validMediaTypesSurviveConstructionAndTheWire(string $mediaType): void


### PR DESCRIPTION
Remove the direct tests for the internal attachment media-type validator. The existing attachment construction and wire-decoding tests use the same valid and invalid datasets, so they keep the behavioral contract at the owning type seam.

The focused surviving cases pass, as do static analysis and the complete suite. Isolated coverage for both removed methods is a subset of the reduced full-suite coverage map: neither method contributes a unique covered line.