### PR TITLE
docs(api): document interruption signal validation

### DIFF
--- a/docs/api-plugins.md
+++ b/docs/api-plugins.md
@@ -274,7 +274,11 @@ public static function usage(): self
 public static function interrupted(int $signal): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/CommandResult.php#L35)
+PHPDoc:
+
+- `@throws \InvalidArgumentException if the signal is outside 1 through 127`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/CommandResult.php#L39)
 
 ## `CoverageMapTransformer`
 

--- a/src/Plugin/CommandResult.php
+++ b/src/Plugin/CommandResult.php
@@ -31,7 +31,11 @@ final readonly class CommandResult
         return new self(CommandOutcome::UsageError);
     }
 
-    /** @phpstan-assert int<1, 127> $signal */
+    /**
+     * @phpstan-assert int<1, 127> $signal
+     *
+     * @throws \InvalidArgumentException if the signal is outside 1 through 127
+     */
     public static function interrupted(int $signal): self
     {
         if ($signal < 1 || $signal > 127) {


### PR DESCRIPTION
Document the 1 through 127 signal range and InvalidArgumentException contract for CommandResult::interrupted(), then regenerate the plugin API reference.