### PR TITLE
docs(api): document outcome transformation validation

### DIFF
--- a/docs/api-results.md
+++ b/docs/api-results.md
@@ -693,8 +693,9 @@ public function withOutcome(Outcome $outcome, string $transformedBy): self
 PHPDoc:
 
 - `@param non-empty-string $transformedBy`
+- `@throws \InvalidArgumentException if the transformation source is empty`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L74)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L76)
 
 ## `ThrowableDetail`
 

--- a/src/Result/TestResult.php
+++ b/src/Result/TestResult.php
@@ -70,6 +70,8 @@ final readonly class TestResult
 
     /**
      * @param non-empty-string $transformedBy
+     *
+     * @throws \InvalidArgumentException if the transformation source is empty
      */
     public function withOutcome(Outcome $outcome, string $transformedBy): self
     {

--- a/tests/Unit/Result/TestResultTest.php
+++ b/tests/Unit/Result/TestResultTest.php
@@ -161,6 +161,19 @@ final class TestResultTest
     }
 
     #[Test]
+    public function withOutcomeRejectsAnEmptyTransformationSource(): void
+    {
+        $result = new TestResult(new TestId('App\FooTest', 'bar'), Outcome::Failed, 0.1, 0);
+
+        Expect::that(static fn(): TestResult => $result->withOutcome(Outcome::Skipped, '')) // @phpstan-ignore argument.type (deliberately invalid: tests runtime validation)
+            ->because('an outcome transformation MUST identify its source')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Outcome transformation source must not be empty.',
+            );
+    }
+
+    #[Test]
     public function errorTransitionPreservesEarlierFailureEvidence(): void
     {
         $failure = new FailureDetail('The assertion failed.', 'ready', 'waiting');


### PR DESCRIPTION
Document the InvalidArgumentException raised when TestResult::withOutcome() receives an empty transformation source. Add direct regression coverage and regenerate the results API reference.