### PR TITLE
test(expect): remove redundant within pass case

### DIFF
--- a/tests/Unit/Expect/NumericMatchersTest.php
+++ b/tests/Unit/Expect/NumericMatchersTest.php
@@ -163,14 +163,6 @@ final class NumericMatchersTest
     }
 
     #[Test]
-    public function toBeWithinPasses(): void
-    {
-        Expect::that(1.05)->because('toBeWithin() passes')->toBeWithin(0.1, 1.0);
-        Expect::that(0.95)->because('toBeWithin() passes')->toBeWithin(0.1, 1.0);
-        Expect::that(3)->because('toBeWithin() passes')->toBeWithin(0.5, 3.0);
-    }
-
-    #[Test]
     #[DataSet('toleranceBoundaries')]
     public function toBeWithinIncludesTheToleranceBoundary(float $subject): void
     {


### PR DESCRIPTION
Remove the older generic `toBeWithin()` pass test. The later regression test proves that both exact tolerance boundaries pass, which is a stronger contract and subsumes the three interior examples.

The surviving boundary cases pass, as do static analysis and the complete suite. Coverage from the removed test is a subset of the reduced full-suite coverage map, so the test contributes no unique covered line.