### PR TITLE
test(doubles): remove redundant untouched stub test

### DIFF
--- a/tests/Unit/Doubles/StubTest.php
+++ b/tests/Unit/Doubles/StubTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Doubles;
 
-use Greenlight\Attribute\NoExpectations;
 use Greenlight\Attribute\Test;
 use Greenlight\Doubles\Doubles;
 use Greenlight\Doubles\InvalidDoubleUsage;
@@ -59,13 +58,4 @@ final class StubTest
         $doubles->dispose();
     }
 
-    #[Test]
-    #[NoExpectations]
-    public function anUntouchedStubVerifiesCleanly(): void
-    {
-        $doubles = new Doubles();
-        $doubles->stub(Stubbable::class);
-
-        $doubles->dispose();
-    }
 }


### PR DESCRIPTION
Remove `anUntouchedStubVerifiesCleanly`. The neighboring `satisfiesTheTypeWithoutRunningAnything` test already creates an untouched stub, disposes its owner successfully, and also verifies that the stub satisfies the requested type.

The surviving focused test passes, as do static analysis and the complete suite. Coverage from the removed zero-expectation test is a subset of the reduced full-suite coverage map, so it contributes no unique covered line.