### PR TITLE
docs(rector): document configuration errors

### DIFF
--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -471,8 +471,9 @@ public function configure(array $configuration): void
 PHPDoc:
 
 - `@param mixed[] $configuration`
+- `@throws \InvalidArgumentException if a key is unknown or \`drop_assertion_messages\` is not a boolean`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Rector/PhpUnitToGreenlightRector.php#L113)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Rector/PhpUnitToGreenlightRector.php#L115)
 
 ### `getRuleDefinition()`
 
@@ -480,7 +481,7 @@ PHPDoc:
 public function getRuleDefinition(): RuleDefinition
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Rector/PhpUnitToGreenlightRector.php#L137)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Rector/PhpUnitToGreenlightRector.php#L139)
 
 ### `getNodeTypes()`
 
@@ -492,7 +493,7 @@ PHPDoc:
 
 - `@return array<class-string<Node>>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Rector/PhpUnitToGreenlightRector.php#L171)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Rector/PhpUnitToGreenlightRector.php#L173)
 
 ### `refactor()`
 
@@ -500,7 +501,7 @@ PHPDoc:
 public function refactor(Node $node): ?Node
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Rector/PhpUnitToGreenlightRector.php#L176)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Rector/PhpUnitToGreenlightRector.php#L178)
 
 ## `SymfonyPlugin`
 

--- a/src/Rector/PhpUnitToGreenlightRector.php
+++ b/src/Rector/PhpUnitToGreenlightRector.php
@@ -109,6 +109,8 @@ final class PhpUnitToGreenlightRector extends AbstractRector implements Configur
 
     /**
      * @param mixed[] $configuration
+     *
+     * @throws \InvalidArgumentException if a key is unknown or `drop_assertion_messages` is not a boolean
      */
     public function configure(array $configuration): void
     {

--- a/tests/Unit/Rector/PhpUnitToGreenlightRectorConfigurationTest.php
+++ b/tests/Unit/Rector/PhpUnitToGreenlightRectorConfigurationTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Rector;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Rector\PhpUnitToGreenlightRector;
+
+final class PhpUnitToGreenlightRectorConfigurationTest
+{
+    #[Test]
+    public function unknownConfigurationKeysAreRejected(): void
+    {
+        $rector = new PhpUnitToGreenlightRector();
+
+        Expect::that(static fn() => $rector->configure(['unknown' => true]))
+            ->because('the Rector configuration MUST reject unknown keys')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Unknown configuration key "unknown". The only supported key is "drop_assertion_messages".',
+            );
+    }
+
+    #[Test]
+    public function dropAssertionMessagesRequiresABoolean(): void
+    {
+        $rector = new PhpUnitToGreenlightRector();
+
+        Expect::that(static fn() => $rector->configure([
+            PhpUnitToGreenlightRector::DROP_ASSERTION_MESSAGES => 'yes',
+        ]))
+            ->because('the Rector configuration MUST reject a non-boolean option value')
+            ->toThrow(
+                \InvalidArgumentException::class,
+                message: 'Configuration key "drop_assertion_messages" expects a boolean.',
+            );
+    }
+}


### PR DESCRIPTION
Document the Rector rule configuration validation contract and add focused tests for unknown keys and non-boolean option values.