### PR TITLE
docs(rector): clarify assertion message migration

### DIFF
--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -453,8 +453,8 @@ final class PhpUnitToGreenlightRector extends AbstractRector implements Configur
 ### `DROP_ASSERTION_MESSAGES`
 
 Configuration key: remove PHPUnit failure-message arguments. Without
-this option, a custom message rejects the class. Greenlight
-expectations carry no custom message.
+this option, a custom message rejects the class. A manual migration can
+preserve the message with `because()`.
 
 ```php
 public const string DROP_ASSERTION_MESSAGES = 'drop_assertion_messages';

--- a/docs/migrating-from-phpunit.md
+++ b/docs/migrating-from-phpunit.md
@@ -53,9 +53,9 @@ A class does not convert when it uses:
 * `#[RunClassInSeparateProcess]` or `#[PreserveGlobalState]`
 * other inherited `TestCase` API that the rule cannot prove safe
 
-A custom failure message on an assertion has no Greenlight equivalent. By
-default, a message prevents the conversion of the class. Use this
-configuration to remove the messages:
+The Rector rule does not translate a custom assertion failure message to
+`because()`. By default, a message prevents the conversion of the class. Use
+this configuration to drop assertion messages during automatic conversion:
 
 <!-- php-example {"example":"migrating-from-phpunit-example-02","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php

--- a/src/Rector/PhpUnitToGreenlightRector.php
+++ b/src/Rector/PhpUnitToGreenlightRector.php
@@ -55,8 +55,8 @@ final class PhpUnitToGreenlightRector extends AbstractRector implements Configur
 {
     /**
      * Configuration key: remove PHPUnit failure-message arguments. Without
-     * this option, a custom message rejects the class. Greenlight
-     * expectations carry no custom message.
+     * this option, a custom message rejects the class. A manual migration can
+     * preserve the message with `because()`.
      */
     public const string DROP_ASSERTION_MESSAGES = 'drop_assertion_messages';
 


### PR DESCRIPTION
Clarify that Greenlight supports custom expectation messages through `because()`, while the automated Rector rule cannot translate PHPUnit assertion messages. Document that manual migrations can preserve them.