### PR TITLE
docs(doubles): document lifecycle methods

### DIFF
--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -244,3 +244,8 @@ implementations. Calls through these methods can run application code.
 
 Greenlight does not run the class constructor when it creates a double. Prefer
 an interface at the application boundary.
+
+Greenlight suppresses a non-final destructor. It cannot suppress a final
+destructor, which can run application code. Greenlight does not intercept
+`__clone()`. Cloning a class double runs the class implementation of
+`__clone()`.


### PR DESCRIPTION
Complete the class-double lifecycle documentation. Explain how Greenlight handles non-final and final destructors, and that cloning runs the doubled class implementation of `__clone()`.