### PR TITLE
fix(coverage): accept newline paths in schema

### DIFF
--- a/resources/schema/coverage-v1.schema.json
+++ b/resources/schema/coverage-v1.schema.json
@@ -12,7 +12,7 @@
         "files": {
             "type": "object",
             "patternProperties": {
-                "^.+$": {"$ref": "#/definitions/file"}
+                "^[\\s\\S]+$": {"$ref": "#/definitions/file"}
             },
             "additionalProperties": false
         },

--- a/tests/Unit/Coverage/Export/JsonExporterJsonSchemaTest.php
+++ b/tests/Unit/Coverage/Export/JsonExporterJsonSchemaTest.php
@@ -22,6 +22,9 @@ final readonly class JsonExporterJsonSchemaTest
             'populated map' => $exporter->export(new CoverageMap([
                 new FileCoverage('/project/src/A.php', [3, 7], [5]),
             ]))[JsonExporter::FILE_NAME],
+            'path with line feed' => $exporter->export(new CoverageMap([
+                new FileCoverage("/project/src/Line\nBreak.php", [1], []),
+            ]))[JsonExporter::FILE_NAME],
             'empty map' => $exporter->export(CoverageMap::empty())[JsonExporter::FILE_NAME],
         ];
 


### PR DESCRIPTION
Align the coverage JSON schema with the exporter contract. Accept any non-empty UTF-8 path, including a path that contains a line feed, and cover the exported document with the schema test.