### PR TITLE
fix(protocol): reject empty map keys in schema

### DIFF
--- a/resources/schema/worker-protocol-v1.schema.json
+++ b/resources/schema/worker-protocol-v1.schema.json
@@ -112,7 +112,10 @@
             "oneOf": [
                 {
                     "type": "object",
-                    "additionalProperties": {"$ref": "#/definitions/fixtureResource"}
+                    "patternProperties": {
+                        "^[\\s\\S]+$": {"$ref": "#/definitions/fixtureResource"}
+                    },
+                    "additionalProperties": false
                 },
                 {"$ref": "#/definitions/emptyMap"}
             ]
@@ -130,7 +133,10 @@
             "oneOf": [
                 {
                     "type": "object",
-                    "additionalProperties": {"$ref": "#/definitions/jsonValue"}
+                    "patternProperties": {
+                        "^[\\s\\S]+$": {"$ref": "#/definitions/jsonValue"}
+                    },
+                    "additionalProperties": false
                 },
                 {"$ref": "#/definitions/emptyMap"}
             ]
@@ -147,7 +153,10 @@
                 },
                 {
                     "type": "object",
-                    "additionalProperties": {"$ref": "#/definitions/jsonValue"}
+                    "patternProperties": {
+                        "^[\\s\\S]+$": {"$ref": "#/definitions/jsonValue"}
+                    },
+                    "additionalProperties": false
                 }
             ]
         },
@@ -155,7 +164,10 @@
             "oneOf": [
                 {
                     "type": "object",
-                    "additionalProperties": {"type": "string"}
+                    "patternProperties": {
+                        "^[\\s\\S]+$": {"type": "string"}
+                    },
+                    "additionalProperties": false
                 },
                 {"$ref": "#/definitions/emptyMap"}
             ]
@@ -404,7 +416,10 @@
                     "oneOf": [
                         {
                             "type": "object",
-                            "additionalProperties": {"$ref": "#/definitions/coverageLineSets"}
+                            "patternProperties": {
+                                "^[\\s\\S]+$": {"$ref": "#/definitions/coverageLineSets"}
+                            },
+                            "additionalProperties": false
                         },
                         {"$ref": "#/definitions/emptyMap"}
                     ]

--- a/tests/Unit/Execution/ProcessPool/Protocol/WorkerProtocolSchemaTest.php
+++ b/tests/Unit/Execution/ProcessPool/Protocol/WorkerProtocolSchemaTest.php
@@ -140,6 +140,27 @@ final class WorkerProtocolSchemaTest
     }
 
     #[Test]
+    public function emptyMapKeysAreRejected(): void
+    {
+        /** @var array{resources: array{fixtures: array<string, mixed>}} $bootstrapPayload */
+        $bootstrapPayload = $this->messages()['bootstrap']->toWire();
+        $bootstrapPayload['resources']['fixtures'][''] = $bootstrapPayload['resources']['fixtures']['postgres'];
+
+        /** @var array{coverage: array{files: array<string, mixed>}} $donePayload */
+        $donePayload = $this->messages()['done']->toWire();
+        $donePayload['coverage']['files'][''] = [[1], []];
+
+        Expect::that($this->validationErrors($this->asJsonObject(['v' => 1, 't' => 'bootstrap', 'p' => $bootstrapPayload])))
+            ->because('the schema MUST reject an empty fixture ID')
+            ->not()
+            ->toBe([]);
+        Expect::that($this->validationErrors($this->asJsonObject(['v' => 1, 't' => 'done', 'p' => $donePayload])))
+            ->because('the schema MUST reject an empty coverage path')
+            ->not()
+            ->toBe([]);
+    }
+
+    #[Test]
     public function anExternalDataProviderWithoutAMethodIsRejected(): void
     {
         /** @var array{slice: array{entries: non-empty-list<array{definition: array{dataProvider: mixed}}>}} $payload */


### PR DESCRIPTION
Align worker protocol map validation with the wire decoders. Reject empty fixture IDs, fixture value and secret keys, nested object keys, and coverage paths, with focused schema cases for fixture IDs and coverage paths.