### PR TITLE
docs(ci): add basic test workflows

### DIFF
--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -3,6 +3,43 @@
 Greenlight can publish test annotations and retained attachments in GitHub
 Actions. It can also reuse run state and merge coverage from parallel shards.
 
+## Run Greenlight
+
+Use this workflow to run Greenlight without additional CI integration:
+
+```yaml
+name: Tests
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
+      - name: Run tests
+        run: vendor/bin/greenlight run
+```
+
+Greenlight returns a nonzero exit code when the run fails. GitHub Actions then
+marks the job as failed. The following sections add optional CI integrations.
+
 ## Publish test results and attachments
 
 The `github` reporter writes GitHub workflow annotations for failed and errored

--- a/docs/gitlab-ci.md
+++ b/docs/gitlab-ci.md
@@ -3,6 +3,24 @@
 GitLab reads Greenlight JUnit output through `artifacts:reports:junit`.
 Greenlight does not need a GitLab-specific reporter.
 
+## Run Greenlight
+
+Use this job to run Greenlight without additional CI integration:
+
+```yaml
+tests:
+  stage: test
+  before_script:
+    - composer install --no-interaction --prefer-dist
+  script:
+    - vendor/bin/greenlight run
+```
+
+This example assumes that the runner has PHP and Composer. Greenlight returns a
+nonzero exit code when the run fails. GitLab then marks the job as failed.
+
+The following sections add optional CI integrations.
+
 ## Configure attachment storage
 
 Configure a project-relative parent directory for Greenlight run directories.

--- a/website/src/lib/docs.ts
+++ b/website/src/lib/docs.ts
@@ -29,12 +29,12 @@ export const docSections = [
       {
         id: 'github-actions',
         title: 'GitHub Actions',
-        description: 'This guide explains how to publish Greenlight test results, attachments, run state, and coverage in GitHub Actions.',
+        description: 'This guide explains how to run Greenlight and publish test results, attachments, run state, and coverage in GitHub Actions.',
       },
       {
         id: 'gitlab-ci',
         title: 'GitLab CI/CD',
-        description: 'This guide explains how to publish Greenlight test results, attachments, and coverage in GitLab.',
+        description: 'This guide explains how to run Greenlight and publish test results, attachments, and coverage in GitLab.',
       },
       {
         id: 'attributes',


### PR DESCRIPTION
## Summary

- add a minimal GitHub Actions workflow that runs Greenlight
- add a minimal GitLab CI job that runs Greenlight
- present annotations, artifacts, caching, sharding, and coverage as optional integrations