### PR TITLE
feat(doubles): intercept clone methods

### DIFF
--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -244,3 +244,8 @@ implementations. Calls through these methods can run application code.
 
 Greenlight does not run the class constructor when it creates a double. Prefer
 an interface at the application boundary.
+
+Greenlight suppresses a non-final destructor. It cannot suppress a final
+destructor, which can run application code. Greenlight intercepts a public,
+non-final `__clone()`. A final `__clone()` keeps its implementation and can run
+application code.

--- a/src/Doubles/CallHandler.php
+++ b/src/Doubles/CallHandler.php
@@ -21,9 +21,13 @@ use Greenlight\Result\FailureDetail;
  */
 final readonly class CallHandler
 {
+    /**
+     * @param \WeakMap<object, DoubleState> $doubles
+     */
     public function __construct(
         private DoubleState $state,
         private ValueRenderer $renderer,
+        private \WeakMap $doubles,
     ) {}
 
     /**
@@ -35,6 +39,8 @@ final readonly class CallHandler
      */
     public function invoke(object $double, string $method, array $arguments): mixed
     {
+        $this->doubles[$double] = $this->state;
+
         MethodCallContract::from($this->state->type, $method)
             ->assertCallArgumentCount(\count($arguments));
 

--- a/src/Doubles/Doubles.php
+++ b/src/Doubles/Doubles.php
@@ -211,7 +211,7 @@ final class Doubles implements Disposable
         $double = new \ReflectionClass($proxyClass)->newInstanceWithoutConstructor();
 
         \assert($double instanceof GeneratedProxy);
-        $double->__greenlightAttachHandler(new CallHandler($state, $this->renderer));
+        $double->__greenlightAttachHandler(new CallHandler($state, $this->renderer, $this->doubles));
 
         \assert($double instanceof $type);
 

--- a/src/Doubles/ProxyGenerator.php
+++ b/src/Doubles/ProxyGenerator.php
@@ -200,7 +200,7 @@ final readonly class ProxyGenerator
     {
         $name = \strtolower($method->name);
 
-        if (\in_array($name, ['__construct', '__destruct', '__clone'], true)) {
+        if (\in_array($name, ['__construct', '__destruct'], true)) {
             return null;
         }
 

--- a/tests/Fixture/Doubles/CloneProbe.php
+++ b/tests/Fixture/Doubles/CloneProbe.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+class CloneProbe
+{
+    public static int $calls = 0;
+
+    public function __clone(): void
+    {
+        ++self::$calls;
+    }
+}

--- a/tests/Fixture/Doubles/FinalCloneProbe.php
+++ b/tests/Fixture/Doubles/FinalCloneProbe.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+class FinalCloneProbe
+{
+    public static int $calls = 0;
+
+    final public function __clone(): void
+    {
+        ++self::$calls;
+    }
+}

--- a/tests/Unit/Doubles/BoundaryTest.php
+++ b/tests/Unit/Doubles/BoundaryTest.php
@@ -89,7 +89,7 @@ final readonly class BoundaryTest
     }
 
     #[Test]
-    public function mixedCaseConstructorAndCloneMethodsAreNotIntercepted(): void
+    public function mixedCaseLifecycleMethodsUseTheirInterceptionRules(): void
     {
         $double = $this->doubles->stub(MixedCaseMagicMethods::class);
         $reflection = new \ReflectionClass($double);
@@ -99,7 +99,7 @@ final readonly class BoundaryTest
         Expect::that($constructor->getDeclaringClass()->name)
             ->because('PHP magic method names MUST remain case-insensitive in generated proxies')
             ->toBe(MixedCaseMagicMethods::class);
-        Expect::that($clone->getDeclaringClass()->name)->toBe(MixedCaseMagicMethods::class);
+        Expect::that($clone->getDeclaringClass()->name)->toBe($double::class);
     }
 
     #[Test]

--- a/tests/Unit/Doubles/CloneInterceptionTest.php
+++ b/tests/Unit/Doubles/CloneInterceptionTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\InvalidDoubleUsage;
+use Greenlight\Doubles\MockPlan;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Doubles\CloneProbe;
+use Greenlight\Tests\Fixture\Doubles\FinalCloneProbe;
+
+final readonly class CloneInterceptionTest
+{
+    public function __construct(private Doubles $doubles) {}
+
+    #[Test]
+    public function mocksInterceptCloneAndRegisterTheClone(): void
+    {
+        CloneProbe::$calls = 0;
+        $double = $this->doubles->mock(CloneProbe::class, static function (MockPlan $plan): void {
+            $plan->expects('__clone')->once();
+        });
+
+        $clone = clone $double;
+
+        Expect::that(CloneProbe::$calls)
+            ->because('a mock MUST NOT run the doubled clone method')
+            ->toBe(0);
+        Expect::that($this->doubles->callsTo($clone, '__clone'))
+            ->because('the clone MUST use the same interaction state as the original double')
+            ->toEqual([[]]);
+    }
+
+    #[Test]
+    public function spiesRecordClone(): void
+    {
+        $double = $this->doubles->spy(CloneProbe::class);
+        $clone = clone $double;
+
+        Expect::that($this->doubles->callsTo($clone, '__clone'))
+            ->because('a spy MUST record the clone interaction')
+            ->toEqual([[]]);
+    }
+
+    #[Test]
+    public function stubsRejectClone(): void
+    {
+        $double = $this->doubles->stub(CloneProbe::class);
+
+        Expect::that(static fn(): object => clone $double)
+            ->because('a stub MUST reject the clone interaction')
+            ->toThrow(
+                InvalidDoubleUsage::class,
+                message: 'Code called "__clone()" on the stub of "' . CloneProbe::class . '". '
+                    . 'Stubs only satisfy a type. Use mock() with explicit expectations for interactions.',
+            );
+    }
+
+    #[Test]
+    public function finalCloneMethodsKeepTheirImplementation(): void
+    {
+        FinalCloneProbe::$calls = 0;
+        $double = $this->doubles->stub(FinalCloneProbe::class);
+
+        $clone = clone $double;
+
+        Expect::that(FinalCloneProbe::$calls)
+            ->because('a class double cannot intercept a final clone method')
+            ->toBe(1);
+        Expect::that($clone)->toBeInstanceOf(FinalCloneProbe::class);
+    }
+}


### PR DESCRIPTION
Intercept public, non-final __clone() methods through the normal double call handler. Register cloned proxies with the original double state so callsTo() accepts the original or clone. Keep final clone implementations and document the lifecycle behavior. Supersedes #1742.