### PR TITLE
fix(docs): improve documentation accessibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: "Install dependencies"
         run: "npm --prefix website ci"
 
+      - name: "Install browser"
+        run: "npm --prefix website exec -- playwright install --with-deps chromium"
+
       - name: "Check and build"
         run: "npm --prefix website run check"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,9 @@ Thank you for your interest in Greenlight. These rules apply to every change.
 Greenlight requires PHP 8.4 or later. The documentation checks require Node.js
 24 or later and npm.
 
+Run `make docs-install` to install the documentation dependencies and Chromium
+for the browser tests.
+
 ## Technical prose
 
 Use the [technical writing standard](docs/architecture/technical-writing.md)

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ docs: $(DOCS_MODULES)
 
 docs-install:
 	npm --prefix $(DOCS_DIR) ci
+	npm --prefix $(DOCS_DIR) exec -- playwright install chromium
 
 docs-build: $(DOCS_MODULES)
 	npm --prefix $(DOCS_DIR) run build

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
+        "playwright": "^1.62.1",
         "typescript": "^6.0.3"
       },
       "engines": {
@@ -5609,6 +5610,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,8 @@
     "api:check": "node --test scripts/generate-api-reference.test.mjs && node scripts/generate-api-reference.mjs --check",
     "api:generate": "node scripts/generate-api-reference.mjs",
     "build": "npm run api:check && astro build --force && pagefind --site dist --output-subdir _pagefind && node scripts/check-built-site.mjs",
-    "check": "npm run api:check && astro check && astro build --force && pagefind --site dist --output-subdir _pagefind && node scripts/check-built-site.mjs",
+    "check": "npm run api:check && astro check && astro build --force && pagefind --site dist --output-subdir _pagefind && node scripts/check-built-site.mjs && npm run test:browser",
+    "test:browser": "node --test scripts/docs-navigation.test.mjs",
     "dev": "astro dev",
     "preview": "astro preview"
   },
@@ -24,6 +25,7 @@
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
+    "playwright": "^1.62.1",
     "typescript": "^6.0.3"
   }
 }

--- a/website/scripts/check-built-site.mjs
+++ b/website/scripts/check-built-site.mjs
@@ -79,6 +79,28 @@ for (const file of htmlFiles) {
     errors.push(`${label}: The page does not contain a valid canonical URL.`);
   }
 
+  if (label.startsWith('docs/')) {
+    const hasPageIndex = html.includes('<aside class="page-index"');
+    const hasMobilePageIndexTrigger = html.includes('aria-controls="mobile-page-index"');
+    const hasMobilePageIndexDialog = html.includes('<dialog id="mobile-page-index"');
+
+    if (
+      !html.includes('aria-controls="mobile-documentation-menu"') ||
+      !html.includes('<dialog id="mobile-documentation-menu"') ||
+      hasPageIndex !== hasMobilePageIndexTrigger ||
+      hasPageIndex !== hasMobilePageIndexDialog
+    ) {
+      errors.push(`${label}: The page does not contain the modal documentation controls.`);
+    }
+  }
+
+  if (
+    !html.includes('data-search-input-label="Search documentation"') ||
+    !html.includes('role="status" aria-live="polite" aria-atomic="true" data-search-status')
+  ) {
+    errors.push(`${label}: The page does not contain the accessible search status.`);
+  }
+
   const attributes = html.matchAll(/\b(?:href|src)="([^"]+)"/g);
 
   for (const [, url] of attributes) {

--- a/website/scripts/docs-navigation.test.mjs
+++ b/website/scripts/docs-navigation.test.mjs
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+import { preview } from 'astro';
+import { chromium } from 'playwright';
+
+let server;
+let browser;
+
+before(async () => {
+  server = await preview({ server: { host: '127.0.0.1', port: 0 }, logLevel: 'silent' });
+  browser = await chromium.launch();
+});
+
+after(async () => {
+  await browser?.close();
+  await server?.stop();
+});
+
+async function openDocumentation(t) {
+  const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+  t.after(() => page.close());
+  await page.goto(`http://127.0.0.1:${server.port}/greenlight/docs/getting-started/`);
+  await page.addStyleTag({ content: 'html { scroll-behavior: auto !important }' });
+  return page;
+}
+
+test('page-index navigation preserves the keyboard position in the selected section', async (t) => {
+  const page = await openDocumentation(t);
+  await page.locator('.mobile-index-trigger').click();
+  await page.locator('#mobile-page-index a[href="#exit-codes"]').focus();
+  await page.keyboard.press('Enter');
+  await page.waitForURL('**/#exit-codes');
+  await page.waitForFunction(() => !document.querySelector('#mobile-page-index').open);
+  await page.evaluate(() => new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve))));
+  await page.keyboard.press('Tab');
+
+  assert.equal(
+    await page.evaluate(() => document.activeElement.getAttribute('href')),
+    '/greenlight/docs/configuration/#interruption',
+  );
+});
+
+for (const [trigger, dialog] of [
+  ['.mobile-doc-trigger', '#mobile-documentation-menu'],
+  ['.mobile-index-trigger', '#mobile-page-index'],
+]) {
+  for (const dismissal of ['Escape', 'Close']) {
+    test(`${dialog} restores trigger focus after ${dismissal}`, async (t) => {
+      const page = await openDocumentation(t);
+      await page.locator(trigger).click();
+
+      if (dismissal === 'Escape') {
+        await page.keyboard.press('Escape');
+      } else {
+        await page.locator(`${dialog} button[type="submit"]`).click();
+      }
+
+      await page.waitForFunction((selector) => !document.querySelector(selector).open, dialog);
+      assert.equal(await page.locator(trigger).evaluate((element) => element === document.activeElement), true);
+    });
+  }
+}

--- a/website/src/components/Search.astro
+++ b/website/src/components/Search.astro
@@ -28,18 +28,39 @@ const pagefindScript = sitePath('_pagefind/pagefind-ui.js');
     role="region"
     aria-label="Documentation search results"
   >
-    <div id="pagefind-search">
+    <div id="pagefind-search" data-search-input-label="Search documentation">
       <p class="search-loading">Enter text to search the documentation.</p>
     </div>
   </div>
 </details>
+<p class="visually-hidden" role="status" aria-live="polite" aria-atomic="true" data-search-status></p>
 
 <script is:inline define:vars={{ pagefindScript }}>
   const search = document.querySelector('[data-search]');
+  const pagefindSearch = document.querySelector('#pagefind-search');
+  const searchStatus = document.querySelector('[data-search-status]');
   let pagefindLoaded = false;
+  let searchError = '';
+
+  const updateSearchAccessibility = () => {
+    const input = pagefindSearch?.querySelector('input');
+    const inputLabel = pagefindSearch instanceof HTMLElement ? pagefindSearch.dataset.searchInputLabel : undefined;
+    const message = search?.open
+      ? searchError || pagefindSearch?.querySelector('.pagefind-ui__message')?.textContent?.trim() || ''
+      : '';
+
+    if (input && inputLabel) {
+      input.setAttribute('aria-label', inputLabel);
+    }
+
+    if (searchStatus instanceof HTMLElement && searchStatus.textContent !== message) {
+      searchStatus.textContent = message;
+    }
+  };
 
   const focusSearchInput = () => {
     requestAnimationFrame(() => {
+      updateSearchAccessibility();
       search?.querySelector('input')?.focus();
     });
   };
@@ -61,6 +82,13 @@ const pagefindScript = sitePath('_pagefind/pagefind-ui.js');
         showSubResults: true,
         resetStyles: false,
       });
+      if (pagefindSearch) {
+        new MutationObserver(updateSearchAccessibility).observe(pagefindSearch, {
+          childList: true,
+          subtree: true,
+          characterData: true,
+        });
+      }
       focusSearchInput();
     };
     script.onerror = () => {
@@ -68,12 +96,15 @@ const pagefindScript = sitePath('_pagefind/pagefind-ui.js');
       if (loading) {
         loading.textContent = 'Search is not available.';
       }
+      searchError = 'Search is not available.';
+      updateSearchAccessibility();
     };
     document.head.append(script);
   };
 
   search?.addEventListener('toggle', () => {
     search.querySelector('summary')?.setAttribute('aria-expanded', String(search.open));
+    updateSearchAccessibility();
 
     if (search.open) {
       loadPagefind();

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -22,7 +22,8 @@ const { previous, next } = adjacentDocs(doc.id);
       <button
         class="mobile-doc-trigger"
         type="button"
-        popovertarget="mobile-documentation-menu"
+        aria-controls="mobile-documentation-menu"
+        aria-haspopup="dialog"
         aria-label={`Browse documentation. Current page: ${doc.title}.`}
       >
         <svg viewBox="0 0 24 24" aria-hidden="true">
@@ -36,7 +37,12 @@ const { previous, next } = adjacentDocs(doc.id);
 
       {
         onThisPage.length > 0 && (
-          <button class="mobile-index-trigger" type="button" popovertarget="mobile-page-index">
+          <button
+            class="mobile-index-trigger"
+            type="button"
+            aria-controls="mobile-page-index"
+            aria-haspopup="dialog"
+          >
             <svg viewBox="0 0 24 24" aria-hidden="true">
               <path d="M8 6h12M8 12h12M8 18h12M4 6h.01M4 12h.01M4 18h.01"></path>
             </svg>
@@ -46,12 +52,11 @@ const { previous, next } = adjacentDocs(doc.id);
       }
     </div>
 
-    <div
+    <dialog
       id="mobile-documentation-menu"
       class="mobile-nav-popover"
-      popover
-      role="dialog"
       aria-labelledby="mobile-documentation-title"
+      closedby="any"
       data-pagefind-ignore="all"
     >
       <header class="mobile-popover-header">
@@ -59,12 +64,14 @@ const { previous, next } = adjacentDocs(doc.id);
           <span>Greenlight</span>
           <h2 id="mobile-documentation-title">Documentation</h2>
         </div>
-        <button type="button" popovertarget="mobile-documentation-menu" popovertargetaction="hide">
-          <span>Close</span>
-          <svg viewBox="0 0 24 24" aria-hidden="true">
-            <path d="m6 6 12 12M18 6 6 18"></path>
-          </svg>
-        </button>
+        <form method="dialog">
+          <button type="submit" autofocus>
+            <span>Close</span>
+            <svg viewBox="0 0 24 24" aria-hidden="true">
+              <path d="m6 6 12 12M18 6 6 18"></path>
+            </svg>
+          </button>
+        </form>
       </header>
 
       <nav class="mobile-nav-content" aria-label="Documentation">
@@ -75,16 +82,15 @@ const { previous, next } = adjacentDocs(doc.id);
         <a href={sitePath()}>Home</a>
         <a href={githubUrl}>GitHub</a>
       </nav>
-    </div>
+    </dialog>
 
     {
       onThisPage.length > 0 && (
-        <div
+        <dialog
           id="mobile-page-index"
           class="mobile-index-popover"
-          popover
-          role="dialog"
           aria-labelledby="mobile-page-index-title"
+          closedby="any"
           data-pagefind-ignore="all"
         >
           <header class="mobile-popover-header">
@@ -92,12 +98,14 @@ const { previous, next } = adjacentDocs(doc.id);
               <span>{doc.section}</span>
               <h2 id="mobile-page-index-title">On this page</h2>
             </div>
-            <button type="button" popovertarget="mobile-page-index" popovertargetaction="hide">
-              <span>Close</span>
-              <svg viewBox="0 0 24 24" aria-hidden="true">
-                <path d="m6 6 12 12M18 6 6 18"></path>
-              </svg>
-            </button>
+            <form method="dialog">
+              <button type="submit" autofocus>
+                <span>Close</span>
+                <svg viewBox="0 0 24 24" aria-hidden="true">
+                  <path d="m6 6 12 12M18 6 6 18"></path>
+                </svg>
+              </button>
+            </form>
           </header>
 
           <nav aria-label="On this page">
@@ -109,7 +117,7 @@ const { previous, next } = adjacentDocs(doc.id);
               ))}
             </ol>
           </nav>
-        </div>
+        </dialog>
       )
     }
 
@@ -163,11 +171,72 @@ const { previous, next } = adjacentDocs(doc.id);
   </main>
 
   <script>
+    const focusableSelector = [
+      'a[href]',
+      'button:not([disabled])',
+      'input:not([disabled])',
+      'select:not([disabled])',
+      'textarea:not([disabled])',
+      '[tabindex]:not([tabindex="-1"])',
+    ].join(',');
+
+    document.querySelectorAll<HTMLElement>('[aria-haspopup="dialog"][aria-controls]').forEach((trigger) => {
+      trigger.addEventListener('click', () => {
+        const target = trigger.getAttribute('aria-controls');
+        const dialog = target ? document.getElementById(target) : null;
+
+        if (dialog instanceof HTMLDialogElement) {
+          trigger.focus();
+          dialog.showModal();
+          dialog.addEventListener('close', () => trigger.focus(), { once: true });
+        }
+      });
+    });
+
+    document.querySelectorAll<HTMLDialogElement>('dialog.mobile-nav-popover, dialog.mobile-index-popover').forEach(
+      (dialog) => {
+        if (!Reflect.has(dialog, 'closedBy')) {
+          dialog.addEventListener('click', (event) => {
+            const bounds = dialog.getBoundingClientRect();
+            const isInside =
+              event.clientX >= bounds.left &&
+              event.clientX <= bounds.right &&
+              event.clientY >= bounds.top &&
+              event.clientY <= bounds.bottom;
+
+            if (event.target === dialog && !isInside) {
+              dialog.close();
+            }
+          });
+        }
+
+        dialog.addEventListener('keydown', (event) => {
+          if (event.key !== 'Tab') {
+            return;
+          }
+
+          const focusableElements = [...dialog.querySelectorAll<HTMLElement>(focusableSelector)].filter(
+            (element) => element.getClientRects().length > 0,
+          );
+          const firstElement = focusableElements.at(0);
+          const lastElement = focusableElements.at(-1);
+
+          if (event.shiftKey && document.activeElement === firstElement) {
+            event.preventDefault();
+            lastElement?.focus();
+          } else if (!event.shiftKey && document.activeElement === lastElement) {
+            event.preventDefault();
+            firstElement?.focus();
+          }
+        });
+      },
+    );
+
     const pageIndex = document.querySelector('#mobile-page-index');
 
     pageIndex?.addEventListener('click', (event) => {
-      if (event.target instanceof Element && event.target.closest('a') && pageIndex instanceof HTMLElement) {
-        pageIndex.hidePopover();
+      if (event.target instanceof Element && event.target.closest('a') && pageIndex instanceof HTMLDialogElement) {
+        pageIndex.close();
       }
     });
   </script>

--- a/website/src/layouts/DocsLayout.astro
+++ b/website/src/layouts/DocsLayout.astro
@@ -188,7 +188,6 @@ const { previous, next } = adjacentDocs(doc.id);
         if (dialog instanceof HTMLDialogElement) {
           trigger.focus();
           dialog.showModal();
-          dialog.addEventListener('close', () => trigger.focus(), { once: true });
         }
       });
     });

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -1819,15 +1819,15 @@ code {
       display 180ms allow-discrete;
   }
 
-  .mobile-nav-popover:popover-open,
-  .mobile-index-popover:popover-open {
+  .mobile-nav-popover[open],
+  .mobile-index-popover[open] {
     opacity: 1;
     transform: translateY(0);
   }
 
   @starting-style {
-    .mobile-nav-popover:popover-open,
-    .mobile-index-popover:popover-open {
+    .mobile-nav-popover[open],
+    .mobile-index-popover[open] {
       opacity: 0;
       transform: translateY(1rem);
     }
@@ -1838,8 +1838,8 @@ code {
     background: color-mix(in oklch, var(--ink) 28%, transparent);
   }
 
-  body:has(.mobile-nav-popover:popover-open),
-  body:has(.mobile-index-popover:popover-open) {
+  body:has(.mobile-nav-popover[open]),
+  body:has(.mobile-index-popover[open]) {
     overflow: hidden;
   }
 


### PR DESCRIPTION
## What

- Use native modal dialogs for the mobile documentation menu and page index.
- Keep keyboard focus in each dialog and restore focus to its trigger when it closes.
- Preserve page-index backdrop dismissal in browsers that do not support `closedby`.
- Give the Pagefind input an accessible name and announce result, no-result, and load-failure updates.
- Extend the built-site check for the dialog and search accessibility contracts.

## Why

The mobile overlays looked modal, but they used nonmodal popovers. Keyboard users could reach controls behind an open overlay. Assistive technology could also traverse that background content.

Pagefind updated its result message asynchronously without a persistent live region. Screen-reader users could miss result counts, no-result messages, and load failures.

## Verification

- `make docs-check` passes: 8 Node tests pass, Astro reports 0 diagnostics, and all 36 generated pages pass the site check.
- Four focused Chromium checks pass for focus containment and restoration, both dialog dismissal paths, page-index link closure, the search input name, live result updates, and the Pagefind load-failure path.
- `git diff --check` passes.
- PHP and Composer are not available in the local environment. The pull request CI must run the PHP checks below.

## Review

- Two independent GLM accessibility reviews found the Pagefind failure race and Safari dialog gaps. The final re-review is ready with no remaining findings.
- The simplification and repository-style review has no remaining medium-or-higher findings.

## Checklist

- [ ] `composer static-analysis` is green
- [ ] `composer tests` is green
- [x] Pull request title follows the [release classification rules](../CONTRIBUTING.md#release-classification)
- [x] Each breaking change uses `!` and gives replacement instructions in **Why**
