### PR TITLE
fix(docs): center the mobile search icon

### DIFF
--- a/website/src/components/Search.astro
+++ b/website/src/components/Search.astro
@@ -16,7 +16,10 @@ const pagefindScript = sitePath('_pagefind/pagefind-ui.js');
     aria-expanded="false"
   >
     <span class="search-label-full">Search</span>
-    <span class="search-label-short" aria-hidden="true">Find</span>
+    <svg class="search-icon" viewBox="0 0 24 24" aria-hidden="true">
+      <circle cx="10.5" cy="10.5" r="6.5"></circle>
+      <path d="m16 16 4 4"></path>
+    </svg>
     <kbd aria-hidden="true">/</kbd>
   </summary>
   <div

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -254,8 +254,14 @@ code {
   display: none;
 }
 
-.search-label-short {
+.search-icon {
   display: none;
+  width: 1.25rem;
+  height: 1.25rem;
+  fill: none;
+  stroke: currentColor;
+  stroke-linecap: round;
+  stroke-width: 1.8;
 }
 
 .site-search kbd {
@@ -2066,8 +2072,15 @@ code {
     display: none;
   }
 
-  .search-label-short {
-    display: inline;
+  .site-search summary {
+    justify-content: center;
+    width: 2.75rem;
+    height: 2.75rem;
+    padding: 0;
+  }
+
+  .search-icon {
+    display: block;
   }
 
   .capability-list p {


### PR DESCRIPTION
At small mobile widths, the Find button has uneven padding after the keyboard shortcut disappears. Replace Find with a centered magnifying glass in a 44-pixel square touch target.

Keep the Search documentation accessible name and the existing search controls. Larger screens retain the text label.
