### PR TITLE
fix(docs): preserve the mobile close button gutter

### DIFF
--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -1839,7 +1839,7 @@ code {
 
   .mobile-nav-popover {
     inset: 0;
-    width: 100%;
+    width: 100dvw;
     height: 100dvh;
     max-width: none;
     max-height: none;
@@ -1969,7 +1969,7 @@ code {
 
   .mobile-index-popover {
     inset: auto 0 0;
-    width: 100%;
+    width: 100dvw;
     max-width: none;
     max-height: min(72dvh, 38rem);
     margin: 0;


### PR DESCRIPTION
Mobile Chrome can expand the layout viewport beyond the visible screen when page content overflows. The documentation menu and page index use that expanded width, which moves their Close buttons against or beyond the screen edge.

Use the dynamic viewport width for both mobile panels. This keeps the existing header padding and Close buttons inside the device viewport.
