### PR TITLE
fix(docs): support keyboard scrolling in tables

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -3,6 +3,7 @@ import sitemap from '@astrojs/sitemap';
 import { defineConfig } from 'astro/config';
 
 import { rewriteDocumentationLinks } from './src/lib/remark-documentation-links.mjs';
+import { scrollableTables } from './src/lib/rehype-scrollable-tables.mjs';
 
 export default defineConfig({
   site: 'https://ben-challis.github.io',
@@ -12,6 +13,7 @@ export default defineConfig({
   markdown: {
     processor: unified({
       remarkPlugins: [[rewriteDocumentationLinks, { base: '/greenlight' }]],
+      rehypePlugins: [scrollableTables],
     }),
     shikiConfig: {
       langAlias: {

--- a/website/scripts/docs-navigation.test.mjs
+++ b/website/scripts/docs-navigation.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { after, before, test } from 'node:test';
+import { setTimeout } from 'node:timers/promises';
 import { preview } from 'astro';
 import { chromium } from 'playwright';
 
@@ -60,3 +61,24 @@ for (const [trigger, dialog] of [
     });
   }
 }
+
+test('wide tables retain their semantics and support keyboard scrolling without scripts', async (t) => {
+  const page = await browser.newPage({ viewport: { width: 390, height: 844 }, javaScriptEnabled: false });
+  t.after(() => page.close());
+  await page.goto(`http://127.0.0.1:${server.port}/greenlight/docs/migrating-from-phpunit/`);
+  const table = page.getByRole('table').first();
+  const region = page.getByRole('region', { name: 'Convert tests automatically table', exact: true });
+  assert.equal(await region.getByRole('table').count(), 1);
+  assert.ok(await table.getByRole('columnheader').count() > 0);
+  assert.equal(await region.getAttribute('tabindex'), '0');
+  assert.equal(await region.evaluate((element) => element.scrollWidth > element.clientWidth), true);
+  await region.scrollIntoViewIfNeeded();
+  await region.focus();
+  await page.keyboard.press('ArrowRight');
+  for (let attempt = 0; attempt < 20 && await region.evaluate((element) => element.scrollLeft === 0); attempt++) {
+    await setTimeout(50);
+  }
+  assert.ok(await region.evaluate((element) => element.scrollLeft) > 0);
+  assert.equal(await region.evaluate((element) => element === document.activeElement), true);
+  assert.equal(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth), true);
+});

--- a/website/src/lib/rehype-scrollable-tables.mjs
+++ b/website/src/lib/rehype-scrollable-tables.mjs
@@ -1,0 +1,44 @@
+function textContent(node) {
+  return node.type === 'text' ? node.value : (node.children ?? []).map(textContent).join('');
+}
+
+export function scrollableTables() {
+  return (tree) => {
+    let heading = 'Documentation';
+
+    const visit = (parent) => {
+      parent.children = parent.children.map((node) => {
+        if (node.type !== 'element') {
+          return node;
+        }
+
+        if (/^h[1-6]$/.test(node.tagName)) {
+          heading = textContent(node).trim();
+        }
+
+        if (node.tagName === 'table') {
+          const caption = node.children.find((child) => child.tagName === 'caption');
+          return {
+            type: 'element',
+            tagName: 'div',
+            properties: {
+              className: ['table-scroll'],
+              tabIndex: 0,
+              role: 'region',
+              ariaLabel: caption ? textContent(caption).trim() : `${heading} table`,
+            },
+            children: [node],
+          };
+        }
+
+        if (node.children) {
+          visit(node);
+        }
+
+        return node;
+      });
+    };
+
+    visit(tree);
+  };
+}

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -1347,7 +1347,7 @@ code {
 .docs-article ol,
 .docs-article pre,
 .docs-article blockquote,
-.docs-article table {
+.docs-article .table-scroll {
   margin-top: 1.15rem;
   margin-bottom: 1.15rem;
 }
@@ -1478,11 +1478,14 @@ code {
   text-transform: uppercase;
 }
 
-.docs-article table {
-  display: block;
+.docs-article .table-scroll {
   max-width: 100%;
-  border-collapse: collapse;
   overflow-x: auto;
+  overscroll-behavior-inline: contain;
+}
+
+.docs-article table {
+  border-collapse: collapse;
   font-size: 0.93rem;
 }
 


### PR DESCRIPTION
Wide documentation tables have no explicit keyboard focus target. Their block display also replaces the native table layout.

Wrap Markdown tables in named, focusable scroll regions at build time. Preserve native table markup and column headers. Arrow keys can move the table horizontally without client JavaScript.

Add a browser regression for table semantics, horizontal keyboard scrolling, and page width with scripts disabled. The region follows the [MDN overflow accessibility guidance](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/overflow#accessibility).
