### PR TITLE
fix(docs): wrap long identifiers in narrow layouts

### DIFF
--- a/website/scripts/docs-navigation.test.mjs
+++ b/website/scripts/docs-navigation.test.mjs
@@ -40,6 +40,20 @@ test('page-index navigation preserves the keyboard position in the selected sect
   );
 });
 
+for (const route of ['getting-started', 'api-expectations', 'phpstan', 'migrating-from-phpunit']) {
+  test(`${route} keeps prose within a narrow viewport`, async (t) => {
+    const page = await openDocumentation(t);
+    await page.setViewportSize({ width: 320, height: 844 });
+    await page.goto(`http://127.0.0.1:${server.port}/greenlight/docs/${route}/`);
+    await page.evaluate(() => document.fonts.ready);
+    assert.equal(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth), true);
+    assert.equal(await page.locator('.docs-article pre').first().evaluate((element) => {
+      const style = getComputedStyle(element);
+      return style.whiteSpace === 'pre' && style.overflowX === 'auto';
+    }), true);
+  });
+}
+
 for (const [trigger, dialog] of [
   ['.mobile-doc-trigger', '#mobile-documentation-menu'],
   ['.mobile-index-trigger', '#mobile-page-index'],

--- a/website/src/styles/global.css
+++ b/website/src/styles/global.css
@@ -1318,6 +1318,10 @@ code {
   max-width: 70ch;
 }
 
+.docs-article :is(p, li, h1, h2, h3, h4, h5, h6) {
+  overflow-wrap: anywhere;
+}
+
 .docs-article h1 {
   margin-bottom: 1.8rem;
   font-size: clamp(2.8rem, 6vw, 5rem);


### PR DESCRIPTION
Long inline PHP identifiers extend beyond narrow documentation pages. At a 320-pixel viewport, the getting-started page is 416 pixels wide and the expectation reference is 452 pixels wide.

Allow headings, paragraphs, and list items to wrap at any character when needed. Preserve the whitespace and horizontal scroll behavior of code blocks and tables.

Add browser regressions for four affected pages at a 320-pixel viewport. Each check waits for web fonts and confirms that code blocks retain their scroll behavior.
