### PR TITLE
fix(docs): preserve content in print layouts

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -10,7 +10,7 @@
     "api:generate": "node scripts/generate-api-reference.mjs",
     "build": "npm run api:check && astro build --force && pagefind --site dist --output-subdir _pagefind && node scripts/check-built-site.mjs",
     "check": "npm run api:check && astro check && astro build --force && pagefind --site dist --output-subdir _pagefind && node scripts/check-built-site.mjs && npm run test:browser",
-    "test:browser": "node --test scripts/docs-navigation.test.mjs",
+    "test:browser": "node --test scripts/docs-*.test.mjs",
     "dev": "astro dev",
     "preview": "astro preview"
   },

--- a/website/scripts/docs-print.test.mjs
+++ b/website/scripts/docs-print.test.mjs
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict';
+import { after, before, test } from 'node:test';
+import { preview } from 'astro';
+import { chromium } from 'playwright';
+
+let server;
+let browser;
+
+before(async () => {
+  server = await preview({ server: { host: '127.0.0.1', port: 0 }, logLevel: 'silent' });
+  browser = await chromium.launch();
+});
+
+after(async () => {
+  await browser?.close();
+  await server?.stop();
+});
+
+for (const route of ['attributes', 'phpstan', 'migrating-from-phpunit']) {
+  test(`${route} prints complete content without navigation or controls`, async (t) => {
+    const page = await browser.newPage({ viewport: { width: 794, height: 1123 } });
+    t.after(() => page.close());
+    await page.goto(`http://127.0.0.1:${server.port}/greenlight/docs/${route}/`);
+    await page.locator('.mobile-doc-trigger').click();
+    await page.emulateMedia({ media: 'print' });
+    await page.evaluate(() => document.fonts.ready);
+
+    for (const selector of ['.site-header', '.docs-sidebar', '.page-index', '.mobile-doc-toolbar',
+      '#mobile-documentation-menu', '.doc-pagination', '.command-copy']) {
+      assert.equal(await page.locator(selector).first().isVisible(), false, `${selector} is absent from print output.`);
+    }
+
+    assert.equal(await page.locator('.docs-article').isVisible(), true);
+    assert.equal(await page.evaluate(() => getComputedStyle(document.body).overflow), 'visible');
+    assert.deepEqual(await page.locator('.docs-article pre, .docs-article table').evaluateAll((elements) =>
+      elements.filter((element) => element.scrollWidth > element.clientWidth + 1).map((element) => element.tagName),
+    ), []);
+    assert.equal(await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth), true);
+
+    await page.emulateMedia({ media: 'screen' });
+    assert.equal(await page.locator('#mobile-documentation-menu').isVisible(), true);
+    await page.keyboard.press('Escape');
+    assert.equal(await page.locator('.site-header').isVisible(), true);
+  });
+}

--- a/website/src/layouts/BaseLayout.astro
+++ b/website/src/layouts/BaseLayout.astro
@@ -3,6 +3,7 @@ import '@fontsource-variable/geologica';
 import '@fontsource-variable/recursive';
 import '@fontsource-variable/source-sans-3';
 import '../styles/global.css';
+import '../styles/print.css';
 
 import Footer from '../components/Footer.astro';
 import Header from '../components/Header.astro';

--- a/website/src/styles/print.css
+++ b/website/src/styles/print.css
@@ -1,0 +1,105 @@
+@media print {
+  @page {
+    margin: 15mm;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation: none !important;
+    transition: none !important;
+  }
+
+  html,
+  body {
+    overflow: visible !important;
+  }
+
+  body {
+    display: block;
+    min-height: 0;
+    background: none;
+    font-size: 11pt;
+  }
+
+  .site-header,
+  .site-footer,
+  .skip-link,
+  .docs-sidebar,
+  .page-index,
+  .mobile-doc-toolbar,
+  .mobile-nav-popover,
+  .mobile-index-popover,
+  .doc-pagination,
+  .command-copy {
+    display: none !important;
+  }
+
+  dialog::backdrop {
+    background: none;
+  }
+
+  .docs-shell {
+    display: block;
+    width: auto;
+    min-height: 0;
+    padding: 0;
+  }
+
+  .docs-article {
+    max-width: none;
+    overflow-wrap: anywhere;
+  }
+
+  .docs-article h1 {
+    font-size: 24pt;
+  }
+
+  .docs-article h2 {
+    margin-top: 2rem;
+    font-size: 18pt;
+  }
+
+  .docs-article h3 {
+    font-size: 14pt;
+  }
+
+  .docs-article :is(h1, h2, h3, h4, h5, h6) {
+    break-after: avoid;
+  }
+
+  .docs-article p {
+    orphans: 3;
+    widows: 3;
+  }
+
+  .docs-article pre,
+  .docs-article pre code,
+  .docs-article pre .line {
+    overflow-wrap: anywhere !important;
+    white-space: pre-wrap !important;
+  }
+
+  .docs-article pre {
+    overflow: visible;
+    padding: 0.5rem;
+    background: none !important;
+    font-size: 8pt;
+  }
+
+  .docs-article .table-scroll {
+    overflow: visible;
+  }
+
+  .docs-article table {
+    display: table;
+    width: 100%;
+    overflow: visible;
+    table-layout: fixed;
+    font-size: 9pt;
+  }
+
+  .docs-article tr {
+    break-inside: avoid;
+  }
+}


### PR DESCRIPTION
Documentation pages use the screen layout in print output. Sticky navigation and controls remain visible, and wide code blocks and tables can lose content at the page edge.

Add print media styles with page margins, a single content column, wrapped code, full-width tables, and page-break rules. Hide navigation, copy buttons, dialogs, and backdrops. Disable transitions so open dialogs disappear as soon as print mode starts.

Add browser regressions for code-heavy and table-heavy pages, including print mode with an open dialog and the return to screen mode.
