### PR TITLE
docs: clarify technical writing and contributor guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@
 - Obey `docs/architecture/conventions.md` and the dependency boundaries in `deptrac.yaml`.
 - Use `docs/architecture/technical-writing.md` for all repository-owned technical prose.
 - Technical prose includes documentation, PHPDoc, comments, contributor material, accessibility text, diagnostics, CLI help, and human-readable output.
-- Use ASD-STE100 Issue 9 for technical prose.
-- Use uppercase `MUST`, `MUST NOT`, `SHOULD`, `SHOULD NOT`, and `MAY` as normative tokens.
+- Use Simplified Technical English principles for technical prose. Do not claim formal compliance without verification.
+- Use direct language in user-facing prose. Preserve normative terms in formal specifications, protocol requirements, and exact quotations.
 - Use STE clarity principles for marketing copy. The controlled vocabulary is optional for marketing copy.
 - Add focused unit or acceptance tests. Use `Greenlight\Expect`. Treat shared fixture directories as append-only.
 - Run focused tests with `php bin/greenlight run --filter=<test-id>`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,13 +13,13 @@ for the browser tests.
 ## Technical prose
 
 Use the [technical writing standard](docs/architecture/technical-writing.md)
-for all repository-owned technical prose. The standard applies ASD-STE100 Issue
-9 to documentation, PHPDoc, comments, contributor material, accessibility text,
+for all repository-owned technical prose. The policy uses Simplified Technical English principles
+for documentation, PHPDoc, comments, contributor material, accessibility text,
 diagnostics, CLI help, and human-readable output.
 
-Use uppercase `MUST`, `MUST NOT`, `SHOULD`, `SHOULD NOT`, and `MAY` as
-normative tokens. Use STE clarity principles for marketing copy. The
-controlled vocabulary is optional for marketing copy.
+Write direct instructions for requirements. Identify recommendations and options
+clearly. Preserve normative terms in formal specifications and protocol rules.
+Use the same clarity principles for marketing copy.
 
 Before you push prose changes, review the prose:
 
@@ -39,7 +39,8 @@ composer tests
 make docs-check
 ```
 
-CI runs the same checks. All three MUST pass locally.
+All three commands must pass before you push. CI also runs these checks across
+its supported environments.
 
 The Composer CI commands use one shared local slot by default. The slot applies
 across Git worktrees. Set `GREENLIGHT_LOCAL_CI_MAX_PARALLELISM` to a positive
@@ -50,7 +51,7 @@ integer to permit more concurrent commands. Hosted CI does not use this limit.
 Submit changes in pull requests to `main`.
 
 Greenlight uses squash merges. The pull request title becomes the commit
-message. It MUST use the
+message. Use the
 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
 format:
 
@@ -123,8 +124,7 @@ composer phpstan:stubs
 Greenlight is a development dependency. A runtime dependency can conflict with
 the project under test. Implement each necessary capability in Greenlight.
 
-You MAY add development dependencies for tools. You MUST NOT add runtime
-dependencies.
+You can add development dependencies for tools. Do not add runtime dependencies.
 
 ## Questions
 

--- a/docs/architecture/conventions.md
+++ b/docs/architecture/conventions.md
@@ -8,10 +8,10 @@ and **MAY** specify normative requirements.
 
 ## Technical prose
 
-Repository-owned technical prose **MUST** comply with
-[the technical writing standard](technical-writing.md). The standard applies
-ASD-STE100 Issue 9 to documentation, PHPDoc, comments, contributor material,
-accessibility copy, diagnostics, CLI help, and human-readable output.
+Follow [the technical writing policy](technical-writing.md) for repository-owned
+technical prose. It applies to documentation, PHPDoc, comments, contributor
+material, accessibility text, diagnostics, CLI help, and human-readable output.
+Do not claim formal ASD-STE100 compliance without a complete review.
 
 Authors **MUST** manually review the meaning and the controlled vocabulary.
 They **MUST** also review active voice, verbal `-ing` forms, and instruction

--- a/docs/architecture/technical-writing.md
+++ b/docs/architecture/technical-writing.md
@@ -1,7 +1,8 @@
 # Technical writing
 
-Greenlight technical prose follows ASD-STE100 Simplified Technical English,
-Issue 9, dated January 15, 2025.
+Greenlight uses Simplified Technical English principles to make technical prose
+clear and consistent. ASD-STE100 Issue 9 is a reference for this policy.
+This policy does not certify that project prose complies with the standard.
 
 This policy applies to repository-owned technical prose:
 
@@ -56,13 +57,16 @@ and proper names also count as one word.
 
 ## Normative requirements
 
-Architecture rules use the uppercase control terms **MUST**, **MUST NOT**,
+Formal specifications and protocol requirements use the uppercase control terms **MUST**, **MUST NOT**,
 **SHOULD**, **SHOULD NOT**, and **MAY**. These terms preserve distinct
 requirement levels and are explicit project exceptions.
 
-Use these terms only in normative rules. Do not replace one control term with
-another during a language rewrite. Such a replacement can change a
-requirement.
+Preserve these terms in formal rules and exact quotations. Do not replace one
+control term with another during a language rewrite. This can change a requirement.
+
+In user-facing prose, use direct instructions for requirements. Use explicit
+recommendations for preferred actions and `can` for options. Preserve the
+requirement level when you rewrite a sentence.
 
 Do not use lowercase modal `should` or `may` in other technical prose. Rewrite
 the sentence with an approved construction.


### PR DESCRIPTION
The contributor guidance required uppercase normative terms in user-facing text and described project prose as following ASD-STE100 without a verified compliance assessment.

Use direct instructions for user-facing requirements and explicit wording for recommendations and options. Preserve formal specification terms and exact quotations. Align AGENTS.md, contributor guidance, and the writing policy so later edits follow the same rule. The policy now states that it does not certify formal compliance.
