### PR TITLE
docs(cli): clarify command help and required option pairs

### DIFF
--- a/src/Cli/Input/Definition.php
+++ b/src/Cli/Input/Definition.php
@@ -19,7 +19,7 @@ final readonly class Definition
     /** @var array<non-empty-string, non-empty-string> */
     public const array COMMAND_DESCRIPTIONS = [
         'run' => 'Find and run tests (default)',
-        'list-tests' => 'List each found test ID, one per line',
+        'list-tests' => 'List selected test IDs and the total test count',
         'coverage:merge' => 'Merge coverage JSON exports',
         'coverage:diff' => 'Compare two coverage JSON exports',
         'profile:report' => 'Create a run profile from a saved JSONL stream',
@@ -43,7 +43,8 @@ final readonly class Definition
 
         Commands:
           run            Find and run tests (default)
-          list-tests     List each found test ID, one per line
+          list-tests     List selected test IDs and the total test count.
+                         Use --format=json for a machine-readable test manifest.
           coverage:merge Merge coverage JSON exports. Repeat --input for each
                          source and --export for each output.
           coverage:diff  Compare two coverage JSON exports. Fail if total coverage
@@ -125,20 +126,27 @@ final readonly class Definition
           --require-coverage-driver
                              Fail if no configured coverage driver is available.
           --input=<path>     Read an input file. Repeat for coverage:merge.
+          --output=<path>    Set the ide-helper output file
+                             (default _greenlight_ide_helper.php).
           --export=<format>=<path>
                              Write merged coverage. Repeat for more formats.
+                             Formats: json, lcov, clover, cobertura, html.
           --input-root=<path>
-                             Set one source root. Repeat once for each input.
+                             Set one coverage:merge source root per --input.
+                             Use with --project-root.
           --project-root=<path>
                              Set the project root for merged coverage paths.
+                             Use with --input-root for each input.
           --baseline=<path>  Read the baseline coverage JSON for coverage:diff.
           --current=<path>   Read the current coverage JSON for coverage:diff.
           --baseline-root=<path>
                              Set the baseline project root for coverage:diff.
+                             Use with --current-root.
           --current-root=<path>
                              Set the current project root for coverage:diff.
-          --dry-run          Print a run-settings summary without test discovery
-                             or execution.
+                             Use with --baseline-root.
+          --dry-run          For run, print settings without test discovery or execution.
+                             For artifacts:prune, list selected runs without deletion.
           -h, --help         Show this help
           -V, --version      Show the version
 

--- a/src/Cli/Run/RunSession.php
+++ b/src/Cli/Run/RunSession.php
@@ -112,7 +112,7 @@ final readonly class RunSession
     public function persist(array $failedTests, array $classSeconds): void
     {
         if (!$this->state->record($failedTests, $classSeconds)) {
-            $this->console->err("Greenlight did not save run state. On the next run, --failed and longest-first scheduling have no prior data.\n");
+            $this->console->err("Greenlight did not save run state. The next run will use older or missing data for --failed and longest-first scheduling.\n");
         }
     }
 

--- a/src/Cli/Watch/WatchLoop.php
+++ b/src/Cli/Watch/WatchLoop.php
@@ -49,7 +49,7 @@ final readonly class WatchLoop
         $this->detector->poll();
         $failedClasses = $runOnce([]);
         $iterations = 1;
-        ($this->out)("\nWaiting for changes. Press Enter to run all tests. Press q to quit.\n");
+        ($this->out)("\nWaiting for changes. Press Enter to rerun the selected tests. Press q to quit.\n");
 
         while ($maxIterations === null || $iterations < $maxIterations) {
             if ($this->shutdown?->requested() === true) {
@@ -75,7 +75,7 @@ final readonly class WatchLoop
                 $this->debouncer->reset();
                 $failedClasses = $runOnce($runNow ? [] : $failedClasses);
                 ++$iterations;
-                ($this->out)("\nWaiting for changes. Press Enter to run all tests. Press q to quit.\n");
+                ($this->out)("\nWaiting for changes. Press Enter to rerun the selected tests. Press q to quit.\n");
 
                 continue;
             }

--- a/tests/Acceptance/CliTest.php
+++ b/tests/Acceptance/CliTest.php
@@ -67,7 +67,10 @@ final readonly class CliTest
             ->because('help and version exit zero and lists required coverage diff inputs')
             ->toContain('Usage:')
             ->toContain('--baseline=<path>')
-            ->toContain('--current=<path>');
+            ->toContain('--current=<path>')
+            ->toContain('--output=<path>')
+            ->toContain('Use with --project-root.')
+            ->toContain('For artifacts:prune, list selected runs without deletion.');
 
         $result = $this->runCli(['--version']);
         Expect::that($result->exitCode)->because('help and version exit zero')->toBe(0);

--- a/tests/Unit/Cli/Input/CompletionScriptsTest.php
+++ b/tests/Unit/Cli/Input/CompletionScriptsTest.php
@@ -34,7 +34,7 @@ final class CompletionScriptsTest
 
         Expect::that($script)
             ->toContain('Find and run tests (default)')
-            ->toContain('List each found test ID, one per line')
+            ->toContain('List selected test IDs and the total test count')
             ->toContain('Merge coverage JSON exports')
             ->toContain('Compare two coverage JSON exports')
             ->toContain('Create a run profile from a saved JSONL stream')

--- a/tests/Unit/Cli/Watch/WatchTest.php
+++ b/tests/Unit/Cli/Watch/WatchTest.php
@@ -153,7 +153,7 @@ final readonly class WatchTest
             },
         )->run(static fn(array $priorityClasses): array => [], maxIterations: 2);
 
-        $ready = "\nWaiting for changes. Press Enter to run all tests. Press q to quit.\n";
+        $ready = "\nWaiting for changes. Press Enter to rerun the selected tests. Press q to quit.\n";
 
         Expect::that($output)
             ->because('a multi-file watch batch MUST use the plural notification')


### PR DESCRIPTION
The CLI help omitted `--output` and did not explain the paired coverage-root options. It also described every `--dry-run` as a run-settings preview, although `artifacts:prune` lists retained-run deletion candidates.

Document the command-specific behavior, supported coverage export formats, JSON test manifests, and the text listing total. These corrections follow `IdeHelperCommand`, `CoverageExport`, `CoverageMergeCommand`, `CoverageDiffCommand`, `ListCommand`, and `ArtifactsPruneCommand`. The help acceptance case also checks the added guidance.
