### PR TITLE
docs: clarify guide requirements and runtime behavior

### DIFF
--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -111,9 +111,9 @@ Each attachment records its name, kind, media type, byte size, SHA-256 digest,
 attempt number, retention policy, and published path. The metadata does not
 include the original source path or the attachment content.
 
-Attachment names are labels, not paths. They **MUST** be non-empty, use valid
-UTF-8, and contain no more than 120 bytes. They cannot contain directory
-separators or control characters. They cannot equal `.` or `..`. Repeated names
+Use a non-empty label for each attachment name. Use valid UTF-8 and no more
+than 120 bytes. Names cannot contain directory separators or control characters.
+They cannot equal `.` or `..`. Repeated names
 within one attempt receive `-2`, `-3`, and later suffixes in their published
 filenames. Their logical names remain unchanged in the result metadata.
 

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -102,17 +102,16 @@ or:
 #[DataSet(CurrencyDataSets::class, 'currencies')]
 ```
 
-The provider **MUST** return a non-empty iterable. Each value **MUST** be the
-argument array for one test invocation.
+Return a non-empty iterable from the provider. Use one argument array for each
+test invocation.
 
 Greenlight invokes the provider during discovery to create the execution plan.
 The plan contains data-set keys, not argument values. Greenlight invokes the
 provider again once for each worker-side class assignment to create the values
-in that worker. The provider **MUST** return every planned key on each
-invocation. Keep providers pure, deterministic, and free of I/O and global
-state. Each invocation has a five-second time budget.
+in that worker. Return every planned key on each invocation. Keep providers
+pure, deterministic, and free of I/O and global state. Each invocation has a five-second time budget.
 
-A provider key **MUST** be an integer or a string. Greenlight changes an integer
+Use an integer or string for each provider key. Greenlight changes an integer
 key to `#<key>`. It keeps a non-empty printable string key unchanged. It changes
 an empty or nonprintable string key to the first eight hexadecimal characters
 of its SHA-256 hash. The normalized key appears in test IDs and reports.

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -108,9 +108,10 @@ test invocation.
 Greenlight invokes the provider during discovery to create the execution plan.
 The plan contains data-set keys, not argument values. Greenlight invokes the
 provider again once for each worker-side class assignment to create the values
-in that worker. Return every planned key on each invocation. Keep providers
-pure, deterministic, and free of I/O and global state. Each invocation has a
-five-second time budget. Greenlight checks elapsed time after the call and as
+in that worker. Return every planned key on each invocation.
+
+Keep providers pure, deterministic, and free of I/O and global state. Each
+invocation has a five-second time budget. Greenlight checks elapsed time after the call and as
 it reads rows. This check cannot interrupt a blocked provider.
 
 Use an integer or string for each provider key. Greenlight changes an integer

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -109,7 +109,9 @@ Greenlight invokes the provider during discovery to create the execution plan.
 The plan contains data-set keys, not argument values. Greenlight invokes the
 provider again once for each worker-side class assignment to create the values
 in that worker. Return every planned key on each invocation. Keep providers
-pure, deterministic, and free of I/O and global state. Each invocation has a five-second time budget.
+pure, deterministic, and free of I/O and global state. Each invocation has a
+five-second time budget. Greenlight checks elapsed time after the call and as
+it reads rows. This check cannot interrupt a blocked provider.
 
 Use an integer or string for each provider key. Greenlight changes an integer
 key to `#<key>`. It keeps a non-empty printable string key unchanged. It changes

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1279,8 +1279,8 @@ Both human reporters start with a one-line header that contains:
 * seed, when randomized
 * worker count
 
-They end with a "Slowest tests" block when a test took at least 500 ms. The
-block lists the five slowest tests.
+They end with a "Slowest tests" block when a test took more than 500 ms. The
+block lists up to five tests that exceed this threshold.
 
 Fast suites do not print the block.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,20 +16,20 @@ Greenlight applies configuration in this order:
 
 Later layers override earlier ones.
 
-For example, use this configuration:
+For example, configure automatic worker selection:
 
 <!-- php-example {"example":"configuration-example-01","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 ->workers('auto')
 ```
 
-combined with this CLI flag:
+Then select one worker for a run:
 
 ```sh
 greenlight run --workers=1
 ```
 
-runs with one worker.
+The CLI flag overrides the configured worker count.
 
 ## GreenlightConfig
 
@@ -40,7 +40,7 @@ Create the builder with:
 GreenlightConfig::create()
 ```
 
-Every builder method returns `$this`. Thus, you can chain method calls.
+Configuration setters return `$this`, so you can chain their calls.
 
 ### `paths(array $tests): self`
 
@@ -159,8 +159,7 @@ Default: coverage off.
 The `coverage()` method enables coverage collection. Greenlight gives a
 `CoverageBuilder` to the configurator.
 
-Multiple calls to `coverage()` use the same builder. Thus, its settings
-accumulate.
+Repeated calls to `coverage()` preserve earlier settings.
 
 `CoverageBuilder` methods:
 
@@ -433,8 +432,8 @@ A `ReporterProvider` plugin registers custom names for `--reporter`. See
 
 Default: output below `build/greenlight-artifacts`, with failure-only retention.
 
-Greenlight gives an `ArtifactBuilder` to the configurator. Repeated calls use
-the same builder.
+Greenlight gives an `ArtifactBuilder` to the configurator. Repeated calls
+preserve earlier settings.
 
 <!-- php-example {"example":"configuration-example-07","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
@@ -468,8 +467,8 @@ See [test attachments](attachments.md) for the runtime API and security model.
 
 Default: all storage uses the system temporary directory.
 
-The configurator receives a `StorageBuilder`. Repeated calls use the same
-builder.
+The configurator receives a `StorageBuilder`. Repeated calls preserve earlier
+settings.
 
 Use `rootDirectory()` to put all Greenlight storage below one directory. An
 area-specific directory replaces its directory below the root.
@@ -961,7 +960,7 @@ Built-in reporters:
 * `github`
 * `teamcity`
 
-Repeatable. Multiple reporters write concurrently.
+Repeatable. Greenlight sends each event to the reporters in flag order.
 
 `ReporterProvider` plugins can add names. Greenlight creates reporters in flag
 order. A repeated name creates a separate reporter for each occurrence.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -454,9 +454,10 @@ final readonly class ServerTest
 Greenlight runs cleanup callbacks once in reverse registration order. It runs
 them after `After` hooks and before per-test sandbox disposal.
 
-A callback failure does not prevent the remaining callbacks. A cleanup failure
-errors a passed or skipped test. An earlier test failure or error remains
-primary.
+A callback failure does not prevent the remaining callbacks. For a passed or
+skipped test, the first cleanup failure determines the new outcome. An
+`ExpectationFailed` changes the outcome to failed. Another throwable changes
+it to errored. An earlier test failure or error remains primary.
 
 ## Exit codes
 

--- a/docs/migrating-from-phpunit.md
+++ b/docs/migrating-from-phpunit.md
@@ -301,16 +301,14 @@ Replace `setUpBeforeClass()` and static fixture properties with per-class
 harness services.
 
 A per-class harness service is a typed object with `PerClass` scope. Greenlight
-creates one instance for each test class.
+creates one instance for each test class. It injects the instance into each test
+constructor and disposes it after the class completes.
 
 External infrastructure such as database servers, message brokers, or
 containers belongs in an `IntegrationFixtureProvider`. It provisions in the
 orchestrator, can allocate one resource per worker channel, and tears down after
 the run even if workers fail. Worker-side tests consume its serializable
 connection data through `IntegrationResources` or a `HarnessProvider` bridge.
-
-Greenlight injects this instance into each test constructor. It disposes the
-instance after the class completes.
 
 Plugins register harness services. A plugin implements `HarnessProvider` and
 returns service definitions with their scopes.

--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -194,7 +194,7 @@ final class DigestMatchers implements ExpectationExtension
     {
         return [
             'toBeValidUuid' => static fn(string $subject): bool =>
-                \preg_match('/^[0-9a-f-]{36}$/', $subject) === 1,
+                \preg_match('/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/', $subject) === 1,
             'toHaveDigestLength' => static fn(string $subject, int $length): bool =>
                 \strlen($subject) === $length,
         ];
@@ -400,7 +400,7 @@ a known incompatible subject before the test runs:
 | Required subject | Matchers |
 | --- | --- |
 | `string` or `iterable` | `toContain()` |
-| `Countable` or `Traversable` | `toHaveCount()` |
+| `array`, `Countable`, or `Traversable` | `toHaveCount()` |
 | `string`, `array`, `Countable`, or `Traversable` | `toBeEmpty()` |
 | `string`, `array`, or `Countable` | `toHaveLength()` |
 | `array` or `ArrayAccess` | `toHaveKey()` |

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -244,7 +244,7 @@ transformers.
 
 ### CoverageMapTransformer
 
-Command-side, once for each completed standard or repeat run.
+Command-side, for a completed standard run with coverage enabled.
 
 A `CoverageMapTransformer` changes merged coverage before Greenlight writes
 coverage reports or checks thresholds. Greenlight first removes lines that
@@ -511,7 +511,7 @@ final class BrokerPlugin implements WorkerBootstrapSubscriber, HarnessProvider
 ```
 
 `WorkerBootstrapContext` contains the `workerId`, `TestChannel`, and
-`IntegrationResources`. Subscribers may implement `Prioritized`. Lower values
+`IntegrationResources`. Subscribers can implement `Prioritized`. Lower values
 run first. An exception fails the run before tests begin.
 
 ### WorkerRuntimeRunner

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -599,7 +599,9 @@ includes an attachment after a failure inspection in `afterTest()`. The usual
 retention and size limits apply. See [attachments](attachments.md).
 
 The `service()` method is available during `beforeTest()` and the test. The
-per-test scope closes before `afterTest()`, so `service()` throws in that hook.
+per-test scope closes before `afterTest()`. A request for a per-test service
+then throws. Per-class and per-worker services remain available. Fallback
+resolvers can also supply services if their own lifecycle permits it.
 
 ### TestAttemptRunner
 

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -107,7 +107,7 @@ $plan->expects('load')
 `andReturnsSequence()` consumes one value for each call that matches. Greenlight
 reports an error if a call occurs after the sequence is empty.
 
-Methods that declare `never` MUST use `andThrows()`. If a configured answer
+For a method that declares `never`, use `andThrows()`. If a configured answer
 returns, Greenlight reports an `InvalidDoubleUsage` error.
 
 ## Argument matches
@@ -213,7 +213,7 @@ Expect::that($captor->value())->toBeInstanceOf(Order::class);
 ```
 
 `values()` returns each captured value. `value()` returns the last value. It
-fails if `Argument::captor()` did not capture a value.
+fails if the captor did not capture a value.
 
 If a plan must capture more than one argument, put an explicit
 `Argument::captor()` inside `with()` for each argument.


### PR DESCRIPTION
Some guides describe builder identity, reporter execution, and coverage plugin lifetimes incorrectly. Other passages use standards-style requirements or leave fixture ownership unclear.

Use direct instructions for data providers, attachment labels, and never-returning double methods. Clarify class fixture ownership, preserve-setting behavior across configuration calls, ordered reporter callbacks, and the supported coverage-transformer lifecycle. Correct cleanup outcomes and after-test service availability from TestExecutor and HarnessScopes. State the non-preemptive provider budget and exact slow-test reporting threshold. Include arrays in the PHPStan count matcher table and correct the UUID format example.

These corrections follow GreenlightConfig setter cloning, CompositeReporter callback order, RunCommand repeat/coverage validation, NativeMatcherSubjectRule, and Expectation::toHaveCount(). The local prose check passes.
