### PR TITLE
docs: correct public API behavior descriptions

### DIFF
--- a/docs/api-configuration.md
+++ b/docs/api-configuration.md
@@ -357,7 +357,7 @@ PHPDoc:
 ### `storage()`
 
 Sets directories for persistent state, caches, generated code, and
-temporary run data. Multiple calls use the same builder.
+temporary run data. Each call starts with the current configuration.
 
 ```php
 public function storage(callable $configurator): self
@@ -372,8 +372,8 @@ PHPDoc:
 ### `failOnDeprecation()`
 
 Fails an otherwise passed test if captured output contains a
-deprecation. The diagnostic becomes the failure detail. Use a regular
-expression to exempt known dependency messages.
+deprecation. The diagnostic becomes the failure detail. Use
+`ignoreDeprecationsMatching()` to exempt known dependency messages.
 
 ```php
 public function failOnDeprecation(bool $enabled = true): self

--- a/docs/api-coverage.md
+++ b/docs/api-coverage.md
@@ -10,21 +10,16 @@ These signatures are the public API.
 
 Namespace: `Greenlight\Coverage`
 
-The map sorts files by path. Thus, identical coverage always has identical
-serialized data.
+Contains line coverage for source files in path order.
 
-`merge()` is commutative, associative, and idempotent. Thus, the orchestrator
-can merge worker payloads in all arrival orders. It does not require a final
-merge operation at the end of a run.
-
-The wire payload is compact. Under "files", each path maps to a two-item
-list. The covered line list is first. The uncovered line list is second.
+`merge()` combines covered and uncovered lines for each file. Covered lines
+take priority. Merge order and repeated inputs do not change the result.
 
 ```php
 final readonly class CoverageMap
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/CoverageMap.php#L23)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/CoverageMap.php#L17)
 
 ### `__construct()`
 
@@ -36,7 +31,7 @@ PHPDoc:
 
 - `@param list<FileCoverage> $files duplicated paths are merged, covered wins`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/CoverageMap.php#L33)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/CoverageMap.php#L27)
 
 ### `empty()`
 
@@ -44,7 +39,7 @@ PHPDoc:
 public static function empty(): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/CoverageMap.php#L47)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/CoverageMap.php#L41)
 
 ### `files()`
 
@@ -56,7 +51,7 @@ PHPDoc:
 
 - `@return array<non-empty-string, FileCoverage> keyed by file path, sorted by path`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/CoverageMap.php#L55)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/CoverageMap.php#L49)
 
 ### `isEmpty()`
 
@@ -64,7 +59,7 @@ PHPDoc:
 public function isEmpty(): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/CoverageMap.php#L60)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/CoverageMap.php#L54)
 
 ### `merge()`
 
@@ -72,7 +67,7 @@ public function isEmpty(): bool
 public function merge(self $other): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/CoverageMap.php#L65)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/CoverageMap.php#L59)
 
 ### `coveredLineTotal()`
 
@@ -84,7 +79,7 @@ PHPDoc:
 
 - `@return int<0, max>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/CoverageMap.php#L71)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/CoverageMap.php#L65)
 
 ### `executableLineTotal()`
 
@@ -96,7 +91,7 @@ PHPDoc:
 
 - `@return int<0, max>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/CoverageMap.php#L83)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/CoverageMap.php#L77)
 
 ### `uncoveredLineTotal()`
 
@@ -108,7 +103,7 @@ PHPDoc:
 
 - `@return int<0, max>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/CoverageMap.php#L95)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/CoverageMap.php#L89)
 
 ### `totalPercentage()`
 
@@ -120,7 +115,7 @@ An empty map has full coverage because it has no executable lines.
 public function totalPercentage(): float
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/CoverageMap.php#L111)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Coverage/CoverageMap.php#L105)
 
 ## `FileCoverage`
 

--- a/docs/api-doubles.md
+++ b/docs/api-doubles.md
@@ -95,7 +95,7 @@ PHPDoc:
 
 ### `equals()`
 
-This matcher uses the same deep equality as `Expect::toEqual()`.
+This matcher uses the same deep equality as `Expectation::toEqual()`.
 Use it when `with()` must compare by value instead of identity.
 
 ```php
@@ -394,7 +394,7 @@ This type does not declare public members.
 Namespace: `Greenlight\Doubles`
 
 Identifies incorrect use of the doubles API. Examples include an
-unsupported type or a method that Doubles cannot intercept. Other examples
+unsupported type or a method that `Doubles` cannot intercept. Other examples
 are a prohibited interaction or a return value without a configured
 result.
 

--- a/docs/api-expectations.md
+++ b/docs/api-expectations.md
@@ -552,8 +552,8 @@ object.
 The throwable can instead be a callback with one typed Throwable
 parameter. Its parameter type specifies the expected throwable class.
 Greenlight gives the caught throwable to the callback after its type
-matches. The callback matches when it returns without an expectation
-failure.
+matches. The callback matches when it returns no value without an
+expectation failure.
 
 The optional `matching:` argument checks the message with a regular
 expression. The `message:` argument checks the exact message. Do not use
@@ -1127,8 +1127,8 @@ object.
 The throwable can instead be a callback with one typed Throwable
 parameter. Its parameter type specifies the expected throwable class.
 Greenlight gives the caught throwable to the callback after its type
-matches. The callback matches when it returns without an expectation
-failure.
+matches. The callback matches when it returns no value without an
+expectation failure.
 
 The optional `matching:` argument checks the message with a regular
 expression. The `message:` argument checks the exact message. Do not use
@@ -1796,8 +1796,8 @@ object.
 The throwable can instead be a callback with one typed Throwable
 parameter. Its parameter type specifies the expected throwable class.
 Greenlight gives the caught throwable to the callback after its type
-matches. The callback matches when it returns without an expectation
-failure.
+matches. The callback matches when it returns no value without an
+expectation failure.
 
 The optional `matching:` argument checks the message with a regular
 expression. The `message:` argument checks the exact message. Do not use
@@ -2580,8 +2580,8 @@ object.
 The throwable can instead be a callback with one typed Throwable
 parameter. Its parameter type specifies the expected throwable class.
 Greenlight gives the caught throwable to the callback after its type
-matches. The callback matches when it returns without an expectation
-failure.
+matches. The callback matches when it returns no value without an
+expectation failure.
 
 The optional `matching:` argument checks the message with a regular
 expression. The `message:` argument checks the exact message. Do not use

--- a/docs/api-expectations.md
+++ b/docs/api-expectations.md
@@ -88,7 +88,7 @@ PHPDoc:
 ### `toEqual()`
 
 Passes when the subject and expected value satisfy the rules for deep
-equality on this class.
+equality in the `Expectation` class description.
 
 ```php
 public function toEqual(mixed $expected): Expectation
@@ -299,8 +299,8 @@ PHPDoc:
 ### `toContain()`
 
 For a string subject, checks for a string needle. For an iterable
-subject, checks for the value by identity (===). The check consumes a
-`Traversable` subject.
+subject, checks for the value by identity (===). Iteration stops at the
+first match or the end of the subject.
 
 ```php
 public function toContain(mixed $needle): Expectation
@@ -315,8 +315,8 @@ PHPDoc:
 
 ### `toHaveCount()`
 
-The subject must be `Countable` or `Traversable`. The count consumes a
-`Traversable` subject.
+Accepts an array, `Countable`, or `Traversable` subject. Uses `count()`
+for arrays and `Countable` objects. Otherwise, consumes the iterator.
 
 ```php
 public function toHaveCount(int $count): Expectation
@@ -332,8 +332,9 @@ PHPDoc:
 ### `toBeEmpty()`
 
 Passes when the subject is an empty string or contains no elements.
-The subject must be a string, array, `Countable`, or iterable. The check
-consumes a `Traversable` subject.
+Accepts a string, array, `Countable`, or `Traversable` subject. Uses
+`count()` for arrays and `Countable` objects. For other `Traversable`
+objects, consumes the iterator.
 
 ```php
 public function toBeEmpty(): Expectation
@@ -344,7 +345,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L463)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L464)
 
 ### `toHaveLength()`
 
@@ -361,7 +362,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L490)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L491)
 
 ### `toHaveKey()`
 
@@ -378,7 +379,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L521)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L522)
 
 ### `toContainSubset()`
 
@@ -397,7 +398,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L553)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L554)
 
 ### `toBeGreaterThan()`
 
@@ -410,7 +411,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L583)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L584)
 
 ### `toBeGreaterThanOrEqual()`
 
@@ -423,7 +424,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L597)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L598)
 
 ### `toBeLessThan()`
 
@@ -436,7 +437,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L611)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L612)
 
 ### `toBeLessThanOrEqual()`
 
@@ -449,7 +450,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L625)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L626)
 
 ### `toBeWithin()`
 
@@ -465,7 +466,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L642)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L643)
 
 ### `toMatch()`
 
@@ -479,7 +480,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L669)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L670)
 
 ### `toStartWith()`
 
@@ -492,7 +493,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L685)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L686)
 
 ### `toEndWith()`
 
@@ -505,7 +506,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L699)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L700)
 
 ### `toBeJson()`
 
@@ -521,7 +522,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L716)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L717)
 
 ### `toMatchJson()`
 
@@ -539,7 +540,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L735)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L736)
 
 ### `toThrow()`
 
@@ -578,7 +579,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L794)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L795)
 
 ## `EventuallyExpectation`
 
@@ -662,7 +663,7 @@ PHPDoc:
 ### `toEqual()`
 
 Passes when the subject and expected value satisfy the rules for deep
-equality on this class.
+equality in the `Expectation` class description.
 
 ```php
 public function toEqual(mixed $expected): Expectation
@@ -873,8 +874,8 @@ PHPDoc:
 ### `toContain()`
 
 For a string subject, checks for a string needle. For an iterable
-subject, checks for the value by identity (===). The check consumes a
-`Traversable` subject.
+subject, checks for the value by identity (===). Iteration stops at the
+first match or the end of the subject.
 
 ```php
 public function toContain(mixed $needle): Expectation
@@ -889,8 +890,8 @@ PHPDoc:
 
 ### `toHaveCount()`
 
-The subject must be `Countable` or `Traversable`. The count consumes a
-`Traversable` subject.
+Accepts an array, `Countable`, or `Traversable` subject. Uses `count()`
+for arrays and `Countable` objects. Otherwise, consumes the iterator.
 
 ```php
 public function toHaveCount(int $count): Expectation
@@ -906,8 +907,9 @@ PHPDoc:
 ### `toBeEmpty()`
 
 Passes when the subject is an empty string or contains no elements.
-The subject must be a string, array, `Countable`, or iterable. The check
-consumes a `Traversable` subject.
+Accepts a string, array, `Countable`, or `Traversable` subject. Uses
+`count()` for arrays and `Countable` objects. For other `Traversable`
+objects, consumes the iterator.
 
 ```php
 public function toBeEmpty(): Expectation
@@ -918,7 +920,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L463)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L464)
 
 ### `toHaveLength()`
 
@@ -935,7 +937,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L490)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L491)
 
 ### `toHaveKey()`
 
@@ -952,7 +954,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L521)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L522)
 
 ### `toContainSubset()`
 
@@ -971,7 +973,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L553)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L554)
 
 ### `toBeGreaterThan()`
 
@@ -984,7 +986,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L583)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L584)
 
 ### `toBeGreaterThanOrEqual()`
 
@@ -997,7 +999,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L597)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L598)
 
 ### `toBeLessThan()`
 
@@ -1010,7 +1012,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L611)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L612)
 
 ### `toBeLessThanOrEqual()`
 
@@ -1023,7 +1025,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L625)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L626)
 
 ### `toBeWithin()`
 
@@ -1039,7 +1041,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L642)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L643)
 
 ### `toMatch()`
 
@@ -1053,7 +1055,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L669)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L670)
 
 ### `toStartWith()`
 
@@ -1066,7 +1068,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L685)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L686)
 
 ### `toEndWith()`
 
@@ -1079,7 +1081,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L699)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L700)
 
 ### `toBeJson()`
 
@@ -1095,7 +1097,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L716)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L717)
 
 ### `toMatchJson()`
 
@@ -1113,7 +1115,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L735)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L736)
 
 ### `toThrow()`
 
@@ -1152,16 +1154,16 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L794)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L795)
 
 ## `Expect`
 
 Namespace: `Greenlight\Expect`
 
-Extension matchers are worker-local state. `install()` stores the configured
-`ExpectationExtension` list when the worker starts. Each chain from `that()`
-uses a snapshot of this list. The runner changes the list before test
-execution starts. Before `install()` runs, `that()` uses no extensions.
+Creates immediate and temporal expectations.
+
+The worker loads the configured expectation extensions before test execution.
+Each expectation chain uses a snapshot of those extensions.
 
 ```php
 final class Expect
@@ -1330,7 +1332,7 @@ PHPDoc:
 ### `toEqual()`
 
 Passes when the subject and expected value satisfy the rules for deep
-equality on this class.
+equality in the `Expectation` class description.
 
 ```php
 public function toEqual(mixed $expected): self
@@ -1541,8 +1543,8 @@ PHPDoc:
 ### `toContain()`
 
 For a string subject, checks for a string needle. For an iterable
-subject, checks for the value by identity (===). The check consumes a
-`Traversable` subject.
+subject, checks for the value by identity (===). Iteration stops at the
+first match or the end of the subject.
 
 ```php
 public function toContain(mixed $needle): self
@@ -1557,8 +1559,8 @@ PHPDoc:
 
 ### `toHaveCount()`
 
-The subject must be `Countable` or `Traversable`. The count consumes a
-`Traversable` subject.
+Accepts an array, `Countable`, or `Traversable` subject. Uses `count()`
+for arrays and `Countable` objects. Otherwise, consumes the iterator.
 
 ```php
 public function toHaveCount(int $count): self
@@ -1574,8 +1576,9 @@ PHPDoc:
 ### `toBeEmpty()`
 
 Passes when the subject is an empty string or contains no elements.
-The subject must be a string, array, `Countable`, or iterable. The check
-consumes a `Traversable` subject.
+Accepts a string, array, `Countable`, or `Traversable` subject. Uses
+`count()` for arrays and `Countable` objects. For other `Traversable`
+objects, consumes the iterator.
 
 ```php
 public function toBeEmpty(): self
@@ -1586,7 +1589,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L463)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L464)
 
 ### `toHaveLength()`
 
@@ -1603,7 +1606,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L490)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L491)
 
 ### `toHaveKey()`
 
@@ -1620,7 +1623,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L521)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L522)
 
 ### `toContainSubset()`
 
@@ -1639,7 +1642,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L553)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L554)
 
 ### `toBeGreaterThan()`
 
@@ -1652,7 +1655,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L583)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L584)
 
 ### `toBeGreaterThanOrEqual()`
 
@@ -1665,7 +1668,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L597)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L598)
 
 ### `toBeLessThan()`
 
@@ -1678,7 +1681,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L611)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L612)
 
 ### `toBeLessThanOrEqual()`
 
@@ -1691,7 +1694,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L625)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L626)
 
 ### `toBeWithin()`
 
@@ -1707,7 +1710,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L642)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L643)
 
 ### `toMatch()`
 
@@ -1721,7 +1724,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L669)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L670)
 
 ### `toStartWith()`
 
@@ -1734,7 +1737,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L685)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L686)
 
 ### `toEndWith()`
 
@@ -1747,7 +1750,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L699)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L700)
 
 ### `toBeJson()`
 
@@ -1763,7 +1766,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L716)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L717)
 
 ### `toMatchJson()`
 
@@ -1781,7 +1784,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L735)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L736)
 
 ### `toThrow()`
 
@@ -1820,7 +1823,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L794)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L795)
 
 ## `ExpectationExtension`
 
@@ -2113,7 +2116,7 @@ PHPDoc:
 ### `toEqual()`
 
 Passes when the subject and expected value satisfy the rules for deep
-equality on this class.
+equality in the `Expectation` class description.
 
 ```php
 public function toEqual(mixed $expected): Expectation
@@ -2324,8 +2327,8 @@ PHPDoc:
 ### `toContain()`
 
 For a string subject, checks for a string needle. For an iterable
-subject, checks for the value by identity (===). The check consumes a
-`Traversable` subject.
+subject, checks for the value by identity (===). Iteration stops at the
+first match or the end of the subject.
 
 ```php
 public function toContain(mixed $needle): Expectation
@@ -2340,8 +2343,8 @@ PHPDoc:
 
 ### `toHaveCount()`
 
-The subject must be `Countable` or `Traversable`. The count consumes a
-`Traversable` subject.
+Accepts an array, `Countable`, or `Traversable` subject. Uses `count()`
+for arrays and `Countable` objects. Otherwise, consumes the iterator.
 
 ```php
 public function toHaveCount(int $count): Expectation
@@ -2357,8 +2360,9 @@ PHPDoc:
 ### `toBeEmpty()`
 
 Passes when the subject is an empty string or contains no elements.
-The subject must be a string, array, `Countable`, or iterable. The check
-consumes a `Traversable` subject.
+Accepts a string, array, `Countable`, or `Traversable` subject. Uses
+`count()` for arrays and `Countable` objects. For other `Traversable`
+objects, consumes the iterator.
 
 ```php
 public function toBeEmpty(): Expectation
@@ -2369,7 +2373,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L463)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L464)
 
 ### `toHaveLength()`
 
@@ -2386,7 +2390,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L490)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L491)
 
 ### `toHaveKey()`
 
@@ -2403,7 +2407,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L521)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L522)
 
 ### `toContainSubset()`
 
@@ -2422,7 +2426,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L553)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L554)
 
 ### `toBeGreaterThan()`
 
@@ -2435,7 +2439,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L583)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L584)
 
 ### `toBeGreaterThanOrEqual()`
 
@@ -2448,7 +2452,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L597)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L598)
 
 ### `toBeLessThan()`
 
@@ -2461,7 +2465,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L611)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L612)
 
 ### `toBeLessThanOrEqual()`
 
@@ -2474,7 +2478,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L625)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L626)
 
 ### `toBeWithin()`
 
@@ -2490,7 +2494,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L642)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L643)
 
 ### `toMatch()`
 
@@ -2504,7 +2508,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L669)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L670)
 
 ### `toStartWith()`
 
@@ -2517,7 +2521,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L685)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L686)
 
 ### `toEndWith()`
 
@@ -2530,7 +2534,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L699)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L700)
 
 ### `toBeJson()`
 
@@ -2546,7 +2550,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L716)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L717)
 
 ### `toMatchJson()`
 
@@ -2564,7 +2568,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L735)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L736)
 
 ### `toThrow()`
 
@@ -2603,4 +2607,4 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L794)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L795)

--- a/docs/api-harness.md
+++ b/docs/api-harness.md
@@ -35,7 +35,7 @@ Namespace: `Greenlight\Harness`
 
 Defines the lifetime of a harness service.
 
-PerWorker matches the physical worker lifetime.
+`PerWorker` matches the physical worker lifetime.
 
 ```php
 enum Scope: string

--- a/docs/api-plugins.md
+++ b/docs/api-plugins.md
@@ -562,15 +562,16 @@ PHPDoc:
 
 Namespace: `Greenlight\Plugin`
 
-`service()` is available during `beforeTest()` and the test. The per-test
-service scope closes before `afterTest()`, so `service()` throws during
-`afterTest()`.
+Supplies the test instance, identity, attachments, and service access to plugins.
+
+The per-test service scope closes before `afterTest()`. A `service()` call
+for a per-test service then throws. Other service scopes remain available.
 
 ```php
 final readonly class TestContext
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L21)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L22)
 
 ### `$attachments`
 
@@ -578,7 +579,7 @@ final readonly class TestContext
 public Attachments $attachments;
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L23)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L24)
 
 ### `$instance`
 
@@ -586,7 +587,7 @@ public Attachments $attachments;
 public object $instance
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L27)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L28)
 
 ### `$id`
 
@@ -594,7 +595,7 @@ public object $instance
 public TestId $id
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L28)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L29)
 
 ### `$definition`
 
@@ -602,7 +603,7 @@ public TestId $id
 public TestDefinition $definition
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L29)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L30)
 
 ### `service()`
 
@@ -617,7 +618,7 @@ PHPDoc:
 - `@return T`
 - `@throws ServiceResolutionFailed when a service resolver cannot supply a valid service`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L45)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L46)
 
 ### `skip()`
 
@@ -633,7 +634,7 @@ PHPDoc:
 - `@param non-empty-string $reason`
 - `@throws SkipTest`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L64)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L65)
 
 ## `TestPlan`
 

--- a/docs/api-results.md
+++ b/docs/api-results.md
@@ -701,7 +701,7 @@ PHPDoc:
 
 Namespace: `Greenlight\Result`
 
-Greenlight records at most 32 stack frames when it creates this value.
+Contains a throwable's class, message, source location, and stack trace.
 
 ```php
 final readonly class ThrowableDetail
@@ -782,8 +782,10 @@ PHPDoc:
 
 ### `fromThrowable()`
 
+Records at most 32 stack frames. Adds a truncation marker if more frames exist.
+
 ```php
 public static function fromThrowable(\Throwable $throwable): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/ThrowableDetail.php#L60)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/ThrowableDetail.php#L63)

--- a/docs/api-results.md
+++ b/docs/api-results.md
@@ -10,8 +10,8 @@ These signatures are the public API.
 
 Namespace: `Greenlight\Result`
 
-When output is too long, Greenlight keeps the first part. This part usually
-identifies the cause. The last part usually contains repeated information.
+Contains standard output, diagnostics, and truncation flags for one attempt.
+When output exceeds the capture limit, Greenlight keeps the first part.
 
 Greenlight converts captured standard output to valid UTF-8 before it adds
 the output to a test result.

--- a/docs/api-sandboxes.md
+++ b/docs/api-sandboxes.md
@@ -162,8 +162,8 @@ PHPDoc:
 
 Namespace: `Greenlight\Sandbox`
 
-Creates one root directory on first use. A path inside it cannot escape the
-root.
+Creates one root directory on first use. `subdirectory()` rejects traversal
+segments and symbolic links in the requested path.
 Disposal removes a symbolic link and leaves its target unchanged.
 
 ```php

--- a/docs/api-test-contracts.md
+++ b/docs/api-test-contracts.md
@@ -14,14 +14,15 @@ Stores cleanup callbacks for one test attempt. Greenlight runs the callbacks
 in reverse registration order after the `After` hooks. Per-test service
 disposal starts after the callbacks finish.
 
-Greenlight runs all callbacks if one fails. A cleanup failure errors a passed
-or skipped test. It does not replace an earlier test failure or error.
+Greenlight runs all callbacks if one fails. An expectation failure during
+cleanup fails a passed or skipped test. Other cleanup exceptions cause an
+errored result. Cleanup does not replace an earlier test failure or error.
 
 ```php
 final class Cleanup
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Test/Cleanup.php#L15)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Test/Cleanup.php#L16)
 
 ### `defer()`
 
@@ -39,7 +40,7 @@ PHPDoc:
 - `@param \Closure(): TReturn $cleanup`
 - `@throws \LogicException If test cleanup has started.`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Test/Cleanup.php#L33)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Test/Cleanup.php#L34)
 
 ## `DataProvider`
 

--- a/src/Config/GreenlightConfig.php
+++ b/src/Config/GreenlightConfig.php
@@ -255,7 +255,7 @@ final class GreenlightConfig
 
     /**
      * Sets directories for persistent state, caches, generated code, and
-     * temporary run data. Multiple calls use the same builder.
+     * temporary run data. Each call starts with the current configuration.
      *
      * @param callable(StorageBuilder): mixed $configurator
      */
@@ -270,8 +270,8 @@ final class GreenlightConfig
 
     /**
      * Fails an otherwise passed test if captured output contains a
-     * deprecation. The diagnostic becomes the failure detail. Use a regular
-     * expression to exempt known dependency messages.
+     * deprecation. The diagnostic becomes the failure detail. Use
+     * `ignoreDeprecationsMatching()` to exempt known dependency messages.
      *
      * @see self::ignoreDeprecationsMatching()
      */

--- a/src/Coverage/CoverageMap.php
+++ b/src/Coverage/CoverageMap.php
@@ -9,16 +9,10 @@ use Greenlight\Internal\Wire\Wire;
 use Greenlight\Internal\Wire\WireCommunicationFailed;
 
 /**
- * The map sorts files by path. Thus, identical coverage always has identical
- * serialized data.
+ * Contains line coverage for source files in path order.
  *
- * `merge()` is commutative, associative, and idempotent. Thus, the orchestrator
- * can merge worker payloads in all arrival orders. It does not require a final
- * merge operation at the end of a run.
- *
- * The wire payload is compact. Under "files", each path maps to a two-item
- * list. The covered line list is first. The uncovered line list is second.
- *
+ * `merge()` combines covered and uncovered lines for each file. Covered lines
+ * take priority. Merge order and repeated inputs do not change the result.
  */
 final readonly class CoverageMap
 {

--- a/src/Doubles/Argument.php
+++ b/src/Doubles/Argument.php
@@ -101,7 +101,7 @@ final class Argument
     }
 
     /**
-     * This matcher uses the same deep equality as `Expect::toEqual()`.
+     * This matcher uses the same deep equality as `Expectation::toEqual()`.
      * Use it when `with()` must compare by value instead of identity.
      *
      * @template T

--- a/src/Doubles/InvalidDoubleUsage.php
+++ b/src/Doubles/InvalidDoubleUsage.php
@@ -6,7 +6,7 @@ namespace Greenlight\Doubles;
 
 /**
  * Identifies incorrect use of the doubles API. Examples include an
- * unsupported type or a method that Doubles cannot intercept. Other examples
+ * unsupported type or a method that `Doubles` cannot intercept. Other examples
  * are a prohibited interaction or a return value without a configured
  * result.
  *

--- a/src/Expect/Expect.php
+++ b/src/Expect/Expect.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace Greenlight\Expect;
 
 /**
- * Extension matchers are worker-local state. `install()` stores the configured
- * `ExpectationExtension` list when the worker starts. Each chain from `that()`
- * uses a snapshot of this list. The runner changes the list before test
- * execution starts. Before `install()` runs, `that()` uses no extensions.
+ * Creates immediate and temporal expectations.
+ *
+ * The worker loads the configured expectation extensions before test execution.
+ * Each expectation chain uses a snapshot of those extensions.
  */
 final class Expect
 {

--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -772,8 +772,8 @@ final class Expectation
      * The throwable can instead be a callback with one typed Throwable
      * parameter. Its parameter type specifies the expected throwable class.
      * Greenlight gives the caught throwable to the callback after its type
-     * matches. The callback matches when it returns without an expectation
-     * failure.
+     * matches. The callback matches when it returns no value without an
+     * expectation failure.
      *
      * The optional `matching:` argument checks the message with a regular
      * expression. The `message:` argument checks the exact message. Do not use

--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -149,7 +149,7 @@ final class Expectation
 
     /**
      * Passes when the subject and expected value satisfy the rules for deep
-     * equality on this class.
+     * equality in the `Expectation` class description.
      *
      * @return self<T>
      *
@@ -374,8 +374,8 @@ final class Expectation
 
     /**
      * For a string subject, checks for a string needle. For an iterable
-     * subject, checks for the value by identity (===). The check consumes a
-     * `Traversable` subject.
+     * subject, checks for the value by identity (===). Iteration stops at the
+     * first match or the end of the subject.
      *
      * @return self<T>
      *
@@ -423,8 +423,8 @@ final class Expectation
     }
 
     /**
-     * The subject must be `Countable` or `Traversable`. The count consumes a
-     * `Traversable` subject.
+     * Accepts an array, `Countable`, or `Traversable` subject. Uses `count()`
+     * for arrays and `Countable` objects. Otherwise, consumes the iterator.
      *
      * @return self<T>
      *
@@ -453,8 +453,9 @@ final class Expectation
 
     /**
      * Passes when the subject is an empty string or contains no elements.
-     * The subject must be a string, array, `Countable`, or iterable. The check
-     * consumes a `Traversable` subject.
+     * Accepts a string, array, `Countable`, or `Traversable` subject. Uses
+     * `count()` for arrays and `Countable` objects. For other `Traversable`
+     * objects, consumes the iterator.
      *
      * @return self<T>
      *

--- a/src/Harness/Scope.php
+++ b/src/Harness/Scope.php
@@ -7,7 +7,7 @@ namespace Greenlight\Harness;
 /**
  * Defines the lifetime of a harness service.
  *
- * PerWorker matches the physical worker lifetime.
+ * `PerWorker` matches the physical worker lifetime.
  */
 enum Scope: string
 {

--- a/src/Plugin/TestContext.php
+++ b/src/Plugin/TestContext.php
@@ -14,9 +14,10 @@ use Greenlight\Test\TestDefinition;
 use Greenlight\Test\TestId;
 
 /**
- * `service()` is available during `beforeTest()` and the test. The per-test
- * service scope closes before `afterTest()`, so `service()` throws during
- * `afterTest()`.
+ * Supplies the test instance, identity, attachments, and service access to plugins.
+ *
+ * The per-test service scope closes before `afterTest()`. A `service()` call
+ * for a per-test service then throws. Other service scopes remain available.
  */
 final readonly class TestContext
 {

--- a/src/Result/CapturedOutput.php
+++ b/src/Result/CapturedOutput.php
@@ -9,8 +9,8 @@ use Greenlight\Internal\Wire\Wire;
 use Greenlight\Internal\Wire\WireCommunicationFailed;
 
 /**
- * When output is too long, Greenlight keeps the first part. This part usually
- * identifies the cause. The last part usually contains repeated information.
+ * Contains standard output, diagnostics, and truncation flags for one attempt.
+ * When output exceeds the capture limit, Greenlight keeps the first part.
  *
  * Greenlight converts captured standard output to valid UTF-8 before it adds
  * the output to a test result.

--- a/src/Result/ThrowableDetail.php
+++ b/src/Result/ThrowableDetail.php
@@ -8,7 +8,7 @@ use Greenlight\Internal\Text\Utf8;
 use Greenlight\Internal\Wire\Wire;
 use Greenlight\Internal\Wire\WireCommunicationFailed;
 
-/** Greenlight records at most 32 stack frames when it creates this value. */
+/** Contains a throwable's class, message, source location, and stack trace. */
 final readonly class ThrowableDetail
 {
     private const int MAX_STACK_FRAMES = 32;
@@ -57,6 +57,9 @@ final readonly class ThrowableDetail
         $this->line = $line;
     }
 
+    /**
+     * Records at most 32 stack frames. Adds a truncation marker if more frames exist.
+     */
     public static function fromThrowable(\Throwable $throwable): self
     {
         $frames = [];

--- a/src/Sandbox/TemporaryDirectory.php
+++ b/src/Sandbox/TemporaryDirectory.php
@@ -8,8 +8,8 @@ use Greenlight\Harness\Disposable;
 use Greenlight\Internal\Php\ErrorTrap;
 
 /**
- * Creates one root directory on first use. A path inside it cannot escape the
- * root.
+ * Creates one root directory on first use. `subdirectory()` rejects traversal
+ * segments and symbolic links in the requested path.
  * Disposal removes a symbolic link and leaves its target unchanged.
  */
 final class TemporaryDirectory implements Disposable

--- a/src/Test/Cleanup.php
+++ b/src/Test/Cleanup.php
@@ -9,8 +9,9 @@ namespace Greenlight\Test;
  * in reverse registration order after the `After` hooks. Per-test service
  * disposal starts after the callbacks finish.
  *
- * Greenlight runs all callbacks if one fails. A cleanup failure errors a passed
- * or skipped test. It does not replace an earlier test failure or error.
+ * Greenlight runs all callbacks if one fails. An expectation failure during
+ * cleanup fails a passed or skipped test. Other cleanup exceptions cause an
+ * errored result. Cleanup does not replace an earlier test failure or error.
  */
 final class Cleanup
 {


### PR DESCRIPTION
The API reference contains behavior descriptions that do not match the implementation. It describes deprecation filters as regular expressions, excludes arrays from `toHaveCount()`, and says `toContain()` consumes the iterator. It also says all service access stops before after-test callbacks and treats every cleanup failure as an error.

Correct the maintained PHPDoc and regenerate the API pages. Clarify matcher inputs, iteration, throwable callbacks and exception outcomes. Explain that only the per-test service scope closes before after-test callbacks. Correct the nonexistent `Expect::toEqual()` reference, scope the stack-frame limit to `fromThrowable()`, and remove unsupported capture and sandbox guarantees. Explain public coverage and expectation behavior without internal operations.

The corrections follow `Wildcard::matches()`, `Expectation`, `GreenlightConfig::storage()`, `ThrowableDetail::fromThrowable()`, `HarnessScopes::containerFor()`, and the cleanup branch in `TestExecutor`. Public signatures and runtime behavior are unchanged.
