### PR TITLE
docs: correct architecture and contributor reference details

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -81,7 +81,7 @@ public.
 | `Plugin` | Public capability interfaces and immutable plugin factory definitions | Artifact, coverage, event, harness, fixture, reporting, result, and test contracts |
 | `Doubles`, `Sandbox` | Test-author tools that use harness scopes | Lower test-author modules |
 | `Discovery` | PHP declaration discovery, metadata, and caching | Public contracts, `Discovery/Plan`, `Test/DataSet`, internal utilities, and `Attribute` |
-| `Discovery/Plan` | Immutable execution plans, ordering, and sharding | `Attribute`, `Test`, and `Internal/Wire` |
+| `Discovery/Plan` | Immutable execution plans, ordering, and sharding | `Attribute`, `Plugin`, `Test`, and `Internal/Wire` |
 | `Coverage` | Line-coverage values and errors | `Internal/Wire` |
 | `Coverage/Collection` | Coverage drivers and raw coverage collection | `Coverage` |
 | `Coverage/Diff` | Baseline coverage comparison | `Coverage` |
@@ -112,8 +112,11 @@ public.
 
 Dependencies point from modules near the bottom of the table to modules near
 the top. Modules near the top do not depend on the `Execution` or `Cli` modules.
-Public contract modules **MUST NOT** know about discovery, reporters, or integrations.
-Internal utility modules **MUST NOT** depend on public contract modules.
+
+Public contract modules do not depend on discovery or integration implementations.
+`Plugin` depends on public reporting contracts. `Internal/Event` depends on
+`Event` to encode and decode events. Other internal utility modules do not
+depend on public contract modules.
 Reporters **MUST NOT** control execution. Optional integrations **MUST NOT**
 become runtime package dependencies.
 

--- a/docs/architecture/documentation-php-examples.md
+++ b/docs/architecture/documentation-php-examples.md
@@ -5,8 +5,8 @@ Rector. The check uses generated files because both tools operate most reliably
 on PHP files and projects. It does not change the documentation or extend the
 tools.
 
-The generated workspace is disposable. It is in `build/docs-php`, and its
-contents MUST NOT be committed. `composer docs:php:check` replaces this
+The generated workspace is disposable. It is in `build/docs-php`. Do not commit
+its contents. `composer docs:php:check` replaces this
 directory on each run.
 
 ## Select an example
@@ -18,13 +18,13 @@ that invalid and unknown fields cause an error.
 <!-- php-example {"example":"getting-started","file":"src/Greeter.php","mode":"file","tools":["phpstan","rector"]} -->
 ```
 
-`example` identifies a virtual project. Multiple fences MAY supply different
+`example` identifies a virtual project. Multiple fences can supply different
 files to the same project. This method lets one example define a class in one
-fence and use it in another fence. File paths MUST be unique within the project,
-and all files in one project MUST select the same tools.
+fence and use it in another fence. Use unique file paths within each project. Select the same tools for all files
+in one project.
 
-`file` is a stable path within the virtual project. It MUST end in `.php` and
-MUST NOT contain an absolute or parent path. Do not derive this value from the
+`file` is a stable path within the virtual project. Use a `.php` extension. Do not use an
+absolute path or a parent path. Do not derive this value from the
 position of the fence. Stable names keep diagnostics and tool caches useful
 when prose moves.
 
@@ -45,15 +45,15 @@ Use `class-members` for properties or methods that need a class body. The
 extractor puts the members in a synthetic final class. Imports can precede the
 members. The extractor keeps the imports outside the class.
 
-Use `display` only when analysis would make the example less useful. A display
-example MUST give a nonempty `reason` and does not use the other fields. Every
-PHP fence in a manually maintained document MUST have metadata. The command
+Use `display` only when analysis would make the example less useful. Give each display
+example a nonempty `reason`. Do not use the other fields for that example. Add
+metadata to every PHP fence in a manually maintained document. The command
 fails when metadata is absent. Generated reference documents are excluded from
 the inventory because their source generator owns their PHP examples.
 
-Undefined names in an otherwise complete example SHOULD be supplied in another
-file in the same virtual project. A short analysis-only support file MAY be in a
-separate documentation fence. Use a PHPStan inline ignore only when the
+We recommend definitions for otherwise undefined names in another file in the
+same virtual project. You can put a short analysis-only support file in a separate
+documentation fence. Use a PHPStan inline ignore only when the
 undefined name is the behavior that the documentation must show. Use `display`
 for pseudocode, deliberately invalid syntax, or fragments that no small wrapper
 can represent honestly.
@@ -88,8 +88,8 @@ edit into Markdown. Wrappers and indentation make automatic reverse patches
 hard to review, and a change can cross more than one virtual file.
 
 To apply a finding, edit the reported documentation fence and run
-`composer docs:php:check` again. The generated diff MAY be used as a reference,
-but `build/docs-php` is not a source directory.
+`composer docs:php:check` again. You can use the generated diff as a reference.
+Do not edit `build/docs-php` as a source directory.
 
 ## Configuration and CI
 

--- a/docs/architecture/mutation-testing.md
+++ b/docs/architecture/mutation-testing.md
@@ -4,7 +4,7 @@ Status: deferred until Greenlight has a per-test coverage map.
 
 ## Requirement
 
-Infection needs the tests that cover each mutated line.
+The planned Infection adapter needs the tests that cover each mutated line.
 
 Its adapter can then run this loop:
 
@@ -14,8 +14,8 @@ Its adapter can then run this loop:
 4. Run only those tests.
 5. Treat a run with a test failure or test error as a killed mutant.
 
-This process keeps mutation tests within a practical limit. Infection can run
-the complete suite for every mutant, but that integration is too slow.
+This process avoids a complete suite run for each mutant. Greenlight defers an
+adapter that repeats the complete suite until per-test selection is available.
 
 ## Current Greenlight support
 
@@ -60,7 +60,8 @@ The export layer **MUST** then write a format Infection can consume.
 ## Adapter shape
 
 After per-test coverage exists, a small external package can add Infection
-support. The package contains an Infection `TestFrameworkAdapter` and a factory.
+support. The package implements Infection
+[`TestFrameworkAdapter` and `TestFrameworkAdapterFactory`](https://github.com/infection/abstract-testframework-adapter).
 
 The adapter has these responsibilities:
 
@@ -73,5 +74,5 @@ The adapter has these responsibilities:
 
 Defer the adapter until a per-test coverage map exists.
 
-Before that work is complete, the adapter **MUST** run the complete suite for
-each mutant. This process is too slow for a useful Greenlight integration.
+Without per-test coverage, the proposed adapter would run the complete suite for
+each mutant. This does not meet the selected-test execution goal.

--- a/docs/architecture/orchestrator-integration-fixtures.md
+++ b/docs/architecture/orchestrator-integration-fixtures.md
@@ -13,10 +13,11 @@ execution adapter.
 
 The provider instance belongs to the orchestrator. If the same plugin class has
 worker capabilities, those capabilities use a separate instance in each
-worker. Plugin properties do not cross this seam. The provider MUST use
+worker. Plugin properties do not cross this seam. Use
 `IntegrationFixtureContext::expose()` to transfer supported fixture data.
 
-Greenlight provisions one fixture graph per selected run. Each repeat iteration
+Greenlight provisions one fixture graph per nonempty selected run. An empty plan
+emits run lifecycle events without fixture provisioning. Each repeat iteration
 and watch rerun gets a fresh graph. CI shards provision independently because
 Greenlight does not coordinate them across machines.
 
@@ -35,8 +36,8 @@ because PHP converts those map keys to integers.
 `IntegrationFixtureContext::configuredWorkers()` returns the configured worker
 ceiling. `IntegrationFixtureContext::channels()` returns the consecutive channel
 numbers that the selected plan can use. Selected work and resource capacity can
-reduce the number of channels below the ceiling. Providers MUST create overlays
-only for these numbers. Replacement workers reuse released numbers.
+reduce the number of channels below the ceiling. Create overlays only for these
+numbers. Replacement workers reuse released numbers.
 
 Call `IntegrationFixtureContext::defer()` as soon as the provisioner acquires a
 resource. The callback will then run even if the rest of the provisioner fails.
@@ -64,7 +65,7 @@ stderr. A worker receives only its own channel overlay.
 ## Worker bootstrap
 
 After a worker sends `hello`, the orchestrator replies with a `bootstrap`
-message that contains the channel, config path, and resources. The worker loads
+message that contains the channel, configuration path, and resources. The worker loads
 its plugin definitions and creates its worker-side instances. It calls
 `WorkerBootstrapSubscriber`, builds the harness service scopes, and then replies
 with `ready`.

--- a/docs/architecture/test-manifest.md
+++ b/docs/architecture/test-manifest.md
@@ -30,11 +30,14 @@ Each test entry has these identity and source fields:
 - `dataSetKey`: The normalized data-set key, or `null`.
 - `source.file`: The absolute declaring file.
 - `source.line`: The test method declaration line.
-- `groups`: The selected test groups.
+- `groups`: All groups declared for the test, sorted by name.
 - `suites`: Each configured suite whose path contains the test class file.
 
 A labeled data row or provider key keeps its printable label in `dataSetKey`.
 An integer key uses `#<value>`. Greenlight hashes an empty or nonprintable key.
+
+Group selection filters tests. It does not remove other groups from a selected
+test entry.
 
 Each entry also contains this execution metadata:
 


### PR DESCRIPTION
The architecture summary omitted a permitted plan dependency and made a blanket internal-module claim that contradicted deptrac.yaml. The manifest guide described only selected groups, although TestManifest exports every declared group. The fixture guide omitted the empty-plan path in RunCoordinator.

Correct these claims against the dependency rules, TestManifest::test(), and RunCoordinator::run(). Rewrite contributor instructions for PHP examples as direct requirements, recommendations, and options. Preserve formal protocol and schema requirements.

The mutation adapter decision now states its selected-test execution goal instead of asserting unmeasured performance. Its interface names link to the official Infection adapter repository.
