### PR TITLE
fix(docs): correct integration examples and external links

### DIFF
--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -154,6 +154,15 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-progress --prefer-dist
+
       - name: Restore Greenlight run state
         uses: actions/cache/restore@v6
         with:

--- a/docs/gitlab-ci.md
+++ b/docs/gitlab-ci.md
@@ -111,7 +111,8 @@ and [parallel job variables](https://docs.gitlab.com/ci/variables/predefined_var
 ## Add coverage annotations
 
 Greenlight can write the Cobertura report that GitLab uses for merge request
-diff annotations. Add this configuration to `greenlight.php`:
+diff annotations. Enable PCOV or Xdebug coverage mode in the test job. Add this
+configuration to `greenlight.php`:
 
 <!-- php-example {"mode":"display","reason":"Shows a configuration call after omitted calls."} -->
 ```php
@@ -119,6 +120,7 @@ return GreenlightConfig::create()
     // ...
     ->coverage(fn ($coverage) => $coverage
         ->include('src')
+        ->requireDriver()
         ->export('cobertura', 'build/coverage/cobertura.xml'));
 ```
 

--- a/docs/hyperf.md
+++ b/docs/hyperf.md
@@ -11,7 +11,7 @@ Swow engine.
 Install the Hyperf framework and dependency injector in the application:
 
 ```console
-composer require hyperf/framework:^3.2 hyperf/di:^3.2
+composer require hyperf/framework:~3.2.0 hyperf/di:~3.2.0
 ```
 
 Enable the Swoole and pcntl extensions for the PHP command that runs
@@ -168,7 +168,7 @@ available only during the current test attempt.
 Hyperf does not supply one reset operation for all application services. The
 application keeps request state in coroutine context or resets that state after
 each attempt. See Hyperf's
-[coroutine guidance](https://hyperf.wiki/3.1/#/en/coroutine).
+[coroutine guidance](https://github.com/hyperf/hyperf/blob/3.2/docs/en/coroutine.md).
 
 Use `reset:` to reset project state after each attempt. Use
 `dispose:` for resources that belong to the selected container lifetime:

--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -33,7 +33,7 @@ new LaravelPlugin(static fn(): Application => Application::configure(basePath: _
     ->create());
 ```
 
-A custom factory **MUST** return an application that binds
+For a custom factory, return an application that binds
 `Illuminate\Contracts\Console\Kernel` to an implementation of that interface.
 `Application::configure(...)->create()` registers this binding.
 
@@ -178,9 +178,9 @@ return GreenlightConfig::create()
     ->resourceLimit('payments-sandbox', 2);
 ```
 
-The limit controls how many classes that require this resource can run. It does
-not choose a service instance, and it does not coordinate another Greenlight
-process or CI shard. See [configuration](configuration.md) for the complete
+The limit controls how many assignments that require this resource can run. It
+does not choose a service instance or coordinate another Greenlight process or
+CI shard. See [configuration](configuration.md) for the complete
 resource rules.
 
 ## Doubles and the container

--- a/docs/psr15.md
+++ b/docs/psr15.md
@@ -42,28 +42,39 @@ handler from the factory.
 
 [Mezzio](https://docs.mezzio.dev/mezzio/) is a framework for PSR-15 middleware
 applications. A Mezzio `Application` implements `RequestHandlerInterface`.
-Return the application from the factory:
+Create `bootstrap/http.php` for the factory in the setup example. Load the
+container, middleware pipeline, and routes, then return the application:
 
 <!-- php-example {"example":"psr15-example-02","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Mezzio\Application;
+use Mezzio\MiddlewareFactory;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Server\RequestHandlerInterface;
 
-return static function (): RequestHandlerInterface {
-    /** @var ContainerInterface $container */
-    $container = require __DIR__ . '/config/container.php';
-    $application = $container->get(Application::class);
+/** @var ContainerInterface $container */
+$container = require __DIR__ . '/../config/container.php';
+$application = $container->get(Application::class);
+$middlewareFactory = $container->get(MiddlewareFactory::class);
 
-    if (!$application instanceof RequestHandlerInterface) {
-        throw new \RuntimeException('The application service is not a PSR-15 request handler.');
-    }
+if (!$application instanceof Application) {
+    throw new \RuntimeException('The application service is not a Mezzio application.');
+}
 
-    return $application;
-};
+if (!$middlewareFactory instanceof MiddlewareFactory) {
+    throw new \RuntimeException('The middleware factory service has an incorrect type.');
+}
+
+(require __DIR__ . '/../config/pipeline.php')($application, $middlewareFactory, $container);
+(require __DIR__ . '/../config/routes.php')($application, $middlewareFactory, $container);
+
+return $application;
 ```
 
-This factory uses the PSR-11 container to get the Mezzio request handler.
+The Mezzio skeleton keeps pipeline and route setup outside the container.
+Without these steps, the handler cannot dispatch application routes. See the
+[Mezzio quick start](https://docs.mezzio.dev/mezzio/v3/getting-started/quick-start/).
+
+This bootstrap file returns the handler that the plugin factory expects.
 `Psr15Plugin` does not supply container services to test constructors.
 
 If tests need application services, also register the

--- a/docs/symfony.md
+++ b/docs/symfony.md
@@ -136,8 +136,12 @@ doctrine:
         dbname: 'app_test_%env(default:fallback_channel:GREENLIGHT_CHANNEL)%'
 
 parameters:
-    env(fallback_channel): '1'
+    fallback_channel: '1'
 ```
+
+The `default:` processor reads the `fallback_channel` container parameter when
+`GREENLIGHT_CHANNEL` is absent. See the Symfony
+[environment variable processors](https://symfony.com/doc/current/configuration/env_var_processors.html).
 
 The same pattern works for cache directories, upload paths, message transport
 names, and similar resources.

--- a/website/package.json
+++ b/website/package.json
@@ -8,8 +8,9 @@
   "scripts": {
     "api:check": "node --test scripts/generate-api-reference.test.mjs && node scripts/generate-api-reference.mjs --check",
     "api:generate": "node scripts/generate-api-reference.mjs",
-    "build": "npm run api:check && astro build --force && pagefind --site dist --output-subdir _pagefind && node scripts/check-built-site.mjs",
-    "check": "npm run api:check && astro check && astro build --force && pagefind --site dist --output-subdir _pagefind && node scripts/check-built-site.mjs && npm run test:browser",
+    "build": "npm run api:check && npm run test:links && astro build --force && pagefind --site dist --output-subdir _pagefind && node scripts/check-built-site.mjs",
+    "check": "npm run api:check && npm run test:links && astro check && astro build --force && pagefind --site dist --output-subdir _pagefind && node scripts/check-built-site.mjs && npm run test:browser",
+    "test:links": "node --test scripts/remark-documentation-links.test.mjs",
     "test:browser": "node --test scripts/docs-navigation.test.mjs",
     "dev": "astro dev",
     "preview": "astro preview"

--- a/website/scripts/remark-documentation-links.test.mjs
+++ b/website/scripts/remark-documentation-links.test.mjs
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { rewriteDocumentationLinks } from '../src/lib/remark-documentation-links.mjs';
+
+function transform(url) {
+  const link = { type: 'link', url, children: [] };
+  const tree = { type: 'root', children: [{ type: 'paragraph', children: [link] }] };
+  rewriteDocumentationLinks({ base: '/greenlight' })(tree);
+  return link.url;
+}
+
+test('external Markdown links retain their complete URL', () => {
+  const urls = [
+    'https://github.com/hyperf/hyperf/blob/3.2/docs/en/coroutine.md',
+    'https://example.com/guide.md?plain=1#setup',
+    'http://example.com/guide.md',
+    '//example.com/guide.md#setup',
+    'custom+docs://example.com/guide.md',
+  ];
+
+  for (const url of urls) {
+    assert.equal(transform(url), url);
+  }
+});
+
+test('relative guide links resolve to website pages and retain fragments', () => {
+  assert.equal(transform('configuration.md#workers'), '/greenlight/docs/configuration/#workers');
+  assert.equal(transform('./getting-started.md'), '/greenlight/docs/getting-started/');
+});
+
+test('architecture links resolve to repository sources', () => {
+  assert.equal(
+    transform('architecture/jsonl.md#events'),
+    'https://github.com/ben-challis/greenlight/blob/main/docs/architecture/jsonl.md#events',
+  );
+});

--- a/website/src/lib/remark-documentation-links.mjs
+++ b/website/src/lib/remark-documentation-links.mjs
@@ -19,6 +19,10 @@ export function rewriteDocumentationLinks(options = {}) {
         return;
       }
 
+      if (/^(?:[a-z][a-z0-9+.-]*:|\/\/)/i.test(node.url)) {
+        return;
+      }
+
       const match = node.url.match(/^([^?#]+)\.md([?#].*)?$/);
 
       if (!match) {


### PR DESCRIPTION
The integration API says a per-test handler factory gives each test a new handler, but a factory can return a shared instance. It also leaves Laravel's default application lifetime unclear.

Document when `HttpHarness` calls a factory and release callback. Explain that callers need a factory that creates a new handler for each test attempt. Clarify Laravel application release and shared-instance options. Use the same channel terminology throughout integration resource descriptions and scope the data claim to the supplied object.

These corrections follow `HttpHarness::handler()` and `dispose()`, `Psr15Plugin` service scopes, `LaravelPlugin::afterTest()`, and the integration fixture resource map. Update the maintained PHPDoc and regenerate the API pages.
