### PR TITLE
docs: correct execution and timeout claims on the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Greenlight runs its own test suite with `bin/greenlight run`.
 * Leak detection, crash recovery, timeouts, and process isolation
 * Strict mocks, stubs, and spies with automatic verification
 * Typed expectations with clear differences
-* Stable CI shards and deterministic reports
+* Stable CI shards and machine-readable reports
 * Test attachments for values, text, bytes, and files
 * Coverage through pcov or Xdebug
 * Plain PHP test classes and PHP configuration
@@ -68,6 +68,9 @@ final class PriceTest
     }
 }
 ```
+
+`Price` represents application code in this example. See the
+[start guide](docs/getting-started.md) for a complete application and test.
 
 Tests use typed PHP classes. Attributes identify tests, before and after
 methods, data sets, retries, timeouts, skip conditions, groups, resource
@@ -118,8 +121,9 @@ Greenlight normally schedules complete test classes. It schedules each
 `#[Isolated]` test separately. Add `#[AllowParallel]` to split an independent
 large class into one assignment for each selected test or data set.
 
-Greenlight preserves execution-plan order. Worker placement and completion
-order remain load-dependent.
+Greenlight assigns scheduling units in execution-plan order as resource capacity
+permits. Worker placement and completion order depend on the run. Reporters
+receive events as they arrive.
 
 Use a channel to give each worker a separate external resource. Use
 `#[RequiresResource]` to limit concurrent access to a shared resource.

--- a/website/src/components/WorkerFlow.astro
+++ b/website/src/components/WorkerFlow.astro
@@ -1,7 +1,7 @@
 <figure class="worker-flow" aria-labelledby="worker-flow-caption">
   <figcaption id="worker-flow-caption" class="worker-flow__caption">
     <span>Execution plan</span>
-    <strong>Classes move independently. Results return in order.</strong>
+    <strong>Classes run independently. One report combines their results.</strong>
   </figcaption>
 
   <div class="worker-flow__stage" aria-hidden="true">
@@ -29,13 +29,13 @@
     </ol>
 
     <div class="worker-flow__result">
-      <span>one ordered report</span>
+      <span>one combined report</span>
       <strong>802 tests</strong>
     </div>
   </div>
 
   <p class="worker-flow__description">
     Greenlight discovers the suite once, assigns test classes to available workers,
-    and combines their results into one ordered report.
+    and combines their results into one combined report.
   </p>
 </figure>

--- a/website/src/components/WorkerFlow.astro
+++ b/website/src/components/WorkerFlow.astro
@@ -36,6 +36,6 @@
 
   <p class="worker-flow__description">
     Greenlight discovers the suite once, assigns test classes to available workers,
-    and combines their results into one combined report.
+    and combines their results into one report.
   </p>
 </figure>

--- a/website/src/pages/404.astro
+++ b/website/src/pages/404.astro
@@ -10,7 +10,7 @@ import { sitePath } from '../lib/paths';
   <main id="main-content" class="not-found">
     <p class="eyebrow">404</p>
     <h1>Page not found.</h1>
-    <p>Return to the documentation index to select an available page.</p>
+    <p>Open the start guide to browse the documentation.</p>
     <a class="button primary" href={sitePath('docs/getting-started/')}>Browse documentation</a>
   </main>
 </BaseLayout>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -56,7 +56,7 @@ final class PriceTest
     </section>
 
     <section class="proof-line" aria-label="Greenlight characteristics">
-      <p><strong>Use every available core</strong><span>The runner executes test classes in parallel.</span></p>
+      <p><strong>Use parallel workers</strong><span>The runner executes test classes in parallel.</span></p>
       <p><strong>Use plain PHP tests</strong><span>Tests need no base class or method-name convention.</span></p>
       <p><strong>Use your current tools</strong><span>Typed APIs work with your IDE and PHPStan.</span></p>
     </section>
@@ -82,8 +82,8 @@ final class PriceTest
           <p class="eyebrow">Run the suite</p>
           <h2>Greenlight manages the worker pool for you.</h2>
           <p>
-            The runner discovers the suite once, keeps the available workers busy,
-            and returns one ordered result.
+            The runner discovers the suite once, assigns work as resources become
+            available, and combines the results in one report.
           </p>
         </div>
       </div>
@@ -98,7 +98,7 @@ final class PriceTest
         <li>
           <span>02</span>
           <div>
-            <h3>Keep every worker busy</h3>
+            <h3>Assign work to available workers</h3>
             <p>The orchestrator assigns one scheduling unit to each available worker. Greenlight starts known slow classes and previously failed classes early.</p>
           </div>
         </li>
@@ -106,7 +106,7 @@ final class PriceTest
           <span>03</span>
           <div>
             <h3>Read one clear result</h3>
-            <p>Greenlight checks every worker result and prints one ordered report.</p>
+            <p>Greenlight checks every worker result and combines the results in one report.</p>
           </div>
         </li>
       </ol>
@@ -118,7 +118,7 @@ final class PriceTest
         <h2>Failures stay contained and readable.</h2>
         <div class="capability-list">
           <p><strong>Crashed worker</strong><span>The orchestrator returns the rest of the assignment to the queue and starts a replacement worker.</span></p>
-          <p><strong>Hung test</strong><span>A hard timeout stops the worker. A replacement worker continues the suite.</span></p>
+          <p><strong>Hung test</strong><span>Set a test timeout to stop a blocked worker after the timeout grace period. A replacement worker continues the suite.</span></p>
           <p><strong>External resources</strong><span>Use channels to select separate resources for each worker. Resource limits restrict concurrent access to shared dependencies.</span></p>
           <p><strong>Missed mock call</strong><span>When the test ends, Greenlight verifies strict doubles and reports unmet expectations.</span></p>
         </div>
@@ -172,7 +172,7 @@ final class PriceTest
     <section class="closing-cta">
       <div class="closing-cta-intro">
         <p class="eyebrow">Run Greenlight</p>
-        <h2>Put every available core to work.</h2>
+        <h2>Run your tests in parallel.</h2>
         <p>
           Start with a complete configuration and one small test class, or move an
           existing PHPUnit class when you are ready.


### PR DESCRIPTION
The README and homepage promised ordered reports even though ReporterSink forwards events on arrival. The homepage also implied that every blocked test has a hard timeout, but ExecutionPolicy defaults to no timeout and the orchestrator skips that check when the budget is null.

Describe event arrival and combined reports accurately. Tell users to set a timeout, including its grace period. Explain that the README Price class represents application code, and make the 404 text match its start-guide destination. These changes keep the parallel execution description consistent with the runner and resource limits.
