### PR TITLE
docs(diagnostics): clarify event and report validation errors

### DIFF
--- a/src/Coverage/Export/JsonExporter.php
+++ b/src/Coverage/Export/JsonExporter.php
@@ -28,7 +28,7 @@ final readonly class JsonExporter implements CoverageExporter
 
         foreach ($map->files() as $path => $file) {
             if (\preg_match('//u', $path) !== 1) {
-                throw new \InvalidArgumentException('Coverage JSON file paths MUST contain valid UTF-8.');
+                throw new \InvalidArgumentException('Use valid UTF-8 in coverage JSON file paths.');
             }
 
             $files[$path] = [

--- a/src/Coverage/Export/LcovExporter.php
+++ b/src/Coverage/Export/LcovExporter.php
@@ -25,11 +25,11 @@ final readonly class LcovExporter implements CoverageExporter
 
         foreach ($map->files() as $path => $file) {
             if (\str_contains($path, "\0")) {
-                throw new \InvalidArgumentException('LCOV file paths MUST NOT contain null bytes.');
+                throw new \InvalidArgumentException('LCOV file paths cannot contain null bytes.');
             }
 
             if (\strpbrk($path, "\r\n") !== false) {
-                throw new \InvalidArgumentException('LCOV file paths MUST NOT contain line breaks.');
+                throw new \InvalidArgumentException('LCOV file paths cannot contain line breaks.');
             }
 
             $out .= 'SF:' . $path . "\n";

--- a/src/Event/RunFinished.php
+++ b/src/Event/RunFinished.php
@@ -39,7 +39,7 @@ final readonly class RunFinished implements WireEvent
         }
 
         if (!\is_finite($occurredAt)) {
-            throw new \InvalidArgumentException('Event timestamp MUST be finite.');
+            throw new \InvalidArgumentException('Use a finite event timestamp.');
         }
 
         $this->runId = $runId;

--- a/src/Event/RunStarted.php
+++ b/src/Event/RunStarted.php
@@ -52,7 +52,7 @@ final readonly class RunStarted implements WireEvent
         }
 
         if (!\is_finite($occurredAt)) {
-            throw new \InvalidArgumentException('Event timestamp MUST be finite.');
+            throw new \InvalidArgumentException('Use a finite event timestamp.');
         }
 
         $this->runId = $runId;

--- a/src/Event/TestClassFinished.php
+++ b/src/Event/TestClassFinished.php
@@ -25,11 +25,11 @@ final readonly class TestClassFinished implements WireEvent
         public string $workerId = '',
     ) {
         if ($class === '') {
-            throw new \InvalidArgumentException('Test class name MUST NOT be empty.');
+            throw new \InvalidArgumentException('Test class name cannot be empty.');
         }
 
         if (!\is_finite($occurredAt)) {
-            throw new \InvalidArgumentException('Event timestamp MUST be finite.');
+            throw new \InvalidArgumentException('Use a finite event timestamp.');
         }
 
         $this->class = $class;

--- a/src/Event/TestClassStarted.php
+++ b/src/Event/TestClassStarted.php
@@ -26,11 +26,11 @@ final readonly class TestClassStarted implements WireEvent
         public bool $isolated = false,
     ) {
         if ($class === '') {
-            throw new \InvalidArgumentException('Test class name MUST NOT be empty.');
+            throw new \InvalidArgumentException('Test class name cannot be empty.');
         }
 
         if (!\is_finite($occurredAt)) {
-            throw new \InvalidArgumentException('Event timestamp MUST be finite.');
+            throw new \InvalidArgumentException('Use a finite event timestamp.');
         }
 
         $this->class = $class;

--- a/src/Event/TestFinished.php
+++ b/src/Event/TestFinished.php
@@ -15,7 +15,7 @@ final readonly class TestFinished implements WireEvent
     public function __construct(public TestResult $result, public float $occurredAt)
     {
         if (!\is_finite($occurredAt)) {
-            throw new \InvalidArgumentException('Event timestamp MUST be finite.');
+            throw new \InvalidArgumentException('Use a finite event timestamp.');
         }
     }
 

--- a/src/Event/TestStarted.php
+++ b/src/Event/TestStarted.php
@@ -15,7 +15,7 @@ final readonly class TestStarted implements WireEvent
     public function __construct(public TestId $id, public float $occurredAt)
     {
         if (!\is_finite($occurredAt)) {
-            throw new \InvalidArgumentException('Event timestamp MUST be finite.');
+            throw new \InvalidArgumentException('Use a finite event timestamp.');
         }
     }
 

--- a/src/Event/WorkerSpawned.php
+++ b/src/Event/WorkerSpawned.php
@@ -27,15 +27,15 @@ final readonly class WorkerSpawned implements WireEvent
         public float $occurredAt,
     ) {
         if ($workerId === '') {
-            throw new \InvalidArgumentException('Worker ID MUST NOT be empty.');
+            throw new \InvalidArgumentException('Worker ID cannot be empty.');
         }
 
         if ($pid < 1) {
-            throw new \InvalidArgumentException('Worker PID MUST be greater than zero.');
+            throw new \InvalidArgumentException('Use a worker PID greater than zero.');
         }
 
         if (!\is_finite($occurredAt)) {
-            throw new \InvalidArgumentException('Event timestamp MUST be finite.');
+            throw new \InvalidArgumentException('Use a finite event timestamp.');
         }
 
         $this->workerId = $workerId;

--- a/src/Event/WorkerTiming.php
+++ b/src/Event/WorkerTiming.php
@@ -38,7 +38,7 @@ final readonly class WorkerTiming
         public ?float $retirementToExitSeconds,
     ) {
         if ($workerId === '') {
-            throw new \InvalidArgumentException('Worker ID MUST NOT be empty.');
+            throw new \InvalidArgumentException('Worker ID cannot be empty.');
         }
 
         foreach ([
@@ -52,12 +52,12 @@ final readonly class WorkerTiming
             $retirementToExitSeconds,
         ] as $duration) {
             if ($duration !== null && (!\is_finite($duration) || $duration < 0.0)) {
-                throw new \InvalidArgumentException('Worker timing durations MUST be finite and nonnegative.');
+                throw new \InvalidArgumentException('Use finite, nonnegative worker timing durations.');
             }
         }
 
         if ($assignmentGaps < 0) {
-            throw new \InvalidArgumentException('Worker assignment gap count MUST NOT be negative.');
+            throw new \InvalidArgumentException('Worker assignment gap count cannot be negative.');
         }
 
         $this->workerId = $workerId;

--- a/src/Reporting/ReportGenerationFailed.php
+++ b/src/Reporting/ReportGenerationFailed.php
@@ -26,7 +26,7 @@ final class ReportGenerationFailed extends \RuntimeException
         $reason = \trim($reason);
 
         if ($reason === '') {
-            throw new \InvalidArgumentException('Report generation failure reason MUST NOT be empty.');
+            throw new \InvalidArgumentException('Report generation failure reason cannot be empty.');
         }
 
         return new self(\sprintf(

--- a/src/Result/CapturedOutput.php
+++ b/src/Result/CapturedOutput.php
@@ -38,7 +38,7 @@ final readonly class CapturedOutput
         foreach ($diagnostics as $index => $diagnostic) {
             if ($index !== \count($validatedDiagnostics) || !$diagnostic instanceof Diagnostic) {
                 throw new \InvalidArgumentException(
-                    'Captured output diagnostics MUST be a list of Diagnostic instances.',
+                    'Use a list of Diagnostic instances for captured output diagnostics.',
                 );
             }
 

--- a/src/Result/Diagnostic.php
+++ b/src/Result/Diagnostic.php
@@ -30,7 +30,7 @@ final readonly class Diagnostic
         int $line,
     ) {
         if ($line < 1) {
-            throw new \InvalidArgumentException('Diagnostic line MUST be greater than zero.');
+            throw new \InvalidArgumentException('Use a diagnostic line number greater than zero.');
         }
 
         $this->line = $line;

--- a/src/Result/ResultPolicy.php
+++ b/src/Result/ResultPolicy.php
@@ -52,7 +52,7 @@ final readonly class ResultPolicy
         foreach ($ignoreDeprecations as $index => $pattern) {
             if ($index !== \count($validatedPatterns) || !\is_string($pattern) || $pattern === '') {
                 throw new \InvalidArgumentException(
-                    'Deprecation ignore patterns MUST be a list of non-empty strings.',
+                    'Use a list of non-empty strings for deprecation ignore patterns.',
                 );
             }
 

--- a/src/Result/ResultSummary.php
+++ b/src/Result/ResultSummary.php
@@ -40,19 +40,19 @@ final readonly class ResultSummary
         int $skipped = 0,
     ) {
         if ($passed < 0) {
-            throw new \InvalidArgumentException('Result summary passed count MUST NOT be negative.');
+            throw new \InvalidArgumentException('Result summary passed count cannot be negative.');
         }
 
         if ($failed < 0) {
-            throw new \InvalidArgumentException('Result summary failed count MUST NOT be negative.');
+            throw new \InvalidArgumentException('Result summary failed count cannot be negative.');
         }
 
         if ($errored < 0) {
-            throw new \InvalidArgumentException('Result summary errored count MUST NOT be negative.');
+            throw new \InvalidArgumentException('Result summary errored count cannot be negative.');
         }
 
         if ($skipped < 0) {
-            throw new \InvalidArgumentException('Result summary skipped count MUST NOT be negative.');
+            throw new \InvalidArgumentException('Result summary skipped count cannot be negative.');
         }
 
         $this->passed = $passed;

--- a/src/Result/TestResult.php
+++ b/src/Result/TestResult.php
@@ -61,7 +61,7 @@ final readonly class TestResult
         }
 
         if ($expectations < 0) {
-            throw new \InvalidArgumentException('Expectation count MUST NOT be negative.');
+            throw new \InvalidArgumentException('Expectation count cannot be negative.');
         }
 
         $this->attempts = $attempts;

--- a/tests/Acceptance/CoverageMergeErrorTest.php
+++ b/tests/Acceptance/CoverageMergeErrorTest.php
@@ -271,7 +271,7 @@ final readonly class CoverageMergeErrorTest
         Expect::that($result->exitCode)->toBe(1);
         Expect::that($result->output())
             ->toContain('Greenlight could not create the "lcov" coverage export')
-            ->toContain('LCOV file paths MUST NOT contain line breaks.');
+            ->toContain('LCOV file paths cannot contain line breaks.');
         Expect::that(\file_exists($directory . '/coverage.lcov'))->toBeFalse();
     }
 }

--- a/tests/Unit/Coverage/Export/JsonExporterTest.php
+++ b/tests/Unit/Coverage/Export/JsonExporterTest.php
@@ -61,7 +61,7 @@ final class JsonExporterTest
             ->because('distinct coverage paths MUST NOT collapse to the same JSON object key')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Coverage JSON file paths MUST contain valid UTF-8.',
+                message: 'Use valid UTF-8 in coverage JSON file paths.',
             );
     }
 

--- a/tests/Unit/Coverage/Export/LcovExporterTest.php
+++ b/tests/Unit/Coverage/Export/LcovExporterTest.php
@@ -61,7 +61,7 @@ final class LcovExporterTest
             ->because('LCOV SF records MUST stay on one line')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'LCOV file paths MUST NOT contain line breaks.',
+                message: 'LCOV file paths cannot contain line breaks.',
             );
     }
 

--- a/tests/Unit/Coverage/Export/LcovNullPathValidationTest.php
+++ b/tests/Unit/Coverage/Export/LcovNullPathValidationTest.php
@@ -23,7 +23,7 @@ final class LcovNullPathValidationTest
             ->because('LCOV source records MUST contain valid file paths')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'LCOV file paths MUST NOT contain null bytes.',
+                message: 'LCOV file paths cannot contain null bytes.',
             );
     }
 }

--- a/tests/Unit/Event/EventTimestampValidationTest.php
+++ b/tests/Unit/Event/EventTimestampValidationTest.php
@@ -33,7 +33,7 @@ final readonly class EventTimestampValidationTest
             ->because('direct and wire event construction MUST enforce the same timestamp invariant')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Event timestamp MUST be finite.',
+                message: 'Use a finite event timestamp.',
             );
     }
 

--- a/tests/Unit/Event/TestClassEventValidationTest.php
+++ b/tests/Unit/Event/TestClassEventValidationTest.php
@@ -23,7 +23,7 @@ final readonly class TestClassEventValidationTest
             ->because('a test-class lifecycle event MUST identify its class')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Test class name MUST NOT be empty.',
+                message: 'Test class name cannot be empty.',
             );
     }
 

--- a/tests/Unit/Event/WorkerEventValidationTest.php
+++ b/tests/Unit/Event/WorkerEventValidationTest.php
@@ -33,7 +33,7 @@ final readonly class WorkerEventValidationTest
             ->because('a spawned-worker event MUST identify its worker')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Worker ID MUST NOT be empty.',
+                message: 'Worker ID cannot be empty.',
             );
     }
 
@@ -45,7 +45,7 @@ final readonly class WorkerEventValidationTest
             ->because('a spawned-worker event MUST identify a positive process ID')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Worker PID MUST be greater than zero.',
+                message: 'Use a worker PID greater than zero.',
             );
     }
 
@@ -61,7 +61,7 @@ final readonly class WorkerEventValidationTest
             ->because('a spawned-worker wire event MUST identify a positive process ID')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Worker PID MUST be greater than zero.',
+                message: 'Use a worker PID greater than zero.',
             );
     }
 

--- a/tests/Unit/Event/WorkerTimingTest.php
+++ b/tests/Unit/Event/WorkerTimingTest.php
@@ -39,7 +39,7 @@ final readonly class WorkerTimingTest
             ->because('worker timing durations MUST be nonnegative')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Worker timing durations MUST be finite and nonnegative.',
+                message: 'Use finite, nonnegative worker timing durations.',
             );
     }
 }

--- a/tests/Unit/Reporting/ReportGenerationFailedTest.php
+++ b/tests/Unit/Reporting/ReportGenerationFailedTest.php
@@ -28,7 +28,7 @@ final class ReportGenerationFailedTest
         Expect::that(static fn() => ReportGenerationFailed::because(" \n\t "))
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Report generation failure reason MUST NOT be empty.',
+                message: 'Report generation failure reason cannot be empty.',
             );
     }
 

--- a/tests/Unit/Result/CapturedOutputValidationTest.php
+++ b/tests/Unit/Result/CapturedOutputValidationTest.php
@@ -24,7 +24,7 @@ final class CapturedOutputValidationTest
             ->because('captured output diagnostics MUST be a list of Diagnostic instances')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Captured output diagnostics MUST be a list of Diagnostic instances.',
+                message: 'Use a list of Diagnostic instances for captured output diagnostics.',
             );
     }
 

--- a/tests/Unit/Result/DiagnosticValidationTest.php
+++ b/tests/Unit/Result/DiagnosticValidationTest.php
@@ -22,7 +22,7 @@ final class DiagnosticValidationTest
             ->because('a diagnostic MUST identify a positive source line')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Diagnostic line MUST be greater than zero.',
+                message: 'Use a diagnostic line number greater than zero.',
             );
     }
 

--- a/tests/Unit/Result/ResultPolicyValidationTest.php
+++ b/tests/Unit/Result/ResultPolicyValidationTest.php
@@ -24,7 +24,7 @@ final class ResultPolicyValidationTest
             ->because('deprecation ignore patterns MUST be a list of non-empty strings')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Deprecation ignore patterns MUST be a list of non-empty strings.',
+                message: 'Use a list of non-empty strings for deprecation ignore patterns.',
             );
     }
 

--- a/tests/Unit/Result/ResultSummaryTest.php
+++ b/tests/Unit/Result/ResultSummaryTest.php
@@ -43,7 +43,7 @@ final class ResultSummaryTest
         foreach (['passed', 'failed', 'errored', 'skipped'] as $field) {
             yield $field => [
                 $field,
-                \sprintf('Result summary %s count MUST NOT be negative.', $field),
+                \sprintf('Result summary %s count cannot be negative.', $field),
             ];
         }
     }

--- a/tests/Unit/Result/TestResultExpectationValidationTest.php
+++ b/tests/Unit/Result/TestResultExpectationValidationTest.php
@@ -30,7 +30,7 @@ final class TestResultExpectationValidationTest
             ->because('a result MUST NOT contain a negative expectation count')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Expectation count MUST NOT be negative.',
+                message: 'Expectation count cannot be negative.',
             );
     }
 }


### PR DESCRIPTION
Validation errors for events, test results, and coverage exports use uppercase specification terms in user-facing messages. Replace these with direct instructions and ordinary prohibitions. Preserve the accepted values, exception types, and validation order.

Each message was checked against its validation guard, including finite timestamps, nonnegative counts, list-shaped diagnostics, UTF-8 JSON paths, and LCOV path restrictions. Update the existing exact-message assertions to match.
