### PR TITLE
ci: include guides and website sources in external link checks

### DIFF
--- a/.github/workflows/external-links.yml
+++ b/.github/workflows/external-links.yml
@@ -32,7 +32,7 @@ jobs:
             README.md
             CONTRIBUTING.md
             SECURITY.md
-            'docs/**/*.md'
-            'website/src/**/*.astro'
+            docs/**/*.md
+            website/src/**/*.astro
         env:
           GITHUB_TOKEN: "${{ github.token }}"


### PR DESCRIPTION
The weekly External links job passed while it skipped guides and website sources. Run 33387779753 reported `No files found for this input source` for both quoted glob arguments. The Docker action passed the single quotes to lychee as part of each input.

Remove those literal quotes so lychee can expand both patterns. The corrected manual run scanned 946 links, reported zero errors, and had no unmatched-input warnings. The old run scanned only 42 links.

Previous run: https://github.com/ben-challis/greenlight/actions/runs/33387779753
Corrected branch run: https://github.com/ben-challis/greenlight/actions/runs/33914000796
Latest commit run after the base update: https://github.com/ben-challis/greenlight/actions/runs/33914262054
