### PR TITLE
docs(diagnostics): use direct test input validation messages

### DIFF
--- a/src/Attribute/DataSet.php
+++ b/src/Attribute/DataSet.php
@@ -36,13 +36,13 @@ final readonly class DataSet
         if ($provider === '') {
             throw new \InvalidArgumentException(
                 $method === null
-                    ? 'Data set provider MUST NOT be empty.'
-                    : 'Data set provider class MUST NOT be empty.',
+                    ? 'Data set provider cannot be empty.'
+                    : 'Data set provider class cannot be empty.',
             );
         }
 
         if ($method === '') {
-            throw new \InvalidArgumentException('Data set provider method MUST NOT be empty.');
+            throw new \InvalidArgumentException('Data set provider method cannot be empty.');
         }
 
         $this->provider = $method ?? $provider;

--- a/src/Attribute/Retry.php
+++ b/src/Attribute/Retry.php
@@ -38,7 +38,7 @@ final readonly class Retry
         $this->times = $times;
 
         if ($onlyOn !== null && !\is_a($onlyOn, \Throwable::class, true)) {
-            throw new \InvalidArgumentException('Retry onlyOn MUST name a Throwable type.');
+            throw new \InvalidArgumentException('Set Retry onlyOn to a Throwable type.');
         }
 
         $this->onlyOn = $onlyOn;

--- a/src/Attribute/SkipUnless.php
+++ b/src/Attribute/SkipUnless.php
@@ -34,7 +34,7 @@ final readonly class SkipUnless
     ) {
         if (!\is_a($condition, Condition::class, true)) {
             throw new \InvalidArgumentException(
-                'SkipUnless condition MUST name an instantiable Condition class.',
+                'Set the SkipUnless condition to an instantiable Condition class.',
             );
         }
 
@@ -42,7 +42,7 @@ final readonly class SkipUnless
 
         if (!$reflection->isInstantiable()) {
             throw new \InvalidArgumentException(
-                'SkipUnless condition MUST name an instantiable Condition class.',
+                'Set the SkipUnless condition to an instantiable Condition class.',
             );
         }
 
@@ -50,7 +50,7 @@ final readonly class SkipUnless
 
         foreach ($arguments as $argument) {
             if (\is_float($argument) && !\is_finite($argument)) {
-                throw new \InvalidArgumentException('SkipUnless arguments MUST use finite floats.');
+                throw new \InvalidArgumentException('Use finite floats in SkipUnless arguments.');
             }
         }
 

--- a/src/Condition/ClassAvailable.php
+++ b/src/Condition/ClassAvailable.php
@@ -22,7 +22,7 @@ final readonly class ClassAvailable implements Condition
     public function __construct(string $class)
     {
         if ($class === '') {
-            throw new \InvalidArgumentException('Class name MUST NOT be empty.');
+            throw new \InvalidArgumentException('Class name cannot be empty.');
         }
 
         $this->class = $class;

--- a/src/Condition/ExtensionLoaded.php
+++ b/src/Condition/ExtensionLoaded.php
@@ -19,7 +19,7 @@ final readonly class ExtensionLoaded implements Condition
     public function __construct(string $extension)
     {
         if ($extension === '') {
-            throw new \InvalidArgumentException('Extension name MUST NOT be empty.');
+            throw new \InvalidArgumentException('Extension name cannot be empty.');
         }
 
         $this->extension = $extension;

--- a/src/Condition/ExtensionMissing.php
+++ b/src/Condition/ExtensionMissing.php
@@ -19,7 +19,7 @@ final readonly class ExtensionMissing implements Condition
     public function __construct(string $extension)
     {
         if ($extension === '') {
-            throw new \InvalidArgumentException('Extension name MUST NOT be empty.');
+            throw new \InvalidArgumentException('Extension name cannot be empty.');
         }
 
         $this->extension = $extension;

--- a/src/Condition/FunctionAvailable.php
+++ b/src/Condition/FunctionAvailable.php
@@ -19,7 +19,7 @@ final readonly class FunctionAvailable implements Condition
     public function __construct(string $function)
     {
         if ($function === '') {
-            throw new \InvalidArgumentException('Function name MUST NOT be empty.');
+            throw new \InvalidArgumentException('Function name cannot be empty.');
         }
 
         $this->function = $function;

--- a/src/Condition/OperatingSystemFamily.php
+++ b/src/Condition/OperatingSystemFamily.php
@@ -20,7 +20,7 @@ final readonly class OperatingSystemFamily implements Condition
     public function __construct(string $family)
     {
         if ($family === '') {
-            throw new \InvalidArgumentException('Operating system family MUST NOT be empty.');
+            throw new \InvalidArgumentException('Operating system family cannot be empty.');
         }
 
         $this->family = $family;

--- a/src/Condition/PhpVersionAtLeast.php
+++ b/src/Condition/PhpVersionAtLeast.php
@@ -19,7 +19,7 @@ final readonly class PhpVersionAtLeast implements Condition
     public function __construct(string $version)
     {
         if ($version === '') {
-            throw new \InvalidArgumentException('PHP version MUST NOT be empty.');
+            throw new \InvalidArgumentException('PHP version cannot be empty.');
         }
 
         $this->version = $version;

--- a/src/Condition/PhpVersionLessThan.php
+++ b/src/Condition/PhpVersionLessThan.php
@@ -19,7 +19,7 @@ final readonly class PhpVersionLessThan implements Condition
     public function __construct(string $version)
     {
         if ($version === '') {
-            throw new \InvalidArgumentException('PHP version MUST NOT be empty.');
+            throw new \InvalidArgumentException('PHP version cannot be empty.');
         }
 
         $this->version = $version;

--- a/src/Doubles/Doubles.php
+++ b/src/Doubles/Doubles.php
@@ -54,7 +54,7 @@ final class Doubles implements Disposable
     public function __construct(?string $proxyDirectory = null)
     {
         if ($proxyDirectory === '') {
-            throw new \InvalidArgumentException('Proxy directory MUST NOT be empty.');
+            throw new \InvalidArgumentException('Proxy directory cannot be empty.');
         }
 
         if ($proxyDirectory === null) {

--- a/src/Laravel/LaravelProcessState.php
+++ b/src/Laravel/LaravelProcessState.php
@@ -30,7 +30,7 @@ final readonly class LaravelProcessState
     public static function setEnvironment(string $environment): self
     {
         if (\str_contains($environment, "\0")) {
-            throw new \InvalidArgumentException('Laravel environment MUST NOT contain a null byte.');
+            throw new \InvalidArgumentException('Laravel environment cannot contain a null byte.');
         }
 
         $backup = EnvironmentBackup::capture('APP_ENV');

--- a/src/Sandbox/TemporaryDirectory.php
+++ b/src/Sandbox/TemporaryDirectory.php
@@ -22,7 +22,7 @@ final class TemporaryDirectory implements Disposable
     public function __construct(?string $temporaryRoot = null)
     {
         if ($temporaryRoot !== null && \str_contains($temporaryRoot, "\0")) {
-            throw new \InvalidArgumentException('Temporary root MUST NOT contain a null byte.');
+            throw new \InvalidArgumentException('Temporary root cannot contain a null byte.');
         }
 
         $this->temporaryRoot = $temporaryRoot;
@@ -60,7 +60,7 @@ final class TemporaryDirectory implements Disposable
     public function subdirectory(string $name): string
     {
         if (\str_contains($name, "\0")) {
-            throw new \InvalidArgumentException('Subdirectory name MUST NOT contain a null byte.');
+            throw new \InvalidArgumentException('Subdirectory name cannot contain a null byte.');
         }
 
         if ($name === '' || \str_starts_with($name, '/') || \str_contains($name, '\\')) {

--- a/src/Tempest/TempestPlugin.php
+++ b/src/Tempest/TempestPlugin.php
@@ -53,11 +53,11 @@ final class TempestPlugin implements AfterTestSubscriber, BeforeTestSubscriber, 
         private readonly array $discoveryLocations = [],
     ) {
         if ($root === '') {
-            throw new \InvalidArgumentException('Tempest application root MUST NOT be empty.');
+            throw new \InvalidArgumentException('Tempest application root cannot be empty.');
         }
 
         if ($environment === '') {
-            throw new \InvalidArgumentException('Tempest environment MUST NOT be empty.');
+            throw new \InvalidArgumentException('Tempest environment cannot be empty.');
         }
     }
 

--- a/src/Tempest/TempestProcessState.php
+++ b/src/Tempest/TempestProcessState.php
@@ -26,7 +26,7 @@ final readonly class TempestProcessState
     public static function activate(string $environment, ?GenericContainer $container = null): self
     {
         if (\str_contains($environment, "\0")) {
-            throw new \InvalidArgumentException('Tempest environment MUST NOT contain a null byte.');
+            throw new \InvalidArgumentException('Tempest environment cannot contain a null byte.');
         }
 
         $backup = EnvironmentBackup::capture('ENVIRONMENT');

--- a/src/Test/SkipPolicy.php
+++ b/src/Test/SkipPolicy.php
@@ -49,7 +49,7 @@ final readonly class SkipPolicy
             }
 
             if (\is_float($argument) && !\is_finite($argument)) {
-                throw new \InvalidArgumentException('Skip condition arguments MUST use finite floats.');
+                throw new \InvalidArgumentException('Use finite floats in skip condition arguments.');
             }
 
             $validated[] = $argument;

--- a/src/Test/TestChannel.php
+++ b/src/Test/TestChannel.php
@@ -26,7 +26,7 @@ final readonly class TestChannel
     public function __construct(int $number)
     {
         if ($number < 1) {
-            throw new \InvalidArgumentException('Test channel number MUST be greater than zero.');
+            throw new \InvalidArgumentException('Use a test channel number greater than zero.');
         }
 
         $this->number = $number;

--- a/tests/Unit/Attribute/DataSetTest.php
+++ b/tests/Unit/Attribute/DataSetTest.php
@@ -32,19 +32,19 @@ final class DataSetTest
         yield 'local provider' => [
             '',
             null,
-            'Data set provider MUST NOT be empty.',
+            'Data set provider cannot be empty.',
         ];
 
         yield 'external provider class' => [
             '',
             'rows',
-            'Data set provider class MUST NOT be empty.',
+            'Data set provider class cannot be empty.',
         ];
 
         yield 'external provider method' => [
             self::class,
             '',
-            'Data set provider method MUST NOT be empty.',
+            'Data set provider method cannot be empty.',
         ];
     }
 }

--- a/tests/Unit/Attribute/RetryTest.php
+++ b/tests/Unit/Attribute/RetryTest.php
@@ -32,7 +32,7 @@ final class RetryTest
             ->because('a retry filter MUST name a Throwable type')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Retry onlyOn MUST name a Throwable type.',
+                message: 'Set Retry onlyOn to a Throwable type.',
             );
     }
 

--- a/tests/Unit/Attribute/SkipUnlessTest.php
+++ b/tests/Unit/Attribute/SkipUnlessTest.php
@@ -23,7 +23,7 @@ final class SkipUnlessTest
             ->because('a skip condition MUST name an instantiable Condition class')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'SkipUnless condition MUST name an instantiable Condition class.',
+                message: 'Set the SkipUnless condition to an instantiable Condition class.',
             );
     }
 
@@ -51,7 +51,7 @@ final class SkipUnlessTest
             ->because('skip condition arguments MUST be safe for the JSON worker protocol')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'SkipUnless arguments MUST use finite floats.',
+                message: 'Use finite floats in SkipUnless arguments.',
             );
     }
 

--- a/tests/Unit/Condition/ConditionsTest.php
+++ b/tests/Unit/Condition/ConditionsTest.php
@@ -202,7 +202,7 @@ final readonly class ConditionsTest
             ->because('a class availability condition MUST identify the class')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Class name MUST NOT be empty.',
+                message: 'Class name cannot be empty.',
             );
     }
 

--- a/tests/Unit/Condition/ExtensionConditionValidationTest.php
+++ b/tests/Unit/Condition/ExtensionConditionValidationTest.php
@@ -21,7 +21,7 @@ final readonly class ExtensionConditionValidationTest
             ->because('an extension availability condition MUST identify the extension')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Extension name MUST NOT be empty.',
+                message: 'Extension name cannot be empty.',
             );
     }
 

--- a/tests/Unit/Condition/FunctionAvailableTest.php
+++ b/tests/Unit/Condition/FunctionAvailableTest.php
@@ -17,7 +17,7 @@ final readonly class FunctionAvailableTest
             ->because('a function availability condition MUST identify the function')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Function name MUST NOT be empty.',
+                message: 'Function name cannot be empty.',
             );
     }
 }

--- a/tests/Unit/Condition/OperatingSystemFamilyValidationTest.php
+++ b/tests/Unit/Condition/OperatingSystemFamilyValidationTest.php
@@ -17,7 +17,7 @@ final readonly class OperatingSystemFamilyValidationTest
             ->because('an operating-system condition MUST identify the family')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Operating system family MUST NOT be empty.',
+                message: 'Operating system family cannot be empty.',
             );
     }
 }

--- a/tests/Unit/Condition/PhpVersionConditionValidationTest.php
+++ b/tests/Unit/Condition/PhpVersionConditionValidationTest.php
@@ -24,7 +24,7 @@ final readonly class PhpVersionConditionValidationTest
             ->because('a PHP version condition MUST identify its comparison version')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'PHP version MUST NOT be empty.',
+                message: 'PHP version cannot be empty.',
             );
     }
 

--- a/tests/Unit/Doubles/DoublesProxyDirectoryValidationTest.php
+++ b/tests/Unit/Doubles/DoublesProxyDirectoryValidationTest.php
@@ -17,7 +17,7 @@ final class DoublesProxyDirectoryValidationTest
             ->because('an empty proxy directory MUST NOT resolve generated files from the filesystem root')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Proxy directory MUST NOT be empty.',
+                message: 'Proxy directory cannot be empty.',
             );
     }
 }

--- a/tests/Unit/Laravel/LaravelProcessEnvironmentValidationTest.php
+++ b/tests/Unit/Laravel/LaravelProcessEnvironmentValidationTest.php
@@ -26,7 +26,7 @@ final readonly class LaravelProcessEnvironmentValidationTest
             ->because('a NUL environment MUST be rejected before putenv truncates it')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Laravel environment MUST NOT contain a null byte.',
+                message: 'Laravel environment cannot contain a null byte.',
             );
         Expect::that(\getenv('APP_ENV'))
             ->because('a rejected Laravel environment MUST NOT change the process environment')

--- a/tests/Unit/Sandbox/TemporaryDirectoryTest.php
+++ b/tests/Unit/Sandbox/TemporaryDirectoryTest.php
@@ -52,7 +52,7 @@ final class TemporaryDirectoryTest
             ->because('the fixture MUST reject an invalid temporary root before a file-system operation')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Temporary root MUST NOT contain a null byte.',
+                message: 'Temporary root cannot contain a null byte.',
             );
     }
 
@@ -221,7 +221,7 @@ final class TemporaryDirectoryTest
         ];
         yield 'null byte' => [
             "a\0b",
-            'Subdirectory name MUST NOT contain a null byte.',
+            'Subdirectory name cannot contain a null byte.',
         ];
     }
 

--- a/tests/Unit/Tempest/TempestPluginConfigurationTest.php
+++ b/tests/Unit/Tempest/TempestPluginConfigurationTest.php
@@ -46,14 +46,14 @@ final readonly class TempestPluginConfigurationTest
     public function rejectsAnEmptyApplicationRoot(): void
     {
         Expect::that(static fn(): TempestPlugin => new TempestPlugin(''))
-            ->toThrow(\InvalidArgumentException::class, message: 'Tempest application root MUST NOT be empty.');
+            ->toThrow(\InvalidArgumentException::class, message: 'Tempest application root cannot be empty.');
     }
 
     #[Test]
     public function rejectsAnEmptyEnvironment(): void
     {
         Expect::that(static fn(): TempestPlugin => new TempestPlugin('/project', environment: ''))
-            ->toThrow(\InvalidArgumentException::class, message: 'Tempest environment MUST NOT be empty.');
+            ->toThrow(\InvalidArgumentException::class, message: 'Tempest environment cannot be empty.');
     }
 
     private function context(): TestContext

--- a/tests/Unit/Tempest/TempestProcessEnvironmentValidationTest.php
+++ b/tests/Unit/Tempest/TempestProcessEnvironmentValidationTest.php
@@ -17,7 +17,7 @@ final readonly class TempestProcessEnvironmentValidationTest
             ->because('environment validation MUST run before Tempest framework access')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Tempest environment MUST NOT contain a null byte.',
+                message: 'Tempest environment cannot contain a null byte.',
             );
     }
 }

--- a/tests/Unit/Test/TestChannelTest.php
+++ b/tests/Unit/Test/TestChannelTest.php
@@ -28,7 +28,7 @@ final readonly class TestChannelTest
             ->because('a test channel MUST identify a positive worker slot')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Test channel number MUST be greater than zero.',
+                message: 'Use a test channel number greater than zero.',
             );
     }
 


### PR DESCRIPTION
Attribute, condition, sandbox, and framework-bridge validation errors use uppercase specification terms. Use direct instructions and ordinary prohibitions in these user-facing messages.

Keep the existing requirements for non-empty names, finite skip arguments, Throwable retry types, instantiable conditions, positive test channel numbers, and paths without null bytes. The validation guards support each message. Update existing exact-message assertions without changing fixture data or runtime behavior.
