### PR TITLE
docs(diagnostics): clarify callback and plugin contracts

### DIFF
--- a/src/Cli/Input/OptionSpec.php
+++ b/src/Cli/Input/OptionSpec.php
@@ -36,14 +36,14 @@ final readonly class OptionSpec
 
         if (\preg_match('/^[A-Za-z0-9][A-Za-z0-9-]*$/D', $name) !== 1) {
             throw new \InvalidArgumentException(\sprintf(
-                'Option name "%s" MUST start with an ASCII letter or digit and MUST contain only ASCII letters, digits, or hyphens.',
+                'Start option name "%s" with an ASCII letter or digit. Use only ASCII letters, digits, or hyphens.',
                 $name,
             ));
         }
 
         if ($short !== null && \preg_match('/^[A-Za-z]$/D', $short) !== 1) {
             throw new \InvalidArgumentException(\sprintf(
-                'Short option alias "%s" MUST be one ASCII letter.',
+                'Use one ASCII letter for short option alias "%s".',
                 $short,
             ));
         }

--- a/src/Cli/Watch/WatchSourceFailed.php
+++ b/src/Cli/Watch/WatchSourceFailed.php
@@ -31,7 +31,7 @@ final class WatchSourceFailed extends \RuntimeException
     public static function invalidChange(string $plugin, mixed $change): self
     {
         return new self(\sprintf(
-            'Watch source plugin "%s" returned %s. It MUST return non-empty string paths or labels.',
+            'Watch source plugin "%s" returned %s. Return non-empty string paths or labels.',
             $plugin,
             \get_debug_type($change),
         ));

--- a/src/Doubles/InvalidDoubleUsage.php
+++ b/src/Doubles/InvalidDoubleUsage.php
@@ -102,7 +102,7 @@ final class InvalidDoubleUsage extends \LogicException
 
     public static function cannotDoubleReadonly(string $type): self
     {
-        return new self(\sprintf('%s is a readonly class. Doubles v1 does not support readonly classes. Use an interface instead.', $type));
+        return new self(\sprintf('%s is a readonly class. Doubles does not support readonly classes. Use an interface instead.', $type));
     }
 
     public static function cannotDoubleFinal(string $type): self

--- a/src/Execution/ExecutionTopology.php
+++ b/src/Execution/ExecutionTopology.php
@@ -24,7 +24,7 @@ final readonly class ExecutionTopology
     public function __construct(int $workers, int $fixtureChannels)
     {
         if ($workers < 1 || $fixtureChannels < 1) {
-            throw new \InvalidArgumentException('Execution topology counts MUST be positive.');
+            throw new \InvalidArgumentException('Use positive execution topology counts.');
         }
 
         $this->workers = $workers;

--- a/src/Execution/Plugin/PluginRuntimeError.php
+++ b/src/Execution/Plugin/PluginRuntimeError.php
@@ -80,7 +80,7 @@ final class PluginRuntimeError extends \RuntimeException
     public static function addedUnknownTest(string $plugin, TestId $test): self
     {
         return new self(\sprintf(
-            'Plugin "%s" added unknown test "%s" during transformTestPlan(). A plan transformer MAY only remove or reorder selected tests.',
+            'Plugin "%s" added unknown test "%s" during transformTestPlan(). A plan transformer can only remove or reorder selected tests.',
             $plugin,
             $test,
         ));

--- a/src/Execution/ProcessPool/Protocol/Messages/AttemptStarted.php
+++ b/src/Execution/ProcessPool/Protocol/Messages/AttemptStarted.php
@@ -32,7 +32,7 @@ final readonly class AttemptStarted implements Message
     ) {
         if ($attempt < 1) {
             throw new \InvalidArgumentException(\sprintf(
-                'Attempt numbers MUST be positive. Actual value: %d.',
+                'Use positive attempt numbers. Actual value: %d.',
                 $attempt,
             ));
         }

--- a/src/Execution/ProcessPool/Protocol/Messages/Done.php
+++ b/src/Execution/ProcessPool/Protocol/Messages/Done.php
@@ -38,7 +38,7 @@ final readonly class Done implements Message
     ) {
         if ($peakMemoryBytes < 0) {
             throw new \InvalidArgumentException(\sprintf(
-                'Done message peak memory MUST NOT be negative. Actual value: %d.',
+                'Done message peak memory cannot be negative. Actual value: %d.',
                 $peakMemoryBytes,
             ));
         }

--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -853,7 +853,7 @@ final class Expectation
 
             if ($result !== null) {
                 $this->usageFailure(\sprintf(
-                    'The throwable callback for toThrow() MUST return void. It returned %s.',
+                    'Return void from the throwable callback for toThrow(). It returned %s.',
                     \get_debug_type($result),
                 ));
             }
@@ -1007,11 +1007,11 @@ final class Expectation
             || $parameter->isVariadic()
             || $reflection->getNumberOfRequiredParameters() > 1
         ) {
-            $this->usageFailure('The throwable callback for toThrow() MUST accept one typed Throwable argument.');
+            $this->usageFailure('Give the throwable callback for toThrow() one typed Throwable argument.');
         }
 
         if ($parameter->isPassedByReference()) {
-            $this->usageFailure('The throwable callback for toThrow() MUST accept its argument by value.');
+            $this->usageFailure('Pass the throwable callback argument for toThrow() by value.');
         }
 
         $returnType = $reflection->getReturnType();
@@ -1021,7 +1021,7 @@ final class Expectation
                 || ($returnType->getName() !== 'void' && $returnType->getName() !== 'never'))
         ) {
             $this->usageFailure(\sprintf(
-                'The throwable callback for toThrow() MUST return void. Its return type is %s.',
+                'Return void from the throwable callback for toThrow(). Its return type is %s.',
                 $this->renderReflectionType($returnType),
             ));
         }
@@ -1030,7 +1030,7 @@ final class Expectation
 
         if (!$type instanceof \ReflectionNamedType || $type->isBuiltin() || $type->allowsNull()) {
             $this->usageFailure(\sprintf(
-                'The throwable callback for toThrow() MUST declare one named, non-null Throwable parameter type. Its parameter type is %s.',
+                'Declare one named, non-null Throwable parameter type for the toThrow() callback. Its parameter type is %s.',
                 $type instanceof \ReflectionType ? $this->renderReflectionType($type) : 'missing',
             ));
         }
@@ -1045,7 +1045,7 @@ final class Expectation
 
         if (!\is_a($throwable, \Throwable::class, true)) {
             $this->usageFailure(\sprintf(
-                'The throwable callback for toThrow() MUST declare a Throwable parameter type. Its parameter type is %s.',
+                'Declare a Throwable parameter type for the toThrow() callback. Its parameter type is %s.',
                 $type->getName(),
             ));
         }

--- a/src/Harness/HarnessScopes.php
+++ b/src/Harness/HarnessScopes.php
@@ -51,7 +51,7 @@ final class HarnessScopes
 
         foreach ($resolvers as $resolver) {
             if ($terminalSeen) {
-                throw new \InvalidArgumentException('A terminal service resolver MUST be the final resolver.');
+                throw new \InvalidArgumentException('Place a terminal service resolver last.');
             }
 
             $terminalSeen = $resolver instanceof TerminalServiceResolver;

--- a/src/Harness/ServiceDefinition.php
+++ b/src/Harness/ServiceDefinition.php
@@ -29,7 +29,7 @@ final readonly class ServiceDefinition
         public \Closure $factory,
     ) {
         if ($type === '') {
-            throw new \InvalidArgumentException('Harness service type MUST NOT be empty.');
+            throw new \InvalidArgumentException('Harness service type cannot be empty.');
         }
 
         $this->type = $type;

--- a/src/Harness/UnresolvableService.php
+++ b/src/Harness/UnresolvableService.php
@@ -51,7 +51,7 @@ final class UnresolvableService extends ServiceResolutionFailed
     public static function factoryTypeMismatch(string $type, mixed $actual): self
     {
         return new self(\sprintf(
-            'Service definition for type "%s" created "%s". Its factory MUST return an instance of "%s".',
+            'Service definition for type "%s" created "%s". Make its factory return an instance of "%s".',
             $type,
             \get_debug_type($actual),
             $type,

--- a/src/Harness/UnresolvableService.php
+++ b/src/Harness/UnresolvableService.php
@@ -72,7 +72,7 @@ final class UnresolvableService extends ServiceResolutionFailed
     {
         return new self(\sprintf(
             'Constructor parameter $%s of "%s" has no resolvable type. '
-            . 'A test constructor can declare only harness service types.',
+            . 'Use one class or interface type, or give the parameter a default value.',
             $parameter,
             $consumer,
         ));

--- a/src/IntegrationFixture/IntegrationFixtureError.php
+++ b/src/IntegrationFixture/IntegrationFixtureError.php
@@ -45,7 +45,7 @@ final class IntegrationFixtureError extends \RuntimeException
     {
         return new self(\sprintf(
             'Integration fixture provider "%s" returned %s. '
-            . 'It MUST return IntegrationFixtureDefinition instances.',
+            . 'Return IntegrationFixtureDefinition instances.',
             $provider,
             \get_debug_type($definition),
         ));

--- a/src/PhpStan/ToThrowCallbackRule.php
+++ b/src/PhpStan/ToThrowCallbackRule.php
@@ -107,7 +107,7 @@ final class ToThrowCallbackRule implements Rule
 
         if ($parameters === [] || $parameters[0]->isVariadic()) {
             return $this->error(
-                'The throwable callback for toThrow() MUST accept one typed Throwable argument.',
+                'Give the throwable callback for toThrow() one typed Throwable argument.',
                 $line,
             );
         }
@@ -118,7 +118,7 @@ final class ToThrowCallbackRule implements Rule
 
         if ($parameters[0]->passedByReference()->yes()) {
             return $this->error(
-                'The throwable callback for toThrow() MUST accept its argument by value.',
+                'Pass the throwable callback argument for toThrow() by value.',
                 $line,
             );
         }
@@ -138,7 +138,7 @@ final class ToThrowCallbackRule implements Rule
             || !$throwable->isSuperTypeOf($parameterType)->yes()
         ) {
             return $this->error(\sprintf(
-                'The throwable callback for toThrow() MUST declare one named, non-null Throwable parameter type. Its parameter type is %s.',
+                'Declare one named, non-null Throwable parameter type for the toThrow() callback. Its parameter type is %s.',
                 $parameterType->describe(VerbosityLevel::typeOnly()),
             ), $line);
         }

--- a/src/Plugin/CommandDefinition.php
+++ b/src/Plugin/CommandDefinition.php
@@ -27,12 +27,12 @@ final readonly class CommandDefinition
     ) {
         if (\preg_match('/^[a-z][a-z0-9]*(?:[:-][a-z0-9]+)*$/D', $name) !== 1) {
             throw new \InvalidArgumentException(
-                'Command names MUST start with a lowercase ASCII letter. They MUST contain only lowercase ASCII letters, digits, hyphens, or colons.',
+                'Start command names with a lowercase ASCII letter. Use lowercase ASCII letters and digits, with single hyphens or colons between segments.',
             );
         }
 
         if ($description === '' || \str_contains($description, "\n") || \str_contains($description, "\r")) {
-            throw new \InvalidArgumentException('Command descriptions MUST be non-empty single-line strings.');
+            throw new \InvalidArgumentException('Use a non-empty single-line string for each command description.');
         }
 
         $this->name = $name;

--- a/src/Plugin/CommandResult.php
+++ b/src/Plugin/CommandResult.php
@@ -39,7 +39,7 @@ final readonly class CommandResult
     public static function interrupted(int $signal): self
     {
         if ($signal < 1 || $signal > 127) {
-            throw new \InvalidArgumentException('Signal number MUST be from 1 through 127.');
+            throw new \InvalidArgumentException('Use a signal number from 1 through 127.');
         }
 
         return new self(CommandOutcome::Interrupted, $signal);

--- a/src/Psr15/Psr15Error.php
+++ b/src/Psr15/Psr15Error.php
@@ -20,7 +20,7 @@ final class Psr15Error extends \RuntimeException
     public static function invalidHandler(mixed $handler): self
     {
         return new self(\sprintf(
-            'The PSR-15 handler factory returned "%s". It MUST return an instance of "Psr\\Http\\Server\\RequestHandlerInterface".',
+            'The PSR-15 handler factory returned "%s". Return an instance of "Psr\\Http\\Server\\RequestHandlerInterface".',
             \get_debug_type($handler),
         ));
     }

--- a/tests/Acceptance/CustomTestPlanTest.php
+++ b/tests/Acceptance/CustomTestPlanTest.php
@@ -66,7 +66,7 @@ final readonly class CustomTestPlanTest
 
         Expect::that($result->exitCode)->toBe(1);
         Expect::that($result->stderr)->toBe(
-            'greenlight: Plugin "InvalidPlan" added unknown test "UnknownTest::passes" during transformTestPlan(). A plan transformer MAY only remove or reorder selected tests.',
+            'greenlight: Plugin "InvalidPlan" added unknown test "UnknownTest::passes" during transformTestPlan(). A plan transformer can only remove or reorder selected tests.',
         );
     }
 

--- a/tests/Acceptance/PhpStanToThrowRuleTest.php
+++ b/tests/Acceptance/PhpStanToThrowRuleTest.php
@@ -246,10 +246,10 @@ final readonly class PhpStanToThrowRuleTest
         Expect::that($probe->goodPassed)->toBeTrue();
         Expect::that(\count($probe->errors))->toBe(7);
         Expect::that($probe->messages())->toContain(
-            'The throwable callback for toThrow() MUST accept one typed Throwable argument.',
+            'Give the throwable callback for toThrow() one typed Throwable argument.',
         );
         Expect::that($probe->messages())->toContain(
-            'The throwable callback for toThrow() MUST declare one named, non-null Throwable parameter type.',
+            'Declare one named, non-null Throwable parameter type for the toThrow() callback.',
         );
         Expect::that($probe->messages())->toContain(
             'Parameter #1 $throwable of method Greenlight\\Expect\\Expectation<Closure>::toThrow() expects',

--- a/tests/Unit/Cli/Input/OptionSpecTest.php
+++ b/tests/Unit/Cli/Input/OptionSpecTest.php
@@ -47,37 +47,37 @@ final readonly class OptionSpecTest
         yield 'long name with leading hyphen' => [
             '-workers',
             null,
-            'Option name "-workers" MUST start with an ASCII letter or digit and MUST contain only ASCII letters, digits, or hyphens.',
+            'Start option name "-workers" with an ASCII letter or digit. Use only ASCII letters, digits, or hyphens.',
         ];
         yield 'long name with value delimiter' => [
             'workers=fast',
             null,
-            'Option name "workers=fast" MUST start with an ASCII letter or digit and MUST contain only ASCII letters, digits, or hyphens.',
+            'Start option name "workers=fast" with an ASCII letter or digit. Use only ASCII letters, digits, or hyphens.',
         ];
         yield 'long name with whitespace' => [
             'worker count',
             null,
-            'Option name "worker count" MUST start with an ASCII letter or digit and MUST contain only ASCII letters, digits, or hyphens.',
+            'Start option name "worker count" with an ASCII letter or digit. Use only ASCII letters, digits, or hyphens.',
         ];
         yield 'long name with non-ASCII letter' => [
             'wörkers',
             null,
-            'Option name "wörkers" MUST start with an ASCII letter or digit and MUST contain only ASCII letters, digits, or hyphens.',
+            'Start option name "wörkers" with an ASCII letter or digit. Use only ASCII letters, digits, or hyphens.',
         ];
         yield 'empty short alias' => [
             'help',
             '',
-            'Short option alias "" MUST be one ASCII letter.',
+            'Use one ASCII letter for short option alias "".',
         ];
         yield 'multi-letter short alias' => [
             'help',
             'help',
-            'Short option alias "help" MUST be one ASCII letter.',
+            'Use one ASCII letter for short option alias "help".',
         ];
         yield 'numeric short alias' => [
             'workers',
             '1',
-            'Short option alias "1" MUST be one ASCII letter.',
+            'Use one ASCII letter for short option alias "1".',
         ];
     }
 }

--- a/tests/Unit/Execution/Plugin/OrchestratorPluginRuntimeFixtureTest.php
+++ b/tests/Unit/Execution/Plugin/OrchestratorPluginRuntimeFixtureTest.php
@@ -71,7 +71,7 @@ final readonly class OrchestratorPluginRuntimeFixtureTest
                 IntegrationFixtureError::class,
                 message: 'Integration fixture provider "'
                     . FakeIntegrationFixtureProvider::class
-                    . '" returned stdClass. It MUST return IntegrationFixtureDefinition instances.',
+                    . '" returned stdClass. Return IntegrationFixtureDefinition instances.',
             );
     }
 

--- a/tests/Unit/Execution/ProcessPool/Protocol/AttemptStartedTest.php
+++ b/tests/Unit/Execution/ProcessPool/Protocol/AttemptStartedTest.php
@@ -22,7 +22,7 @@ final class AttemptStartedTest
             ->because('attempt-started messages MUST identify a positive attempt number')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: \sprintf('Attempt numbers MUST be positive. Actual value: %d.', $attempt),
+                message: \sprintf('Use positive attempt numbers. Actual value: %d.', $attempt),
             );
     }
 

--- a/tests/Unit/Execution/ProcessPool/Protocol/DoneValidationTest.php
+++ b/tests/Unit/Execution/ProcessPool/Protocol/DoneValidationTest.php
@@ -21,7 +21,7 @@ final readonly class DoneValidationTest
             ->toThrow(
                 \InvalidArgumentException::class,
                 message: \sprintf(
-                    'Done message peak memory MUST NOT be negative. Actual value: %d.',
+                    'Done message peak memory cannot be negative. Actual value: %d.',
                     $peakMemoryBytes,
                 ),
             );

--- a/tests/Unit/Execution/Worker/WorkerTest.php
+++ b/tests/Unit/Execution/Worker/WorkerTest.php
@@ -313,7 +313,7 @@ final class WorkerTest
         Expect::that($result->error?->message)
             ->toBe(\sprintf(
                 'Constructor parameter $value of "%s" has no resolvable type. '
-                . 'A test constructor can declare only harness service types.',
+                . 'Use one class or interface type, or give the parameter a default value.',
                 UnsupportedConstructorProbe::class,
             ));
     }

--- a/tests/Unit/Expect/ToThrowTest.php
+++ b/tests/Unit/Expect/ToThrowTest.php
@@ -382,47 +382,47 @@ final class ToThrowTest
     {
         yield 'no throwable parameter' => [
             static function (): void {},
-            'The throwable callback for toThrow() MUST accept one typed Throwable argument.',
+            'Give the throwable callback for toThrow() one typed Throwable argument.',
         ];
         yield 'too many required parameters' => [
             static function (\DomainException $error, string $context): void {},
-            'The throwable callback for toThrow() MUST accept one typed Throwable argument.',
+            'Give the throwable callback for toThrow() one typed Throwable argument.',
         ];
         yield 'variadic throwable parameter' => [
             static function (\DomainException ...$error): void {},
-            'The throwable callback for toThrow() MUST accept one typed Throwable argument.',
+            'Give the throwable callback for toThrow() one typed Throwable argument.',
         ];
         yield 'parameter by reference' => [
             static function (\DomainException &$error): void {},
-            'The throwable callback for toThrow() MUST accept its argument by value.',
+            'Pass the throwable callback argument for toThrow() by value.',
         ];
         yield 'declared return value' => [
             static fn(\DomainException $error): int => 1,
-            'The throwable callback for toThrow() MUST return void. Its return type is int.',
+            'Return void from the throwable callback for toThrow(). Its return type is int.',
         ];
         yield 'missing parameter type' => [
             static function ($error): void {},
-            'The throwable callback for toThrow() MUST declare one named, non-null Throwable parameter type. Its parameter type is missing.',
+            'Declare one named, non-null Throwable parameter type for the toThrow() callback. Its parameter type is missing.',
         ];
         yield 'built-in parameter type' => [
             static function (string $error): void {},
-            'The throwable callback for toThrow() MUST declare one named, non-null Throwable parameter type. Its parameter type is string.',
+            'Declare one named, non-null Throwable parameter type for the toThrow() callback. Its parameter type is string.',
         ];
         yield 'nullable parameter type' => [
             static function (?\DomainException $error): void {},
-            'The throwable callback for toThrow() MUST declare one named, non-null Throwable parameter type. Its parameter type is ?DomainException.',
+            'Declare one named, non-null Throwable parameter type for the toThrow() callback. Its parameter type is ?DomainException.',
         ];
         yield 'union parameter type' => [
             static function (\LengthException|\OutOfBoundsException $error): void {},
-            'The throwable callback for toThrow() MUST declare one named, non-null Throwable parameter type. Its parameter type is LengthException|OutOfBoundsException.',
+            'Declare one named, non-null Throwable parameter type for the toThrow() callback. Its parameter type is LengthException|OutOfBoundsException.',
         ];
         yield 'intersection parameter type' => [
             static function (\Throwable&\Countable $error): void {},
-            'The throwable callback for toThrow() MUST declare one named, non-null Throwable parameter type. Its parameter type is Throwable&Countable.',
+            'Declare one named, non-null Throwable parameter type for the toThrow() callback. Its parameter type is Throwable&Countable.',
         ];
         yield 'non-throwable class parameter type' => [
             static function (\stdClass $error): void {},
-            'The throwable callback for toThrow() MUST declare a Throwable parameter type. Its parameter type is stdClass.',
+            'Declare a Throwable parameter type for the toThrow() callback. Its parameter type is stdClass.',
         ];
     }
 
@@ -471,7 +471,7 @@ final class ToThrowTest
         );
 
         Expect::that($detail->message)->toBe(
-            'The throwable callback for toThrow() MUST return void. It returned int.',
+            'Return void from the throwable callback for toThrow(). It returned int.',
         );
     }
 }

--- a/tests/Unit/Harness/HarnessScopesTest.php
+++ b/tests/Unit/Harness/HarnessScopesTest.php
@@ -309,7 +309,7 @@ final class HarnessScopesTest
 
         Expect::that(static fn(): HarnessScopes => new HarnessScopes([], [$terminal, $fallback]))
             ->because('a terminal resolver MUST be the final resolver')
-            ->toThrow(\InvalidArgumentException::class, message: 'A terminal service resolver MUST be the final resolver.');
+            ->toThrow(\InvalidArgumentException::class, message: 'Place a terminal service resolver last.');
     }
 
     #[Test]

--- a/tests/Unit/Harness/HarnessServiceFactoryContractTest.php
+++ b/tests/Unit/Harness/HarnessServiceFactoryContractTest.php
@@ -35,7 +35,7 @@ final class HarnessServiceFactoryContractTest
                 UnresolvableService::class,
                 message: \sprintf(
                     'Service definition for type "Countable" created "%s". '
-                    . 'Its factory MUST return an instance of "Countable".',
+                    . 'Make its factory return an instance of "Countable".',
                     $type,
                 ),
             );
@@ -60,7 +60,7 @@ final class HarnessServiceFactoryContractTest
             ->toThrow(
                 UnresolvableService::class,
                 message: 'Service definition for type "Countable" created "stdClass". '
-                . 'Its factory MUST return an instance of "Countable".',
+                . 'Make its factory return an instance of "Countable".',
             );
     }
 
@@ -74,7 +74,7 @@ final class HarnessServiceFactoryContractTest
             ->toThrow(
                 UnresolvableService::class,
                 message: 'Service definition for type "Greenlight\\Tests\\Fixture\\Harness\\FactoryContractTarget" '
-                . 'created "stdClass". Its factory MUST return an instance of '
+                . 'created "stdClass". Make its factory return an instance of '
                 . '"Greenlight\\Tests\\Fixture\\Harness\\FactoryContractTarget".',
             );
     }

--- a/tests/Unit/Harness/ServiceDefinitionValidationTest.php
+++ b/tests/Unit/Harness/ServiceDefinitionValidationTest.php
@@ -22,7 +22,7 @@ final readonly class ServiceDefinitionValidationTest
             ->because('a harness service definition MUST identify its injected type')
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Harness service type MUST NOT be empty.',
+                message: 'Harness service type cannot be empty.',
             );
     }
 }

--- a/tests/Unit/Plugin/CommandDefinitionTest.php
+++ b/tests/Unit/Plugin/CommandDefinitionTest.php
@@ -30,22 +30,32 @@ final readonly class CommandDefinitionTest
         yield 'empty name' => [
             '',
             'Description',
-            'Command names MUST start with a lowercase ASCII letter. They MUST contain only lowercase ASCII letters, digits, hyphens, or colons.',
+            'Start command names with a lowercase ASCII letter. Use lowercase ASCII letters and digits, with single hyphens or colons between segments.',
         ];
         yield 'uppercase name' => [
             'Company:hello',
             'Description',
-            'Command names MUST start with a lowercase ASCII letter. They MUST contain only lowercase ASCII letters, digits, hyphens, or colons.',
+            'Start command names with a lowercase ASCII letter. Use lowercase ASCII letters and digits, with single hyphens or colons between segments.',
         ];
         yield 'empty description' => [
             'company:hello',
             '',
-            'Command descriptions MUST be non-empty single-line strings.',
+            'Use a non-empty single-line string for each command description.',
+        ];
+        yield 'repeated separator' => [
+            'company::hello',
+            'Description',
+            'Start command names with a lowercase ASCII letter. Use lowercase ASCII letters and digits, with single hyphens or colons between segments.',
+        ];
+        yield 'trailing separator' => [
+            'company:',
+            'Description',
+            'Start command names with a lowercase ASCII letter. Use lowercase ASCII letters and digits, with single hyphens or colons between segments.',
         ];
         yield 'multiline description' => [
             'company:hello',
             "First line\nsecond line",
-            'Command descriptions MUST be non-empty single-line strings.',
+            'Use a non-empty single-line string for each command description.',
         ];
     }
 }

--- a/tests/Unit/Plugin/CommandResultTest.php
+++ b/tests/Unit/Plugin/CommandResultTest.php
@@ -16,13 +16,13 @@ final readonly class CommandResultTest
         Expect::that(static fn(): CommandResult => CommandResult::interrupted(0))
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Signal number MUST be from 1 through 127.',
+                message: 'Use a signal number from 1 through 127.',
             );
 
         Expect::that(static fn(): CommandResult => CommandResult::interrupted(128))
             ->toThrow(
                 \InvalidArgumentException::class,
-                message: 'Signal number MUST be from 1 through 127.',
+                message: 'Use a signal number from 1 through 127.',
             );
     }
 }

--- a/tests/Unit/Psr15/HttpHarnessTest.php
+++ b/tests/Unit/Psr15/HttpHarnessTest.php
@@ -99,7 +99,7 @@ final class HttpHarnessTest
         ))->toThrow(
             Psr15Error::class,
             message: 'The PSR-15 handler factory returned "stdClass". '
-                . 'It MUST return an instance of "Psr\\Http\\Server\\RequestHandlerInterface".',
+                . 'Return an instance of "Psr\\Http\\Server\\RequestHandlerInterface".',
         );
     }
 


### PR DESCRIPTION
Callback and plugin errors use uppercase specification terms instead of direct corrective instructions. Rewrite the messages for command options, callback signatures, harness factories, fixture providers, watch sources, and worker values. Keep runtime and PHPStan callback diagnostics consistent.

The command-name message also omitted separator placement restrictions. The existing regex permits only single hyphens or colons between alphanumeric segments. Document that constraint and cover repeated and trailing separators in the existing data set. Other changes preserve the validation guards and update their exact-message assertions.
