### PR TITLE
docs: clarify integration API lifetimes and resource data

### DIFF
--- a/docs/api-integration-fixtures.md
+++ b/docs/api-integration-fixtures.md
@@ -364,8 +364,8 @@ Namespace: `Greenlight\IntegrationFixture`
 
 The integration fixtures visible to one worker channel.
 
-A worker receives shared data merged with only its own channel data. It
-cannot inspect credentials allocated to another concurrent lane.
+A worker receives shared data merged with only its own channel data.
+This object does not contain data allocated only to other channels.
 Fixture IDs must remain string keys in PHP maps.
 
 ```php

--- a/docs/api-integration-fixtures.md
+++ b/docs/api-integration-fixtures.md
@@ -26,7 +26,8 @@ final readonly class FixtureResource
 Creates one resource from ordinary values and secrets.
 
 Values can contain null, integers, booleans, finite floats, UTF-8 strings, lists, and maps.
-Map keys must be non-empty UTF-8 strings. The maximum container depth is 16.
+Map keys must be non-empty UTF-8 strings.
+Values can contain up to 16 nested lists or maps below the top-level map.
 Secrets must map non-empty UTF-8 string keys to UTF-8 string values.
 
 ```php
@@ -39,7 +40,7 @@ PHPDoc:
 - `@param array<mixed> $secrets`
 - `@throws \InvalidArgumentException when an input does not satisfy these requirements`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L47)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L48)
 
 ### `empty()`
 
@@ -47,7 +48,7 @@ PHPDoc:
 public static function empty(): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L68)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L69)
 
 ### `has()`
 
@@ -55,7 +56,7 @@ public static function empty(): self
 public function has(string $key): bool
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L73)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L74)
 
 ### `value()`
 
@@ -67,7 +68,7 @@ PHPDoc:
 
 - `@throws \OutOfBoundsException when no ordinary value has the key`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L81)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L82)
 
 ### `string()`
 
@@ -80,7 +81,7 @@ PHPDoc:
 - `@throws \OutOfBoundsException when no ordinary value has the key`
 - `@throws \UnexpectedValueException when the value is not a string`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L94)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L95)
 
 ### `int()`
 
@@ -93,7 +94,7 @@ PHPDoc:
 - `@throws \OutOfBoundsException when no ordinary value has the key`
 - `@throws \UnexpectedValueException when the value is not an integer`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L109)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L110)
 
 ### `float()`
 
@@ -106,7 +107,7 @@ PHPDoc:
 - `@throws \OutOfBoundsException when no ordinary value has the key`
 - `@throws \UnexpectedValueException when the value is not an integer or float`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L124)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L125)
 
 ### `bool()`
 
@@ -119,7 +120,7 @@ PHPDoc:
 - `@throws \OutOfBoundsException when no ordinary value has the key`
 - `@throws \UnexpectedValueException when the value is not a boolean`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L139)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L140)
 
 ### `list()`
 
@@ -133,7 +134,7 @@ PHPDoc:
 - `@throws \OutOfBoundsException when no ordinary value has the key`
 - `@throws \UnexpectedValueException when the value is not a list`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L155)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L156)
 
 ### `map()`
 
@@ -147,7 +148,7 @@ PHPDoc:
 - `@throws \OutOfBoundsException when no ordinary value has the key`
 - `@throws \UnexpectedValueException when the value is not a map`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L171)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L172)
 
 ### `secret()`
 
@@ -159,7 +160,7 @@ PHPDoc:
 
 - `@throws \OutOfBoundsException when no secret has the key`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L186)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L187)
 
 ### `mergedWith()`
 
@@ -167,7 +168,7 @@ PHPDoc:
 public function mergedWith(self $channel): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L197)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L198)
 
 ### `__debugInfo()`
 
@@ -179,7 +180,7 @@ PHPDoc:
 
 - `@return array{values: array<string, mixed>, secrets: array<string, string>}`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L248)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/FixtureResource.php#L249)
 
 ## `IntegrationFixtureContext`
 

--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -149,7 +149,9 @@ PHPDoc:
 
 Namespace: `Greenlight\Laravel`
 
-Boots one Laravel application lazily for a test and resolves bound services.
+Boots a Laravel application on first use and resolves bound services.
+By default, Greenlight releases the application after each test attempt.
+
 `#[Service]` selects an explicit binding ID. Isolate external test resources
 by `GREENLIGHT_CHANNEL`.
 
@@ -157,7 +159,7 @@ by `GREENLIGHT_CHANNEL`.
 final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, ServiceResolver
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L27)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L29)
 
 ### `__construct()`
 
@@ -171,11 +173,11 @@ public function __construct(
 
 PHPDoc:
 
-- `@param string|\Closure(): Application $application A path to the file that returns the application, usually bootstrap/app.php, or a closure returning the application when exotic construction is needed.`
+- `@param string|\Closure(): Application $application A path to a file that returns the application, usually bootstrap/app.php. For other application setup, pass a closure that returns the application.`
 - `@param non-empty-string $env`
-- `@param bool $refreshBetweenTests Set to false only when no service carries state; tests on one worker then share one unreset application for the worker lifetime.`
+- `@param bool $refreshBetweenTests Set to false only when no service keeps state between tests. Tests on one worker then share one application without resets.`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L47)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L48)
 
 ### `services()`
 
@@ -187,7 +189,7 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L75)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L76)
 
 ### `resolve()`
 
@@ -201,7 +203,7 @@ PHPDoc:
 - `@param list<object> $attributes`
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L92)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L93)
 
 ### `afterTest()`
 
@@ -209,7 +211,7 @@ PHPDoc:
 public function afterTest(TestContext $context, TestResult $result): TestResult
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L128)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L129)
 
 ## `Psr11Plugin`
 
@@ -288,13 +290,15 @@ PHPDoc:
 Namespace: `Greenlight\Psr15`
 
 Sends PSR-7 server requests directly to one PSR-15 request handler.
-The optional release callback closes handler state when the harness scope closes.
+If a factory supplies the handler, the first request creates it.
+
+Disposal calls the optional release callback only if a handler exists.
 
 ```php
 final class HttpHarness implements Disposable
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/HttpHarness.php#L16)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/HttpHarness.php#L18)
 
 ### `__construct()`
 
@@ -310,7 +314,7 @@ PHPDoc:
 - `@param RequestHandlerInterface|\Closure(): RequestHandlerInterface $handler`
 - `@param null|\Closure(RequestHandlerInterface): void $release`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/HttpHarness.php#L29)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/HttpHarness.php#L31)
 
 ### `send()`
 
@@ -322,7 +326,7 @@ PHPDoc:
 
 - `@throws Psr15Error`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/HttpHarness.php#L46)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/HttpHarness.php#L48)
 
 ### `dispose()`
 
@@ -334,7 +338,7 @@ PHPDoc:
 
 - `@throws Psr15Error`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/HttpHarness.php#L72)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/HttpHarness.php#L74)
 
 ## `Psr15Error`
 
@@ -397,14 +401,17 @@ public static function disposed(): self
 
 Namespace: `Greenlight\Psr15`
 
-Supplies one HTTP harness in the configured service scope. A handler factory
-with the per-test scope gives each test a new application handler.
+Supplies one HTTP harness in the configured service scope.
+Each harness calls its handler factory on the first request.
+
+For a new application handler in each test attempt, use the per-test scope.
+Supply a factory that creates a new handler each time.
 
 ```php
 final readonly class Psr15Plugin implements HarnessProvider
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/Psr15Plugin.php#L16)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/Psr15Plugin.php#L19)
 
 ### `__construct()`
 
@@ -421,7 +428,7 @@ PHPDoc:
 - `@param RequestHandlerInterface|\Closure(): RequestHandlerInterface $handler A handler or a factory that returns a handler.`
 - `@param null|\Closure(RequestHandlerInterface): void $release A callback that releases the active handler when its scope closes.`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/Psr15Plugin.php#L27)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/Psr15Plugin.php#L30)
 
 ### `services()`
 
@@ -433,7 +440,7 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/Psr15Plugin.php#L41)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr15/Psr15Plugin.php#L44)
 
 ## `PhpUnitToGreenlightRector`
 

--- a/src/IntegrationFixture/FixtureResource.php
+++ b/src/IntegrationFixture/FixtureResource.php
@@ -37,7 +37,8 @@ final readonly class FixtureResource
      * Creates one resource from ordinary values and secrets.
      *
      * Values can contain null, integers, booleans, finite floats, UTF-8 strings, lists, and maps.
-     * Map keys must be non-empty UTF-8 strings. The maximum container depth is 16.
+     * Map keys must be non-empty UTF-8 strings.
+     * Values can contain up to 16 nested lists or maps below the top-level map.
      * Secrets must map non-empty UTF-8 string keys to UTF-8 string values.
      *
      * @param array<string, mixed> $values

--- a/src/IntegrationFixture/IntegrationResources.php
+++ b/src/IntegrationFixture/IntegrationResources.php
@@ -11,8 +11,8 @@ use Greenlight\Internal\Wire\WireCommunicationFailed;
 /**
  * The integration fixtures visible to one worker channel.
  *
- * A worker receives shared data merged with only its own channel data. It
- * cannot inspect credentials allocated to another concurrent lane.
+ * A worker receives shared data merged with only its own channel data.
+ * This object does not contain data allocated only to other channels.
  * Fixture IDs must remain string keys in PHP maps.
  */
 final readonly class IntegrationResources

--- a/src/Laravel/LaravelPlugin.php
+++ b/src/Laravel/LaravelPlugin.php
@@ -20,7 +20,9 @@ use Illuminate\Foundation\Bootstrap\HandleExceptions;
 use Illuminate\Foundation\Bootstrap\RegisterProviders;
 
 /**
- * Boots one Laravel application lazily for a test and resolves bound services.
+ * Boots a Laravel application on first use and resolves bound services.
+ * By default, Greenlight releases the application after each test attempt.
+ *
  * `#[Service]` selects an explicit binding ID. Isolate external test resources
  * by `GREENLIGHT_CHANNEL`.
  */
@@ -36,13 +38,12 @@ final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, Servi
 
     /**
      * @param string|\Closure(): Application $application
-     *   A path to the file that returns the application, usually
-     *   bootstrap/app.php, or a closure returning the application when
-     *   exotic construction is needed.
+     *   A path to a file that returns the application, usually bootstrap/app.php.
+     *   For other application setup, pass a closure that returns the application.
      * @param non-empty-string $env
      * @param bool $refreshBetweenTests
-     *   Set to false only when no service carries state; tests on one worker
-     *   then share one unreset application for the worker lifetime.
+     *   Set to false only when no service keeps state between tests.
+     *   Tests on one worker then share one application without resets.
      */
     public function __construct(
         string|\Closure $application,

--- a/src/Psr15/HttpHarness.php
+++ b/src/Psr15/HttpHarness.php
@@ -11,7 +11,9 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 /**
  * Sends PSR-7 server requests directly to one PSR-15 request handler.
- * The optional release callback closes handler state when the harness scope closes.
+ * If a factory supplies the handler, the first request creates it.
+ *
+ * Disposal calls the optional release callback only if a handler exists.
  */
 final class HttpHarness implements Disposable
 {

--- a/src/Psr15/Psr15Plugin.php
+++ b/src/Psr15/Psr15Plugin.php
@@ -10,8 +10,11 @@ use Greenlight\Plugin\HarnessProvider;
 use Psr\Http\Server\RequestHandlerInterface;
 
 /**
- * Supplies one HTTP harness in the configured service scope. A handler factory
- * with the per-test scope gives each test a new application handler.
+ * Supplies one HTTP harness in the configured service scope.
+ * Each harness calls its handler factory on the first request.
+ *
+ * For a new application handler in each test attempt, use the per-test scope.
+ * Supply a factory that creates a new handler each time.
  */
 final readonly class Psr15Plugin implements HarnessProvider
 {


### PR DESCRIPTION
The integration API says a per-test handler factory gives each test a new handler, but a factory can return a shared instance. It also leaves Laravel's default application lifetime unclear.

Document when `HttpHarness` calls a factory and release callback. Explain that callers need a factory that creates a new handler for each test attempt. Clarify Laravel application release and shared-instance options. Use the same channel terminology throughout integration resource descriptions and scope the data claim to the supplied object.

These corrections follow `HttpHarness::handler()` and `dispose()`, `Psr15Plugin` service scopes, `LaravelPlugin::afterTest()`, and the integration fixture resource map. Update the maintained PHPDoc and regenerate the API pages.
