### PR TITLE
docs(internals): align maintainer comments with runtime behavior

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -126,7 +126,7 @@
         "code-style:check": "Checks code style without changes to files.",
         "code-style:fix": "Corrects code-style violations.",
         "deptrac": "Checks the dependency boundaries.",
-        "docs:php:check": "Checks the PHP API documentation.",
+        "docs:php:check": "Checks classified PHP examples in the documentation.",
         "lint": "Checks the PHP syntax.",
         "memory-gate": "Checks for memory growth during a long test run.",
         "phpstan": "Analyzes PHP types with PHPStan.",

--- a/src/Cli/State/RunState.php
+++ b/src/Cli/State/RunState.php
@@ -9,8 +9,9 @@ use Greenlight\Internal\Filesystem\AtomicFileError;
 use Greenlight\Internal\Php\ErrorTrap;
 
 /**
- * Stores failures and class durations in the system temporary directory.
- * The project directory identifies the state.
+ * Stores failed test IDs and class durations in a selected file.
+ * forWorkingDirectory() selects a project-specific file in the system temporary
+ * directory. CLI runs use forFile() with the resolved storage configuration.
  *
  * @internal
  */
@@ -43,8 +44,8 @@ final class RunState
      * Returns failed test IDs from the previous run.
      *
      * Returns null if no usable state exists. This occurs before the first run
-     * or when the file is unreadable or corrupt. An empty list means that all
-     * tests passed in the previous run.
+     * or when the file is unreadable or corrupt. An empty list means that no
+     * test failed or errored in the recorded run.
      *
      * @return list<non-empty-string>|null
      */

--- a/src/Coverage/Diff/BaselineDiffReport.php
+++ b/src/Coverage/Diff/BaselineDiffReport.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Greenlight\Coverage\Diff;
 
 /**
- * Omits files with no percentage change and no new uncovered lines.
+ * Contains changed, added, and removed files from a baseline comparison.
+ * Unchanged files appear only when the caller supplies them directly.
  * hasRegressions() compares the total coverage of files that are in both maps.
  * Thus, a removed file cannot cause a regression.
  *

--- a/src/Execution/Worker/OutputCapture.php
+++ b/src/Execution/Worker/OutputCapture.php
@@ -15,10 +15,8 @@ use Greenlight\Result\DiagnosticSeverity;
  * Direct writes to stream resources bypass output capture. Examples include
  * fwrite(STDERR, ...) and fwrite(STDOUT, ...).
  *
- * If output is too long, Greenlight keeps the first part. This part usually
- * contains useful error information. The final part frequently contains
- * repeated information. Greenlight removes a partial multibyte character at
- * the size limit.
+ * If output is too long, Greenlight keeps the first part and records truncation.
+ * Greenlight removes a partial multibyte character at the size limit.
  *
  * @internal
  */

--- a/src/Rector/AssertionConversion.php
+++ b/src/Rector/AssertionConversion.php
@@ -7,8 +7,9 @@ namespace Greenlight\Rector;
 /**
  * Describes how one PHPUnit assertion maps onto a Greenlight expectation.
  * The entry selects the subject argument, the matcher arguments, and the
- * negation. Arguments beyond the arity form the PHPUnit failure message,
- * which has no Greenlight equivalent.
+ * negation. Arguments beyond the arity form the PHPUnit failure message.
+ * The converter rejects such messages unless drop_assertion_messages is enabled.
+ * A manual migration can preserve a message with because().
  *
  * @internal
  */

--- a/src/Reporting/GithubReporter.php
+++ b/src/Reporting/GithubReporter.php
@@ -13,10 +13,10 @@ use Greenlight\Result\TestResult;
 use Greenlight\Result\ThrowableDetail;
 
 /**
- * Writes GitHub Actions workflow commands for test failures and errors.
+ * Writes GitHub Actions errors for test failures and errors.
  *
- * Only failures and errors produce output. Thus, annotations occur on the
- * pull request diff, and passed tests do not add log output.
+ * Retried passes produce warnings. Retained attachments produce a notice
+ * with the artifact directory when the run finishes.
  *
  * The reporter escapes messages and properties with the workflow-command rules.
  *

--- a/src/Reporting/Style.php
+++ b/src/Reporting/Style.php
@@ -7,7 +7,8 @@ namespace Greenlight\Reporting;
 /**
  * Duration colors change at one second and five seconds.
  *
- * Without ANSI support, every method returns its text unchanged.
+ * Without ANSI support, text methods return their input unchanged.
+ * duration() formats seconds with three decimal places and an "s" suffix.
  *
  * @internal
  */

--- a/src/Test/DataSet/DataSetExpander.php
+++ b/src/Test/DataSet/DataSetExpander.php
@@ -13,7 +13,8 @@ use Greenlight\Internal\Php\ErrorTrap;
  *
  * Discovery executes only data providers. Providers MUST be pure. For the
  * same inputs, a provider MUST supply the same data. A provider MUST NOT
- * change external state. Each provider has a time limit.
+ * change external state. Greenlight checks the time budget between rows and
+ * after iteration. The budget cannot interrupt a blocked provider.
  *
  * Greenlight does not change a printable string key. It converts an integer
  * key to "#<value>". For an empty or nonprintable string key, it uses the

--- a/tools/local-ci-lock.php
+++ b/tools/local-ci-lock.php
@@ -7,8 +7,8 @@ const MAX_PARALLELISM_ENVIRONMENT_VARIABLE = 'GREENLIGHT_LOCAL_CI_MAX_PARALLELIS
 const LOCK_DIRECTORY_ENVIRONMENT_VARIABLE = 'GREENLIGHT_LOCAL_CI_LOCK_DIRECTORY';
 
 /**
- * Limits concurrent local CI commands from Git worktrees. Hosted CI bypasses
- * the limit because each job has independent resources.
+ * Limits concurrent local CI commands from Git worktrees.
+ * A truthy CI environment variable bypasses the limit.
  *
  * @param list<string> $arguments
  */

--- a/tools/memory-gate.php
+++ b/tools/memory-gate.php
@@ -10,8 +10,8 @@ declare(strict_types=1);
  */
 
 // A small set of methods runs many times with data sets. Per-method runtime
-// caches reach their limit during engine warmup. Thus, a remaining slope
-// identifies a per-test lifecycle leak.
+// caches can stabilize during engine warmup. Growth after warmup can indicate
+// a per-test lifecycle leak. The measurements do not identify its cause.
 const CLASS_COUNT = 20;
 const METHODS_PER_CLASS = 5;
 const ROWS_PER_METHOD = 100;

--- a/tools/memory-gate.php
+++ b/tools/memory-gate.php
@@ -210,7 +210,7 @@ echo \sprintf(
 $cleanup();
 
 if ($drift > MAX_DRIFT_BYTES) {
-    \fwrite(\STDERR, "FLAT-MEMORY GATE FAILED: Greenlight leaks memory during a long run.\n");
+    \fwrite(\STDERR, "Flat-memory gate failed: measured memory growth exceeds the limit.\n");
     exit(1);
 }
 


### PR DESCRIPTION
Several maintainer comments describe older behavior or claim more than the implementation guarantees. Correct the descriptions of configured run-state files, empty failure lists, GitHub reporter warnings and notices, duration formatting, coverage-diff entries, provider time budgets, and Rector message conversion.

The corrections follow the relevant source methods and their callers. Output-capture and memory-gate comments now describe measured behavior without claiming that a retained prefix identifies a failure or that memory growth proves a lifecycle leak. Clarify the CI lock bypass condition and the Composer documentation-example check description.
