### PR TITLE
fix: enforce bail after worker crashes and timeouts

### DIFF
--- a/src/Execution/ProcessPool/Orchestrator/Orchestrator.php
+++ b/src/Execution/ProcessPool/Orchestrator/Orchestrator.php
@@ -625,8 +625,14 @@ final class Orchestrator
 
         $sink->emit($event);
 
-        if ($event instanceof TestFinished
-            && $this->configuration->stopAfterFailures !== null
+        if ($event instanceof TestFinished) {
+            $this->enforceFailureLimit();
+        }
+    }
+
+    private function enforceFailureLimit(): void
+    {
+        if ($this->configuration->stopAfterFailures !== null
             && !$this->draining
             && $this->summary->failed + $this->summary->errored >= $this->configuration->stopAfterFailures
         ) {
@@ -853,6 +859,7 @@ final class Orchestrator
         unset($this->entriesById[(string) $result->id]);
         $this->summary = $this->summary->add($result->outcome);
         $sink->emit(new TestFinished($result, \microtime(true)));
+        $this->enforceFailureLimit();
     }
 
     private function retireFailedWorker(WorkerState $handle, bool $kill = false): void

--- a/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorTest.php
+++ b/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorTest.php
@@ -344,6 +344,30 @@ final class OrchestratorTest
 
     #[Test]
     #[Timeout(30.0)]
+    public function aWorkerCrashReachesTheFailureLimitBeforeReassignment(): void
+    {
+        $root = \dirname(__DIR__, 5);
+        $sink = new CollectingEventSink();
+        $orchestrator = NativeOrchestrator::create(
+            workerCommand: PhpSubprocess::command([$root . '/bin/greenlight']),
+            workingDirectory: $root,
+            stopAfterFailures: 1,
+        );
+
+        $summary = $orchestrator->run(
+            $this->crashThenPassingPlan(),
+            $sink,
+            1,
+            [CrashDiagnosticsTest::class => 0.001, CleanTest::class => 0.001],
+        );
+
+        Expect::that($summary->errored)->toBe(1);
+        Expect::that($summary->total())->toBe(1);
+        Expect::that($sink->results())->toHaveCount(1);
+    }
+
+    #[Test]
+    #[Timeout(30.0)]
     public function crashedWorkerKeepsACompleteUnicodeDiagnosticTail(): void
     {
         $root = \dirname(__DIR__, 5);

--- a/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorTransportTest.php
+++ b/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorTransportTest.php
@@ -10,6 +10,7 @@ use Greenlight\Discovery\Plan\PlanEntry;
 use Greenlight\Event\TestFinished;
 use Greenlight\Event\TestStarted;
 use Greenlight\Execution\ProcessPool\Orchestrator\Orchestrator;
+use Greenlight\Execution\ProcessPool\Orchestrator\OrchestratorConfiguration;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\Done;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\EventEnvelope;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\Ready;
@@ -86,6 +87,27 @@ final readonly class OrchestratorTransportTest
         Expect::that($orchestrator->workerTimings())
             ->because('forced transport retirement MUST complete before the run returns')
             ->toHaveCount(1);
+    }
+
+    #[Test]
+    public function aContainedTimeoutReachesTheFailureLimitBeforeAnotherWorkerStarts(): void
+    {
+        $id = new TestId('Example\\ScriptedTest', 'timesOut');
+        $transport = new ScriptedWorkerTransport([[
+            new Ready(),
+            new EventEnvelope(new TestStarted($id, 1.0)),
+        ]], pollSeconds: 3.0);
+        $orchestrator = new Orchestrator($transport, new OrchestratorConfiguration(stopAfterFailures: 1));
+        $plan = new ExecutionPlan([
+            ...$this->plan($id, timeoutSeconds: 0.1)->entries,
+            ...$this->plan(new TestId('Example\\LaterTest', 'passes'))->entries,
+        ]);
+
+        $summary = $orchestrator->run($plan, new CollectingEventSink(), 1);
+
+        Expect::that($summary->failed)->toBe(1);
+        Expect::that($summary->total())->toBe(1);
+        Expect::that($transport->started)->toHaveCount(1);
     }
 
     private function plan(TestId $id, ?float $timeoutSeconds = null): ExecutionPlan


### PR DESCRIPTION
Worker crashes and hard timeouts did not enforce the configured failed-or-errored test limit. With `--bail=1`, a crash could start replacement workers and run the rest of a batched assignment.

Apply the same failure-limit rule to worker results and synthetic crash or timeout results. Reaching the limit now drains active workers and clears queued work before crash recovery can reassign it.

A native-worker regression reproduced two results instead of one after a crash. A deterministic transport regression reproduced a replacement-worker start after a timeout. Both regressions pass with this change.
