### PR TITLE
fix(expect): canonicalize dates by instant

### DIFF
--- a/src/Expect/Equality.php
+++ b/src/Expect/Equality.php
@@ -84,6 +84,10 @@ final class Equality
             return 'number:' . $value;
         }
 
+        if ($value instanceof \DateTimeInterface) {
+            return 'DateTime:' . $value->format('U.u');
+        }
+
         if ($value instanceof \Closure) {
             return 'Closure#' . \spl_object_id($value);
         }

--- a/tests/Unit/Expect/CanonicalDateTimeTest.php
+++ b/tests/Unit/Expect/CanonicalDateTimeTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+
+final class CanonicalDateTimeTest
+{
+    #[Test]
+    public function dateListsCompareByInstantAcrossImplementations(): void
+    {
+        $first = new \DateTime('2026-01-01T00:00:00.123456+00:00');
+        $second = new \DateTimeImmutable('2026-01-02T00:00:00.654321+00:00');
+
+        Expect::that([$first, $second])->toEqualCanonicalizing([
+            new \DateTime('2026-01-02T00:00:00.654321+00:00'),
+            new \DateTimeImmutable('2026-01-01T00:00:00.123456+00:00'),
+        ]);
+    }
+
+    #[Test]
+    public function dateListsCompareByInstantAcrossTimeZones(): void
+    {
+        $first = new \DateTimeImmutable('2026-01-01T00:00:00+00:00');
+        $second = new \DateTimeImmutable('2026-01-01T01:00:00+00:00');
+
+        Expect::that([$first, $second])->toEqualCanonicalizing([
+            new \DateTimeImmutable('2026-01-01T01:00:00+00:00'),
+            new \DateTimeImmutable('2026-01-01T02:00:00+02:00'),
+        ]);
+    }
+
+    #[Test]
+    public function dateListsPreserveMicrosecondDifferences(): void
+    {
+        Expect::that([new \DateTime('2026-01-01T00:00:00.123456+00:00')])
+            ->not()->toEqualCanonicalizing([
+                new \DateTimeImmutable('2026-01-01T00:00:00.123457+00:00'),
+            ]);
+    }
+}


### PR DESCRIPTION
`toEqualCanonicalizing()` can reject lists that contain the same date instants when one list uses `DateTime` and the other uses `DateTimeImmutable`. The sort key included the implementation class, although deep equality compares dates by instant. For example, two dates with exchanged mutable and immutable implementations compare equal in order but fail after canonicalization.

Use the Unix timestamp and microseconds as the date sort key. This keeps implementation and timezone differences out of the order while preserving distinct instants. The new regression fails before the fix and passes after it. Companion cases cover timezone equivalence and microsecond differences.
