### PR TITLE
fix(sandbox): preserve existing autoloaders

### DIFF
--- a/docs/api-sandboxes.md
+++ b/docs/api-sandboxes.md
@@ -36,7 +36,7 @@ PHPDoc:
 public function dispose(): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/Autoloaders.php#L25)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/Autoloaders.php#L29)
 
 ## `EnvironmentVariables`
 

--- a/src/Sandbox/Autoloaders.php
+++ b/src/Sandbox/Autoloaders.php
@@ -17,8 +17,12 @@ final class Autoloaders implements Disposable
     /** @param callable(string): void $autoloader */
     public function register(callable $autoloader): void
     {
+        $count = \count(\spl_autoload_functions());
         \spl_autoload_register($autoloader);
-        $this->autoloaders[] = $autoloader;
+
+        if (\count(\spl_autoload_functions()) > $count) {
+            $this->autoloaders[] = $autoloader;
+        }
     }
 
     #[\Override]

--- a/tests/Unit/Sandbox/AutoloadersOwnershipTest.php
+++ b/tests/Unit/Sandbox/AutoloadersOwnershipTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Sandbox;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\Autoloaders;
+
+final class AutoloadersOwnershipTest
+{
+    #[Test]
+    public function disposalPreservesAnExistingAutoloader(): void
+    {
+        $calls = [];
+        $loader = static function (string $class) use (&$calls): void {
+            $calls[] = $class;
+        };
+        \spl_autoload_register($loader);
+        $sandbox = new Autoloaders();
+
+        try {
+            $sandbox->register($loader);
+            $sandbox->dispose();
+            \class_exists('GreenlightExistingAutoloaderProbe');
+
+            Expect::that($calls)->toBe(['GreenlightExistingAutoloaderProbe']);
+        } finally {
+            $sandbox->dispose();
+            \spl_autoload_unregister($loader);
+        }
+    }
+
+    #[Test]
+    public function nestedSandboxDisposalPreservesTheOuterAutoloader(): void
+    {
+        $calls = [];
+        $loader = static function (string $class) use (&$calls): void {
+            $calls[] = $class;
+        };
+        $outer = new Autoloaders();
+        $inner = new Autoloaders();
+
+        try {
+            $outer->register($loader);
+            $inner->register($loader);
+            $inner->dispose();
+            \class_exists('GreenlightOuterAutoloaderProbe');
+            Expect::that($calls)->toBe(['GreenlightOuterAutoloaderProbe']);
+
+            $outer->dispose();
+            $calls = [];
+            \class_exists('GreenlightClosedAutoloaderProbe');
+            Expect::that($calls)->toBe([]);
+        } finally {
+            $inner->dispose();
+            $outer->dispose();
+        }
+    }
+}


### PR DESCRIPTION
Registering an existing autoloader through `Autoloaders` made the sandbox remove that loader during disposal. PHP ignores duplicate registration, so the sandbox had not added a loader. This could break application autoloading in later tests, including when an inner sandbox used an outer sandbox's callback.

Record ownership only when registration adds an autoloader. PHP retains control of callable normalization and duplicate detection. Both new regressions fail before the fix and pass after it. They check actual class lookup callbacks and confirm that the owning sandbox still removes its loader.
