### PR TITLE
fix: invalidate discovery cache when inherited sources change

### DIFF
--- a/src/Discovery/DiscoveryCache.php
+++ b/src/Discovery/DiscoveryCache.php
@@ -11,8 +11,8 @@ use Greenlight\Internal\Php\ErrorTrap;
 
 /**
  * Stores one discovery cache entry for each file. The path, modification time,
- * size, content hash, and external provider files identify an entry. Entries
- * do not contain filter results. Thus, a filter change does not require
+ * size, content hash, inherited sources, and provider files identify an entry.
+ * Entries do not contain filter results. Thus, a filter change does not require
  * another parse operation.
  *
  * Discovery parses the file after a cache miss, stale file, corrupt cache, or
@@ -23,7 +23,7 @@ use Greenlight\Internal\Php\ErrorTrap;
  */
 final class DiscoveryCache
 {
-    private const int VERSION = 1;
+    private const int VERSION = 2;
 
     /**
      * @var array<string, DiscoveryCacheEntry>
@@ -108,8 +108,9 @@ final class DiscoveryCache
     /**
      * @param non-empty-string $file
      * @param list<PlanEntry> $entries
+     * @param class-string|null $class The declared class, including classes with no test entries.
      */
-    public function store(string $file, array $entries): void
+    public function store(string $file, array $entries, ?string $class = null): void
     {
         $stat = $this->stat($file);
 
@@ -121,47 +122,75 @@ final class DiscoveryCache
             $stat['mtime'],
             $stat['size'],
             \array_map(static fn(PlanEntry $entry): array => $entry->toWire(), $entries),
-            $this->providerDependencies($entries),
+            $this->dependencies($file, $entries, $class),
             $stat['contentHash'],
         );
     }
 
     /**
      * @param list<PlanEntry> $entries
+     * @param class-string|null $class
      *
      * @return array<non-empty-string, array{mtime: int, size: int, contentHash?: string}>
      */
-    private function providerDependencies(array $entries): array
+    private function dependencies(string $source, array $entries, ?string $class): array
     {
-        $dependencies = [];
+        $classes = $class === null ? [] : [$class => true];
 
         foreach ($entries as $entry) {
-            $class = $entry->definition->dataProvider->class;
+            $classes[$entry->definition->class] = true;
 
-            if ($class === null || !\class_exists($class)) {
+            if ($entry->definition->dataProvider->class !== null) {
+                $classes[$entry->definition->dataProvider->class] = true;
+            }
+        }
+
+        $pending = [];
+
+        foreach (\array_keys($classes) as $name) {
+            if (\class_exists($name, false)) {
+                $pending[] = new \ReflectionClass($name);
+            }
+        }
+
+        $seen = [];
+        $files = [];
+
+        while ($pending !== []) {
+            $reflection = \array_pop($pending);
+            $name = $reflection->getName();
+
+            if (isset($seen[$name])) {
                 continue;
             }
 
-            $reflection = new \ReflectionClass($class);
-            $files = [$reflection->getFileName()];
-            $provider = $entry->definition->dataProvider->method;
+            $seen[$name] = true;
+            $file = $reflection->getFileName();
 
-            if ($provider !== null && $reflection->hasMethod($provider)) {
-                $files[] = $reflection->getMethod($provider)->getFileName();
+            if (\is_string($file) && $file !== '' && $file !== $source) {
+                $files[$file] = true;
             }
 
-            foreach ($files as $file) {
-                if (!\is_string($file) || $file === '') {
-                    continue;
-                }
+            $parent = $reflection->getParentClass();
 
-                $stat = $this->stat($file);
+            if ($parent !== false) {
+                $pending[] = $parent;
+            }
 
-                if ($stat !== null) {
-                    $dependencies[$file] = $stat['contentHash'] === null
-                        ? ['mtime' => $stat['mtime'], 'size' => $stat['size']]
-                        : ['mtime' => $stat['mtime'], 'size' => $stat['size'], 'contentHash' => $stat['contentHash']];
-                }
+            foreach ($reflection->getTraits() as $trait) {
+                $pending[] = $trait;
+            }
+        }
+
+        $dependencies = [];
+
+        foreach (\array_keys($files) as $file) {
+            $stat = $this->stat($file);
+
+            if ($stat !== null) {
+                $dependencies[$file] = $stat['contentHash'] === null
+                    ? ['mtime' => $stat['mtime'], 'size' => $stat['size']]
+                    : ['mtime' => $stat['mtime'], 'size' => $stat['size'], 'contentHash' => $stat['contentHash']];
             }
         }
 

--- a/src/Discovery/TestDiscoverer.php
+++ b/src/Discovery/TestDiscoverer.php
@@ -59,12 +59,12 @@ final readonly class TestDiscoverer
 
             if ($unfiltered === null) {
                 try {
-                    $unfiltered = $this->entriesForFile($file);
+                    $unfiltered = $this->entriesForFile($file, $class);
                 } catch (DataSetError $error) {
                     throw DiscoveryError::invalidDataSet($error);
                 }
 
-                $cache?->store($file, $unfiltered);
+                $cache?->store($file, $unfiltered, $class);
             }
 
             $entries = $this->filtered($unfiltered, $selection, $file);
@@ -122,11 +122,13 @@ final readonly class TestDiscoverer
      *
      * @param non-empty-string $file
      *
+     * @param-out class-string|null $class
+     *
      * @return list<PlanEntry>
      * @throws DataSetError
      * @throws DiscoveryError
      */
-    private function entriesForFile(string $file): array
+    private function entriesForFile(string $file, ?string &$class): array
     {
         $class = $this->resolveClass($file);
 

--- a/tests/Unit/Discovery/DiscoveryCacheCorruptPlanTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheCorruptPlanTest.php
@@ -22,7 +22,7 @@ final readonly class DiscoveryCacheCorruptPlanTest
         $cacheFile = DiscoveryCachePath::forDirectories([$directory]);
         \file_put_contents($source, '<?php');
         \file_put_contents($cacheFile, \json_encode([
-            'version' => 1,
+            'version' => 2,
             'files' => [
                 $source => [
                     'mtime' => \filemtime($source),

--- a/tests/Unit/Discovery/DiscoveryCacheInheritanceTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheInheritanceTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Discovery;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\PhpSubprocess;
+
+final readonly class DiscoveryCacheInheritanceTest
+{
+    public function __construct(private TemporaryDirectory $temporaryDirectory) {}
+
+    #[Test]
+    #[DataSet("inheritedSources")]
+    public function sourceChangesUpdateTheCachedPlan(
+        string $testSource,
+        string $dependencyName,
+        string $dependencySource,
+        string $replacementSource,
+        string $before,
+        string $after,
+    ): void {
+        $directory = $this->temporaryDirectory->subdirectory("inherited-cache");
+        \file_put_contents($directory . "/InheritedTest.php", "<?php namespace CacheInheritance; " . $testSource);
+        \file_put_contents($directory . "/" . $dependencyName . ".php", "<?php namespace CacheInheritance; " . $dependencySource);
+        $script = $directory . "/discover.php";
+        \file_put_contents($script, <<<'PHP'
+            <?php
+            require $argv[1];
+            spl_autoload_register(static function (string $class): void {
+                $prefix = "CacheInheritance\\";
+                if (str_starts_with($class, $prefix)) {
+                    require __DIR__ . "/" . substr($class, strlen($prefix)) . ".php";
+                }
+            });
+            $plan = new \Greenlight\Discovery\TestDiscoverer()->discover(
+                [__DIR__],
+                cache: \Greenlight\Discovery\DiscoveryCache::forDirectories([__DIR__], __DIR__),
+            );
+            foreach ($plan->entries as $entry) {
+                echo $entry->id, "\n";
+            }
+            PHP);
+        $arguments = [$script, \dirname(__DIR__, 3) . "/vendor/autoload.php"];
+        $cold = PhpSubprocess::run($directory, $arguments);
+        Expect::that($cold->exitCode)->toBe(0);
+        Expect::that($cold->stdout)->toBe($before);
+
+        $warm = PhpSubprocess::run($directory, $arguments);
+        Expect::that($warm->exitCode)->toBe(0);
+        Expect::that($warm->stdout)->toBe($before);
+
+        \file_put_contents($directory . "/" . $dependencyName . ".php", "<?php namespace CacheInheritance; " . $replacementSource);
+        $changed = PhpSubprocess::run($directory, $arguments);
+        Expect::that($changed->exitCode)->toBe(0);
+        Expect::that($changed->stdout)->toBe($after);
+    }
+
+    /** @return iterable<string, array{string, string, string, string, string, string}> */
+    public static function inheritedSources(): iterable
+    {
+        yield "parent test method" => [
+            "class InheritedTest extends Base {}",
+            "Base",
+            "class Base { #[\\Greenlight\\Attribute\\Test] public function original(): void {} }",
+            "class Base { #[\\Greenlight\\Attribute\\Test] public function replacement(): void {} }",
+            "CacheInheritance\\InheritedTest::original",
+            "CacheInheritance\\InheritedTest::replacement",
+        ];
+        yield "trait test method" => [
+            "class InheritedTest { use SharedMethods; }",
+            "SharedMethods",
+            "trait SharedMethods { #[\\Greenlight\\Attribute\\Test] public function original(): void {} }",
+            "trait SharedMethods { #[\\Greenlight\\Attribute\\Test] public function replacement(): void {} }",
+            "CacheInheritance\\InheritedTest::original",
+            "CacheInheritance\\InheritedTest::replacement",
+        ];
+        yield "inherited local provider" => [
+            "class InheritedTest extends Base { #[\\Greenlight\\Attribute\\Test] #[\\Greenlight\\Attribute\\DataSet(\"rows\")] public function probe(int \$value): void {} }",
+            "Base",
+            "class Base { public static function rows(): iterable { yield \"original\" => [1]; } }",
+            "class Base { public static function rows(): iterable { yield \"replacement\" => [2]; } }",
+            "CacheInheritance\\InheritedTest::probe[original]",
+            "CacheInheritance\\InheritedTest::probe[replacement]",
+        ];
+        yield "previously empty parent" => [
+            "class InheritedTest extends Base {}",
+            "Base",
+            "class Base {}",
+            "class Base { #[\\Greenlight\\Attribute\\Test] public function added(): void {} }",
+            "",
+            "CacheInheritance\\InheritedTest::added",
+        ];
+    }
+}

--- a/tests/Unit/Discovery/DiscoveryCacheTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheTest.php
@@ -97,7 +97,7 @@ final readonly class DiscoveryCacheTest
                 ->because('an invalid cache document becomes a cache miss')
                 ->toBe(2);
             Expect::that($rewritten)
-                ->toContain('"version":1')
+                ->toContain('"version":2')
                 ->toContain($className . '.php');
         } finally {
             @\unlink($cacheFile);
@@ -112,10 +112,10 @@ final readonly class DiscoveryCacheTest
     public static function structurallyInvalidCacheDocuments(): iterable
     {
         yield 'scalar document' => ['null'];
-        yield 'wrong version' => ['{"version":2,"files":{}}'];
-        yield 'files is not a map' => ['{"version":1,"files":"invalid"}'];
-        yield 'file path is not a string' => ['{"version":1,"files":{"0":{}}}'];
-        yield 'file entry is not a map' => ['{"version":1,"files":{"/project/Test.php":"invalid"}}'];
+        yield 'wrong version' => ['{"version":0,"files":{}}'];
+        yield 'files is not a map' => ['{"version":2,"files":"invalid"}'];
+        yield 'file path is not a string' => ['{"version":2,"files":{"0":{}}}'];
+        yield 'file entry is not a map' => ['{"version":2,"files":{"/project/Test.php":"invalid"}}'];
     }
 
     #[Test]
@@ -149,7 +149,7 @@ final readonly class DiscoveryCacheTest
                 ->toBeInt();
 
             \file_put_contents($cacheFile, \json_encode([
-                'version' => 1,
+                'version' => 2,
                 'files' => [
                     $source => [
                         'mtime' => $mtime,


### PR DESCRIPTION
Discovery cached only the test file and explicit external providers. A parent or trait change could retain removed test IDs, omit new tests, or reuse stale inherited provider keys. This also affected classes that previously contained no tests.

Track the complete parent and trait source graph for test and provider classes. Fingerprint each source once per cache entry, and invalidate the previous cache version. Four regressions use fresh PHP processes to show stale IDs before the fix and updated plans afterward. All 42 focused discovery cache tests pass. Required full checks are queued locally, and GitHub CI will validate the PR head.
