### PR TITLE
fix: enforce progress deadlines during worker shutdown

### DIFF
--- a/src/Execution/ProcessPool/Orchestrator/Orchestrator.php
+++ b/src/Execution/ProcessPool/Orchestrator/Orchestrator.php
@@ -462,7 +462,7 @@ final class Orchestrator
                 // Crash detection processes a worker that is already gone.
             }
 
-            $handle->requestStop();
+            $handle->requestStop($this->monotonicTime());
 
             return;
         }
@@ -549,7 +549,7 @@ final class Orchestrator
                     // The worker is already gone after Done. No drain is necessary.
                 }
 
-                $handle->requestStop();
+                $handle->requestStop($this->monotonicTime());
 
                 return;
             }
@@ -687,7 +687,7 @@ final class Orchestrator
                     // Crash detection processes a worker that is already gone.
                 }
 
-                $handle->requestStop();
+                $handle->requestStop($this->monotonicTime());
             }
         }
     }
@@ -737,7 +737,7 @@ final class Orchestrator
             }
 
             if ($handle->inFlight === null) {
-                if ($handle->assigned === null && $handle->ready) {
+                if ($handle->assigned === null && $handle->ready && !$handle->stopRequested) {
                     // The scheduler keeps this connected worker idle until a
                     // resource lease is available.
                     continue;

--- a/src/Execution/ProcessPool/Orchestrator/WorkerState.php
+++ b/src/Execution/ProcessPool/Orchestrator/WorkerState.php
@@ -94,9 +94,10 @@ final class WorkerState
         return !$this->retiring;
     }
 
-    public function requestStop(): void
+    public function requestStop(float $at): void
     {
         $this->stopRequested = true;
+        $this->lastProgressAt = $at;
     }
 
     /** @return list<TestId> */

--- a/tests/Unit/Execution/ProcessPool/Orchestrator/WorkerShutdownDeadlineTest.php
+++ b/tests/Unit/Execution/ProcessPool/Orchestrator/WorkerShutdownDeadlineTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Execution\ProcessPool\Orchestrator;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Attribute\Timeout;
+use Greenlight\Discovery\Plan\ExecutionPlan;
+use Greenlight\Execution\ProcessPool\Protocol\ProtocolError;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\CollectingEventSink;
+use Greenlight\Tests\Support\NativeOrchestrator;
+use Greenlight\Tests\Support\PhpSubprocess;
+use Greenlight\Tests\Support\PlanEntryFixture;
+
+final readonly class WorkerShutdownDeadlineTest
+{
+    #[Test]
+    #[Timeout(10.0)]
+    public function aWorkerThatStallsAfterDrainFailsTheRun(): void
+    {
+        $root = \dirname(__DIR__, 5);
+        $script = \sprintf(
+            <<<'PHP'
+                require %s;
+                [, , $address, $workerId, $token] = $argv;
+                $channel = new Greenlight\Execution\ProcessPool\Protocol\SocketChannel(stream_socket_client($address));
+                $channel->send(new Greenlight\Execution\ProcessPool\Protocol\Messages\Hello($workerId, $token, getmypid()));
+                $channel->receive(5.0);
+                $channel->send(new Greenlight\Execution\ProcessPool\Protocol\Messages\Ready());
+                $assignment = $channel->receive(5.0);
+                $id = $assignment->slice->entries[0]->id;
+                $channel->send(new Greenlight\Execution\ProcessPool\Protocol\Messages\EventEnvelope(
+                    new Greenlight\Event\TestStarted($id, microtime(true)),
+                ));
+                $channel->send(new Greenlight\Execution\ProcessPool\Protocol\Messages\EventEnvelope(
+                    new Greenlight\Event\TestFinished(
+                        new Greenlight\Result\TestResult($id, Greenlight\Result\Outcome::Passed, 0.0, 0),
+                        microtime(true),
+                    ),
+                ));
+                $channel->send(new Greenlight\Execution\ProcessPool\Protocol\Messages\Done(
+                    new Greenlight\Result\ResultSummary(passed: 1),
+                    0,
+                ));
+                $channel->receive(5.0);
+                sleep(2);
+                PHP,
+            \var_export($root . '/vendor/autoload.php', true),
+        );
+        $orchestrator = NativeOrchestrator::create(
+            workerCommand: PhpSubprocess::command(['-r', $script]),
+            workingDirectory: $root,
+            progressDeadlineSeconds: 0.5,
+        );
+        $sink = new CollectingEventSink();
+        $plan = new ExecutionPlan([PlanEntryFixture::create('Example\\ShutdownTest', 'passes')]);
+
+        Expect::that(static fn() => $orchestrator->run($plan, $sink, 1))
+            ->toThrow(ProtocolError::class, '/sent no message for 0\.5 seconds/');
+        Expect::that($sink->results())->toHaveCount(1);
+    }
+}


### PR DESCRIPTION
A worker that completed its assignment and then stalled during shutdown could keep the run open without a time limit. The orchestrator treated every ready worker without an assignment as idle, including workers that had received `Drain`.

Keep the idle exemption only while a worker can still receive work. Start a fresh progress deadline when the orchestrator requests shutdown, so previous idle time does not reduce the cleanup budget.

A native worker regression completes one test, receives `Drain`, and stalls for two seconds. Before the fix, the run incorrectly succeeded despite a 0.5-second progress deadline. With the fix, the run reports the stalled worker and closes the transport.
