### PR TITLE
perf: avoid repeated output capture copies

### DIFF
--- a/src/Execution/Worker/OutputCapture.php
+++ b/src/Execution/Worker/OutputCapture.php
@@ -160,15 +160,13 @@ final class OutputCapture
             return '';
         }
 
-        $combined = $this->stdout . $chunk;
-
-        if (\strlen($combined) <= $this->maxStdoutBytes) {
-            $this->stdout = $combined;
+        if (\strlen($chunk) <= $this->maxStdoutBytes - \strlen($this->stdout)) {
+            $this->stdout .= $chunk;
 
             return '';
         }
 
-        $this->stdout = Utf8::headBytes($combined, $this->maxStdoutBytes);
+        $this->stdout = Utf8::headBytes($this->stdout . $chunk, $this->maxStdoutBytes);
         $this->stdoutTruncated = true;
 
         return '';

--- a/tests/Unit/Execution/Worker/Capture/OutputCaptureChunkTest.php
+++ b/tests/Unit/Execution/Worker/Capture/OutputCaptureChunkTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Execution\Worker\Capture;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Execution\Worker\OutputCapture;
+use Greenlight\Expect\Expect;
+
+final readonly class OutputCaptureChunkTest
+{
+    #[Test]
+    public function smallWritesPreserveTheirOrderThroughTheCaptureLimit(): void
+    {
+        $capture = new OutputCapture(maxStdoutBytes: 65_536);
+        $capture->start();
+
+        for ($write = 0; $write < 16_384; ++$write) {
+            echo 'abcd';
+        }
+
+        $output = $capture->stop();
+
+        Expect::that($output->stdout)->toBe(\str_repeat('abcd', 16_384));
+        Expect::that($output->stdoutTruncated)->toBeFalse();
+    }
+
+    #[Test]
+    public function aUnicodeCharacterSplitAcrossWritesSurvivesTruncation(): void
+    {
+        $capture = new OutputCapture(maxStdoutBytes: 5);
+        $capture->start();
+        echo "ab\xE2";
+        echo "\x82";
+        echo "\xACtail";
+        $output = $capture->stop();
+
+        Expect::that($output->stdout)->toBe('ab€');
+        Expect::that($output->stdoutTruncated)->toBeTrue();
+    }
+}

--- a/tools/output-capture-benchmark.php
+++ b/tools/output-capture-benchmark.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Measures output capture for repeated four-byte writes up to the default limit.
+ * Run on an idle machine with Xdebug disabled. Compare the same command at each revision.
+ * Each shape has one warmup and five measured samples. Every sample checks the captured bytes.
+ *
+ * Usage: XDEBUG_MODE=off php tools/output-capture-benchmark.php
+ */
+
+use Greenlight\Execution\Worker\OutputCapture;
+
+require \dirname(__DIR__) . '/vendor/autoload.php';
+
+foreach ([16_384, 65_536, 262_144] as $writes) {
+    $samples = [];
+
+    for ($round = 0; $round < 6; ++$round) {
+        $capture = new OutputCapture();
+        $started = \hrtime(true);
+        $capture->start();
+
+        for ($write = 0; $write < $writes; ++$write) {
+            echo 'abcd';
+        }
+
+        $output = $capture->stop();
+        $elapsed = (\hrtime(true) - $started) / 1_000_000_000;
+
+        if ($output->stdout !== \str_repeat('abcd', $writes) || $output->stdoutTruncated) {
+            throw new \RuntimeException('Output capture did not preserve the benchmark output.');
+        }
+
+        if ($round > 0) {
+            $samples[] = $elapsed;
+        }
+    }
+
+    \sort($samples);
+    \printf("%d writes, %d bytes: median %.6f seconds\n", $writes, $writes * 4, $samples[2]);
+}

--- a/tools/output-capture-benchmark.php
+++ b/tools/output-capture-benchmark.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Greenlight\Tools;
+
 /**
  * Measures output capture for repeated four-byte writes up to the default limit.
  * Run on an idle machine with Xdebug disabled. Compare the same command at each revision.


### PR DESCRIPTION
Output capture copied all accumulated output on each small write. A test that emitted 1 MiB through 262,144 four-byte writes spent about four seconds in capture on this machine.

Append directly while the next chunk fits the byte limit. Keep the existing UTF-8 and truncation path when a chunk exceeds the limit. The new benchmark checks every captured byte and uses one warmup plus five samples per size.

With PHP 8.4.14 and `XDEBUG_MODE=off`, median times for 16,384 / 65,536 / 262,144 writes changed from 0.032559 / 0.421142 / 3.982013 seconds to 0.004685 / 0.008404 / 0.045392 seconds. The largest shape improved about 88 times. These are local microbenchmark results, not whole-suite speed claims. Focused tests cover repeated writes, exact bounds, truncation, binary output, and a Unicode character split across writes.
