### PR TITLE
fix: reject extension names that match native methods

### DIFF
--- a/docs/api-expectations.md
+++ b/docs/api-expectations.md
@@ -1841,6 +1841,9 @@ interface ExpectationExtension extends Plugin
 
 Maps each expectation-chain matcher name to its predicate.
 
+Names must not match public native expectation methods. The comparison
+ignores letter case. Rename a matcher that has a conflicting name.
+
 The predicate receives the subject and then the matcher arguments.
 Native parameter types declare the arguments. The predicate must return
 true for the expectation to hold. All other results fail it. Each
@@ -1855,7 +1858,7 @@ PHPDoc:
 
 - `@return array<non-empty-string, \Closure>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/ExpectationExtension.php#L23)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/ExpectationExtension.php#L26)
 
 ## `ExpectationFailed`
 

--- a/src/Expect/Expect.php
+++ b/src/Expect/Expect.php
@@ -82,9 +82,20 @@ final class Expect
      * @param list<ExpectationExtension> $extensions
      *
      * @return \Closure(): void A callback that restores the previous extension list.
+     * @throws ExpectationExtensionError
      */
     public static function install(array $extensions): \Closure
     {
+        $nativeMethods = \array_fill_keys(\array_map(\strtolower(...), \get_class_methods(Expectation::class)), true);
+
+        foreach ($extensions as $extension) {
+            foreach (\array_keys($extension->matchers()) as $name) {
+                if (isset($nativeMethods[\strtolower($name)])) {
+                    throw ExpectationExtensionError::nativeMethod($name);
+                }
+            }
+        }
+
         $previous = self::$extensions;
         self::$extensions = $extensions;
 

--- a/src/Expect/ExpectationExtension.php
+++ b/src/Expect/ExpectationExtension.php
@@ -12,6 +12,9 @@ interface ExpectationExtension extends Plugin
     /**
      * Maps each expectation-chain matcher name to its predicate.
      *
+     * Names must not match public native expectation methods. The comparison
+     * ignores letter case. Rename a matcher that has a conflicting name.
+     *
      * The predicate receives the subject and then the matcher arguments.
      * Native parameter types declare the arguments. The predicate must return
      * true for the expectation to hold. All other results fail it. Each

--- a/src/Expect/ExpectationExtensionError.php
+++ b/src/Expect/ExpectationExtensionError.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Expect;
+
+/**
+ * An extension matcher name conflicts with a public native expectation method.
+ *
+ * @internal
+ */
+final class ExpectationExtensionError extends \InvalidArgumentException
+{
+    public static function nativeMethod(string $name): self
+    {
+        return new self(\sprintf(
+            'Extension matcher "%s" conflicts with a native expectation method. Rename the extension matcher.',
+            $name,
+        ));
+    }
+}

--- a/src/PhpStan/MatcherMap.php
+++ b/src/PhpStan/MatcherMap.php
@@ -7,6 +7,7 @@ namespace Greenlight\PhpStan;
 use Greenlight\Config\ConfigFileError;
 use Greenlight\Config\ConfigLoader;
 use Greenlight\Config\InvalidConfiguration;
+use Greenlight\Expect\Expectation;
 use Greenlight\Expect\ExpectationExtension;
 
 /**
@@ -43,6 +44,7 @@ final readonly class MatcherMap
         $loader = new ConfigLoader();
         $matchers = [];
         $declaredIn = [];
+        $nativeMethods = \array_fill_keys(\array_map(\strtolower(...), \get_class_methods(Expectation::class)), true);
 
         foreach ($configFiles as $file) {
             if (!\str_starts_with($file, '/')) {
@@ -63,6 +65,10 @@ final readonly class MatcherMap
                 }
 
                 foreach ($plugin->matchers() as $name => $matcher) {
+                    if (isset($nativeMethods[\strtolower($name)])) {
+                        continue;
+                    }
+
                     $reflection = new \ReflectionFunction($matcher);
                     $signature = self::signature($reflection);
                     $existingSignature = isset($matchers[$name]) ? self::signature($matchers[$name]) : null;

--- a/src/PhpStan/MatcherMap.php
+++ b/src/PhpStan/MatcherMap.php
@@ -9,6 +9,7 @@ use Greenlight\Config\ConfigLoader;
 use Greenlight\Config\InvalidConfiguration;
 use Greenlight\Expect\Expectation;
 use Greenlight\Expect\ExpectationExtension;
+use Greenlight\Expect\ExpectationExtensionError;
 
 /**
  * Combines extension matchers from a set of Greenlight configuration files.
@@ -66,7 +67,7 @@ final readonly class MatcherMap
 
                 foreach ($plugin->matchers() as $name => $matcher) {
                     if (isset($nativeMethods[\strtolower($name)])) {
-                        continue;
+                        throw MatcherMapError::invalidExtension(ExpectationExtensionError::nativeMethod($name));
                     }
 
                     $reflection = new \ReflectionFunction($matcher);

--- a/src/PhpStan/MatcherMapError.php
+++ b/src/PhpStan/MatcherMapError.php
@@ -4,12 +4,23 @@ declare(strict_types=1);
 
 namespace Greenlight\PhpStan;
 
-/** @internal */
+use Greenlight\Expect\ExpectationExtensionError;
+
+/**
+ * Configured extension matchers have conflicting names or signatures.
+ *
+ * @internal
+ */
 final class MatcherMapError extends \RuntimeException
 {
-    private function __construct(string $message)
+    private function __construct(string $message, ?\Throwable $previous = null)
     {
-        parent::__construct($message);
+        parent::__construct($message, previous: $previous);
+    }
+
+    public static function invalidExtension(ExpectationExtensionError $error): self
+    {
+        return new self($error->getMessage(), $error);
     }
 
     public static function conflictingSignatures(

--- a/tests/Acceptance/PhpStanNativeMatcherOverrideTest.php
+++ b/tests/Acceptance/PhpStanNativeMatcherOverrideTest.php
@@ -7,70 +7,43 @@ namespace Greenlight\Tests\Acceptance;
 use Greenlight\Attribute\RequiresResource;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
-use Greenlight\PhpStan\IdeHelper;
 use Greenlight\PhpStan\MatcherMap;
-use Greenlight\Sandbox\TemporaryDirectory;
-use Greenlight\Tests\Fixture\PhpStanNativeMatcherOverride\NativeMatcherOverrideExtension;
+use Greenlight\PhpStan\MatcherMapError;
 use Greenlight\Tests\Support\FixturePath;
-use Greenlight\Tests\Support\PhpStanProbe;
+use Greenlight\Tests\Support\GreenlightCli;
+use Greenlight\Tests\Support\PhpSubprocess;
 
 #[RequiresResource('analysis-process')]
-final readonly class PhpStanNativeMatcherOverrideTest
+final class PhpStanNativeMatcherOverrideTest
 {
-    public function __construct(private TemporaryDirectory $tempDirectory) {}
+    private const string MESSAGE = 'Extension matcher "toBeInt" conflicts with a native expectation method. Rename the extension matcher.';
 
     #[Test]
-    public function nativeMatchersKeepTheirSignaturesWhenAnExtensionReusesTheirNames(): void
+    public function runtimeAndToolingRejectNativeMatcherNames(): void
     {
-        $restore = Expect::install([new NativeMatcherOverrideExtension()]);
+        $root = \dirname(__DIR__, 2);
+        $config = FixturePath::get('PhpStanNativeMatcherOverride/greenlight.php');
 
-        try {
-            Expect::that(1)->toBeInt();
-        } finally {
-            $restore();
-        }
+        Expect::that(static fn() => MatcherMap::fromConfigFiles([$config]))
+            ->toThrow(MatcherMapError::class, message: self::MESSAGE);
 
-        $probe = PhpStanProbe::analyze(
-            $this->tempDirectory,
-            <<<'PHP'
-            <?php
+        $run = GreenlightCli::run($root, ['run', '--config=' . $config, '--workers=1', '--no-ansi']);
+        Expect::that($run->exitCode)->not()->toBe(0);
+        Expect::that($run->output())->toContain(self::MESSAGE);
 
-            declare(strict_types=1);
+        $helper = GreenlightCli::run($root, ['ide-helper', '--config=' . $config, '--no-ansi']);
+        Expect::that($helper->exitCode)->not()->toBe(0);
+        Expect::that($helper->output())->toContain(self::MESSAGE);
 
-            use Greenlight\Expect\Expect;
-
-            function nativeMatcherOverrideGoodProbe(): void
-            {
-                Expect::that(1)->toBeInt();
-                Expect::eventually(static fn(): int => 1)->within(0.1)->toBeInt();
-                Expect::consistently(static fn(): int => 1)->for(0.1)->toBeInt();
-                Expect::that(1)->toHavePositiveValue();
-            }
-            PHP,
-            <<<'PHP'
-            <?php
-
-            declare(strict_types=1);
-
-            use Greenlight\Expect\Expect;
-
-            function nativeMatcherOverrideBadProbe(): void
-            {
-                Expect::that('wrong subject')->toHavePositiveValue();
-            }
-            PHP,
-            FixturePath::get('PhpStanNativeMatcherOverride/probe.neon'),
-        );
-
-        Expect::that($probe->exitCode)->toBe(1);
-        Expect::that($probe->goodErrors)->toBe([]);
-        Expect::that(\count($probe->errors))->toBe(1);
-        Expect::that($probe->messages())->toContain('requires subject type int, but the subject has type string');
-
-        $helper = IdeHelper::render(MatcherMap::fromConfigFiles([
-            FixturePath::get('PhpStanNativeMatcherOverride/greenlight.php'),
-        ]));
-        Expect::that($helper)->not()->toContain('@method self toBeInt(');
-        Expect::that($helper)->toContain('@method self toHavePositiveValue()');
+        $analysis = PhpSubprocess::run($root, [
+            $root . '/vendor/bin/phpstan',
+            'analyse',
+            '--no-progress',
+            '--error-format=json',
+            '--configuration=' . FixturePath::get('PhpStanNativeMatcherOverride/probe.neon'),
+            FixturePath::get('PhpStanNativeMatcherOverride/Probe.php'),
+        ]);
+        Expect::that($analysis->exitCode)->not()->toBe(0);
+        Expect::that($analysis->output())->toContain('conflicts with a native expectation method. Rename the extension matcher.');
     }
 }

--- a/tests/Acceptance/PhpStanNativeMatcherOverrideTest.php
+++ b/tests/Acceptance/PhpStanNativeMatcherOverrideTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\PhpStan\IdeHelper;
+use Greenlight\PhpStan\MatcherMap;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Fixture\PhpStanNativeMatcherOverride\NativeMatcherOverrideExtension;
+use Greenlight\Tests\Support\FixturePath;
+use Greenlight\Tests\Support\PhpStanProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class PhpStanNativeMatcherOverrideTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function nativeMatchersKeepTheirSignaturesWhenAnExtensionReusesTheirNames(): void
+    {
+        $restore = Expect::install([new NativeMatcherOverrideExtension()]);
+
+        try {
+            Expect::that(1)->toBeInt();
+        } finally {
+            $restore();
+        }
+
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Expect\Expect;
+
+            function nativeMatcherOverrideGoodProbe(): void
+            {
+                Expect::that(1)->toBeInt();
+                Expect::eventually(static fn(): int => 1)->within(0.1)->toBeInt();
+                Expect::consistently(static fn(): int => 1)->for(0.1)->toBeInt();
+                Expect::that(1)->toHavePositiveValue();
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Expect\Expect;
+
+            function nativeMatcherOverrideBadProbe(): void
+            {
+                Expect::that('wrong subject')->toHavePositiveValue();
+            }
+            PHP,
+            FixturePath::get('PhpStanNativeMatcherOverride/probe.neon'),
+        );
+
+        Expect::that($probe->exitCode)->toBe(1);
+        Expect::that($probe->goodErrors)->toBe([]);
+        Expect::that(\count($probe->errors))->toBe(1);
+        Expect::that($probe->messages())->toContain('requires subject type int, but the subject has type string');
+
+        $helper = IdeHelper::render(MatcherMap::fromConfigFiles([
+            FixturePath::get('PhpStanNativeMatcherOverride/greenlight.php'),
+        ]));
+        Expect::that($helper)->not()->toContain('@method self toBeInt(');
+        Expect::that($helper)->toContain('@method self toHavePositiveValue()');
+    }
+}

--- a/tests/Fixture/PhpStanNativeMatcherOverride/NativeMatcherOverrideExtension.php
+++ b/tests/Fixture/PhpStanNativeMatcherOverride/NativeMatcherOverrideExtension.php
@@ -8,11 +8,14 @@ use Greenlight\Expect\ExpectationExtension;
 
 final class NativeMatcherOverrideExtension implements ExpectationExtension
 {
+    /** @param non-empty-string $name */
+    public function __construct(private readonly string $name = 'toBeInt') {}
+
+    /** @return array<non-empty-string, \Closure(string): string> */
     public function matchers(): array
     {
         return [
-            'toBeInt' => static fn(string $subject): string => $subject,
-            'toHavePositiveValue' => static fn(int $subject): bool => $subject > 0,
+            $this->name => static fn(string $subject): string => $subject,
         ];
     }
 }

--- a/tests/Fixture/PhpStanNativeMatcherOverride/NativeMatcherOverrideExtension.php
+++ b/tests/Fixture/PhpStanNativeMatcherOverride/NativeMatcherOverrideExtension.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\PhpStanNativeMatcherOverride;
+
+use Greenlight\Expect\ExpectationExtension;
+
+final class NativeMatcherOverrideExtension implements ExpectationExtension
+{
+    public function matchers(): array
+    {
+        return [
+            'toBeInt' => static fn(string $subject): string => $subject,
+            'toHavePositiveValue' => static fn(int $subject): bool => $subject > 0,
+        ];
+    }
+}

--- a/tests/Fixture/PhpStanNativeMatcherOverride/Probe.php
+++ b/tests/Fixture/PhpStanNativeMatcherOverride/Probe.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\PhpStanNativeMatcherOverride;
+
+use Greenlight\Expect\Expect;
+
+function nativeMatcherOverrideProbe(): void
+{
+    Expect::that(1)->toBeInt();
+}

--- a/tests/Fixture/PhpStanNativeMatcherOverride/greenlight.php
+++ b/tests/Fixture/PhpStanNativeMatcherOverride/greenlight.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Tests\Fixture\PhpStanNativeMatcherOverride\NativeMatcherOverrideExtension;
+
+return GreenlightConfig::create()
+    ->plugins(static fn(): NativeMatcherOverrideExtension => new NativeMatcherOverrideExtension());

--- a/tests/Fixture/PhpStanNativeMatcherOverride/greenlight.php
+++ b/tests/Fixture/PhpStanNativeMatcherOverride/greenlight.php
@@ -6,4 +6,5 @@ use Greenlight\Config\GreenlightConfig;
 use Greenlight\Tests\Fixture\PhpStanNativeMatcherOverride\NativeMatcherOverrideExtension;
 
 return GreenlightConfig::create()
+    ->paths([__DIR__ . '/../DiscoveryBasic'])
     ->plugins(static fn(): NativeMatcherOverrideExtension => new NativeMatcherOverrideExtension());

--- a/tests/Fixture/PhpStanNativeMatcherOverride/probe.neon
+++ b/tests/Fixture/PhpStanNativeMatcherOverride/probe.neon
@@ -1,0 +1,8 @@
+includes:
+    - ../../../extension.neon
+
+parameters:
+    level: max
+    greenlight:
+        configFiles:
+            - tests/Fixture/PhpStanNativeMatcherOverride/greenlight.php

--- a/tests/Unit/Expect/NativeMatcherNameTest.php
+++ b/tests/Unit/Expect/NativeMatcherNameTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\DataRow;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\ExpectationExtensionError;
+use Greenlight\Tests\Fixture\Expect\EvenNumbersExtension;
+use Greenlight\Tests\Fixture\PhpStanNativeMatcherOverride\NativeMatcherOverrideExtension;
+
+final class NativeMatcherNameTest
+{
+    /** @param non-empty-string $name */
+    #[Test]
+    #[DataRow(['toBeInt'], label: 'native matcher')]
+    #[DataRow(['TOBEINT'], label: 'case variant')]
+    #[DataRow(['not'], label: 'negation')]
+    #[DataRow(['because'], label: 'reason')]
+    public function rejectsNativeNamesWithoutReplacingInstalledExtensions(string $name): void
+    {
+        $restore = Expect::install([new EvenNumbersExtension()]);
+
+        try {
+            Expect::that(static fn() => Expect::install([new NativeMatcherOverrideExtension($name)]))
+                ->toThrow(
+                    ExpectationExtensionError::class,
+                    message: \sprintf(
+                        'Extension matcher "%s" conflicts with a native expectation method. Rename the extension matcher.',
+                        $name,
+                    ),
+                );
+            Expect::that(4)->toBeEven();
+        } finally {
+            $restore();
+        }
+    }
+}


### PR DESCRIPTION
Extension entries that reuse a public native expectation method cannot replace that method at runtime, but their signatures previously replaced its type information in PHPStan and generated IDE annotations. A `toBeInt` entry with a string signature caused false errors for valid integer expectations.

Reject these entries when the worker installs extensions and when PHPStan or the IDE helper loads their configuration. The comparison ignores letter case and covers modifiers such as `not` and `because`. A rejected installation preserves the previous extensions. Runtime, CLI, IDE-helper, and PHPStan regressions cover the diagnostic; all four runtime name cases failed before the fix and pass after it.

This is a configuration compatibility change: rename or remove extension entries that reuse public native method names. The API reference documents the restriction.
