### PR TITLE
fix: preserve the HTML coverage export directory for empty maps

### DIFF
--- a/src/Cli/Coverage/CoverageWriter.php
+++ b/src/Cli/Coverage/CoverageWriter.php
@@ -62,7 +62,7 @@ final readonly class CoverageWriter
                 return false;
             }
             $target = ConfigurationLoader::absolutePath($export->target, $workingDirectory);
-            if (\count($files) === 1) {
+            if ($export->format !== 'html') {
                 ErrorTrap::run(static fn() => \mkdir(\dirname($target), 0o777, true));
                 try {
                     AtomicFile::write($target, \reset($files));

--- a/tests/Acceptance/EmptyHtmlCoverageExportTest.php
+++ b/tests/Acceptance/EmptyHtmlCoverageExportTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\DataRow;
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\CoverageJson;
+use Greenlight\Tests\Support\GreenlightCli;
+
+final readonly class EmptyHtmlCoverageExportTest
+{
+    public function __construct(private TemporaryDirectory $temporaryDirectory) {}
+
+    #[Test]
+    #[DataRow([false], label: "new directory")]
+    #[DataRow([true], label: "existing directory")]
+    public function emptyCoverageWritesAnIndexInsideTheTargetDirectory(bool $existing): void
+    {
+        $directory = $this->temporaryDirectory->subdirectory("empty-html-coverage");
+        CoverageJson::write($directory . "/one.json", CoverageMap::empty());
+        CoverageJson::write($directory . "/two.json", CoverageMap::empty());
+
+        if ($existing) {
+            \mkdir($directory . "/html");
+        }
+
+        $result = GreenlightCli::run($directory, [
+            "coverage:merge",
+            "--input=one.json",
+            "--input=two.json",
+            "--export=html=html",
+            "--no-ansi",
+        ]);
+
+        Expect::that($result->exitCode)->toBe(0);
+        Expect::that(\is_dir($directory . "/html"))->toBeTrue();
+        Expect::that((string) \file_get_contents($directory . "/html/index.html"))
+            ->toContain("Greenlight Coverage")
+            ->toContain("100.00%");
+    }
+}


### PR DESCRIPTION
An empty coverage map produces only the HTML index. The writer used the number of exported files to choose a file or directory target, so it wrote HTML directly to the directory path. An existing target directory made the command fail.

Choose the target shape from the export format. Empty HTML reports now write index.html inside the target directory. Both acceptance cases fail before the change and pass afterward. Full local checks are queued, and GitHub CI will validate the PR head.
