### PR TITLE
fix(doubles): resolve class identity in argument plans

### DIFF
--- a/src/Doubles/ArgumentType.php
+++ b/src/Doubles/ArgumentType.php
@@ -319,6 +319,10 @@ final readonly class ArgumentType
             return true;
         }
 
+        if ($leftReflection->getName() === $rightReflection->getName()) {
+            return true;
+        }
+
         if ($leftReflection->isSubclassOf($right) || $rightReflection->isSubclassOf($left)) {
             return true;
         }

--- a/tests/Unit/Doubles/ArgumentTypeIdentityTest.php
+++ b/tests/Unit/Doubles/ArgumentTypeIdentityTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Argument;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\MockPlan;
+use Greenlight\Expect\Expect;
+
+final readonly class ArgumentTypeIdentityTest
+{
+    public function __construct(private Doubles $doubles) {}
+
+    #[Test]
+    public function argumentPlansAcceptDifferentClassNameCase(): void
+    {
+        $this->verifyTypeName(\strtolower(ArgumentTypeIdentityValue::class));
+    }
+
+    #[Test]
+    public function argumentPlansAcceptClassAliases(): void
+    {
+        $alias = __NAMESPACE__ . '\\ArgumentTypeIdentityAlias';
+
+        if (!\class_exists($alias, false)) {
+            \class_alias(ArgumentTypeIdentityValue::class, $alias);
+        }
+
+        $this->verifyTypeName($alias);
+    }
+
+    private function verifyTypeName(string $type): void
+    {
+        $double = $this->doubles->mock(
+            ArgumentTypeIdentityConsumer::class,
+            static function (MockPlan $plan) use ($type): void {
+                $plan->expects('receive')->with(Argument::type($type))->once();
+            },
+        );
+        $value = new ArgumentTypeIdentityValue();
+        $double->receive($value);
+
+        Expect::that($this->doubles->callsTo($double, 'receive'))->toBe([[$value]]);
+    }
+}
+
+final class ArgumentTypeIdentityValue {}
+
+interface ArgumentTypeIdentityConsumer
+{
+    public function receive(ArgumentTypeIdentityValue $value): void;
+}


### PR DESCRIPTION
Mock argument plans reject valid class aliases and class names with different letter case. The matcher accepts the value, but the overlap check treats two spellings of the same class as unrelated classes. This prevents the mock from being created.

Compare the resolved reflection names before checking inheritance. Both new regressions fail before the change. After the change, they create a mock, deliver the typed value, and verify the recorded call. Existing type-overlap cases still reject unrelated classes.
