### PR TITLE
fix(expect): preserve JSON container types

### DIFF
--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -738,7 +738,7 @@ final class Expectation
         $subject = $this->stringSubject('toMatchJson');
 
         try {
-            $decodedExpected = \json_decode($expected, true, 512, \JSON_THROW_ON_ERROR);
+            $decodedExpected = \json_decode($expected, false, 512, \JSON_THROW_ON_ERROR);
         } catch (\JsonException) {
             $this->usageFailure('Pass valid JSON as the expected value to toMatchJson().');
         }
@@ -746,7 +746,7 @@ final class Expectation
         $renderedExpected = $this->renderer->render($decodedExpected);
 
         try {
-            $decodedSubject = \json_decode($subject, true, 512, \JSON_THROW_ON_ERROR);
+            $decodedSubject = \json_decode($subject, false, 512, \JSON_THROW_ON_ERROR);
         } catch (\JsonException) {
             return $this->verify(
                 false,

--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -738,15 +738,15 @@ final class Expectation
         $subject = $this->stringSubject('toMatchJson');
 
         try {
-            $decodedExpected = \json_decode($expected, false, 512, \JSON_THROW_ON_ERROR);
+            $decodedExpected = $this->decodeJsonForComparison($expected);
         } catch (\JsonException) {
             $this->usageFailure('Pass valid JSON as the expected value to toMatchJson().');
         }
 
-        $renderedExpected = $this->renderer->render($decodedExpected);
+        $renderedExpected = $this->renderer->render($expected);
 
         try {
-            $decodedSubject = \json_decode($subject, false, 512, \JSON_THROW_ON_ERROR);
+            $decodedSubject = $this->decodeJsonForComparison($subject);
         } catch (\JsonException) {
             return $this->verify(
                 false,
@@ -759,7 +759,7 @@ final class Expectation
             Equality::equals($decodedSubject, $decodedExpected),
             'to match the JSON structure ' . $renderedExpected,
             $renderedExpected,
-            $this->renderer->render($decodedSubject),
+            $this->renderer->render($subject),
         );
     }
 
@@ -1104,5 +1104,40 @@ final class Expectation
                 $warning === null ? '' : ' (' . $warning . ')',
             ));
         }
+    }
+
+    /**
+     * Prefixes every JSON string for comparison. This keeps string equality
+     * and prevents PHP from rejecting object keys that start with a null byte.
+     * The original JSON is used for diagnostics.
+     */
+    private function decodeJsonForComparison(string $json): mixed
+    {
+        $prefixed = '';
+        $insideString = false;
+        $offset = 0;
+        $bytes = \strlen($json);
+
+        while ($offset < $bytes) {
+            $span = \strcspn($json, '"\\', $offset);
+            $prefixed .= \substr($json, $offset, $span);
+            $offset += $span;
+
+            if ($offset === $bytes) {
+                break;
+            }
+
+            if ($json[$offset] === '\\') {
+                $prefixed .= \substr($json, $offset, 2);
+                $offset += 2;
+                continue;
+            }
+
+            $insideString = !$insideString;
+            $prefixed .= $insideString ? '"_' : '"';
+            ++$offset;
+        }
+
+        return \json_decode($prefixed, false, 512, \JSON_THROW_ON_ERROR);
     }
 }

--- a/tests/Unit/Expect/JsonContainerShapeTest.php
+++ b/tests/Unit/Expect/JsonContainerShapeTest.php
@@ -36,4 +36,51 @@ final class JsonContainerShapeTest
         Expect::that('{"items":[],"options":{}}')
             ->toMatchJson('{"options":{},"items":[]}');
     }
+
+    #[Test]
+    public function validNullCharacterKeysRetainTheirNamesAndContainerShapes(): void
+    {
+        Expect::that('{"\u0000name":{}}')->toMatchJson('{"\u0000name":{}}');
+        Expect::that('{"\u0000name":{}}')->not()->toMatchJson('{"\u0000name":[]}');
+        Expect::that('{"\u0000name":1}')->not()->toMatchJson('{"name":1}');
+        Expect::that('{"\u0000name":1}')->not()->toMatchJson('{"_\u0000name":1}');
+    }
+
+    #[Test]
+    public function escapedStringsAndDuplicateKeysKeepNativeJsonSemantics(): void
+    {
+        Expect::that('{"quote":"\"","slash":"\\\\","brackets":"[{}]"}')
+            ->toMatchJson('{"brackets":"[{}]","slash":"\u005c","quote":"\u0022"}');
+        Expect::that('{"name":1,"\u006eame":2}')->toMatchJson('{"name":2}');
+        Expect::that('""')->not()->toMatchJson('"_"');
+        Expect::that('"0"')->not()->toMatchJson('0');
+    }
+
+    #[Test]
+    public function validDeepContainersKeepTheNativeDepthLimit(): void
+    {
+        $json = \str_repeat('[', 511) . '"value"' . \str_repeat(']', 511);
+
+        Expect::that($json)->not()->toMatchJson('[]');
+        Expect::that('[]')->not()->toMatchJson($json);
+    }
+
+    #[Test]
+    public function invalidEscapesAndExcessiveDepthRemainUsageErrors(): void
+    {
+        foreach ([
+            '"unterminated',
+            '"\q"',
+            '"\uD800"',
+            '"first" "second"',
+            "\"line\nbreak\"",
+            \str_repeat('[', 512) . '0' . \str_repeat(']', 512),
+        ] as $invalid) {
+            $detail = FailureProbe::detailOf(
+                static fn() => Expect::that('{}')->toMatchJson($invalid),
+            );
+
+            Expect::that($detail->message)->toBe('Pass valid JSON as the expected value to toMatchJson().');
+        }
+    }
 }

--- a/tests/Unit/Expect/JsonContainerShapeTest.php
+++ b/tests/Unit/Expect/JsonContainerShapeTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+
+final class JsonContainerShapeTest
+{
+    #[Test]
+    public function emptyObjectsDifferFromEmptyArrays(): void
+    {
+        Expect::that('{}')->not()->toMatchJson('[]');
+        Expect::that('[]')->not()->toMatchJson('{}');
+    }
+
+    #[Test]
+    public function numericObjectKeysDoNotBecomeArrayIndices(): void
+    {
+        Expect::that('{"0":"first","1":"second"}')
+            ->not()->toMatchJson('["first","second"]');
+    }
+
+    #[Test]
+    public function nestedContainersPreserveTheirTypes(): void
+    {
+        Expect::that('{"items":{}}')->not()->toMatchJson('{"items":[]}');
+        Expect::that('[{}]')->not()->toMatchJson('[[]]');
+    }
+
+    #[Test]
+    public function objectKeyOrderDoesNotAffectEquality(): void
+    {
+        Expect::that('{"items":[],"options":{}}')
+            ->toMatchJson('{"options":{},"items":[]}');
+    }
+}

--- a/tests/Unit/Expect/JsonMatchersTest.php
+++ b/tests/Unit/Expect/JsonMatchersTest.php
@@ -59,9 +59,9 @@ final class JsonMatchersTest
             static fn() => Expect::that('{"a": 2}')->toMatchJson('{"a": 1}'),
         );
 
-        Expect::that($detail->message)->because('toMatchJson() fails on structural mismatch')->toBe("Expected ['a' => 2] to match the JSON structure ['a' => 1].");
-        Expect::that($detail->expected)->because('toMatchJson() fails on structural mismatch')->toBe("['a' => 1]");
-        Expect::that($detail->actual)->because('toMatchJson() fails on structural mismatch')->toBe("['a' => 2]");
+        Expect::that($detail->message)->because('toMatchJson() fails on structural mismatch')->toBe('Expected stdClass {a: 2} to match the JSON structure stdClass {a: 1}.');
+        Expect::that($detail->expected)->because('toMatchJson() fails on structural mismatch')->toBe('stdClass {a: 1}');
+        Expect::that($detail->actual)->because('toMatchJson() fails on structural mismatch')->toBe('stdClass {a: 2}');
     }
 
     #[Test]
@@ -71,7 +71,7 @@ final class JsonMatchersTest
             static fn() => Expect::that('nope')->toMatchJson('{"a": 1}'),
         );
 
-        Expect::that($detail->message)->because('toMatchJson() fails distinctly on invalid subject JSON')->toBe("Expected 'nope' to be valid JSON matching ['a' => 1].");
+        Expect::that($detail->message)->because('toMatchJson() fails distinctly on invalid subject JSON')->toBe("Expected 'nope' to be valid JSON matching stdClass {a: 1}.");
     }
 
     #[Test]

--- a/tests/Unit/Expect/JsonMatchersTest.php
+++ b/tests/Unit/Expect/JsonMatchersTest.php
@@ -59,9 +59,9 @@ final class JsonMatchersTest
             static fn() => Expect::that('{"a": 2}')->toMatchJson('{"a": 1}'),
         );
 
-        Expect::that($detail->message)->because('toMatchJson() fails on structural mismatch')->toBe('Expected stdClass {a: 2} to match the JSON structure stdClass {a: 1}.');
-        Expect::that($detail->expected)->because('toMatchJson() fails on structural mismatch')->toBe('stdClass {a: 1}');
-        Expect::that($detail->actual)->because('toMatchJson() fails on structural mismatch')->toBe('stdClass {a: 2}');
+        Expect::that($detail->message)->because('toMatchJson() fails on structural mismatch')->toBe('Expected \'{"a": 2}\' to match the JSON structure \'{"a": 1}\'.');
+        Expect::that($detail->expected)->because('toMatchJson() fails on structural mismatch')->toBe('\'{"a": 1}\'');
+        Expect::that($detail->actual)->because('toMatchJson() fails on structural mismatch')->toBe('\'{"a": 2}\'');
     }
 
     #[Test]
@@ -71,7 +71,7 @@ final class JsonMatchersTest
             static fn() => Expect::that('nope')->toMatchJson('{"a": 1}'),
         );
 
-        Expect::that($detail->message)->because('toMatchJson() fails distinctly on invalid subject JSON')->toBe("Expected 'nope' to be valid JSON matching stdClass {a: 1}.");
+        Expect::that($detail->message)->because('toMatchJson() fails distinctly on invalid subject JSON')->toBe('Expected \'nope\' to be valid JSON matching \'{"a": 1}\'.');
     }
 
     #[Test]


### PR DESCRIPTION
toMatchJson() decoded JSON objects as PHP arrays, so an empty object matched an empty array and numeric object keys could match array indices. Preserve objects and arrays as distinct native types before deep comparison. Object-key order, duplicate-key handling, and numeric equality retain their existing behavior.

A private lexical scan prefixes every JSON string before native decoding. This preserves string equality and lets PHP decode valid object keys that start with a null character. It does not parse JSON, use regular expressions, or change the native depth limit. Diagnostics render the original JSON with the existing size bounds, so they show the container type and do not expose the internal prefix. The scan adds linear work and a temporary string copy; no performance improvement is claimed.

The original object/array examples incorrectly passed. Cross-review also reproduced a valid null-character key that a direct object decode rejected; its regression now passes. Eighteen focused matcher cases pass with 42 expectations, covering container types, key order, null-character keys and prefix collisions, escaped strings, duplicate keys, valid depth 511, excessive depth 512, and invalid escapes.
