### PR TITLE
fix(hyperf): dispose attempt containers after reset failures

### DIFF
--- a/.github/fixtures/hyperf-bridge/cleanup.php
+++ b/.github/fixtures/hyperf-bridge/cleanup.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Greenlight\Config\GreenlightConfig;
+
+return GreenlightConfig::create()
+    ->paths([__DIR__ . '/tests/Cleanup'])
+    ->workers(1);

--- a/.github/fixtures/hyperf-bridge/tests/Cleanup/HyperfCleanupFailureTest.php
+++ b/.github/fixtures/hyperf-bridge/tests/Cleanup/HyperfCleanupFailureTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfBridgeAcceptance\Cleanup;
+
+use App\Greeter;
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Hyperf\ContainerLifetime;
+use Greenlight\Hyperf\HyperfPlugin;
+use Greenlight\IntegrationFixture\IntegrationResources;
+use Greenlight\Plugin\WorkerBootstrapContext;
+use Greenlight\Test\TestChannel;
+use Hyperf\Context\ApplicationContext;
+use Hyperf\Coroutine\Coroutine;
+use Psr\Container\ContainerInterface;
+
+final readonly class HyperfCleanupFailureTest
+{
+    #[Test]
+    #[DataSet('failures')]
+    public function resetFailureStillDisposesTheContainer(bool $attemptFails, bool $disposeFails): void
+    {
+        $resetFailure = new \RuntimeException('The reset failed.');
+        $attemptFailure = new \RuntimeException('The attempt failed.');
+        $resetContainer = null;
+        $disposedContainer = null;
+        $disposedInCoroutine = false;
+        $plugin = new HyperfPlugin(
+            \dirname(__DIR__, 2),
+            containerLifetime: ContainerLifetime::TestAttempt,
+            reset: static function (ContainerInterface $container) use (&$resetContainer, $resetFailure): void {
+                $resetContainer = $container;
+
+                throw $resetFailure;
+            },
+            dispose: static function (ContainerInterface $container) use (&$disposedContainer, &$disposedInCoroutine, $disposeFails): void {
+                $disposedContainer = $container;
+                $disposedInCoroutine = Coroutine::inCoroutine();
+
+                if ($disposeFails) {
+                    throw new \RuntimeException('The disposal failed.');
+                }
+            },
+        );
+        $plugin->onWorkerBootstrap(new WorkerBootstrapContext('cleanup-probe', new TestChannel(1), IntegrationResources::empty()));
+        $caught = null;
+
+        try {
+            $plugin->runTestAttempt(static function () use ($attemptFails, $attemptFailure): void {
+                if ($attemptFails) {
+                    throw $attemptFailure;
+                }
+            });
+        } catch (\Throwable $failure) {
+            $caught = $failure;
+        }
+
+        Expect::that($disposedContainer)->toBeInstanceOf(ContainerInterface::class);
+        Expect::that($disposedContainer)->toBe($resetContainer);
+        Expect::that($disposedInCoroutine)->toBeTrue();
+        Expect::that($caught)->toBe($attemptFails ? $attemptFailure : $resetFailure);
+        Expect::that(ApplicationContext::getContainer()->has(Greeter::class))->toBeFalse();
+    }
+
+    /** @return iterable<string, array{bool, bool}> */
+    public static function failures(): iterable
+    {
+        yield 'reset failure' => [false, false];
+        yield 'reset and disposal failures' => [false, true];
+        yield 'attempt and cleanup failures' => [true, true];
+    }
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,10 @@ jobs:
         working-directory: ".github/fixtures/hyperf-bridge"
         run: "php verify-lifecycle.php attempt"
 
+      - name: "Run Hyperf cleanup failure acceptance tests"
+        working-directory: ".github/fixtures/hyperf-bridge"
+        run: "vendor/bin/greenlight run --config=cleanup.php --no-ansi --reporter=plain"
+
   ci:
     name: "CI (PHP ${{ matrix.php-version }}, ${{ matrix.dependencies }} deps${{ matrix.symfony-version && format(', Symfony {0}', matrix.symfony-version) || '' }})"
     runs-on: "ubuntu-latest"

--- a/src/Hyperf/HyperfPlugin.php
+++ b/src/Hyperf/HyperfPlugin.php
@@ -415,10 +415,15 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemp
 
         try {
             if ($container instanceof ContainerInterface) {
-                $this->resetContainer($container);
+                $failure = null;
+                $this->captureCleanup($failure, fn() => $this->resetContainer($container));
 
                 if ($this->dispose instanceof \Closure) {
-                    ($this->dispose)($container);
+                    $this->captureCleanup($failure, fn() => ($this->dispose)($container));
+                }
+
+                if ($failure instanceof \Throwable) {
+                    throw $failure;
                 }
             }
         } finally {


### PR DESCRIPTION
When an attempt-scoped Hyperf container reset throws, the dispose callback does not run. External resources owned by that container can remain open.

Run reset and dispose as separate cleanup operations, then rethrow the first cleanup failure. Preserve an earlier test failure and always clear the active application container. Both callbacks still run inside the test coroutine.

The initial regression commit failed all three cases against real Hyperf and Swoole in [the Hyperf bridge job](https://github.com/ben-challis/greenlight/actions/runs/33917643285/job/101168414748): the dispose callback never received a container. The cases cover a reset failure, simultaneous reset and disposal failures, and an earlier attempt failure. The final commit checks disposal, coroutine context, primary failure identity, and container removal.
