### PR TITLE
fix: skip excluded prose directories before traversal

### DIFF
--- a/tests/Acceptance/ProseCheckDirectoryExclusionTest.php
+++ b/tests/Acceptance/ProseCheckDirectoryExclusionTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Test\SkipTest;
+use Greenlight\Tests\Support\PhpSubprocess;
+use Greenlight\Tests\Support\ProjectFiles;
+
+final readonly class ProseCheckDirectoryExclusionTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function doesNotOpenExcludedDirectories(): void
+    {
+        if (\function_exists('posix_getuid') && \posix_getuid() === 0) {
+            throw new SkipTest('An unreadable directory cannot be staged when running as root.');
+        }
+
+        $project = ProjectFiles::create($this->tempDirectory, 'unreadable-exclusions');
+        $project->write('README.md', "The worker stops.\n");
+        $directories = ['vendor', 'packages/example/node_modules', 'build/cache', '.git'];
+
+        foreach ($directories as $directory) {
+            $project->write($directory . '/README.md', "Excluded content.\n");
+            \chmod($project->path($directory), 0o000);
+        }
+
+        try {
+            $result = PhpSubprocess::run($project->directory, [
+                \dirname(__DIR__, 2) . '/tools/prose-check.php',
+                'check',
+                '--root=' . $project->directory,
+            ]);
+
+            Expect::that($result->exitCode)->because('excluded directories do not need read access')->toBe(0);
+        } finally {
+            foreach ($directories as $directory) {
+                \chmod($project->path($directory), 0o755);
+            }
+        }
+    }
+}

--- a/tools/prose-check.php
+++ b/tools/prose-check.php
@@ -335,7 +335,10 @@ function proseFiles(string $root): array
 {
     $files = [];
     $iterator = new RecursiveIteratorIterator(
-        new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
+        new RecursiveCallbackFilterIterator(
+            new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS),
+            fn(SplFileInfo $file): bool => !\proseIsExcluded(\proseRelativePath($root, $file->getPathname())),
+        ),
     );
 
     foreach ($iterator as $file) {
@@ -345,10 +348,6 @@ function proseFiles(string $root): array
 
         $path = $file->getPathname();
         $relative = \proseRelativePath($root, $path);
-
-        if (\proseIsExcluded($relative)) {
-            continue;
-        }
 
         if (
             $relative !== 'bin/greenlight'


### PR DESCRIPTION
The prose checker opens excluded directories before it filters their files. An unreadable `vendor`, nested `node_modules`, `.git`, or cache directory therefore stops the command with an uncaught exception, even though none of its files is in scope.

Apply the existing exclusion rules before directory traversal. The new acceptance case stages unreadable excluded directories and demonstrates exit 255 before the change and exit 0 after it. All 32 focused prose checks pass.

A five-sample local check of a project with one maintained document and 20,000 excluded files in 200 packages reduced median elapsed time from 0.389 s to 0.141 s. Both versions returned the same empty output and successful status. This measures one dependency-heavy fixture, not general repository performance.
