### PR TITLE
perf: stream saved profile reports

### DIFF
--- a/src/Cli/Command/ProfileReportCommand.php
+++ b/src/Cli/Command/ProfileReportCommand.php
@@ -40,33 +40,30 @@ final readonly class ProfileReportCommand
         }
         $aggregator = new ProfileAggregator();
         try {
-            $result = ErrorTrap::run(function () use ($stream, $aggregator, $arguments): ?CommandResult {
-                while (($line = \fgets($stream)) !== false) {
-                    if (\trim($line) === '') {
-                        continue;
-                    }
-
-                    try {
-                        $aggregator->onEvent(EventCodec::decodeJsonLine($line));
-                    } catch (EventCodecFailed $failure) {
-                        $result = $this->handleCodecFailure($failure, $arguments->has('no-ansi'));
-
-                        if ($result instanceof CommandResult) {
-                            return $result;
-                        }
-                    }
+            while (true) {
+                $line = ErrorTrap::run(static fn() => \fgets($stream), $warning);
+                if ($warning !== null || ($line === false && !\feof($stream))) {
+                    $this->console->err(\sprintf("Greenlight could not read \"%s\"%s.\n", $path, $warning === null ? '' : ': ' . $warning));
+                    return CommandResult::failure();
                 }
 
-                return null;
-            }, $warning);
+                if ($line === false) {
+                    break;
+                }
 
-            if ($result instanceof CommandResult) {
-                return $result;
-            }
+                if (\trim($line) === '') {
+                    continue;
+                }
 
-            if (!\feof($stream)) {
-                $this->console->err(\sprintf("Greenlight could not read \"%s\"%s.\n", $path, $warning === null ? '' : ': ' . $warning));
-                return CommandResult::failure();
+                try {
+                    $aggregator->onEvent(EventCodec::decodeJsonLine($line));
+                } catch (EventCodecFailed $failure) {
+                    $result = $this->handleCodecFailure($failure, $arguments->has('no-ansi'));
+
+                    if ($result instanceof CommandResult) {
+                        return $result;
+                    }
+                }
             }
         } finally {
             \fclose($stream);

--- a/src/Cli/Command/ProfileReportCommand.php
+++ b/src/Cli/Command/ProfileReportCommand.php
@@ -33,28 +33,43 @@ final readonly class ProfileReportCommand
             return CommandResult::usage();
         }
         $path = ConfigurationLoader::absolutePath($input, $workingDirectory);
-        $raw = ErrorTrap::run(static fn() => \file_get_contents($path), $warning);
-        if (!\is_string($raw)) {
+        $stream = ErrorTrap::run(static fn() => \fopen($path, 'rb'), $warning);
+        if ($stream === false) {
             $this->console->err(\sprintf("Greenlight could not read \"%s\"%s.\n", $path, $warning === null ? '' : ': ' . $warning));
             return CommandResult::failure();
         }
         $aggregator = new ProfileAggregator();
-        foreach (\explode("\n", $raw) as $line) {
-            if (\trim($line) === '') {
-                continue;
-            }
+        try {
+            $result = ErrorTrap::run(function () use ($stream, $aggregator, $arguments): ?CommandResult {
+                while (($line = \fgets($stream)) !== false) {
+                    if (\trim($line) === '') {
+                        continue;
+                    }
 
-            try {
-                $aggregator->onEvent(EventCodec::decodeJsonLine($line));
-            } catch (EventCodecFailed $failure) {
-                $result = $this->handleCodecFailure($failure, $arguments->has('no-ansi'));
+                    try {
+                        $aggregator->onEvent(EventCodec::decodeJsonLine($line));
+                    } catch (EventCodecFailed $failure) {
+                        $result = $this->handleCodecFailure($failure, $arguments->has('no-ansi'));
 
-                if (!$result instanceof CommandResult) {
-                    continue;
+                        if ($result instanceof CommandResult) {
+                            return $result;
+                        }
+                    }
                 }
 
+                return null;
+            }, $warning);
+
+            if ($result instanceof CommandResult) {
                 return $result;
             }
+
+            if (!\feof($stream)) {
+                $this->console->err(\sprintf("Greenlight could not read \"%s\"%s.\n", $path, $warning === null ? '' : ': ' . $warning));
+                return CommandResult::failure();
+            }
+        } finally {
+            \fclose($stream);
         }
         $report = $aggregator->render(new Style($this->console->capabilities($arguments->has('no-ansi'), $arguments->has('ansi'))->color));
         if ($report === '') {

--- a/tests/Acceptance/ProfileReportMemoryTest.php
+++ b/tests/Acceptance/ProfileReportMemoryTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Event\RunFinished;
+use Greenlight\Event\RunStarted;
+use Greenlight\Event\TestFinished;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Internal\Event\EventCodec;
+use Greenlight\Result\Outcome;
+use Greenlight\Result\ResultSummary;
+use Greenlight\Result\TestResult;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Test\TestId;
+use Greenlight\Tests\Support\GreenlightCli;
+
+final readonly class ProfileReportMemoryTest
+{
+    public function __construct(private TemporaryDirectory $temporaryDirectory) {}
+
+    #[Test]
+    public function aLargeSavedStreamCanBeProfiledWithALowerMemoryLimit(): void
+    {
+        $directory = $this->temporaryDirectory->subdirectory('profile-memory');
+        $path = $directory . '/profile.jsonl';
+        $stream = \fopen($path, 'wb');
+        if ($stream === false) {
+            Fail::because('Cannot create the profile fixture.');
+        }
+
+        try {
+            \fwrite($stream, EventCodec::encodeJsonLine(new RunStarted('large-stream', 40_000, 1, 1.0)));
+
+            for ($index = 0; $index < 40_000; ++$index) {
+                $id = new TestId('Example\\SuiteTest', 'probe', \str_repeat('x', 500) . $index);
+                \fwrite($stream, EventCodec::encodeJsonLine(new TestFinished(
+                    new TestResult($id, Outcome::Passed, 0.001, 1),
+                    1.0,
+                )));
+            }
+
+            \fwrite($stream, \rtrim(EventCodec::encodeJsonLine(new RunFinished(
+                'large-stream',
+                new ResultSummary(passed: 40_000),
+                1.0,
+                2.0,
+            )), "\n"));
+        } finally {
+            \fclose($stream);
+        }
+
+        Expect::that(\filesize($path))->toBeGreaterThan(32 * 1024 * 1024);
+        $result = GreenlightCli::run($directory, ['profile:report', '--input=profile.jsonl', '--no-ansi'], phpArguments: ['-d', 'memory_limit=32M']);
+        Expect::that($result->exitCode)->toBe(0);
+        Expect::that($result->stdout)->toBe("Profile:\n  Workers: 1 requested, 0 spawned");
+    }
+}

--- a/tests/Fixture/Cli/Profile/EofReadFailureStream.php
+++ b/tests/Fixture/Cli/Profile/EofReadFailureStream.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Cli\Profile;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Event\RunFinished;
+use Greenlight\Internal\Event\EventCodec;
+use Greenlight\Result\ResultSummary;
+
+/** Returns a complete event, then reports a read error and end of input. */
+final class EofReadFailureStream implements Fake
+{
+    public mixed $context;
+
+    public static bool $closed = false;
+
+    private int $reads = 0;
+
+    public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
+    {
+        self::$closed = false;
+        return true;
+    }
+
+    public function stream_read(int $count): string|false
+    {
+        if (++$this->reads === 1) {
+            return EventCodec::encodeJsonLine(new RunFinished('partial', new ResultSummary(), 0.0, 1.0));
+        }
+
+        \trigger_error('The profile input read failed.', \E_USER_WARNING);
+        return false;
+    }
+
+    public function stream_eof(): bool
+    {
+        return $this->reads > 1;
+    }
+
+    public function stream_close(): void
+    {
+        self::$closed = true;
+    }
+}

--- a/tests/Fixture/Cli/Profile/FailedReadStream.php
+++ b/tests/Fixture/Cli/Profile/FailedReadStream.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Cli\Profile;
+
+use Greenlight\Doubles\Fake;
+
+/** Opens a stream that fails before the end of its input. */
+final class FailedReadStream implements Fake
+{
+    public mixed $context;
+
+    public static bool $closed = false;
+
+    public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
+    {
+        self::$closed = false;
+        return true;
+    }
+
+    public function stream_read(int $count): false
+    {
+        return false;
+    }
+
+    public function stream_eof(): bool
+    {
+        return false;
+    }
+
+    public function stream_close(): void
+    {
+        self::$closed = true;
+    }
+}

--- a/tests/Unit/Cli/ProfileReportReadFailureTest.php
+++ b/tests/Unit/Cli/ProfileReportReadFailureTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Cli;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Cli\Application;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\StreamWrappers;
+use Greenlight\Test\Cleanup;
+use Greenlight\Tests\Fixture\Cli\Profile\FailedReadStream;
+use Greenlight\Tests\Support\MemoryStream;
+
+final readonly class ProfileReportReadFailureTest
+{
+    public function __construct(private StreamWrappers $wrappers, private Cleanup $cleanup) {}
+
+    #[Test]
+    public function readFailureClosesTheInputAndDoesNotPrintAProfile(): void
+    {
+        $this->wrappers->register('greenlight-profile-read-failure', FailedReadStream::class);
+        $stdout = MemoryStream::open();
+        $stderr = MemoryStream::open();
+        $this->cleanup->defer(static fn() => MemoryStream::close($stdout, $stderr));
+        $exit = Application::forStreams($stdout, $stderr)->run(
+            ['profile:report', '--input=events.jsonl', '--no-ansi'],
+            'greenlight-profile-read-failure://root',
+        );
+        \rewind($stdout);
+        \rewind($stderr);
+
+        Expect::that($exit)->toBe(1);
+        Expect::that(\stream_get_contents($stdout))->toBe('');
+        Expect::that((string) \stream_get_contents($stderr))->toContain('Greenlight could not read');
+        Expect::that(FailedReadStream::$closed)->toBeTrue();
+    }
+}

--- a/tests/Unit/Cli/ProfileReportReadFailureTest.php
+++ b/tests/Unit/Cli/ProfileReportReadFailureTest.php
@@ -9,6 +9,7 @@ use Greenlight\Cli\Application;
 use Greenlight\Expect\Expect;
 use Greenlight\Sandbox\StreamWrappers;
 use Greenlight\Test\Cleanup;
+use Greenlight\Tests\Fixture\Cli\Profile\EofReadFailureStream;
 use Greenlight\Tests\Fixture\Cli\Profile\FailedReadStream;
 use Greenlight\Tests\Support\MemoryStream;
 
@@ -34,5 +35,25 @@ final readonly class ProfileReportReadFailureTest
         Expect::that(\stream_get_contents($stdout))->toBe('');
         Expect::that((string) \stream_get_contents($stderr))->toContain('Greenlight could not read');
         Expect::that(FailedReadStream::$closed)->toBeTrue();
+    }
+
+    #[Test]
+    public function readFailureAtEndOfInputDoesNotPrintAPartialProfile(): void
+    {
+        $this->wrappers->register('greenlight-profile-eof-failure', EofReadFailureStream::class);
+        $stdout = MemoryStream::open();
+        $stderr = MemoryStream::open();
+        $this->cleanup->defer(static fn() => MemoryStream::close($stdout, $stderr));
+        $exit = Application::forStreams($stdout, $stderr)->run(
+            ['profile:report', '--input=events.jsonl', '--no-ansi'],
+            'greenlight-profile-eof-failure://root',
+        );
+        \rewind($stdout);
+        \rewind($stderr);
+
+        Expect::that($exit)->toBe(1);
+        Expect::that(\stream_get_contents($stdout))->toBe('');
+        Expect::that((string) \stream_get_contents($stderr))->toContain('The profile input read failed.');
+        Expect::that(EofReadFailureStream::$closed)->toBeTrue();
     }
 }

--- a/tools/benchmark-profile-report.php
+++ b/tools/benchmark-profile-report.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Measures profile-report time and peak memory with a synthetic JSONL stream.
+ * Run: php tools/benchmark-profile-report.php [test-count]
+ * The default is 100,000 tests. Compare identical counts on an idle machine.
+ */
+
+require \dirname(__DIR__) . '/vendor/autoload.php';
+
+use Greenlight\Cli\Application;
+use Greenlight\Event\RunFinished;
+use Greenlight\Event\RunStarted;
+use Greenlight\Event\TestClassFinished;
+use Greenlight\Event\TestClassStarted;
+use Greenlight\Event\TestFinished;
+use Greenlight\Event\TestStarted;
+use Greenlight\Internal\Event\EventCodec;
+use Greenlight\Result\Outcome;
+use Greenlight\Result\ResultSummary;
+use Greenlight\Result\TestResult;
+use Greenlight\Test\TestId;
+
+if (($argv[1] ?? null) === '--measure') {
+    $input = $argv[2] ?? throw new InvalidArgumentException('Supply the input path.');
+    $output = \fopen('php://temp', 'w+');
+
+    if ($output === false) {
+        throw new RuntimeException('Cannot open the report output.');
+    }
+
+    $start = \hrtime(true);
+    $exit = Application::forStreams($output)->run(['profile:report', '--input=' . $input, '--no-ansi'], \dirname(__DIR__));
+    $elapsed = (\hrtime(true) - $start) / 1_000_000_000;
+    \rewind($output);
+    $report = (string) \stream_get_contents($output);
+    \fclose($output);
+    echo \json_encode([
+        'inputBytes' => \filesize($input),
+        'peakBytes' => \memory_get_peak_usage(true),
+        'seconds' => $elapsed,
+        'reportHash' => \hash('sha256', $report),
+        'exitCode' => $exit,
+    ], \JSON_THROW_ON_ERROR), "\n";
+    exit($exit);
+}
+
+$count = \filter_var($argv[1] ?? '100000', \FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+
+if (!\is_int($count)) {
+    throw new InvalidArgumentException('Supply a positive test count.');
+}
+
+$path = \tempnam(\sys_get_temp_dir(), 'greenlight-profile-benchmark-');
+
+if ($path === false) {
+    throw new RuntimeException('Cannot create the benchmark input.');
+}
+
+try {
+    $stream = \fopen($path, 'wb');
+
+    if ($stream === false) {
+        throw new RuntimeException('Cannot open the benchmark input.');
+    }
+
+    try {
+        \fwrite($stream, EventCodec::encodeJsonLine(new RunStarted('benchmark', $count, 1, 1.0)));
+        \fwrite($stream, EventCodec::encodeJsonLine(new TestClassStarted('Benchmark\\SuiteTest', 1.0, 'worker-1')));
+
+        for ($index = 0; $index < $count; ++$index) {
+            $id = new TestId('Benchmark\\SuiteTest', 'probe', (string) $index);
+            \fwrite($stream, EventCodec::encodeJsonLine(new TestStarted($id, 1.0)));
+            \fwrite($stream, EventCodec::encodeJsonLine(new TestFinished(new TestResult($id, Outcome::Passed, 0.001, 1), 1.001)));
+        }
+
+        \fwrite($stream, EventCodec::encodeJsonLine(new TestClassFinished('Benchmark\\SuiteTest', 2.0, 'worker-1')));
+        \fwrite($stream, EventCodec::encodeJsonLine(new RunFinished('benchmark', new ResultSummary(passed: $count), 1.0, 2.0)));
+    } finally {
+        \fclose($stream);
+    }
+
+    $process = \proc_open([\PHP_BINARY, '-d', 'memory_limit=-1', __FILE__, '--measure', $path], [0 => \STDIN, 1 => \STDOUT, 2 => \STDERR], $pipes);
+
+    if (!\is_resource($process)) {
+        throw new RuntimeException('Cannot start the profile measurement.');
+    }
+
+    $exit = \proc_close($process);
+} finally {
+    \unlink($path);
+}
+
+exit($exit);

--- a/tools/benchmark-profile-report.php
+++ b/tools/benchmark-profile-report.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Greenlight\Tools;
+
 /**
  * Measures profile-report time and peak memory with a synthetic JSONL stream.
  * Run: php tools/benchmark-profile-report.php [test-count]
@@ -24,11 +26,11 @@ use Greenlight\Result\TestResult;
 use Greenlight\Test\TestId;
 
 if (($argv[1] ?? null) === '--measure') {
-    $input = $argv[2] ?? throw new InvalidArgumentException('Supply the input path.');
+    $input = $argv[2] ?? throw new \InvalidArgumentException('Supply the input path.');
     $output = \fopen('php://temp', 'w+');
 
     if ($output === false) {
-        throw new RuntimeException('Cannot open the report output.');
+        throw new \RuntimeException('Cannot open the report output.');
     }
 
     $start = \hrtime(true);
@@ -50,20 +52,20 @@ if (($argv[1] ?? null) === '--measure') {
 $count = \filter_var($argv[1] ?? '100000', \FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
 
 if (!\is_int($count)) {
-    throw new InvalidArgumentException('Supply a positive test count.');
+    throw new \InvalidArgumentException('Supply a positive test count.');
 }
 
 $path = \tempnam(\sys_get_temp_dir(), 'greenlight-profile-benchmark-');
 
 if ($path === false) {
-    throw new RuntimeException('Cannot create the benchmark input.');
+    throw new \RuntimeException('Cannot create the benchmark input.');
 }
 
 try {
     $stream = \fopen($path, 'wb');
 
     if ($stream === false) {
-        throw new RuntimeException('Cannot open the benchmark input.');
+        throw new \RuntimeException('Cannot open the benchmark input.');
     }
 
     try {
@@ -85,7 +87,7 @@ try {
     $process = \proc_open([\PHP_BINARY, '-d', 'memory_limit=-1', __FILE__, '--measure', $path], [0 => \STDIN, 1 => \STDOUT, 2 => \STDERR], $pipes);
 
     if (!\is_resource($process)) {
-        throw new RuntimeException('Cannot start the profile measurement.');
+        throw new \RuntimeException('Cannot start the profile measurement.');
     }
 
     $exit = \proc_close($process);


### PR DESCRIPTION
Saved profile streams are read into one string and split into a second array before aggregation. Large runs can exhaust the PHP memory limit even though the aggregator retains only worker and class summaries. Read each JSONL line from the input stream, report read failures, and close the stream on every return path. Existing decoding behavior and final lines without a newline are preserved.

The new memory regression profiles a stream larger than 32 MiB under a 32 MiB PHP limit. The original command exits 255; the streamed command exits 0 with the expected report. Read-failure regressions check the diagnostic, empty output, and resource closure, including a complete report prefix followed by a read warning that also reports EOF. That prefix returned success before the cross-review correction. The benchmark tool measures a fresh process independently of fixture generation. For 100,000 tests (48,278,291 input bytes), peak allocated memory falls from 113,311,744 to 6,291,456 bytes, a 94.4% reduction, with identical report hashes. Final streamed measurements on the loaded host took 4.45–9.09 seconds. A subsequent paired comparison took 11.93 seconds before and 6.83 seconds after, with the same memory values and report hash. Host contention makes these timings unsuitable for a CPU-speed claim. Trapping each native read has per-line overhead in exchange for a bounded working set and explicit read-error handling. Memory still scales with the largest JSONL line and retained aggregation state.
