### PR TITLE
fix(execution): close services after event delivery fails

### DIFF
--- a/src/Execution/Worker/Worker.php
+++ b/src/Execution/Worker/Worker.php
@@ -73,85 +73,99 @@ final readonly class Worker
         $remaining = [];
         $leaks = [];
 
-        foreach ($plan->entriesByClass() as $class => $entries) {
-            if ($stopped) {
-                $remaining = [...$remaining, ...\array_map(static fn(PlanEntry $entry): TestId => $entry->id, $entries)];
+        try {
+            foreach ($plan->entriesByClass() as $class => $entries) {
+                if ($stopped) {
+                    $remaining = [...$remaining, ...\array_map(static fn(PlanEntry $entry): TestId => $entry->id, $entries)];
 
-                continue;
-            }
-
-            $isolated = \count($entries) === 1 && $entries[0]->definition->scheduling->isolated;
-            $sink->emit(new TestClassStarted($class, \microtime(true), $this->workerId, $isolated));
-            $scopes->openClass(allowPerClassServices: !$entries[0]->definition->scheduling->allowParallel);
-            $lastIndex = \count($entries) - 1;
-
-            $context = null;
-            $executor = null;
-
-            foreach ($entries as $index => $entry) {
-                $sink->emit(new TestStarted($entry->id, \microtime(true)));
-
-                try {
-                    $context ??= ClassContext::for($class);
-                    $executor ??= new TestExecutor(
-                        $scopes,
-                        $context,
-                        $plugins,
-                        $this->leakDetector,
-                        $this->artifactStore,
-                        $attemptStarted,
-                    );
-                    $result = $executor->execute($entry);
-                } catch (\Throwable $threw) {
-                    $result = new TestResult(
-                        $entry->id,
-                        Outcome::Errored,
-                        0.0,
-                        0,
-                        error: ThrowableDetail::fromThrowable($threw),
-                    );
+                    continue;
                 }
 
-                $result = $plugins->terminalResult($entry->definition, $result);
+                $isolated = \count($entries) === 1 && $entries[0]->definition->scheduling->isolated;
+                $sink->emit(new TestClassStarted($class, \microtime(true), $this->workerId, $isolated));
+                $scopes->openClass(allowPerClassServices: !$entries[0]->definition->scheduling->allowParallel);
+                $lastIndex = \count($entries) - 1;
 
-                $candidateSummary = $summary->add($result->outcome);
-                $failureLimitReached = $stopAfterFailures !== null
-                    && $candidateSummary->failed + $candidateSummary->errored >= $stopAfterFailures;
-                $drainReached = $drainRequested instanceof \Closure && $drainRequested();
+                $context = null;
+                $executor = null;
 
-                if ($index === $lastIndex || $failureLimitReached || $drainReached) {
-                    $result = HarnessServiceDisposal::applyToTest($result, $scopes->closeClass());
-                }
+                foreach ($entries as $index => $entry) {
+                    $sink->emit(new TestStarted($entry->id, \microtime(true)));
 
-                $summary = $summary->add($result->outcome);
-                $sink->emit(new TestFinished($result, \microtime(true)));
-
-                if ($this->leakDetector instanceof LeakDetector) {
-                    $leaks = [...$leaks, ...$this->leakDetector->sweep()];
-                }
-
-                $stopReached = match (true) {
-                    $stopAfterFailures !== null && $summary->failed + $summary->errored >= $stopAfterFailures => 'bail',
-                    $drainReached => 'drain',
-                    default => null,
-                };
-
-                if ($stopReached !== null) {
-                    $stopped = true;
-                    $drained = true;
-
-                    if ($index !== $lastIndex) {
-                        $remaining = \array_map(
-                            static fn(PlanEntry $unexecuted): TestId => $unexecuted->id,
-                            \array_slice($entries, $index + 1),
+                    try {
+                        $context ??= ClassContext::for($class);
+                        $executor ??= new TestExecutor(
+                            $scopes,
+                            $context,
+                            $plugins,
+                            $this->leakDetector,
+                            $this->artifactStore,
+                            $attemptStarted,
+                        );
+                        $result = $executor->execute($entry);
+                    } catch (\Throwable $threw) {
+                        $result = new TestResult(
+                            $entry->id,
+                            Outcome::Errored,
+                            0.0,
+                            0,
+                            error: ThrowableDetail::fromThrowable($threw),
                         );
                     }
 
-                    break;
+                    $result = $plugins->terminalResult($entry->definition, $result);
+
+                    $candidateSummary = $summary->add($result->outcome);
+                    $failureLimitReached = $stopAfterFailures !== null
+                        && $candidateSummary->failed + $candidateSummary->errored >= $stopAfterFailures;
+                    $drainReached = $drainRequested instanceof \Closure && $drainRequested();
+
+                    if ($index === $lastIndex || $failureLimitReached || $drainReached) {
+                        $result = HarnessServiceDisposal::applyToTest($result, $scopes->closeClass());
+                    }
+
+                    $summary = $summary->add($result->outcome);
+                    $sink->emit(new TestFinished($result, \microtime(true)));
+
+                    if ($this->leakDetector instanceof LeakDetector) {
+                        $leaks = [...$leaks, ...$this->leakDetector->sweep()];
+                    }
+
+                    $stopReached = match (true) {
+                        $stopAfterFailures !== null && $summary->failed + $summary->errored >= $stopAfterFailures => 'bail',
+                        $drainReached => 'drain',
+                        default => null,
+                    };
+
+                    if ($stopReached !== null) {
+                        $stopped = true;
+                        $drained = true;
+
+                        if ($index !== $lastIndex) {
+                            $remaining = \array_map(
+                                static fn(PlanEntry $unexecuted): TestId => $unexecuted->id,
+                                \array_slice($entries, $index + 1),
+                            );
+                        }
+
+                        break;
+                    }
                 }
+
+                $sink->emit(new TestClassFinished($class, \microtime(true), $this->workerId));
+            }
+        } catch (\Throwable $primary) {
+            $failures = $scopes->closeClass();
+
+            if ($ownScopes) {
+                $failures = [...$failures, ...$scopes->closeWorker()];
             }
 
-            $sink->emit(new TestClassFinished($class, \microtime(true), $this->workerId));
+            if ($failures !== []) {
+                throw WorkerError::afterHarnessServiceDisposal($primary, $failures);
+            }
+
+            throw $primary;
         }
 
         $outcome = new WorkerRunOutcome($summary, $remaining, $drained, $leaks);

--- a/tests/Unit/Execution/Worker/WorkerEventFailureCleanupTest.php
+++ b/tests/Unit/Execution/Worker/WorkerEventFailureCleanupTest.php
@@ -82,7 +82,7 @@ final readonly class WorkerEventFailureCleanupTest
 
     private function failingSink(\Throwable $failure): EventSink
     {
-        return new class ($failure) implements EventSink {
+        return new readonly class ($failure) implements EventSink {
             public function __construct(private \Throwable $failure) {}
 
             public function emit(Event $event): void

--- a/tests/Unit/Execution/Worker/WorkerEventFailureCleanupTest.php
+++ b/tests/Unit/Execution/Worker/WorkerEventFailureCleanupTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Execution\Worker;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\TestDiscoverer;
+use Greenlight\Event\Event;
+use Greenlight\Event\EventSink;
+use Greenlight\Event\TestFinished;
+use Greenlight\Execution\Worker\HarnessServiceDisposal;
+use Greenlight\Execution\Worker\Worker;
+use Greenlight\Execution\Worker\WorkerError;
+use Greenlight\Expect\Expect;
+use Greenlight\Harness\HarnessScopes;
+use Greenlight\Harness\Scope;
+use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Tests\Fixture\HarnessDisposalMatrix\FailingHarnessService;
+use Greenlight\Tests\Fixture\Lifecycle\Services\ServiceProbe;
+use Greenlight\Tests\Fixture\Lifecycle\TraceLog;
+use Greenlight\Tests\Support\FixturePath;
+
+final readonly class WorkerEventFailureCleanupTest
+{
+    #[Test]
+    #[DataSet('scopeOwners')]
+    public function eventFailureClosesAcquiredServices(Scope $scope, bool $externalOwner): void
+    {
+        TraceLog::drain();
+        ServiceProbe::reset();
+        $definitions = [new ServiceDefinition(ServiceProbe::class, $scope, static fn(): ServiceProbe => new ServiceProbe())];
+        $plan = new TestDiscoverer()->discover([FixturePath::get('Lifecycle/Services')]);
+        $failure = new \RuntimeException('Event delivery failed.');
+        $sink = $this->failingSink($failure);
+        $worker = new Worker($definitions);
+        $caught = null;
+
+        try {
+            if ($externalOwner) {
+                $scopes = new HarnessScopes($definitions);
+                HarnessServiceDisposal::runAndClose($scopes, static fn() => $worker->run($plan, $sink, scopes: $scopes));
+            } else {
+                $worker->run($plan, $sink);
+            }
+        } catch (\Throwable $error) {
+            $caught = $error;
+        }
+
+        Expect::that($caught)->toBe($failure);
+        Expect::that(TraceLog::drain())->toBe(['probe1:created', 'probe1:touched', 'probe1:disposed']);
+    }
+
+    #[Test]
+    public function disposalFailurePreservesTheEventFailure(): void
+    {
+        $failure = new \RuntimeException('Event delivery failed.');
+        $plan = new TestDiscoverer()->discover([FixturePath::get('HarnessDisposalMatrix')]);
+        $worker = new Worker([
+            new ServiceDefinition(FailingHarnessService::class, Scope::PerClass, static fn(): FailingHarnessService => new FailingHarnessService()),
+        ]);
+
+        Expect::that(fn() => $worker->run($plan, $this->failingSink($failure)))->toThrow(
+            static function (WorkerError $error) use ($failure): void {
+                Expect::that($error->getPrevious())->toBe($failure);
+                Expect::that($error->getMessage())
+                    ->toContain('Event delivery failed.')
+                    ->toContain('harness service disposal broke');
+            },
+        );
+    }
+
+    /** @return iterable<string, array{Scope, bool}> */
+    public static function scopeOwners(): iterable
+    {
+        yield 'owned class services' => [Scope::PerClass, false];
+        yield 'owned worker services' => [Scope::PerWorker, false];
+        yield 'external class services' => [Scope::PerClass, true];
+        yield 'external worker services' => [Scope::PerWorker, true];
+    }
+
+    private function failingSink(\Throwable $failure): EventSink
+    {
+        return new class ($failure) implements EventSink {
+            public function __construct(private \Throwable $failure) {}
+
+            public function emit(Event $event): void
+            {
+                if ($event instanceof TestFinished) {
+                    throw $this->failure;
+                }
+            }
+        };
+    }
+}


### PR DESCRIPTION
If event delivery fails between tests in one class, the worker leaves its class services open. Direct worker callers also leave worker services open. The production in-process and process-pool callers close the worker scope but do not close the abandoned class scope, so a failing reporter, subscriber, or channel can skip resource disposal.

Close the active class on an execution error, and close worker services when the worker owns them. Keep external worker scopes with their caller. Preserve the original error and report any additional disposal failures. Normal test result and disposal behavior stays the same.

The regression failed before the fix in three cases: internally owned class and worker services, and externally owned class services. It now checks all four ownership combinations and an additional cleanup failure; all five cases pass with 12 expectations. Full repository checks run locally and on GitHub.
