### PR TITLE
fix: require the expectation extension error factory

### DIFF
--- a/src/Expect/ExpectationExtensionError.php
+++ b/src/Expect/ExpectationExtensionError.php
@@ -11,6 +11,11 @@ namespace Greenlight\Expect;
  */
 final class ExpectationExtensionError extends \InvalidArgumentException
 {
+    private function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+
     public static function nativeMethod(string $name): self
     {
         return new self(\sprintf(

--- a/tests/Unit/Expect/NativeMatcherNameTest.php
+++ b/tests/Unit/Expect/NativeMatcherNameTest.php
@@ -13,13 +13,6 @@ use Greenlight\Tests\Fixture\PhpStanNativeMatcherOverride\NativeMatcherOverrideE
 
 final class NativeMatcherNameTest
 {
-    #[Test]
-    public function extensionErrorsRequireANamedFactory(): void
-    {
-        Expect::that(static fn(): object => new \ReflectionClass(ExpectationExtensionError::class)->newInstance('arbitrary'))
-            ->toThrow(\ReflectionException::class);
-    }
-
     /** @param non-empty-string $name */
     #[Test]
     #[DataRow(['toBeInt'], label: 'native matcher')]

--- a/tests/Unit/Expect/NativeMatcherNameTest.php
+++ b/tests/Unit/Expect/NativeMatcherNameTest.php
@@ -13,6 +13,13 @@ use Greenlight\Tests\Fixture\PhpStanNativeMatcherOverride\NativeMatcherOverrideE
 
 final class NativeMatcherNameTest
 {
+    #[Test]
+    public function extensionErrorsRequireANamedFactory(): void
+    {
+        Expect::that(static fn(): object => new \ReflectionClass(ExpectationExtensionError::class)->newInstance('arbitrary'))
+            ->toThrow(\ReflectionException::class);
+    }
+
     /** @param non-empty-string $name */
     #[Test]
     #[DataRow(['toBeInt'], label: 'native matcher')]


### PR DESCRIPTION
`ExpectationExtensionError`, introduced in #1781, inherits a public constructor. Callers can bypass `nativeMethod()` and create errors without the required diagnostic.

Add a private constructor and keep the existing named factory. This follows the private-constructor pattern in the other expectation errors. The native-name cases retain their exact messages.
