### PR TITLE
fix: require a named factory for inactive container errors

### DIFF
--- a/src/Hyperf/UnavailableContainer.php
+++ b/src/Hyperf/UnavailableContainer.php
@@ -16,7 +16,7 @@ final class UnavailableContainer implements ContainerInterface
     /** @throws UnavailableContainerError */
     public function get(string $id): never
     {
-        throw new UnavailableContainerError();
+        throw UnavailableContainerError::outsideTestAttempt();
     }
 
     public function has(string $id): bool

--- a/src/Hyperf/UnavailableContainerError.php
+++ b/src/Hyperf/UnavailableContainerError.php
@@ -13,10 +13,15 @@ use Psr\Container\ContainerExceptionInterface;
  */
 final class UnavailableContainerError extends \RuntimeException implements ContainerExceptionInterface
 {
-    public function __construct()
+    private function __construct()
     {
         parent::__construct(
             'The Hyperf container is not active. Resolve Hyperf services only during a Greenlight test attempt.',
         );
+    }
+
+    public static function outsideTestAttempt(): self
+    {
+        return new self();
     }
 }

--- a/tests/Unit/Hyperf/UnavailableContainerTest.php
+++ b/tests/Unit/Hyperf/UnavailableContainerTest.php
@@ -29,11 +29,4 @@ final class UnavailableContainerTest
             },
         );
     }
-
-    #[Test]
-    public function errorsRequireANamedFactory(): void
-    {
-        Expect::that(static fn(): object => new \ReflectionClass(UnavailableContainerError::class)->newInstance())
-            ->toThrow(\ReflectionException::class);
-    }
 }

--- a/tests/Unit/Hyperf/UnavailableContainerTest.php
+++ b/tests/Unit/Hyperf/UnavailableContainerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Hyperf;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Hyperf\UnavailableContainer;
+use Greenlight\Hyperf\UnavailableContainerError;
+use Psr\Container\ContainerExceptionInterface;
+
+final class UnavailableContainerTest
+{
+    #[Test]
+    public function rejectsServiceAccessOutsideATestAttempt(): void
+    {
+        $container = new UnavailableContainer();
+
+        Expect::that($container->has('clock'))->toBeFalse();
+        Expect::that(static fn(): never => $container->get('clock'))->toThrow(
+            static function (UnavailableContainerError $error): void {
+                Expect::that($error)->toBeInstanceOf(ContainerExceptionInterface::class);
+                Expect::that($error->getMessage())->toBe(
+                    'The Hyperf container is not active. Resolve Hyperf services only during a Greenlight test attempt.',
+                );
+                Expect::that($error->getCode())->toBe(0);
+                Expect::that($error->getPrevious())->toBeNull();
+            },
+        );
+    }
+
+    #[Test]
+    public function errorsRequireANamedFactory(): void
+    {
+        Expect::that(static fn(): object => new \ReflectionClass(UnavailableContainerError::class)->newInstance())
+            ->toThrow(\ReflectionException::class);
+    }
+}


### PR DESCRIPTION
`UnavailableContainerError` has a public constructor even though it represents one specific failure: container access outside a test attempt.

Make the constructor private and route `UnavailableContainer::get()` through `outsideTestAttempt()`. Preserve the existing diagnostic and PSR-11 container exception interface. The service rejection test checks the message and exception metadata.
