### PR TITLE
refactor!: require named configuration error factories

### DIFF
--- a/docs/api-configuration.md
+++ b/docs/api-configuration.md
@@ -328,7 +328,7 @@ PHPDoc:
 
 - `@param callable(CoverageBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L222)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L218)
 
 ### `watch()`
 
@@ -340,7 +340,7 @@ PHPDoc:
 
 - `@param callable(WatchBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L235)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L231)
 
 ### `artifacts()`
 
@@ -352,7 +352,7 @@ PHPDoc:
 
 - `@param callable(ArtifactBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L247)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L243)
 
 ### `storage()`
 
@@ -367,7 +367,7 @@ PHPDoc:
 
 - `@param callable(StorageBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L262)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L258)
 
 ### `failOnDeprecation()`
 
@@ -383,7 +383,7 @@ PHPDoc:
 
 - `@see self::ignoreDeprecationsMatching()`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L278)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L274)
 
 ### `failOnNotice()`
 
@@ -393,7 +393,7 @@ Fails an otherwise passed test if captured output contains a notice.
 public function failOnNotice(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L286)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L282)
 
 ### `failOnWarning()`
 
@@ -403,7 +403,7 @@ Fails an otherwise passed test if captured output contains a warning.
 public function failOnWarning(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L294)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L290)
 
 ### `failOnRisky()`
 
@@ -415,7 +415,7 @@ expectations.
 public function failOnRisky(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L306)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L302)
 
 ### `failOnSkipped()`
 
@@ -426,7 +426,7 @@ keeps its skipped outcome and reason.
 public function failOnSkipped(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L317)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L313)
 
 ### `failOnRetriedPass()`
 
@@ -437,7 +437,7 @@ outcome and attempt count.
 public function failOnRetriedPass(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L328)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L324)
 
 ### `ignoreDeprecationsMatching()`
 
@@ -454,7 +454,7 @@ PHPDoc:
 - `@param non-empty-string ...$patterns`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L344)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L340)
 
 ### `plugins()`
 
@@ -467,7 +467,7 @@ PHPDoc:
 - `@param \Closure(): Plugin ...$plugins`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L365)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L361)
 
 ### `failFast()`
 
@@ -475,7 +475,7 @@ PHPDoc:
 public function failFast(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L382)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L378)
 
 ### `randomizeOrder()`
 
@@ -490,21 +490,413 @@ PHPDoc:
 - `@param int<0, max>|null $seed`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L395)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L391)
 
 ## `InvalidConfiguration`
 
 Namespace: `Greenlight\Config`
 
 A configuration builder received an invalid value or an invalid combination.
+Use a named factory to create an error for a specific validation failure.
+The constructor is private.
 
 ```php
 final class InvalidConfiguration extends \InvalidArgumentException
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L10)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L12)
 
-This type does not declare public members.
+### `emptyArtifactDirectory()`
+
+```php
+public static function emptyArtifactDirectory(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L19)
+
+### `artifactDirectoryContainsNullByte()`
+
+```php
+public static function artifactDirectoryContainsNullByte(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L24)
+
+### `invalidArtifactCountPerTest()`
+
+```php
+public static function invalidArtifactCountPerTest(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L29)
+
+### `invalidArtifactCountPerRun()`
+
+```php
+public static function invalidArtifactCountPerRun(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L34)
+
+### `invalidCompletedRunCount()`
+
+```php
+public static function invalidCompletedRunCount(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L39)
+
+### `invalidCompletedRunAge()`
+
+```php
+public static function invalidCompletedRunAge(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L44)
+
+### `emptyCoveragePath()`
+
+```php
+public static function emptyCoveragePath(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L49)
+
+### `coveragePathContainsNullByte()`
+
+```php
+public static function coveragePathContainsNullByte(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L54)
+
+### `emptyCoverageDriver()`
+
+```php
+public static function emptyCoverageDriver(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L59)
+
+### `coveragePercentageOutOfRange()`
+
+```php
+public static function coveragePercentageOutOfRange(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L64)
+
+### `coveragePercentageTooPrecise()`
+
+```php
+public static function coveragePercentageTooPrecise(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L69)
+
+### `negativeUncoveredLineLimit()`
+
+```php
+public static function negativeUncoveredLineLimit(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L74)
+
+### `emptyCoverageExport()`
+
+```php
+public static function emptyCoverageExport(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L79)
+
+### `unknownCoverageFormat()`
+
+```php
+public static function unknownCoverageFormat(string $format): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L84)
+
+### `coverageTargetContainsNullByte()`
+
+```php
+public static function coverageTargetContainsNullByte(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L94)
+
+### `testPathsNotAList()`
+
+```php
+public static function testPathsNotAList(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L99)
+
+### `testPathNotAString()`
+
+```php
+public static function testPathNotAString(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L104)
+
+### `emptyTestPath()`
+
+```php
+public static function emptyTestPath(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L109)
+
+### `testPathContainsNullByte()`
+
+```php
+public static function testPathContainsNullByte(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L114)
+
+### `missingTestPaths()`
+
+```php
+public static function missingTestPaths(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L119)
+
+### `emptySuiteName()`
+
+```php
+public static function emptySuiteName(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L124)
+
+### `duplicateSuite()`
+
+```php
+public static function duplicateSuite(string $name): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L129)
+
+### `invalidResourceName()`
+
+```php
+public static function invalidResourceName(\InvalidArgumentException $previous): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L134)
+
+### `invalidResourceLimit()`
+
+```php
+public static function invalidResourceLimit(string $name, int $limit): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L139)
+
+### `duplicateResourceLimit()`
+
+```php
+public static function duplicateResourceLimit(string $name): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L144)
+
+### `emptyDeprecationPattern()`
+
+```php
+public static function emptyDeprecationPattern(): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L149)
+
+### `invalidPluginFactory()`
+
+```php
+public static function invalidPluginFactory(\InvalidArgumentException $previous): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L154)
+
+### `negativeRandomSeed()`
+
+```php
+public static function negativeRandomSeed(int $seed): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L159)
+
+### `invalidWorkerCountString()`
+
+```php
+public static function invalidWorkerCountString(string $count): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L164)
+
+### `invalidMemorySizeSyntax()`
+
+```php
+public static function invalidMemorySizeSyntax(string $value): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L169)
+
+### `memorySizeOverflow()`
+
+```php
+public static function memorySizeOverflow(string $value): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L179)
+
+### `nonPositiveMemorySize()`
+
+```php
+public static function nonPositiveMemorySize(string $value): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L184)
+
+### `emptyStoragePath()`
+
+```php
+public static function emptyStoragePath(string $name): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L189)
+
+### `storagePathContainsNullByte()`
+
+```php
+public static function storagePathContainsNullByte(string $name): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L194)
+
+### `emptySuitePath()`
+
+```php
+public static function emptySuitePath(string $name): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L199)
+
+### `suitePathContainsNullByte()`
+
+```php
+public static function suitePathContainsNullByte(string $name): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L204)
+
+### `emptySuiteTag()`
+
+```php
+public static function emptySuiteTag(string $name): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L209)
+
+### `missingSuitePaths()`
+
+```php
+public static function missingSuitePaths(string $name): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L214)
+
+### `suitePathsNotAList()`
+
+```php
+public static function suitePathsNotAList(string $name): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L224)
+
+### `suitePathNotAString()`
+
+```php
+public static function suitePathNotAString(string $name): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L229)
+
+### `suiteTagsNotAList()`
+
+```php
+public static function suiteTagsNotAList(string $name): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L234)
+
+### `suiteTagNotAString()`
+
+```php
+public static function suiteTagNotAString(string $name): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L239)
+
+### `invalidWatchDebounce()`
+
+```php
+public static function invalidWatchDebounce(int $milliseconds): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L244)
+
+### `invalidWatchFileLimit()`
+
+```php
+public static function invalidWatchFileLimit(int $maximumFiles): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L249)
+
+### `emptyWatchPath()`
+
+```php
+public static function emptyWatchPath(string $name): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L254)
+
+### `watchPathContainsNullByte()`
+
+```php
+public static function watchPathContainsNullByte(string $name): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L259)
+
+### `watchPathsNotAList()`
+
+```php
+public static function watchPathsNotAList(string $name): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L264)
+
+### `watchPathNotANonEmptyString()`
+
+```php
+public static function watchPathNotANonEmptyString(string $name): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L269)
+
+### `nonPositiveWorkerCount()`
+
+```php
+public static function nonPositiveWorkerCount(int $count): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/InvalidConfiguration.php#L274)
 
 ## `StorageBuilder`
 

--- a/src/Config/ArtifactBuilder.php
+++ b/src/Config/ArtifactBuilder.php
@@ -44,11 +44,11 @@ final class ArtifactBuilder
     public function directory(string $directory): self
     {
         if ($directory === '') {
-            throw new InvalidConfiguration('Artifact directory cannot be empty.');
+            throw InvalidConfiguration::emptyArtifactDirectory();
         }
 
         if (\str_contains($directory, "\0")) {
-            throw new InvalidConfiguration('Artifact directory cannot contain a null byte.');
+            throw InvalidConfiguration::artifactDirectoryContainsNullByte();
         }
 
         $this->directory = $directory;
@@ -64,7 +64,7 @@ final class ArtifactBuilder
     public function maxAttachmentsPerTest(int $count): self
     {
         if ($count < 1) {
-            throw new InvalidConfiguration('Artifact count per test must be at least 1.');
+            throw InvalidConfiguration::invalidArtifactCountPerTest();
         }
 
         $this->maxAttachmentsPerTest = $count;
@@ -104,7 +104,7 @@ final class ArtifactBuilder
     public function maxRunAttachments(int $count): self
     {
         if ($count < 1) {
-            throw new InvalidConfiguration('Artifact count per run must be at least 1.');
+            throw InvalidConfiguration::invalidArtifactCountPerRun();
         }
 
         $this->maxRunAttachments = $count;
@@ -132,7 +132,7 @@ final class ArtifactBuilder
     public function maxCompletedRuns(int $count): self
     {
         if ($count < 1) {
-            throw new InvalidConfiguration('Completed artifact run count must be at least 1.');
+            throw InvalidConfiguration::invalidCompletedRunCount();
         }
 
         $this->maxCompletedRuns = $count;
@@ -148,7 +148,7 @@ final class ArtifactBuilder
     public function maxCompletedRunAge(int $seconds): self
     {
         if ($seconds < 1) {
-            throw new InvalidConfiguration('Completed artifact run age must be at least 1 second.');
+            throw InvalidConfiguration::invalidCompletedRunAge();
         }
 
         $this->maxCompletedRunAgeSeconds = $seconds;

--- a/src/Config/CoverageBuilder.php
+++ b/src/Config/CoverageBuilder.php
@@ -40,11 +40,11 @@ final class CoverageBuilder
 
         foreach ($paths as $path) {
             if ($path === '') {
-                throw new InvalidConfiguration('Coverage include paths cannot be empty.');
+                throw InvalidConfiguration::emptyCoveragePath();
             }
 
             if (\str_contains($path, "\0")) {
-                throw new InvalidConfiguration('Coverage include paths cannot contain a null byte.');
+                throw InvalidConfiguration::coveragePathContainsNullByte();
             }
 
             $validated[] = $path;
@@ -63,7 +63,7 @@ final class CoverageBuilder
     public function driver(string $driver): self
     {
         if ($driver === '') {
-            throw new InvalidConfiguration('Coverage driver cannot be empty.');
+            throw InvalidConfiguration::emptyCoverageDriver();
         }
 
         $this->driver = $driver;
@@ -81,11 +81,11 @@ final class CoverageBuilder
     public function minimumPercentage(float $percentage): self
     {
         if (!\is_finite($percentage) || $percentage < 0.0 || $percentage > 100.0) {
-            throw new InvalidConfiguration('Minimum coverage percentage must be from 0 through 100.');
+            throw InvalidConfiguration::coveragePercentageOutOfRange();
         }
 
         if (\round($percentage, 2) !== $percentage) {
-            throw new InvalidConfiguration('Minimum coverage percentage can have at most two decimal places.');
+            throw InvalidConfiguration::coveragePercentageTooPrecise();
         }
 
         $this->minimumPercentage = $percentage;
@@ -102,7 +102,7 @@ final class CoverageBuilder
     public function maximumUncoveredLines(int $lines): self
     {
         if ($lines < 0) {
-            throw new InvalidConfiguration('Maximum uncovered lines cannot be negative.');
+            throw InvalidConfiguration::negativeUncoveredLineLimit();
         }
 
         $this->maximumUncoveredLines = $lines;
@@ -127,11 +127,11 @@ final class CoverageBuilder
     public function export(string $format, string $target): self
     {
         if ($format === '') {
-            throw new InvalidConfiguration('Coverage exports need a non-empty format and target.');
+            throw InvalidConfiguration::emptyCoverageExport();
         }
 
         if ($target === '') {
-            throw new InvalidConfiguration('Coverage exports need a non-empty format and target.');
+            throw InvalidConfiguration::emptyCoverageExport();
         }
 
         $this->exports[] = new CoverageExport($format, $target);

--- a/src/Config/CoverageExport.php
+++ b/src/Config/CoverageExport.php
@@ -25,18 +25,15 @@ final readonly class CoverageExport
     public function __construct(string $format, string $target)
     {
         if ($format === '' || $target === '') {
-            throw new InvalidConfiguration('Coverage exports need a non-empty format and target.');
+            throw InvalidConfiguration::emptyCoverageExport();
         }
 
         if (!\in_array($format, self::FORMATS, true)) {
-            throw new InvalidConfiguration(\sprintf(
-                'Unknown coverage export format "%s". Use "json", "lcov", "clover", "cobertura", or "html".',
-                $format,
-            ));
+            throw InvalidConfiguration::unknownCoverageFormat($format);
         }
 
         if (\str_contains($target, "\0")) {
-            throw new InvalidConfiguration('Coverage export target cannot contain a null byte.');
+            throw InvalidConfiguration::coverageTargetContainsNullByte();
         }
 
         $this->format = $format;

--- a/src/Config/GreenlightConfig.php
+++ b/src/Config/GreenlightConfig.php
@@ -108,29 +108,29 @@ final class GreenlightConfig
     private function validatePaths(array $tests): array
     {
         if (!\array_is_list($tests)) {
-            throw new InvalidConfiguration('Test paths must be a list.');
+            throw InvalidConfiguration::testPathsNotAList();
         }
 
         $validated = [];
 
         foreach ($tests as $path) {
             if (!\is_string($path)) {
-                throw new InvalidConfiguration('Test paths must contain only strings.');
+                throw InvalidConfiguration::testPathNotAString();
             }
 
             if ($path === '') {
-                throw new InvalidConfiguration('Test paths cannot be empty strings.');
+                throw InvalidConfiguration::emptyTestPath();
             }
 
             if (\str_contains($path, "\0")) {
-                throw new InvalidConfiguration('Test paths cannot contain a null byte.');
+                throw InvalidConfiguration::testPathContainsNullByte();
             }
 
             $validated[] = $path;
         }
 
         if ($validated === []) {
-            throw new InvalidConfiguration('paths() needs at least one directory.');
+            throw InvalidConfiguration::missingTestPaths();
         }
 
         return $validated;
@@ -152,11 +152,11 @@ final class GreenlightConfig
     public function suite(string $name, callable $configurator): self
     {
         if ($name === '') {
-            throw new InvalidConfiguration('Suite names cannot be empty.');
+            throw InvalidConfiguration::emptySuiteName();
         }
 
         if (isset($this->suites[$name])) {
-            throw new InvalidConfiguration(\sprintf('Suite "%s" is declared twice.', $name));
+            throw InvalidConfiguration::duplicateSuite($name);
         }
 
         $builder = new SuiteBuilder($name);
@@ -196,19 +196,15 @@ final class GreenlightConfig
         try {
             ResourceName::assertValid($name);
         } catch (\InvalidArgumentException $error) {
-            throw new InvalidConfiguration($error->getMessage(), $error->getCode(), previous: $error);
+            throw InvalidConfiguration::invalidResourceName($error);
         }
 
         if ($limit < 1) {
-            throw new InvalidConfiguration(\sprintf(
-                'Resource "%s" must have a limit of at least 1, got %d.',
-                $name,
-                $limit,
-            ));
+            throw InvalidConfiguration::invalidResourceLimit($name, $limit);
         }
 
         if (\array_key_exists($name, $this->resourceLimits)) {
-            throw new InvalidConfiguration(\sprintf('Resource limit "%s" is declared twice.', $name));
+            throw InvalidConfiguration::duplicateResourceLimit($name);
         }
 
         $this->resourceLimits[$name] = $limit;
@@ -347,7 +343,7 @@ final class GreenlightConfig
 
         foreach ($patterns as $pattern) {
             if ($pattern === '') {
-                throw new InvalidConfiguration('ignoreDeprecationsMatching() patterns cannot be empty.');
+                throw InvalidConfiguration::emptyDeprecationPattern();
             }
 
             $validated[] = $pattern;
@@ -370,7 +366,7 @@ final class GreenlightConfig
             try {
                 $definitions[] = PluginDefinition::fromFactory($factory);
             } catch (\InvalidArgumentException $error) {
-                throw new InvalidConfiguration($error->getMessage(), $error->getCode(), previous: $error);
+                throw InvalidConfiguration::invalidPluginFactory($error);
             }
         }
 
@@ -395,10 +391,7 @@ final class GreenlightConfig
     public function randomizeOrder(?int $seed = null): self
     {
         if ($seed !== null && $seed < 0) {
-            throw new InvalidConfiguration(\sprintf(
-                'Random order seed must be a nonnegative integer. Actual value: %d.',
-                $seed,
-            ));
+            throw InvalidConfiguration::negativeRandomSeed($seed);
         }
 
         $this->randomizeOrder = true;
@@ -425,10 +418,7 @@ final class GreenlightConfig
             return WorkerCount::auto();
         }
 
-        throw new InvalidConfiguration(\sprintf(
-            'Worker count must be a positive integer or "auto", got "%s".',
-            $count,
-        ));
+        throw InvalidConfiguration::invalidWorkerCountString($count);
     }
 
     /**

--- a/src/Config/InvalidConfiguration.php
+++ b/src/Config/InvalidConfiguration.php
@@ -6,5 +6,273 @@ namespace Greenlight\Config;
 
 /**
  * A configuration builder received an invalid value or an invalid combination.
+ * Use a named factory to create an error for a specific validation failure.
+ * The constructor is private.
  */
-final class InvalidConfiguration extends \InvalidArgumentException {}
+final class InvalidConfiguration extends \InvalidArgumentException
+{
+    private function __construct(string $message, int $code = 0, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public static function emptyArtifactDirectory(): self
+    {
+        return new self('Artifact directory cannot be empty.');
+    }
+
+    public static function artifactDirectoryContainsNullByte(): self
+    {
+        return new self('Artifact directory cannot contain a null byte.');
+    }
+
+    public static function invalidArtifactCountPerTest(): self
+    {
+        return new self('Artifact count per test must be at least 1.');
+    }
+
+    public static function invalidArtifactCountPerRun(): self
+    {
+        return new self('Artifact count per run must be at least 1.');
+    }
+
+    public static function invalidCompletedRunCount(): self
+    {
+        return new self('Completed artifact run count must be at least 1.');
+    }
+
+    public static function invalidCompletedRunAge(): self
+    {
+        return new self('Completed artifact run age must be at least 1 second.');
+    }
+
+    public static function emptyCoveragePath(): self
+    {
+        return new self('Coverage include paths cannot be empty.');
+    }
+
+    public static function coveragePathContainsNullByte(): self
+    {
+        return new self('Coverage include paths cannot contain a null byte.');
+    }
+
+    public static function emptyCoverageDriver(): self
+    {
+        return new self('Coverage driver cannot be empty.');
+    }
+
+    public static function coveragePercentageOutOfRange(): self
+    {
+        return new self('Minimum coverage percentage must be from 0 through 100.');
+    }
+
+    public static function coveragePercentageTooPrecise(): self
+    {
+        return new self('Minimum coverage percentage can have at most two decimal places.');
+    }
+
+    public static function negativeUncoveredLineLimit(): self
+    {
+        return new self('Maximum uncovered lines cannot be negative.');
+    }
+
+    public static function emptyCoverageExport(): self
+    {
+        return new self('Coverage exports need a non-empty format and target.');
+    }
+
+    public static function unknownCoverageFormat(string $format): self
+    {
+        return new self(
+            \sprintf(
+                'Unknown coverage export format "%s". Use "json", "lcov", "clover", "cobertura", or "html".',
+                $format,
+            ),
+        );
+    }
+
+    public static function coverageTargetContainsNullByte(): self
+    {
+        return new self('Coverage export target cannot contain a null byte.');
+    }
+
+    public static function testPathsNotAList(): self
+    {
+        return new self('Test paths must be a list.');
+    }
+
+    public static function testPathNotAString(): self
+    {
+        return new self('Test paths must contain only strings.');
+    }
+
+    public static function emptyTestPath(): self
+    {
+        return new self('Test paths cannot be empty strings.');
+    }
+
+    public static function testPathContainsNullByte(): self
+    {
+        return new self('Test paths cannot contain a null byte.');
+    }
+
+    public static function missingTestPaths(): self
+    {
+        return new self('paths() needs at least one directory.');
+    }
+
+    public static function emptySuiteName(): self
+    {
+        return new self('Suite names cannot be empty.');
+    }
+
+    public static function duplicateSuite(string $name): self
+    {
+        return new self(\sprintf('Suite "%s" is declared twice.', $name));
+    }
+
+    public static function invalidResourceName(\InvalidArgumentException $previous): self
+    {
+        return new self($previous->getMessage(), $previous->getCode(), $previous);
+    }
+
+    public static function invalidResourceLimit(string $name, int $limit): self
+    {
+        return new self(\sprintf('Resource "%s" must have a limit of at least 1, got %d.', $name, $limit));
+    }
+
+    public static function duplicateResourceLimit(string $name): self
+    {
+        return new self(\sprintf('Resource limit "%s" is declared twice.', $name));
+    }
+
+    public static function emptyDeprecationPattern(): self
+    {
+        return new self('ignoreDeprecationsMatching() patterns cannot be empty.');
+    }
+
+    public static function invalidPluginFactory(\InvalidArgumentException $previous): self
+    {
+        return new self($previous->getMessage(), $previous->getCode(), $previous);
+    }
+
+    public static function negativeRandomSeed(int $seed): self
+    {
+        return new self(\sprintf('Random order seed must be a nonnegative integer. Actual value: %d.', $seed));
+    }
+
+    public static function invalidWorkerCountString(string $count): self
+    {
+        return new self(\sprintf('Worker count must be a positive integer or "auto", got "%s".', $count));
+    }
+
+    public static function invalidMemorySizeSyntax(string $value): self
+    {
+        return new self(
+            \sprintf(
+                'Invalid memory size "%s". Use a positive byte count or a K, M, or G suffix, for example "256M".',
+                $value,
+            ),
+        );
+    }
+
+    public static function memorySizeOverflow(string $value): self
+    {
+        return new self(\sprintf('Invalid memory size "%s". The value does not fit in an integer byte count.', $value));
+    }
+
+    public static function nonPositiveMemorySize(string $value): self
+    {
+        return new self(\sprintf('Invalid memory size "%s". The amount must be at least 1.', $value));
+    }
+
+    public static function emptyStoragePath(string $name): self
+    {
+        return new self($name . ' cannot be empty.');
+    }
+
+    public static function storagePathContainsNullByte(string $name): self
+    {
+        return new self($name . ' cannot contain a null byte.');
+    }
+
+    public static function emptySuitePath(string $name): self
+    {
+        return new self(\sprintf('Suite "%s" was given an empty path.', $name));
+    }
+
+    public static function suitePathContainsNullByte(string $name): self
+    {
+        return new self(\sprintf('Suite "%s" paths cannot contain a null byte.', $name));
+    }
+
+    public static function emptySuiteTag(string $name): self
+    {
+        return new self(\sprintf('Suite "%s" was given an empty tag.', $name));
+    }
+
+    public static function missingSuitePaths(string $name): self
+    {
+        return new self(
+            \sprintf(
+                'Suite "%s" has no paths. Call in() with at least one directory inside its configurator.',
+                $name,
+            ),
+        );
+    }
+
+    public static function suitePathsNotAList(string $name): self
+    {
+        return new self(\sprintf('Suite "%s" paths must be a list.', $name));
+    }
+
+    public static function suitePathNotAString(string $name): self
+    {
+        return new self(\sprintf('Suite "%s" was given a path that is not a string.', $name));
+    }
+
+    public static function suiteTagsNotAList(string $name): self
+    {
+        return new self(\sprintf('Suite "%s" tags must be a list.', $name));
+    }
+
+    public static function suiteTagNotAString(string $name): self
+    {
+        return new self(\sprintf('Suite "%s" was given a tag that is not a string.', $name));
+    }
+
+    public static function invalidWatchDebounce(int $milliseconds): self
+    {
+        return new self(\sprintf('The watch debounce must be at least 1 millisecond, got %d.', $milliseconds));
+    }
+
+    public static function invalidWatchFileLimit(int $maximumFiles): self
+    {
+        return new self(\sprintf('The watch file limit must be at least 1, got %d.', $maximumFiles));
+    }
+
+    public static function emptyWatchPath(string $name): self
+    {
+        return new self($name . ' cannot contain an empty string.');
+    }
+
+    public static function watchPathContainsNullByte(string $name): self
+    {
+        return new self($name . ' cannot contain a null byte.');
+    }
+
+    public static function watchPathsNotAList(string $name): self
+    {
+        return new self($name . ' must be a list.');
+    }
+
+    public static function watchPathNotANonEmptyString(string $name): self
+    {
+        return new self($name . ' must contain non-empty strings.');
+    }
+
+    public static function nonPositiveWorkerCount(int $count): self
+    {
+        return new self(\sprintf('Worker count must be at least 1, got %d.', $count));
+    }
+}

--- a/src/Config/MemorySize.php
+++ b/src/Config/MemorySize.php
@@ -31,26 +31,17 @@ final class MemorySize
         $trimmed = \trim($value);
 
         if (\preg_match('/^(\d+)\s*([KMGkmg])?[Bb]?$/', $trimmed, $matches) !== 1) {
-            throw new InvalidConfiguration(\sprintf(
-                'Invalid memory size "%s". Use a positive byte count or a K, M, or G suffix, for example "256M".',
-                $value,
-            ));
+            throw InvalidConfiguration::invalidMemorySizeSyntax($value);
         }
 
         $number = DecimalInteger::parse($matches[1]);
 
         if ($number === null) {
-            throw new InvalidConfiguration(\sprintf(
-                'Invalid memory size "%s". The value does not fit in an integer byte count.',
-                $value,
-            ));
+            throw InvalidConfiguration::memorySizeOverflow($value);
         }
 
         if ($number < 1) {
-            throw new InvalidConfiguration(\sprintf(
-                'Invalid memory size "%s". The amount must be at least 1.',
-                $value,
-            ));
+            throw InvalidConfiguration::nonPositiveMemorySize($value);
         }
 
         $multiplier = match (\strtoupper($matches[2] ?? '')) {
@@ -61,10 +52,7 @@ final class MemorySize
         };
 
         if ($number > \intdiv(\PHP_INT_MAX, $multiplier)) {
-            throw new InvalidConfiguration(\sprintf(
-                'Invalid memory size "%s". The value does not fit in an integer byte count.',
-                $value,
-            ));
+            throw InvalidConfiguration::memorySizeOverflow($value);
         }
 
         return $number * $multiplier;

--- a/src/Config/StorageBuilder.php
+++ b/src/Config/StorageBuilder.php
@@ -96,11 +96,11 @@ final class StorageBuilder
     private function validate(string $directory, string $name): string
     {
         if ($directory === '') {
-            throw new InvalidConfiguration($name . ' cannot be empty.');
+            throw InvalidConfiguration::emptyStoragePath($name);
         }
 
         if (\str_contains($directory, "\0")) {
-            throw new InvalidConfiguration($name . ' cannot contain a null byte.');
+            throw InvalidConfiguration::storagePathContainsNullByte($name);
         }
 
         return $directory;

--- a/src/Config/SuiteBuilder.php
+++ b/src/Config/SuiteBuilder.php
@@ -33,11 +33,11 @@ final class SuiteBuilder
 
         foreach ($paths as $path) {
             if ($path === '') {
-                throw new InvalidConfiguration(\sprintf('Suite "%s" was given an empty path.', $this->name));
+                throw InvalidConfiguration::emptySuitePath($this->name);
             }
 
             if (\str_contains($path, "\0")) {
-                throw new InvalidConfiguration(\sprintf('Suite "%s" paths cannot contain a null byte.', $this->name));
+                throw InvalidConfiguration::suitePathContainsNullByte($this->name);
             }
 
             $validated[] = $path;
@@ -59,7 +59,7 @@ final class SuiteBuilder
 
         foreach ($tags as $tag) {
             if ($tag === '') {
-                throw new InvalidConfiguration(\sprintf('Suite "%s" was given an empty tag.', $this->name));
+                throw InvalidConfiguration::emptySuiteTag($this->name);
             }
 
             $validated[] = $tag;
@@ -78,10 +78,7 @@ final class SuiteBuilder
     public function toConfiguration(): SuiteConfiguration
     {
         if ($this->paths === []) {
-            throw new InvalidConfiguration(\sprintf(
-                'Suite "%s" has no paths. Call in() with at least one directory inside its configurator.',
-                $this->name,
-            ));
+            throw InvalidConfiguration::missingSuitePaths($this->name);
         }
 
         return new SuiteConfiguration($this->name, $this->paths, $this->tags);

--- a/src/Config/SuiteConfiguration.php
+++ b/src/Config/SuiteConfiguration.php
@@ -31,57 +31,48 @@ final readonly class SuiteConfiguration
     public function __construct(string $name, array $paths, array $tags)
     {
         if ($name === '') {
-            throw new InvalidConfiguration('Suite names cannot be empty.');
+            throw InvalidConfiguration::emptySuiteName();
         }
 
         if (!\array_is_list($paths)) {
-            throw new InvalidConfiguration(\sprintf('Suite "%s" paths must be a list.', $name));
+            throw InvalidConfiguration::suitePathsNotAList($name);
         }
 
         $validatedPaths = [];
 
         foreach ($paths as $path) {
             if (!\is_string($path)) {
-                throw new InvalidConfiguration(\sprintf(
-                    'Suite "%s" was given a path that is not a string.',
-                    $name,
-                ));
+                throw InvalidConfiguration::suitePathNotAString($name);
             }
 
             if ($path === '') {
-                throw new InvalidConfiguration(\sprintf('Suite "%s" was given an empty path.', $name));
+                throw InvalidConfiguration::emptySuitePath($name);
             }
 
             if (\str_contains($path, "\0")) {
-                throw new InvalidConfiguration(\sprintf('Suite "%s" paths cannot contain a null byte.', $name));
+                throw InvalidConfiguration::suitePathContainsNullByte($name);
             }
 
             $validatedPaths[] = $path;
         }
 
         if ($validatedPaths === []) {
-            throw new InvalidConfiguration(\sprintf(
-                'Suite "%s" has no paths. Call in() with at least one directory inside its configurator.',
-                $name,
-            ));
+            throw InvalidConfiguration::missingSuitePaths($name);
         }
 
         if (!\array_is_list($tags)) {
-            throw new InvalidConfiguration(\sprintf('Suite "%s" tags must be a list.', $name));
+            throw InvalidConfiguration::suiteTagsNotAList($name);
         }
 
         $validatedTags = [];
 
         foreach ($tags as $tag) {
             if (!\is_string($tag)) {
-                throw new InvalidConfiguration(\sprintf(
-                    'Suite "%s" was given a tag that is not a string.',
-                    $name,
-                ));
+                throw InvalidConfiguration::suiteTagNotAString($name);
             }
 
             if ($tag === '') {
-                throw new InvalidConfiguration(\sprintf('Suite "%s" was given an empty tag.', $name));
+                throw InvalidConfiguration::emptySuiteTag($name);
             }
 
             $validatedTags[] = $tag;

--- a/src/Config/WatchBuilder.php
+++ b/src/Config/WatchBuilder.php
@@ -41,7 +41,7 @@ final class WatchBuilder
     public function debounceMilliseconds(int $milliseconds): self
     {
         if ($milliseconds < 1) {
-            throw new InvalidConfiguration(\sprintf('The watch debounce must be at least 1 millisecond, got %d.', $milliseconds));
+            throw InvalidConfiguration::invalidWatchDebounce($milliseconds);
         }
 
         $this->debounceMilliseconds = $milliseconds;
@@ -97,7 +97,7 @@ final class WatchBuilder
     public function maximumFiles(int $maximumFiles): self
     {
         if ($maximumFiles < 1) {
-            throw new InvalidConfiguration(\sprintf('The watch file limit must be at least 1, got %d.', $maximumFiles));
+            throw InvalidConfiguration::invalidWatchFileLimit($maximumFiles);
         }
 
         $this->maximumFiles = $maximumFiles;
@@ -129,11 +129,11 @@ final class WatchBuilder
     {
         foreach ($values as $value) {
             if ($value === '') {
-                throw new InvalidConfiguration($name . ' cannot contain an empty string.');
+                throw InvalidConfiguration::emptyWatchPath($name);
             }
 
             if (\str_contains($value, "\0")) {
-                throw new InvalidConfiguration($name . ' cannot contain a null byte.');
+                throw InvalidConfiguration::watchPathContainsNullByte($name);
             }
         }
 

--- a/src/Config/WatchConfiguration.php
+++ b/src/Config/WatchConfiguration.php
@@ -39,14 +39,11 @@ final readonly class WatchConfiguration
         int $maximumFiles = 100_000,
     ) {
         if ($debounceMilliseconds < 1) {
-            throw new InvalidConfiguration(\sprintf(
-                'The watch debounce must be at least 1 millisecond, got %d.',
-                $debounceMilliseconds,
-            ));
+            throw InvalidConfiguration::invalidWatchDebounce($debounceMilliseconds);
         }
 
         if ($maximumFiles < 1) {
-            throw new InvalidConfiguration(\sprintf('The watch file limit must be at least 1, got %d.', $maximumFiles));
+            throw InvalidConfiguration::invalidWatchFileLimit($maximumFiles);
         }
 
         $this->debounceMilliseconds = $debounceMilliseconds;
@@ -64,17 +61,17 @@ final readonly class WatchConfiguration
     private function validate(array $values, string $name): array
     {
         if (!\array_is_list($values)) {
-            throw new InvalidConfiguration($name . ' must be a list.');
+            throw InvalidConfiguration::watchPathsNotAList($name);
         }
 
         $validated = [];
         foreach ($values as $value) {
             if (!\is_string($value) || $value === '') {
-                throw new InvalidConfiguration($name . ' must contain non-empty strings.');
+                throw InvalidConfiguration::watchPathNotANonEmptyString($name);
             }
 
             if (\str_contains($value, "\0")) {
-                throw new InvalidConfiguration($name . ' cannot contain a null byte.');
+                throw InvalidConfiguration::watchPathContainsNullByte($name);
             }
 
             $validated[] = $value;

--- a/src/Config/WorkerCount.php
+++ b/src/Config/WorkerCount.php
@@ -31,7 +31,7 @@ final readonly class WorkerCount
     public static function exactly(int $count): self
     {
         if ($count < 1) {
-            throw new InvalidConfiguration(\sprintf('Worker count must be at least 1, got %d.', $count));
+            throw InvalidConfiguration::nonPositiveWorkerCount($count);
         }
 
         return new self($count);

--- a/tests/Unit/Config/InvalidConfigurationTest.php
+++ b/tests/Unit/Config/InvalidConfigurationTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Config;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Config\InvalidConfiguration;
+use Greenlight\Expect\Expect;
+
+final class InvalidConfigurationTest
+{
+    #[Test]
+    public function errorsRequireANamedFactory(): void
+    {
+        Expect::that(static fn(): object => new \ReflectionClass(InvalidConfiguration::class)->newInstance('arbitrary'))
+            ->toThrow(\ReflectionException::class);
+    }
+
+    /** @param \Closure(\InvalidArgumentException): InvalidConfiguration $wrap */
+    #[Test]
+    #[DataSet('wrappers')]
+    public function wrappedValidationFailuresPreserveTheirCause(\Closure $wrap): void
+    {
+        $previous = new \InvalidArgumentException('The supplied value is invalid.', 17);
+        $error = $wrap($previous);
+
+        Expect::that($error->getMessage())->toBe($previous->getMessage());
+        Expect::that($error->getCode())->toBe(17);
+        Expect::that($error->getPrevious())->toBe($previous);
+    }
+
+    /** @return iterable<string, array{\Closure(\InvalidArgumentException): InvalidConfiguration}> */
+    public static function wrappers(): iterable
+    {
+        yield 'resource name' => [InvalidConfiguration::invalidResourceName(...)];
+        yield 'plugin factory' => [InvalidConfiguration::invalidPluginFactory(...)];
+    }
+}

--- a/tests/Unit/Config/InvalidConfigurationTest.php
+++ b/tests/Unit/Config/InvalidConfigurationTest.php
@@ -11,13 +11,6 @@ use Greenlight\Expect\Expect;
 
 final class InvalidConfigurationTest
 {
-    #[Test]
-    public function errorsRequireANamedFactory(): void
-    {
-        Expect::that(static fn(): object => new \ReflectionClass(InvalidConfiguration::class)->newInstance('arbitrary'))
-            ->toThrow(\ReflectionException::class);
-    }
-
     /** @param \Closure(\InvalidArgumentException): InvalidConfiguration $wrap */
     #[Test]
     #[DataSet('wrappers')]


### PR DESCRIPTION
`InvalidConfiguration` inherits a public constructor, and configuration code assembles its messages at 60 call sites. Repeated failures such as empty suite paths and invalid watch limits have duplicate message definitions.

Make the constructor private and move each failure mode into a named static factory. Update all callers, preserve messages and exception chains, and regenerate the configuration API reference. The cause-preservation tests supplement the existing validation tests.

This changes the public construction API: callers that create `InvalidConfiguration` directly must use the matching named factory. Catch behavior and diagnostics remain the same.
