### PR TITLE
test: remove attribute flag reflection tests

### DIFF
--- a/tests/Unit/Attribute/AttributeContractTest.php
+++ b/tests/Unit/Attribute/AttributeContractTest.php
@@ -4,19 +4,11 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Attribute;
 
-use Greenlight\Attribute\After;
-use Greenlight\Attribute\AllowParallel;
-use Greenlight\Attribute\Before;
-use Greenlight\Attribute\CoverageIgnore;
-use Greenlight\Attribute\DataRow;
 use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Group;
-use Greenlight\Attribute\Isolated;
-use Greenlight\Attribute\NoExpectations;
 use Greenlight\Attribute\RequiresResource;
 use Greenlight\Attribute\Retry;
 use Greenlight\Attribute\Skip;
-use Greenlight\Attribute\SkipUnless;
 use Greenlight\Attribute\Test;
 use Greenlight\Attribute\Timeout;
 use Greenlight\Expect\Expect;
@@ -40,28 +32,6 @@ final class AttributeContractTest
     }
 
     #[Test]
-    public function methodOnlyAttributesTargetMethods(): void
-    {
-        foreach ([Test::class, Before::class, After::class, DataSet::class, NoExpectations::class] as $attribute) {
-            Expect::that($this->flags($attribute))->toBe(\Attribute::TARGET_METHOD);
-        }
-    }
-
-    #[Test]
-    public function allowParallelTargetsClasses(): void
-    {
-        Expect::that($this->flags(AllowParallel::class))->toBe(\Attribute::TARGET_CLASS);
-    }
-
-    #[Test]
-    public function inlineDataRowsAreRepeatableOnMethods(): void
-    {
-        Expect::that($this->flags(DataRow::class))
-            ->because('inline data rows MUST be repeatable on methods')
-            ->toBe(\Attribute::TARGET_METHOD | \Attribute::IS_REPEATABLE);
-    }
-
-    #[Test]
     public function dataSetAcceptsLocalAndExternalProviders(): void
     {
         $local = new DataSet('rows');
@@ -71,35 +41,6 @@ final class AttributeContractTest
         Expect::that($local->providerClass)->toBeNull();
         Expect::that($external->provider)->toBe('rows');
         Expect::that($external->providerClass)->toBe(self::class);
-    }
-
-    /**
-     * @param class-string<Skip|SkipUnless|Retry|Timeout|Isolated> $attribute
-     */
-    #[Test]
-    #[DataSet('methodOrClassAttributes')]
-    public function methodOrClassAttributesTargetBoth(string $attribute): void
-    {
-        Expect::that($this->flags($attribute))->toBe(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS);
-    }
-
-    /**
-     * @return iterable<string, array{class-string<Skip|SkipUnless|Retry|Timeout|Isolated>}>
-     */
-    public static function methodOrClassAttributes(): iterable
-    {
-        yield 'Skip' => [Skip::class];
-        yield 'SkipUnless' => [SkipUnless::class];
-        yield 'Retry' => [Retry::class];
-        yield 'Timeout' => [Timeout::class];
-        yield 'Isolated' => [Isolated::class];
-    }
-
-    #[Test]
-    public function groupIsRepeatableOnMethodsAndClasses(): void
-    {
-        Expect::that($this->flags(Group::class))->because('group is repeatable on methods and classes')
-            ->toBe(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE);
     }
 
     #[Test]
@@ -119,26 +60,12 @@ final class AttributeContractTest
     }
 
     #[Test]
-    public function resourceRequirementsAreRepeatableOnMethodsAndClasses(): void
-    {
-        Expect::that($this->flags(RequiresResource::class))->because('resource requirements are repeatable on methods and classes')
-            ->toBe(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS | \Attribute::IS_REPEATABLE);
-    }
-
-    #[Test]
     public function resourceRequirementsRejectNonCanonicalNames(): void
     {
         foreach (['', 'Postgres', 'postgres primary', '-postgres'] as $name) {
             Expect::that(static fn(): object => new \ReflectionClass(RequiresResource::class)->newInstance($name))
                 ->toThrow(\InvalidArgumentException::class);
         }
-    }
-
-    #[Test]
-    public function coverageIgnoreTargetsClassesMethodsAndFunctions(): void
-    {
-        Expect::that($this->flags(CoverageIgnore::class))->because('coverage ignore targets classes methods and functions')
-            ->toBe(\Attribute::TARGET_CLASS | \Attribute::TARGET_METHOD | \Attribute::TARGET_FUNCTION);
     }
 
     #[Test]
@@ -159,16 +86,5 @@ final class AttributeContractTest
     {
         Expect::that(static fn(): Timeout => new Timeout(\NAN))->because('timeout rejects nonfinite seconds')->toThrow(\InvalidArgumentException::class); // @phpstan-ignore greenlight.timeoutConstructor.seconds (deliberately invalid: tests runtime validation)
         Expect::that(static fn(): Timeout => new Timeout(\INF))->because('timeout rejects nonfinite seconds')->toThrow(\InvalidArgumentException::class); // @phpstan-ignore greenlight.timeoutConstructor.seconds (deliberately invalid: tests runtime validation)
-    }
-
-    /**
-     * @param class-string $attributeClass
-     */
-    private function flags(string $attributeClass): int
-    {
-        $attributes = new \ReflectionClass($attributeClass)->getAttributes(\Attribute::class);
-        Expect::that($attributes)->toHaveCount(1);
-
-        return $attributes[0]->newInstance()->flags;
     }
 }

--- a/tests/Unit/Attribute/AttributesTest.php
+++ b/tests/Unit/Attribute/AttributesTest.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Unit\Attribute;
 
-use Greenlight\Attribute\After;
 use Greenlight\Attribute\Before;
-use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
 
@@ -24,31 +22,5 @@ final class AttributesTest
     public function beforeHookRunsBeforeTests(): void
     {
         Expect::that($this->beforeRan)->because('before hook runs before tests')->toBeTrue();
-    }
-
-    /**
-     * @param class-string<Test|Before|After> $attributeClass
-     */
-    #[Test]
-    #[DataSet('methodAttributes')]
-    public function attributesTargetMethods(string $attributeClass): void
-    {
-        $attributes = new \ReflectionClass($attributeClass)->getAttributes(\Attribute::class);
-
-        Expect::that($attributes)->toHaveCount(1);
-
-        $flags = $attributes[0]->newInstance()->flags;
-
-        Expect::that($flags)->toBe(\Attribute::TARGET_METHOD);
-    }
-
-    /**
-     * @return iterable<string, array{class-string<Test|Before|After>}>
-     */
-    public static function methodAttributes(): iterable
-    {
-        yield 'Test' => [Test::class];
-        yield 'Before' => [Before::class];
-        yield 'After' => [After::class];
     }
 }


### PR DESCRIPTION
Remove eight tests that use reflection to compare attribute target and repeatability flags with the declarations. Remove their unused data providers, helper, and imports.

The hook execution, attribute value, runtime validation, and discovery tests remain.
