### PR TITLE
chore(doubles): document and verify clone behavior

### DIFF
--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -233,6 +233,29 @@ Expect::that(
 )->toEqual([[new OrderPlaced('order-1')]]);
 ```
 
+## Clone calls
+
+Greenlight intercepts a public, non-final `__clone()` method. It does not run
+the application implementation:
+
+* A mock requires a planned `__clone` call. An unexpected clone fails immediately
+  and at verification, even if application code catches the exception.
+* A spy records the clone call.
+* A stub rejects the clone call.
+
+An intercepted clone is a separate object with the same expectations and call
+history as the original double. This also applies to a clone of a clone.
+`callsTo()` accepts each of these objects and returns the same call history.
+This history contains calls to other methods.
+
+Call counts apply across all these objects.
+A clone does not reset a planned count. For example, `expects('__clone')->once()`
+permits one clone in total.
+
+If a test clones a mock, add a `__clone` expectation to its plan.
+If the test clones a stub, use a mock with an explicit clone expectation.
+A final `__clone()` keeps its implementation and can run application code.
+
 ## Supported types and limits
 
 Double targets are interfaces or non-final, non-readonly classes.
@@ -246,6 +269,4 @@ Greenlight does not run the class constructor when it creates a double. Prefer
 an interface at the application boundary.
 
 Greenlight suppresses a non-final destructor. It cannot suppress a final
-destructor, which can run application code. Greenlight intercepts a public,
-non-final `__clone()`. A final `__clone()` keeps its implementation and can run
-application code.
+destructor, which can run application code.

--- a/tests/Fixture/Doubles/CloneableRecorder.php
+++ b/tests/Fixture/Doubles/CloneableRecorder.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+interface CloneableRecorder
+{
+    public function __clone(): void;
+
+    public function record(string $value): void;
+}

--- a/tests/Unit/Doubles/CloneInterceptionTest.php
+++ b/tests/Unit/Doubles/CloneInterceptionTest.php
@@ -9,8 +9,11 @@ use Greenlight\Doubles\Doubles;
 use Greenlight\Doubles\InvalidDoubleUsage;
 use Greenlight\Doubles\MockPlan;
 use Greenlight\Expect\Expect;
+use Greenlight\Expect\ExpectationFailed;
+use Greenlight\Tests\Fixture\Doubles\CloneableRecorder;
 use Greenlight\Tests\Fixture\Doubles\CloneProbe;
 use Greenlight\Tests\Fixture\Doubles\FinalCloneProbe;
+use Greenlight\Tests\Fixture\Doubles\MixedCaseMagicMethods;
 
 final readonly class CloneInterceptionTest
 {
@@ -43,6 +46,123 @@ final readonly class CloneInterceptionTest
         Expect::that($this->doubles->callsTo($clone, '__clone'))
             ->because('a spy MUST record the clone interaction')
             ->toEqual([[]]);
+    }
+
+    #[Test]
+    public function repeatedClonesShareExpectationsAndCallHistoryWithTheOriginal(): void
+    {
+        $original = $this->doubles->mock(CloneableRecorder::class, static function (MockPlan $plan): void {
+            $plan->expects('__clone')->times(2);
+            $plan->expects('record')->times(3);
+        });
+
+        $first = clone $original;
+        $second = clone $first;
+        $original->record('original');
+        $first->record('first');
+        $second->record('second');
+
+        Expect::that($first)->not()->toBe($original);
+        Expect::that($second)->not()->toBe($first);
+        Expect::that($this->doubles->callsTo($original, '__clone'))->toEqual([[], []]);
+        Expect::that($this->doubles->callsTo($first, '__clone'))->toEqual([[], []]);
+        Expect::that($this->doubles->callsTo($second, '__clone'))->toEqual([[], []]);
+        Expect::that($this->doubles->callsTo($original, 'record'))->toEqual([['original'], ['first'], ['second']]);
+        Expect::that($this->doubles->callsTo($first, 'record'))->toEqual([['original'], ['first'], ['second']]);
+        Expect::that($this->doubles->callsTo($second, 'record'))->toEqual([['original'], ['first'], ['second']]);
+    }
+
+    #[Test]
+    public function aCloneDoesNotResetThePlannedCloneCount(): void
+    {
+        $doubles = new Doubles();
+        $original = $doubles->mock(CloneProbe::class, static function (MockPlan $plan): void {
+            $plan->expects('__clone')->once();
+        });
+        $clone = clone $original;
+
+        Expect::that(static fn(): object => clone $clone)
+            ->toThrow(ExpectationFailed::class, '/unexpected call to .*::__clone\(\)/');
+        Expect::that(static fn() => $doubles->dispose())
+            ->toThrow(ExpectationFailed::class, '/unexpected call to .*::__clone\(\)/');
+    }
+
+    #[Test]
+    public function anUnplannedCloneFailsImmediatelyAndAtDisposal(): void
+    {
+        $doubles = new Doubles();
+        $double = $doubles->mock(CloneProbe::class);
+
+        Expect::that(static fn(): object => clone $double)
+            ->toThrow(ExpectationFailed::class, '/unexpected call to .*::__clone\(\)/');
+        Expect::that($doubles->callsTo($double, '__clone'))->toEqual([[]]);
+        Expect::that(static fn() => $doubles->dispose())
+            ->toThrow(ExpectationFailed::class, '/unexpected call to .*::__clone\(\)/');
+    }
+
+    #[Test]
+    public function aCloneCanThrowTheConfiguredException(): void
+    {
+        $failure = new \RuntimeException('Clone failed.');
+        $double = $this->doubles->mock(CloneProbe::class, static function (MockPlan $plan) use ($failure): void {
+            $plan->expects('__clone')->once()->andThrows($failure);
+        });
+
+        Expect::that(static fn(): object => clone $double)
+            ->toThrow(static function (\RuntimeException $actual) use ($failure): void {
+                Expect::that($actual)->toBe($failure);
+            });
+        Expect::that($this->doubles->callsTo($double, '__clone'))->toEqual([[]]);
+    }
+
+    #[Test]
+    public function mixedCaseUntypedCloneMethodsNeedNoConfiguredAnswer(): void
+    {
+        $double = $this->doubles->mock(MixedCaseMagicMethods::class, static function (MockPlan $plan): void {
+            $plan->expects('__clone')->once();
+        });
+        $clone = clone $double;
+
+        Expect::that($this->doubles->callsTo($double, '__clone'))->toEqual([[]]);
+        Expect::that($this->doubles->callsTo($clone, '__CLONE'))->toEqual([[]]);
+    }
+
+    #[Test]
+    public function theOriginalCanBeCollectedWhileItsCloneKeepsTheCallHistory(): void
+    {
+        $doubles = new Doubles();
+        $original = $doubles->spy(CloneableRecorder::class);
+        $clone = clone $original;
+        $originalReference = \WeakReference::create($original);
+        $cloneReference = \WeakReference::create($clone);
+
+        unset($original);
+        \gc_collect_cycles();
+
+        Expect::that($originalReference->get())->toBeNull();
+        $clone->record('after release');
+        Expect::that($doubles->callsTo($clone, '__clone'))->toEqual([[]]);
+        Expect::that($doubles->callsTo($clone, 'record'))->toEqual([['after release']]);
+
+        $doubles->dispose();
+        unset($clone);
+        \gc_collect_cycles();
+
+        Expect::that($cloneReference->get())->toBeNull();
+    }
+
+    #[Test]
+    public function aCloneCanBeCollectedWhileItsOriginalKeepsTheCallHistory(): void
+    {
+        $original = $this->doubles->spy(CloneProbe::class);
+        $clone = clone $original;
+        $reference = \WeakReference::create($clone);
+
+        unset($clone);
+        \gc_collect_cycles();
+
+        Expect::that($reference->get())->toBeNull();
+        Expect::that($this->doubles->callsTo($original, '__clone'))->toEqual([[]]);
     }
 
     #[Test]


### PR DESCRIPTION
## What

Document that intercepted clones share expectations and call history with the original double. Explain the clone rules for mocks, spies, and stubs, and how to update tests that clone doubles.

Add regression coverage for repeated clones, shared call limits and history, unexpected and configured exceptions, mixed-case untyped clone methods, and independent garbage collection.

## Why

The clone support added in #1748 needs explicit guidance and regression coverage for shared state and object lifetime. A clone is a separate object, but it does not receive a fresh mock plan or call count.
