### PR TITLE
chore(ci): prevent releases for ordinary chore commits

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -27,7 +27,8 @@
                 },
                 {
                     "type": "chore",
-                    "section": "Miscellaneous Chores"
+                    "section": "Miscellaneous Chores",
+                    "hidden": true
                 },
                 {
                     "type": "docs",


### PR DESCRIPTION
Release Please created #1798 for a single documentation and test chore because the chore section was visible in release notes.

Set `hidden: true` for the `chore` section so ordinary chore commits do not produce release notes or trigger a release on their own.
