### PR TITLE
docs(results): clarify retained evidence and expectation counts

### DIFF
--- a/docs/architecture/artifacts.md
+++ b/docs/architecture/artifacts.md
@@ -31,9 +31,14 @@ to a temporary file beside the destination. It then renames the file into place
 atomically. The public `TestResult` contains the published metadata without the
 storage key.
 
-The terminal result retains attachments from failed attempts across retries. A
-successful attempt retains only attachments with the `always` value. A sealed
-attempt cannot receive more attachments. This seal does not apply retention.
+By default, the terminal result retains attachments from earlier retry attempts.
+It also retains attachments when the final outcome is failed or errored, or a
+plugin changed an earlier failed or errored outcome.
+
+For a passed or skipped result without such a transformation, the final attempt
+retains only attachments with the `always` value. An `AttachmentRetentionDecider`
+plugin can change these decisions. A sealed attempt cannot receive more
+attachments. This seal does not apply retention.
 
 The publication process decides retention after all result changes. These
 changes include retries, teardown, plugin transformations, and result policy.

--- a/docs/architecture/jsonl.md
+++ b/docs/architecture/jsonl.md
@@ -277,8 +277,9 @@ Greenlight verifies it. Stubs do not count.
 An `eventually()` or `consistently()` matcher counts once. Calls to its probe do
 not count separately.
 
-Failed, errored, and skipped tests contain the partial count from before the
-test stopped.
+Greenlight takes this count after the final attempt's cleanup and per-test
+service disposal. Cleanup can therefore add expectations after the test body
+fails, errors, or skips. Earlier retry attempts do not contribute to this count.
 
 ### attachments
 

--- a/docs/architecture/jsonl.md
+++ b/docs/architecture/jsonl.md
@@ -304,9 +304,13 @@ content or its base64 form in JSONL.
 `path` is a published path, not the caller source path. Internal storage keys
 never appear in reporter output.
 
-Attachments from failed retry attempts remain on the final result. They keep
-their original `attempt` number. A successful test can have attachments with
-the `always` retention value.
+By default, attachments from earlier retry attempts remain on the final result.
+They keep their original `attempt` number. Greenlight also retains attachments
+when a plugin changes a failed or errored outcome to passed or skipped.
+Thus, a passed result can contain `on-failure` attachments.
+
+An `AttachmentRetentionDecider` plugin can change retention. The list contains
+only the attachments that remain after that decision.
 
 Source locations and published artifact paths are absolute. They can disclose
 the layout of the workspace that produced them. They are not portable


### PR DESCRIPTION
A passed JSONL result can contain `on-failure` attachments. The storage documentation incorrectly said that a successful attempt keeps only `always` attachments. The JSONL reference also placed the expectation-count snapshot before teardown.

Describe the built-in retention rules for earlier retry attempts, failed or errored outcomes, and plugin transformations from those outcomes. Explain that attachment retention plugins can override the decision. State that the final attempt's expectation count includes cleanup and per-test service disposal.

The correction follows `DefaultAttachmentRetention::retainAttachment()`, `ArtifactStore::publish()`, `OrchestratorPluginRuntime::retainAttachment()`, and `TestExecutor::attempt()`. It changes prose only and preserves the JSONL schema.
