### PR TITLE
fix: bound attachment copies by reserved source size

### DIFF
--- a/src/Execution/Artifact/ArtifactStore.php
+++ b/src/Execution/Artifact/ArtifactStore.php
@@ -261,6 +261,10 @@ final class ArtifactStore
                             continue;
                         }
 
+                        if (\strlen($chunk) > $size - $copied) {
+                            throw AttachmentError::source($sourcePath, 'changed while it was being copied');
+                        }
+
                         $copied += \strlen($chunk);
                         \hash_update($hash, $chunk);
                         StreamWriter::writeFully($destination, $chunk);

--- a/tests/Fixture/Execution/Artifact/GrowingFileStream.php
+++ b/tests/Fixture/Execution/Artifact/GrowingFileStream.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Execution\Artifact;
+
+use Greenlight\Doubles\Fake;
+
+/** Simulates a file that grows after the initial size check. */
+final class GrowingFileStream implements Fake
+{
+    public mixed $context;
+    public static int $initialSize = 8192;
+    public static string $stagingDirectory = '';
+    public static int $maximumStagedBytes = 0;
+
+    private int $offset = 0;
+
+    public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
+    {
+        return $mode === 'rb';
+    }
+
+    public function stream_read(int $count): string
+    {
+        foreach (\glob(self::$stagingDirectory . '/*/attempt-*/*.part') ?: [] as $path) {
+            \clearstatcache(true, $path);
+            self::$maximumStagedBytes = \max(self::$maximumStagedBytes, (int) \filesize($path));
+        }
+
+        $bytes = \min($count, 32768 - $this->offset);
+        $this->offset += $bytes;
+
+        return \str_repeat('x', $bytes);
+    }
+
+    public function stream_eof(): bool
+    {
+        return $this->offset >= 32768;
+    }
+
+    /** @return array{mode: int, size: int, mtime: int} */
+    public function stream_stat(): array
+    {
+        return ['mode' => 0100600, 'size' => self::$initialSize, 'mtime' => 1];
+    }
+
+    /** @return array{mode: int, size: int, mtime: int} */
+    public function url_stat(string $path, int $flags): array
+    {
+        return $this->stream_stat();
+    }
+}

--- a/tests/Fixture/Execution/Artifact/GrowingFileStream.php
+++ b/tests/Fixture/Execution/Artifact/GrowingFileStream.php
@@ -23,7 +23,9 @@ final class GrowingFileStream implements Fake
 
     public function stream_read(int $count): string
     {
-        foreach (\glob(self::$stagingDirectory . '/*/attempt-*/*.part') ?: [] as $path) {
+        $parts = \glob(self::$stagingDirectory . '/*/attempt-*/*.part');
+
+        foreach ($parts === false ? [] : $parts as $path) {
             \clearstatcache(true, $path);
             self::$maximumStagedBytes = \max(self::$maximumStagedBytes, (int) \filesize($path));
         }

--- a/tests/Unit/Execution/Artifact/ArtifactGrowingSourceTest.php
+++ b/tests/Unit/Execution/Artifact/ArtifactGrowingSourceTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Execution\Artifact;
+
+use Greenlight\Artifact\AttachmentError;
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Execution\Artifact\ArtifactStore;
+use Greenlight\Execution\Artifact\TestArtifactBudget;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Test\Cleanup;
+use Greenlight\Test\TestId;
+use Greenlight\Tests\Fixture\Execution\Artifact\GrowingFileStream;
+
+final readonly class ArtifactGrowingSourceTest
+{
+    public function __construct(private TemporaryDirectory $directory, private Cleanup $cleanup) {}
+
+    #[Test]
+    #[DataSet('initialSizes')]
+    public function aGrowingSourceCannotWriteBeyondItsReservedBytes(int $initialSize): void
+    {
+        \stream_wrapper_register('growingattachment', GrowingFileStream::class);
+        $this->cleanup->defer(static fn(): bool => \stream_wrapper_unregister('growingattachment'));
+        $configuration = new ArtifactConfiguration(
+            $this->directory->path() . '/published',
+            maxAttachmentBytes: 8192,
+            maxRunBytes: 8192,
+        );
+        $store = ArtifactStore::open($configuration, $this->directory->path(), 'growing-source');
+        $this->cleanup->defer($store->cleanup(...));
+        GrowingFileStream::$initialSize = $initialSize;
+        GrowingFileStream::$stagingDirectory = $store->session()->stagingDirectory;
+        GrowingFileStream::$maximumStagedBytes = 0;
+        $attachments = $store->forAttempt(new TestId(self::class, __FUNCTION__), 1, new TestArtifactBudget());
+
+        Expect::that(static fn() => $attachments->file('growing.txt', 'growingattachment://source'))
+            ->toThrow(AttachmentError::class, message: 'Attachment source "growingattachment://source" changed while it was being copied.');
+        Expect::that(GrowingFileStream::$maximumStagedBytes)->toBeLessThanOrEqual($initialSize);
+        Expect::that(\glob($store->session()->stagingDirectory . '/*/attempt-*/*.part'))->toBe([]);
+        Expect::that($attachments->collected())->toBe([]);
+
+        $attachments->bytes('valid.bin', \str_repeat('v', 8192));
+
+        Expect::that($attachments->collected()[0]->sizeBytes)->toBe(8192);
+    }
+
+    /** @return iterable<string, array{int}> */
+    public static function initialSizes(): iterable
+    {
+        yield 'empty file grows' => [0];
+        yield 'file at the quota grows' => [8192];
+    }
+}


### PR DESCRIPTION
Attachment staging reserves the source file's initial size, but previously copied to EOF before checking whether the file changed. A growing source could therefore write beyond the attachment and shared run limits before Greenlight rejected it.

Check each chunk against the remaining reserved bytes before writing it. The existing changed-source error and rollback path remove incomplete data and release the reservation.

Two regression cases simulate growth from zero and 8,192 bytes. Before this change, both observed 24,576 bytes already staged beyond their reservations. They now keep staging within the reserved size, remove partial files, and permit a subsequent attachment to use the released quota.
