### PR TITLE
docs: clarify CLI filter rules and policy exemptions

### DIFF
--- a/src/Cli/Input/Definition.php
+++ b/src/Cli/Input/Definition.php
@@ -47,8 +47,9 @@ final readonly class Definition
                          Use --format=json for a machine-readable test manifest.
           coverage:merge Merge coverage JSON exports. Supply at least two --input
                          options and at least one --export option.
-          coverage:diff  Compare two coverage JSON exports. Fail if total coverage
-                         decreases or a line becomes newly uncovered.
+          coverage:diff  Compare two coverage JSON exports. Fail if coverage across
+                         files in both maps decreases or a line becomes newly uncovered.
+                         Removed files do not cause a regression.
           profile:report Create a run profile from a saved JSONL stream (--input)
           artifacts:prune Apply configured retention to completed artifact runs.
                          Use --dry-run to list selected runs without deletion.

--- a/src/Cli/Input/Definition.php
+++ b/src/Cli/Input/Definition.php
@@ -45,8 +45,8 @@ final readonly class Definition
           run            Find and run tests (default)
           list-tests     List selected test IDs and the total test count.
                          Use --format=json for a machine-readable test manifest.
-          coverage:merge Merge coverage JSON exports. Repeat --input for each
-                         source and --export for each output.
+          coverage:merge Merge coverage JSON exports. Supply at least two --input
+                         options and at least one --export option.
           coverage:diff  Compare two coverage JSON exports. Fail if total coverage
                          decreases or a line becomes newly uncovered.
           profile:report Create a run profile from a saved JSONL stream (--input)
@@ -68,15 +68,18 @@ final readonly class Definition
           --suite-tag=<tag>  Select suites with this tag. You can repeat this option.
           --group=<name>     Run only this group. You can repeat this option.
           --filter=<pattern> Run only tests with a matching test ID. Use a
-                             substring or a full match with * wildcards.
+                             substring or a full match with * and ? wildcards.
+                             Matching is case-insensitive.
                              You can repeat this option.
           --test-id=<id>     Run only this exact test ID. You can repeat this option.
           --exclude-group=<name>     Skip tests in this group. You can repeat this option.
           --exclude-class=<pattern>  Skip classes that match this pattern.
-                             Matching is case-sensitive. Use a substring or * wildcards.
+                             Matching is case-sensitive. Use a substring or
+                             a full match with * and ? wildcards.
                              You can repeat this option.
           --exclude-method=<pattern> Skip methods that match this pattern.
-                             Matching is case-sensitive. Use a substring or * wildcards.
+                             Matching is case-sensitive. Use a substring or
+                             a full match with * and ? wildcards.
                              You can repeat this option.
           --exclude-path=<prefix>    Skip test files under this path prefix.
                              Greenlight resolves relative prefixes against the
@@ -109,10 +112,12 @@ final readonly class Definition
           --ansi             Enable colors in append-only reporter output.
           --no-ansi          Disable colors and the live progress window.
                              Use plain append-only output.
-          --fail-on-deprecation  Fail passed tests that captured a deprecation
+          --fail-on-deprecation  Fail passed tests that captured a deprecation.
+                             Configured deprecation ignore patterns still apply.
           --fail-on-notice   Fail passed tests that captured a notice
           --fail-on-warning  Fail passed tests that captured a warning
-          --fail-on-risky    Fail passed tests that verified no expectations
+          --fail-on-risky    Fail passed tests that verified no expectations,
+                             except tests marked #[NoExpectations].
           --fail-on-skipped  Fail the run if its final summary contains a skipped test
           --fail-on-retried-pass
                              Fail the run if a test passes after retry

--- a/src/Result/ResultPolicy.php
+++ b/src/Result/ResultPolicy.php
@@ -17,14 +17,15 @@ use Greenlight\Internal\Wire\WireCommunicationFailed;
  *
  * The applicable flag changes a passed test with a captured deprecation,
  * notice, or warning to a failed test. The diagnostic becomes the failure
- * detail. The transformation log records the change.
+ * detail. Configured ignore patterns exempt matching deprecations.
+ * The transformation log records the change.
  *
  * A pattern without "*" or "?" matches part of a deprecation message without
  * case sensitivity. A pattern with either character matches the complete
  * message.
  *
- * A passed test with no verified expectations becomes risky. failOnRisky
- * changes this result to failed.
+ * A passed test with no verified expectations becomes risky unless it has
+ * #[NoExpectations]. failOnRisky changes a risky result to failed.
  *
  * @internal
  */

--- a/tests/Acceptance/CliTest.php
+++ b/tests/Acceptance/CliTest.php
@@ -89,6 +89,8 @@ final readonly class CliTest
             ->toContain('Matching is case-sensitive.')
             ->toContain('Configured deprecation ignore patterns still apply.')
             ->toContain('except tests marked #[NoExpectations].')
+            ->toContain('files in both maps decreases or a line becomes newly uncovered.')
+            ->toContain('Removed files do not cause a regression.')
             ->toContain('Supply at least two --input')
             ->toContain('options and at least one --export option.');
     }

--- a/tests/Acceptance/CliTest.php
+++ b/tests/Acceptance/CliTest.php
@@ -78,6 +78,22 @@ final readonly class CliTest
     }
 
     #[Test]
+    public function helpDescribesFilterRulesAndPolicyExceptions(): void
+    {
+        $result = $this->runCli(['--help']);
+
+        Expect::that($result->exitCode)->toBe(0);
+        Expect::that($result->output())
+            ->toContain('a full match with * and ? wildcards.')
+            ->toContain('Matching is case-insensitive.')
+            ->toContain('Matching is case-sensitive.')
+            ->toContain('Configured deprecation ignore patterns still apply.')
+            ->toContain('except tests marked #[NoExpectations].')
+            ->toContain('Supply at least two --input')
+            ->toContain('options and at least one --export option.');
+    }
+
+    #[Test]
     public function runExecutesAPassingSuiteAndExitsZero(): void
     {
         $project = AcceptanceProject::createWithOnePassingTest($this->tempDirectory, 'cli-run');


### PR DESCRIPTION
CLI help omits the supported `?` wildcard, test ID filter case rules, and result-policy exemptions. It also leaves the minimum coverage merge inputs unclear and incorrectly implies that removed files can cause a coverage regression.

Describe `*` and `?` full matches and case sensitivity. State that `#[NoExpectations]` exempts tests from the risky-test policy and that configured ignore patterns still apply to deprecations. State the two-input and one-export minimum for coverage merges. Explain that the percentage regression check compares files present in both maps.

The descriptions follow `Wildcard::matches()`, `TestSelection`, `TestExecutor`, `ResultPolicy::apply()`, `BaselineDiffReport::hasRegressions()`, and the guards in `CoverageMergeCommand::run()`. Keep the internal result-policy description consistent and add a focused acceptance test for the help text.
