### PR TITLE
docs: clarify retry timeout and attachment lifecycles

### DIFF
--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -45,10 +45,13 @@ Greenlight copies the content before the method returns. You can remove a
 temporary source file after `file()` returns. Later changes to a value or file
 do not change the attachment.
 
-Greenlight retains attachments when the attempt fails or has an error. This
-rule includes a successful attempt that a result policy changes to another
-outcome. To retain an attachment from a successful attempt, set its retention to
-`AttachmentRetention::Always`:
+By default, Greenlight retains attachments when the final result fails or has
+an error. It also retains them when the transformation log contains an earlier
+failed or errored outcome. Thus, a plugin cannot discard failure evidence only
+by changing the outcome to passed or skipped.
+
+To retain an attachment from a result without failure evidence, set its
+retention to `AttachmentRetention::Always`:
 
 <!-- php-example {"example":"attachments-example-02","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
@@ -61,8 +64,8 @@ $attachments->text(
 
 Each retry has separate attachments. Attachments from failed attempts stay on
 the final result even if a later attempt passes. The `attempt` field identifies
-the source attempt for each attachment. Greenlight discards attachments from
-the successful attempt unless their retention is `always`.
+the source attempt for each attachment. For the final attempt, the retention
+rules above apply to the final result and its transformation log.
 
 ## Output directory
 

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -54,8 +54,9 @@ Marks a public method to run before each test in the class.
 If a class has multiple before-hooks, Greenlight runs them in declaration
 order.
 
-A before-hook can throw `SkipTest` to skip the test. A throwable other than
-`SkipTest` gives the test an error.
+A before-hook can throw `SkipTest` to skip the test. An `ExpectationFailed`
+from the hook fails the test. Another throwable gives the test an error.
+In each case, Greenlight skips the test method and runs the after-hooks.
 
 ## After
 
@@ -319,7 +320,7 @@ environment checks, so most `#[SkipUnless]` uses need no hand-written class:
 * `ClassAvailable(Redis::class)` checks that the class exists.
 
 The skip reason names the condition and its arguments, for example
-`Condition ExtensionLoaded("redis") is not satisfied.`
+`Condition ExtensionLoaded("redis") is not satisfied`.
 
 ## Retry
 
@@ -342,7 +343,9 @@ only when the attempt cause has that throwable type. It does not retry an
 unsuccessful attempt that has no matching cause.
 
 Greenlight gives each attempt a new test instance and a new per-test scope.
-Thus, state does not pass between attempts.
+Per-class services, per-worker services, plugin instances, and process-global
+state remain in the same worker. Reset shared state before another attempt
+uses it. Retries do not start a new worker, even for an isolated test.
 
 Each retry also starts `eventually()` and `consistently()` with a new deadline
 and an empty observation log. `retryOnException()` retries a probe within the
@@ -374,18 +377,23 @@ float $seconds
 
 `$seconds` must be finite and greater than zero.
 
-Fails the test if it runs longer than the configured budget.
+The worker checks elapsed time after hooks, deferred cleanup, and per-test
+service disposal. An otherwise passed attempt fails if it exceeds the budget.
+This check cannot interrupt PHP code that is still active. Each retry starts
+a new attempt budget.
 
-Greenlight enforces a timeout in two layers. The worker checks elapsed time
-cooperatively and fails a test that exceeds its budget. If the worker does not
-return, the orchestrator terminates it after the hard-kill grace period.
+With process-pool execution, the orchestrator also stops a worker that exceeds
+the timeout plus a grace period. This outer deadline starts with the test and
+does not restart for retries. Greenlight replaces the stopped worker and
+continues the run.
 
-The orchestrator replaces the stopped worker and continues the run.
+In-process execution has no separate worker to stop. This includes
+`--workers=1` and automatic fallback when process functions are unavailable.
+A blocked test can therefore prevent an in-process run from completing.
 
-An `eventually()` or `consistently()` matcher cannot run past the current test
-timeout. If the test timeout occurs first, the failure gives the requested
-duration. A blocked probe remains subject to the orchestrator hard-kill grace
-period.
+An `eventually()` or `consistently()` matcher checks the current attempt
+deadline between probe calls. A blocked probe cannot check this deadline.
+Only process-pool execution provides the outer timeout for a blocked probe.
 
 <!-- php-example {"mode":"display","reason":"Uses an ellipsis to omit code that is not relevant to the example."} -->
 ```php

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -383,8 +383,7 @@ This check cannot interrupt PHP code that is still active. Each retry starts
 a new attempt budget.
 
 With process-pool execution, the orchestrator also stops a worker that exceeds
-the timeout plus a grace period. This outer deadline starts with the test and
-does not restart for retries. Greenlight replaces the stopped worker and
+the timeout plus a grace period. Greenlight replaces the stopped worker and
 continues the run.
 
 In-process execution has no separate worker to stop. This includes

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -248,8 +248,11 @@ Expect::consistently(fn() => $outbox->messagesFor($id))
 For both temporal chains, `pollEvery()` accepts a finite duration of at least
 0.001 seconds. `within()` and `for()` accept finite durations greater than zero.
 
-Each temporal matcher counts as one expectation. The test timeout limits its
-duration. The worker timeout remains the hard limit for a blocked probe.
+Each temporal matcher counts as one expectation. Temporal matchers check the
+test-attempt deadline between probe calls. These checks cannot interrupt a
+blocked probe. With process-pool execution, the orchestrator can stop the
+worker after the timeout grace period. In-process execution has no such
+protection. See [timeouts](attributes.md#timeout).
 
 ## Explicit failures
 

--- a/docs/migrating-from-phpunit.md
+++ b/docs/migrating-from-phpunit.md
@@ -222,7 +222,11 @@ Expect::eventually(fn() => $repository->find($id))
 ```
 
 Use `consistently()->for()` when a value must not change. A probe exception
-stops the poll unless `retryOnException()` lists its type.
+always stops this consistency check.
+
+With `eventually()`, a probe exception stops the poll unless
+`retryOnException()` lists its type. Consistency checks do not support
+`retryOnException()`.
 
 ## Convert test doubles
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -289,8 +289,10 @@ public function retainAttachment(TestResult $result, Attachment $attachment, boo
 
 An `AttachmentRetentionDecider` changes whether Greenlight publishes one
 completed test attachment. Greenlight first applies the retention selected by
-the test. `Always` retains the attachment. `OnFailure` retains it for an
-unsuccessful result, a transformed failure, or an earlier failed attempt.
+the test. `Always` retains the attachment. `OnFailure` retains it for a failed
+or errored result, an earlier attempt, or a transformation from failed or
+errored. A final passed or skipped outcome does not erase failure evidence
+from the transformation log.
 
 Each configured decider receives that current decision and returns the next
 decision. Thus, a decider can retain evidence that the built-in rule would


### PR DESCRIPTION
The guides overstate retry isolation and timeout guarantees. They also say a passed attempt loses failure-only attachments even when its transformation log contains a failure.

Describe the actual worker behavior: retries replace only the test instance and per-test scope; elapsed-time checks cannot interrupt active PHP; and failure evidence survives a later outcome change. Also distinguish an expectation failure in a before-hook from an error, correct the literal conditional-skip reason, and clarify that `retryOnException()` is available only for eventual checks.

These corrections follow `TestExecutor::attempt()`, `HarnessScopes::openTest()`, `Orchestrator::enforceTimeouts()`, `DefaultAttachmentRetention::retainAttachment()`, `Outcome::isSuccessful()`, `PendingEventually`, and `PendingConsistently`. Runtime behavior is unchanged.
