### PR TITLE
docs(execution): clarify timeout and polling limits

### DIFF
--- a/docs/architecture/temporal-expectations.md
+++ b/docs/architecture/temporal-expectations.md
@@ -25,8 +25,10 @@ The PHPStan extension supplies the native methods on temporal chains. The IDE
 helper supplies the same methods as annotations. Thus, normal temporal matcher
 syntax keeps its static signatures in these tools.
 
-An exception from matcher code stops the poll operation. `eventually()` retries
-a probe exception only if `retryOnException()` lists its type.
+An `ExpectationFailed` from matcher code records a mismatch. `eventually()`
+continues after a mismatch, while `consistently()` fails. Other exceptions from
+matcher code stop the poll operation. `eventually()` retries a probe exception
+only if `retryOnException()` lists its type.
 
 A successful temporal matcher returns an ordinary `Expectation` for the last
 value. Each matcher after it checks that value one time.
@@ -46,8 +48,9 @@ interval and call the probe again. Probe calls never overlap.
 `eventually()` sets its deadline before the first call and returns after the
 first match. `consistently()` requires its first call to match, starts its
 stability period after that call, and fails on the first mismatch.
-`eventually()` makes a final call at its deadline if no earlier call matches.
-`consistently()` makes a final call at the end of its stability period.
+The next wait ends at the applicable deadline if a full interval would exceed
+it. Greenlight then calls the probe again. An earlier probe call that reaches
+or exceeds the deadline can end the operation without another call.
 
 The poll operation has no backoff or jitter. A fixed interval gives a
 predictable schedule. It does not guarantee detection of states between probe
@@ -62,7 +65,8 @@ deadline is the earlier of its own deadline and the test deadline.
 
 If the test deadline comes first, the failure includes the requested poll
 duration. Greenlight cannot interrupt a blocked probe. Therefore, the
-orchestrator process timeout remains the hard limit.
+process-pool orchestrator timeout remains the hard limit. An in-process run
+cannot forcibly stop a blocked probe.
 
 Each test retry has a new instance, scope, deadline, and observation log. With
 `ext-pcntl` available, the first interrupt signal still lets active tests

--- a/docs/architecture/worker-lifecycle.md
+++ b/docs/architecture/worker-lifecycle.md
@@ -315,16 +315,22 @@ stateDiagram-v2
 ### Crashes
 
 If a worker dies mid-assignment, the orchestrator reports its in-flight test as
-errored and attaches the tail of the worker's stderr. It returns the rest of the
+errored and includes the tail of its combined stdout and stderr diagnostics.
+It returns the rest of the
 assignment to the queue. It does not re-queue the crashed test because a test
 that kills its process would kill each replacement in turn.
 
 ### Timeouts
 
-The orchestrator enforces each test timeout with a grace window of twice the
-budget plus two seconds. The worker may be too stuck to enforce the timeout
-itself. When the grace window expires, the orchestrator kills the process with
-SIGKILL and handles it as a crash. It reports the test as timed out.
+The orchestrator measures a hard timeout from its receipt of `TestStarted`.
+The limit is twice the configured test budget plus two seconds. Retries do not
+restart this clock. When the limit expires, the orchestrator kills the process
+with SIGKILL. It reports the test as failed with a timeout diagnostic.
+
+The worker checks each attempt against the configured test budget after teardown.
+This check changes only a passed result to failed. It cannot interrupt blocked
+code. An in-process run has this check but no separate orchestrator process to
+enforce the hard timeout.
 
 The worker also gives `eventually()` and `consistently()` the current attempt's
 monotonic deadline. Their polling stops at that deadline, but a probe can still

--- a/docs/architecture/worker-lifecycle.md
+++ b/docs/architecture/worker-lifecycle.md
@@ -322,9 +322,8 @@ that kills its process would kill each replacement in turn.
 
 ### Timeouts
 
-The orchestrator measures a hard timeout from its receipt of `TestStarted`.
-The limit is twice the configured test budget plus two seconds. Retries do not
-restart this clock. When the limit expires, the orchestrator kills the process
+The orchestrator enforces a hard timeout of twice the configured test budget
+plus two seconds. When the limit expires, the orchestrator kills the process
 with SIGKILL. It reports the test as failed with a timeout diagnostic.
 
 The worker checks each attempt against the configured test budget after teardown.


### PR DESCRIPTION
The execution notes overstate timeout and polling guarantees. They also describe crash diagnostics as stderr only.

Explain the difference between the per-attempt timeout check and the process-pool hard timeout. In-process execution cannot interrupt blocked code. Clarify that matcher `ExpectationFailed` exceptions are mismatches and that a probe can itself reach the polling deadline. Describe the combined stdout/stderr crash diagnostics.

These corrections follow `Orchestrator::enforceTimeouts()`, `TestExecutor::attempt()`, `TemporalExpectation::observe()`, both temporal polling loops, and `WorkerHandle::drainPipes()`. No runtime behavior or protocol shape changes.
