### PR TITLE
fix(cli): keep watch status outside JSONL output

### DIFF
--- a/src/Cli/Run/WatchRuns.php
+++ b/src/Cli/Run/WatchRuns.php
@@ -76,6 +76,9 @@ final readonly class WatchRuns
             return $session->watchAttempt($reporter, $priorityClasses);
         };
         $keys = new StdinKeyInput();
+        $statusOutput = $reporterOutputs->writesReporterToStandardOutput('jsonl')
+            ? $this->console->err(...)
+            : $this->console->out(...);
         try {
             $sources = WatchSourceRuntime::fromDefinitions(
                 $resolved->execution->plugins,
@@ -90,7 +93,7 @@ final readonly class WatchRuns
                     maximumFiles: $resolved->watch->maximumFiles,
                 )],
             );
-            new WatchLoop($sources, new Debouncer($resolved->watch->debounceMilliseconds / 1000), $keys, new SystemWatchClock(), $this->console->out(...), $shutdown)->run($runOnce);
+            new WatchLoop($sources, new Debouncer($resolved->watch->debounceMilliseconds / 1000), $keys, new SystemWatchClock(), $statusOutput, $shutdown)->run($runOnce);
         } catch (ReporterSetupFailed|RunPolicyError|WatchSourceFailed $error) {
             $this->console->error($error->getMessage(), $arguments->has('no-ansi'));
             return CommandResult::failure();

--- a/tests/Acceptance/WatchJsonlOutputTest.php
+++ b/tests/Acceptance/WatchJsonlOutputTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Test\Cleanup;
+use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\GreenlightCli;
+
+final readonly class WatchJsonlOutputTest
+{
+    public function __construct(private TemporaryDirectory $directory, private Cleanup $cleanup) {}
+
+    #[Test]
+    #[DataSet('outputTargets')]
+    public function watchKeepsStatusOutsideTheJsonlEventStream(bool $fileOutput): void
+    {
+        $project = AcceptanceProject::create($this->directory, 'watch-jsonl');
+        $project->writeFile('tests/ProbeTest.php', <<<'PHP'
+            <?php
+
+            namespace WatchJsonlProbe;
+
+            use Greenlight\Attribute\Test;
+
+            final class ProbeTest
+            {
+                #[Test]
+                public function passes(): void {}
+            }
+            PHP);
+        $project->configureWithTestFiles(['tests/ProbeTest.php']);
+        $reporter = $fileOutput ? '--reporter=jsonl=events.jsonl' : '--reporter=jsonl';
+        $ready = $fileOutput ? 'Waiting for changes' : 'run-finished';
+        $process = GreenlightCli::start($project->directory, ['run', '--watch', $reporter, '--workers=1']);
+        $this->cleanup->defer($process->terminate(...));
+        $process->readStdoutUntil($ready, 20.0);
+        $process->write("\n");
+        $process->readStdoutUntil($ready, 20.0);
+        $process->write('q');
+        $result = $process->wait(10.0);
+        $events = [];
+        $lines = $fileOutput
+            ? \file($project->path('events.jsonl'), \FILE_IGNORE_NEW_LINES | \FILE_SKIP_EMPTY_LINES)
+            : $result->stdoutLines();
+
+        foreach ($lines === false ? [] : $lines as $line) {
+            /** @var array{event: string} $envelope */
+            $envelope = \json_decode($line, true, flags: \JSON_THROW_ON_ERROR);
+            $events[] = $envelope['event'];
+        }
+
+        Expect::that($result->exitCode)->toBe(0);
+        Expect::that(\array_count_values($events)['run-started'] ?? 0)->toBe(2);
+        Expect::that(\array_count_values($events)['run-finished'] ?? 0)->toBe(2);
+        Expect::that($fileOutput ? $result->stdout : $result->stderr)->toContain('Waiting for changes');
+    }
+
+    /** @return iterable<string, array{bool}> */
+    public static function outputTargets(): iterable
+    {
+        yield 'standard output' => [false];
+        yield 'file' => [true];
+    }
+}


### PR DESCRIPTION
Watch mode writes `Waiting for changes` and change notifications to standard output. With `--reporter=jsonl`, these lines enter the event stream and cause JSON consumers to fail, including after a manual rerun.

Send watch status to standard error when JSONL uses standard output. Keep status on standard output when JSONL targets a file. The focused CLI regression failed with `JsonException: Syntax error` before the change; both output targets now pass across two watch iterations (2 cases, 8 expectations).
