### PR TITLE
docs: clarify attempt timing and expectation results

### DIFF
--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -469,15 +469,17 @@ public function __construct(public bool $capture = true)
 
 Namespace: `Greenlight\Attribute`
 
-Fails the test if its run time exceeds the specified number of seconds. A
-class attribute applies the limit to each test in the class.
+Fails an otherwise passed attempt if its run time exceeds the specified
+number of seconds. Greenlight checks elapsed time after per-test service
+disposal. This check does not interrupt PHP code that is still running.
+A class attribute applies the limit to each test in the class.
 
 ```php
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS)]
 final readonly class Timeout
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Timeout.php#L12)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Timeout.php#L14)
 
 ### `$seconds`
 
@@ -485,7 +487,7 @@ final readonly class Timeout
 public float $seconds
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Timeout.php#L18)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Timeout.php#L20)
 
 ### `__construct()`
 
@@ -499,7 +501,7 @@ PHPDoc:
 
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Timeout.php#L17)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Timeout.php#L19)
 
 ## `ClassAvailable`
 

--- a/docs/api-expectations.md
+++ b/docs/api-expectations.md
@@ -1906,8 +1906,8 @@ PHPDoc:
 
 ### `detail()`
 
-Returns the first failure. In the default mode, this is the only
-failure.
+Returns the first failure. Use `$details` to read all failures, including
+multiple unmet mock expectations.
 
 ```php
 public function detail(): FailureDetail

--- a/docs/api-results.md
+++ b/docs/api-results.md
@@ -533,15 +533,18 @@ Namespace: `Greenlight\Result`
 A plugin does not change a result object. It uses `withOutcome()` to produce
 a replacement and record the source of the change.
 
-The expectations value counts each matcher in a chain separately. It counts
-each mock expectation when disposal verifies it. Stubs do not add to the
-count. An unsuccessful result contains the count at the time of the abort.
+The expectations value counts each immediate matcher and each mock
+expectation that disposal verifies. Each temporal matcher counts once,
+regardless of the number of polls. Stubs do not add to the count.
+
+The worker records the count after cleanup and per-test service disposal,
+before `afterTest()` subscribers. Retries report the final attempt's count.
 
 ```php
 final readonly class TestResult
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L21)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L24)
 
 ### `$attempts`
 
@@ -553,7 +556,7 @@ PHPDoc:
 
 - `@var positive-int`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L26)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L29)
 
 ### `$expectations`
 
@@ -565,7 +568,7 @@ PHPDoc:
 
 - `@var non-negative-int`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L31)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L34)
 
 ### `$id`
 
@@ -573,7 +576,7 @@ PHPDoc:
 public TestId $id
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L41)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L44)
 
 ### `$outcome`
 
@@ -581,7 +584,7 @@ public TestId $id
 public Outcome $outcome
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L42)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L45)
 
 ### `$durationSeconds`
 
@@ -589,7 +592,7 @@ public Outcome $outcome
 public float $durationSeconds
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L43)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L46)
 
 ### `$memoryDeltaBytes`
 
@@ -597,7 +600,7 @@ public float $durationSeconds
 public int $memoryDeltaBytes
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L44)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L47)
 
 ### `$failures`
 
@@ -605,7 +608,7 @@ public int $memoryDeltaBytes
 public array $failures
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L46)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L49)
 
 ### `$error`
 
@@ -613,7 +616,7 @@ public array $failures
 public ?ThrowableDetail $error
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L47)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L50)
 
 ### `$skipReason`
 
@@ -621,7 +624,7 @@ public ?ThrowableDetail $error
 public ?string $skipReason
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L48)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L51)
 
 ### `$transformations`
 
@@ -629,7 +632,7 @@ public ?string $skipReason
 public array $transformations
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L49)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L52)
 
 ### `$output`
 
@@ -637,7 +640,7 @@ public array $transformations
 public ?CapturedOutput $output
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L50)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L53)
 
 ### `$risky`
 
@@ -645,7 +648,7 @@ public ?CapturedOutput $output
 public bool $risky
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L51)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L54)
 
 ### `$attachments`
 
@@ -653,7 +656,7 @@ public bool $risky
 public array $attachments
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L53)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L56)
 
 ### `__construct()`
 
@@ -682,7 +685,7 @@ PHPDoc:
 - `@param list<Attachment> $attachments`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L40)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L43)
 
 ### `withOutcome()`
 
@@ -695,7 +698,7 @@ PHPDoc:
 - `@param non-empty-string $transformedBy`
 - `@throws \InvalidArgumentException if the transformation source is empty`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L76)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Result/TestResult.php#L79)
 
 ## `ThrowableDetail`
 

--- a/src/Attribute/Timeout.php
+++ b/src/Attribute/Timeout.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Greenlight\Attribute;
 
 /**
- * Fails the test if its run time exceeds the specified number of seconds. A
- * class attribute applies the limit to each test in the class.
+ * Fails an otherwise passed attempt if its run time exceeds the specified
+ * number of seconds. Greenlight checks elapsed time after per-test service
+ * disposal. This check does not interrupt PHP code that is still running.
+ * A class attribute applies the limit to each test in the class.
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS)]
 final readonly class Timeout

--- a/src/Expect/ExpectationFailed.php
+++ b/src/Expect/ExpectationFailed.php
@@ -58,8 +58,8 @@ final class ExpectationFailed extends \Exception
     }
 
     /**
-     * Returns the first failure. In the default mode, this is the only
-     * failure.
+     * Returns the first failure. Use `$details` to read all failures, including
+     * multiple unmet mock expectations.
      */
     public function detail(): FailureDetail
     {

--- a/src/Result/TestResult.php
+++ b/src/Result/TestResult.php
@@ -14,9 +14,12 @@ use Greenlight\Test\TestId;
  * A plugin does not change a result object. It uses `withOutcome()` to produce
  * a replacement and record the source of the change.
  *
- * The expectations value counts each matcher in a chain separately. It counts
- * each mock expectation when disposal verifies it. Stubs do not add to the
- * count. An unsuccessful result contains the count at the time of the abort.
+ * The expectations value counts each immediate matcher and each mock
+ * expectation that disposal verifies. Each temporal matcher counts once,
+ * regardless of the number of polls. Stubs do not add to the count.
+ *
+ * The worker records the count after cleanup and per-test service disposal,
+ * before `afterTest()` subscribers. Retries report the final attempt's count.
  */
 final readonly class TestResult
 {


### PR DESCRIPTION
The API reference described an unsuccessful result's expectation count as the count at the abort and referred to an undefined default failure mode. It also omitted when the attempt timeout is checked.

Explain that the worker records expectations after cleanup and per-test service disposal, before after-test subscribers, and reports the final retry attempt's count. Temporal matchers count once per matcher. Describe the timeout as an elapsed-time check after disposal that changes an otherwise passed attempt. Replace the undefined failure-mode statement with the distinction between the first failure and the complete details list.

The descriptions follow `TestExecutor::attempt()`, temporal matcher counter suppression, and `ExpectationFailed::detail()`. Regenerate the API pages from the maintained PHPDoc.
