### PR TITLE
fix(ci): reject failed runs in the flat-memory gate

### DIFF
--- a/tests/Unit/Tools/RuntimeMessageTest.php
+++ b/tests/Unit/Tools/RuntimeMessageTest.php
@@ -131,6 +131,29 @@ final readonly class RuntimeMessageTest
     }
 
     #[Test]
+    public function memoryGateRejectsAFailedRunThatWritesCompleteSamples(): void
+    {
+        [$root, $script] = $this->toolSandbox('memory-run-failure', 'memory-gate.php');
+        $bin = $this->tempDirectory->subdirectory('memory-run-failure/bin');
+        \file_put_contents($bin . '/greenlight', <<<'PHP'
+        <?php
+
+        file_put_contents(getcwd() . '/samples.json', json_encode(['2000' => 1_048_576, '10000' => 1_048_576]));
+        file_put_contents(__DIR__ . '/run-directory', getcwd());
+        fwrite(STDERR, "Synthetic test run failed.\n");
+        exit(17);
+        PHP);
+
+        $result = PhpSubprocess::run($root, [$script]);
+
+        Expect::that($result->exitCode)->toBe(1);
+        Expect::that($result->stdout)->toContain('Synthetic test run failed.');
+        Expect::that($result->stdout)->not()->toContain('Flat-memory gate passed.');
+        Expect::that($result->stderr)->toContain('The generated test run failed with exit code 17.');
+        Expect::that(\is_dir((string) \file_get_contents($bin . '/run-directory')))->toBeFalse();
+    }
+
+    #[Test]
     public function memoryGateReportsDirectoryCreationFailureExactly(): void
     {
         [$root, $script] = $this->toolSandbox('memory-directory', 'memory-gate.php');

--- a/tools/memory-gate.php
+++ b/tools/memory-gate.php
@@ -162,8 +162,12 @@ $cleanup = static function () use ($workDir): void {
 };
 
 $process = \proc_open(
-    [\PHP_BINARY, $root . '/bin/greenlight', 'run', '--reporter=plain'],
-    [0 => \STDIN, 1 => ['pipe', 'w'], 2 => ['redirect', '1']],
+    \sprintf(
+        '%s %s run --reporter=plain 2>&1',
+        \escapeshellarg(\PHP_BINARY),
+        \escapeshellarg($root . '/bin/greenlight'),
+    ),
+    [0 => \STDIN, 1 => ['pipe', 'w'], 2 => \STDERR],
     $pipes,
     $workDir,
 );

--- a/tools/memory-gate.php
+++ b/tools/memory-gate.php
@@ -163,7 +163,7 @@ $cleanup = static function () use ($workDir): void {
 
 $process = \proc_open(
     [\PHP_BINARY, $root . '/bin/greenlight', 'run', '--reporter=plain'],
-    [0 => \STDIN, 1 => ['pipe', 'w'], 2 => ['redirect', 1]],
+    [0 => \STDIN, 1 => ['pipe', 'w'], 2 => ['redirect', '1']],
     $pipes,
     $workDir,
 );

--- a/tools/memory-gate.php
+++ b/tools/memory-gate.php
@@ -157,18 +157,35 @@ $config = \str_replace(['{WARMUP}', '{TOTAL}'], [(string) WARMUP_TESTS, (string)
 
 echo \sprintf("Greenlight runs %d generated tests in one worker...\n", $totalTests);
 
-$command = \sprintf(
-    'cd %s && %s %s run --reporter=plain 2>&1 | tail -4',
-    \escapeshellarg($workDir),
-    \escapeshellarg(\PHP_BINARY),
-    \escapeshellarg($root . '/bin/greenlight'),
-);
-\exec($command, $output, $exitCode);
-echo \implode("\n", $output) . "\n";
-
 $cleanup = static function () use ($workDir): void {
     \exec('rm -rf ' . \escapeshellarg($workDir));
 };
+
+$process = \proc_open(
+    [\PHP_BINARY, $root . '/bin/greenlight', 'run', '--reporter=plain'],
+    [0 => \STDIN, 1 => ['pipe', 'w'], 2 => ['redirect', 1]],
+    $pipes,
+    $workDir,
+);
+
+if (!\is_resource($process)) {
+    $cleanup();
+    throw new RuntimeException('Greenlight could not start the generated test run.');
+}
+
+$output = [];
+
+while (($line = \fgets($pipes[1])) !== false) {
+    $output[] = \rtrim($line, "\r\n");
+
+    if (\count($output) > 4) {
+        \array_shift($output);
+    }
+}
+
+\fclose($pipes[1]);
+$exitCode = \proc_close($process);
+echo \implode("\n", $output) . "\n";
 
 $samplesJson = \is_file($samplesFile) ? \file_get_contents($samplesFile) : false;
 
@@ -191,6 +208,12 @@ if (\is_array($samples)) {
 
 if ($baseline === null || $final === null) {
     \fwrite(\STDERR, "The probe output does not contain all sample points.\n");
+    $cleanup();
+    exit(1);
+}
+
+if ($exitCode !== 0) {
+    \fwrite(\STDERR, \sprintf("The generated test run failed with exit code %d.\n", $exitCode));
     $cleanup();
     exit(1);
 }


### PR DESCRIPTION
The flat-memory gate could pass after its generated test run failed. The shell pipeline returned `tail`'s exit status, and the gate accepted complete memory samples without checking the runner result. A subprocess regression writes both flat samples and exits 17: the old gate incorrectly exits 0.

Start the runner without a pipeline and require a successful exit before accepting its measurements. Keep only the last four output lines, preserve combined diagnostics, and remove the temporary suite on failure. The regression now rejects the failed run and confirms cleanup. The existing tool cases pass, and the real 10,000-test memory gate still passes with 1,336 bytes of measured drift against its 1 MiB limit.
