### PR TITLE
docs: correct Hyperf disposal after reset failures

### DIFF
--- a/docs/hyperf.md
+++ b/docs/hyperf.md
@@ -194,8 +194,9 @@ runs inside the test coroutine in both modes.
 The disposal callback runs before Greenlight discards its container. In worker
 mode, it runs once when the worker exits. In test-attempt mode, the reset
 callback runs first. Greenlight calls disposal even if reset throws. If either
-callback throws, the attempt has an error. The first throwable remains the
-cause. Greenlight still removes access to the container, clears the coroutine
+callback throws, the attempt has an error.
+
+The first throwable remains the cause. Greenlight still removes access to the container, clears the coroutine
 runtime, and ends the coroutine.
 
 The bridge does not reset application static properties or global variables.

--- a/docs/hyperf.md
+++ b/docs/hyperf.md
@@ -119,7 +119,7 @@ The isolated mode uses this lifecycle for each attempt:
 3. Resolve `Hyperf\Contract\ApplicationInterface` to boot the application.
 4. Construct the test and run all hooks, plugins, and the test method.
 5. Close the Greenlight test service scope.
-6. Call the reset callback. If it succeeds, call the disposal callback.
+6. Call the reset callback, then the disposal callback, even if reset fails.
 7. Remove access to the discarded application container.
 8. Clear Swoole timers and resume Hyperf's worker-exit coordinator.
 9. End the coroutine.
@@ -193,10 +193,10 @@ runs inside the test coroutine in both modes.
 
 The disposal callback runs before Greenlight discards its container. In worker
 mode, it runs once when the worker exits. In test-attempt mode, the reset
-callback runs first. If reset succeeds, disposal runs after the attempt. If
-reset throws, the attempt has an error and Greenlight does not call disposal
-for that container. Greenlight still removes access to the container, clears
-the coroutine runtime, and ends the coroutine.
+callback runs first. Greenlight calls disposal even if reset throws. If either
+callback throws, the attempt has an error. The first throwable remains the
+cause. Greenlight still removes access to the container, clears the coroutine
+runtime, and ends the coroutine.
 
 The bridge does not reset application static properties or global variables.
 Reset these values in an `#[After]` hook or the `reset:` callback.


### PR DESCRIPTION
The Hyperf guide still says a failed reset prevents the test-attempt disposal callback. The current bridge attempts both callbacks and preserves the first failure.

Correct the lifecycle sequence and callback explanation to match `HyperfPlugin::disposeAttemptContainer()` and `captureCleanup()`. This keeps the guide consistent with the cleanup behavior now on main.
