### PR TITLE
docs: retain coverage evidence after failed CI gates

### DIFF
--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -330,12 +330,17 @@ jobs:
             --maximum-uncovered-lines=100
 
       - name: Upload whole-suite coverage
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v7
         with:
           name: whole-suite-coverage
           path: build/coverage
           if-no-files-found: error
 ```
+
+The final upload runs after a passed or failed merge command. Greenlight writes
+coverage exports before it checks the gates, so a failed gate keeps its
+coverage evidence. The upload does not run after job cancellation.
 
 GitHub-hosted matrix jobs use the same workspace path for one repository. Thus,
 their absolute paths match.


### PR DESCRIPTION
The sharded-coverage example skips the whole-suite artifact upload when the coverage gate fails. GitHub applies its default success condition to that step, even though Greenlight already wrote the coverage exports.

Run the upload with `!cancelled()` and explain that failed gates retain their coverage evidence. The condition follows GitHub's documented status-check semantics, and `CoverageMergeCommand` writes exports before it evaluates the coverage gate.
