### PR TITLE
fix(doubles): preserve private constant defaults

### DIFF
--- a/src/Doubles/ProxyGenerator.php
+++ b/src/Doubles/ProxyGenerator.php
@@ -372,7 +372,7 @@ final readonly class ProxyGenerator
             }
 
             if (\str_starts_with($constant, 'self::')) {
-                return '\\' . $context->name . '::' . \substr($constant, 6);
+                $constant = $context->name . '::' . \substr($constant, 6);
             }
 
             if (\str_starts_with($constant, 'parent::')) {
@@ -382,7 +382,22 @@ final readonly class ProxyGenerator
                     throw InvalidDoubleUsage::parentTypeWithoutParent($context->name);
                 }
 
-                return '\\' . $parent->name . '::' . \substr($constant, 8);
+                $constant = $parent->name . '::' . \substr($constant, 8);
+            }
+
+            $separator = \strrpos($constant, '::');
+
+            if ($separator !== false) {
+                $owner = \substr($constant, 0, $separator);
+
+                if (\class_exists($owner)) {
+                    $member = new \ReflectionClass($owner)->getReflectionConstant(\substr($constant, $separator + 2));
+
+                    if ($member instanceof \ReflectionClassConstant && $member->isPrivate()) {
+                        // A child proxy cannot access the parent's private constant.
+                        return \var_export($parameter->getDefaultValue(), true);
+                    }
+                }
             }
 
             return '\\' . $constant;

--- a/tests/Fixture/Doubles/InheritedPrivateConstantDefault.php
+++ b/tests/Fixture/Doubles/InheritedPrivateConstantDefault.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+class InheritedPrivateConstantDefault extends PrivateConstantDefault {}

--- a/tests/Fixture/Doubles/PrivateConstantDefault.php
+++ b/tests/Fixture/Doubles/PrivateConstantDefault.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+class PrivateConstantDefault
+{
+    private const string MODE = 'fast';
+
+    /** @var array<string, string> */
+    private const array OPTIONS = ['mode' => 'fast'];
+
+    public function mode(string $value = self::MODE): string
+    {
+        return $value;
+    }
+
+    /**
+     * @param array<string, string> $value
+     * @return array<string, string>
+     */
+    public function options(array $value = PrivateConstantDefault::OPTIONS): array
+    {
+        return $value;
+    }
+}

--- a/tests/Unit/Doubles/ProxyPrivateConstantDefaultTest.php
+++ b/tests/Unit/Doubles/ProxyPrivateConstantDefaultTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\MockPlan;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Doubles\InheritedPrivateConstantDefault;
+use Greenlight\Tests\Fixture\Doubles\PrivateConstantDefault;
+
+final readonly class ProxyPrivateConstantDefaultTest
+{
+    public function __construct(private Doubles $doubles) {}
+
+    #[Test]
+    public function privateSelfDefaultsAllowOmittedArguments(): void
+    {
+        Expect::that(new PrivateConstantDefault()->mode())->toBe('fast');
+        $double = $this->doubles->mock(PrivateConstantDefault::class, static function (MockPlan $plan): void {
+            $plan->expects('mode')->once()->andReturns('answered');
+        });
+
+        Expect::that($double->mode())->toBe('answered');
+    }
+
+    #[Test]
+    public function privateQualifiedDefaultsAllowOmittedArguments(): void
+    {
+        Expect::that(new PrivateConstantDefault()->options())->toBe(['mode' => 'fast']);
+        $double = $this->doubles->mock(PrivateConstantDefault::class, static function (MockPlan $plan): void {
+            $plan->expects('options')->once()->andReturns(['mode' => 'answered']);
+        });
+
+        Expect::that($double->options())->toBe(['mode' => 'answered']);
+    }
+
+    #[Test]
+    public function inheritedMethodsKeepTheirPrivateDefaults(): void
+    {
+        Expect::that(new InheritedPrivateConstantDefault()->mode())->toBe('fast');
+        $double = $this->doubles->mock(InheritedPrivateConstantDefault::class, static function (MockPlan $plan): void {
+            $plan->expects('mode')->once()->andReturns('answered');
+        });
+
+        Expect::that($double->mode())->toBe('answered');
+    }
+}


### PR DESCRIPTION
A public method can use a private class constant as its parameter default. The native method accepts an omitted argument, but its generated double fails with `Cannot access private constant` before the mock handler runs.

Render private constant defaults as their resolved values. Keep accessible class and global constants as references, preserving their existing reflection metadata. This also handles inherited methods and explicitly qualified private constants.

All three new public-call regressions error before the change and pass afterward. The doubles selection passes 242 tests with 478 expectations.
