### PR TITLE
docs(contributing): centralize shared contributor guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,14 +1,7 @@
-# Repository guidance
+# Agent instructions
 
-- Use PHP 8.4 or a later version. Greenlight MUST have zero runtime dependencies.
-- Obey `docs/architecture/conventions.md` and the dependency boundaries in `deptrac.yaml`.
-- Use `docs/architecture/technical-writing.md` for all repository-owned technical prose.
-- Technical prose includes documentation, PHPDoc, comments, contributor material, accessibility text, diagnostics, CLI help, and human-readable output.
-- Use Simplified Technical English principles for technical prose. Do not claim formal compliance without verification.
-- Use direct language in user-facing prose. Preserve normative terms in formal specifications, protocol requirements, and exact quotations.
-- Use STE clarity principles for marketing copy. The controlled vocabulary is optional for marketing copy.
-- Add focused unit or acceptance tests. Use `Greenlight\Expect`. Treat shared fixture directories as append-only.
-- Run focused tests with `php bin/greenlight run --filter=<test-id>`.
-- Before you complete PHP changes, run `composer static-analysis && composer tests`.
-- For website changes, run `make docs-check`.
-- Use Conventional Commits for commit messages and pull request titles.
+Use the [contributor guide](CONTRIBUTING.md) and the standards it links to.
+
+Before you complete PHP changes, run the Composer checks in
+[Before you push](CONTRIBUTING.md#before-you-push).
+For website changes, run the documentation check in that section.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,29 @@ Greenlight requires PHP 8.4 or later. The documentation checks require Node.js
 Run `make docs-install` to install the documentation dependencies and Chromium
 for the browser tests.
 
+## Documentation sources
+
+Edit guides in `docs/`. The website uses these Markdown files directly.
+Architecture pages in `docs/architecture/` remain repository documentation.
+
+The API reference is generated from public PHP declarations and PHPDoc in
+`src/`. Edit those sources, then run:
+
+```sh
+npm --prefix website run api:generate
+```
+
+Commit the updated API pages with their source changes. Do not edit generated
+`docs/api.md` or `docs/api-*.md` pages directly. The generator is
+`website/scripts/generate-api-reference.mjs`.
+
+Edit website text and accessibility labels in `website/src/`. Do not edit
+`website/dist/`, `build/docs-php/`, or `.phpstan-api-stubs/`. Build and
+development tools generate these directories.
+
+The [PHP example guide](docs/architecture/documentation-php-examples.md)
+explains the metadata required for PHP code fences in `README.md` and `docs/`.
+
 ## Technical prose
 
 Use the [technical writing standard](docs/architecture/technical-writing.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,13 +10,20 @@ Greenlight requires PHP 8.4 or later. The documentation checks require Node.js
 Run `make docs-install` to install the documentation dependencies and Chromium
 for the browser tests.
 
+## Code and architecture
+
+Use the [code conventions](docs/architecture/conventions.md).
+Read the [architecture overview](docs/architecture/README.md) for module
+responsibilities and dependency direction.
+Keep dependencies within the boundaries in [deptrac.yaml](deptrac.yaml).
+
 ## Documentation sources
 
 Edit guides in `docs/`. The website uses these Markdown files directly.
 Architecture pages in `docs/architecture/` remain repository documentation.
 
-The API reference is generated from public PHP declarations and PHPDoc in
-`src/`. Edit those sources, then run:
+The API generator reads public PHP declarations and PHPDoc in `src/`.
+To change the API reference, edit those sources. Then run:
 
 ```sh
 npm --prefix website run api:generate
@@ -52,6 +59,21 @@ Before you push prose changes, review the prose:
 - Review each `-ing` form. Correct each verbal use.
 - Put only one instruction in each sentence.
 
+## Tests
+
+Add focused unit or acceptance tests for behavior changes.
+Use `Greenlight\Expect` for assertions.
+Use the [test conventions](docs/architecture/conventions.md#tests) for test
+names, assertion exceptions, and shared fixture changes.
+
+Run focused tests with:
+
+```sh
+php bin/greenlight run --filter='<test-id>'
+```
+
+Replace `<test-id>` with the test ID to run.
+
 ## Before you push
 
 Run:
@@ -76,7 +98,7 @@ Submit changes in pull requests to `main`.
 Greenlight uses squash merges. The pull request title becomes the commit
 message. Use the
 [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/)
-format:
+format for commit messages and pull request titles:
 
 ```text
 type(scope): short description

--- a/docs/architecture/documentation-php-examples.md
+++ b/docs/architecture/documentation-php-examples.md
@@ -5,6 +5,10 @@ Rector. The check uses generated files because both tools operate most reliably
 on PHP files and projects. It does not change the documentation or extend the
 tools.
 
+The extractor reads `README.md` and Markdown files below `docs/`. It does not
+read PHP examples in website components, issue templates, or other root files.
+Review those examples separately.
+
 The generated workspace is disposable. It is in `build/docs-php`. Do not commit
 its contents. `composer docs:php:check` replaces this
 directory on each run.
@@ -47,7 +51,7 @@ members. The extractor keeps the imports outside the class.
 
 Use `display` only when analysis would make the example less useful. Give each display
 example a nonempty `reason`. Do not use the other fields for that example. Add
-metadata to every PHP fence in a manually maintained document. The command
+metadata to every PHP fence in a manually maintained document within this scope. The command
 fails when metadata is absent. Generated reference documents are excluded from
 the inventory because their source generator owns their PHP examples.
 

--- a/docs/architecture/technical-writing.md
+++ b/docs/architecture/technical-writing.md
@@ -24,7 +24,7 @@ The checker also examines structured text fields, script strings and comments,
 and PHP strings that resemble messages. It examines extensionless PHP command
 entry points. It checks multiline PHPDoc tag descriptions, visible Markdown
 link labels, and website accessibility attributes. It applies only mandatory
-rules to PHPDoc tag descriptions and human-readable strings. Review all strings
+rules to PHPDoc tag descriptions and PHP message strings. Review all strings
 manually because code literals can resemble prose.
 
 ## Writing rules


### PR DESCRIPTION
The contributor guide did not link code and test conventions or explain how to run focused tests. `AGENTS.md` repeated shared rules, which could drift from the contributor documentation.

Make `CONTRIBUTING.md` the shared entry point for contributor guidance. Add architecture and dependency references, focused-test instructions, and commit-message requirements. Reduce `AGENTS.md` to links to the shared guidance and the existing agent completion checks.

Document the maintained sources for guides, API pages, and website text, including API regeneration and generated-directory rules. Clarify that PHP example extraction covers only `README.md` and `docs/`. Correct the prose policy to distinguish PHP message strings from script and JSON text.
