### PR TITLE
docs: correct internal behavior descriptions

### DIFF
--- a/src/Discovery/TestDiscoverer.php
+++ b/src/Discovery/TestDiscoverer.php
@@ -14,8 +14,9 @@ use Random\Engine\Mt19937;
 use Random\Randomizer;
 
 /**
- * Discovery does not invoke test methods. It invokes only user callables that
- * are data providers.
+ * Builds an execution plan from test metadata and data providers.
+ * Discovery loads test classes through registered autoloaders. It does not
+ * invoke test methods or lifecycle hooks.
  *
  * @internal
  */
@@ -96,8 +97,8 @@ final readonly class TestDiscoverer
     }
 
     /**
-     * Uses Fisher-Yates with a seeded engine. Thus, the same seed always
-     * produces the same class order without dependence on global random state.
+     * Uses Fisher-Yates with a seeded engine. The same input order and seed
+     * produce the same class order without dependence on global random state.
      *
      * @param list<non-empty-string> $classes
      *

--- a/src/Execution/Worker/ClassContext.php
+++ b/src/Execution/Worker/ClassContext.php
@@ -76,10 +76,10 @@ final class ClassContext
      *
      * The method gets them from #[DataRow] attributes and the #[DataSet] data
      * provider.
- *
-     * The execution plan supplies the key. If the method data sets do not
-     * contain it, the code changed after discovery. This condition is an
-     * error.
+     *
+     * The execution plan supplies the key. If the current data sets do not
+     * contain it, Greenlight reports an error. The code or provider output
+     * can differ from discovery.
      *
      * @param non-empty-string|null $provider
      * @param non-empty-string|null $providerClass

--- a/src/Execution/Worker/TestExecutor.php
+++ b/src/Execution/Worker/TestExecutor.php
@@ -48,9 +48,9 @@ use Greenlight\Test\TestId;
  *
  * An `After` hook runs if constructor injection created a test instance. It
  * runs even when a previous test-body operation did not complete.
- * `applyAfterSubscribers()` preserves the test identity. It validates each
- * outcome change against the transformation log. Greenlight removes each
- * reference to the test instance when the attempt ends.
+ * The plugin runtime preserves the test identity when it applies `afterTest()`
+ * results. It validates each outcome change against the transformation log.
+ * The executor releases its test-instance references when the attempt ends.
  *
  * @internal
  */

--- a/src/Internal/Filesystem/AtomicFileError.php
+++ b/src/Internal/Filesystem/AtomicFileError.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Greenlight\Internal\Filesystem;
 
 /**
- * Messages include the target path and each warning that PHP supplies.
+ * Reports a failure to name, write, or rename a temporary state file.
+ * The message includes the affected path and available failure details.
  *
  * @internal
  */


### PR DESCRIPTION
Internal comments make inaccurate claims about discovery, test lifecycles, and state-file errors. They also refer to an executor method that no longer exists.

Describe class loading through registered autoloaders and state that discovery does not invoke test methods or lifecycle hooks. Make reproducible shuffle order conditional on the same input order and seed. A missing data-set key can reflect a change to provider output as well as source code. Attribute `afterTest()` result validation to the plugin runtime and limit the reference-release claim to references owned by the executor.

Describe the actual atomic-file failure conditions without claiming that every error contains the final target path or every PHP warning. Write failures identify the temporary path, and the error trap keeps the last warning.

These descriptions follow `TestDiscoverer::resolveClass()`, `TestDiscoverer::shuffled()`, `ClassContext::argumentsFor()`, `TestExecutor::attempt()`, and `WorkerPluginRuntime::afterTest()`. Existing discovery tests exercise custom autoloaders and reproducible plans. This change affects comments only.
