### PR TITLE
docs: clarify container lifetimes and release errors

### DIFF
--- a/docs/psr11.md
+++ b/docs/psr11.md
@@ -124,7 +124,8 @@ new Psr11Plugin(
 );
 ```
 
-Tests on the same worker receive the same service instances.
+Tests on the same worker share the container. The container controls whether
+each service request returns an existing instance or a new instance.
 
 When the shared container is active, the callback runs after each test attempt.
 This includes an attempt that does not request the container.

--- a/docs/psr15.md
+++ b/docs/psr15.md
@@ -147,8 +147,10 @@ new Psr15Plugin(
 Greenlight calls the callback only if the harness has an active handler. It
 calls the callback when the configured service scope closes.
 
-The callback runs once for each active handler. If the callback throws,
-Greenlight reports a test error and keeps the throwable as its cause.
+The callback runs once when each active harness closes. With the default
+per-test scope, a callback failure gives an otherwise passed test an error.
+With per-worker scope, the failure makes the worker run unsuccessful.
+Greenlight keeps the throwable as the cause.
 
 ### Worker lifetime
 
@@ -180,5 +182,7 @@ The PSR-15 harness reports:
 A request failure identifies the handler, HTTP method, and URI path. The
 diagnostic omits the query because it can contain sensitive values.
 
-Each harness error keeps the original throwable as its cause. Greenlight also
-reports the application stack trace.
+When an application callback throws, the harness error keeps that throwable
+as its cause. Greenlight also reports its application stack trace. Errors such
+as an invalid handler or a closed harness have no original application
+throwable.

--- a/docs/symfony.md
+++ b/docs/symfony.md
@@ -111,7 +111,9 @@ mechanism Symfony uses between requests. The resetter resets services with the
 each stateful service that must keep tests isolated.
 
 The bridge captures and checks the resetter when the kernel boots. If service
-resets are active without a container resetter, every test fails.
+resets are active without a container resetter, each test that requests the
+kernel or a container service has an error. Tests that use only other harness
+services do not boot the kernel.
 
 For a container that has no stateful services, pass `resetBetweenTests: false`
 to the plugin. This value disables the resetter requirement. Do not use this


### PR DESCRIPTION
The container guides promise more than the bridges provide: a shared PSR-11 container can still return transient services, and lazy Symfony boot does not affect harness-only tests. The PSR-15 guide also assigns every release failure to a test and assumes every harness error wraps an application throwable.

Clarify container-controlled service lifetimes, Symfony's lazy resetter check, and per-test versus per-worker release failures. Distinguish callback failures from validation errors with no original throwable. These statements follow the bridge resolver methods, `HttpHarness`, `Psr15Error`, and `HarnessServiceDisposal`.
