### PR TITLE
docs: state double interception and disposal limits

### DIFF
--- a/docs/api-doubles.md
+++ b/docs/api-doubles.md
@@ -250,23 +250,27 @@ public function describe(): string;
 
 Namespace: `Greenlight\Doubles`
 
-Mocks are strict. A call without a planned expectation fails the test
-immediately. Each return value needs a configured result. Stubs cause an
-error for all interactions. Spies record calls to methods without a return
-value.
+Creates mocks, stubs, and spies. For intercepted methods, mocks fail on
+calls without a planned expectation. Each return value needs a configured
+result. Stubs cause an error for intercepted calls. Spies record intercepted
+calls to methods without a return value.
 
 A verification failure throws one `ExpectationFailed`. It contains one
 `FailureDetail` for each unmet expectation. Thus, the reporter shows it in
 the same format as an `Expect` failure.
 
-`Doubles` supports interfaces and non-final classes. Class constructors do
-not run. `Doubles` does not support partial mocks or static interception.
+`Doubles` supports interfaces and classes that are neither final nor
+readonly. Class constructors do not run. Final methods keep their original
+implementation. `Doubles` does not support partial mocks or static interception.
+
+Greenlight disposes injected factories after each test attempt. If you
+construct a factory directly, call `dispose()` to verify its mocks.
 
 ```php
 final class Doubles implements Disposable
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L26)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L30)
 
 ### `__construct()`
 
@@ -280,12 +284,12 @@ PHPDoc:
 - `@throws \InvalidArgumentException if the proxy directory is empty`
 - `@throws InvalidDoubleUsage if PHP cannot resolve the default working directory`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L54)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L58)
 
 ### `mock()`
 
-Creates a strict double. Verification checks each planned expectation
-at test end. A call without an expectation fails the test immediately.
+Creates a strict double. Disposal checks each planned expectation.
+An intercepted call without an expectation fails the test immediately.
 
 ```php
 public function mock(string $type, ?\Closure $plan = null): object
@@ -299,13 +303,13 @@ PHPDoc:
 - `@return T`
 - `@throws InvalidDoubleUsage`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L91)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L95)
 
 ### `stub()`
 
-Creates an inert double that satisfies the specified type. All
-interactions cause a test error. Use a mock with explicit expectations
-when a collaborator must supply results.
+Creates a double that satisfies the specified type. Intercepted calls
+cause a test error. Use a mock with explicit expectations when a
+collaborator must supply results.
 
 ```php
 public function stub(string $type): object
@@ -318,13 +322,13 @@ PHPDoc:
 - `@return T`
 - `@throws InvalidDoubleUsage`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L108)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L112)
 
 ### `spy()`
 
-Creates a spy that records each call and its arguments. A call to a
-method that returns a value causes a test error. Use `callsTo()` to get the
-calls. Use `Expect` to check them.
+Creates a spy that records intercepted calls and their arguments.
+An intercepted method that returns a value causes a test error.
+Use `callsTo()` to get the calls. Use `Expect` to check them.
 
 ```php
 public function spy(string $type): object
@@ -337,7 +341,7 @@ PHPDoc:
 - `@return T`
 - `@throws InvalidDoubleUsage`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L125)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L129)
 
 ### `callsTo()`
 
@@ -354,7 +358,7 @@ PHPDoc:
 - `@return list<list<mixed>>`
 - `@throws InvalidDoubleUsage`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L138)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L142)
 
 ### `dispose()`
 
@@ -369,7 +373,7 @@ PHPDoc:
 
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L163)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L167)
 
 ## `Fake`
 

--- a/src/Doubles/Doubles.php
+++ b/src/Doubles/Doubles.php
@@ -11,17 +11,21 @@ use Greenlight\Result\FailureDetail;
 use Greenlight\Test\ExpectationCounter;
 
 /**
- * Mocks are strict. A call without a planned expectation fails the test
- * immediately. Each return value needs a configured result. Stubs cause an
- * error for all interactions. Spies record calls to methods without a return
- * value.
+ * Creates mocks, stubs, and spies. For intercepted methods, mocks fail on
+ * calls without a planned expectation. Each return value needs a configured
+ * result. Stubs cause an error for intercepted calls. Spies record intercepted
+ * calls to methods without a return value.
  *
  * A verification failure throws one `ExpectationFailed`. It contains one
  * `FailureDetail` for each unmet expectation. Thus, the reporter shows it in
  * the same format as an `Expect` failure.
  *
- * `Doubles` supports interfaces and non-final classes. Class constructors do
- * not run. `Doubles` does not support partial mocks or static interception.
+ * `Doubles` supports interfaces and classes that are neither final nor
+ * readonly. Class constructors do not run. Final methods keep their original
+ * implementation. `Doubles` does not support partial mocks or static interception.
+ *
+ * Greenlight disposes injected factories after each test attempt. If you
+ * construct a factory directly, call `dispose()` to verify its mocks.
  */
 final class Doubles implements Disposable
 {
@@ -77,8 +81,8 @@ final class Doubles implements Disposable
     }
 
     /**
-     * Creates a strict double. Verification checks each planned expectation
-     * at test end. A call without an expectation fails the test immediately.
+     * Creates a strict double. Disposal checks each planned expectation.
+     * An intercepted call without an expectation fails the test immediately.
      *
      * @template T of object
      *
@@ -94,9 +98,9 @@ final class Doubles implements Disposable
     }
 
     /**
-     * Creates an inert double that satisfies the specified type. All
-     * interactions cause a test error. Use a mock with explicit expectations
-     * when a collaborator must supply results.
+     * Creates a double that satisfies the specified type. Intercepted calls
+     * cause a test error. Use a mock with explicit expectations when a
+     * collaborator must supply results.
      *
      * @template T of object
      *
@@ -111,9 +115,9 @@ final class Doubles implements Disposable
     }
 
     /**
-     * Creates a spy that records each call and its arguments. A call to a
-     * method that returns a value causes a test error. Use `callsTo()` to get the
-     * calls. Use `Expect` to check them.
+     * Creates a spy that records intercepted calls and their arguments.
+     * An intercepted method that returns a value causes a test error.
+     * Use `callsTo()` to get the calls. Use `Expect` to check them.
      *
      * @template T of object
      *


### PR DESCRIPTION
The public double reference said that all non-final classes were supported and all stub interactions caused an error. The implementation rejects readonly classes and preserves final methods, which still execute their original code.

State these limits explicitly, qualify mock/stub/spy behavior as applying to intercepted calls, and explain that callers who construct a factory directly must dispose it to verify its mocks. Injected factories still receive automatic disposal after each attempt.

These details follow `ProxyGenerator::reflectDoubleable()` and `renderMethod()`, the built-in per-test harness registration, and `Doubles::dispose()`. The existing final-method test covers the retained implementation. Regenerate the API page from the source PHPDoc.
