### PR TITLE
docs: refresh PHPStan diagnostic examples

### DIFF
--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -374,8 +374,8 @@ Typical messages:
 ```text
 Data provider sums() for adds() does not exist on PriceTest.
 Data provider PriceTest::sums() must be public and static.
-Data provider PriceTest::sums() must return an iterable of argument arrays, returns string.
-Data provider sums() row argument #3 of adds() expects int, string given.
+Data provider PriceTest::sums() must return an iterable of argument arrays. It returns string.
+Data provider sums() row argument #3 for adds() has type string, but the parameter requires int.
 #[DataRow] supplies 2 arguments, but adds() expects exactly 3.
 ```
 


### PR DESCRIPTION
Two diagnostic examples still show wording that the PHPStan extension no longer emits. Update the return-type and row-argument examples to match the current format strings in `DataProviderSignatureRule`.
