### PR TITLE
fix(documentation): preserve symbolic link targets during cleanup

### DIFF
--- a/src/Documentation/PhpExample/Workspace.php
+++ b/src/Documentation/PhpExample/Workspace.php
@@ -244,7 +244,7 @@ final readonly class Workspace
 
     private function removeDirectory(string $directory, string $allowedParent): void
     {
-        if (!\file_exists($directory)) {
+        if (!\file_exists($directory) && !\is_link($directory)) {
             return;
         }
 
@@ -253,6 +253,14 @@ final readonly class Workspace
 
         if (!\str_starts_with($normalizedDirectory, $normalizedParent . '/docs-php')) {
             throw DocumentationExampleError::unexpectedRemovalDirectory($directory);
+        }
+
+        if (\is_link($directory)) {
+            if (!\unlink($directory)) {
+                throw DocumentationExampleError::generatedFileRemovalFailed($directory);
+            }
+
+            return;
         }
 
         $iterator = new \RecursiveIteratorIterator(
@@ -265,7 +273,7 @@ final readonly class Workspace
                 throw DocumentationExampleError::unknownGeneratedEntry();
             }
 
-            if ($item->isDir()) {
+            if ($item->isDir() && !$item->isLink()) {
                 if (!\rmdir($item->getPathname())) {
                     throw DocumentationExampleError::generatedDirectoryRemovalFailed($item->getPathname());
                 }

--- a/tests/Unit/Documentation/PhpExample/WorkspaceSymbolicLinkTest.php
+++ b/tests/Unit/Documentation/PhpExample/WorkspaceSymbolicLinkTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Documentation\PhpExample;
+
+use Greenlight\Attribute\DataRow;
+use Greenlight\Attribute\Test;
+use Greenlight\Documentation\PhpExample\Workspace;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+
+final readonly class WorkspaceSymbolicLinkTest
+{
+    public function __construct(private TemporaryDirectory $temporaryDirectory) {}
+
+    #[Test]
+    #[DataRow(['docs-php'], label: 'destination')]
+    #[DataRow(['staging'], label: 'staging')]
+    #[DataRow(['docs-php/nested'], label: 'nested')]
+    public function publicationPreservesSymbolicLinkTargets(string $entry): void
+    {
+        $root = $this->temporaryDirectory->subdirectory('project');
+        $target = $this->temporaryDirectory->subdirectory('target');
+        $path = $root . '/build/' . ($entry === 'staging' ? 'docs-php.next-' . \getmypid() : $entry);
+        \mkdir(\dirname($path), 0o777, true);
+        \file_put_contents($target . '/sentinel.txt', 'keep');
+        \symlink($target, $path);
+
+        (new Workspace())->publish($root, []);
+
+        Expect::that(\file_get_contents($target . '/sentinel.txt'))->toBe('keep');
+        Expect::that(\is_link($path))->toBeFalse();
+        Expect::that(\is_file($root . '/build/docs-php/manifest.json'))->toBeTrue();
+    }
+
+    #[Test]
+    public function publicationReplacesABrokenDestinationLink(): void
+    {
+        $root = $this->temporaryDirectory->subdirectory('project');
+        \mkdir($root . '/build');
+        \symlink($root . '/missing', $root . '/build/docs-php');
+
+        (new Workspace())->publish($root, []);
+
+        Expect::that(\is_link($root . '/build/docs-php'))->toBeFalse();
+        Expect::that(\is_file($root . '/build/docs-php/manifest.json'))->toBeTrue();
+    }
+}

--- a/tests/Unit/Documentation/PhpExample/WorkspaceSymbolicLinkTest.php
+++ b/tests/Unit/Documentation/PhpExample/WorkspaceSymbolicLinkTest.php
@@ -27,7 +27,7 @@ final readonly class WorkspaceSymbolicLinkTest
         \file_put_contents($target . '/sentinel.txt', 'keep');
         \symlink($target, $path);
 
-        (new Workspace())->publish($root, []);
+        new Workspace()->publish($root, []);
 
         Expect::that(\file_get_contents($target . '/sentinel.txt'))->toBe('keep');
         Expect::that(\is_link($path))->toBeFalse();
@@ -41,7 +41,7 @@ final readonly class WorkspaceSymbolicLinkTest
         \mkdir($root . '/build');
         \symlink($root . '/missing', $root . '/build/docs-php');
 
-        (new Workspace())->publish($root, []);
+        new Workspace()->publish($root, []);
 
         Expect::that(\is_link($root . '/build/docs-php'))->toBeFalse();
         Expect::that(\is_file($root . '/build/docs-php/manifest.json'))->toBeTrue();


### PR DESCRIPTION
The documentation PHP generator recursively deletes files through an existing `build/docs-php` or staging symbolic link, then fails when it tries to remove the link as a directory. A disposable reproduction confirmed that the target sentinel file was deleted. Nested directory links and broken destination links also prevent publication.

Remove links with `unlink()` before directory traversal and treat nested links as files. Four regression cases failed before the fix and now pass, with 11 expectations that cover target preservation and successful publication.
