### PR TITLE
fix(ci): restore temporary directory portability cases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -459,8 +459,8 @@ jobs:
             --filter=ServerSocketUnixCleanupTest \
             --filter=SocketChannelTest \
             --filter=SuitePathDiscoveryTest \
-            --filter=TempDirectoryRootSymbolicLinkTest \
-            --filter=TempDirectorySubdirectoryLinkTest \
+            --filter=TemporaryDirectoryRootSymbolicLinkTest \
+            --filter=TemporaryDirectorySubdirectoryLinkTest \
             --filter=TerminalTest \
             --filter=WorkerProcessRunTest
 


### PR DESCRIPTION
The macOS smoke job used two obsolete `TempDirectory...` filters. They selected zero tests, which omitted root symbolic-link cleanup and subdirectory symbolic-link rejection from macOS CI.

Use the current `TemporaryDirectory...` class names. The old filters select zero tests. The corrected filters run all five existing regression cases on macOS, with 13 passing expectations. The workflow shell contract check also passes.
