### PR TITLE
fix(expect): avoid canonical sort key collisions

### DIFF
--- a/src/Expect/Equality.php
+++ b/src/Expect/Equality.php
@@ -44,7 +44,8 @@ final class Equality
             // Compute each key one time for each element. A comparator
             // serializes both operands again for each comparison.
             $keys = \array_map(static fn(mixed $item): string => self::sortKey($item, []), $canonical);
-            \array_multisort($keys, \SORT_ASC, \SORT_STRING, $canonical);
+            \asort($keys, \SORT_STRING);
+            $canonical = \array_map(static fn(int $index): mixed => $canonical[$index], \array_keys($keys));
         }
 
         return $canonical;
@@ -71,17 +72,16 @@ final class Equality
             return '[' . \implode(',', $parts) . ']';
         }
 
-        if (\is_int($value)) {
-            // A float cannot hold an integer above 2**53 exactly. Keep the
-            // exact digits to give different large integers different keys.
-            // Otherwise, the integers can remain in their initial positions.
-            return \abs($value) <= 2 ** 53
-                ? 'number:' . (float) $value
-                : 'number:' . $value;
-        }
+        if (\is_int($value) || \is_float($value)) {
+            if (\is_int($value) && (int) (float) $value !== $value) {
+                return 'integer:' . $value;
+            }
 
-        if (\is_float($value)) {
-            return 'number:' . $value;
+            $number = (float) $value;
+
+            // Keep every float bit without depending on display precision.
+            // Both signs of zero compare equal and need the same key.
+            return 'number:' . \bin2hex(\pack('E', $number === 0.0 ? 0.0 : $number));
         }
 
         if ($value instanceof \DateTimeInterface) {

--- a/src/Expect/Equality.php
+++ b/src/Expect/Equality.php
@@ -79,9 +79,13 @@ final class Equality
 
             $number = (float) $value;
 
-            // Keep every float bit without depending on display precision.
             // Both signs of zero compare equal and need the same key.
-            return 'number:' . \bin2hex(\pack('E', $number === 0.0 ? 0.0 : $number));
+            if ($number === 0.0) {
+                return 'number:zero';
+            }
+
+            // Keep every float bit without depending on display precision.
+            return 'number:' . \bin2hex(\pack('E', $number));
         }
 
         if ($value instanceof \DateTimeInterface) {

--- a/tests/Unit/Expect/CanonicalSortCollisionTest.php
+++ b/tests/Unit/Expect/CanonicalSortCollisionTest.php
@@ -27,6 +27,7 @@ final class CanonicalSortCollisionTest
         $second = 1.000000000000002;
 
         Expect::that([$first, $second])->toEqualCanonicalizing([$second, $first]);
+        Expect::that([$first, $first])->not()->toEqualCanonicalizing([$first, $second]);
     }
 
     #[Test]
@@ -35,6 +36,14 @@ final class CanonicalSortCollisionTest
         $integer = 2 ** 54;
 
         Expect::that([$integer, 17.0])->toEqualCanonicalizing([17.0, (float) $integer]);
+    }
+
+    #[Test]
+    public function exactLargeNegativeIntegerAndFloatValuesShareSortPositions(): void
+    {
+        $integer = -(2 ** 54);
+
+        Expect::that([$integer, -17.0])->toEqualCanonicalizing([-17.0, (float) $integer]);
     }
 
     #[Test]

--- a/tests/Unit/Expect/CanonicalSortCollisionTest.php
+++ b/tests/Unit/Expect/CanonicalSortCollisionTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+
+final class CanonicalSortCollisionTest
+{
+    #[Test]
+    public function equalCyclicObjectsDoNotTriggerNativeRecursiveComparison(): void
+    {
+        $first = new \stdClass();
+        $first->next = $first;
+        $second = new \stdClass();
+        $second->next = $second;
+
+        Expect::that([$first, $second])->toEqualCanonicalizing([$second, $first]);
+    }
+
+    #[Test]
+    public function nearbyFloatsKeepDistinctSortPositions(): void
+    {
+        $first = 1.000000000000001;
+        $second = 1.000000000000002;
+
+        Expect::that([$first, $second])->toEqualCanonicalizing([$second, $first]);
+    }
+
+    #[Test]
+    public function exactLargeIntegerAndFloatValuesShareSortPositions(): void
+    {
+        $integer = 2 ** 54;
+
+        Expect::that([$integer, 17.0])->toEqualCanonicalizing([17.0, (float) $integer]);
+    }
+
+    #[Test]
+    public function signedZeroValuesShareSortPositions(): void
+    {
+        Expect::that([-0.0, -1.0])->toEqualCanonicalizing([-1.0, 0.0]);
+    }
+}


### PR DESCRIPTION
Canonical equality can throw a recursive-dependency error when equal sort keys cause PHP to compare cyclic objects as a tie-breaker. It can also reject equal lists that contain signed zero or exactly representable large integer/float pairs because those values receive different keys.

Sort the key-to-index map and rebuild the list without comparing the original values. Use a precise binary float representation for numeric keys, normalize signed zero, and retain exact integer keys when a float cannot represent the integer.

The new cases reproduce one recursive-comparison error and two false mismatches before the fix. The five regression cases pass with six expectations, including negative large integer/float pairs and a check that nearby floats remain distinct when their multiplicities differ. The canonical selection passes 38 tests with 57 expectations. An explicit zero key preserves signed-zero equality under the configured Rector rules. This change adds an index mapping; it does not claim a performance improvement.

A separate existing limitation remains: distinct objects with equal properties can compare unequal when repeated references are reordered, such as [a, a, b] versus [a, b, a]. The audit records that reference-matching defect separately.
