### PR TITLE
fix(execution): reset the hard timeout for each retry

### DIFF
--- a/docs/architecture/worker-lifecycle.md
+++ b/docs/architecture/worker-lifecycle.md
@@ -322,7 +322,8 @@ that kills its process would kill each replacement in turn.
 ### Timeouts
 
 The orchestrator enforces each test timeout with a grace window of twice the
-budget plus two seconds. The worker may be too stuck to enforce the timeout
+budget plus two seconds. Each valid attempt-start message resets this window.
+The worker may be too stuck to enforce the timeout
 itself. When the grace window expires, the orchestrator kills the process with
 SIGKILL and handles it as a crash. It reports the test as timed out.
 

--- a/docs/architecture/worker-lifecycle.md
+++ b/docs/architecture/worker-lifecycle.md
@@ -322,14 +322,15 @@ that kills its process would kill each replacement in turn.
 ### Timeouts
 
 The orchestrator enforces each test timeout with a grace window of twice the
-budget plus two seconds. Each valid attempt-start message resets this window.
-The worker may be too stuck to enforce the timeout
+budget plus two seconds. The worker may be too stuck to enforce the timeout
 itself. When the grace window expires, the orchestrator kills the process with
 SIGKILL and handles it as a crash. It reports the test as timed out.
 
 The worker also gives `eventually()` and `consistently()` the current attempt's
 monotonic deadline. Their polling stops at that deadline, but a probe can still
 block. The orchestrator's grace window remains the hard limit.
+
+Each valid attempt-start message resets the orchestrator's grace window.
 
 ### Fatal errors
 

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -380,8 +380,6 @@ Greenlight enforces a timeout in two layers. The worker checks elapsed time
 cooperatively and fails a test that exceeds its budget. If the worker does not
 return, the orchestrator terminates it after the hard-kill grace period.
 
-Each retry starts a new timeout budget and a new hard-kill grace period.
-
 The orchestrator replaces the stopped worker and continues the run.
 
 An `eventually()` or `consistently()` matcher cannot run past the current test
@@ -395,6 +393,8 @@ period.
 #[Timeout(seconds: 5.0)]
 public function convergesQuickly(): void { ... }
 ```
+
+Each retry starts a new timeout budget and a new hard-kill grace period.
 
 ## AllowParallel
 

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -380,6 +380,8 @@ Greenlight enforces a timeout in two layers. The worker checks elapsed time
 cooperatively and fails a test that exceeds its budget. If the worker does not
 return, the orchestrator terminates it after the hard-kill grace period.
 
+Each retry starts a new timeout budget and a new hard-kill grace period.
+
 The orchestrator replaces the stopped worker and continues the run.
 
 An `eventually()` or `consistently()` matcher cannot run past the current test

--- a/src/Execution/ProcessPool/Orchestrator/Orchestrator.php
+++ b/src/Execution/ProcessPool/Orchestrator/Orchestrator.php
@@ -609,6 +609,7 @@ final class Orchestrator
         if ($event instanceof TestStarted) {
             $handle->inFlight = $event->id;
             $handle->inFlightSince = $this->monotonicTime();
+            $handle->inFlightAttemptSince = $handle->inFlightSince;
             $handle->inFlightAttempt = 0;
         }
 
@@ -662,7 +663,7 @@ final class Orchestrator
         }
 
         $handle->inFlightAttempt = $message->attempt;
-        $handle->inFlightSince = $this->monotonicTime();
+        $handle->inFlightAttemptSince = $this->monotonicTime();
     }
 
     /**
@@ -777,7 +778,7 @@ final class Orchestrator
                 continue;
             }
 
-            $deadline = $handle->inFlightSince + $budget * self::TIMEOUT_GRACE_FACTOR + self::TIMEOUT_GRACE_FLAT_SECONDS;
+            $deadline = $handle->inFlightAttemptSince + $budget * self::TIMEOUT_GRACE_FACTOR + self::TIMEOUT_GRACE_FLAT_SECONDS;
 
             if ($this->monotonicTime() > $deadline) {
                 $this->containTimeout($handle, $sink, $budget);

--- a/src/Execution/ProcessPool/Orchestrator/Orchestrator.php
+++ b/src/Execution/ProcessPool/Orchestrator/Orchestrator.php
@@ -662,6 +662,7 @@ final class Orchestrator
         }
 
         $handle->inFlightAttempt = $message->attempt;
+        $handle->inFlightSince = $this->monotonicTime();
     }
 
     /**

--- a/src/Execution/ProcessPool/Orchestrator/WorkerState.php
+++ b/src/Execution/ProcessPool/Orchestrator/WorkerState.php
@@ -42,6 +42,8 @@ final class WorkerState
 
     public float $inFlightSince = 0.0;
 
+    public float $inFlightAttemptSince = 0.0;
+
     /** @var non-negative-int */
     public int $inFlightAttempt = 0;
 

--- a/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorRetryTimeoutTest.php
+++ b/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorRetryTimeoutTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Execution\ProcessPool\Orchestrator;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\Plan\ExecutionPlan;
+use Greenlight\Discovery\Plan\PlanEntry;
+use Greenlight\Event\TestFinished;
+use Greenlight\Event\TestStarted;
+use Greenlight\Execution\ProcessPool\Orchestrator\Orchestrator;
+use Greenlight\Execution\ProcessPool\Protocol\Messages\AttemptStarted;
+use Greenlight\Execution\ProcessPool\Protocol\Messages\Done;
+use Greenlight\Execution\ProcessPool\Protocol\Messages\EventEnvelope;
+use Greenlight\Execution\ProcessPool\Protocol\Messages\Ready;
+use Greenlight\Expect\Expect;
+use Greenlight\Result\Outcome;
+use Greenlight\Result\ResultSummary;
+use Greenlight\Result\TestResult;
+use Greenlight\Test\ExecutionPolicy;
+use Greenlight\Test\RetryPolicy;
+use Greenlight\Test\TestDefinition;
+use Greenlight\Test\TestId;
+use Greenlight\Tests\Support\CollectingEventSink;
+use Greenlight\Tests\Support\ScriptedWorkerTransport;
+
+final readonly class OrchestratorRetryTimeoutTest
+{
+    #[Test]
+    public function eachRetryGetsANewHardTimeoutDeadline(): void
+    {
+        $id = new TestId('Example\RetryTest', 'passes');
+        $messages = [new Ready(), new EventEnvelope(new TestStarted($id, 1.0))];
+
+        for ($attempt = 1; $attempt <= 40; ++$attempt) {
+            $messages[] = new AttemptStarted($id, $attempt);
+        }
+
+        $messages[] = new EventEnvelope(new TestFinished(
+            new TestResult($id, Outcome::Passed, 0.08, 0, attempts: 40),
+            4.28,
+        ));
+        $messages[] = new Done(new ResultSummary(passed: 1), 1_024);
+        $transport = new ScriptedWorkerTransport([$messages], pollSeconds: 0.08);
+        $sink = new CollectingEventSink();
+
+        $summary = new Orchestrator($transport)->run($this->plan($id), $sink, 1);
+
+        Expect::that($summary->passed)->toBe(1);
+        Expect::that($summary->failed)->toBe(0);
+        Expect::that($sink->results()[0]->attempts)->toBe(40);
+        Expect::that($transport->started)->toHaveCount(1);
+    }
+
+    #[Test]
+    public function aBlockedRetryStillReachesItsHardTimeout(): void
+    {
+        $id = new TestId('Example\RetryTest', 'blocks');
+        $transport = new ScriptedWorkerTransport([[
+            new Ready(),
+            new EventEnvelope(new TestStarted($id, 1.0)),
+            new AttemptStarted($id, 1),
+            new AttemptStarted($id, 2),
+        ]], pollSeconds: 0.08);
+        $sink = new CollectingEventSink();
+
+        $summary = new Orchestrator($transport)->run($this->plan($id), $sink, 1);
+
+        Expect::that($summary->failed)->toBe(1);
+        Expect::that($sink->results()[0]->attempts)->toBe(2);
+        Expect::that($sink->results()[0]->failures[0]->message)->toContain('exceeded its 0.100-second time limit');
+    }
+
+    private function plan(TestId $id): ExecutionPlan
+    {
+        return new ExecutionPlan([new PlanEntry(new TestDefinition(
+            $id->class,
+            $id->method,
+            execution: new ExecutionPolicy(timeoutSeconds: 0.1),
+            retry: new RetryPolicy(39),
+        ))]);
+    }
+}

--- a/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorRetryTimeoutTest.php
+++ b/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorRetryTimeoutTest.php
@@ -70,6 +70,8 @@ final readonly class OrchestratorRetryTimeoutTest
         Expect::that($summary->failed)->toBe(1);
         Expect::that($sink->results()[0]->attempts)->toBe(2);
         Expect::that($sink->results()[0]->failures[0]->message)->toContain('exceeded its 0.100-second time limit');
+        Expect::that($sink->results()[0]->durationSeconds)->toBeGreaterThan(2.3);
+        Expect::that($sink->results()[0]->failures[0]->message)->toContain('after 2.400 seconds');
     }
 
     private function plan(TestId $id): ExecutionPlan

--- a/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorRetryTimeoutTest.php
+++ b/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorRetryTimeoutTest.php
@@ -79,8 +79,8 @@ final readonly class OrchestratorRetryTimeoutTest
         return new ExecutionPlan([new PlanEntry(new TestDefinition(
             $id->class,
             $id->method,
-            execution: new ExecutionPolicy(timeoutSeconds: 0.1),
             retry: new RetryPolicy(39),
+            execution: new ExecutionPolicy(timeoutSeconds: 0.1),
         ))]);
     }
 }


### PR DESCRIPTION
A test with retries can exceed the orchestrator hard-kill window across several attempts, even when each attempt stays within its timeout. The worker gives each attempt a new timeout, but the orchestrator kept the first test start time and could stop a valid retry before it finished.

Reset the hard-kill deadline when the orchestrator accepts a valid attempt-start message. Keep a separate test start time so synthetic timeout results still report the total duration. A deterministic regression runs 40 attempts of 0.08 seconds with a 0.1-second budget: it fails before the fix and passes afterward. A second regression confirms that a blocked retry still reaches its hard timeout and retains its attempt count and total duration. The two focused regressions pass with nine expectations.
