### PR TITLE
fix: preserve canonical equality for cycles and exact numbers

### DIFF
--- a/src/Expect/Equality.php
+++ b/src/Expect/Equality.php
@@ -44,7 +44,10 @@ final class Equality
             // Compute each key one time for each element. A comparator
             // serializes both operands again for each comparison.
             $keys = \array_map(static fn(mixed $item): string => self::sortKey($item, []), $canonical);
-            \array_multisort($keys, \SORT_ASC, \SORT_STRING, $canonical);
+            // Sort keys only. A native comparison of equal-key values can
+            // recurse without a limit when those values contain cycles.
+            \asort($keys, \SORT_STRING);
+            $canonical = \array_map(static fn(int $index): mixed => $canonical[$index], \array_keys($keys));
         }
 
         return $canonical;
@@ -71,17 +74,15 @@ final class Equality
             return '[' . \implode(',', $parts) . ']';
         }
 
-        if (\is_int($value)) {
-            // A float cannot hold an integer above 2**53 exactly. Keep the
-            // exact digits to give different large integers different keys.
-            // Otherwise, the integers can remain in their initial positions.
-            return \abs($value) <= 2 ** 53
-                ? 'number:' . (float) $value
-                : 'number:' . $value;
+        if (\is_int($value) && (int) (float) $value !== $value) {
+            // Keep exact digits when a float cannot represent the integer.
+            return 'integer:' . $value;
         }
 
-        if (\is_float($value)) {
-            return 'number:' . $value;
+        if (\is_int($value) || \is_float($value)) {
+            // Seventeen significant digits distinguish finite doubles. Zero
+            // has one key because positive and negative zero are equal.
+            return 'number:' . ($value === 0 || $value === 0.0 ? '0' : \sprintf('%.17g', $value));
         }
 
         if ($value instanceof \DateTimeInterface) {

--- a/tests/Unit/Expect/CanonicalSortCollisionTest.php
+++ b/tests/Unit/Expect/CanonicalSortCollisionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Expect\Node;
+
+final readonly class CanonicalSortCollisionTest
+{
+    #[Test]
+    public function canonicalEqualityAcceptsEqualCyclicListElements(): void
+    {
+        $first = new Node();
+        $first->next = $first;
+        $second = new Node();
+        $second->next = $second;
+
+        Expect::that([$first, $second])->toEqualCanonicalizing([$second, $first]);
+    }
+
+    #[Test]
+    #[DataSet('exactNumbers')]
+    public function canonicalEqualityAlignsExactIntegersAndFloats(int $integer, float $float, int $other): void
+    {
+        Expect::that([$integer, $other])->toEqualCanonicalizing([(float) $other, $float]);
+    }
+
+    /** @return iterable<string, array{int, float, int}> */
+    public static function exactNumbers(): iterable
+    {
+        yield 'large positive integer' => [2 ** 54, (float) (2 ** 54), 15];
+        yield 'large negative integer' => [-(2 ** 54), (float) -(2 ** 54), -15];
+        yield 'negative zero' => [0, -0.0, -1];
+    }
+
+    #[Test]
+    public function canonicalEqualityDistinguishesFloatsWithTheSameShortRepresentation(): void
+    {
+        $first = 1.000000000000001;
+        $second = 1.000000000000002;
+
+        Expect::that([$second, $first])->toEqualCanonicalizing([$first, $second]);
+        Expect::that([$first, $first])->not()->toEqualCanonicalizing([$first, $second]);
+    }
+}


### PR DESCRIPTION
`toEqualCanonicalizing()` can throw a recursive-dependency error for equal cyclic objects. When sort keys match, `array_multisort()` compares the values with PHP's native object comparison. Sort only the cached keys and use their indices to reorder the values.

Canonical numeric keys also differ for some equal integer and float values. For example, `[2 ** 54, 15]` does not match `[15.0, (float) (2 ** 54)]`. Use a full-precision numeric representation, keep integers that floats cannot represent exact, and give both signed zeros the same key.

Focused regressions cover equal cyclic elements, positive and negative large integers, signed zero, and close float values. The existing canonical equality suite also passes. No performance improvement is claimed.
