### PR TITLE
fix: preserve harness factories and disposal order for lazy services

### DIFF
--- a/src/Harness/ScopeContainer.php
+++ b/src/Harness/ScopeContainer.php
@@ -22,6 +22,9 @@ final class ScopeContainer
      */
     private array $services = [];
 
+    /** @var list<object> */
+    private array $initializedServices = [];
+
     /**
      * @throws UnresolvableService
      */
@@ -49,7 +52,7 @@ final class ScopeContainer
     {
         $failures = [];
 
-        foreach (\array_reverse($this->services) as $service) {
+        while (($service = \array_pop($this->initializedServices)) !== null) {
             $reflection = new \ReflectionClass($service);
 
             if ($reflection->isUninitializedLazyObject($service)) {
@@ -78,7 +81,8 @@ final class ScopeContainer
     private function instantiate(ServiceDefinition $definition): object
     {
         $reflection = new \ReflectionClass($definition->type);
-        $factory = static function () use ($definition): object {
+        $initializedServices = &$this->initializedServices;
+        $factory = static function () use ($definition, &$initializedServices): object {
             $service = ($definition->factory)();
 
             if (!$service instanceof $definition->type) {
@@ -88,16 +92,21 @@ final class ScopeContainer
                 );
             }
 
+            $initializedServices[] = $service;
+
             return $service;
         };
 
         try {
-            return $reflection->newLazyProxy($factory);
+            $proxy = $reflection->newLazyProxy($factory);
         } catch (\ReflectionException|\Error) {
             // Greenlight constructs a class immediately if PHP cannot create a
             // lazy proxy for it. The factory has not run, so this catch does
             // not hide a factory error.
             return $factory();
         }
+
+        // PHP does not make stateless classes lazy and does not call their initializer.
+        return $reflection->isUninitializedLazyObject($proxy) ? $proxy : $factory();
     }
 }

--- a/tests/Unit/Harness/ScopeContainerLazyDisposalOrderTest.php
+++ b/tests/Unit/Harness/ScopeContainerLazyDisposalOrderTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Harness;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Harness\Scope;
+use Greenlight\Harness\ScopeContainer;
+use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Tests\Fixture\Harness\FailingDisposable;
+use Greenlight\Tests\Fixture\Lifecycle\Services\SecondaryServiceProbe;
+use Greenlight\Tests\Fixture\Lifecycle\Services\ServiceProbe;
+use Greenlight\Tests\Fixture\Lifecycle\TraceLog;
+
+final class ScopeContainerLazyDisposalOrderTest
+{
+    #[Test]
+    public function statelessServicesUseTheirFactoryAndRemainDisposable(): void
+    {
+        $calls = 0;
+        $container = new ScopeContainer();
+        $container->get(new ServiceDefinition(
+            FailingDisposable::class,
+            Scope::PerTest,
+            static function () use (&$calls): FailingDisposable {
+                ++$calls;
+
+                return new FailingDisposable();
+            },
+        ));
+
+        Expect::that($calls)->toBe(1);
+        Expect::that($container->dispose())->toHaveCount(1);
+        Expect::that($container->dispose())->toBe([]);
+    }
+
+    #[Test]
+    public function lazyServicesDisposeInReverseInitializationOrder(): void
+    {
+        ServiceProbe::reset();
+        TraceLog::drain();
+        $container = new ScopeContainer();
+        $first = $container->get(new ServiceDefinition(
+            ServiceProbe::class,
+            Scope::PerTest,
+            static fn(): ServiceProbe => new ServiceProbe(),
+        ));
+        $second = $container->get(new ServiceDefinition(
+            SecondaryServiceProbe::class,
+            Scope::PerTest,
+            static fn(): SecondaryServiceProbe => new SecondaryServiceProbe(),
+        ));
+
+        Expect::that($first)->toBeInstanceOf(ServiceProbe::class);
+        Expect::that($second)->toBeInstanceOf(SecondaryServiceProbe::class);
+        $second->touch();
+        $first->touch();
+
+        Expect::that($container->dispose())->toBe([]);
+        Expect::that(TraceLog::drain())->toBe([
+            'secondary:created',
+            'secondary:touched',
+            'probe1:created',
+            'probe1:touched',
+            'probe1:disposed',
+            'secondary:disposed',
+        ]);
+        Expect::that($container->dispose())->toBe([]);
+        Expect::that(TraceLog::drain())->toBe([]);
+    }
+}


### PR DESCRIPTION
Harness services now use their registered factories and dispose in reverse creation order when PHP lazy proxies are involved. Previously, reverse proxy-request order could dispose a dependency before a service created later. PHP also skips the initializer entirely for classes without instance properties, so those service factories never ran.

Record services when their factories succeed, and dispose that list in reverse order. When PHP returns an object that is already non-lazy, call the factory immediately. Untouched lazy services remain unconstructed, failed factories remain undisposed, and one disposal failure does not stop the remaining cleanup.

The regressions first fail with reversed disposal events and zero calls to a stateless service factory. Both now pass, along with all 75 harness-related cases and 174 expectations.
