### PR TITLE
fix(phpstan): resolve generated IDE helper types

### DIFF
--- a/src/PhpStan/IdeHelper.php
+++ b/src/PhpStan/IdeHelper.php
@@ -85,6 +85,8 @@ final readonly class IdeHelper
                 namespace %s;
 
                 /**
+                 * @template T
+                 *
                 %s
                  */
                 final class %s {}

--- a/src/PhpStan/MatcherMap.php
+++ b/src/PhpStan/MatcherMap.php
@@ -206,8 +206,9 @@ final readonly class MatcherMap
         }
 
         $nullable = $type->allowsNull() && !\in_array($type->getName(), ['mixed', 'null'], true);
+        $qualifier = $type->isBuiltin() || \in_array($type->getName(), ['self', 'static', 'parent'], true) ? '' : '\\';
 
-        return ($nullable ? '?' : '') . self::resolvedTypeName($type->getName(), $scopeClass);
+        return ($nullable ? '?' : '') . $qualifier . self::resolvedTypeName($type->getName(), $scopeClass);
     }
 
     /** @param ?\ReflectionClass<object> $scopeClass */

--- a/tests/Acceptance/IdeHelperTypeResolutionTest.php
+++ b/tests/Acceptance/IdeHelperTypeResolutionTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\PhpStan\IdeHelper;
+use Greenlight\PhpStan\MatcherMap;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\FixturePath;
+use Greenlight\Tests\Support\PhpSubprocess;
+use Greenlight\Tests\Support\ProjectFiles;
+
+#[RequiresResource('analysis-process')]
+final readonly class IdeHelperTypeResolutionTest
+{
+    public function __construct(private TemporaryDirectory $temporaryDirectory) {}
+
+    #[Test]
+    public function generatedMatcherTypesResolveInTheHelperNamespace(): void
+    {
+        $project = ProjectFiles::create($this->temporaryDirectory, 'helper');
+        $map = MatcherMap::fromConfigFiles([FixturePath::get('PhpStanIdeHelperDnf/greenlight.php')]);
+        $project->write('helper.php', IdeHelper::render($map));
+        $project->write('phpstan.neon', "parameters:\n    level: 2\n    tmpDir: cache\n");
+        $result = PhpSubprocess::run($project->directory, [
+            \dirname(__DIR__, 2) . '/vendor/bin/phpstan',
+            'analyse',
+            '--configuration=' . $project->path('phpstan.neon'),
+            '--no-progress',
+            '--error-format=raw',
+            $project->path('helper.php'),
+        ]);
+
+        Expect::that($result->exitCode)->because('PHPStan output: ' . $result->output())->toBe(0);
+    }
+}

--- a/tests/Unit/PhpStan/IdeHelperTest.php
+++ b/tests/Unit/PhpStan/IdeHelperTest.php
@@ -36,6 +36,6 @@ final class IdeHelperTest
 
         Expect::that(IdeHelper::render($map))
             ->because('generated matcher annotations preserve disjunctive normal form types')
-            ->toContain(' * @method self toCompareWith((Countable&Iterator)|string $comparison)');
+            ->toContain(' * @method self toCompareWith((\\Countable&\\Iterator)|string $comparison)');
     }
 }

--- a/tests/Unit/PhpStan/MatcherMapTest.php
+++ b/tests/Unit/PhpStan/MatcherMapTest.php
@@ -113,6 +113,6 @@ final class MatcherMapTest
     {
         yield 'untyped' => ['untyped', 'mixed'];
         yield 'union' => ['union', 'string|int'];
-        yield 'intersection' => ['intersection', 'Countable&Iterator'];
+        yield 'intersection' => ['intersection', '\\Countable&\\Iterator'];
     }
 }


### PR DESCRIPTION
Generated IDE helpers place matcher annotations in `Greenlight\Expect` but omit the leading namespace separator from reflected class types. An independent PHPStan run resolves `Countable`, `Iterator`, `Throwable`, and `Closure` to nonexistent classes in that namespace. The helper also uses `Expectation<T>` without declaring its template.

Qualify reflected class names and declare the copied expectation template. A new acceptance test analyzes the generated helper without the Greenlight extension. It fails on the original output and passes with these changes. Existing union and intersection signature expectations now require fully qualified names.
