### PR TITLE
perf(coverage): bound reports for unavailable source

### DIFF
--- a/src/Coverage/Export/HtmlExporter.php
+++ b/src/Coverage/Export/HtmlExporter.php
@@ -16,8 +16,8 @@ use Greenlight\Internal\Php\ErrorTrap;
  * absolute. Each file page name contains a hash of its absolute path. Thus,
  * page names are deterministic and safe for a file system.
  *
- * If Greenlight cannot read a source file, the page shows only line numbers
- * and statuses.
+ * If Greenlight cannot read a source file, the page shows only known coverage
+ * line numbers and statuses. It omits gaps between those lines.
  *
  * @internal
  */
@@ -158,15 +158,12 @@ final readonly class HtmlExporter implements CoverageExporter
 
         $lineHits = $file->lineHits();
         $source = $this->highlightedLines($file->file);
-        $lastLine = $source === null
-            ? (\array_key_last($lineHits) ?? 0)
-            : \count($source);
-
         $body .= '<pre>' . "\n";
 
-        for ($line = 1; $line <= $lastLine; ++$line) {
+        foreach ($source ?? \array_fill_keys(\array_keys($lineHits), '') as $index => $text) {
+            $line = $source === null ? $index : $index + 1;
             $lineClass = ($lineHits[$line] ?? null) === 1 ? 'cov' : (isset($lineHits[$line]) ? 'unc' : '');
-            $content = \sprintf('<span class="num">%d</span>%s', $line, $source[$line - 1] ?? '');
+            $content = \sprintf('<span class="num">%d</span>%s', $line, $text);
             // Lines with a class appear as blocks. A final newline adds an
             // empty line box inside the <pre>.
             $body .= $lineClass === '' ? $content . "\n" : \sprintf('<span class="%s">%s</span>', $lineClass, $content);

--- a/tests/Unit/Coverage/Export/HtmlExporterSparseSourceTest.php
+++ b/tests/Unit/Coverage/Export/HtmlExporterSparseSourceTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage\Export;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Coverage\Export\HtmlExporter;
+use Greenlight\Coverage\FileCoverage;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+
+final readonly class HtmlExporterSparseSourceTest
+{
+    public function __construct(private TemporaryDirectory $directory) {}
+
+    #[Test]
+    #[DataSet('distantLines')]
+    public function unavailableSourceShowsOnlyKnownCoverageLines(int $lastLine): void
+    {
+        $path = $this->directory->path() . '/missing.php';
+        $map = new CoverageMap([new FileCoverage($path, [2], [$lastLine])]);
+        $page = new HtmlExporter()->export($map)[HtmlExporter::pageName($path)];
+
+        Expect::that($page)
+            ->toContain('<span class="cov"><span class="num">2</span></span>')
+            ->toContain(\sprintf('<span class="unc"><span class="num">%d</span></span>', $lastLine));
+        Expect::that(\substr_count($page, '<span class="num">'))->toBe(2);
+    }
+
+    /** @return iterable<string, array{positive-int}> */
+    public static function distantLines(): iterable
+    {
+        yield 'large gap' => [10_000];
+        yield 'maximum line' => [\PHP_INT_MAX];
+    }
+}


### PR DESCRIPTION
HTML coverage reports can consume excessive memory when source files are unavailable. The fallback rendered every line from 1 to the largest coverage line, even when the imported map contained only one executable line. A valid line number of `PHP_INT_MAX` could prevent the export from completing.

Render only known coverage lines when source text is unavailable. Keep their line numbers and covered or uncovered status. Readable files still show every source line. Two regression cases cover a large gap and the maximum integer line. The existing HTML cases pass, including empty, unreadable, restricted, escaped, and highlighted source output.

On PHP 8.4.14 with Xdebug disabled, a missing source with one covered line at 1,000,000 changed as follows. Times are medians of five exports after one warmup:

| Measurement | Before | After |
| --- | ---: | ---: |
| Export time | 293.651 ms | 0.005 ms |
| Additional peak memory | 63,803,312 bytes | 6,784 bytes |
| File page size | 31,891,348 bytes | 2,485 bytes |

A readable source produced identical HTML bytes and the same 23,696-byte additional peak memory. Its measured time was 0.106 ms before and 0.111 ms after. Small timing differences are noise. The missing-source improvement removes work proportional to the largest line number. It omits blank gaps for which no source text exists.

Run this benchmark body after the project autoloader loads. Use `XDEBUG_MODE=off`, one warmup, and five measured runs on each revision:

```php
$map = new Greenlight\Coverage\CoverageMap([
    new Greenlight\Coverage\FileCoverage('/no/such/file.php', [1_000_000], []),
]);
memory_reset_peak_usage();
$baseline = memory_get_usage();
$start = hrtime(true);
$pages = new Greenlight\Coverage\Export\HtmlExporter()->export($map);
printf("%.3f ms; %d additional peak bytes\n",
    (hrtime(true) - $start) / 1e6,
    memory_get_peak_usage() - $baseline,
);
```
