### PR TITLE
perf(execution): poll worker diagnostic pipe readiness

### DIFF
--- a/src/Execution/ProcessPool/Orchestrator/NativeWorkerTransport.php
+++ b/src/Execution/ProcessPool/Orchestrator/NativeWorkerTransport.php
@@ -121,7 +121,8 @@ final class NativeWorkerTransport implements WorkerTransport
             }
 
             foreach ([$handle->stdout, $handle->stderr] as $pipe) {
-                if (\is_resource($pipe) && !\feof($pipe)) {
+                // Windows cannot select process pipes.
+                if (\PHP_OS_FAMILY !== 'Windows' && \is_resource($pipe) && !\feof($pipe)) {
                     $read[] = $pipe;
                 }
             }

--- a/src/Execution/ProcessPool/Orchestrator/NativeWorkerTransport.php
+++ b/src/Execution/ProcessPool/Orchestrator/NativeWorkerTransport.php
@@ -119,6 +119,12 @@ final class NativeWorkerTransport implements WorkerTransport
             if ($handle->lifecycle === WorkerLifecycle::Active && $handle->channel !== null) {
                 $read[] = $handle->channel->stream();
             }
+
+            foreach ([$handle->stdout, $handle->stderr] as $pipe) {
+                if (\is_resource($pipe) && !\feof($pipe)) {
+                    $read[] = $pipe;
+                }
+            }
         }
 
         $waitMicroseconds = $this->hasRetiringWorkers() ? 10_000 : 200_000;

--- a/tests/Unit/Execution/ProcessPool/Orchestrator/NativeWorkerDiagnosticsTest.php
+++ b/tests/Unit/Execution/ProcessPool/Orchestrator/NativeWorkerDiagnosticsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Execution\ProcessPool\Orchestrator;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Attribute\Timeout;
+use Greenlight\Execution\ProcessPool\Orchestrator\NativeWorkerTransport;
+use Greenlight\Execution\ProcessPool\Orchestrator\WorkerTransportEventKind;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\PhpSubprocess;
+
+final readonly class NativeWorkerDiagnosticsTest
+{
+    #[Test]
+    #[DataSet('streams')]
+    #[Timeout(30.0)]
+    public function largeDiagnosticWritesCompleteAndKeepTheBoundedTail(string $stream): void
+    {
+        $transport = NativeWorkerTransport::listen(PhpSubprocess::command([
+            '-r',
+            \sprintf('fwrite(%s, str_repeat("x", 1024 * 1024) . "final diagnostic");', $stream),
+        ]), \dirname(__DIR__, 5));
+
+        try {
+            $transport->start('diagnostics', 1);
+            $disconnected = false;
+
+            while (!$disconnected) {
+                foreach ($transport->poll() as $event) {
+                    if ($event->kind === WorkerTransportEventKind::WorkerDisconnected) {
+                        $disconnected = true;
+                    }
+                }
+            }
+
+            Expect::that($transport->diagnostics('diagnostics'))
+                ->toBe(\str_repeat('x', 65_536 - \strlen('final diagnostic')) . 'final diagnostic');
+        } finally {
+            $transport->close();
+        }
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function streams(): iterable
+    {
+        yield 'standard output' => ['STDOUT'];
+        yield 'standard error' => ['STDERR'];
+    }
+}

--- a/tools/worker-diagnostics-benchmark.php
+++ b/tools/worker-diagnostics-benchmark.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+namespace Greenlight\Tools;
+
 use Greenlight\Execution\ProcessPool\Orchestrator\NativeWorkerTransport;
 use Greenlight\Execution\ProcessPool\Orchestrator\WorkerTransportEventKind;
 

--- a/tools/worker-diagnostics-benchmark.php
+++ b/tools/worker-diagnostics-benchmark.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Greenlight\Execution\ProcessPool\Orchestrator\NativeWorkerTransport;
+use Greenlight\Execution\ProcessPool\Orchestrator\WorkerTransportEventKind;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+// Measure pipe throughput without worker protocol messages.
+foreach (['STDOUT', 'STDERR'] as $stream) {
+    for ($sample = 1; $sample <= 3; ++$sample) {
+        $transport = NativeWorkerTransport::listen([
+            \PHP_BINARY,
+            '-n',
+            '-r',
+            \sprintf('fwrite(%s, str_repeat("x", 1024 * 1024));', $stream),
+        ], \dirname(__DIR__));
+        $startedAt = \hrtime(true);
+        $polls = 0;
+
+        try {
+            $transport->start('diagnostics', 1);
+            $disconnected = false;
+
+            while (!$disconnected) {
+                ++$polls;
+
+                foreach ($transport->poll() as $event) {
+                    if ($event->kind === WorkerTransportEventKind::WorkerDisconnected) {
+                        $disconnected = true;
+                    }
+                }
+            }
+
+            \printf(
+                "%s sample=%d bytes=1048576 seconds=%.6f polls=%d retained=%d\n",
+                $stream,
+                $sample,
+                (\hrtime(true) - $startedAt) / 1_000_000_000,
+                $polls,
+                \strlen($transport->diagnostics('diagnostics')),
+            );
+        } finally {
+            $transport->close();
+        }
+    }
+}


### PR DESCRIPTION
Worker stdout and stderr were absent from the transport read set. When a direct write filled a pipe, the worker could not continue until the 200 ms protocol poll expired. Repeated waits slowed large diagnostic writes and could consume test timeout budgets.

Include open diagnostic pipes in the read set on supported platforms. Windows keeps its existing polling because PHP cannot select process pipes there. Exclude pipes after EOF so closed streams do not cause an idle polling loop. The existing bounded diagnostic tail remains unchanged. Native regressions cover large writes to both streams.

The included benchmark emits 1 MiB through each stream without protocol messages, with three samples per stream. On PHP 8.4.14/macOS, median stdout time fell from 2.260 seconds to 0.122 seconds, and median stderr time fell from 1.423 seconds to 0.094 seconds. Every sample retained the same 65,536-byte tail. More polls can occur while output is active because the transport responds to ready pipes immediately.
