### PR TITLE
fix: resolve generated IDE helper types

### DIFF
--- a/src/PhpStan/IdeHelper.php
+++ b/src/PhpStan/IdeHelper.php
@@ -85,6 +85,8 @@ final readonly class IdeHelper
                 namespace %s;
 
                 /**
+                 * @template T
+                 *
                 %s
                  */
                 final class %s {}

--- a/src/PhpStan/MatcherMap.php
+++ b/src/PhpStan/MatcherMap.php
@@ -207,7 +207,13 @@ final readonly class MatcherMap
 
         $nullable = $type->allowsNull() && !\in_array($type->getName(), ['mixed', 'null'], true);
 
-        return ($nullable ? '?' : '') . self::resolvedTypeName($type->getName(), $scopeClass);
+        $name = $type->getName();
+
+        if (!$type->isBuiltin() && !\in_array($name, ['self', 'static', 'parent'], true)) {
+            $name = '\\' . $name;
+        }
+
+        return ($nullable ? '?' : '') . self::resolvedTypeName($name, $scopeClass);
     }
 
     /** @param ?\ReflectionClass<object> $scopeClass */

--- a/tests/Acceptance/IdeHelperTypeResolutionTest.php
+++ b/tests/Acceptance/IdeHelperTypeResolutionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\FixturePath;
+use Greenlight\Tests\Support\GreenlightCli;
+use Greenlight\Tests\Support\PhpSubprocess;
+
+#[RequiresResource('analysis-process')]
+final readonly class IdeHelperTypeResolutionTest
+{
+    public function __construct(private TemporaryDirectory $temporaryDirectory) {}
+
+    #[Test]
+    public function generatedHelperResolvesNativeAndExtensionTypes(): void
+    {
+        $root = \dirname(__DIR__, 2);
+        $helper = $this->temporaryDirectory->path() . '/helper.php';
+        $generated = GreenlightCli::run($root, [
+            'ide-helper',
+            '--config=' . FixturePath::get('IdeHelperClassNames/greenlight.php'),
+            '--output=' . $helper,
+        ]);
+        Expect::that($generated->exitCode)->toBe(0);
+
+        $configuration = $this->temporaryDirectory->path() . '/phpstan.neon';
+        \file_put_contents($configuration, "parameters:\n    level: 2\n");
+        $analysis = PhpSubprocess::run($root, [
+            $root . '/vendor/bin/phpstan',
+            'analyse',
+            '--no-progress',
+            '--error-format=json',
+            '--configuration=' . $configuration,
+            '--autoload-file=' . $root . '/vendor/autoload.php',
+            $helper,
+        ]);
+
+        Expect::that($analysis->exitCode)->because($analysis->output())->toBe(0);
+    }
+}

--- a/tests/Fixture/IdeHelperClassNames/ClassNamesExtension.php
+++ b/tests/Fixture/IdeHelperClassNames/ClassNamesExtension.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\IdeHelperClassNames;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Expect\ExpectationExtension;
+
+final class ClassNamesExtension implements ExpectationExtension, Fake
+{
+    /** @return array{toAcceptNames: \Closure(mixed, (\Countable&\Iterator<mixed, mixed>)|string, ?\DateTimeInterface, ClassNamesExtension): true} */
+    #[\Override]
+    public function matchers(): array
+    {
+        return [
+            'toAcceptNames' => static fn(
+                mixed $subject,
+                (\Countable&\Iterator)|string $comparison,
+                ?\DateTimeInterface $date,
+                ClassNamesExtension $extension,
+            ): bool => true,
+        ];
+    }
+}

--- a/tests/Fixture/IdeHelperClassNames/greenlight.php
+++ b/tests/Fixture/IdeHelperClassNames/greenlight.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Tests\Fixture\IdeHelperClassNames\ClassNamesExtension;
+
+return GreenlightConfig::create()
+    ->plugins(static fn(): ClassNamesExtension => new ClassNamesExtension());

--- a/tests/Unit/PhpStan/IdeHelperTest.php
+++ b/tests/Unit/PhpStan/IdeHelperTest.php
@@ -36,6 +36,6 @@ final class IdeHelperTest
 
         Expect::that(IdeHelper::render($map))
             ->because('generated matcher annotations preserve disjunctive normal form types')
-            ->toContain(' * @method self toCompareWith((Countable&Iterator)|string $comparison)');
+            ->toContain(' * @method self toCompareWith((\\Countable&\\Iterator)|string $comparison)');
     }
 }

--- a/tests/Unit/PhpStan/MatcherMapTest.php
+++ b/tests/Unit/PhpStan/MatcherMapTest.php
@@ -113,6 +113,6 @@ final class MatcherMapTest
     {
         yield 'untyped' => ['untyped', 'mixed'];
         yield 'union' => ['union', 'string|int'];
-        yield 'intersection' => ['intersection', 'Countable&Iterator'];
+        yield 'intersection' => ['intersection', '\\Countable&\\Iterator'];
     }
 }


### PR DESCRIPTION
Generated IDE helpers put unqualified class names inside the Greenlight\Expect namespace. Native and extension matcher annotations then resolve names such as Countable to nonexistent classes. The generated Expectation class also uses T without declaring its template. An acceptance test generates the helper through the CLI and analyzes the resulting file; it reports 44 errors before this change.

Qualify reflected class names and declare the Expectation template. Preserve built-in, nullable, intersection, and union types. The generated helper now passes analysis, and all 29 focused helper and matcher-map cases pass.
