### PR TITLE
fix(doubles): preserve arguments in generated calls

### DIFF
--- a/src/Doubles/CallHandler.php
+++ b/src/Doubles/CallHandler.php
@@ -33,7 +33,7 @@ final readonly class CallHandler
 
     /**
      * @param non-empty-string $method
-     * @param list<mixed> $arguments
+     * @param array<array-key, mixed> $arguments
      *
      * @throws ExpectationFailed
      * @throws InvalidDoubleUsage
@@ -45,35 +45,37 @@ final readonly class CallHandler
         $this->contracts->get($this->state->type, $method)
             ->assertCallArgumentCount(\count($arguments));
 
-        $this->state->recordedCalls[$method][] = $arguments;
+        $positionalArguments = \array_values($arguments);
+        $this->state->recordedCalls[$method][] = $positionalArguments;
 
         return match ($this->state->kind) {
-            DoubleKind::Mock => $this->invokeOnMock($double, $method, $arguments),
+            DoubleKind::Mock => $this->invokeOnMock($double, $method, $arguments, $positionalArguments),
             DoubleKind::Stub => throw InvalidDoubleUsage::stubWasCalled($this->state->type, $method),
             DoubleKind::Spy => $this->invokeOnSpy($double, $method),
         };
     }
 
     /**
-     * @param list<mixed> $arguments
+     * @param array<array-key, mixed> $arguments
+     * @param list<mixed> $positionalArguments
      *
      * @throws ExpectationFailed
      * @throws InvalidDoubleUsage
      */
-    private function invokeOnMock(object $double, string $method, array $arguments): mixed
+    private function invokeOnMock(object $double, string $method, array $arguments, array $positionalArguments): mixed
     {
         foreach ($this->state->expectationsFor($method) as $expectation) {
-            if ($expectation->isSaturated() || !$expectation->matchesArguments($arguments)) {
+            if ($expectation->isSaturated() || !$expectation->matchesArguments($positionalArguments)) {
                 continue;
             }
 
             ++$expectation->actualCalls;
-            $expectation->recordMatchedCall($arguments);
+            $expectation->recordMatchedCall($positionalArguments);
 
             return $this->answer($expectation, $double, $method, $arguments);
         }
 
-        $detail = $this->unexpectedCallDetail($method, $arguments);
+        $detail = $this->unexpectedCallDetail($method, $positionalArguments);
         $this->state->callFailures[] = $detail;
 
         throw ExpectationFailed::fromDetail($detail);
@@ -92,7 +94,7 @@ final readonly class CallHandler
     }
 
     /**
-     * @param list<mixed> $arguments
+     * @param array<array-key, mixed> $arguments
      * @throws InvalidDoubleUsage
      */
     private function answer(MethodExpectation $expectation, object $double, string $method, array $arguments): mixed

--- a/src/Doubles/ProxyGenerator.php
+++ b/src/Doubles/ProxyGenerator.php
@@ -272,6 +272,25 @@ final readonly class ProxyGenerator
 
     private function renderInvocationArguments(\ReflectionMethod $method): string
     {
+        $arguments = $this->renderPositionalArguments($method);
+
+        if (!$method->isVariadic()) {
+            return $arguments;
+        }
+
+        $parameters = $method->getParameters();
+        $last = $parameters[\count($parameters) - 1];
+
+        return \sprintf(
+            '\\array_merge(\\array_slice(%s, 0, %d), $%s)',
+            $arguments,
+            \count($parameters) - 1,
+            $last->name,
+        );
+    }
+
+    private function renderPositionalArguments(\ReflectionMethod $method): string
+    {
         $parameters = $method->getParameters();
 
         if (!\array_any($parameters, static fn(\ReflectionParameter $parameter): bool => $parameter->isPassedByReference())) {

--- a/src/Doubles/ProxyGenerator.php
+++ b/src/Doubles/ProxyGenerator.php
@@ -275,7 +275,13 @@ final readonly class ProxyGenerator
         $arguments = $this->renderPositionalArguments($method);
 
         if (!$method->isVariadic()) {
-            return $arguments;
+            return $arguments === '\\func_get_args()'
+                ? $arguments
+                : \sprintf(
+                    '\\array_merge(%s, \\array_slice(\\func_get_args(), %d))',
+                    $arguments,
+                    $method->getNumberOfParameters(),
+                );
         }
 
         $parameters = $method->getParameters();

--- a/tests/Fixture/Doubles/NamedVariadicContract.php
+++ b/tests/Fixture/Doubles/NamedVariadicContract.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+interface NamedVariadicContract
+{
+    public function record(string ...$values): void;
+
+    public function withPrefix(string $prefix = 'default', string ...$values): void;
+
+    public function mutate(string &$prefix, string &...$values): void;
+}

--- a/tests/Unit/Doubles/NamedVariadicArgumentTest.php
+++ b/tests/Unit/Doubles/NamedVariadicArgumentTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\MockPlan;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Doubles\NamedVariadicContract;
+
+final readonly class NamedVariadicArgumentTest
+{
+    public function __construct(private Doubles $doubles) {}
+
+    #[Test]
+    public function spiesRecordPositionalAndNamedVariadicValues(): void
+    {
+        $spy = $this->doubles->spy(NamedVariadicContract::class);
+        $spy->record('one', second: 'two');
+
+        Expect::that($this->doubles->callsTo($spy, 'record'))->toBe([['one', 'two']]);
+    }
+
+    #[Test]
+    public function callbacksKeepNamesWhilePlansAndCaptorsUsePositions(): void
+    {
+        $captor = null;
+        $double = $this->doubles->mock(NamedVariadicContract::class, static function (MockPlan $plan) use (&$captor): void {
+            $captor = $plan->expects('record')->with('one', 'two')->once()
+                ->andReturnsUsing(static function (string ...$values): void {
+                    Expect::that($values)->toBe(['one', 'second' => 'two']);
+                })
+                ->captureArgument(1);
+        });
+        $double->record('one', second: 'two');
+
+        Expect::that($captor?->values())->toBe(['two']);
+    }
+
+    #[Test]
+    public function callbacksCanChangeFixedAndNamedVariadicReferences(): void
+    {
+        $double = $this->doubles->mock(NamedVariadicContract::class, static function (MockPlan $plan): void {
+            $plan->expects('mutate')->once()->andReturnsUsing(static function (string &$prefix, string &...$values): void {
+                $prefix .= ' changed';
+                Expect::that(\array_keys($values))->toBe(['tail']);
+                foreach ($values as &$value) {
+                    $value .= ' changed';
+                }
+            });
+        });
+        $prefix = 'prefix';
+        $tail = 'tail';
+        $double->mutate($prefix, tail: $tail);
+
+        Expect::that($prefix)->toBe('prefix changed');
+        Expect::that($tail)->toBe('tail changed');
+    }
+
+    #[Test]
+    public function namedVariadicValuesDoNotSupplyOmittedFixedArguments(): void
+    {
+        $double = $this->doubles->mock(NamedVariadicContract::class, static function (MockPlan $plan): void {
+            $plan->expects('withPrefix')->once()->andReturnsUsing(static function (string $prefix = 'callback-default', string ...$values): void {
+                Expect::that($prefix)->toBe('callback-default');
+                Expect::that($values)->toBe(['tail' => 'one']);
+                Expect::that(\func_num_args())->toBe(0);
+            });
+        });
+
+        $double->withPrefix(tail: 'one');
+        Expect::that($this->doubles->callsTo($double, 'withPrefix'))->toBe([['one']]);
+    }
+}

--- a/tests/Unit/Doubles/ReferenceArgumentCountTest.php
+++ b/tests/Unit/Doubles/ReferenceArgumentCountTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\InvalidDoubleUsage;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Doubles\Wide;
+
+final readonly class ReferenceArgumentCountTest
+{
+    public function __construct(private Doubles $doubles) {}
+
+    #[Test]
+    public function referenceMethodsRejectSurplusArguments(): void
+    {
+        $spy = $this->doubles->spy(Wide::class);
+        $items = [];
+
+        Expect::that(static function () use ($spy, &$items): void {
+            $spy->byReference($items, 'extra'); // @phpstan-ignore arguments.count (Deliberately passes too many arguments.)
+        })->toThrow(InvalidDoubleUsage::class, '/supplies 2 arguments, but the method accepts at most 1 argument/');
+    }
+}


### PR DESCRIPTION
Generated doubles omit named variadic arguments and truncate surplus arguments on methods with reference parameters. Spies silently lose values, mock callbacks miss names and reference updates, and surplus arguments bypass the existing call-count check.

Combine the supplied fixed arguments with the actual variadic parameter array. Keep names and references for callback invocation. Continue to use positional value lists for call records, plans and captors. Omitted optional fixed arguments remain omitted. Preserve surplus arguments on non-variadic reference methods so the handler can reject them.

All five new public-call cases fail before the fixes and pass afterward with 14 expectations. The complete doubles selection passes 244 tests with 483 expectations, including existing positional, named fixed-parameter and reference cases.
