### PR TITLE
fix: preserve explicit framework service selection

### DIFF
--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -545,9 +545,9 @@ PHPDoc:
 
 - `@param class-string<KernelInterface>|\Closure(): KernelInterface $kernel A kernel class name that Greenlight constructs as new $kernel($env, $debug), or a closure that constructs the kernel. Use a closure for other constructor requirements.`
 - `@param non-empty-string $env`
-- `@param bool $resetBetweenTests For a container without stateful services, use false to disable resets. Tests on one worker then share all service instances.`
+- `@param bool $resetBetweenTests For a container without stateful services, use false to disable resets. Tests on one worker then reuse the container without resets. Symfony service configuration determines which instances are shared.`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L54)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L55)
 
 ### `services()`
 
@@ -559,7 +559,7 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L75)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L76)
 
 ### `resolve()`
 
@@ -573,7 +573,7 @@ PHPDoc:
 - `@param list<object> $attributes`
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L88)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L89)
 
 ### `afterTest()`
 
@@ -581,7 +581,7 @@ PHPDoc:
 public function afterTest(TestContext $context, TestResult $result): TestResult
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L124)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L125)
 
 ## `TempestPlugin`
 

--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -113,7 +113,7 @@ PHPDoc:
 
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L129)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L131)
 
 ### `runWorker()`
 
@@ -128,7 +128,7 @@ PHPDoc:
 - `@return T`
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L186)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L188)
 
 ### `runTestAttempt()`
 
@@ -143,7 +143,7 @@ PHPDoc:
 - `@return T`
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L230)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L232)
 
 ## `LaravelPlugin`
 
@@ -211,7 +211,7 @@ PHPDoc:
 public function afterTest(TestContext $context, TestResult $result): TestResult
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L129)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L131)
 
 ## `Psr11Plugin`
 
@@ -581,7 +581,7 @@ PHPDoc:
 public function afterTest(TestContext $context, TestResult $result): TestResult
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L125)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L127)
 
 ## `TempestPlugin`
 

--- a/src/Hyperf/HyperfPlugin.php
+++ b/src/Hyperf/HyperfPlugin.php
@@ -92,10 +92,12 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemp
     public function resolve(string $type, array $attributes): ?object
     {
         $id = $type;
+        $explicit = false;
 
         foreach ($attributes as $attribute) {
             if ($attribute instanceof Service) {
                 $id = $attribute->id;
+                $explicit = true;
             }
         }
 
@@ -103,7 +105,7 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemp
             $container = $this->container();
 
             if (!$container->has($id)) {
-                if ($id !== $type) {
+                if ($explicit) {
                     throw HyperfBridgeError::unknownServiceId($id, $type);
                 }
 

--- a/src/Laravel/LaravelPlugin.php
+++ b/src/Laravel/LaravelPlugin.php
@@ -93,10 +93,12 @@ final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, Servi
     public function resolve(string $type, array $attributes): ?object
     {
         $id = $type;
+        $explicit = false;
 
         foreach ($attributes as $attribute) {
             if ($attribute instanceof Service) {
                 $id = $attribute->id;
+                $explicit = true;
             }
         }
 
@@ -104,7 +106,7 @@ final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, Servi
             $app = $this->application();
 
             if (!$app->bound($id)) {
-                if ($id !== $type) {
+                if ($explicit) {
                     throw LaravelBridgeError::unknownServiceId($id, $type);
                 }
 

--- a/src/Symfony/SymfonyPlugin.php
+++ b/src/Symfony/SymfonyPlugin.php
@@ -89,10 +89,12 @@ final class SymfonyPlugin implements AfterTestSubscriber, HarnessProvider, Servi
     public function resolve(string $type, array $attributes): ?object
     {
         $id = $type;
+        $explicit = false;
 
         foreach ($attributes as $attribute) {
             if ($attribute instanceof Service) {
                 $id = $attribute->id;
+                $explicit = true;
             }
         }
 
@@ -100,7 +102,7 @@ final class SymfonyPlugin implements AfterTestSubscriber, HarnessProvider, Servi
             $container = $this->container();
 
             if (!$container->has($id)) {
-                if ($id !== $type) {
+                if ($explicit) {
                     throw SymfonyBridgeError::unknownServiceId($id, $type);
                 }
 

--- a/src/Symfony/SymfonyPlugin.php
+++ b/src/Symfony/SymfonyPlugin.php
@@ -49,7 +49,8 @@ final class SymfonyPlugin implements AfterTestSubscriber, HarnessProvider, Servi
      * @param non-empty-string $env
      * @param bool $resetBetweenTests
      *   For a container without stateful services, use false to disable
-     *   resets. Tests on one worker then share all service instances.
+     *   resets. Tests on one worker then reuse the container without resets.
+     *   Symfony service configuration determines which instances are shared.
      */
     public function __construct(
         string|\Closure $kernel,

--- a/tests/Unit/Hyperf/HyperfExplicitServiceTest.php
+++ b/tests/Unit/Hyperf/HyperfExplicitServiceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Hyperf;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Harness\HarnessScopes;
+use Greenlight\Harness\Service;
+use Greenlight\Hyperf\HyperfBridgeError;
+use Greenlight\Hyperf\HyperfPlugin;
+use Greenlight\Tests\Support\Psr11\ArrayContainer;
+use Greenlight\Tests\Support\ServiceResolverProbe;
+
+final readonly class HyperfExplicitServiceTest
+{
+    #[Test]
+    public function anExplicitTypeIdStopsTheResolverChainWhenTheServiceIsMissing(): void
+    {
+        $plugin = new HyperfPlugin(__DIR__);
+        new \ReflectionProperty(HyperfPlugin::class, 'activeContainer')->setValue($plugin, new ArrayContainer([]));
+        $later = new ServiceResolverProbe(new \ArrayObject());
+        $scopes = new HarnessScopes([], [$plugin, $later]);
+
+        Expect::that(static fn(): object => $scopes->resolve(
+            \ArrayObject::class,
+            'test',
+            [new Service(\ArrayObject::class)],
+        ))->toThrow(HyperfBridgeError::class);
+        Expect::that($later->calls)->toBe(0);
+    }
+}

--- a/tests/Unit/Laravel/LaravelPluginTest.php
+++ b/tests/Unit/Laravel/LaravelPluginTest.php
@@ -137,6 +137,20 @@ final class LaravelPluginTest
     }
 
     #[Test]
+    public function anExplicitTypeIdStopsTheResolverChainWhenTheBindingIsMissing(): void
+    {
+        $later = new ServiceResolverProbe(new \ArrayObject());
+        $scopes = new HarnessScopes([], [$this->plugin(), $later]);
+
+        Expect::that(static fn(): object => $scopes->resolve(
+            \ArrayObject::class,
+            'test',
+            [new Service(\ArrayObject::class)],
+        ))->toThrow(LaravelBridgeError::class);
+        Expect::that($later->calls)->toBe(0);
+    }
+
+    #[Test]
     public function anUnknownExplicitIdFailsLoudly(): void
     {
         $plugin = $this->plugin();

--- a/tests/Unit/Symfony/SymfonyPluginTest.php
+++ b/tests/Unit/Symfony/SymfonyPluginTest.php
@@ -96,6 +96,20 @@ final class SymfonyPluginTest
     }
 
     #[Test]
+    public function anExplicitTypeIdStopsTheResolverChainWhenTheServiceIsMissing(): void
+    {
+        $later = new ServiceResolverProbe(new \ArrayObject());
+        $scopes = new HarnessScopes([], [$this->plugin(), $later]);
+
+        Expect::that(static fn(): object => $scopes->resolve(
+            \ArrayObject::class,
+            'test',
+            [new Service(\ArrayObject::class)],
+        ))->toThrow(SymfonyBridgeError::class);
+        Expect::that($later->calls)->toBe(0);
+    }
+
+    #[Test]
     public function anUnknownExplicitIdFailsLoudly(): void
     {
         $plugin = $this->plugin();


### PR DESCRIPTION
An explicit `#[Service(Type::class)]` request can fall through to another resolver when the selected Symfony, Laravel, or Hyperf container lacks the service. This can supply a service from the wrong container and hide a missing binding.

Track whether a `Service` attribute was supplied, as the PSR-11 bridge already does. Missing explicit IDs now stop the resolver chain, including IDs that equal the requested type. Implicit type lookup keeps its fallback behavior.

Regenerate the API reference to keep framework source links current.
