### PR TITLE
fix: prepare temporal matchers independent of name case

### DIFF
--- a/src/Expect/ExpectationCall.php
+++ b/src/Expect/ExpectationCall.php
@@ -29,11 +29,13 @@ final readonly class ExpectationCall
      */
     public static function forTemporal(string $name, array $arguments): self
     {
-        if ($name === 'toBeIn') {
+        $nativeName = \strtolower($name);
+
+        if ($nativeName === 'tobein') {
             self::makeIterableReusable($arguments, 'haystack', 0);
         }
 
-        if ($name === 'toThrow') {
+        if ($nativeName === 'tothrow') {
             $throwable = self::argument($arguments, 'throwable', 0);
             $matching = self::argument($arguments, 'matching', 1);
             $message = self::argument($arguments, 'message', 2);

--- a/src/PhpStan/ToThrowConstraintRule.php
+++ b/src/PhpStan/ToThrowConstraintRule.php
@@ -36,7 +36,7 @@ final class ToThrowConstraintRule implements Rule
     #[\Override]
     public function processNode(Node $node, Scope $scope): array
     {
-        if (!$node->name instanceof Identifier || $node->name->toString() !== 'toThrow') {
+        if (!$node->name instanceof Identifier || \strtolower($node->name->toString()) !== 'tothrow') {
             return [];
         }
 

--- a/tests/Acceptance/PhpStanTemporalMatcherCaseTest.php
+++ b/tests/Acceptance/PhpStanTemporalMatcherCaseTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\PhpStanProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class PhpStanTemporalMatcherCaseTest
+{
+    public function __construct(private TemporaryDirectory $temporaryDirectory) {}
+
+    #[Test]
+    public function uppercaseNativeMatchersKeepTheirSignaturesAndConstraints(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->temporaryDirectory,
+            <<<'PHP'
+            <?php
+            use Greenlight\Expect\Expect;
+            Expect::eventually(static fn(): float => 1.0)->within(1.0)->toBeWithin(of: 1.0, delta: 0.1);
+            PHP,
+            <<<'PHP'
+            <?php
+            use Greenlight\Expect\Expect;
+            Expect::eventually(static fn(): float => 1.0)->within(1.0)->TOBEWITHIN(of: 1.0, delta: 'close');
+            Expect::eventually(static fn(): Closure => static function (): void {})->within(1.0)
+                ->TOTHROW(RuntimeException::class, matching: '/x/', message: 'x');
+            PHP,
+        );
+
+        Expect::that($probe->goodPassed)->toBeTrue();
+        Expect::that($probe->exitCode)->toBe(1);
+        Expect::that($probe->messages())->toContain('expects float, string given')
+            ->toContain('toThrow() accepts either matching: or message:, not both.')
+            ->not()->toContain('undefined method');
+    }
+}

--- a/tests/Unit/Expect/TemporalMatcherCaseTest.php
+++ b/tests/Unit/Expect/TemporalMatcherCaseTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\ExpectationFailed;
+use Greenlight\Expect\ExpectationRuntime;
+use Greenlight\Tests\Fixture\Expect\FakePollingClock;
+
+final class TemporalMatcherCaseTest
+{
+    #[Test]
+    public function uppercaseMembershipReusesAnIterableAcrossRetries(): void
+    {
+        $clock = new FakePollingClock();
+        $calls = 0;
+        $haystack = (static function (): \Generator {
+            yield 'ready';
+        })();
+
+        ExpectationRuntime::withClock($clock, static function () use (&$calls, $haystack): void {
+            Expect::eventually(static function () use (&$calls): string {
+                return ++$calls === 1 ? 'pending' : 'ready';
+            })->pollEvery(0.010)->within(0.100)->__call('TOBEIN', [$haystack]);
+        });
+
+        Expect::that($calls)->toBe(2);
+        Expect::that($clock->sleeps)->toEqual([0.010]);
+    }
+
+    #[Test]
+    public function uppercaseThrowableConstraintsFailBeforeTheProbeRuns(): void
+    {
+        $probed = false;
+        Expect::that(static function () use (&$probed): void {
+            Expect::eventually(static function () use (&$probed): \Closure {
+                $probed = true;
+
+                return static function (): void {};
+            })->within(0.100)->__call('TOTHROW', [\RuntimeException::class, 'matching' => '/x/', 'message' => 'x']);
+        })->toThrow(ExpectationFailed::class, matching: '/^Specify matching: or message:/');
+
+        Expect::that($probed)->toBeFalse();
+    }
+}


### PR DESCRIPTION
Native PHP matcher names are case insensitive, but temporal preparation compared exact spelling. `TOBEIN` consumes a one-shot iterator again on a retry and throws “Cannot traverse an already closed generator.” `TOTHROW` also runs the probe before rejecting incompatible throwable constraints, then retries that configuration failure until the deadline.

Normalize names only for native preparation checks and preserve the original name for dispatch. Apply the same case handling to PHPStan's throwable-constraint diagnostic. Three focused regressions fail before the change and pass after it: iterator replay, validation before probe execution, and the analyzer diagnostic. Native matcher signature checks remain in place.
