### PR TITLE
fix(artifacts): preserve staging root symlink targets

### DIFF
--- a/src/Execution/Artifact/ArtifactStore.php
+++ b/src/Execution/Artifact/ArtifactStore.php
@@ -499,6 +499,12 @@ final class ArtifactStore
         $this->runHandle?->close();
         $directory = $this->session->stagingDirectory;
 
+        if (\is_link($directory)) {
+            ErrorTrap::run(static fn() => \unlink($directory));
+
+            return;
+        }
+
         if (!\is_dir($directory)) {
             return;
         }

--- a/tests/Unit/Execution/Artifact/ArtifactCleanupRootSymlinkTest.php
+++ b/tests/Unit/Execution/Artifact/ArtifactCleanupRootSymlinkTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Execution\Artifact;
+
+use Greenlight\Attribute\DataRow;
+use Greenlight\Attribute\Test;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Execution\Artifact\ArtifactStore;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+
+final readonly class ArtifactCleanupRootSymlinkTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    #[DataRow([false], label: 'directory target')]
+    #[DataRow([true], label: 'missing target')]
+    public function cleanupRemovesTheRootLinkAndPreservesItsTarget(bool $broken): void
+    {
+        $root = $this->tempDirectory->path();
+        $target = $this->tempDirectory->subdirectory('target');
+        $sentinel = $target . '/keep.txt';
+        \file_put_contents($sentinel, 'keep');
+        $store = ArtifactStore::open(
+            new ArtifactConfiguration($root . '/output'),
+            $root,
+            'root-symlink',
+            temporaryDirectory: $root,
+        );
+        $staging = $store->session()->stagingDirectory;
+        \symlink($broken ? $target . '/missing' : $target, $staging);
+
+        try {
+            $store->cleanup();
+
+            Expect::that(\is_file($sentinel))
+                ->because('artifact cleanup preserves files outside its staging directory')
+                ->toBeTrue();
+            Expect::that(\file_get_contents($sentinel))->toBe('keep');
+            Expect::that(\is_link($staging))->toBeFalse();
+            $store->cleanup();
+        } finally {
+            if (\is_link($staging)) {
+                \unlink($staging);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Artifact cleanup follows a symbolic link when the link occupies the staging root. The recursive iterator then deletes files in the target directory. A broken root link is left behind. This differs from the existing behavior for links inside the staging directory.

Check the staging root before creating the iterator. Remove a root link and return, preserving its target and the existing idempotent cleanup behavior.

Two regression cases fail on the previous code: one loses a sentinel outside staging, and one retains a broken link. Both pass with this change. All four focused cleanup cases pass with 12 expectations, including the existing nested-link and repeated-cleanup cases.
