### PR TITLE
fix(phpstan): check values of unpacked containment arguments

### DIFF
--- a/src/PhpStan/NativeMatcherSubjectRule.php
+++ b/src/PhpStan/NativeMatcherSubjectRule.php
@@ -155,6 +155,10 @@ final class NativeMatcherSubjectRule implements Rule
 
         $needle = $scope->getType($argument->value);
 
+        if ($argument->unpack) {
+            $needle = $needle->getIterableValueType();
+        }
+
         if ($needle instanceof ErrorType || $needle instanceof MixedType || !new StringType()->accepts($needle, true)->no()) {
             return [];
         }

--- a/tests/Acceptance/PhpStanNativeMatcherSubjectRuleTest.php
+++ b/tests/Acceptance/PhpStanNativeMatcherSubjectRuleTest.php
@@ -18,6 +18,9 @@ final readonly class PhpStanNativeMatcherSubjectRuleTest
     #[Test]
     public function nativeMatcherSubjectTypesFollowExpectationChains(): void
     {
+        Expect::that('greenlight')->toContain(...['light']);
+        Expect::that('greenlight')->toContain(...['needle' => 'light']);
+
         $probe = PhpStanProbe::analyze(
             $this->tempDirectory,
             <<<'PHP'
@@ -30,6 +33,8 @@ final readonly class PhpStanNativeMatcherSubjectRuleTest
             function greenlightGoodNativeMatcherSubjectProbe(mixed $subject): void
             {
                 Expect::that('greenlight')->toContain('light');
+                Expect::that('greenlight')->toContain(...['light']);
+                Expect::that('greenlight')->toContain(...['needle' => 'light']);
                 Expect::that([1, 2])->toHaveCount(2);
                 Expect::that(new ArrayIterator())->toBeEmpty();
                 Expect::that('greenlight')->toHaveLength(10);
@@ -57,6 +62,8 @@ final readonly class PhpStanNativeMatcherSubjectRuleTest
             {
                 Expect::that(1)->toContain('1');
                 Expect::that('greenlight')->toContain(1);
+                Expect::that('greenlight')->toContain(...[1]);
+                Expect::that('greenlight')->toContain(...['needle' => []]);
                 Expect::that('greenlight')->toHaveCount(10);
                 Expect::that(1)->toBeEmpty();
                 Expect::that(1)->toHaveLength(1);
@@ -82,7 +89,7 @@ final readonly class PhpStanNativeMatcherSubjectRuleTest
 
         Expect::that($probe->exitCode)->because('native matchers require compatible subject types')->toBe(1);
         Expect::that($probe->goodPassed)->toBeTrue();
-        Expect::that(\count($probe->errors))->toBe(17);
+        Expect::that(\count($probe->errors))->toBe(19);
         Expect::that($probe->messages())->toContain('toContain() requires a string or iterable subject');
         Expect::that($probe->messages())->toContain('toContain() requires a string needle for a string subject');
         Expect::that($probe->messages())->toContain('toMatchJson() requires a string subject');


### PR DESCRIPTION
PHPStan rejects valid string containment calls when their arguments are unpacked. Both `toContain(...['light'])` and `toContain(...['needle' => 'light'])` pass at runtime, but the rule reports the containing array as the needle type.

Check the iterable's value type for an unpacked argument. The acceptance test now runs both valid forms and analyzes them without errors, while retaining diagnostics for unpacked integer and array needles. The regression failed before the change and passes with eight expectations after it.
