### PR TITLE
fix(cli): keep profiles out of machine reporter output

### DIFF
--- a/src/Cli/Reporting/ReporterFactory.php
+++ b/src/Cli/Reporting/ReporterFactory.php
@@ -16,6 +16,7 @@ use Greenlight\Reporting\Profile\ProfileReporter;
 use Greenlight\Reporting\Reporter;
 use Greenlight\Reporting\ReporterDefinition;
 use Greenlight\Reporting\RunHeader;
+use Greenlight\Reporting\StreamOutput;
 use Greenlight\Reporting\Style;
 
 /**
@@ -107,9 +108,12 @@ final readonly class ReporterFactory
         $reporters = $outputs->createReporters($catalog);
 
         if ($arguments->has('profile')) {
+            $machineOutput = $outputs->writesOnlyReportersToStandardOutput('jsonl', 'junit');
             $reporters[] = new ProfileReporter(
-                $outputs->standardOutput,
-                new Style($outputs->standardOutput->capabilities->color),
+                $machineOutput ? new StreamOutput($this->console->stderr()) : $outputs->standardOutput,
+                $machineOutput
+                    ? $this->console->stderrStyle($arguments->has('no-ansi'))
+                    : new Style($outputs->standardOutput->capabilities->color),
             );
         }
 

--- a/src/Cli/Reporting/ReporterOutputPlan.php
+++ b/src/Cli/Reporting/ReporterOutputPlan.php
@@ -139,6 +139,25 @@ final readonly class ReporterOutputPlan
         );
     }
 
+    public function writesOnlyReportersToStandardOutput(string ...$names): bool
+    {
+        $selected = false;
+
+        foreach ($this->selections as $selection) {
+            if ($selection['output'] !== $this->standardOutput) {
+                continue;
+            }
+
+            if (!\in_array($selection['name'], $names, true)) {
+                return false;
+            }
+
+            $selected = true;
+        }
+
+        return $selected;
+    }
+
     /**
      * @return array{non-empty-string, ?non-empty-string}
      *

--- a/tests/Acceptance/ProfileMachineOutputTest.php
+++ b/tests/Acceptance/ProfileMachineOutputTest.php
@@ -35,7 +35,9 @@ final readonly class ProfileMachineOutputTest
                 static fn(string $line): mixed => \json_decode($line, true, flags: \JSON_THROW_ON_ERROR),
                 \explode("\n", \trim($report)),
             );
-            Expect::that(\array_column($events, 'event'))->toContain('run-started', 'run-finished');
+            Expect::that(\array_column($events, 'event'))
+                ->toContain('run-started')
+                ->toContain('run-finished');
         } else {
             $document = \simplexml_load_string($report);
             Expect::that($document)->toBeInstanceOf(\SimpleXMLElement::class);

--- a/tests/Acceptance/ProfileMachineOutputTest.php
+++ b/tests/Acceptance/ProfileMachineOutputTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\GreenlightCli;
+
+final readonly class ProfileMachineOutputTest
+{
+    public function __construct(private TemporaryDirectory $directory) {}
+
+    #[Test]
+    #[DataSet('destinations')]
+    public function profilingKeepsMachineReportsParseable(string $reporter, bool $fileOutput): void
+    {
+        $project = AcceptanceProject::createWithOnePassingTest($this->directory, 'profile-machine-output');
+        $result = GreenlightCli::run($project->directory, [
+            'run',
+            '--reporter=' . $reporter . ($fileOutput ? '=report.out' : ''),
+            '--profile',
+            '--no-ansi',
+        ]);
+
+        Expect::that($result->exitCode)->toBe(0);
+        $report = $fileOutput ? (string) \file_get_contents($project->path('report.out')) : $result->stdout;
+
+        if ($reporter === 'jsonl') {
+            $events = \array_map(
+                static fn(string $line): mixed => \json_decode($line, true, flags: \JSON_THROW_ON_ERROR),
+                \explode("\n", \trim($report)),
+            );
+            Expect::that(\array_column($events, 'event'))->toContain('run-started', 'run-finished');
+        } else {
+            $document = \simplexml_load_string($report);
+            Expect::that($document)->toBeInstanceOf(\SimpleXMLElement::class);
+            Expect::that((string) $document['tests'])->toBe('1');
+        }
+
+        Expect::that($fileOutput ? $result->stdout : $result->stderr)->toContain('Profile:');
+        Expect::that($report)->not()->toContain('Profile:');
+    }
+
+    /** @return iterable<string, array{string, bool}> */
+    public static function destinations(): iterable
+    {
+        yield 'JSONL stdout' => ['jsonl', false];
+        yield 'JSONL file' => ['jsonl', true];
+        yield 'JUnit stdout' => ['junit', false];
+        yield 'JUnit file' => ['junit', true];
+    }
+}


### PR DESCRIPTION
When `--profile` is used with JSONL or JUnit on standard output, the CLI appends a human profile after the machine report. JSONL readers fail with a syntax error and XML readers report extra content after the document.

Write the profile to standard error when standard output contains only the bundled machine reporters. Keep the existing profile destination for file reporters and intentional mixed human and machine output. The real CLI regression fails for both standard-output formats before the change and passes for both formats and file destinations after it. The existing mixed plain/JSONL live-to-offline comparison also passes: 5 tests and 32 expectations.
