### PR TITLE
fix: skip disabled PCOV coverage collection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -657,6 +657,9 @@ jobs:
       - name: "Collect and export coverage with PCOV"
         run: "php bin/greenlight run --ansi --filter='Greenlight\\Tests\\Acceptance\\CoverageRunTest::collectsAndExportsCoverageThroughTheProcessPool'"
 
+      - name: "Reject disabled PCOV coverage"
+        run: "php bin/greenlight run --ansi --filter='Greenlight\\Tests\\Acceptance\\DisabledPcovTest'"
+
   benchmark-harness:
     name: "Benchmark harness smoke (numbers not published)"
     runs-on: "ubuntu-latest"

--- a/src/Coverage/Collection/Driver/PcovDriver.php
+++ b/src/Coverage/Collection/Driver/PcovDriver.php
@@ -37,7 +37,7 @@ final class PcovDriver implements CoverageDriver
     #[\Override]
     public static function isAvailable(): bool
     {
-        return \extension_loaded('pcov');
+        return \extension_loaded('pcov') && \filter_var(\ini_get('pcov.enabled'), \FILTER_VALIDATE_BOOL);
     }
 
     #[\Override]

--- a/tests/Acceptance/DisabledPcovTest.php
+++ b/tests/Acceptance/DisabledPcovTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Acceptance;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\SkipUnless;
 use Greenlight\Attribute\Test;
 use Greenlight\Condition\ExtensionLoaded;
@@ -18,10 +19,11 @@ final readonly class DisabledPcovTest
     public function __construct(private TemporaryDirectory $directory) {}
 
     #[Test]
-    public function aDisabledPcovExtensionCannotSatisfyRequiredCoverage(): void
+    #[DataSet('requirements')]
+    public function aDisabledPcovExtensionIsTreatedAsUnavailable(bool $required): void
     {
         $project = AcceptanceProject::createWithOnePassingTest($this->directory, 'disabled-pcov');
-        $project->writeFile('greenlight.php', <<<'PHP'
+        $project->writeFile('greenlight.php', \sprintf(<<<'PHP'
             <?php
 
             use Greenlight\Config\CoverageBuilder;
@@ -34,8 +36,8 @@ final readonly class DisabledPcovTest
                 ->workers(1)
                 ->coverage(static fn(CoverageBuilder $coverage) => $coverage
                     ->driver('pcov')
-                    ->requireDriver(true));
-            PHP);
+                    ->requireDriver(%s));
+            PHP, $required ? 'true' : 'false'));
 
         $result = GreenlightCli::run(
             $project->directory,
@@ -45,9 +47,19 @@ final readonly class DisabledPcovTest
 
         $evidence = \sprintf('stdout: %s\nstderr: %s', \substr($result->stdout, 0, 2_000), \substr($result->stderr, 0, 2_000));
 
-        Expect::that($result->exitCode)->because($evidence)->toBe(1);
+        Expect::that($result->exitCode)->because($evidence)->toBe($required ? 1 : 0);
         Expect::that($result->stdout)->because($evidence)->toContain('PASS ');
-        Expect::that($result->stderr)->because($evidence)->toContain('Coverage is required, but no worker collected it.');
-        Expect::that($result->stdout)->not()->toContain('Coverage: 100.00%');
+        Expect::that($result->output())->not()->toContain('NativePcovRuntime::collect()');
+
+        if ($required) {
+            Expect::that($result->stderr)->because($evidence)->toContain('Coverage is required, but no worker collected it.');
+        }
+    }
+
+    /** @return iterable<string, array{bool}> */
+    public static function requirements(): iterable
+    {
+        yield 'optional coverage' => [false];
+        yield 'required coverage' => [true];
     }
 }

--- a/tests/Acceptance/DisabledPcovTest.php
+++ b/tests/Acceptance/DisabledPcovTest.php
@@ -43,9 +43,11 @@ final readonly class DisabledPcovTest
             phpArguments: ['-d', 'pcov.enabled=0'],
         );
 
-        Expect::that($result->exitCode)->toBe(1);
-        Expect::that($result->stdout)->toContain('1 test, 1 passed');
-        Expect::that($result->stderr)->toContain('Coverage is required, but no worker collected it.');
+        $evidence = \sprintf('stdout: %s\nstderr: %s', \substr($result->stdout, 0, 2_000), \substr($result->stderr, 0, 2_000));
+
+        Expect::that($result->exitCode)->because($evidence)->toBe(1);
+        Expect::that($result->stdout)->because($evidence)->toContain('PASS ');
+        Expect::that($result->stderr)->because($evidence)->toContain('Coverage is required, but no worker collected it.');
         Expect::that($result->stdout)->not()->toContain('Coverage: 100.00%');
     }
 }

--- a/tests/Acceptance/DisabledPcovTest.php
+++ b/tests/Acceptance/DisabledPcovTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\SkipUnless;
+use Greenlight\Attribute\Test;
+use Greenlight\Condition\ExtensionLoaded;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\GreenlightCli;
+
+#[SkipUnless(ExtensionLoaded::class, 'pcov')]
+final readonly class DisabledPcovTest
+{
+    public function __construct(private TemporaryDirectory $directory) {}
+
+    #[Test]
+    public function aDisabledPcovExtensionCannotSatisfyRequiredCoverage(): void
+    {
+        $project = AcceptanceProject::createWithOnePassingTest($this->directory, 'disabled-pcov');
+        $project->writeFile('greenlight.php', <<<'PHP'
+            <?php
+
+            use Greenlight\Config\CoverageBuilder;
+            use Greenlight\Config\GreenlightConfig;
+
+            require_once __DIR__ . '/tests/PassingTest.php';
+
+            return GreenlightConfig::create()
+                ->paths([__DIR__ . '/tests'])
+                ->workers(1)
+                ->coverage(static fn(CoverageBuilder $coverage) => $coverage
+                    ->driver('pcov')
+                    ->requireDriver(true));
+            PHP);
+
+        $result = GreenlightCli::run(
+            $project->directory,
+            ['run', '--reporter=plain', '--no-ansi'],
+            phpArguments: ['-d', 'pcov.enabled=0'],
+        );
+
+        Expect::that($result->exitCode)->toBe(1);
+        Expect::that($result->stdout)->toContain('1 test, 1 passed');
+        Expect::that($result->stderr)->toContain('Coverage is required, but no worker collected it.');
+        Expect::that($result->stdout)->not()->toContain('Coverage: 100.00%');
+    }
+}

--- a/tests/Unit/Coverage/Collection/PcovDriverTest.php
+++ b/tests/Unit/Coverage/Collection/PcovDriverTest.php
@@ -13,12 +13,12 @@ use Greenlight\Tests\Fixture\Coverage\FakePcovDriverRuntime;
 final class PcovDriverTest
 {
     #[Test]
-    public function availabilityMatchesTheExtensionAndMissingDriverIsActionable(): void
+    public function availabilityRequiresAnEnabledExtensionAndMissingDriverIsActionable(): void
     {
-        $available = \extension_loaded('pcov');
+        $available = \extension_loaded('pcov') && \filter_var(\ini_get('pcov.enabled'), \FILTER_VALIDATE_BOOL);
 
         Expect::that(PcovDriver::isAvailable())
-            ->because('PCOV availability matches the loaded extension')
+            ->because('PCOV availability requires its execution hooks to be enabled')
             ->toBe($available);
 
         if ($available) {


### PR DESCRIPTION
PCOV can be loaded while disabled by `pcov.enabled=0`. Greenlight selected it based only on the loaded extension. A native CI regression confirmed that a passing test then fails during coverage collection: `NativePcovRuntime::collect()` receives `null` instead of an array.

Require both the loaded extension and enabled execution hooks before selecting PCOV. Interpret the INI setting as a boolean so values such as `On` and `true` remain valid. A disabled extension now follows the existing unavailable-driver path: optional coverage permits a passing run, while required coverage reports that no worker collected it.

The real subprocess regression runs in the native PCOV CI job and covers both optional and required coverage. The required-coverage case reproduced the TypeError on the unchanged driver before the fix. Existing enabled-PCOV collection remains covered by the same job. Focused PHPStan and Rector checks pass, and local coverage regressions pass with the two native PCOV cases skipped because the extension is not installed locally.
