### PR TITLE
perf(doubles): reuse loaded proxy class mappings

### DIFF
--- a/src/Doubles/ProxyGenerator.php
+++ b/src/Doubles/ProxyGenerator.php
@@ -39,6 +39,14 @@ final readonly class ProxyGenerator
      */
     public function proxyClass(string $type): string
     {
+        /** @var array<string, class-string> $classes */
+        static $classes = [];
+        $key = \strtolower($type);
+
+        if (isset($classes[$key])) {
+            return $classes[$key];
+        }
+
         $reflection = $this->reflectDoubleable($type);
 
         $body = $this->renderBody($reflection);
@@ -67,7 +75,7 @@ final readonly class ProxyGenerator
             }
         }
 
-        return $proxyClass;
+        return $classes[$key] = $proxyClass;
     }
 
     /**

--- a/tests/Fixture/Doubles/ProxyCacheContract.php
+++ b/tests/Fixture/Doubles/ProxyCacheContract.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+interface ProxyCacheContract
+{
+    public function notify(): void;
+}

--- a/tests/Unit/Doubles/ProxyClassCacheTest.php
+++ b/tests/Unit/Doubles/ProxyClassCacheTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\InvalidDoubleUsage;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Tests\Fixture\Doubles\ProxyCacheContract;
+
+final class ProxyClassCacheTest
+{
+    #[Test]
+    public function aliasesAndCaseVariantsReuseTheClassAcrossFactories(): void
+    {
+        $alias = __NAMESPACE__ . '\\ProxyCacheAlias';
+        \class_alias(ProxyCacheContract::class, $alias);
+        $firstFactory = new Doubles();
+        $first = $firstFactory->stub(ProxyCacheContract::class);
+        $firstFactory->dispose();
+
+        foreach ([ProxyCacheContract::class, \strtolower(ProxyCacheContract::class), '\\' . ProxyCacheContract::class, $alias, \strtoupper($alias)] as $type) {
+            if (!\interface_exists($type)) {
+                Fail::because('The contract name must resolve before double creation.');
+            }
+
+            $factory = new Doubles();
+            $double = $factory->stub($type);
+
+            Expect::that($double)->toBeInstanceOf(ProxyCacheContract::class);
+            Expect::that($double::class)->toBe($first::class);
+            $factory->dispose();
+        }
+    }
+
+    #[Test]
+    public function aLoadedProxyDoesNotMakeAnInvalidNameValid(): void
+    {
+        $doubles = new Doubles();
+        $doubles->stub(ProxyCacheContract::class);
+        $stub = new \ReflectionMethod(Doubles::class, 'stub');
+
+        Expect::that(static fn(): mixed => $stub->invoke($doubles, '\\\\' . ProxyCacheContract::class))
+            ->because('extra namespace separators must remain invalid after the valid type is cached')
+            ->toThrow(InvalidDoubleUsage::class);
+        $doubles->dispose();
+    }
+
+    #[Test]
+    public function aFailedLookupCanSucceedAfterTheTypeIsDefined(): void
+    {
+        $type = __NAMESPACE__ . '\\ProxyCacheLateAlias';
+        $doubles = new Doubles();
+        $stub = new \ReflectionMethod(Doubles::class, 'stub');
+
+        Expect::that(static fn(): mixed => $stub->invoke($doubles, $type))
+            ->toThrow(InvalidDoubleUsage::class);
+        \class_alias(ProxyCacheContract::class, $type);
+
+        Expect::that($stub->invoke($doubles, $type))->toBeInstanceOf(ProxyCacheContract::class);
+        $doubles->dispose();
+    }
+}

--- a/tools/benchmark-doubles-creation.php
+++ b/tools/benchmark-doubles-creation.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tools;
+
+/**
+ * Measures repeated public double creation with loaded proxy classes.
+ * Run: php tools/benchmark-doubles-creation.php [iterations]
+ * Each contract uses seven samples after 100 warm-up iterations.
+ * Compare identical counts on an idle machine with the same PHP settings.
+ */
+
+require \dirname(__DIR__) . '/vendor/autoload.php';
+
+use Greenlight\Doubles\Doubles;
+use Greenlight\Tests\Fixture\Doubles\Calculator;
+use Greenlight\Tests\Fixture\Doubles\Wide;
+
+$iterations = \filter_var($argv[1] ?? '5000', \FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+
+if (!\is_int($iterations)) {
+    throw new \InvalidArgumentException('Supply a positive iteration count.');
+}
+
+$rows = [];
+
+foreach ([Calculator::class, Wide::class] as $type) {
+    foreach ([false, true] as $newFactory) {
+        $doubles = new Doubles();
+
+        for ($index = 0; $index < 100; ++$index) {
+            $double = $doubles->stub($type);
+            $doubles->dispose();
+            unset($double);
+        }
+
+        $wallSamples = [];
+        $cpuSamples = [];
+
+        for ($sample = 0; $sample < 7; ++$sample) {
+            $start = \hrtime(true);
+            $cpuStart = cpuMilliseconds();
+
+            for ($index = 0; $index < $iterations; ++$index) {
+                if ($newFactory) {
+                    $doubles = new Doubles();
+                }
+
+                $double = $doubles->stub($type);
+                $doubles->dispose();
+                unset($double);
+            }
+
+            $cpuSamples[] = cpuMilliseconds() - $cpuStart;
+            $wallSamples[] = (\hrtime(true) - $start) / 1_000_000;
+        }
+
+        $rows[] = [
+            'type' => $type,
+            'methodCount' => \count(new \ReflectionClass($type)->getMethods()),
+            'newFactory' => $newFactory,
+            'iterations' => $iterations,
+            'wallMilliseconds' => $wallSamples,
+            'cpuMilliseconds' => $cpuSamples,
+        ];
+    }
+}
+
+echo \json_encode(['php' => \PHP_VERSION, 'rows' => $rows], \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT), "\n";
+
+function cpuMilliseconds(): float
+{
+    $usage = \getrusage();
+
+    if ($usage === false) {
+        throw new \RuntimeException('Cannot read process CPU usage.');
+    }
+
+    $userSeconds = $usage['ru_utime.tv_sec'] ?? null;
+    $systemSeconds = $usage['ru_stime.tv_sec'] ?? null;
+    $userMicroseconds = $usage['ru_utime.tv_usec'] ?? null;
+    $systemMicroseconds = $usage['ru_stime.tv_usec'] ?? null;
+
+    if (!\is_int($userSeconds) || !\is_int($systemSeconds) || !\is_int($userMicroseconds) || !\is_int($systemMicroseconds)) {
+        throw new \RuntimeException('Process CPU usage does not contain integer time values.');
+    }
+
+    return ($userSeconds + $systemSeconds) * 1000 + ($userMicroseconds + $systemMicroseconds) / 1000;
+}


### PR DESCRIPTION
Repeated double creation reflects the contract, renders every proxy method and hashes the generated body before checking whether the proxy class is already loaded. This repeats work even though loaded PHP type definitions cannot change within the process.

Keep successful type-to-proxy class mappings for the process lifetime. The key uses the exact input name in lowercase, so case variants share an entry while invalid namespace separators remain invalid. Failed lookups and failed generation are not cached. The cache holds class-name strings and does not retain double instances, factories or recorded calls.

On PHP 8.4.14 on macOS, `php tools/benchmark-doubles-creation.php` takes seven warm samples of 5,000 public `stub()` calls followed by disposal. These medians compare base `a510c977342d5f3e2fb98e6d1df5ce2cefce5c31` with this change at `517c3e08672f693484cfc6b61bdc6890e5871a0c`. Values are milliseconds per sample:

| Existing contract | Factory per iteration | CPU before → after | Wall before → after |
| --- | --- | ---: | ---: |
| Calculator, 2 methods | Reused | 91.647 → 10.858 | 92.141 → 10.895 |
| Calculator, 2 methods | New | 183.405 → 81.378 | 193.939 → 81.890 |
| Wide, 10 methods | Reused | 451.433 → 10.536 | 494.066 → 10.591 |
| Wide, 10 methods | New | 474.589 → 82.003 | 478.213 → 82.310 |

These figures measure creation throughput with loaded proxies, not whole-suite speed. A separate 256-type process memory probe retained 59,072 extra bytes, about 231 bytes per type for that workload. Entries remain until process exit; aliases can add separate entries. The cache does not store rendered source or reflection graphs.

The focused Doubles selection passes 242 cases and 482 expectations. New public-behavior cases cover aliases and case variants across factories, invalid names after a valid type is cached, and a failed lookup followed by defining the type. Existing cache-storage, corrupt-file, disposal-isolation and collection cases remain green. Targeted PHPStan, Rector and prose checks pass. GitHub runs the full required commands against the PR commit.
