### PR TITLE
fix(cli): keep empty failed-run notices outside JSONL

### DIFF
--- a/src/Cli/Run/RunCommand.php
+++ b/src/Cli/Run/RunCommand.php
@@ -166,7 +166,10 @@ final readonly class RunCommand
                 }
 
                 if ($previousFailures === []) {
-                    ($this->out)("No tests failed in the previous run. There are no tests to run again.\n");
+                    $noticeOutput = $reporterOutputs->writesReporterToStandardOutput('jsonl')
+                        ? $this->err
+                        : $this->out;
+                    $noticeOutput("No tests failed in the previous run. There are no tests to run again.\n");
 
                     return CommandResult::success();
                 }

--- a/tests/Acceptance/SelectionTest.php
+++ b/tests/Acceptance/SelectionTest.php
@@ -183,6 +183,35 @@ final readonly class SelectionTest
         $result = $this->run($project, '--failed');
         Expect::that($result->exitCode)->because('failed reruns exactly the previous failures')->toBe(0);
         Expect::that($result->output())->because('failed reruns exactly the previous failures')->toContain('No tests failed');
+        Expect::that($result->stdout)->toBe('');
+        Expect::that($result->stderr)->toContain('No tests failed');
+    }
+
+    #[Test]
+    public function failedKeepsTheEmptySelectionNoticeOnStandardOutputForPlainReports(): void
+    {
+        $project = $this->writeProject();
+        $this->run($project, '--filter=alwaysPasses');
+
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=plain', '--failed']);
+
+        Expect::that($result->exitCode)->toBe(0);
+        Expect::that($result->stdout)->toContain('No tests failed');
+        Expect::that($result->stderr)->toBe('');
+    }
+
+    #[Test]
+    public function failedKeepsTheEmptySelectionNoticeOnStandardOutputWhenJsonlUsesAFile(): void
+    {
+        $project = $this->writeProject();
+        $this->run($project, '--filter=alwaysPasses');
+
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=jsonl=events.jsonl', '--failed']);
+
+        Expect::that($result->exitCode)->toBe(0);
+        Expect::that($result->stdout)->toContain('No tests failed');
+        Expect::that($result->stderr)->toBe('');
+        Expect::that(\file_get_contents($project->directory . '/events.jsonl'))->toBe('');
     }
 
     #[Test]


### PR DESCRIPTION
When the previous run has no failures, `greenlight run --failed --reporter=jsonl` writes a plain-text notice to standard output. A consumer that expects JSONL cannot parse that output.

Send this notice to standard error when JSONL uses standard output. Keep the existing notice location for plain reports and JSONL file output. The command still exits successfully without running tests.

The regression failed before the change because standard output contained the notice. The focused cases also cover plain output and a JSONL file destination.
