### PR TITLE
fix(artifacts): reject named pipes before opening sources

### DIFF
--- a/src/Execution/Artifact/ArtifactStore.php
+++ b/src/Execution/Artifact/ArtifactStore.php
@@ -211,6 +211,12 @@ final class ArtifactStore
                 return null;
             }
 
+            $stat = \stat($sourcePath);
+
+            if (\is_array($stat) && ($stat['mode'] & 0170000) !== 0100000) {
+                throw AttachmentError::source($sourcePath, 'is not a regular file');
+            }
+
             return \fopen($sourcePath, 'rb');
         });
 

--- a/tests/Unit/Execution/Artifact/AttachmentNamedPipeTest.php
+++ b/tests/Unit/Execution/Artifact/AttachmentNamedPipeTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Execution\Artifact;
+
+use Greenlight\Artifact\AttachmentError;
+use Greenlight\Attribute\Test;
+use Greenlight\Attribute\Timeout;
+use Greenlight\Config\ArtifactConfiguration;
+use Greenlight\Execution\Artifact\ArtifactStore;
+use Greenlight\Execution\Artifact\TestArtifactBudget;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Test\Cleanup;
+use Greenlight\Test\SkipTest;
+use Greenlight\Test\TestId;
+
+final readonly class AttachmentNamedPipeTest
+{
+    public function __construct(
+        private TemporaryDirectory $directory,
+        private Cleanup $cleanup,
+    ) {}
+
+    #[Test]
+    #[Timeout(2.0)]
+    public function aNamedPipeWithoutAWriterIsRejectedBeforeItIsOpened(): void
+    {
+        if (!\function_exists('posix_mkfifo')) {
+            throw new SkipTest('The posix extension is not available.');
+        }
+
+        $path = $this->directory->path() . '/source.pipe';
+
+        if (!\posix_mkfifo($path, 0o600)) {
+            throw new SkipTest('The filesystem did not create a named pipe.');
+        }
+
+        $root = $this->directory->path();
+        $store = ArtifactStore::open(new ArtifactConfiguration($root . '/artifacts'), $root, 'named-pipe');
+        $this->cleanup->defer($store->cleanup(...));
+        $attachments = $store->forAttempt(new TestId(self::class, __FUNCTION__), 1, new TestArtifactBudget());
+
+        Expect::that(static fn() => $attachments->file('evidence.bin', $path))
+            ->toThrow(AttachmentError::class, message: \sprintf('Attachment source "%s" is not a regular file.', $path));
+    }
+}


### PR DESCRIPTION
Passing a named pipe without a writer to `Attachments::file()` blocks in `fopen()` before Greenlight checks the file type. The worker reaches its hard timeout instead of rejecting the invalid source.

Check the source type before opening a known non-regular file. Keep the existing check on the open file handle and the existing errors for missing files, directories, and symbolic links. The native named-pipe regression failed before the change when Greenlight stopped its worker after 6.110 seconds. All 132 attachment unit tests now pass, with 353 expectations. Targeted Rector and code style checks also pass.
