### PR TITLE
fix(cli): preserve numeric suite names in manifests

### DIFF
--- a/src/Cli/Command/TestManifest.php
+++ b/src/Cli/Command/TestManifest.php
@@ -52,7 +52,7 @@ final class TestManifest
     }
 
     /**
-     * @param array<non-empty-string, list<string>> $suitePaths
+     * @param array<int|non-empty-string, list<string>> $suitePaths
      * @return array<string, mixed>
      */
     private static function test(PlanEntry $entry, array $suitePaths): array
@@ -108,7 +108,7 @@ final class TestManifest
 
     /**
      * @param list<SuiteConfiguration> $suites
-     * @return array<non-empty-string, list<string>>
+     * @return array<int|non-empty-string, list<string>>
      */
     private static function suitePaths(array $suites, string $workingDirectory): array
     {
@@ -126,7 +126,7 @@ final class TestManifest
     }
 
     /**
-     * @param array<non-empty-string, list<string>> $suitePaths
+     * @param array<int|non-empty-string, list<string>> $suitePaths
      * @return list<non-empty-string>
      */
     private static function memberships(string $file, array $suitePaths): array
@@ -136,7 +136,7 @@ final class TestManifest
         foreach ($suitePaths as $suite => $directories) {
             foreach ($directories as $directory) {
                 if (self::isBelow($file, $directory)) {
-                    $memberships[] = $suite;
+                    $memberships[] = (string) $suite;
                     break;
                 }
             }

--- a/tests/Unit/Cli/Command/TestManifestTest.php
+++ b/tests/Unit/Cli/Command/TestManifestTest.php
@@ -20,6 +20,25 @@ use Greenlight\Test\TestDefinition;
 final class TestManifestTest
 {
     #[Test]
+    public function numericSuiteNamesRemainStringsInTheManifest(): void
+    {
+        $document = TestManifest::document(
+            new ExecutionPlan([new PlanEntry(new TestDefinition(self::class, __FUNCTION__))]),
+            [
+                new SuiteConfiguration('123', ['tests/Unit'], []),
+                new SuiteConfiguration('0', ['tests/Unit'], []),
+                new SuiteConfiguration('01', ['tests/Unit'], []),
+                new SuiteConfiguration('-1', ['tests/Unit'], []),
+            ],
+            null,
+            \dirname(__DIR__, 4),
+        );
+
+        Expect::that(\json_encode($document, \JSON_THROW_ON_ERROR))
+            ->toContain('"suites":["-1","0","01","123"]');
+    }
+
+    #[Test]
     public function documentKeepsThePublicContractSmallAndDeterministic(): void
     {
         $root = \dirname(__DIR__, 4);


### PR DESCRIPTION
Suite names such as `"123"` and `"0"` are valid configuration values. The test manifest used these names as PHP array keys, which converted them to integers. `list-tests --format=json` then emitted numbers in the `suites` list, contrary to its string-only schema.

Convert membership keys back to strings when building the public manifest. Keep lexical ordering and names with leading zeroes. The regression covers positive, negative, zero, and leading-zero names. It fails before the change and passes afterward; all six manifest tests pass.
