### PR TITLE
perf(reporting): release unused successful result output

### DIFF
--- a/src/Reporting/PlainReporter.php
+++ b/src/Reporting/PlainReporter.php
@@ -34,12 +34,12 @@ final class PlainReporter implements Reporter
     private array $problems = [];
 
     /**
-     * @var list<TestResult>
+     * @var list<TestSummary>
      */
     private array $skipped = [];
 
     /**
-     * @var list<TestResult>
+     * @var list<TestSummary>
      */
     private array $retriedPasses = [];
 
@@ -115,11 +115,11 @@ final class PlainReporter implements Reporter
             }
 
             if ($result->outcome === Outcome::Skipped) {
-                $this->skipped[] = $result;
+                $this->skipped[] = new TestSummary($result);
             }
 
             if ($result->outcome === Outcome::Passed && $result->attempts > 1) {
-                $this->retriedPasses[] = $result;
+                $this->retriedPasses[] = new TestSummary($result);
             }
 
             if ($result->risky && $result->outcome->isSuccessful() && ($id = (string) $result->id) !== '') {

--- a/src/Reporting/SummaryFormat.php
+++ b/src/Reporting/SummaryFormat.php
@@ -55,7 +55,7 @@ final class SummaryFormat
     }
 
     /**
-     * @param list<TestResult> $skipped
+     * @param list<TestResult|TestSummary> $skipped
      */
     public static function skipped(array $skipped, Style $style): string
     {
@@ -98,7 +98,7 @@ final class SummaryFormat
     }
 
     /**
-     * @param list<TestResult> $retriedPasses
+     * @param list<TestResult|TestSummary> $retriedPasses
      */
     public static function retriedPasses(array $retriedPasses, Style $style): string
     {

--- a/src/Reporting/TestSummary.php
+++ b/src/Reporting/TestSummary.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Reporting;
+
+use Greenlight\Result\TestResult;
+use Greenlight\Test\TestId;
+
+/**
+ * Retains only the fields that skipped and retried-pass footers use.
+ *
+ * @internal
+ */
+final readonly class TestSummary
+{
+    public TestId $id;
+
+    /** @var positive-int */
+    public int $attempts;
+
+    public ?string $skipReason;
+
+    public function __construct(TestResult $result)
+    {
+        $this->id = $result->id;
+        $this->attempts = $result->attempts;
+        $this->skipReason = $result->skipReason;
+    }
+}

--- a/src/Reporting/TtyReporter.php
+++ b/src/Reporting/TtyReporter.php
@@ -47,12 +47,12 @@ final class TtyReporter implements Reporter, Ticking
     private array $problems = [];
 
     /**
-     * @var list<TestResult>
+     * @var list<TestSummary>
      */
     private array $skipped = [];
 
     /**
-     * @var list<TestResult>
+     * @var list<TestSummary>
      */
     private array $retriedPasses = [];
 
@@ -186,11 +186,11 @@ final class TtyReporter implements Reporter, Ticking
             }
 
             if ($result->outcome === Outcome::Skipped) {
-                $this->skipped[] = $result;
+                $this->skipped[] = new TestSummary($result);
             }
 
             if ($result->outcome === Outcome::Passed && $result->attempts > 1) {
-                $this->retriedPasses[] = $result;
+                $this->retriedPasses[] = new TestSummary($result);
 
                 if (isset($this->live[$class])) {
                     ++$this->live[$class]['retried'];

--- a/tests/Unit/Reporting/SuccessfulResultRetentionTest.php
+++ b/tests/Unit/Reporting/SuccessfulResultRetentionTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Reporting;
+
+use Greenlight\Artifact\Attachment;
+use Greenlight\Artifact\AttachmentKind;
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Event\TestFinished;
+use Greenlight\Expect\Expect;
+use Greenlight\Reporting\PlainReporter;
+use Greenlight\Reporting\TtyReporter;
+use Greenlight\Result\CapturedOutput;
+use Greenlight\Result\Outcome;
+use Greenlight\Result\TestResult;
+use Greenlight\Test\TestId;
+
+final readonly class SuccessfulResultRetentionTest
+{
+    /** @return iterable<string, array{bool, Outcome}> */
+    public static function summaries(): iterable
+    {
+        yield 'plain skipped' => [false, Outcome::Skipped];
+        yield 'plain retried pass' => [false, Outcome::Passed];
+        yield 'tty skipped' => [true, Outcome::Skipped];
+        yield 'tty retried pass' => [true, Outcome::Passed];
+    }
+
+    #[Test]
+    #[DataSet('summaries')]
+    public function successfulFootersReleaseCapturedOutput(bool $tty, Outcome $outcome): void
+    {
+        $output = new BufferOutput();
+        $reporter = $tty
+            ? new TtyReporter($output, color: false, cursor: false)
+            : new PlainReporter($output);
+        $captured = new CapturedOutput('Successful output does not appear in the footer.');
+        $reference = \WeakReference::create($captured);
+        $result = new TestResult(
+            new TestId('ExampleTest', 'example'),
+            $outcome,
+            0.01,
+            0,
+            attempts: 2,
+            skipReason: 'Example skip reason.',
+            output: $captured,
+            attachments: [new Attachment(
+                'response.json',
+                AttachmentKind::File,
+                'application/json',
+                2,
+                \str_repeat('0', 64),
+                2,
+                'artifacts/response.json',
+            )],
+        );
+        $reporter->onEvent(new TestFinished($result, 1.0));
+        unset($result, $captured);
+
+        Expect::that($reference->get())
+            ->because('successful footers do not need captured output')
+            ->toBeNull();
+
+        $reporter->finish();
+
+        Expect::that($output->buffer())->toContain('artifacts/response.json');
+        Expect::that($output->buffer())->toContain($outcome === Outcome::Skipped
+            ? 'ExampleTest::example (Example skip reason.)'
+            : 'ExampleTest::example (2 attempts)');
+    }
+}

--- a/tools/benchmark-reporter-retention.php
+++ b/tools/benchmark-reporter-retention.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tools;
+
+use Greenlight\Event\TestFinished;
+use Greenlight\Reporting\Output;
+use Greenlight\Reporting\PlainReporter;
+use Greenlight\Reporting\TtyReporter;
+use Greenlight\Result\CapturedOutput;
+use Greenlight\Result\Outcome;
+use Greenlight\Result\TestResult;
+use Greenlight\Test\TestId;
+
+require \dirname(__DIR__) . '/vendor/autoload.php';
+
+$kind = $argv[1] ?? 'plain';
+$status = $argv[2] ?? 'skip';
+
+if (!\in_array($kind, ['plain', 'tty'], true) || !\in_array($status, ['skip', 'retry'], true)) {
+    throw new \InvalidArgumentException('Use plain or tty, followed by skip or retry.');
+}
+
+$output = new class implements Output {
+    public string $bytes = '';
+
+    #[\Override]
+    public function write(string $text): void
+    {
+        $this->bytes .= $text;
+    }
+};
+$reporter = $kind === 'plain' ? new PlainReporter($output) : new TtyReporter($output, color: false, cursor: false);
+$outcome = $status === 'skip' ? Outcome::Skipped : Outcome::Passed;
+
+// Load the reporter dependencies before the memory measurement.
+$reporter->onEvent(new TestFinished(new TestResult(new TestId('ExampleTest', 'warmup'), Outcome::Passed, 0.01, 0), 1.0));
+$before = \memory_get_usage();
+$reference = null;
+
+for ($i = 0; $i < 200; ++$i) {
+    $captured = new CapturedOutput(\str_repeat(\chr(65 + $i % 26), 65_536));
+    $result = new TestResult(
+        new TestId('ExampleTest', 'case' . $i),
+        $outcome,
+        0.01,
+        0,
+        attempts: 2,
+        skipReason: 'Example reason.',
+        output: $captured,
+    );
+    $reference = \WeakReference::create($captured);
+    $reporter->onEvent(new TestFinished($result, 2.0 + $i));
+    unset($result, $captured);
+}
+
+$retained = \memory_get_usage() - $before;
+$reporter->finish();
+
+echo \json_encode([
+    'reporter' => $kind,
+    'outcome' => $status,
+    'retained_bytes' => $retained,
+    'retains_capture' => $reference?->get() !== null,
+    'output_sha256' => \hash('sha256', $output->bytes),
+], \JSON_THROW_ON_ERROR), "\n";


### PR DESCRIPTION
Plain and TTY reporters kept full results for skipped and retried-pass footers. Captured output, diagnostics, and other result evidence then remained in memory although these footers use only the test ID, attempt count, and skip reason. Large suites with those outcomes could retain megabytes of unused output.

The reporters now retain a small summary entry for those footers. Failure and error details still retain their full results. Footer formatting continues to accept existing `TestResult` callers, and attachment output stays unchanged.

Four regression cases fail before the change because a weak reference confirms that captured output remains alive. They pass after the change and verify the footer and retained attachment text. All 243 reporting tests pass with 629 expectations. Targeted PHPStan, Rector, and style checks pass; complete required checks run in GitHub CI.

Five fresh PHP 8.4.14 process samples, with `XDEBUG_MODE=off`, measured 200 skipped or retried-pass results with 64 KiB output each. Retained memory was 14,053,512 → 74,440 bytes for plain output and 14,041,744 → 62,672 bytes for TTY output. All four before/after output SHA-256 hashes match. These values include buffered visible output and summary metadata, which still grow with the number of reported results.

Reproduce with `XDEBUG_MODE=off php tools/benchmark-reporter-retention.php plain skip`. Use `tty` for the other reporter and `retry` for retried passes. Run the same script against the parent revision for the baseline.
