### PR TITLE
perf(doubles): reuse method contracts within each factory

### DIFF
--- a/docs/api-doubles.md
+++ b/docs/api-doubles.md
@@ -284,7 +284,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException if the proxy directory is empty`
 - `@throws InvalidDoubleUsage if PHP cannot resolve the default working directory`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L58)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L60)
 
 ### `mock()`
 
@@ -303,7 +303,7 @@ PHPDoc:
 - `@return T`
 - `@throws InvalidDoubleUsage`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L95)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L98)
 
 ### `stub()`
 
@@ -322,7 +322,7 @@ PHPDoc:
 - `@return T`
 - `@throws InvalidDoubleUsage`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L112)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L115)
 
 ### `spy()`
 
@@ -341,7 +341,7 @@ PHPDoc:
 - `@return T`
 - `@throws InvalidDoubleUsage`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L129)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L132)
 
 ### `callsTo()`
 
@@ -358,7 +358,7 @@ PHPDoc:
 - `@return list<list<mixed>>`
 - `@throws InvalidDoubleUsage`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L142)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L145)
 
 ### `dispose()`
 
@@ -373,7 +373,7 @@ PHPDoc:
 
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L167)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/Doubles.php#L170)
 
 ## `Fake`
 

--- a/src/Doubles/CallHandler.php
+++ b/src/Doubles/CallHandler.php
@@ -28,6 +28,7 @@ final readonly class CallHandler
         private DoubleState $state,
         private ValueRenderer $renderer,
         private \WeakMap $doubles,
+        private MethodCallContracts $contracts,
     ) {}
 
     /**
@@ -41,7 +42,7 @@ final readonly class CallHandler
     {
         $this->doubles[$double] = $this->state;
 
-        MethodCallContract::from($this->state->type, $method)
+        $this->contracts->get($this->state->type, $method)
             ->assertCallArgumentCount(\count($arguments));
 
         $this->state->recordedCalls[$method][] = $arguments;

--- a/src/Doubles/Doubles.php
+++ b/src/Doubles/Doubles.php
@@ -33,6 +33,8 @@ final class Doubles implements Disposable
 
     private readonly ValueRenderer $renderer;
 
+    private readonly MethodCallContracts $contracts;
+
     /**
      * The factory stores states for verification. The states do not refer to
      * the proxy objects. Thus, PHP can collect a double after the test releases it.
@@ -77,6 +79,7 @@ final class Doubles implements Disposable
 
         $this->generator = new ProxyGenerator($proxyDirectory);
         $this->renderer = new ValueRenderer();
+        $this->contracts = new MethodCallContracts();
         $this->doubles = new \WeakMap();
     }
 
@@ -187,6 +190,7 @@ final class Doubles implements Disposable
         }
 
         $this->states = [];
+        $this->contracts->clear();
         $this->doubles = new \WeakMap();
 
         if ($details !== []) {
@@ -215,7 +219,7 @@ final class Doubles implements Disposable
         $double = new \ReflectionClass($proxyClass)->newInstanceWithoutConstructor();
 
         \assert($double instanceof GeneratedProxy);
-        $double->__greenlightAttachHandler(new CallHandler($state, $this->renderer, $this->doubles));
+        $double->__greenlightAttachHandler(new CallHandler($state, $this->renderer, $this->doubles, $this->contracts));
 
         \assert($double instanceof $type);
 

--- a/src/Doubles/MethodCallContracts.php
+++ b/src/Doubles/MethodCallContracts.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Doubles;
+
+/**
+ * Reuses immutable method contracts across doubles from one factory.
+ * The factory clears the contracts when its service scope closes.
+ *
+ * @internal
+ */
+final class MethodCallContracts
+{
+    /** @var array<class-string, array<non-empty-string, MethodCallContract>> */
+    private array $contracts = [];
+
+    /**
+     * @param class-string $type
+     * @param non-empty-string $method
+     */
+    public function get(string $type, string $method): MethodCallContract
+    {
+        return $this->contracts[$type][$method] ??= MethodCallContract::from($type, $method);
+    }
+
+    public function clear(): void
+    {
+        $this->contracts = [];
+    }
+}

--- a/tests/Unit/Doubles/RepeatedCallContractTest.php
+++ b/tests/Unit/Doubles/RepeatedCallContractTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\InvalidDoubleUsage;
+use Greenlight\Expect\Expect;
+
+final readonly class RepeatedCallContractTest
+{
+    public function __construct(private Doubles $doubles) {}
+
+    #[Test]
+    public function repeatedCallsKeepEachMethodsArgumentLimit(): void
+    {
+        $spy = $this->doubles->spy(RepeatedCallTarget::class);
+        $spy->record();
+        $spy->record('first');
+        $spy->many('first', 'second');
+        $spy->many();
+
+        Expect::that(static fn(): mixed => new \ReflectionMethod($spy, 'record')->invokeArgs($spy, ['first', 'second']))
+            ->toThrow(InvalidDoubleUsage::class, '/accepts at most 1 argument/');
+
+        $spy->record('last');
+
+        Expect::that($this->doubles->callsTo($spy, 'record'))->toBe([[], ['first'], ['last']]);
+        Expect::that($this->doubles->callsTo($spy, 'many'))->toBe([['first', 'second'], []]);
+    }
+
+    #[Test]
+    public function methodsWithTheSameNameKeepTheirOwnTypeContract(): void
+    {
+        $first = $this->doubles->spy(RepeatedCallTarget::class);
+        $second = $this->doubles->spy(EmptyCallTarget::class);
+        $first->record('first');
+        $second->record();
+
+        Expect::that(static fn(): mixed => new \ReflectionMethod($second, 'record')->invokeArgs($second, ['unexpected']))
+            ->toThrow(InvalidDoubleUsage::class, '/accepts at most 0 arguments/');
+
+        $first->record('last');
+
+        Expect::that($this->doubles->callsTo($first, 'record'))->toBe([['first'], ['last']]);
+        Expect::that($this->doubles->callsTo($second, 'record'))->toBe([[]]);
+    }
+}
+
+interface RepeatedCallTarget
+{
+    public function record(string $value = 'default'): void;
+
+    public function many(string ...$values): void;
+}
+
+interface EmptyCallTarget
+{
+    public function record(): void;
+}

--- a/tools/benchmark-doubles-calls.php
+++ b/tools/benchmark-doubles-calls.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tools;
+
+/**
+ * Measures repeated double calls and separate doubles that receive one call.
+ * Run: php tools/benchmark-doubles-calls.php [iterations]
+ * Each workload uses seven samples. Proxy generation occurs before timing.
+ * Compare equal counts with the same PHP settings on an idle machine.
+ */
+
+require \dirname(__DIR__) . '/vendor/autoload.php';
+
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\MockPlan;
+
+$iterations = \filter_var($argv[1] ?? '10000', \FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+
+if (!\is_int($iterations)) {
+    throw new \InvalidArgumentException('Supply a positive iteration count.');
+}
+
+$warmup = new Doubles();
+$warmup->spy(CallBenchmarkTarget::class)->record(1, 'two');
+$warmup->dispose();
+unset($warmup);
+$rows = [];
+
+foreach (['mock', 'spy', 'one-call-mocks'] as $workload) {
+    $samples = [];
+
+    for ($sample = 0; $sample < 7; ++$sample) {
+        $doubles = new Doubles();
+        $targets = [];
+        $targetCount = $workload === 'one-call-mocks' ? $iterations : 1;
+        $expectedCalls = $workload === 'one-call-mocks' ? 1 : $iterations;
+
+        for ($target = 0; $target < $targetCount; ++$target) {
+            $targets[] = $workload === 'spy'
+                ? $doubles->spy(CallBenchmarkTarget::class)
+                : $doubles->mock(CallBenchmarkTarget::class, static function (MockPlan $plan) use ($expectedCalls): void {
+                    $plan->expects('value')->with(1, 'two')->times($expectedCalls)->andReturns(3);
+                });
+        }
+
+        $memoryBefore = \memory_get_usage();
+        $cpuStartedAt = callCpuMilliseconds();
+        $startedAt = \hrtime(true);
+
+        for ($call = 0; $call < $iterations; ++$call) {
+            $double = $targets[$workload === 'one-call-mocks' ? $call : 0];
+
+            if ($workload === 'spy') {
+                $double->record(1, 'two');
+            } elseif ($double->value(1, 'two') !== 3) {
+                throw new \LogicException('The double returned an incorrect value.');
+            }
+        }
+
+        $samples[] = [
+            'milliseconds' => (\hrtime(true) - $startedAt) / 1_000_000,
+            'cpuMilliseconds' => callCpuMilliseconds() - $cpuStartedAt,
+            'retainedBytes' => \memory_get_usage() - $memoryBefore,
+        ];
+
+        foreach ($targets as $double) {
+            if (\count($doubles->callsTo($double, $workload === 'spy' ? 'record' : 'value')) !== $expectedCalls) {
+                throw new \LogicException('The double recorded an incorrect call count.');
+            }
+        }
+
+        $doubles->dispose();
+        unset($double, $targets, $doubles);
+        \gc_collect_cycles();
+    }
+
+    $rows[] = ['workload' => $workload, 'calls' => $iterations, 'samples' => $samples];
+}
+
+echo \json_encode(['php' => \PHP_VERSION, 'rows' => $rows], \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT), "\n";
+
+function callCpuMilliseconds(): float
+{
+    $usage = \getrusage();
+
+    if ($usage === false) {
+        throw new \RuntimeException('Cannot read process CPU usage.');
+    }
+
+    $userSeconds = $usage['ru_utime.tv_sec'] ?? null;
+    $systemSeconds = $usage['ru_stime.tv_sec'] ?? null;
+    $userMicroseconds = $usage['ru_utime.tv_usec'] ?? null;
+    $systemMicroseconds = $usage['ru_stime.tv_usec'] ?? null;
+
+    if (!\is_int($userSeconds) || !\is_int($systemSeconds) || !\is_int($userMicroseconds) || !\is_int($systemMicroseconds)) {
+        throw new \RuntimeException('Process CPU usage does not contain integer time values.');
+    }
+
+    return ($userSeconds + $systemSeconds) * 1000 + ($userMicroseconds + $systemMicroseconds) / 1000;
+}
+
+interface CallBenchmarkTarget
+{
+    public function value(int $first, string $second): int;
+
+    public function record(int $first, string $second): void;
+}


### PR DESCRIPTION
Each call to a double reconstructs its reflection method, parameters, and argument-count contract. Share these immutable contracts across one Doubles factory and clear the cache at disposal, so repeated calls and separate doubles of the same type reuse the contract.

With PHP 8.4.14 and Xdebug disabled, seven samples of 10,000 calls reduced median process CPU time from 9.66 to 6.64 ms for mocks, 6.64 to 3.38 ms for spies, and 13.38 to 9.14 ms for separate one-call mocks (31%, 49%, and 32%). The one-call workload retained 1,368 additional bytes during calls across all 10,000 mocks. The cache retains one contract per called type/method until disposal. Run `XDEBUG_MODE=off php tools/benchmark-doubles-calls.php 10000` to reproduce the workloads; compare the same script on the base revision.

All 247 doubles-related tests pass after rebasing onto the updated main branch, including focused cases for repeated optional and variadic calls, distinct method limits, same-name methods on different types, and rejected calls staying out of history. Focused PHPStan, Rector, and code style checks pass. The maintained API generator refreshed source links. The latest head passes full composer static-analysis and composer tests: 3,432 passes, 15 environment skips, and 8,766 expectations. The conflict was limited to generated API source links and was resolved by regeneration. This change also merges cleanly with #1829; the combined tree passes seven targeted argument-forwarding and contract regressions.
