### PR TITLE
perf(plugins): sort callback priorities once per runtime

### DIFF
--- a/src/Execution/Plugin/PluginRuntime.php
+++ b/src/Execution/Plugin/PluginRuntime.php
@@ -20,6 +20,9 @@ abstract readonly class PluginRuntime
      */
     private array $plugins;
 
+    /** @var list<Plugin> */
+    private array $orderedPlugins;
+
     /**
      * @param list<Plugin> $plugins
      */
@@ -36,6 +39,13 @@ abstract readonly class PluginRuntime
         }
 
         $this->plugins = $indexed;
+
+        \usort(
+            $indexed,
+            static fn(array $a, array $b): int => [$a['priority'], $a['registration']]
+                <=> [$b['priority'], $b['registration']],
+        );
+        $this->orderedPlugins = \array_column($indexed, 'plugin');
     }
 
     /**
@@ -90,17 +100,9 @@ abstract readonly class PluginRuntime
      */
     final protected function ordered(string $capability): array
     {
-        $matching = \array_values(\array_filter(
-            $this->plugins,
-            static fn(array $entry): bool => $entry['plugin'] instanceof $capability,
+        return \array_values(\array_filter(
+            $this->orderedPlugins,
+            static fn(Plugin $plugin): bool => $plugin instanceof $capability,
         ));
-
-        \usort(
-            $matching,
-            static fn(array $a, array $b): int => [$a['priority'], $a['registration']]
-                <=> [$b['priority'], $b['registration']],
-        );
-
-        return \array_column($matching, 'plugin');
     }
 }

--- a/tools/plugin-dispatch-benchmark.php
+++ b/tools/plugin-dispatch-benchmark.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tools;
+
+use Greenlight\Execution\Plugin\WorkerPluginRuntime;
+use Greenlight\Harness\HarnessScopes;
+use Greenlight\Plugin\BeforeTestSubscriber;
+use Greenlight\Plugin\Prioritized;
+use Greenlight\Plugin\TestContext;
+use Greenlight\Test\TestDefinition;
+use Greenlight\Test\TestId;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+final class DispatchBenchmarkSubscriber implements BeforeTestSubscriber, Prioritized
+{
+    public static int $calls = 0;
+
+    public function __construct(private readonly int $rank) {}
+
+    #[\Override]
+    public function priority(): int
+    {
+        return $this->rank;
+    }
+
+    #[\Override]
+    public function beforeTest(TestContext $context): void
+    {
+        ++self::$calls;
+    }
+}
+
+$context = new TestContext(
+    new \stdClass(),
+    new TestId('ExampleTest', 'test'),
+    new TestDefinition('ExampleTest', 'test'),
+    new HarnessScopes(),
+);
+
+// Measure repeated dispatch separately from runtime construction.
+foreach ([0, 1, 8] as $count) {
+    $plugins = [];
+
+    for ($index = 0; $index < $count; ++$index) {
+        $plugins[] = new DispatchBenchmarkSubscriber($count - $index);
+    }
+
+    $runtime = WorkerPluginRuntime::fromPlugins($plugins);
+
+    for ($sample = 1; $sample <= 3; ++$sample) {
+        DispatchBenchmarkSubscriber::$calls = 0;
+        $startedAt = \hrtime(true);
+
+        for ($iteration = 0; $iteration < 100_000; ++$iteration) {
+            $runtime->beforeTest($context);
+        }
+
+        \printf(
+            "plugins=%d sample=%d iterations=100000 seconds=%.6f calls=%d\n",
+            $count,
+            $sample,
+            (\hrtime(true) - $startedAt) / 1_000_000_000,
+            DispatchBenchmarkSubscriber::$calls,
+        );
+    }
+}


### PR DESCRIPTION
Plugin callback dispatch sorted the same priority snapshot for every capability call. A worker repeats this work before and after each test attempt, even though runtime construction fixes plugin priorities and registration order.

Sort the snapshot once when the runtime is constructed, then select capabilities from that order. Registration-order matching remains unchanged. This adds one array of plugin references per runtime and moves sorting cost to construction.

The included benchmark dispatches 100,000 `beforeTest()` calls with zero, one, and eight subscribers. On PHP 8.4.14, the median eight-subscriber wall time fell from 0.936s to 0.345s across three samples. A separate user-CPU measurement fell from 0.904s to 0.332s (63%); both versions invoked exactly 800,000 callbacks. Measurements in the opposite execution order also showed a reduction. These are dispatch measurements, not a claim about whole-suite speed.

All 172 applicable plugin-filtered tests passed with 371 expectations; eight optional integration tests skipped. Existing tests cover stable ties, reverse teardown, capability selection, and priority snapshots. Targeted PHPStan, Rector, code style, and prose checks passed. GitHub CI runs the complete checks.
