### PR TITLE
fix(execution): preserve after-hook assertion details

### DIFF
--- a/src/Execution/Worker/TestExecutor.php
+++ b/src/Execution/Worker/TestExecutor.php
@@ -253,7 +253,13 @@ final readonly class TestExecutor
                 } catch (\Throwable $threw) {
                     if (!$cause instanceof \Throwable) {
                         $cause = $threw;
-                        $error = ThrowableDetail::fromThrowable($threw);
+                        $skipReason = null;
+
+                        if ($threw instanceof ExpectationFailed) {
+                            $failures = $threw->details;
+                        } else {
+                            $error = ThrowableDetail::fromThrowable($threw);
+                        }
                     }
                 }
             }

--- a/tests/Fixture/Lifecycle/AfterExpectationFails/AfterExpectationFailsTest.php
+++ b/tests/Fixture/Lifecycle/AfterExpectationFails/AfterExpectationFailsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Lifecycle\AfterExpectationFails;
+
+use Greenlight\Attribute\After;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Test\SkipTest;
+
+final class AfterExpectationFailsTest
+{
+    #[Test]
+    public function passesUntilTeardown(): void {}
+
+    #[Test]
+    public function skipsBeforeTeardown(): never
+    {
+        throw new SkipTest('not applicable');
+    }
+
+    #[Test]
+    public function failsBeforeTeardown(): void
+    {
+        Expect::that('body actual')->toBe('body expected');
+    }
+
+    #[After]
+    public function verifies(): void
+    {
+        Expect::that('actual')->toBe('expected');
+    }
+}

--- a/tests/Unit/Execution/Worker/AfterHookExpectationTest.php
+++ b/tests/Unit/Execution/Worker/AfterHookExpectationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Execution\Worker;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\TestDiscoverer;
+use Greenlight\Execution\Worker\Worker;
+use Greenlight\Expect\Expect;
+use Greenlight\Result\Outcome;
+use Greenlight\Result\TestResult;
+use Greenlight\Tests\Support\CollectingEventSink;
+use Greenlight\Tests\Support\FixturePath;
+
+final readonly class AfterHookExpectationTest
+{
+    #[Test]
+    public function anAfterHookExpectationFailureRetainsItsComparison(): void
+    {
+        $result = $this->results()['passesUntilTeardown'];
+
+        Expect::that($result->outcome)->toBe(Outcome::Failed);
+        Expect::that($result->error)->toBeNull();
+        Expect::that($result->failures)->toHaveCount(1);
+        Expect::that($result->failures[0]->expected)->toBe("'expected'");
+        Expect::that($result->failures[0]->actual)->toBe("'actual'");
+        Expect::that($result->expectations)->toBe(1);
+    }
+
+    #[Test]
+    public function anAfterHookExpectationFailureOverridesASkip(): void
+    {
+        $result = $this->results()['skipsBeforeTeardown'];
+
+        Expect::that($result->outcome)->toBe(Outcome::Failed);
+        Expect::that($result->skipReason)->toBeNull();
+        Expect::that($result->error)->toBeNull();
+        Expect::that($result->failures[0]->expected)->toBe("'expected'");
+        Expect::that($result->failures[0]->actual)->toBe("'actual'");
+    }
+
+    #[Test]
+    public function anEarlierAssertionFailureRemainsPrimary(): void
+    {
+        $result = $this->results()['failsBeforeTeardown'];
+
+        Expect::that($result->outcome)->toBe(Outcome::Failed);
+        Expect::that($result->error)->toBeNull();
+        Expect::that($result->failures)->toHaveCount(1);
+        Expect::that($result->failures[0]->expected)->toBe("'body expected'");
+        Expect::that($result->failures[0]->actual)->toBe("'body actual'");
+    }
+
+    /** @return array<string, TestResult> */
+    private function results(): array
+    {
+        $plan = new TestDiscoverer()->discover([FixturePath::get('Lifecycle/AfterExpectationFails')]);
+        $sink = new CollectingEventSink();
+
+        new Worker([])->run($plan, $sink);
+
+        $results = [];
+
+        foreach ($sink->results() as $result) {
+            $results[$result->id->method] = $result;
+        }
+
+        return $results;
+    }
+}


### PR DESCRIPTION
An expectation failure in an `#[After]` hook was reported as an error. This discarded its expected and actual values, although the same assertion in the test body, a before hook, deferred cleanup, or service disposal produced a failed result with comparison details.

Preserve the expectation details when an after hook supplies the first failure. Clear an earlier skip when teardown fails. An existing test failure or error remains primary, and later after hooks still run.

The focused regression failed on the previous code with `Errored` instead of `Failed`. Three regression cases now pass, covering comparison details, a prior skip, and an earlier assertion failure. All 33 worker-filtered tests also pass. Targeted PHPStan, Rector, code style, and prose checks passed; GitHub CI runs the full checks.
