### PR TITLE
fix(doubles): reject nested object parameter defaults

### DIFF
--- a/src/Doubles/ProxyGenerator.php
+++ b/src/Doubles/ProxyGenerator.php
@@ -398,11 +398,20 @@ final readonly class ProxyGenerator
 
         $value = $parameter->getDefaultValue();
 
-        if (\is_object($value) && !$value instanceof \UnitEnum) {
+        if ($this->containsObjectDefault($value)) {
             throw InvalidDoubleUsage::objectDefaultNotReproducible($parameter->name, $context->name, $parameter->getDeclaringFunction()->name);
         }
 
         return \var_export($value, true);
+    }
+
+    private function containsObjectDefault(mixed $value): bool
+    {
+        if (\is_array($value)) {
+            return \array_any($value, $this->containsObjectDefault(...));
+        }
+
+        return \is_object($value) && !$value instanceof \UnitEnum;
     }
 
     /**

--- a/tests/Unit/Doubles/NestedObjectDefaultTest.php
+++ b/tests/Unit/Doubles/NestedObjectDefaultTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\InvalidDoubleUsage;
+use Greenlight\Expect\Expect;
+
+final readonly class NestedObjectDefaultTest
+{
+    public function __construct(private Doubles $doubles) {}
+
+    #[Test]
+    public function nestedObjectDefaultsProduceAnAuthoringError(): void
+    {
+        Expect::that(fn(): object => $this->doubles->stub(NestedObjectDefaultTarget::class))
+            ->toThrow(
+                InvalidDoubleUsage::class,
+                message: 'Doubles cannot reproduce the object default of parameter $values from '
+                    . NestedObjectDefaultTarget::class
+                    . '::run() in a proxy. Use an interface without object defaults instead.',
+            );
+    }
+
+    #[Test]
+    public function nestedScalarAndEnumDefaultsRemainValid(): void
+    {
+        $stub = $this->doubles->stub(NestedValueDefaultTarget::class);
+        $default = new \ReflectionMethod($stub, 'run')->getParameters()[0]->getDefaultValue();
+
+        Expect::that($default)->toBe(['values' => [null, 1, 'value', NestedDefaultChoice::First]]);
+    }
+}
+
+interface NestedObjectDefaultTarget
+{
+    /** @param array<string, list<\stdClass>> $values */
+    public function run(array $values = ['objects' => [new \stdClass()]]): void;
+}
+
+interface NestedValueDefaultTarget
+{
+    /** @param array<string, list<int|string|null|NestedDefaultChoice>> $values */
+    public function run(array $values = ['values' => [null, 1, 'value', NestedDefaultChoice::First]]): void;
+}
+
+enum NestedDefaultChoice
+{
+    case First;
+}


### PR DESCRIPTION
An interface parameter such as `array $values = ['objects' => [new stdClass()]]` is valid PHP, but creating its double writes `stdClass::__set_state()` into the generated parameter default. Loading that proxy terminates the worker with `Constant expression contains invalid operations`; the failure cannot be caught as a normal exception.

Inspect nested array defaults before generating PHP and report the existing `InvalidDoubleUsage` guidance for object defaults. Scalar values and enum cases remain supported.

The isolated baseline probe reproduced the fatal compile error. Two focused regressions now pass: the nested object produces the typed authoring error, and reflection confirms that a nested scalar/enum default retains its exact value. Focused PHPStan, Rector, and style checks pass. The API generator produces no documentation changes. Full composer static-analysis and composer tests pass locally: 3,403 tests passed, 15 optional-environment skips, and 8,665 expectations. The full test rerun used COMPOSER_PROCESS_TIMEOUT=0 because the first invocation spent part of its outer timeout waiting for the shared local validation slot. GitHub CI is still running. This change merges cleanly with #1811 and #1829.
