### PR TITLE
fix(phpstan): avoid default capture types for unpacked arguments

### DIFF
--- a/src/PhpStan/CaptureArgumentReturnTypeExtension.php
+++ b/src/PhpStan/CaptureArgumentReturnTypeExtension.php
@@ -90,6 +90,12 @@ final readonly class CaptureArgumentReturnTypeExtension implements DynamicMethod
 
     private function position(MethodCall $call, Scope $scope): ?int
     {
+        foreach ($call->getArgs() as $argument) {
+            if ($argument->unpack) {
+                return null;
+            }
+        }
+
         $argument = $this->argument($call, 'position', 0);
 
         if (!$argument instanceof Arg) {

--- a/tests/Acceptance/PhpStanUnpackedCaptureArgumentTest.php
+++ b/tests/Acceptance/PhpStanUnpackedCaptureArgumentTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\PhpStanProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class PhpStanUnpackedCaptureArgumentTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function unpackedPositionsDoNotUseTheDefaultParameterType(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            use Greenlight\Doubles\Doubles;
+            use Greenlight\Doubles\MockPlan;
+
+            interface SafeCaptureTarget
+            {
+                public function record(int $id, string $text): void;
+            }
+
+            function acceptsCapturedMixed(mixed $value): void {}
+            function acceptsDefaultInt(int $value): void {}
+
+            function safeCapture(Doubles $doubles): void
+            {
+                $doubles->mock(SafeCaptureTarget::class, static function (MockPlan $plan): void {
+                    acceptsCapturedMixed($plan->expects('record')->captureArgument(...[1])->value());
+                    acceptsDefaultInt($plan->expects('record')->captureArgument()->value());
+                });
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            use Greenlight\Doubles\Doubles;
+            use Greenlight\Doubles\MockPlan;
+
+            interface UnsafeCaptureTarget
+            {
+                public function record(int $id, string $text): void;
+            }
+
+            function requiresCapturedInt(int $value): void {}
+
+            /** @param array{int} $position */
+            function unsafeCapture(Doubles $doubles, array $position): void
+            {
+                $doubles->mock(UnsafeCaptureTarget::class, static function (MockPlan $plan) use ($position): void {
+                    requiresCapturedInt($plan->expects('record')->captureArgument(...[1])->value());
+                    requiresCapturedInt($plan->expects('record')->captureArgument(...['position' => 1])->value());
+                    requiresCapturedInt($plan->expects('record')->captureArgument(...$position)->value());
+                });
+            }
+            PHP,
+        );
+
+        Expect::that($probe->goodPassed)->because('PHPStan messages: ' . \implode("\n", $probe->goodErrors))->toBeTrue();
+        Expect::that($probe->exitCode)->toBe(1);
+        Expect::that(\count($probe->errors))->toBe(3);
+        Expect::that($probe->messages())->toContain('expects int, mixed given');
+    }
+}


### PR DESCRIPTION
PHPStan treated an unpacked `captureArgument()` position as the omitted default position, zero. For a doubled method `record(int $id, string $text)`, `captureArgument(...[1])->value()` was therefore inferred as `int`, although it captures the second, string parameter. This allowed an incompatible use to pass analysis.

Return the declared mixed captor type when a call unpacks arguments. Explicit positional, named, and omitted positions keep their existing inference. This conservative fallback avoids claiming a parameter type when the extension has not resolved the unpacked position.

The new regression checks positional-array, named-array, and dynamic-array unpacking. All three unsafe uses were accepted before the change and are rejected afterward. The existing capture type regression and focused PHPStan, Rector, and style checks pass.
