### PR TITLE
docs(hyperf): correct cleanup callback order

### DIFF
--- a/docs/hyperf.md
+++ b/docs/hyperf.md
@@ -119,7 +119,7 @@ The isolated mode uses this lifecycle for each attempt:
 3. Resolve `Hyperf\Contract\ApplicationInterface` to boot the application.
 4. Construct the test and run all hooks, plugins, and the test method.
 5. Close the Greenlight test service scope.
-6. Call the reset callback. If it succeeds, call the disposal callback.
+6. Call the reset callback, then call the disposal callback even if reset fails.
 7. Remove access to the discarded application container.
 8. Clear Swoole timers and resume Hyperf's worker-exit coordinator.
 9. End the coroutine.
@@ -193,10 +193,9 @@ runs inside the test coroutine in both modes.
 
 The disposal callback runs before Greenlight discards its container. In worker
 mode, it runs once when the worker exits. In test-attempt mode, the reset
-callback runs first. If reset succeeds, disposal runs after the attempt. If
-reset throws, the attempt has an error and Greenlight does not call disposal
-for that container. Greenlight still removes access to the container, clears
-the coroutine runtime, and ends the coroutine.
+callback runs first. Disposal runs even if reset throws. Greenlight keeps an
+earlier attempt failure, or the first cleanup failure, as the cause. It removes
+access to the container, clears the coroutine runtime, and ends the coroutine.
 
 The bridge does not reset application static properties or global variables.
 Reset these values in an `#[After]` hook or the `reset:` callback.


### PR DESCRIPTION
Superseded by #1809, merged into main as `02d58b861`. That change corrects both cleanup passages, so this PR is closed without merging.

The Hyperf guide said that a reset failure prevents disposal in test-attempt mode. The implementation runs both callbacks independently and preserves the earlier failure. Users who follow the guide can make incorrect assumptions about cleanup after a failed attempt.

Correct the lifecycle steps and callback description to match `HyperfPlugin::disposeAttemptContainer()` and the existing cleanup failure fixture. The repository prose check passes.
