### PR TITLE
fix(rector): preserve assertion argument evaluation order

### DIFF
--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -455,7 +455,7 @@ equivalent. It does not change other classes.
 final class PhpUnitToGreenlightRector extends AbstractRector implements ConfigurableRectorInterface, DocumentedRuleInterface
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Rector/PhpUnitToGreenlightRector.php#L54)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Rector/PhpUnitToGreenlightRector.php#L55)
 
 ### `DROP_ASSERTION_MESSAGES`
 
@@ -467,7 +467,7 @@ preserve the message with `because()`.
 public const string DROP_ASSERTION_MESSAGES = 'drop_assertion_messages';
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Rector/PhpUnitToGreenlightRector.php#L61)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Rector/PhpUnitToGreenlightRector.php#L62)
 
 ### `configure()`
 
@@ -480,7 +480,7 @@ PHPDoc:
 - `@param mixed[] $configuration`
 - `@throws \InvalidArgumentException if a key is unknown or \`drop_assertion_messages\` is not a boolean`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Rector/PhpUnitToGreenlightRector.php#L115)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Rector/PhpUnitToGreenlightRector.php#L116)
 
 ### `getRuleDefinition()`
 
@@ -488,7 +488,7 @@ PHPDoc:
 public function getRuleDefinition(): RuleDefinition
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Rector/PhpUnitToGreenlightRector.php#L139)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Rector/PhpUnitToGreenlightRector.php#L140)
 
 ### `getNodeTypes()`
 
@@ -500,7 +500,7 @@ PHPDoc:
 
 - `@return array<class-string<Node>>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Rector/PhpUnitToGreenlightRector.php#L173)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Rector/PhpUnitToGreenlightRector.php#L174)
 
 ### `refactor()`
 
@@ -508,7 +508,7 @@ PHPDoc:
 public function refactor(Node $node): ?Node
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Rector/PhpUnitToGreenlightRector.php#L178)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Rector/PhpUnitToGreenlightRector.php#L179)
 
 ## `SymfonyPlugin`
 

--- a/docs/migrating-from-phpunit.md
+++ b/docs/migrating-from-phpunit.md
@@ -47,6 +47,7 @@ A class does not convert when it uses:
   [strict doubles](test-doubles.md)
 * `#[Depends]`, `setUpBeforeClass()`, `tearDownAfterClass()`, or traits
 * assertions without a Greenlight matcher, for example file or XML assertions
+* assertion arguments whose changed evaluation order can change their values
 * `assertEmpty()` or `assertNotEmpty()`, because Greenlight uses different
   empty-value rules
 * multiple data providers or multiple requirements on one declaration

--- a/src/Rector/PhpUnitToGreenlightRector.php
+++ b/src/Rector/PhpUnitToGreenlightRector.php
@@ -793,7 +793,8 @@ final class PhpUnitToGreenlightRector extends AbstractRector implements Configur
                 return false;
             }
 
-            return \count($arguments) === $conversion->arity || $this->dropAssertionMessages;
+            return (\count($arguments) === $conversion->arity || $this->dropAssertionMessages)
+                && $this->argumentOrderConverts($conversion, $arguments);
         }
 
         if ($name === self::FAIL) {
@@ -817,6 +818,79 @@ final class PhpUnitToGreenlightRector extends AbstractRector implements Configur
         }
 
         return false;
+    }
+
+    /**
+     * @param list<Arg> $arguments
+     */
+    private function argumentOrderConverts(AssertionConversion $conversion, array $arguments): bool
+    {
+        $order = [$conversion->subject, ...$conversion->matcherArguments];
+
+        foreach ($order as $position => $index) {
+            foreach (\array_slice($order, $position + 1) as $laterIndex) {
+                if ($index < $laterIndex) {
+                    continue;
+                }
+
+                $first = $arguments[$index]->value;
+                $second = $arguments[$laterIndex]->value;
+
+                if ($this->isLiteralValue($first) || $this->isLiteralValue($second)) {
+                    continue;
+                }
+
+                if ($first instanceof Variable && \is_string($first->name)
+                    && $second instanceof Variable && \is_string($second->name)
+                ) {
+                    continue;
+                }
+
+                // Calls and property hooks can change the other argument.
+                // Keep the PHPUnit class when their order cannot stay safe.
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function isLiteralValue(Expr $expression): bool
+    {
+        if ($expression instanceof String_ || $expression instanceof Node\Scalar\Int_
+            || $expression instanceof Node\Scalar\Float_ || $expression instanceof Node\Scalar\MagicConst
+        ) {
+            return true;
+        }
+
+        if ($expression instanceof Expr\ConstFetch) {
+            return \in_array($expression->name->toLowerString(), ['true', 'false', 'null'], true);
+        }
+
+        if ($expression instanceof ClassConstFetch) {
+            return $expression->class instanceof Name
+                && $expression->name instanceof Identifier
+                && $expression->name->toLowerString() === 'class';
+        }
+
+        if ($expression instanceof Expr\UnaryMinus || $expression instanceof Expr\UnaryPlus) {
+            return $this->isLiteralValue($expression->expr);
+        }
+
+        if (!$expression instanceof Expr\Array_) {
+            return false;
+        }
+
+        foreach ($expression->items as $item) {
+            if ($item === null || $item->byRef || $item->unpack
+                || ($item->key !== null && !$this->isLiteralValue($item->key))
+                || !$this->isLiteralValue($item->value)
+            ) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private function isSelfReceiver(MethodCall|StaticCall $call): bool

--- a/src/Rector/PhpUnitToGreenlightRector.php
+++ b/src/Rector/PhpUnitToGreenlightRector.php
@@ -19,6 +19,7 @@ use Greenlight\Test\SkipTest;
 use PhpParser\Modifiers;
 use PhpParser\Node;
 use PhpParser\Node\Arg;
+use PhpParser\Node\ArrayItem;
 use PhpParser\Node\Attribute;
 use PhpParser\Node\AttributeGroup;
 use PhpParser\Node\Expr;
@@ -881,16 +882,10 @@ final class PhpUnitToGreenlightRector extends AbstractRector implements Configur
             return false;
         }
 
-        foreach ($expression->items as $item) {
-            if ($item === null || $item->byRef || $item->unpack
-                || ($item->key !== null && !$this->isLiteralValue($item->key))
-                || !$this->isLiteralValue($item->value)
-            ) {
-                return false;
-            }
-        }
-
-        return true;
+        return \array_all($expression->items, fn(?ArrayItem $item): bool => $item instanceof ArrayItem
+            && !$item->byRef && !$item->unpack
+            && (!$item->key instanceof Expr || $this->isLiteralValue($item->key))
+            && $this->isLiteralValue($item->value));
     }
 
     private function isSelfReceiver(MethodCall|StaticCall $call): bool

--- a/tests/Acceptance/RectorArgumentOrderTest.php
+++ b/tests/Acceptance/RectorArgumentOrderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Acceptance;
 
+use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\RequiresResource;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
@@ -16,23 +17,13 @@ final readonly class RectorArgumentOrderTest
     public function __construct(private TemporaryDirectory $workspace) {}
 
     #[Test]
-    public function keepsClassesWhoseAssertionArgumentsCanAffectEachOther(): void
+    #[DataSet('assertionsWhoseArgumentsCanAffectEachOther')]
+    public function keepsClassesWhoseAssertionArgumentsCanAffectEachOther(string $assertion): void
     {
-        $assertions = [
-            'post increment' => 'self::assertSame($value, $value++);',
-            'assignment' => 'self::assertSame($value, $value = 2);',
-            'array mutation' => 'self::assertSame($values, array_pop($values));',
-            'two function calls' => 'self::assertSame(array_shift($values), array_shift($values));',
-            'property and method' => 'self::assertSame($state->value, $state->next());',
-            'two property reads' => 'self::assertSame($state->first, $state->second);',
-            'delta mutation' => 'self::assertEqualsWithDelta($value, 1, $value = 2);',
-        ];
-        $cases = \array_map($this->source(...), $assertions);
-        $probes = RectorProbe::convertBatch($this->workspace, $cases, name: 'assertion-order');
+        $source = $this->source($assertion);
+        $probe = RectorProbe::convert($this->workspace, $source, name: 'assertion-order');
 
-        foreach ($probes as $name => $probe) {
-            Expect::that($probe->code)->because('argument order: ' . $name)->toBe($cases[$name]);
-        }
+        Expect::that($probe->code)->toBe($source);
     }
 
     #[Test]
@@ -48,6 +39,20 @@ final readonly class RectorArgumentOrderTest
 
         Expect::that($probe->changed)->toBeTrue();
         Expect::that($probe->runConvertedTests()->exitCode)->toBe(0);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function assertionsWhoseArgumentsCanAffectEachOther(): iterable
+    {
+        yield 'post increment' => ['self::assertSame($value, $value++);'];
+        yield 'assignment' => ['self::assertSame($value, $value = 2);'];
+        yield 'array mutation' => ['self::assertSame($values, array_pop($values));'];
+        yield 'two function calls' => ['self::assertSame(array_shift($values), array_shift($values));'];
+        yield 'property and method' => ['self::assertSame($state->value, $state->next());'];
+        yield 'two property reads' => ['self::assertSame($state->first, $state->second);'];
+        yield 'delta mutation' => ['self::assertEqualsWithDelta($value, 1, $value = 2);'];
     }
 
     private function source(string $assertion): string

--- a/tests/Acceptance/RectorArgumentOrderTest.php
+++ b/tests/Acceptance/RectorArgumentOrderTest.php
@@ -27,7 +27,7 @@ final readonly class RectorArgumentOrderTest
             'two property reads' => 'self::assertSame($state->first, $state->second);',
             'delta mutation' => 'self::assertEqualsWithDelta($value, 1, $value = 2);',
         ];
-        $cases = \array_map(self::source(...), $assertions);
+        $cases = \array_map($this->source(...), $assertions);
         $probes = RectorProbe::convertBatch($this->workspace, $cases, name: 'assertion-order');
 
         foreach ($probes as $name => $probe) {
@@ -38,7 +38,7 @@ final readonly class RectorArgumentOrderTest
     #[Test]
     public function convertsIndependentArgumentsAndKeepsTheirResults(): void
     {
-        $probe = RectorProbe::convert($this->workspace, self::source(<<<'PHP'
+        $probe = RectorProbe::convert($this->workspace, $this->source(<<<'PHP'
             self::assertSame(1, $value++);
             self::assertSame($value, $value);
             self::assertSame([1, 2], $values);
@@ -50,7 +50,7 @@ final readonly class RectorArgumentOrderTest
         Expect::that($probe->runConvertedTests()->exitCode)->toBe(0);
     }
 
-    private static function source(string $assertion): string
+    private function source(string $assertion): string
     {
         return <<<PHP
             <?php

--- a/tests/Acceptance/RectorArgumentOrderTest.php
+++ b/tests/Acceptance/RectorArgumentOrderTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorArgumentOrderTest
+{
+    public function __construct(private TemporaryDirectory $workspace) {}
+
+    #[Test]
+    public function keepsClassesWhoseAssertionArgumentsCanAffectEachOther(): void
+    {
+        $assertions = [
+            'post increment' => 'self::assertSame($value, $value++);',
+            'assignment' => 'self::assertSame($value, $value = 2);',
+            'array mutation' => 'self::assertSame($values, array_pop($values));',
+            'two function calls' => 'self::assertSame(array_shift($values), array_shift($values));',
+            'property and method' => 'self::assertSame($state->value, $state->next());',
+            'two property reads' => 'self::assertSame($state->first, $state->second);',
+            'delta mutation' => 'self::assertEqualsWithDelta($value, 1, $value = 2);',
+        ];
+        $cases = \array_map(self::source(...), $assertions);
+        $probes = RectorProbe::convertBatch($this->workspace, $cases, name: 'assertion-order');
+
+        foreach ($probes as $name => $probe) {
+            Expect::that($probe->code)->because('argument order: ' . $name)->toBe($cases[$name]);
+        }
+    }
+
+    #[Test]
+    public function convertsIndependentArgumentsAndKeepsTheirResults(): void
+    {
+        $probe = RectorProbe::convert($this->workspace, self::source(<<<'PHP'
+            self::assertSame(1, $value++);
+            self::assertSame($value, $value);
+            self::assertSame([1, 2], $values);
+            self::assertInstanceOf(\stdClass::class, new \stdClass());
+            self::assertEqualsWithDelta(0.3, 0.1 + 0.2, 0.001);
+            PHP), name: 'independent-arguments');
+
+        Expect::that($probe->changed)->toBeTrue();
+        Expect::that($probe->runConvertedTests()->exitCode)->toBe(0);
+    }
+
+    private static function source(string $assertion): string
+    {
+        return <<<PHP
+            <?php
+
+            declare(strict_types=1);
+
+            namespace AssertionOrder;
+
+            final class ProbeTest extends \PHPUnit\Framework\TestCase
+            {
+                public function testOrder(): void
+                {
+                    \$value = 1;
+                    \$values = [1, 2];
+                    {$assertion}
+                }
+            }
+
+            PHP;
+    }
+}


### PR DESCRIPTION
The PHPUnit migration rule changes assertion argument order when it moves the actual value into `Expect::that()`. For example, `assertSame($value, $value++)` passes with `$value = 1`, but the converted assertion reads the incremented expected value and fails. Calls, assignments, and property hooks can cause the same problem.

Keep the PHPUnit class unchanged when reordered arguments can affect one another. Literal values and ordinary variable reads still convert. This conservative check can leave some independent expressions unchanged rather than change their behavior.

The regression failed before the fix and now passes. Seven cases cover mutations, calls, property reads, and delta assertions. A separate case runs converted assertions to confirm that supported independent arguments keep their results. The final commit passes `composer static-analysis` and `composer tests`. An earlier broad local Rector filter also selected directory tests and reported a macOS `open_basedir` diagnostic in `TemporaryDirectoryTest`; the full suite passes.
