### PR TITLE
refactor(cli): convert worker results in Application

### DIFF
--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -168,7 +168,11 @@ deptrac:
     - name: Cli
       collectors:
         - type: directory
-          value: src/Cli/[^/]+\.php
+          value: src/Cli/(?!ExitCode\.php$)[^/]+\.php
+    - name: CliExitCode
+      collectors:
+        - type: directory
+          value: src/Cli/ExitCode\.php$
     - name: CliInput
       collectors:
         - type: directory
@@ -345,9 +349,10 @@ deptrac:
     ExecutionPlugin: [Artifact, DiscoveryPlan, Event, Expect, Harness, IntegrationFixture, Plugin, Result, Test]
     ExecutionWorker: [Artifact, Attribute, Condition, DiscoveryPlan, Doubles, Event, ExecutionArtifact, ExecutionPlugin, Expect, Harness, IntegrationFixture, InternalPhp, InternalText, Plugin, Result, Sandbox, Test, TestDataSet]
     ExecutionProcessProtocol: [Attribute, Config, Coverage, DiscoveryPlan, Event, ExecutionArtifact, IntegrationFixture, InternalEvent, InternalPhp, InternalWire, Result, Test]
-    ExecutionProcessWorker: [Config, CoverageCollection, Event, ExecutionArtifact, ExecutionPlugin, ExecutionProcessProtocol, ExecutionWorker, Harness, InternalPhp, InternalWire, Plugin, Result, Test]
+    ExecutionProcessWorker: [CliExitCode, Config, CoverageCollection, Event, ExecutionArtifact, ExecutionPlugin, ExecutionProcessProtocol, ExecutionWorker, Harness, InternalPhp, InternalWire, Plugin, Result, Test]
     ExecutionProcessOrchestrator: [Artifact, Config, Coverage, CoverageCollection, DiscoveryPlan, Event, ExecutionArtifact, ExecutionProcessProtocol, ExecutionWorker, IntegrationFixture, InternalPhp, InternalProcess, InternalText, InternalWire, Reporting, Result, Test]
-    Cli: [CliCommand, CliOutput, CliPlugin, Coverage, CoverageRelay, ExecutionProcessProtocol, ExecutionProcessWorker, InternalWire, Plugin, Reporting]
+    Cli: [CliCommand, CliExitCode, CliOutput, CliPlugin, Coverage, CoverageRelay, ExecutionProcessProtocol, ExecutionProcessWorker, InternalWire, Plugin, Reporting]
+    CliExitCode: [Plugin]
     CliInput: []
     CliConfiguration: [CliInput, Config, InternalPhp, InternalText, Result, Test]
     CliDiscovery: [CliConfiguration, CliInput, CliState, Config, Discovery, DiscoveryPlan, Test]

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -168,11 +168,7 @@ deptrac:
     - name: Cli
       collectors:
         - type: directory
-          value: src/Cli/(?!ExitCode\.php$)[^/]+\.php
-    - name: CliExitCode
-      collectors:
-        - type: directory
-          value: src/Cli/ExitCode\.php$
+          value: src/Cli/[^/]+\.php
     - name: CliInput
       collectors:
         - type: directory
@@ -349,10 +345,9 @@ deptrac:
     ExecutionPlugin: [Artifact, DiscoveryPlan, Event, Expect, Harness, IntegrationFixture, Plugin, Result, Test]
     ExecutionWorker: [Artifact, Attribute, Condition, DiscoveryPlan, Doubles, Event, ExecutionArtifact, ExecutionPlugin, Expect, Harness, IntegrationFixture, InternalPhp, InternalText, Plugin, Result, Sandbox, Test, TestDataSet]
     ExecutionProcessProtocol: [Attribute, Config, Coverage, DiscoveryPlan, Event, ExecutionArtifact, IntegrationFixture, InternalEvent, InternalPhp, InternalWire, Result, Test]
-    ExecutionProcessWorker: [CliExitCode, Config, CoverageCollection, Event, ExecutionArtifact, ExecutionPlugin, ExecutionProcessProtocol, ExecutionWorker, Harness, InternalPhp, InternalWire, Plugin, Result, Test]
+    ExecutionProcessWorker: [Config, CoverageCollection, Event, ExecutionArtifact, ExecutionPlugin, ExecutionProcessProtocol, ExecutionWorker, Harness, InternalPhp, InternalWire, Plugin, Result, Test]
     ExecutionProcessOrchestrator: [Artifact, Config, Coverage, CoverageCollection, DiscoveryPlan, Event, ExecutionArtifact, ExecutionProcessProtocol, ExecutionWorker, IntegrationFixture, InternalPhp, InternalProcess, InternalText, InternalWire, Reporting, Result, Test]
-    Cli: [CliCommand, CliExitCode, CliOutput, CliPlugin, Coverage, CoverageRelay, ExecutionProcessProtocol, ExecutionProcessWorker, InternalWire, Plugin, Reporting]
-    CliExitCode: [Plugin]
+    Cli: [CliCommand, CliOutput, CliPlugin, Coverage, CoverageRelay, ExecutionProcessProtocol, ExecutionProcessWorker, InternalWire, Plugin, Reporting]
     CliInput: []
     CliConfiguration: [CliInput, Config, InternalPhp, InternalText, Result, Test]
     CliDiscovery: [CliConfiguration, CliInput, CliState, Config, Discovery, DiscoveryPlan, Test]

--- a/src/Cli/Application.php
+++ b/src/Cli/Application.php
@@ -69,7 +69,9 @@ final readonly class Application
                 return ExitCode::fromCommandResult(CommandResult::usage())->value();
             }
 
-            return new WorkerProcess(isolateProcessGroup: true)->run($argv[1], $argv[2], $argv[3]);
+            $result = new WorkerProcess(isolateProcessGroup: true)->run($argv[1], $argv[2], $argv[3]);
+
+            return ExitCode::fromCommandResult($result)->value();
         }
 
         // A run with coverage exports the relay variables to each child

--- a/src/Execution/ProcessPool/Worker/WorkerProcess.php
+++ b/src/Execution/ProcessPool/Worker/WorkerProcess.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Greenlight\Execution\ProcessPool\Worker;
 
-use Greenlight\Cli\ExitCode;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Config\ConfigLoader;
 use Greenlight\Coverage\Collection\CoverageCollector;
@@ -60,7 +59,7 @@ final readonly class WorkerProcess
      * @param non-empty-string $token
      * @throws ProtocolError
      */
-    public function run(string $address, string $workerId, string $token): int
+    public function run(string $address, string $workerId, string $token): CommandResult
     {
         // Keep the worker and its subprocesses outside the terminal process group.
         // Thus, terminal SIGINT reaches only the orchestrator.
@@ -80,7 +79,7 @@ final readonly class WorkerProcess
         }
 
         try {
-            return ExitCode::fromCommandResult($this->runWhileIgnoringInterrupt($address, $workerId, $token))->value();
+            return $this->runWhileIgnoringInterrupt($address, $workerId, $token);
         } finally {
             if ($interruptHandler !== null && \function_exists('pcntl_signal')) {
                 \pcntl_signal(\SIGINT, $interruptHandler);

--- a/src/Execution/ProcessPool/Worker/WorkerProcess.php
+++ b/src/Execution/ProcessPool/Worker/WorkerProcess.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Execution\ProcessPool\Worker;
 
+use Greenlight\Cli\ExitCode;
 use Greenlight\Config\ArtifactConfiguration;
 use Greenlight\Config\ConfigLoader;
 use Greenlight\Coverage\Collection\CoverageCollector;
@@ -32,6 +33,7 @@ use Greenlight\Execution\Worker\WorkerError;
 use Greenlight\Harness\HarnessScopes;
 use Greenlight\Internal\Php\ErrorTrap;
 use Greenlight\Internal\Wire\WireCommunicationFailed;
+use Greenlight\Plugin\CommandResult;
 use Greenlight\Plugin\WorkerBootstrapContext;
 use Greenlight\Result\ResultPolicy;
 use Greenlight\Result\ThrowableDetail;
@@ -78,7 +80,7 @@ final readonly class WorkerProcess
         }
 
         try {
-            return $this->runWhileIgnoringInterrupt($address, $workerId, $token);
+            return ExitCode::fromCommandResult($this->runWhileIgnoringInterrupt($address, $workerId, $token))->value();
         } finally {
             if ($interruptHandler !== null && \function_exists('pcntl_signal')) {
                 \pcntl_signal(\SIGINT, $interruptHandler);
@@ -92,7 +94,7 @@ final readonly class WorkerProcess
      * @param non-empty-string $token
      * @throws ProtocolError
      */
-    private function runWhileIgnoringInterrupt(string $address, string $workerId, string $token): int
+    private function runWhileIgnoringInterrupt(string $address, string $workerId, string $token): CommandResult
     {
         $stream = ErrorTrap::run(static function () use ($address, &$errorCode, &$errorMessage) {
             return \stream_socket_client($address, $errorCode, $errorMessage, 10.0);
@@ -101,7 +103,7 @@ final readonly class WorkerProcess
         if ($stream === false) {
             \fwrite(\STDERR, \sprintf("The worker did not connect to %s: %s\n", $address, $errorMessage));
 
-            return 1;
+            return CommandResult::failure();
         }
 
         $channel = new SocketChannel($stream);
@@ -123,11 +125,11 @@ final readonly class WorkerProcess
                         continue;
                     }
 
-                    return 0;
+                    return CommandResult::success();
                 }
 
                 if ($message instanceof Drain) {
-                    return 0;
+                    return CommandResult::success();
                 }
 
                 if (!$message instanceof Bootstrap) {
@@ -175,7 +177,7 @@ final readonly class WorkerProcess
                     $channel->send($finalMessage);
                 }
 
-                return 0;
+                return CommandResult::success();
             }
         } catch (\Throwable $threw) {
             try {
@@ -185,7 +187,7 @@ final readonly class WorkerProcess
                 // the channel is gone.
             }
 
-            return 1;
+            return CommandResult::failure();
         } finally {
             $scopes?->closeWorker();
             $channel->close();

--- a/tests/Acceptance/InternalWorkerExitCodeTest.php
+++ b/tests/Acceptance/InternalWorkerExitCodeTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Execution\ProcessPool\Protocol\Messages\Drain;
+use Greenlight\Execution\ProcessPool\Protocol\Messages\Hello;
+use Greenlight\Execution\ProcessPool\Protocol\SocketChannel;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\Fail;
+use Greenlight\Test\Cleanup;
+use Greenlight\Tests\Support\GreenlightCli;
+
+final readonly class InternalWorkerExitCodeTest
+{
+    public function __construct(private Cleanup $cleanup) {}
+
+    #[Test]
+    #[DataSet('shutdownModes')]
+    public function shutdownBeforeBootstrapReturnsSuccess(bool $drain): void
+    {
+        $server = \stream_socket_server('tcp://127.0.0.1:0');
+
+        if ($server === false) {
+            Fail::because('Could not start the worker protocol server.');
+        }
+
+        try {
+            $address = \stream_socket_get_name($server, false);
+
+            if ($address === false) {
+                Fail::because('Could not read the worker protocol server address.');
+            }
+
+            $process = GreenlightCli::start(\dirname(__DIR__, 2), ['__worker', 'tcp://' . $address, 'worker-exit', 'token']);
+            $this->cleanup->defer($process->terminate(...));
+            $connection = \stream_socket_accept($server, 5.0);
+
+            if ($connection === false) {
+                Fail::because('The worker did not connect to the protocol server.');
+            }
+
+            $channel = new SocketChannel($connection);
+
+            try {
+                Expect::that($channel->receive(5.0))->toBeInstanceOf(Hello::class);
+
+                if ($drain) {
+                    $channel->send(new Drain());
+                }
+            } finally {
+                $channel->close();
+            }
+
+            $result = $process->wait(5.0);
+
+            Expect::that($result->exitCode)->toBe(0);
+            Expect::that($result->stderr)->toBe('');
+        } finally {
+            \fclose($server);
+        }
+    }
+
+    /** @return iterable<string, array{bool}> */
+    public static function shutdownModes(): iterable
+    {
+        yield 'drain' => [true];
+        yield 'closed connection' => [false];
+    }
+}

--- a/tests/Fixture/Execution/ProcessPool/Orchestrator/DisconnectBeforeAssignmentWorker.php
+++ b/tests/Fixture/Execution/ProcessPool/Orchestrator/DisconnectBeforeAssignmentWorker.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Fixture\Execution\ProcessPool\Orchestrator;
 
+use Greenlight\Cli\ExitCode;
 use Greenlight\Doubles\Fake;
 use Greenlight\Execution\ProcessPool\Protocol\Messages\Hello;
 use Greenlight\Execution\ProcessPool\Protocol\SocketChannel;
@@ -19,7 +20,7 @@ final readonly class DisconnectBeforeAssignmentWorker implements Fake
     public static function run(string $address, string $workerId, string $token): int
     {
         if ($workerId !== 'w-1') {
-            return new WorkerProcess()->run($address, $workerId, $token);
+            return ExitCode::fromCommandResult(new WorkerProcess()->run($address, $workerId, $token))->value();
         }
 
         $stream = \stream_socket_client($address);

--- a/tests/Fixture/Execution/ProcessPool/Orchestrator/LoggedWorkerProcess.php
+++ b/tests/Fixture/Execution/ProcessPool/Orchestrator/LoggedWorkerProcess.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Fixture\Execution\ProcessPool\Orchestrator;
 
+use Greenlight\Cli\ExitCode;
 use Greenlight\Doubles\Fake;
 use Greenlight\Execution\ProcessPool\Worker\WorkerProcess;
 
@@ -29,7 +30,7 @@ final readonly class LoggedWorkerProcess implements Fake
             self::record('exit-end', $workerId);
         });
 
-        return new WorkerProcess()->run($address, $workerId, $token);
+        return ExitCode::fromCommandResult(new WorkerProcess()->run($address, $workerId, $token))->value();
     }
 
     private static function record(string $phase, string $workerId): void

--- a/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorTest.php
+++ b/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorTest.php
@@ -85,6 +85,9 @@ final class OrchestratorTest
         $root = \dirname(__DIR__, 5);
         $script = \sprintf(
             <<<'PHP'
+                use Greenlight\Cli\ExitCode;
+                use Greenlight\Execution\ProcessPool\Worker\WorkerProcess;
+
                 [, , $address, $workerId, $token] = $argv;
                 $socket = stream_socket_client($address);
                 $json = json_encode([
@@ -102,7 +105,7 @@ final class OrchestratorTest
 
                 require %s;
 
-                exit(new \Greenlight\Execution\ProcessPool\Worker\WorkerProcess()->run($address, $workerId, $token));
+                exit(ExitCode::fromCommandResult(new WorkerProcess()->run($address, $workerId, $token))->value());
                 PHP,
             \var_export($root . '/vendor/autoload.php', true),
         );

--- a/tests/Unit/Execution/ProcessPool/Worker/WorkerArtifactSessionTest.php
+++ b/tests/Unit/Execution/ProcessPool/Worker/WorkerArtifactSessionTest.php
@@ -9,6 +9,7 @@ use Greenlight\Attribute\Timeout;
 use Greenlight\Execution\ProcessPool\Worker\WorkerProcess;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
+use Greenlight\Plugin\CommandResult;
 use Greenlight\Sandbox\EnvironmentVariables;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Test\Cleanup;
@@ -133,12 +134,12 @@ final readonly class WorkerArtifactSessionTest
         }
 
         $this->environment->set('GREENLIGHT_CHANNEL', '1');
-        $workerExit = new WorkerProcess(0.01)->run($address, 'worker-under-test', 'token');
+        $workerResult = new WorkerProcess(0.01)->run($address, 'worker-under-test', 'token');
         $serverExit = $server->wait(2.0)->exitCode;
 
-        Expect::that($workerExit)
+        Expect::that($workerResult)
             ->because('a worker with artifact settings MUST complete its assignment')
-            ->toBe(0);
+            ->toEqual(CommandResult::success());
         Expect::that($serverExit)
             ->because('the worker MUST stage evidence in the assigned artifact session')
             ->toBe(0);

--- a/tests/Unit/Execution/ProcessPool/Worker/WorkerProcessFatalSendFailureTest.php
+++ b/tests/Unit/Execution/ProcessPool/Worker/WorkerProcessFatalSendFailureTest.php
@@ -9,6 +9,7 @@ use Greenlight\Attribute\Timeout;
 use Greenlight\Execution\ProcessPool\Worker\WorkerProcess;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
+use Greenlight\Plugin\CommandResult;
 use Greenlight\Sandbox\EnvironmentVariables;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Test\Cleanup;
@@ -157,12 +158,12 @@ final readonly class WorkerProcessFatalSendFailureTest
         }
 
         $this->environment->set('GREENLIGHT_CHANNEL', '1');
-        $workerExit = new WorkerProcess()->run($address, 'worker-under-test', 'token');
+        $workerResult = new WorkerProcess()->run($address, 'worker-under-test', 'token');
         $serverResult = $server->wait(3.0);
 
-        Expect::that($workerExit)
+        Expect::that($workerResult)
             ->because('a failed final report MUST not escape the worker process')
-            ->toBe(1);
+            ->toEqual(CommandResult::failure());
         Expect::that($serverResult->exitCode)
             ->because('the protocol fixture MUST reset the channel before it releases the assignment failure')
             ->toBe(0);

--- a/tests/Unit/Execution/ProcessPool/Worker/WorkerProcessTest.php
+++ b/tests/Unit/Execution/ProcessPool/Worker/WorkerProcessTest.php
@@ -12,9 +12,11 @@ use Greenlight\Condition\FunctionAvailable;
 use Greenlight\Execution\ProcessPool\Worker\WorkerProcess;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
+use Greenlight\Plugin\CommandResult;
 use Greenlight\Sandbox\EnvironmentVariables;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Test\Cleanup;
+use Greenlight\Tests\Support\GreenlightCli;
 use Greenlight\Tests\Support\PhpSubprocess;
 
 final readonly class WorkerProcessTest
@@ -31,20 +33,7 @@ final readonly class WorkerProcessTest
         $root = \dirname(__DIR__, 5);
         $address = 'unix://' . $this->tempDirectory->path() . '/missing-worker.sock';
 
-        $result = PhpSubprocess::run($root, [
-            '-r',
-            <<<'PHP'
-            require $argv[1];
-
-            exit(new Greenlight\Execution\ProcessPool\Worker\WorkerProcess()->run(
-                $argv[2],
-                'worker-under-test',
-                'token',
-            ));
-            PHP,
-            $root . '/vendor/autoload.php',
-            $address,
-        ]);
+        $result = GreenlightCli::run($root, ['__worker', $address, 'worker-under-test', 'token']);
 
         Expect::that($result->exitCode)
             ->because('a worker connection failure MUST fail startup')
@@ -67,7 +56,7 @@ final readonly class WorkerProcessTest
 
             Expect::that(new WorkerProcess()->run($address, 'worker-under-test', 'token'))
                 ->because('a connection failure MUST return control to the calling process')
-                ->toBe(1);
+                ->toEqual(CommandResult::failure());
             Expect::that(\pcntl_signal_get_handler(\SIGINT))
                 ->because('an in-process worker run MUST restore the caller SIGINT handler')
                 ->toBe($callerHandler);
@@ -136,12 +125,12 @@ final readonly class WorkerProcessTest
         }
 
         $this->environment->set('GREENLIGHT_CHANNEL', '1');
-        $workerExit = new WorkerProcess()->run($address, 'worker-under-test', 'token');
+        $workerResult = new WorkerProcess()->run($address, 'worker-under-test', 'token');
         $serverResult = $server->wait(2.0);
 
-        Expect::that($workerExit)
+        Expect::that($workerResult)
             ->because('an assignment setup failure MUST stop the worker abnormally')
-            ->toBe(1);
+            ->toEqual(CommandResult::failure());
         Expect::that($serverResult->exitCode)
             ->because('the orchestrator fixture MUST receive the worker fatal message')
             ->toBe(0);
@@ -154,11 +143,11 @@ final readonly class WorkerProcessTest
     #[Timeout(5.0)]
     public function bootstrapRejectsATruncatedChannelEnvironmentValue(): void
     {
-        [$workerExit, $serverExit] = $this->runScenario('bootstrap-channel-mismatch', '1worker');
+        [$workerResult, $serverExit] = $this->runScenario('bootstrap-channel-mismatch', '1worker');
 
-        Expect::that($workerExit)
+        Expect::that($workerResult)
             ->because('a malformed channel environment value MUST fail worker bootstrap')
-            ->toBe(1);
+            ->toEqual(CommandResult::failure());
         Expect::that($serverExit)
             ->because('the protocol fixture MUST receive the channel mismatch diagnostic')
             ->toBe(0);
@@ -168,9 +157,9 @@ final readonly class WorkerProcessTest
     #[Timeout(5.0)]
     public function itKeepsPollingAfterAnIdleReceiveTimesOut(): void
     {
-        [$workerExit, $serverExit] = $this->runScenario('idle-then-drain');
+        [$workerResult, $serverExit] = $this->runScenario('idle-then-drain');
 
-        Expect::that($workerExit)->toBe(0);
+        Expect::that($workerResult)->toEqual(CommandResult::success());
         Expect::that($serverExit)->toBe(0);
     }
 
@@ -178,11 +167,11 @@ final readonly class WorkerProcessTest
     #[Timeout(5.0)]
     public function emptyAssignmentsCompleteBeforeTheWorkerDrains(): void
     {
-        [$workerExit, $serverExit] = $this->runScenario('empty-assignment');
+        [$workerResult, $serverExit] = $this->runScenario('empty-assignment');
 
-        Expect::that($workerExit)
+        Expect::that($workerResult)
             ->because('an empty assignment MUST complete and leave the worker available to drain')
-            ->toBe(0);
+            ->toEqual(CommandResult::success());
         Expect::that($serverExit)
             ->because('the protocol fixture MUST receive the empty completion before it drains the worker')
             ->toBe(0);
@@ -193,11 +182,11 @@ final readonly class WorkerProcessTest
     #[DataSet('cleanControlChannelEndings')]
     public function controlChannelEndingsStopTheWorkerCleanly(string $scenario): void
     {
-        [$workerExit, $serverExit] = $this->runScenario($scenario);
+        [$workerResult, $serverExit] = $this->runScenario($scenario);
 
-        Expect::that($workerExit)
+        Expect::that($workerResult)
             ->because('a control-channel ending MUST stop the worker cleanly')
-            ->toBe(0);
+            ->toEqual(CommandResult::success());
         Expect::that($serverExit)
             ->toBe(0);
     }
@@ -219,11 +208,11 @@ final readonly class WorkerProcessTest
     #[DataSet('workerProtocolViolations')]
     public function protocolViolationsStopTheWorkerAbnormally(string $scenario): void
     {
-        [$workerExit, $serverExit] = $this->runScenario($scenario);
+        [$workerResult, $serverExit] = $this->runScenario($scenario);
 
-        Expect::that($workerExit)
+        Expect::that($workerResult)
             ->because('a worker protocol violation MUST stop the worker abnormally')
-            ->toBe(1);
+            ->toEqual(CommandResult::failure());
         Expect::that($serverExit)
             ->because('the protocol fixture MUST receive the worker fatal message')
             ->toBe(0);
@@ -239,7 +228,7 @@ final readonly class WorkerProcessTest
     }
 
     /**
-     * @return array{int, int}
+     * @return array{CommandResult, int}
      */
     private function runScenario(string $scenario, string $environmentChannel = '1'): array
     {
@@ -380,9 +369,9 @@ final readonly class WorkerProcessTest
         }
 
         $this->environment->set('GREENLIGHT_CHANNEL', $environmentChannel);
-        $workerExit = new WorkerProcess(0.01)->run($address, 'worker-under-test', 'token');
+        $workerResult = new WorkerProcess(0.01)->run($address, 'worker-under-test', 'token');
         $serverResult = $server->wait(2.0);
 
-        return [$workerExit, $serverResult->exitCode];
+        return [$workerResult, $serverResult->exitCode];
     }
 }


### PR DESCRIPTION
WorkerProcess assigns integer success and failure codes itself. Return CommandResult from run() and convert it through ExitCode in Application for the internal __worker command. The process exit codes stay the same.

Update direct callers to consume CommandResult. Unit tests check the result, and test process launchers convert it to an exit code. The worker uses its existing Plugin dependency, so no dependency-rule changes are needed.
