### PR TITLE
refactor(cli): use ExitCode for unavailable working directories

### DIFF
--- a/bin/greenlight
+++ b/bin/greenlight
@@ -42,7 +42,7 @@ $workingDirectory = \getcwd();
 if ($workingDirectory === false) {
     \fwrite(\STDERR, "Could not determine the current working directory.\n");
 
-    exit(1);
+    exit(\Greenlight\Cli\ExitCode::fromCommandResult(\Greenlight\Plugin\CommandResult::failure())->value());
 }
 
 /** @var list<string> $arguments */

--- a/bin/greenlight
+++ b/bin/greenlight
@@ -5,6 +5,10 @@ declare(strict_types=1);
 
 namespace Greenlight;
 
+use Greenlight\Cli\Application;
+use Greenlight\Cli\ExitCode;
+use Greenlight\Plugin\CommandResult;
+
 // @phpstan-ignore smaller.alwaysFalse (The executable validates the PHP version at run time before it loads Composer.)
 if (\PHP_VERSION_ID < 80400) {
     \fwrite(\STDERR, \sprintf(
@@ -42,7 +46,7 @@ $workingDirectory = \getcwd();
 if ($workingDirectory === false) {
     \fwrite(\STDERR, "Could not determine the current working directory.\n");
 
-    exit(\Greenlight\Cli\ExitCode::fromCommandResult(\Greenlight\Plugin\CommandResult::failure())->value());
+    exit(ExitCode::fromCommandResult(CommandResult::failure())->value());
 }
 
 /** @var list<string> $arguments */
@@ -57,4 +61,4 @@ if (\is_array($serverArguments)) {
     }
 }
 
-exit(\Greenlight\Cli\Application::forStreams()->run($arguments, $workingDirectory, __FILE__));
+exit(Application::forStreams()->run($arguments, $workingDirectory, __FILE__));

--- a/tests/Acceptance/UnavailableWorkingDirectoryTest.php
+++ b/tests/Acceptance/UnavailableWorkingDirectoryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\PhpSubprocess;
+
+final readonly class UnavailableWorkingDirectoryTest
+{
+    public function __construct(private TemporaryDirectory $directory) {}
+
+    #[Test]
+    public function aDeletedWorkingDirectoryReturnsFailure(): void
+    {
+        $root = \dirname(__DIR__, 2);
+        $result = PhpSubprocess::run($root, [
+            '-r',
+            <<<'PHP'
+            if (!chdir($argv[1]) || !rmdir($argv[1])) {
+                exit(2);
+            }
+
+            require $argv[2];
+            PHP,
+            $this->directory->subdirectory('removed'),
+            $root . '/bin/greenlight',
+        ]);
+
+        Expect::that($result->exitCode)->toBe(1);
+        Expect::that($result->stderr)->toBe('Could not determine the current working directory.');
+        Expect::that($result->stdout)->toBe('');
+    }
+}


### PR DESCRIPTION
When getcwd() fails after Composer loads, the executable exits with a literal 1. Use ExitCode::fromCommandResult(CommandResult::failure()) so this path follows the central command exit-code policy.

The diagnostic and failure code stay the same. The PHP-version and missing-autoloader checks still run before project classes can load.
