### PR TITLE
fix(expect): honor enclosing temporal deadlines

### DIFF
--- a/docs/api-expectations.md
+++ b/docs/api-expectations.md
@@ -39,7 +39,7 @@ PHPDoc:
 - `@throws \BadMethodCallException if no native or registered extension matcher has the requested name`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L86)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L85)
 
 ### `not()`
 
@@ -49,7 +49,7 @@ Negates the next matcher for every value returned by the probe.
 final public function not(): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L42)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L41)
 
 ### `because()`
 
@@ -68,7 +68,7 @@ PHPDoc:
 - `@param non-empty-string $reason`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L60)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L59)
 
 ### `toBe()`
 
@@ -614,7 +614,7 @@ PHPDoc:
 - `@throws \BadMethodCallException if no native or registered extension matcher has the requested name`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L86)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L85)
 
 ### `not()`
 
@@ -624,7 +624,7 @@ Negates the next matcher for every value returned by the probe.
 final public function not(): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L42)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L41)
 
 ### `because()`
 
@@ -643,7 +643,7 @@ PHPDoc:
 - `@param non-empty-string $reason`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L60)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L59)
 
 ### `toBe()`
 
@@ -1215,7 +1215,7 @@ PHPDoc:
 - `@param callable(): T $probe`
 - `@return PendingConsistently<T>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expect.php#L64)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expect.php#L63)
 
 ## `Expectation`
 
@@ -1965,7 +1965,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws \InvalidArgumentException if the interval is not finite or is less than 0.001 seconds`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingConsistently.php#L58)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingConsistently.php#L56)
 
 ### `for()`
 
@@ -1978,7 +1978,7 @@ PHPDoc:
 - `@return ConsistentlyExpectation<T>`
 - `@throws \InvalidArgumentException if the duration is not finite or is not positive`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingConsistently.php#L76)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingConsistently.php#L74)
 
 ## `PendingEventually`
 
@@ -2008,7 +2008,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws \InvalidArgumentException if the interval is not finite or is less than 0.001 seconds`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingEventually.php#L63)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingEventually.php#L61)
 
 ### `retryOnException()`
 
@@ -2022,7 +2022,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws \InvalidArgumentException if a type does not extend Exception`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingEventually.php#L78)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingEventually.php#L76)
 
 ### `within()`
 
@@ -2035,7 +2035,7 @@ PHPDoc:
 - `@return EventuallyExpectation<T>`
 - `@throws \InvalidArgumentException if the duration is not finite or is not positive`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingEventually.php#L95)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingEventually.php#L93)
 
 ## `TemporalExpectation`
 
@@ -2070,7 +2070,7 @@ PHPDoc:
 - `@throws \BadMethodCallException if no native or registered extension matcher has the requested name`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L86)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L85)
 
 ### `not()`
 
@@ -2080,7 +2080,7 @@ Negates the next matcher for every value returned by the probe.
 final public function not(): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L42)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L41)
 
 ### `because()`
 
@@ -2099,7 +2099,7 @@ PHPDoc:
 - `@param non-empty-string $reason`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L60)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L59)
 
 ### `toBe()`
 

--- a/docs/architecture/temporal-expectations.md
+++ b/docs/architecture/temporal-expectations.md
@@ -60,13 +60,31 @@ calls.
 
 `TestExecutor` makes the current attempt's absolute monotonic deadline
 available before it constructs the test. It clears the deadline after per-test
-teardown. A temporal expectation uses the first applicable deadline. This
-deadline is the earlier of its own deadline and the test deadline.
+teardown. Each temporal matcher resolves the active deadlines when it runs.
+This rule also applies to an expectation constructed before the matcher call.
 
-If the test deadline comes first, the failure includes the requested poll
-duration. Greenlight cannot interrupt a blocked probe. Therefore, the
-process-pool orchestrator timeout remains the hard limit. An in-process run
-cannot forcibly stop a blocked probe.
+A temporal expectation uses the earliest applicable deadline from these sources:
+
+* Its own wait or observation period
+* An enclosing temporal expectation
+* The current test attempt
+
+The enclosing deadline applies to nested expectations in probes and matchers.
+For `consistently()`, the first observation uses only the inherited deadlines.
+Its own observation period starts after the first successful observation.
+
+Each Fiber has a separate enclosing deadline scope. Main execution has its own
+scope. A new Fiber does not inherit another Fiber's enclosing deadline.
+The test deadline applies to all Fibers in the attempt. Each observation restores
+its previous scope, including when it throws. Each attempt starts with empty scopes.
+
+If an inherited deadline comes first, the failure identifies the test or
+enclosing expectation and includes the requested duration. A test deadline takes
+precedence when both inherited deadlines are equal.
+
+Deadline scopes do not schedule or interrupt Fibers. Greenlight cannot interrupt
+a blocked probe. For tests with a configured timeout, the process-pool orchestrator
+enforces a separate process limit. An in-process run cannot forcibly stop a blocked probe.
 
 Each test retry has a new instance, scope, deadline, and observation log. With
 `ext-pcntl` available, the first interrupt signal still lets active tests

--- a/src/Expect/ConsistentlyExpectation.php
+++ b/src/Expect/ConsistentlyExpectation.php
@@ -26,7 +26,6 @@ final class ConsistentlyExpectation extends TemporalExpectation
     private function __construct(
         \Closure $probe,
         PollingClock $clock,
-        ?float $attemptDeadline,
         float $intervalSeconds,
         private readonly float $forSeconds,
         ValueRenderer $renderer,
@@ -35,7 +34,6 @@ final class ConsistentlyExpectation extends TemporalExpectation
         parent::__construct(
             $probe,
             $clock,
-            $attemptDeadline,
             $intervalSeconds,
             $renderer,
             $extensions,
@@ -55,7 +53,6 @@ final class ConsistentlyExpectation extends TemporalExpectation
     public static function create(
         \Closure $probe,
         PollingClock $clock,
-        ?float $attemptDeadline,
         float $intervalSeconds,
         float $forSeconds,
         ValueRenderer $renderer,
@@ -64,7 +61,6 @@ final class ConsistentlyExpectation extends TemporalExpectation
         return new self(
             $probe,
             $clock,
-            $attemptDeadline,
             $intervalSeconds,
             $forSeconds,
             $renderer,
@@ -105,16 +101,14 @@ final class ConsistentlyExpectation extends TemporalExpectation
         }
 
         $stableStartedAt = $observedAt;
-        $requestedDeadline = $stableStartedAt + $this->forSeconds;
-        $deadline = $this->attemptDeadline === null
-            ? $requestedDeadline
-            : \min($requestedDeadline, $this->attemptDeadline);
-        $truncatedByTest = $deadline < $requestedDeadline;
+        $deadline = TemporalDeadline::forWait($stableStartedAt + $this->forSeconds);
 
-        if ($deadline <= $observedAt) {
+        if ($deadline->time <= $observedAt) {
             $this->failure(
                 \sprintf(
-                    'No time remains for the requested %.3f-second consistently() observation period.',
+                    $deadline->source === TemporalDeadlineSource::Enclosing
+                        ? 'The enclosing expectation time limit left no time for the requested %.3f-second consistently() observation period.'
+                        : 'No time remains for the requested %.3f-second consistently() observation period.',
                     $this->forSeconds,
                 ),
                 $observations,
@@ -125,8 +119,11 @@ final class ConsistentlyExpectation extends TemporalExpectation
         }
 
         while (true) {
-            $this->sleepUntil(\min($this->clock->now() + $this->intervalSeconds, $deadline));
-            $last = $this->observe($matcher, $negated, $reason);
+            $this->sleepUntil(\min($this->clock->now() + $this->intervalSeconds, $deadline->time));
+            $last = ExpectationRuntime::withDeadline(
+                $deadline->time,
+                fn(): TemporalObservation => $this->observe($matcher, $negated, $reason),
+            );
             $observedAt = $this->clock->now();
             $observations->record($observedAt, $last->rendered);
 
@@ -144,11 +141,13 @@ final class ConsistentlyExpectation extends TemporalExpectation
                 );
             }
 
-            if ($observedAt >= $deadline) {
-                if ($truncatedByTest) {
+            if ($observedAt >= $deadline->time) {
+                if ($deadline->source !== TemporalDeadlineSource::Local) {
                     $this->failure(
                         \sprintf(
-                            'The test time limit ended the consistently() expectation early. The requested observation period was %.3f seconds.',
+                            $deadline->source === TemporalDeadlineSource::Test
+                                ? 'The test time limit ended the consistently() expectation early. The requested observation period was %.3f seconds.'
+                                : 'The enclosing expectation time limit ended the consistently() expectation early. The requested observation period was %.3f seconds.',
                             $this->forSeconds,
                         ),
                         $observations,

--- a/src/Expect/EventuallyExpectation.php
+++ b/src/Expect/EventuallyExpectation.php
@@ -28,7 +28,6 @@ final class EventuallyExpectation extends TemporalExpectation
     private function __construct(
         \Closure $probe,
         PollingClock $clock,
-        ?float $attemptDeadline,
         float $intervalSeconds,
         private readonly float $withinSeconds,
         private readonly array $retryOnExceptions,
@@ -38,7 +37,6 @@ final class EventuallyExpectation extends TemporalExpectation
         parent::__construct(
             $probe,
             $clock,
-            $attemptDeadline,
             $intervalSeconds,
             $renderer,
             $extensions,
@@ -59,7 +57,6 @@ final class EventuallyExpectation extends TemporalExpectation
     public static function create(
         \Closure $probe,
         PollingClock $clock,
-        ?float $attemptDeadline,
         float $intervalSeconds,
         float $withinSeconds,
         array $retryOnExceptions,
@@ -69,7 +66,6 @@ final class EventuallyExpectation extends TemporalExpectation
         return new self(
             $probe,
             $clock,
-            $attemptDeadline,
             $intervalSeconds,
             $withinSeconds,
             $retryOnExceptions,
@@ -94,21 +90,19 @@ final class EventuallyExpectation extends TemporalExpectation
         ?SourceLocation $location,
     ): Expectation {
         $startedAt = $this->clock->now();
-        $requestedDeadline = $startedAt + $this->withinSeconds;
-        $deadline = $this->attemptDeadline === null
-            ? $requestedDeadline
-            : \min($requestedDeadline, $this->attemptDeadline);
-        $truncatedByTest = $deadline < $requestedDeadline;
+        $deadline = TemporalDeadline::forWait($startedAt + $this->withinSeconds);
         $observations = new ObservationLog($startedAt);
         $last = null;
         $lastFailure = null;
         $counted = false;
 
-        if ($deadline <= $startedAt) {
+        if ($deadline->time <= $startedAt) {
             ExpectationCounter::increment();
             $this->failure(
                 \sprintf(
-                    'No time remains for the requested %.3f-second eventually() wait.',
+                    $deadline->source === TemporalDeadlineSource::Enclosing
+                        ? 'The enclosing expectation time limit left no time for the requested %.3f-second eventually() wait.'
+                        : 'No time remains for the requested %.3f-second eventually() wait.',
                     $this->withinSeconds,
                 ),
                 $observations,
@@ -119,7 +113,10 @@ final class EventuallyExpectation extends TemporalExpectation
         }
 
         while (true) {
-            $last = $this->observe($matcher, $negated, $reason, $this->retryOnExceptions);
+            $last = ExpectationRuntime::withDeadline(
+                $deadline->time,
+                fn(): TemporalObservation => $this->observe($matcher, $negated, $reason, $this->retryOnExceptions),
+            );
             $observedAt = $this->clock->now();
             $observations->record($observedAt, $last->rendered);
 
@@ -128,7 +125,7 @@ final class EventuallyExpectation extends TemporalExpectation
                 $counted = true;
             }
 
-            if ($last->matched && $observedAt <= $deadline) {
+            if ($last->matched && $observedAt <= $deadline->time) {
                 if (!$last instanceof TemporalValueObservation) {
                     throw new \LogicException('A matched temporal observation must contain a subject.');
                 }
@@ -140,22 +137,28 @@ final class EventuallyExpectation extends TemporalExpectation
                 $lastFailure = $last->failure;
             }
 
-            if ($observedAt >= $deadline) {
-                $summary = $truncatedByTest
-                    ? \sprintf(
+            if ($observedAt >= $deadline->time) {
+                $summary = match ($deadline->source) {
+                    TemporalDeadlineSource::Test => \sprintf(
                         'The test time limit stopped the eventually() expectation after %d observations. The requested wait was %.3f seconds.',
                         $observations->count(),
                         $this->withinSeconds,
-                    )
-                    : \sprintf(
+                    ),
+                    TemporalDeadlineSource::Enclosing => \sprintf(
+                        'The enclosing expectation time limit stopped the eventually() expectation after %d observations. The requested wait was %.3f seconds.',
+                        $observations->count(),
+                        $this->withinSeconds,
+                    ),
+                    TemporalDeadlineSource::Local => \sprintf(
                         'The eventually() expectation did not pass within %.3f seconds after %d observations.',
                         $this->withinSeconds,
                         $observations->count(),
-                    );
+                    ),
+                };
                 $this->failure($summary, $observations, $last, $lastFailure, $location);
             }
 
-            $this->sleepUntil(\min($observedAt + $this->intervalSeconds, $deadline));
+            $this->sleepUntil(\min($observedAt + $this->intervalSeconds, $deadline->time));
         }
     }
 }

--- a/src/Expect/Expect.php
+++ b/src/Expect/Expect.php
@@ -46,7 +46,6 @@ final class Expect
         return PendingEventually::create(
             \Closure::fromCallable($probe),
             ExpectationRuntime::clock(),
-            ExpectationRuntime::deadline(),
             new ValueRenderer(),
             self::$extensions,
         );
@@ -66,7 +65,6 @@ final class Expect
         return PendingConsistently::create(
             \Closure::fromCallable($probe),
             ExpectationRuntime::clock(),
-            ExpectationRuntime::deadline(),
             new ValueRenderer(),
             self::$extensions,
         );

--- a/src/Expect/ExpectationRuntime.php
+++ b/src/Expect/ExpectationRuntime.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Greenlight\Expect;
 
 /**
- * Stores the poll clock and current test deadline for a worker.
+ * Stores the poll clock, test deadline, and active temporal scopes.
+ * Each Fiber has a separate temporal scope. The test deadline applies to all Fibers.
  *
  * @internal
  */
@@ -14,6 +15,13 @@ final class ExpectationRuntime
     private static ?PollingClock $clock = null;
 
     private static ?float $deadline = null;
+
+    private static ?float $mainDeadline = null;
+
+    /** @var \WeakMap<object, float>|null */
+    private static ?\WeakMap $fiberDeadlines = null;
+
+    private static int $generation = 0;
 
     /** @codeCoverageIgnore */
     private function __construct() {}
@@ -31,11 +39,59 @@ final class ExpectationRuntime
     public static function enterAttempt(?float $deadline): void
     {
         self::$deadline = $deadline;
+        self::$mainDeadline = null;
+        self::$fiberDeadlines = null;
+        ++self::$generation;
     }
 
     public static function leaveAttempt(): void
     {
-        self::$deadline = null;
+        self::enterAttempt(null);
+    }
+
+    public static function enclosingDeadline(): ?float
+    {
+        $fiber = \Fiber::getCurrent();
+
+        return $fiber instanceof \Fiber ? (self::$fiberDeadlines[$fiber] ?? null) : self::$mainDeadline;
+    }
+
+    /**
+     * Runs an observation within the current Fiber's temporal time limit.
+     *
+     * @template T
+     *
+     * @param \Closure(): T $operation
+     *
+     * @return T
+     */
+    public static function withDeadline(float $deadline, \Closure $operation): mixed
+    {
+        $fiber = \Fiber::getCurrent();
+        $previous = self::enclosingDeadline();
+        $generation = self::$generation;
+        $deadline = $previous === null ? $deadline : \min($previous, $deadline);
+        $fiberDeadlines = self::$fiberDeadlines ??= new \WeakMap();
+
+        if (!$fiber instanceof \Fiber) {
+            self::$mainDeadline = $deadline;
+        } else {
+            $fiberDeadlines[$fiber] = $deadline;
+        }
+
+        try {
+            return $operation();
+        } finally {
+            if (self::$generation === $generation) {
+                if (!$fiber instanceof \Fiber) {
+                    self::$mainDeadline = $previous;
+                } elseif ($previous === null) {
+                    unset($fiberDeadlines[$fiber]);
+                } else {
+                    $fiberDeadlines[$fiber] = $previous;
+                }
+            }
+        }
     }
 
     /**

--- a/src/Expect/PendingConsistently.php
+++ b/src/Expect/PendingConsistently.php
@@ -25,7 +25,6 @@ final class PendingConsistently
     private function __construct(
         private readonly \Closure $probe,
         private readonly PollingClock $clock,
-        private readonly ?float $attemptDeadline,
         private readonly ValueRenderer $renderer,
         private readonly array $extensions,
     ) {}
@@ -43,11 +42,10 @@ final class PendingConsistently
     public static function create(
         \Closure $probe,
         PollingClock $clock,
-        ?float $attemptDeadline,
         ValueRenderer $renderer,
         array $extensions,
     ): self {
-        return new self($probe, $clock, $attemptDeadline, $renderer, $extensions);
+        return new self($probe, $clock, $renderer, $extensions);
     }
 
     /**
@@ -84,7 +82,6 @@ final class PendingConsistently
         return ConsistentlyExpectation::create(
             $this->probe,
             $this->clock,
-            $this->attemptDeadline,
             $this->intervalSeconds,
             $seconds,
             $this->renderer,

--- a/src/Expect/PendingEventually.php
+++ b/src/Expect/PendingEventually.php
@@ -30,7 +30,6 @@ final class PendingEventually
     private function __construct(
         private readonly \Closure $probe,
         private readonly PollingClock $clock,
-        private readonly ?float $attemptDeadline,
         private readonly ValueRenderer $renderer,
         private readonly array $extensions,
     ) {}
@@ -48,11 +47,10 @@ final class PendingEventually
     public static function create(
         \Closure $probe,
         PollingClock $clock,
-        ?float $attemptDeadline,
         ValueRenderer $renderer,
         array $extensions,
     ): self {
-        return new self($probe, $clock, $attemptDeadline, $renderer, $extensions);
+        return new self($probe, $clock, $renderer, $extensions);
     }
 
     /**
@@ -99,7 +97,6 @@ final class PendingEventually
         return EventuallyExpectation::create(
             $this->probe,
             $this->clock,
-            $this->attemptDeadline,
             $this->intervalSeconds,
             $seconds,
             $this->retryOnExceptions,

--- a/src/Expect/TemporalDeadline.php
+++ b/src/Expect/TemporalDeadline.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Expect;
+
+/**
+ * Selects the earliest time limit for one temporal matcher call.
+ * A test limit takes precedence when inherited deadlines are equal.
+ *
+ * @internal
+ */
+final readonly class TemporalDeadline
+{
+    private function __construct(
+        public float $time,
+        public TemporalDeadlineSource $source,
+    ) {}
+
+    public static function forWait(float $requestedDeadline): self
+    {
+        $testDeadline = ExpectationRuntime::deadline();
+        $enclosingDeadline = ExpectationRuntime::enclosingDeadline();
+
+        if (
+            $testDeadline !== null
+            && $testDeadline < $requestedDeadline
+            && ($enclosingDeadline === null || $testDeadline <= $enclosingDeadline)
+        ) {
+            return new self($testDeadline, TemporalDeadlineSource::Test);
+        }
+
+        if ($enclosingDeadline !== null && $enclosingDeadline < $requestedDeadline) {
+            return new self($enclosingDeadline, TemporalDeadlineSource::Enclosing);
+        }
+
+        return new self($requestedDeadline, TemporalDeadlineSource::Local);
+    }
+}

--- a/src/Expect/TemporalDeadlineSource.php
+++ b/src/Expect/TemporalDeadlineSource.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Expect;
+
+/**
+ * Identifies the time limit that controls a temporal expectation.
+ *
+ * @internal
+ */
+enum TemporalDeadlineSource
+{
+    case Local;
+    case Test;
+    case Enclosing;
+}

--- a/src/Expect/TemporalExpectation.php
+++ b/src/Expect/TemporalExpectation.php
@@ -32,7 +32,6 @@ abstract class TemporalExpectation
         /** @var \Closure(): T */
         protected readonly \Closure $probe,
         protected readonly PollingClock $clock,
-        protected readonly ?float $attemptDeadline,
         protected readonly float $intervalSeconds,
         protected readonly ValueRenderer $renderer,
         protected readonly array $extensions,

--- a/tests/Unit/Expect/TemporalDeadlineCompositionTest.php
+++ b/tests/Unit/Expect/TemporalDeadlineCompositionTest.php
@@ -1,0 +1,481 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\ExpectationRuntime;
+use Greenlight\Result\FailureDetail;
+use Greenlight\Tests\Fixture\Expect\FakePollingClock;
+
+final class TemporalDeadlineCompositionTest
+{
+    #[Test]
+    public function anEnclosingEventuallyWaitLimitsANestedEventuallyWait(): void
+    {
+        $clock = new FakePollingClock();
+        $calls = 0;
+
+        $detail = FailureProbe::detailOf(static function () use ($clock, &$calls): void {
+            ExpectationRuntime::withClock($clock, static function () use (&$calls): void {
+                Expect::eventually(static function () use (&$calls): bool {
+                    Expect::eventually(static function () use (&$calls): bool {
+                        ++$calls;
+
+                        return false;
+                    })->pollEvery(0.010)->within(0.100)->toBeTrue();
+
+                    return true;
+                })->within(0.020)->toBeTrue();
+            });
+        });
+
+        Expect::that($clock->time)->toBe(0.020);
+        Expect::that($calls)->toBe(3);
+        Expect::that($detail->message)->toContain('enclosing expectation')->not()->toContain('test time limit');
+    }
+
+    #[Test]
+    public function anEnclosingEventuallyWaitLimitsANestedConsistencyPeriod(): void
+    {
+        $clock = new FakePollingClock();
+        $calls = 0;
+
+        $detail = FailureProbe::detailOf(static function () use ($clock, &$calls): void {
+            ExpectationRuntime::withClock($clock, static function () use (&$calls): void {
+                Expect::eventually(static function () use (&$calls): bool {
+                    Expect::consistently(static function () use (&$calls): bool {
+                        ++$calls;
+
+                        return true;
+                    })->pollEvery(0.010)->for(0.100)->toBeTrue();
+
+                    return true;
+                })->within(0.020)->toBeTrue();
+            });
+        });
+
+        Expect::that($clock->time)->toBe(0.020);
+        Expect::that($calls)->toBe(3);
+        Expect::that($detail->message)->toContain('enclosing expectation')->toContain('consistently()');
+    }
+
+    #[Test]
+    public function anExpiredEnclosingDeadlinePreventsTheFirstEventuallyObservation(): void
+    {
+        $clock = new FakePollingClock();
+        $calls = 0;
+
+        $detail = FailureProbe::detailOf(static function () use ($clock, &$calls): void {
+            ExpectationRuntime::withClock($clock, static function () use ($clock, &$calls): void {
+                Expect::eventually(static function () use ($clock, &$calls): bool {
+                    $clock->time = 0.020;
+                    Expect::eventually(static function () use (&$calls): bool {
+                        ++$calls;
+
+                        return true;
+                    })->within(0.100)->toBeTrue();
+
+                    return true;
+                })->within(0.020)->toBeTrue();
+            });
+        });
+
+        Expect::that($calls)->toBe(0);
+        Expect::that($detail->message)->toContain('enclosing expectation time limit left no time')
+            ->toContain('eventually() wait');
+    }
+
+    #[Test]
+    public function anExpiredEnclosingDeadlineStillAllowsTheFirstConsistencyObservation(): void
+    {
+        $clock = new FakePollingClock();
+        $calls = 0;
+
+        $detail = FailureProbe::detailOf(static function () use ($clock, &$calls): void {
+            ExpectationRuntime::withClock($clock, static function () use ($clock, &$calls): void {
+                Expect::eventually(static function () use ($clock, &$calls): bool {
+                    $clock->time = 0.020;
+                    Expect::consistently(static function () use (&$calls): bool {
+                        ++$calls;
+
+                        return true;
+                    })->for(0.100)->toBeTrue();
+
+                    return true;
+                })->within(0.020)->toBeTrue();
+            });
+        });
+
+        Expect::that($calls)->toBe(1);
+        Expect::that($detail->message)->toContain('enclosing expectation time limit left no time')
+            ->toContain('consistently() observation period');
+    }
+
+    #[Test]
+    public function aConsistencyPeriodLimitsWaitsInLaterObservations(): void
+    {
+        $clock = new FakePollingClock();
+        $calls = 0;
+
+        $detail = FailureProbe::detailOf(static function () use ($clock, &$calls): void {
+            ExpectationRuntime::withClock($clock, static function () use (&$calls): void {
+                Expect::consistently(static function () use (&$calls): bool {
+                    if (++$calls > 1) {
+                        Expect::eventually(static fn(): bool => false)
+                            ->pollEvery(0.010)->within(0.100)->toBeTrue();
+                    }
+
+                    return true;
+                })->pollEvery(0.010)->for(0.030)->toBeTrue();
+            });
+        });
+
+        Expect::that($clock->time)->toBe(0.030);
+        Expect::that($calls)->toBe(2);
+        Expect::that($detail->message)->toContain('enclosing expectation');
+    }
+
+    #[Test]
+    public function nestedWaitsInMatcherCallbacksUseTheEnclosingDeadline(): void
+    {
+        $clock = new FakePollingClock();
+
+        $detail = FailureProbe::detailOf(static fn() => ExpectationRuntime::withClock(
+            $clock,
+            static fn() => Expect::eventually(
+                static fn(): \Closure => static fn(): never => throw new \RuntimeException('Ready.'),
+            )->within(0.020)->toThrow(static function (\RuntimeException $exception): void {
+                Expect::eventually(static fn(): bool => false)
+                    ->pollEvery(0.010)->within(0.100)->toBeTrue();
+            }),
+        ));
+
+        Expect::that($clock->time)->toBe(0.020);
+        Expect::that($detail->message)->toContain('enclosing expectation');
+    }
+
+    #[Test]
+    public function aPreviouslyConstructedExpectationUsesItsEnclosingDeadlineAtTheMatcherCall(): void
+    {
+        $clock = new FakePollingClock();
+
+        $detail = FailureProbe::detailOf(static fn() => ExpectationRuntime::withClock(
+            $clock,
+            static function (): void {
+                $inner = Expect::eventually(static fn(): bool => false)
+                    ->pollEvery(0.010)->within(0.100);
+
+                Expect::eventually(static function () use ($inner): bool {
+                    $inner->toBeTrue();
+
+                    return true;
+                })->within(0.020)->toBeTrue();
+            },
+        ));
+
+        Expect::that($clock->time)->toBe(0.020);
+        Expect::that($detail->message)->toContain('enclosing expectation');
+    }
+
+    #[Test]
+    public function aShorterLocalWaitKeepsItsOwnDeadlineAndDiagnostic(): void
+    {
+        $clock = new FakePollingClock();
+
+        $detail = FailureProbe::detailOf(static fn() => ExpectationRuntime::withClock(
+            $clock,
+            static fn() => Expect::eventually(static function (): bool {
+                Expect::eventually(static fn(): bool => false)
+                    ->pollEvery(0.010)->within(0.020)->toBeTrue();
+
+                return true;
+            })->within(0.100)->toBeTrue(),
+        ));
+
+        Expect::that($clock->time)->toBe(0.020);
+        Expect::that($detail->message)->toContain('did not pass within 0.020 seconds');
+        Expect::that($detail->message)->not()->toContain('enclosing expectation');
+    }
+
+    #[Test]
+    public function aShorterTestDeadlineKeepsTheTestLimitDiagnosticInNestedWaits(): void
+    {
+        $clock = new FakePollingClock();
+        ExpectationRuntime::enterAttempt(0.015);
+
+        try {
+            $detail = FailureProbe::detailOf(static fn() => ExpectationRuntime::withClock(
+                $clock,
+                static fn() => Expect::eventually(static function (): bool {
+                    Expect::eventually(static fn(): bool => false)
+                        ->pollEvery(0.010)->within(0.100)->toBeTrue();
+
+                    return true;
+                })->within(0.050)->toBeTrue(),
+            ));
+        } finally {
+            ExpectationRuntime::leaveAttempt();
+        }
+
+        Expect::that($clock->time)->toBe(0.015);
+        Expect::that($detail->message)->toContain('test time limit')->not()->toContain('enclosing expectation');
+    }
+
+    #[Test]
+    public function aPreviouslyConstructedExpectationUsesTheCurrentTestDeadline(): void
+    {
+        $clock = new FakePollingClock();
+
+        $detail = ExpectationRuntime::withClock($clock, static function (): FailureDetail {
+            $expectation = Expect::eventually(static fn(): bool => false)
+                ->pollEvery(0.010)->within(0.100);
+            ExpectationRuntime::enterAttempt(0.020);
+
+            try {
+                return FailureProbe::detailOf(static fn() => $expectation->toBeTrue());
+            } finally {
+                ExpectationRuntime::leaveAttempt();
+            }
+        });
+
+        Expect::that($clock->time)->toBe(0.020);
+        Expect::that($detail->message)->toContain('test time limit');
+    }
+
+    #[Test]
+    public function aProbeExceptionRestoresThePreviousDeadlineScope(): void
+    {
+        $clock = new FakePollingClock();
+        $failure = new \RuntimeException('Probe failed.');
+
+        ExpectationRuntime::withClock($clock, static function () use ($failure): void {
+            Expect::that(static fn() => Expect::eventually(static fn(): never => throw $failure)
+                ->within(0.010)->toBeTrue())->toThrow($failure);
+
+            Expect::consistently(static fn(): bool => true)
+                ->pollEvery(0.010)->for(0.030)->toBeTrue();
+        });
+
+        Expect::that($clock->time)->toBe(0.030);
+    }
+
+    #[Test]
+    public function aNestedFailureRestoresTheEnclosingDeadline(): void
+    {
+        $clock = new FakePollingClock();
+
+        $detail = FailureProbe::detailOf(static fn() => ExpectationRuntime::withClock(
+            $clock,
+            static fn() => Expect::eventually(static function (): bool {
+                FailureProbe::detailOf(static fn() => Expect::eventually(static fn(): bool => false)
+                    ->pollEvery(0.010)->within(0.010)->toBeTrue());
+
+                Expect::eventually(static fn(): bool => false)
+                    ->pollEvery(0.010)->within(0.100)->toBeTrue();
+
+                return true;
+            })->within(0.030)->toBeTrue(),
+        ));
+
+        Expect::that($clock->time)->toBe(0.030);
+        Expect::that($detail->message)->toContain('enclosing expectation');
+    }
+
+    #[Test]
+    public function nestedWaitsRestoreTheEnclosingDeadlineInTheSameFiber(): void
+    {
+        $clock = new FakePollingClock();
+
+        ExpectationRuntime::withClock($clock, static function (): void {
+            $fiber = new \Fiber(static function (): void {
+                $detail = FailureProbe::detailOf(static fn() => Expect::eventually(static function (): bool {
+                    Expect::eventually(static fn(): bool => true)->within(0.005)->toBeTrue();
+
+                    FailureProbe::detailOf(static fn() => Expect::eventually(static fn(): bool => false)
+                        ->pollEvery(0.010)->within(0.010)->toBeTrue());
+
+                    Expect::eventually(static fn(): bool => false)
+                        ->pollEvery(0.010)->within(0.100)->toBeTrue();
+
+                    return true;
+                })->within(0.030)->toBeTrue());
+
+                Expect::that($detail->message)->toContain('enclosing expectation');
+            });
+            $fiber->start();
+
+            Expect::that($fiber->isTerminated())->toBeTrue();
+        });
+
+        Expect::that($clock->time)->toBe(0.030);
+    }
+
+    #[Test]
+    public function aNewFiberUsesTheCurrentTestDeadline(): void
+    {
+        $clock = new FakePollingClock();
+        ExpectationRuntime::enterAttempt(0.015);
+
+        try {
+            ExpectationRuntime::withClock($clock, static function (): void {
+                $fiber = new \Fiber(static function (): void {
+                    $detail = FailureProbe::detailOf(static fn() => Expect::eventually(static fn(): bool => false)
+                        ->pollEvery(0.010)->within(0.100)->toBeTrue());
+
+                    Expect::that($detail->message)->toContain('test time limit')
+                        ->not()->toContain('enclosing expectation');
+                });
+                $fiber->start();
+
+                Expect::that($fiber->isTerminated())->toBeTrue();
+            });
+        } finally {
+            ExpectationRuntime::leaveAttempt();
+        }
+
+        Expect::that($clock->time)->toBe(0.015);
+    }
+
+    #[Test]
+    public function aSuspendedFiberDoesNotLimitTheMainContextOrASiblingFiber(): void
+    {
+        $clock = new FakePollingClock();
+
+        ExpectationRuntime::withClock($clock, static function (): void {
+            $suspended = new \Fiber(static function (): void {
+                $detail = FailureProbe::detailOf(static fn() => Expect::eventually(static function (): bool {
+                    \Fiber::suspend();
+
+                    return true;
+                })->within(0.010)->toBeTrue());
+
+                Expect::that($detail->message)->toContain('did not pass within 0.010 seconds');
+            });
+            $suspended->start();
+
+            Expect::consistently(static fn(): bool => true)
+                ->pollEvery(0.010)->for(0.020)->toBeTrue();
+
+            $sibling = new \Fiber(static function (): void {
+                Expect::consistently(static fn(): bool => true)
+                    ->pollEvery(0.010)->for(0.020)->toBeTrue();
+            });
+            $sibling->start();
+            $suspended->resume();
+
+            Expect::that($sibling->isTerminated())->toBeTrue();
+            Expect::that($suspended->isTerminated())->toBeTrue();
+        });
+
+        Expect::that($clock->time)->toBe(0.040);
+    }
+
+    #[Test]
+    public function aNewFiberDoesNotInheritTheMainContextDeadline(): void
+    {
+        $clock = new FakePollingClock();
+
+        $detail = FailureProbe::detailOf(static fn() => ExpectationRuntime::withClock(
+            $clock,
+            static fn() => Expect::eventually(static function (): bool {
+                $fiber = new \Fiber(static function (): void {
+                    Expect::consistently(static fn(): bool => true)
+                        ->pollEvery(0.010)->for(0.030)->toBeTrue();
+                });
+                $fiber->start();
+
+                return true;
+            })->within(0.010)->toBeTrue(),
+        ));
+
+        Expect::that($clock->time)->toBe(0.030);
+        Expect::that($detail->message)->toContain('did not pass within 0.010 seconds');
+    }
+
+    #[Test]
+    public function aResumedFiberDoesNotRestoreAScopeFromThePreviousAttempt(): void
+    {
+        $clock = new FakePollingClock();
+
+        ExpectationRuntime::withClock($clock, static function (): void {
+            ExpectationRuntime::enterAttempt(0.050);
+
+            try {
+                $fiber = new \Fiber(static function (): void {
+                    $detail = FailureProbe::detailOf(static fn() => Expect::eventually(static function (): bool {
+                        Expect::eventually(static function (): bool {
+                            \Fiber::suspend();
+
+                            return true;
+                        })->within(0.010)->toBeTrue();
+
+                        Expect::consistently(static fn(): bool => true)
+                            ->pollEvery(0.010)->for(0.030)->toBeTrue();
+
+                        return true;
+                    })->within(0.020)->toBeTrue());
+
+                    Expect::that($detail->message)->toContain('did not pass within 0.020 seconds');
+                });
+                $fiber->start();
+                ExpectationRuntime::leaveAttempt();
+                ExpectationRuntime::enterAttempt(0.100);
+                $fiber->resume();
+
+                Expect::that($fiber->isTerminated())->toBeTrue();
+            } finally {
+                ExpectationRuntime::leaveAttempt();
+            }
+        });
+
+        Expect::that($clock->time)->toBe(0.030);
+    }
+
+    #[Test]
+    public function theFirstConsistencyObservationUsesTheEnclosingDeadline(): void
+    {
+        $clock = new FakePollingClock();
+
+        $detail = FailureProbe::detailOf(static fn() => ExpectationRuntime::withClock(
+            $clock,
+            static fn() => Expect::eventually(static function (): bool {
+                Expect::consistently(static function (): bool {
+                    Expect::eventually(static fn(): bool => false)
+                        ->pollEvery(0.010)->within(0.100)->toBeTrue();
+
+                    return true;
+                })->for(0.100)->toBeTrue();
+
+                return true;
+            })->within(0.020)->toBeTrue(),
+        ));
+
+        Expect::that($clock->time)->toBe(0.020);
+        Expect::that($detail->message)->toContain('enclosing expectation');
+    }
+
+    #[Test]
+    public function aConsistencyPeriodStartsAfterItsFirstSuccessfulNestedWait(): void
+    {
+        $clock = new FakePollingClock();
+        $calls = 0;
+
+        ExpectationRuntime::withClock($clock, static function () use ($clock, &$calls): void {
+            Expect::consistently(static function () use ($clock, &$calls): bool {
+                if (++$calls === 1) {
+                    Expect::eventually(static fn(): bool => $clock->time >= 0.020)
+                        ->pollEvery(0.010)->within(0.100)->toBeTrue();
+                }
+
+                return true;
+            })->pollEvery(0.010)->for(0.010)->toBeTrue();
+        });
+
+        Expect::that($clock->time)->toBe(0.030);
+        Expect::that($calls)->toBe(2);
+        Expect::that($clock->sleeps)->toHaveCount(3);
+    }
+}


### PR DESCRIPTION
Nested temporal assertions can consume more time than the enclosing wait allows. A 10 ms `eventually()` wait could spend 100 ms in a nested `consistently()` assertion before it failed.

Resolve deadlines when each matcher runs and use the earliest local, enclosing, or test deadline. Keep enclosing scopes separate for each Fiber and restore them after each observation, including failures and attempt changes.

Preserve the immediate and final observations and start each consistency period after its first successful observation. Failure messages distinguish an enclosing expectation's time limit from the test time limit. Fiber scopes do not schedule work or interrupt blocked probes.
