### PR TITLE
feat(doubles): support object parameter defaults

### DIFF
--- a/docs/api-doubles.md
+++ b/docs/api-doubles.md
@@ -587,13 +587,29 @@ public static function objectDefaultNotReproducible(string $parameter, string $c
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L148)
 
+### `objectDefaultSourceUnavailable()`
+
+```php
+public static function objectDefaultSourceUnavailable(string $parameter, string $class, string $method): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L158)
+
+### `objectDefaultScopeUnavailable()`
+
+```php
+public static function objectDefaultScopeUnavailable(string $parameter, string $class, string $method): self
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L168)
+
 ### `proxyDirectoryNotCreated()`
 
 ```php
 public static function proxyDirectoryNotCreated(string $directory, ?string $reason = null): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L158)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L178)
 
 ### `proxyFileNotWritten()`
 
@@ -601,7 +617,7 @@ public static function proxyDirectoryNotCreated(string $directory, ?string $reas
 public static function proxyFileNotWritten(string $file, \Throwable $cause): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L167)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L187)
 
 ### `proxyFileNotLoaded()`
 
@@ -609,7 +625,7 @@ public static function proxyFileNotWritten(string $file, \Throwable $cause): sel
 public static function proxyFileNotLoaded(string $file, ?\Throwable $cause = null): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L172)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L192)
 
 ### `workingDirectoryUnresolved()`
 
@@ -617,7 +633,7 @@ public static function proxyFileNotLoaded(string $file, ?\Throwable $cause = nul
 public static function workingDirectoryUnresolved(): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L177)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L197)
 
 ### `foreignDouble()`
 
@@ -625,7 +641,7 @@ public static function workingDirectoryUnresolved(): self
 public static function foreignDouble(string $class): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L182)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L202)
 
 ### `invalidTimes()`
 
@@ -633,7 +649,7 @@ public static function foreignDouble(string $class): self
 public static function invalidTimes(int $count): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L187)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L207)
 
 ### `invalidAtLeast()`
 
@@ -641,7 +657,7 @@ public static function invalidTimes(int $count): self
 public static function invalidAtLeast(int $count): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L192)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L212)
 
 ### `tooFewPlannedArguments()`
 
@@ -659,7 +675,7 @@ PHPDoc:
 
 - `@param class-string $type`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L200)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L220)
 
 ### `tooManyPlannedArguments()`
 
@@ -677,7 +693,7 @@ PHPDoc:
 
 - `@param class-string $type`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L220)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L240)
 
 ### `incompatiblePlannedArgumentMatcher()`
 
@@ -697,7 +713,7 @@ PHPDoc:
 
 - `@param class-string $type`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L240)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L260)
 
 ### `tooFewCallArguments()`
 
@@ -709,7 +725,7 @@ PHPDoc:
 
 - `@param class-string $type`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L264)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L284)
 
 ### `tooManyCallArguments()`
 
@@ -721,7 +737,7 @@ PHPDoc:
 
 - `@param class-string $type`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L278)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L298)
 
 ### `conflictingAnswers()`
 
@@ -729,7 +745,7 @@ PHPDoc:
 public static function conflictingAnswers(string $method): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L289)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L309)
 
 ### `emptySequence()`
 
@@ -737,7 +753,7 @@ public static function conflictingAnswers(string $method): self
 public static function emptySequence(string $method): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L298)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L318)
 
 ### `sequenceExhausted()`
 
@@ -745,7 +761,7 @@ public static function emptySequence(string $method): self
 public static function sequenceExhausted(string $method, int $count): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L303)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L323)
 
 ### `nothingCaptured()`
 
@@ -753,7 +769,7 @@ public static function sequenceExhausted(string $method, int $count): self
 public static function nothingCaptured(): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L312)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L332)
 
 ### `invalidCaptorPosition()`
 
@@ -761,7 +777,7 @@ public static function nothingCaptured(): self
 public static function invalidCaptorPosition(int $position): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L317)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L337)
 
 ### `invalidArgumentType()`
 
@@ -769,7 +785,7 @@ public static function invalidCaptorPosition(int $position): self
 public static function invalidArgumentType(): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L322)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L342)
 
 ### `invalidArgumentTypeCombination()`
 
@@ -777,7 +793,7 @@ public static function invalidArgumentType(): self
 public static function invalidArgumentTypeCombination(string $factory): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L327)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L347)
 
 ### `compositeArgumentCaptor()`
 
@@ -785,7 +801,7 @@ public static function invalidArgumentTypeCombination(string $factory): self
 public static function compositeArgumentCaptor(): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L335)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Doubles/InvalidDoubleUsage.php#L355)
 
 ## `MethodExpectation`
 

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -270,3 +270,22 @@ an interface at the application boundary.
 
 Greenlight suppresses a non-final destructor. It cannot suppress a final
 destructor, which can run application code.
+
+### Object parameter defaults
+
+Methods can declare object defaults and objects inside nested arrays.
+Greenlight copies each `new` expression from the method's source file into the
+proxy. It preserves constructor arguments, imported names, and literal values.
+It does not construct these default objects when it creates the double.
+PHP constructs them when a call omits the applicable argument.
+
+The method must have a readable PHP source file. Methods declared through
+`eval()` cannot supply object default expressions. Declare methods on separate
+lines so Greenlight can identify the original declaration. A default cannot depend on
+a private constructor that the proxy cannot access. Dynamic constant access
+also requires a class without private constants. These cases produce
+`InvalidDoubleUsage`.
+
+Define unqualified constants before you create the double. Greenlight resolves
+these constants in the original namespace, with PHP's global fallback, when it
+generates the proxy. Private scalar and enum constants retain their values.

--- a/src/Doubles/InvalidDoubleUsage.php
+++ b/src/Doubles/InvalidDoubleUsage.php
@@ -155,6 +155,26 @@ final class InvalidDoubleUsage extends \LogicException
         ));
     }
 
+    public static function objectDefaultSourceUnavailable(string $parameter, string $class, string $method): self
+    {
+        return new self(\sprintf(
+            'Doubles cannot read the object default of parameter "$%s" from "%s::%s()". Declare the method on a separate line in a readable PHP file.',
+            $parameter,
+            $class,
+            $method,
+        ));
+    }
+
+    public static function objectDefaultScopeUnavailable(string $parameter, string $class, string $method): self
+    {
+        return new self(\sprintf(
+            'Doubles cannot access the object default of parameter "$%s" from "%s::%s()" in a proxy. Use a public constructor and accessible constants.',
+            $parameter,
+            $class,
+            $method,
+        ));
+    }
+
     public static function proxyDirectoryNotCreated(string $directory, ?string $reason = null): self
     {
         return new self(\sprintf(

--- a/src/Doubles/ParameterDefaultExpression.php
+++ b/src/Doubles/ParameterDefaultExpression.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Doubles;
+
+/**
+ * Copies object default expressions without running their constructors.
+ * Names and magic constants retain their declaration context in the proxy.
+ *
+ * @internal
+ */
+final readonly class ParameterDefaultExpression
+{
+    /**
+     * @param \ReflectionClass<object> $context
+     * @throws InvalidDoubleUsage
+     */
+    public static function render(\ReflectionParameter $parameter, \ReflectionClass $context, bool $requireSource = false): ?string
+    {
+        // Reflection text identifies new expressions, but loses literal precision.
+        $description = (string) $parameter;
+        $separator = \strpos($description, ' = ');
+
+        if (!$requireSource && ($separator === false
+            || !\array_any(\PhpToken::tokenize('<?php ' . \substr($description, $separator + 3)), static fn(\PhpToken $token): bool => $token->is(\T_NEW)))
+        ) {
+            return null;
+        }
+
+        $source = ParameterDefaultSource::read($parameter);
+
+        if ($source === null) {
+            throw InvalidDoubleUsage::objectDefaultSourceUnavailable($parameter->name, $context->name, $parameter->getDeclaringFunction()->name);
+        }
+
+        $tokens = $source['tokens'];
+
+        $significant = \array_values(\array_filter($tokens, static fn(\PhpToken $token): bool => !$token->isIgnorable()));
+        $replacements = [];
+
+        foreach ($significant as $index => $token) {
+            if (isset($replacements[$token->pos])) {
+                continue;
+            }
+
+            $previous = $significant[$index - 1] ?? null;
+            $next = $significant[$index + 1] ?? null;
+            $magic = match ($token->id) {
+                \T_FILE => $source['file'],
+                \T_DIR => \dirname($source['file']),
+                \T_LINE => $token->line,
+                \T_NS_C => $source['namespace'],
+                \T_CLASS_C => $context->name,
+                \T_TRAIT_C => $source['trait'],
+                \T_FUNC_C => $source['method'],
+                \T_METHOD_C => ($source['trait'] === '' ? $context->name : $source['trait']) . '::' . $source['method'],
+                default => null,
+            };
+
+            if ($magic !== null) {
+                $replacements[$token->pos] = \var_export($magic, true);
+
+                continue;
+            }
+
+            if (!$token->is([\T_STRING, \T_NAME_QUALIFIED, \T_NAME_FULLY_QUALIFIED, \T_NAME_RELATIVE])) {
+                continue;
+            }
+
+            if ($previous?->is([\T_DOUBLE_COLON, \T_OBJECT_OPERATOR, \T_NULLSAFE_OBJECT_OPERATOR]) === true
+                || ($next?->is(':') === true && $previous?->is(['(', ',']) === true)
+                || \in_array(\strtolower($token->text), ['true', 'false', 'null'], true)
+            ) {
+                continue;
+            }
+
+            if ($previous?->is(\T_NEW) === true || $next?->is(\T_DOUBLE_COLON) === true) {
+                $class = self::className($token->text, $source['namespace'], $source['imports'], $context);
+                $replacements[$token->pos] = '\\' . $class;
+
+                if ($previous?->is(\T_NEW) === true && \class_exists($class, false)) {
+                    $constructor = new \ReflectionClass($class)->getConstructor();
+
+                    if ($constructor?->isPrivate() === true) {
+                        throw InvalidDoubleUsage::objectDefaultScopeUnavailable($parameter->name, $context->name, $parameter->getDeclaringFunction()->name);
+                    }
+                }
+
+                $member = $significant[$index + 2] ?? null;
+
+                if ($next?->is(\T_DOUBLE_COLON) === true && $member?->is('{') === true && \class_exists($class, false)
+                    && new \ReflectionClass($class)->getReflectionConstants(\ReflectionClassConstant::IS_PRIVATE) !== []
+                ) {
+                    throw InvalidDoubleUsage::objectDefaultScopeUnavailable($parameter->name, $context->name, $parameter->getDeclaringFunction()->name);
+                }
+
+                if ($next?->is(\T_DOUBLE_COLON) === true && $member?->is(\T_STRING) === true && \class_exists($class, false)) {
+                    $constant = new \ReflectionClass($class)->getReflectionConstant($member->text);
+
+                    if ($constant instanceof \ReflectionClassConstant && $constant->isPrivate()) {
+                        $value = $constant->getValue();
+
+                        if (self::containsObject($value)) {
+                            throw InvalidDoubleUsage::objectDefaultScopeUnavailable($parameter->name, $context->name, $parameter->getDeclaringFunction()->name);
+                        }
+
+                        $replacements[$token->pos] = '(' . \var_export($value, true) . ')';
+                        $replacements[$next->pos] = '';
+                        $replacements[$member->pos] = '';
+                    }
+                }
+
+                continue;
+            }
+
+            $replacements[$token->pos] = self::constantName($token->text, $source['namespace'], $source['imports'], $source['constants'], $parameter);
+        }
+
+        return \implode('', \array_map(static fn(\PhpToken $token): string => $replacements[$token->pos] ?? $token->text, $tokens));
+    }
+
+    /**
+     * @param array<string, string> $imports
+     * @param \ReflectionClass<object> $context
+     * @throws InvalidDoubleUsage
+     */
+    private static function className(string $name, string $namespace, array $imports, \ReflectionClass $context): string
+    {
+        if (\strtolower($name) === 'self') {
+            return $context->name;
+        }
+
+        if (\strtolower($name) === 'parent') {
+            $parent = $context->getParentClass();
+
+            if ($parent === false) {
+                throw InvalidDoubleUsage::parentTypeWithoutParent($context->name);
+            }
+
+            return $parent->name;
+        }
+
+        return self::qualifiedName($name, $namespace, $imports);
+    }
+
+    /** @param array<string, string> $imports */
+    private static function qualifiedName(string $name, string $namespace, array $imports): string
+    {
+        if (\str_starts_with($name, '\\')) {
+            return \substr($name, 1);
+        }
+
+        if (\str_starts_with(\strtolower($name), 'namespace\\')) {
+            return \ltrim($namespace . '\\' . \substr($name, 10), '\\');
+        }
+
+        $parts = \explode('\\', $name, 2);
+        $import = $imports[\strtolower($parts[0])] ?? null;
+
+        if ($import !== null) {
+            return $import . (isset($parts[1]) ? '\\' . $parts[1] : '');
+        }
+
+        return \ltrim($namespace . '\\' . $name, '\\');
+    }
+
+    /**
+     * @param array<string, string> $imports
+     * @param array<string, string> $constants
+     * @throws InvalidDoubleUsage
+     */
+    private static function constantName(string $name, string $namespace, array $imports, array $constants, \ReflectionParameter $parameter): string
+    {
+        if (\str_contains($name, '\\')) {
+            return '\\' . self::qualifiedName($name, $namespace, $imports);
+        }
+
+        if (isset($constants[$name])) {
+            return '\\' . $constants[$name];
+        }
+
+        $qualified = \ltrim($namespace . '\\' . $name, '\\');
+
+        if (\defined($qualified)) {
+            return '\\' . $qualified;
+        }
+
+        if (\defined($name)) {
+            return '\\' . $name;
+        }
+
+        throw InvalidDoubleUsage::defaultConstantUnresolvable($parameter->name);
+    }
+
+    public static function containsObject(mixed $value): bool
+    {
+        if (\is_array($value)) {
+            return \array_any($value, self::containsObject(...));
+        }
+
+        return \is_object($value) && !$value instanceof \UnitEnum;
+    }
+}

--- a/src/Doubles/ParameterDefaultSource.php
+++ b/src/Doubles/ParameterDefaultSource.php
@@ -1,0 +1,408 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Doubles;
+
+use Greenlight\Internal\Php\ErrorTrap;
+
+/**
+ * Reads a parameter default and its original namespace without a call to its constructors.
+ * Source files must remain available while Greenlight generates the proxy class.
+ *
+ * @internal
+ */
+final class ParameterDefaultSource
+{
+    /** @codeCoverageIgnore */
+    private function __construct() {}
+
+    /**
+     * @return array{tokens: list<\PhpToken>, namespace: string, imports: array<string, string>, constants: array<string, string>, file: string, method: string, trait: string}|null
+     */
+    public static function read(\ReflectionParameter $parameter): ?array
+    {
+        $method = $parameter->getDeclaringFunction();
+
+        if (!$method instanceof \ReflectionMethod) {
+            return null;
+        }
+
+        $file = $method->getFileName();
+
+        if ($file === false || !\is_file($file)) {
+            return null;
+        }
+
+        $source = ErrorTrap::run(static fn() => \file_get_contents($file));
+
+        if ($source === false) {
+            return null;
+        }
+
+        $tokens = \array_values(\PhpToken::tokenize($source));
+        $origins = self::origins($method);
+        $namespace = '';
+        $imports = [];
+        $constants = [];
+        $namespaceDepth = 0;
+        $depth = 0;
+        $classes = [];
+        $classStarts = [];
+        $matches = [];
+        $ambiguous = [];
+        $count = \count($tokens);
+
+        for ($i = 0; $i < $count; ++$i) {
+            $token = $tokens[$i];
+
+            if ($token->is(\T_NAMESPACE) && $depth === 0) {
+                $namespace = '';
+                $imports = [];
+                $constants = [];
+
+                while (isset($tokens[++$i]) && !$tokens[$i]->is([';', '{'])) {
+                    if (!$tokens[$i]->isIgnorable()) {
+                        $namespace .= $tokens[$i]->text;
+                    }
+                }
+
+                if (isset($tokens[$i]) && $tokens[$i]->is('{')) {
+                    ++$depth;
+                }
+
+                $namespaceDepth = $depth;
+
+                continue;
+            }
+
+            if ($token->is(\T_USE) && $depth === $namespaceDepth) {
+                $next = self::significantIndex($tokens, $i + 1);
+
+                if ($next !== null && $tokens[$next]->is('(')) {
+                    continue;
+                }
+
+                $end = $i + 1;
+
+                while (isset($tokens[$end]) && !$tokens[$end]->is(';')) {
+                    ++$end;
+                }
+
+                self::readImports(\array_slice($tokens, $i + 1, $end - $i - 1), $imports, $constants);
+                $i = $end;
+
+                continue;
+            }
+
+            if ($token->is([\T_CLASS, \T_INTERFACE, \T_TRAIT, \T_ENUM])) {
+                $previous = self::significantIndex($tokens, $i - 1, -1);
+
+                if ($previous !== null && $tokens[$previous]->is(\T_DOUBLE_COLON)) {
+                    continue;
+                }
+
+                $nameIndex = self::significantIndex($tokens, $i + 1);
+                $name = $nameIndex !== null && $tokens[$nameIndex]->is(\T_STRING)
+                    ? \ltrim($namespace . '\\' . $tokens[$nameIndex]->text, '\\')
+                    : '';
+
+                if ($name === '' && $method->getDeclaringClass()->isAnonymous() && $token->line === $method->getDeclaringClass()->getStartLine()) {
+                    $name = $method->getDeclaringClass()->name;
+                }
+
+                $body = self::classBody($tokens, $i + 1);
+
+                if ($body !== null) {
+                    $classStarts[$body] = ['name' => $name, 'trait' => $token->is(\T_TRAIT) ? $name : ''];
+                }
+            }
+
+            if ($token->is(['{', \T_CURLY_OPEN, \T_DOLLAR_OPEN_CURLY_BRACES])) {
+                ++$depth;
+
+                if (isset($classStarts[$i])) {
+                    $classes[] = $classStarts[$i] + ['depth' => $depth];
+                }
+
+                continue;
+            }
+
+            if ($token->is('}')) {
+                $class = $classes === [] ? null : $classes[\array_key_last($classes)];
+
+                if ($class !== null && $class['depth'] === $depth) {
+                    \array_pop($classes);
+                }
+
+                --$depth;
+
+                if ($depth < $namespaceDepth) {
+                    $namespace = '';
+                    $imports = [];
+                    $constants = [];
+                    $namespaceDepth = 0;
+                }
+
+                continue;
+            }
+
+            if (!$token->is(\T_FUNCTION) || $token->line !== $method->getStartLine() || $classes === []) {
+                continue;
+            }
+
+            $class = $classes[\array_key_last($classes)];
+            $nameIndex = self::significantIndex($tokens, $i + 1);
+
+            if ($nameIndex !== null && $tokens[$nameIndex]->text === '&') {
+                $nameIndex = self::significantIndex($tokens, $nameIndex + 1);
+            }
+
+            if ($class['depth'] !== $depth || $nameIndex === null || !isset($origins[$class['name']]) || $tokens[$nameIndex]->text !== $origins[$class['name']]) {
+                continue;
+            }
+
+            $expression = self::expression($tokens, $nameIndex + 1, $parameter->getPosition());
+
+            if ($expression !== null) {
+                if (isset($matches[$class['name']])) {
+                    $ambiguous[$class['name']] = true;
+                }
+
+                $matches[$class['name']] = [
+                    'tokens' => $expression,
+                    'namespace' => $namespace,
+                    'imports' => $imports,
+                    'constants' => $constants,
+                    'file' => $file,
+                    'method' => $tokens[$nameIndex]->text,
+                    'trait' => $class['trait'],
+                ];
+            }
+        }
+
+        $owner = $method->getDeclaringClass()->name;
+
+        if (isset($matches[$owner])) {
+            return isset($ambiguous[$owner]) ? null : $matches[$owner];
+        }
+
+        return \count($matches) === 1 && $ambiguous === [] ? \array_values($matches)[0] : null;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private static function origins(\ReflectionMethod $method): array
+    {
+        $class = $method->getDeclaringClass();
+        $origins = [$class->name => $method->name];
+
+        foreach ($class->getTraitAliases() as $alias => $original) {
+            if (\strcasecmp($alias, $method->name) === 0) {
+                [$trait, $name] = \explode('::', $original, 2);
+                $origins += self::origins(new \ReflectionMethod($trait, $name));
+            }
+        }
+
+        foreach ($class->getTraits() as $trait) {
+            if (!$trait->hasMethod($method->name)) {
+                continue;
+            }
+
+            $candidate = $trait->getMethod($method->name);
+
+            if ($candidate->getFileName() === $method->getFileName() && $candidate->getStartLine() === $method->getStartLine() && $candidate->getEndLine() === $method->getEndLine()) {
+                $origins += self::origins($candidate);
+            }
+        }
+
+        return $origins;
+    }
+
+    /**
+     * @param list<\PhpToken> $tokens
+     */
+    private static function significantIndex(array $tokens, int $index, int $step = 1): ?int
+    {
+        for ($i = $index; isset($tokens[$i]); $i += $step) {
+            if (!$tokens[$i]->isIgnorable()) {
+                return $i;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<\PhpToken> $tokens
+     */
+    private static function classBody(array $tokens, int $start): ?int
+    {
+        $depth = 0;
+
+        for ($i = $start; isset($tokens[$i]); ++$i) {
+            $token = $tokens[$i];
+
+            if ($token->is('{') && $depth === 0) {
+                return $i;
+            }
+
+            if ($token->is(['(', '[', '{', \T_ATTRIBUTE])) {
+                ++$depth;
+            } elseif ($token->is([')', ']', '}'])) {
+                --$depth;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<\PhpToken> $tokens
+     * @return list<\PhpToken>|null
+     */
+    private static function expression(array $tokens, int $start, int $position): ?array
+    {
+        $open = self::significantIndex($tokens, $start);
+
+        if ($open === null || !$tokens[$open]->is('(')) {
+            return null;
+        }
+
+        $depth = 0;
+        $parameter = 0;
+        $default = null;
+
+        for ($i = $open + 1; isset($tokens[$i]); ++$i) {
+            $token = $tokens[$i];
+
+            if ($depth === 0 && $token->is([',', ')'])) {
+                if ($parameter === $position) {
+                    if ($default === null) {
+                        return null;
+                    }
+
+                    $first = self::significantIndex($tokens, $default);
+                    $last = self::significantIndex($tokens, $i - 1, -1);
+
+                    return $first !== null && $last !== null && $first <= $last
+                        ? \array_slice($tokens, $first, $last - $first + 1)
+                        : null;
+                }
+
+                if ($token->is(')')) {
+                    return null;
+                }
+
+                ++$parameter;
+                $default = null;
+
+                continue;
+            }
+
+            if ($depth === 0 && $token->is('=')) {
+                $default = $i + 1;
+            } elseif ($token->is(['(', '[', '{', \T_ATTRIBUTE])) {
+                ++$depth;
+            } elseif ($token->is([')', ']', '}'])) {
+                --$depth;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param list<\PhpToken> $tokens
+     * @param array<string, string> $imports
+     * @param array<string, string> $constants
+     */
+    private static function readImports(array $tokens, array &$imports, array &$constants): void
+    {
+        $tokens = \array_values(\array_filter($tokens, static fn(\PhpToken $token): bool => !$token->isIgnorable()));
+        $kind = \T_CLASS;
+
+        if (isset($tokens[0]) && $tokens[0]->is([\T_CONST, \T_FUNCTION])) {
+            $kind = $tokens[0]->id;
+            \array_shift($tokens);
+        }
+
+        $prefix = '';
+        $group = null;
+
+        foreach ($tokens as $i => $token) {
+            if ($token->is('{')) {
+                $group = $i;
+
+                break;
+            }
+        }
+
+        if ($group !== null) {
+            $prefix = \implode('', \array_map(static fn(\PhpToken $token): string => $token->text, \array_slice($tokens, 0, $group)));
+            $tokens = \array_slice($tokens, $group + 1, -1);
+        }
+
+        $entry = [];
+
+        foreach ($tokens as $token) {
+            if ($token->is(',')) {
+                self::readImport($entry, $prefix, $kind, $imports, $constants);
+                $entry = [];
+            } else {
+                $entry[] = $token;
+            }
+        }
+
+        self::readImport($entry, $prefix, $kind, $imports, $constants);
+    }
+
+    /**
+     * @param list<\PhpToken> $tokens
+     * @param array<string, string> $imports
+     * @param array<string, string> $constants
+     */
+    private static function readImport(array $tokens, string $prefix, int $kind, array &$imports, array &$constants): void
+    {
+        if ($tokens === []) {
+            return;
+        }
+
+        if ($tokens[0]->is([\T_CONST, \T_FUNCTION])) {
+            $kind = $tokens[0]->id;
+            \array_shift($tokens);
+        }
+
+        if ($kind === \T_FUNCTION) {
+            return;
+        }
+
+        $name = $prefix;
+        $alias = '';
+        $afterAlias = false;
+
+        foreach ($tokens as $token) {
+            if ($token->is(\T_AS)) {
+                $afterAlias = true;
+            } elseif ($afterAlias) {
+                $alias .= $token->text;
+            } else {
+                $name .= $token->text;
+            }
+        }
+
+        $name = \ltrim($name, '\\');
+
+        if ($alias === '') {
+            $parts = \explode('\\', $name);
+            $alias = $parts[\array_key_last($parts)];
+        }
+
+        if ($kind === \T_CONST) {
+            $constants[$alias] = $name;
+        } else {
+            $imports[\strtolower($alias)] = $name;
+        }
+    }
+}

--- a/src/Doubles/ProxyGenerator.php
+++ b/src/Doubles/ProxyGenerator.php
@@ -403,7 +403,13 @@ final readonly class ProxyGenerator
 
                     if ($member instanceof \ReflectionClassConstant && $member->isPrivate()) {
                         // A child proxy cannot access the parent's private constant.
-                        return \var_export($parameter->getDefaultValue(), true);
+                        $value = $parameter->getDefaultValue();
+
+                        if (ParameterDefaultExpression::containsObject($value)) {
+                            throw InvalidDoubleUsage::objectDefaultScopeUnavailable($parameter->name, $context->name, $parameter->getDeclaringFunction()->name);
+                        }
+
+                        return \var_export($value, true);
                     }
                 }
             }
@@ -411,10 +417,17 @@ final readonly class ProxyGenerator
             return '\\' . $constant;
         }
 
+        $expression = ParameterDefaultExpression::render($parameter, $context);
+
+        if ($expression !== null) {
+            return $expression;
+        }
+
         $value = $parameter->getDefaultValue();
 
-        if (\is_object($value) && !$value instanceof \UnitEnum) {
-            throw InvalidDoubleUsage::objectDefaultNotReproducible($parameter->name, $context->name, $parameter->getDeclaringFunction()->name);
+        if (ParameterDefaultExpression::containsObject($value)) {
+            return ParameterDefaultExpression::render($parameter, $context, requireSource: true)
+                ?? throw InvalidDoubleUsage::objectDefaultNotReproducible($parameter->name, $context->name, $parameter->getDeclaringFunction()->name);
         }
 
         return \var_export($value, true);

--- a/tests/Fixture/Doubles/ObjectDefaults/Choice.php
+++ b/tests/Fixture/Doubles/ObjectDefaults/Choice.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles\ObjectDefaults;
+
+enum Choice: string
+{
+    case First = 'first';
+}

--- a/tests/Fixture/Doubles/ObjectDefaults/ConstantObjectDefaults.php
+++ b/tests/Fixture/Doubles/ObjectDefaults/ConstantObjectDefaults.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles\ObjectDefaults;
+
+interface ConstantObjectDefaults extends ObjectConstantContract
+{
+    /** @param list<Value> $values */
+    public function nested(array $values = [SHARED_OBJECT], string $marker = ''): void;
+
+    public function globalConstant(Value $value = SHARED_OBJECT, string $marker = ''): void;
+
+    public function publicConstant(Value $value = self::SHARED_VALUE, string $marker = ''): void;
+}

--- a/tests/Fixture/Doubles/ObjectDefaults/ContextBase.php
+++ b/tests/Fixture/Doubles/ObjectDefaults/ContextBase.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles\ObjectDefaults;
+
+class ContextBase
+{
+    protected const string PARENT_LABEL = 'parent';
+
+    private const string PRIVATE_LABEL = 'private parent';
+
+    public function inherited(
+        Value $value = new Value(self::PRIVATE_LABEL, ['class' => self::class, 'method' => __METHOD__]), // @phpstan-ignore magicConstant.outOfFunction (PHP resolves the method name in parameter defaults.)
+        string $marker = '',
+    ): void {}
+}

--- a/tests/Fixture/Doubles/ObjectDefaults/ContextDefaults.php
+++ b/tests/Fixture/Doubles/ObjectDefaults/ContextDefaults.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles\ObjectDefaults;
+
+class ContextDefaults extends ContextBase
+{
+    protected const string PARENT_LABEL = 'child';
+
+    private const string PRIVATE_LABEL = 'private child';
+
+    public function run(
+        Value $value = new Value(
+            self::PRIVATE_LABEL,
+            [
+                'parent' => parent::PARENT_LABEL,
+                'qualified' => ContextDefaults::PRIVATE_LABEL,
+                'class' => self::class,
+                'parentClass' => parent::class,
+            ],
+        ),
+        string $marker = '',
+    ): void {}
+}

--- a/tests/Fixture/Doubles/ObjectDefaults/DynamicPrivateConstantDefaults.php
+++ b/tests/Fixture/Doubles/ObjectDefaults/DynamicPrivateConstantDefaults.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles\ObjectDefaults;
+
+class DynamicPrivateConstantDefaults
+{
+    private const string SECRET = 'dynamic';
+
+    public function run(Value $value = new Value('dynamic', [self::{'SECRET'}])): void {}
+}

--- a/tests/Fixture/Doubles/ObjectDefaults/ImportedDefaults.php
+++ b/tests/Fixture/Doubles/ObjectDefaults/ImportedDefaults.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles\ObjectDefaults;
+
+use Greenlight\Tests\Fixture\Doubles\ObjectDefaults\{Choice as SelectedChoice, Value as DefaultValue};
+use const Greenlight\Tests\Fixture\Doubles\ObjectDefaults\{DEFAULT_LABEL as Label, DEFAULT_LIMIT as Limit};
+
+const DEFAULT_LABEL = 'imported';
+const DEFAULT_LIMIT = 7;
+
+interface ImportedDefaults
+{
+    public function run(
+        DefaultValue $value = new DefaultValue(
+            payload: ['limit' => Limit, 'choice' => SelectedChoice::First, 'class' => DefaultValue::class],
+            label: Label,
+        ),
+        string $marker = '',
+    ): void;
+
+    /** @param array<array-key, mixed> $values */
+    public function nested(
+        array $values = [
+            'objects' => [new DefaultValue("line\nnull\0slash\\quote'", ['nested' => new DefaultValue(Label)])],
+            'choice' => SelectedChoice::First,
+            'choiceValue' => SelectedChoice::First->value,
+            'choiceName' => SelectedChoice::First->name,
+            'integer' => Limit + 1,
+            'float' => 1.2345678901234567,
+            'text' => 'new Alias() /* text */ $value, ) ]',
+        ],
+        string $marker = '',
+    ): void;
+}

--- a/tests/Fixture/Doubles/ObjectDefaults/ObjectConstantContract.php
+++ b/tests/Fixture/Doubles/ObjectDefaults/ObjectConstantContract.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles\ObjectDefaults;
+
+const SHARED_OBJECT = new Value('global');
+
+interface ObjectConstantContract
+{
+    public const Value SHARED_VALUE = SHARED_OBJECT;
+}

--- a/tests/Fixture/Doubles/ObjectDefaults/PrivateConstructorDefaults.php
+++ b/tests/Fixture/Doubles/ObjectDefaults/PrivateConstructorDefaults.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles\ObjectDefaults;
+
+class PrivateConstructorDefaults
+{
+    private function __construct() {}
+
+    public function run(self $value = new self()): void {}
+}

--- a/tests/Fixture/Doubles/ObjectDefaults/PrivateObjectConstantDefaults.php
+++ b/tests/Fixture/Doubles/ObjectDefaults/PrivateObjectConstantDefaults.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles\ObjectDefaults;
+
+class PrivateObjectConstantDefaults implements ObjectConstantContract
+{
+    private const Value OBJECT = SHARED_OBJECT;
+
+    public function run(Value $value = self::OBJECT): void {}
+}

--- a/tests/Fixture/Doubles/ObjectDefaults/TrackedDefaults.php
+++ b/tests/Fixture/Doubles/ObjectDefaults/TrackedDefaults.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles\ObjectDefaults;
+
+interface TrackedDefaults
+{
+    public function run(TrackedValue $value = new TrackedValue('default'), string $marker = ''): void;
+}

--- a/tests/Fixture/Doubles/ObjectDefaults/TrackedValue.php
+++ b/tests/Fixture/Doubles/ObjectDefaults/TrackedValue.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles\ObjectDefaults;
+
+final class TrackedValue
+{
+    public static int $constructions = 0;
+
+    public function __construct(public readonly string $label)
+    {
+        ++self::$constructions;
+    }
+}

--- a/tests/Fixture/Doubles/ObjectDefaults/TraitConsumer.php
+++ b/tests/Fixture/Doubles/ObjectDefaults/TraitConsumer.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles\ObjectDefaults;
+
+class TraitConsumer
+{
+    use TraitDefaults {
+        fromTrait as aliasDefault;
+    }
+
+    private const string PRIVATE_LABEL = 'trait consumer';
+}

--- a/tests/Fixture/Doubles/ObjectDefaults/TraitDefaults.php
+++ b/tests/Fixture/Doubles/ObjectDefaults/TraitDefaults.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles\ObjectDefaults;
+
+use Greenlight\Tests\Fixture\Doubles\ObjectDefaults\Value as TraitValue;
+
+trait TraitDefaults
+{
+    public function fromTrait(
+        TraitValue $value = new TraitValue(
+            self::PRIVATE_LABEL,
+            [
+                'file' => __FILE__,
+                'directory' => __DIR__,
+                'line' => __LINE__,
+                'namespace' => __NAMESPACE__,
+                'class' => __CLASS__,
+                'trait' => __TRAIT__,
+                'method' => __METHOD__, // @phpstan-ignore magicConstant.outOfFunction (PHP resolves the method name in parameter defaults.)
+                'function' => __FUNCTION__, // @phpstan-ignore magicConstant.outOfFunction (PHP resolves the function name in parameter defaults.)
+            ],
+        ),
+        string $marker = '',
+    ): void {}
+}

--- a/tests/Fixture/Doubles/ObjectDefaults/Value.php
+++ b/tests/Fixture/Doubles/ObjectDefaults/Value.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles\ObjectDefaults;
+
+final readonly class Value
+{
+    /** @param array<array-key, mixed> $payload */
+    public function __construct(public string $label, public array $payload = []) {}
+}

--- a/tests/Fixture/ParameterDefaultSource/Contexts.php
+++ b/tests/Fixture/ParameterDefaultSource/Contexts.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\ParameterDefaultSource\Values {
+    const OPTION = 'option';
+
+    final class Payload
+    {
+        /** @param array<string, mixed> $items */
+        public function __construct(public array $items = [])
+        {
+            throw new \RuntimeException('The default constructor must not run.');
+        }
+    }
+
+    final class Other {}
+
+    function helper(): void {}
+
+    #[\Attribute(\Attribute::TARGET_PARAMETER)]
+    final readonly class ProbeAttribute
+    {
+        /** @param list<int> $values */
+        public function __construct(public array $values) {}
+    }
+}
+
+namespace Greenlight\Tests\Fixture\ParameterDefaultSource\First {
+    use Greenlight\Tests\Fixture\ParameterDefaultSource\Values\{Payload as Value, Other, const OPTION as ALIAS, function helper};
+    use Greenlight\Tests\Fixture\ParameterDefaultSource\Values\ProbeAttribute, DateTimeImmutable as Clock;
+    use const PHP_INT_MAX as MAXIMUM, PHP_INT_MIN;
+
+    $captured = 'value';
+    $closure = static function () use ($captured): string { return "{$captured}"; };
+
+    interface Nested
+    {
+        public function run(
+            #[ProbeAttribute([1, 2])] string $before = 'text',
+            object $value = new Value(items: ['brace' => '}', 'nested' => [new Other()]]),
+        ): void;
+    }
+
+    trait Original { public function original(object $value = new Value()): void {} public function unrelated(object $value = new Other()): void {} }
+    trait Wrapper { use Original { original as wrapped; } }
+    class Host { use Wrapper { wrapped as alias; } }
+    class Child extends Host {}
+
+    interface OwnerA { public function run(object $value = new Value()): void; } interface OwnerB { public function run(object $value = new Other()): void; }
+}
+
+namespace Greenlight\Tests\Fixture\ParameterDefaultSource\Second {
+    use stdClass as Value;
+
+    interface Nested
+    {
+        public function run(object $value = new Value()): void;
+    }
+}
+
+namespace Greenlight\Tests\Fixture\ParameterDefaultSource\Ambiguous {
+    trait First { public function run(object $value = new \ArrayObject()): void {} } trait Second { public function run(object $value = new \stdClass()): void {} } class Selected { use First, Second { Second::run insteadof First; } } class OwnMethod { use First, Second { Second::run insteadof First; } public function run(object $value = new \DateTimeImmutable()): void {} }
+
+    /** @return list<object> */
+    function anonymousPair(): array { return [new class { public function run(object $value = new \ArrayObject()): void {} }, new class { public function run(object $value = new \stdClass()): void {} }]; }
+}

--- a/tests/Unit/Doubles/ObjectDefaultBoundaryTest.php
+++ b/tests/Unit/Doubles/ObjectDefaultBoundaryTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\InvalidDoubleUsage;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Doubles\ObjectDefaults\DynamicPrivateConstantDefaults;
+use Greenlight\Tests\Fixture\Doubles\ObjectDefaults\PrivateConstructorDefaults;
+use Greenlight\Tests\Fixture\Doubles\ObjectDefaults\PrivateObjectConstantDefaults;
+use Greenlight\Tests\Fixture\Doubles\ObjectDefaults\TrackedValue;
+
+final readonly class ObjectDefaultBoundaryTest
+{
+    public function __construct(private Doubles $doubles) {}
+
+    #[Test]
+    public function defaultsWithoutReadableSourceFailWithoutRunningConstructors(): void
+    {
+        TrackedValue::$constructions = 0;
+        $name = 'EvaluatedObjectDefault' . \bin2hex(\random_bytes(6));
+        $type = __NAMESPACE__ . '\\' . $name;
+        eval(\sprintf(
+            <<<'PHP'
+                namespace Greenlight\Tests\Unit\Doubles;
+
+                interface %s
+                {
+                    public function run(
+                        \Greenlight\Tests\Fixture\Doubles\ObjectDefaults\TrackedValue $value =
+                            new \Greenlight\Tests\Fixture\Doubles\ObjectDefaults\TrackedValue('default'),
+                    ): void;
+                }
+                PHP,
+            $name,
+        ));
+        $stub = new \ReflectionMethod(Doubles::class, 'stub');
+
+        Expect::that(fn(): mixed => $stub->invoke($this->doubles, $type))
+            ->toThrow(
+                InvalidDoubleUsage::class,
+                message: 'Doubles cannot read the object default of parameter "$value" from "'
+                    . $type . '::run()". Declare the method on a separate line in a readable PHP file.',
+            );
+        Expect::that(TrackedValue::$constructions)->toBe(0);
+    }
+
+    #[Test]
+    public function privateConstructorsHaveAnExplicitDiagnostic(): void
+    {
+        Expect::that(fn(): object => $this->doubles->stub(PrivateConstructorDefaults::class))
+            ->toThrow(
+                InvalidDoubleUsage::class,
+                message: 'Doubles cannot access the object default of parameter "$value" from "'
+                    . PrivateConstructorDefaults::class
+                    . '::run()" in a proxy. Use a public constructor and accessible constants.',
+            );
+    }
+
+    #[Test]
+    public function dynamicPrivateConstantsHaveAnExplicitDiagnostic(): void
+    {
+        Expect::that(fn(): object => $this->doubles->stub(DynamicPrivateConstantDefaults::class))
+            ->toThrow(
+                InvalidDoubleUsage::class,
+                message: 'Doubles cannot access the object default of parameter "$value" from "'
+                    . DynamicPrivateConstantDefaults::class
+                    . '::run()" in a proxy. Use a public constructor and accessible constants.',
+            );
+    }
+
+    #[Test]
+    public function privateObjectConstantsHaveAnExplicitDiagnostic(): void
+    {
+        Expect::that(fn(): object => $this->doubles->stub(PrivateObjectConstantDefaults::class))
+            ->toThrow(
+                InvalidDoubleUsage::class,
+                message: 'Doubles cannot access the object default of parameter "$value" from "'
+                    . PrivateObjectConstantDefaults::class
+                    . '::run()" in a proxy. Use a public constructor and accessible constants.',
+            );
+    }
+}

--- a/tests/Unit/Doubles/ObjectDefaultTest.php
+++ b/tests/Unit/Doubles/ObjectDefaultTest.php
@@ -6,31 +6,179 @@ namespace Greenlight\Tests\Unit\Doubles;
 
 use Greenlight\Attribute\Test;
 use Greenlight\Doubles\Doubles;
-use Greenlight\Doubles\InvalidDoubleUsage;
 use Greenlight\Expect\Expect;
-use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Fixture\Doubles\ObjectDefault;
+use Greenlight\Tests\Fixture\Doubles\ObjectDefaults\ConstantObjectDefaults;
+use Greenlight\Tests\Fixture\Doubles\ObjectDefaults\ContextDefaults;
+use Greenlight\Tests\Fixture\Doubles\ObjectDefaults\ImportedDefaults;
+use Greenlight\Tests\Fixture\Doubles\ObjectDefaults\TrackedDefaults;
+use Greenlight\Tests\Fixture\Doubles\ObjectDefaults\TrackedValue;
+use Greenlight\Tests\Fixture\Doubles\ObjectDefaults\TraitConsumer;
 
 final readonly class ObjectDefaultTest
 {
-    public function __construct(private TemporaryDirectory $tempDirectory) {}
+    public function __construct(private Doubles $doubles) {}
 
     #[Test]
-    public function objectDefaultsAreRejectedBeforeGeneratingAnInvalidProxy(): void
+    public function objectDefaultsAllowOmittedArguments(): void
     {
-        $doubles = new Doubles($this->tempDirectory->path() . '/proxies');
+        $double = $this->doubles->spy(ObjectDefault::class);
 
-        try {
-            Expect::that(static fn(): object => $doubles->stub(ObjectDefault::class))
-                ->because('an object default cannot be reproduced in generated proxy source')
-                ->toThrow(
-                    InvalidDoubleUsage::class,
-                    message: 'Doubles cannot reproduce the object default of parameter $value from '
-                        . ObjectDefault::class
-                        . '::run() in a proxy. Use an interface without object defaults instead.',
-                );
-        } finally {
-            $doubles->dispose();
-        }
+        $double->run();
+
+        Expect::that($this->doubles->callsTo($double, 'run'))->toBe([[]]);
+        Expect::that(new \ReflectionMethod($double, 'run')->getParameters()[0]->getDefaultValue())
+            ->toBeInstanceOf(\stdClass::class);
+    }
+
+    #[Test]
+    public function proxyCreationDoesNotConstructParameterDefaults(): void
+    {
+        TrackedValue::$constructions = 0;
+
+        $double = $this->doubles->spy(TrackedDefaults::class);
+
+        Expect::that(TrackedValue::$constructions)->toBe(0);
+
+        $double->run();
+
+        Expect::that(TrackedValue::$constructions)->toBe(1);
+        Expect::that($this->doubles->callsTo($double, 'run'))->toBe([[]]);
+    }
+
+    #[Test]
+    public function eachOmittedArgumentConstructsAFreshObject(): void
+    {
+        TrackedValue::$constructions = 0;
+        $double = $this->doubles->spy(TrackedDefaults::class);
+
+        $double->run(marker: 'first');
+        $double->run(marker: 'second');
+
+        $calls = $this->doubles->callsTo($double, 'run');
+        $first = $calls[0][0] ?? null;
+        $second = $calls[1][0] ?? null;
+        Expect::that($calls)->toHaveCount(2);
+        Expect::that($first)->toBeInstanceOf(TrackedValue::class);
+        Expect::that($second)->toBeInstanceOf(TrackedValue::class);
+        Expect::that($first)->not()->toBe($second);
+        Expect::that(TrackedValue::$constructions)->toBe(2);
+    }
+
+    #[Test]
+    public function explicitArgumentsDoNotConstructTheDefault(): void
+    {
+        TrackedValue::$constructions = 0;
+        $value = new TrackedValue('explicit');
+        $double = $this->doubles->spy(TrackedDefaults::class);
+
+        $double->run($value);
+
+        Expect::that(TrackedValue::$constructions)->toBe(1);
+        Expect::that($this->doubles->callsTo($double, 'run'))->toBe([[$value]]);
+    }
+
+    #[Test]
+    public function objectDefaultsPreserveImportsAndNamedConstructorArguments(): void
+    {
+        $double = $this->doubles->spy(ImportedDefaults::class);
+        $original = new \ReflectionMethod(ImportedDefaults::class, 'run')->getParameters()[0]->getDefaultValue();
+        $generated = new \ReflectionMethod($double, 'run')->getParameters()[0]->getDefaultValue();
+
+        $double->run(marker: 'named');
+
+        Expect::that($generated)->toEqual($original);
+        Expect::that($this->doubles->callsTo($double, 'run'))->toEqual([[$original, 'named']]);
+    }
+
+    #[Test]
+    public function arraysPreserveNestedObjectsEnumsAndStringBytes(): void
+    {
+        $double = $this->doubles->spy(ImportedDefaults::class);
+        $original = new \ReflectionMethod(ImportedDefaults::class, 'nested')->getParameters()[0]->getDefaultValue();
+        $generated = new \ReflectionMethod($double, 'nested')->getParameters()[0]->getDefaultValue();
+
+        $double->nested(marker: 'nested');
+
+        Expect::that($generated)->toEqual($original);
+        Expect::that($this->doubles->callsTo($double, 'nested'))->toEqual([[$original, 'nested']]);
+    }
+
+    #[Test]
+    public function classDefaultsResolvePrivateSelfAndParentConstants(): void
+    {
+        $double = $this->doubles->spy(ContextDefaults::class);
+        $original = new \ReflectionMethod(ContextDefaults::class, 'run')->getParameters()[0]->getDefaultValue();
+        $generated = new \ReflectionMethod($double, 'run')->getParameters()[0]->getDefaultValue();
+
+        $double->run(marker: 'class');
+
+        Expect::that($generated)->toEqual($original);
+        Expect::that($this->doubles->callsTo($double, 'run'))->toEqual([[$original, 'class']]);
+    }
+
+    #[Test]
+    public function inheritedMethodsKeepTheirOriginalClassContext(): void
+    {
+        $double = $this->doubles->spy(ContextDefaults::class);
+        $original = new \ReflectionMethod(ContextDefaults::class, 'inherited')->getParameters()[0]->getDefaultValue();
+        $generated = new \ReflectionMethod($double, 'inherited')->getParameters()[0]->getDefaultValue();
+
+        $double->inherited(marker: 'parent');
+
+        Expect::that($generated)->toEqual($original);
+        Expect::that($this->doubles->callsTo($double, 'inherited'))->toEqual([[$original, 'parent']]);
+    }
+
+    #[Test]
+    public function traitAliasesKeepTheOriginalImportsAndMagicConstants(): void
+    {
+        $double = $this->doubles->spy(TraitConsumer::class);
+        $original = new \ReflectionMethod(TraitConsumer::class, 'aliasDefault')->getParameters()[0]->getDefaultValue();
+        $generated = new \ReflectionMethod($double, 'aliasDefault')->getParameters()[0]->getDefaultValue();
+
+        $double->aliasDefault(marker: 'trait');
+
+        Expect::that($generated)->toEqual($original);
+        Expect::that($this->doubles->callsTo($double, 'aliasDefault'))->toEqual([[$original, 'trait']]);
+    }
+
+    #[Test]
+    public function arraysRetainTheIdentityOfObjectConstants(): void
+    {
+        $double = $this->doubles->spy(ConstantObjectDefaults::class);
+        $original = new \ReflectionMethod(ConstantObjectDefaults::class, 'nested')->getParameters()[0]->getDefaultValue();
+        $generated = new \ReflectionMethod($double, 'nested')->getParameters()[0]->getDefaultValue();
+
+        $double->nested(marker: 'shared');
+
+        Expect::that($generated)->toBe($original);
+        Expect::that($this->doubles->callsTo($double, 'nested'))->toBe([[$original, 'shared']]);
+    }
+
+    #[Test]
+    public function globalConstantDefaultsRetainTheirObjectIdentity(): void
+    {
+        $double = $this->doubles->spy(ConstantObjectDefaults::class);
+        $original = new \ReflectionMethod(ConstantObjectDefaults::class, 'globalConstant')->getParameters()[0]->getDefaultValue();
+        $generated = new \ReflectionMethod($double, 'globalConstant')->getParameters()[0]->getDefaultValue();
+
+        $double->globalConstant(marker: 'global');
+
+        Expect::that($generated)->toBe($original);
+        Expect::that($this->doubles->callsTo($double, 'globalConstant'))->toBe([[$original, 'global']]);
+    }
+
+    #[Test]
+    public function publicConstantDefaultsRetainTheirObjectIdentity(): void
+    {
+        $double = $this->doubles->spy(ConstantObjectDefaults::class);
+        $original = new \ReflectionMethod(ConstantObjectDefaults::class, 'publicConstant')->getParameters()[0]->getDefaultValue();
+        $generated = new \ReflectionMethod($double, 'publicConstant')->getParameters()[0]->getDefaultValue();
+
+        $double->publicConstant(marker: 'public');
+
+        Expect::that($generated)->toBe($original);
+        Expect::that($this->doubles->callsTo($double, 'publicConstant'))->toBe([[$original, 'public']]);
     }
 }

--- a/tests/Unit/Doubles/ParameterDefaultSourceTest.php
+++ b/tests/Unit/Doubles/ParameterDefaultSourceTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\ParameterDefaultSource;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\ParameterDefaultSource\Ambiguous;
+use Greenlight\Tests\Fixture\ParameterDefaultSource\First;
+use Greenlight\Tests\Fixture\ParameterDefaultSource\Second;
+
+final class ParameterDefaultSourceTest
+{
+    #[Test]
+    public function nestedExpressionsRetainTheirSourceAndImportsWithoutConstruction(): void
+    {
+        require_once __DIR__ . '/../../Fixture/ParameterDefaultSource/Contexts.php';
+
+        $source = ParameterDefaultSource::read(new \ReflectionMethod(First\Nested::class, 'run')->getParameters()[1]);
+
+        Expect::that($source)->toBeArray();
+        Expect::that(\implode('', \array_map(static fn(\PhpToken $token): string => $token->text, $source['tokens'])))
+            ->toBe("new Value(items: ['brace' => '}', 'nested' => [new Other()]])");
+        Expect::that($source['namespace'])->toBe('Greenlight\\Tests\\Fixture\\ParameterDefaultSource\\First');
+        Expect::that($source['imports'])->toBe([
+            'value' => \Greenlight\Tests\Fixture\ParameterDefaultSource\Values\Payload::class,
+            'other' => \Greenlight\Tests\Fixture\ParameterDefaultSource\Values\Other::class,
+            'probeattribute' => \Greenlight\Tests\Fixture\ParameterDefaultSource\Values\ProbeAttribute::class,
+            'clock' => 'DateTimeImmutable',
+        ]);
+        Expect::that($source['constants'])->toBe([
+            'ALIAS' => 'Greenlight\\Tests\\Fixture\\ParameterDefaultSource\\Values\\OPTION',
+            'MAXIMUM' => 'PHP_INT_MAX',
+            'PHP_INT_MIN' => 'PHP_INT_MIN',
+        ]);
+        Expect::that($source['trait'])->toBe('');
+    }
+
+    #[Test]
+    public function nestedTraitAliasesRetainTheOriginalMethodAndTrait(): void
+    {
+        require_once __DIR__ . '/../../Fixture/ParameterDefaultSource/Contexts.php';
+
+        $source = ParameterDefaultSource::read(new \ReflectionMethod(First\Child::class, 'alias')->getParameters()[0]);
+
+        Expect::that($source)->toBeArray();
+        Expect::that($source['method'])->toBe('original');
+        Expect::that($source['trait'])->toBe(First\Original::class);
+        Expect::that(\implode('', \array_map(static fn(\PhpToken $token): string => $token->text, $source['tokens'])))
+            ->toBe('new Value()');
+    }
+
+    #[Test]
+    public function methodsOnTheSameLineUseTheirOwnClassDeclaration(): void
+    {
+        require_once __DIR__ . '/../../Fixture/ParameterDefaultSource/Contexts.php';
+
+        $source = ParameterDefaultSource::read(new \ReflectionMethod(First\OwnerB::class, 'run')->getParameters()[0]);
+
+        Expect::that($source)->toBeArray();
+        Expect::that(\implode('', \array_map(static fn(\PhpToken $token): string => $token->text, $source['tokens'])))
+            ->toBe('new Other()');
+    }
+
+    #[Test]
+    public function namespaceBlocksHaveSeparateImportTables(): void
+    {
+        require_once __DIR__ . '/../../Fixture/ParameterDefaultSource/Contexts.php';
+
+        $source = ParameterDefaultSource::read(new \ReflectionMethod(Second\Nested::class, 'run')->getParameters()[0]);
+
+        Expect::that($source)->toBeArray();
+        Expect::that($source['namespace'])->toBe('Greenlight\\Tests\\Fixture\\ParameterDefaultSource\\Second');
+        Expect::that($source['imports'])->toBe(['value' => 'stdClass']);
+        Expect::that($source['constants'])->toBe([]);
+    }
+
+    #[Test]
+    public function internalMethodsHaveNoSourceExpression(): void
+    {
+        $parameter = new \ReflectionMethod(\DateTimeImmutable::class, '__construct')->getParameters()[0];
+
+        Expect::that(ParameterDefaultSource::read($parameter))->toBeNull();
+    }
+
+    #[Test]
+    public function sameLineTraitConflictsHaveNoUnambiguousSource(): void
+    {
+        require_once __DIR__ . '/../../Fixture/ParameterDefaultSource/Contexts.php';
+
+        $parameter = new \ReflectionMethod(Ambiguous\Selected::class, 'run')->getParameters()[0];
+
+        Expect::that($parameter->getDefaultValue())->toBeInstanceOf(\stdClass::class);
+        Expect::that(ParameterDefaultSource::read($parameter))->toBeNull();
+    }
+
+    #[Test]
+    public function classMethodsTakePriorityOverSameLineTraitMethods(): void
+    {
+        require_once __DIR__ . '/../../Fixture/ParameterDefaultSource/Contexts.php';
+
+        $source = ParameterDefaultSource::read(new \ReflectionMethod(Ambiguous\OwnMethod::class, 'run')->getParameters()[0]);
+
+        Expect::that($source)->toBeArray();
+        Expect::that(\implode('', \array_map(static fn(\PhpToken $token): string => $token->text, $source['tokens'])))
+            ->toBe('new \\DateTimeImmutable()');
+    }
+
+    #[Test]
+    public function sameLineAnonymousClassesHaveNoUnambiguousSource(): void
+    {
+        require_once __DIR__ . '/../../Fixture/ParameterDefaultSource/Contexts.php';
+
+        $pair = Ambiguous\anonymousPair();
+        $parameter = new \ReflectionMethod($pair[0], 'run')->getParameters()[0];
+
+        Expect::that(ParameterDefaultSource::read($parameter))->toBeNull();
+    }
+}

--- a/tests/Unit/Doubles/ParameterDefaultSourceTest.php
+++ b/tests/Unit/Doubles/ParameterDefaultSourceTest.php
@@ -10,6 +10,9 @@ use Greenlight\Expect\Expect;
 use Greenlight\Tests\Fixture\ParameterDefaultSource\Ambiguous;
 use Greenlight\Tests\Fixture\ParameterDefaultSource\First;
 use Greenlight\Tests\Fixture\ParameterDefaultSource\Second;
+use Greenlight\Tests\Fixture\ParameterDefaultSource\Values\Other;
+use Greenlight\Tests\Fixture\ParameterDefaultSource\Values\Payload;
+use Greenlight\Tests\Fixture\ParameterDefaultSource\Values\ProbeAttribute;
 
 final class ParameterDefaultSourceTest
 {
@@ -25,9 +28,9 @@ final class ParameterDefaultSourceTest
             ->toBe("new Value(items: ['brace' => '}', 'nested' => [new Other()]])");
         Expect::that($source['namespace'])->toBe('Greenlight\\Tests\\Fixture\\ParameterDefaultSource\\First');
         Expect::that($source['imports'])->toBe([
-            'value' => \Greenlight\Tests\Fixture\ParameterDefaultSource\Values\Payload::class,
-            'other' => \Greenlight\Tests\Fixture\ParameterDefaultSource\Values\Other::class,
-            'probeattribute' => \Greenlight\Tests\Fixture\ParameterDefaultSource\Values\ProbeAttribute::class,
+            'value' => Payload::class,
+            'other' => Other::class,
+            'probeattribute' => ProbeAttribute::class,
             'clock' => 'DateTimeImmutable',
         ]);
         Expect::that($source['constants'])->toBe([


### PR DESCRIPTION
Methods with defaults such as `array $values = ['objects' => [new stdClass()]]` now support doubles. The proxy preserves the original default expression, so PHP constructs each object when a call omits that argument. Proxy generation does not run the default constructors.

Read the expression from the declaration's PHP source and resolve imports, class scope, and magic constants. Preserve nested arrays, named constructor arguments, exact literals, enum cases, and object constant identity without runtime dependencies.

Object defaults require readable source files. Private constructors, private object constants, and dynamic constant access on classes with private constants report `InvalidDoubleUsage`. Ambiguous source declarations also report an error. Unqualified constants resolve when Greenlight generates the proxy.

Supersedes #1845.
