### PR TITLE
feat: select services from named plugin sources

### DIFF
--- a/docs/api-harness.md
+++ b/docs/api-harness.md
@@ -71,9 +71,9 @@ case PerWorker = 'per-worker';
 
 Namespace: `Greenlight\Harness`
 
-Selects a service within its source by ID. Each bridge translates the ID
-into its container lookup. The resolved service must have the declared
-parameter type.
+Selects a service ID or a named source for a constructor parameter. Each
+bridge translates the ID into its container lookup, or uses the default
+lookup if the ID is absent. The service must have the declared type.
 
 ```php
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
@@ -85,33 +85,45 @@ final readonly class Service
 ### `$id`
 
 ```php
-public string $id;
+public ?string $id;
 ```
 
 PHPDoc:
 
-- `@var non-empty-string`
+- `@var non-empty-string|null`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/Service.php#L16)
+
+### `$source`
+
+```php
+public ?string $source;
+```
+
+PHPDoc:
+
+- `@var non-empty-string|null`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/Service.php#L19)
 
 ### `__construct()`
 
 ```php
-public function __construct(string $id)
+public function __construct(?string $id = null, ?string $source = null)
 ```
 
 PHPDoc:
 
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/Service.php#L19)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/Service.php#L22)
 
 ## `ServiceDefinition`
 
 Namespace: `Greenlight\Harness`
 
 Defines one harness service. It contains the exact injected type, service
-scope, and factory.
+scope, factory, and optional source name.
 
 ```php
 final readonly class ServiceDefinition
@@ -131,13 +143,25 @@ PHPDoc:
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceDefinition.php#L16)
 
+### `$source`
+
+```php
+public ?string $source;
+```
+
+PHPDoc:
+
+- `@var non-empty-string|null`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceDefinition.php#L19)
+
 ### `$scope`
 
 ```php
 public Scope $scope
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceDefinition.php#L28)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceDefinition.php#L31)
 
 ### `$factory`
 
@@ -145,7 +169,7 @@ public Scope $scope
 public \Closure $factory
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceDefinition.php#L29)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceDefinition.php#L32)
 
 ### `__construct()`
 
@@ -154,6 +178,7 @@ public function __construct(
     string $type,
     public Scope $scope,
     public \Closure $factory,
+    ?string $source = null,
 )
 ```
 
@@ -164,7 +189,7 @@ PHPDoc:
 - `@param \Closure(): T $factory`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceDefinition.php#L26)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceDefinition.php#L29)
 
 ## `ServiceResolutionFailed`
 
@@ -211,6 +236,31 @@ PHPDoc:
 - `@throws ServiceResolutionFailed when the resolver handles the request but cannot supply a valid service`
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolver.php#L23)
+
+## `ServiceSource`
+
+Namespace: `Greenlight\Harness`
+
+Names one source of harness definitions or resolved services. Source names
+are case-sensitive. A null name keeps the source unnamed.
+
+```php
+interface ServiceSource
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceSource.php#L11)
+
+### `source()`
+
+```php
+public function source(): ?string;
+```
+
+PHPDoc:
+
+- `@return non-empty-string|null`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceSource.php#L14)
 
 ## `TerminalServiceResolver`
 

--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -46,17 +46,17 @@ Initializes the Hyperf class loader once in each worker. It creates a
 coroutine context for each test attempt.
 
 The default worker container lifetime matches a long-running Hyperf worker.
-`#[Service]` selects an explicit container ID. Isolate external test
+`#[Service]` selects a container ID or a named source. Isolate external test
 resources by `GREENLIGHT_CHANNEL`.
 
 Requires `hyperf/framework` and `hyperf/di` 3.2. It also requires Swoole 5
 or later and the pcntl extension. It does not support Swow.
 
 ```php
-final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemptRunner, WorkerBootstrapSubscriber, WorkerRuntimeRunner
+final class HyperfPlugin implements HarnessProvider, ServiceResolver, ServiceSource, TestAttemptRunner, WorkerBootstrapSubscriber, WorkerRuntimeRunner
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L43)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L44)
 
 ### `__construct()`
 
@@ -67,6 +67,7 @@ public function __construct(
     private readonly ?\Closure $reset = null,
     private readonly ?\Closure $dispose = null,
     private readonly ?int $hookFlags = null,
+    ?string $source = null,
 )
 ```
 
@@ -74,8 +75,17 @@ PHPDoc:
 
 - `@param null|\Closure(ContainerInterface): void $reset Resets project-owned request state after each test attempt. The callback runs inside the test coroutine.`
 - `@param null|\Closure(ContainerInterface): void $dispose Releases project-owned resources when the selected container lifetime ends. The callback runs inside a coroutine.`
+- `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L66)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L71)
+
+### `source()`
+
+```php
+public function source(): ?string
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L89)
 
 ### `services()`
 
@@ -87,7 +97,7 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L79)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L96)
 
 ### `resolve()`
 
@@ -101,7 +111,7 @@ PHPDoc:
 - `@param list<object> $attributes`
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L92)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L109)
 
 ### `onWorkerBootstrap()`
 
@@ -113,7 +123,7 @@ PHPDoc:
 
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L129)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L148)
 
 ### `runWorker()`
 
@@ -128,7 +138,7 @@ PHPDoc:
 - `@return T`
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L186)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L205)
 
 ### `runTestAttempt()`
 
@@ -143,7 +153,7 @@ PHPDoc:
 - `@return T`
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L230)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L249)
 
 ## `LaravelPlugin`
 
@@ -152,14 +162,14 @@ Namespace: `Greenlight\Laravel`
 Boots a Laravel application on first use and resolves bound services.
 By default, Greenlight releases the application after each test attempt.
 
-`#[Service]` selects an explicit binding ID. Isolate external test resources
+`#[Service]` selects a binding ID or a named source. Isolate external test resources
 by `GREENLIGHT_CHANNEL`.
 
 ```php
-final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, ServiceResolver
+final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, ServiceResolver, ServiceSource
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L29)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L30)
 
 ### `__construct()`
 
@@ -168,6 +178,7 @@ public function __construct(
     string|\Closure $application,
     private readonly string $env = 'testing',
     private readonly bool $refreshBetweenTests = true,
+    ?string $source = null,
 )
 ```
 
@@ -176,8 +187,17 @@ PHPDoc:
 - `@param string|\Closure(): Application $application A path to a file that returns the application, usually bootstrap/app.php. For other application setup, pass a closure that returns the application.`
 - `@param non-empty-string $env`
 - `@param bool $refreshBetweenTests Set to false only when no service keeps state between tests. Tests on one worker then share one application without resets.`
+- `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L48)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L53)
+
+### `source()`
+
+```php
+public function source(): ?string
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L84)
 
 ### `services()`
 
@@ -189,7 +209,7 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L76)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L93)
 
 ### `resolve()`
 
@@ -203,7 +223,7 @@ PHPDoc:
 - `@param list<object> $attributes`
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L93)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L110)
 
 ### `afterTest()`
 
@@ -211,7 +231,7 @@ PHPDoc:
 public function afterTest(TestContext $context, TestResult $result): TestResult
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L129)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Laravel/LaravelPlugin.php#L148)
 
 ## `Psr11Plugin`
 
@@ -220,14 +240,14 @@ Namespace: `Greenlight\Psr11`
 Creates a PSR-11 container lazily and resolves its services. By default, the
 plugin discards the container after each test that uses it.
 
-`#[Service]` selects an explicit ID. Isolate external test resources by
+`#[Service]` selects a service ID or a named source. Isolate external test resources by
 `GREENLIGHT_CHANNEL`.
 
 ```php
-final class Psr11Plugin implements AfterTestSubscriber, HarnessProvider, ServiceResolver
+final class Psr11Plugin implements AfterTestSubscriber, HarnessProvider, ServiceResolver, ServiceSource
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr11/Psr11Plugin.php#L25)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr11/Psr11Plugin.php#L26)
 
 ### `__construct()`
 
@@ -236,6 +256,7 @@ public function __construct(
     private readonly \Closure $factory,
     private readonly bool $refreshBetweenTests = true,
     private readonly ?\Closure $reset = null,
+    ?string $source = null,
 )
 ```
 
@@ -244,8 +265,17 @@ PHPDoc:
 - `@param \Closure():ContainerInterface $factory A factory that returns the application container.`
 - `@param bool $refreshBetweenTests Set to false only when the reset callback removes all container state, or when services do not keep state.`
 - `@param (\Closure(ContainerInterface): void)|null $reset An optional callback that resets the active container after each test.`
+- `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr11/Psr11Plugin.php#L38)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr11/Psr11Plugin.php#L43)
+
+### `source()`
+
+```php
+public function source(): ?string
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr11/Psr11Plugin.php#L57)
 
 ### `services()`
 
@@ -257,7 +287,7 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr11/Psr11Plugin.php#L48)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr11/Psr11Plugin.php#L66)
 
 ### `resolve()`
 
@@ -271,7 +301,7 @@ PHPDoc:
 - `@param list<object> $attributes`
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr11/Psr11Plugin.php#L94)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr11/Psr11Plugin.php#L112)
 
 ### `afterTest()`
 
@@ -283,7 +313,7 @@ PHPDoc:
 
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr11/Psr11Plugin.php#L141)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Psr11/Psr11Plugin.php#L159)
 
 ## `HttpHarness`
 
@@ -521,14 +551,14 @@ The container must expose Symfony's test container. If the configuration
 does not disable resets, the container must expose `services_resetter`. If a
 service keeps state between tests, do not disable resets.
 
-`#[Service]` selects an explicit ID instead of a type-based search. Isolate
-external resources with `GREENLIGHT_CHANNEL`.
+`#[Service]` selects a service ID or a named source. Isolate external
+resources with `GREENLIGHT_CHANNEL`.
 
 ```php
-final class SymfonyPlugin implements AfterTestSubscriber, HarnessProvider, ServiceResolver
+final class SymfonyPlugin implements AfterTestSubscriber, HarnessProvider, ServiceResolver, ServiceSource
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L31)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L32)
 
 ### `__construct()`
 
@@ -538,6 +568,7 @@ public function __construct(
     string $env = 'test',
     bool $debug = false,
     private readonly bool $resetBetweenTests = true,
+    ?string $source = null,
 )
 ```
 
@@ -546,8 +577,17 @@ PHPDoc:
 - `@param class-string<KernelInterface>|\Closure(): KernelInterface $kernel A kernel class name that Greenlight constructs as new $kernel($env, $debug), or a closure that constructs the kernel. Use a closure for other constructor requirements.`
 - `@param non-empty-string $env`
 - `@param bool $resetBetweenTests For a container without stateful services, use false to disable resets. Tests on one worker then reuse the container without resets. Symfony service configuration determines which instances are shared.`
+- `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L55)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L60)
+
+### `source()`
+
+```php
+public function source(): ?string
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L84)
 
 ### `services()`
 
@@ -559,7 +599,7 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L76)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L93)
 
 ### `resolve()`
 
@@ -573,7 +613,7 @@ PHPDoc:
 - `@param list<object> $attributes`
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L89)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L106)
 
 ### `afterTest()`
 
@@ -581,7 +621,7 @@ PHPDoc:
 public function afterTest(TestContext $context, TestResult $result): TestResult
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L125)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Symfony/SymfonyPlugin.php#L144)
 
 ## `TempestPlugin`
 
@@ -596,10 +636,10 @@ a tagged Tempest binding.
 Isolate external test resources by `GREENLIGHT_CHANNEL`.
 
 ```php
-final class TempestPlugin implements AfterTestSubscriber, BeforeTestSubscriber, HarnessProvider, TerminalServiceResolver, WorkerBootstrapSubscriber
+final class TempestPlugin implements AfterTestSubscriber, BeforeTestSubscriber, HarnessProvider, ServiceSource, TerminalServiceResolver, WorkerBootstrapSubscriber
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L37)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L38)
 
 ### `__construct()`
 
@@ -608,6 +648,7 @@ public function __construct(
     private readonly string $root,
     private readonly string $environment = 'testing',
     private readonly array $discoveryLocations = [],
+    ?string $source = null,
 )
 ```
 
@@ -617,7 +658,15 @@ PHPDoc:
 - `@param list<DiscoveryLocation> $discoveryLocations Additional locations for Tempest discovery.`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L50)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L54)
+
+### `source()`
+
+```php
+public function source(): ?string
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L76)
 
 ### `onWorkerBootstrap()`
 
@@ -625,7 +674,7 @@ PHPDoc:
 public function onWorkerBootstrap(WorkerBootstrapContext $context): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L65)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L82)
 
 ### `services()`
 
@@ -637,7 +686,7 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L74)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L91)
 
 ### `resolve()`
 
@@ -651,7 +700,7 @@ PHPDoc:
 - `@param list<object> $attributes`
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L88)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L105)
 
 ### `beforeTest()`
 
@@ -659,7 +708,7 @@ PHPDoc:
 public function beforeTest(TestContext $context): void
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L114)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L131)
 
 ### `afterTest()`
 
@@ -671,4 +720,4 @@ PHPDoc:
 
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L127)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Tempest/TempestPlugin.php#L144)

--- a/docs/architecture/technical-writing.md
+++ b/docs/architecture/technical-writing.md
@@ -200,6 +200,7 @@ and meaning. Use the singular form unless the context requires a plural.
 | service provider | Technical noun | A Laravel class that registers services in the Laravel container |
 | service resolver | Technical noun | A fallback component that supplies constructor arguments by type |
 | service scope | Technical noun | The lifetime and ownership boundary of a harness service |
+| service source | Technical noun | A named provider or resolver that supplies a requested harness or container service |
 | scheduling unit | Technical noun | One test class or isolated test that the orchestrator can assign to a worker |
 | seed | Technical noun | An integer that reproduces randomized test-class order |
 | shard | Technical noun | One disjoint class-based part of an execution plan |

--- a/docs/hyperf.md
+++ b/docs/hyperf.md
@@ -140,8 +140,8 @@ final readonly class RegistrationTest
 }
 ```
 
-Greenlight first checks its harness services. It then asks the active Hyperf
-container.
+Without an explicit service source, Greenlight first checks its harness
+services. It then asks the active Hyperf container.
 
 Use `#[Service]` when the parameter type does not select the necessary ID:
 
@@ -162,6 +162,18 @@ Concrete Hyperf bridge exceptions are internal.
 
 A test can also receive `Psr\Container\ContainerInterface`. This service is
 available only during the current test attempt.
+
+### Select a service source
+
+Pass `source: 'app'` to `HyperfPlugin` to name this plugin instance. Use
+`#[Service(source: 'app')]` to request a service by type from this source.
+Use `#[Service('payments.client', source: 'app')]` to select an explicit ID in
+its container.
+
+An explicit source takes precedence over global harness services. A missing
+service fails without a request to another source. Use the same source
+attribute to select this plugin's `ContainerInterface` harness service. See
+[service sources](plugins.md#servicesource) for naming and resolution rules.
 
 ## Reset and disposal
 

--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -67,9 +67,10 @@ final class RegistrationTest
 }
 ```
 
-Greenlight first resolves constructor parameters from its harness. It then uses
-the Laravel container. Thus, `Doubles`, `TestChannel`, and provider services
-take precedence over container services.
+Without an explicit service source, Greenlight first resolves constructor
+parameters from its harness. It then uses the Laravel container. Thus,
+`Doubles`, `TestChannel`, and provider services take precedence over container
+services.
 
 When neither side can resolve a type, the test fails and reports both misses.
 
@@ -97,6 +98,18 @@ public function __construct(
 
 Greenlight still checks the parameter type. If the named service is not an
 instance of the declared type, the test fails and does not receive the object.
+
+### Select a service source
+
+Pass `source: 'app'` to `LaravelPlugin` to name this plugin instance. Use
+`#[Service(source: 'app')]` to request a service by type from this source.
+Use `#[Service('cache.store', source: 'app')]` to select an explicit ID in its
+container.
+
+An explicit source takes precedence over global harness services. A missing
+service fails without a request to another source. Use the same source
+attribute to select this plugin's `Application` harness service. See
+[service sources](plugins.md#servicesource) for naming and resolution rules.
 
 ### The application itself
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -741,9 +741,13 @@ public function resolve(string $type, array $attributes): ?object;
 
 A service resolver is a fallback source for a constructor parameter type.
 
-Registered harness services always take precedence. If no service matches,
-Greenlight calls resolvers in registration order. Each call receives the
-declared parameter type and the attribute instances.
+Without an explicit service source, global harness services take precedence.
+Greenlight then checks named harness services. One matching definition supplies
+the parameter. Multiple matching definitions cause an ambiguity error.
+
+If no harness service matches, Greenlight calls resolvers in registration
+order. This includes named resolvers. Each call receives the declared parameter
+type and the attribute instances.
 
 The `#[Service]` ID selects a service within its source. Each bridge translates
 this selection into its container lookup. Tempest uses the ID as a tag with
@@ -776,6 +780,54 @@ call disposal methods on these objects.
 The framework bridges use these interfaces to inject container services. See
 [Symfony applications](symfony.md), [Laravel applications](laravel.md), and
 [Tempest applications](tempest.md).
+
+### ServiceSource
+
+In `Greenlight\Harness`. Worker-side.
+
+Implement `ServiceSource` with `HarnessProvider`, `ServiceResolver`, or both to
+name a plugin instance:
+
+<!-- php-example {"mode":"display","reason":"Shows one method signature without its interface declaration."} -->
+```php
+public function source(): ?string;
+```
+
+Return `null` for an unnamed instance. Otherwise, return a nonempty name that
+is unique among plugin instances. Names are case sensitive. The name `"0"` is
+valid.
+
+Greenlight assigns the plugin source to its harness service definitions. A
+direct `ServiceDefinition` can also declare `source:`:
+
+<!-- php-example {"example":"plugins-example-15","file":"snippet.php","mode":"statements","tools":["rector"]} -->
+```php
+new ServiceDefinition(
+    TestDatabase::class,
+    Scope::PerWorker,
+    static fn() => TestDatabase::migrate(),
+    source: 'billing',
+);
+```
+
+Use `#[Service(source: 'billing')]` to request the declared parameter type from
+that source. Greenlight checks only its harness definitions and resolver. The
+source takes precedence over a global harness definition for the same type.
+
+Use `#[Service('users.repository', source: 'billing')]` to request an explicit
+ID from that source's resolver. An explicit ID does not select a harness
+definition.
+
+An unknown source, absent service, or incorrect service type causes
+`ServiceResolutionFailed`. Greenlight does not try another source after an
+explicit source request.
+
+Without `source:`, `#[Service('id')]` retains the normal harness and resolver
+order. An explicit ID does not select a plugin instance. The first applicable
+resolver can supply the service or fail the request.
+
+The Symfony, Laravel, Hyperf, PSR-11, and Tempest plugins accept `source:` in
+their constructors. See the [multiple PSR-11 containers example](psr11.md#multiple-containers).
 
 ### ExpectationExtension
 

--- a/docs/psr11.md
+++ b/docs/psr11.md
@@ -50,9 +50,9 @@ final class RegistrationTest
 }
 ```
 
-Greenlight first resolves constructor parameters from its harness. It then
-uses the PSR-11 container. Harness services have precedence over container
-services.
+Without an explicit service source, Greenlight first resolves constructor
+parameters from its harness. It then uses the PSR-11 container. Harness
+services have precedence over container services.
 
 Container creation, reset, and service-resolution failures throw
 `ServiceResolutionFailed`. Concrete PSR-11 bridge exceptions are internal.
@@ -75,8 +75,9 @@ public function __construct(
 ) {}
 ```
 
-Greenlight reports an error if an explicit ID does not exist. A missing
-type-based ID lets the next service resolver try to supply the parameter.
+Greenlight reports an error if an explicit ID does not exist. Without an
+explicit source or ID, a missing type-based ID lets the next resolver try to
+supply the parameter.
 
 ### The container
 
@@ -89,6 +90,67 @@ public function __construct(private readonly ContainerInterface $container) {}
 
 Use typed constructor dependencies for application services. Use direct
 container access only to verify container configuration.
+
+### Multiple containers
+
+Give each plugin instance a unique `source:` name:
+
+<!-- php-example {"example":"psr-example-07","file":"snippet.php","mode":"file","tools":["rector"]} -->
+```php
+use Greenlight\Config\GreenlightConfig;
+use Greenlight\Psr11\Psr11Plugin;
+use Psr\Container\ContainerInterface;
+
+return GreenlightConfig::create()
+    ->paths(['tests'])
+    ->plugins(
+        static fn(): Psr11Plugin => new Psr11Plugin(
+            static fn(): ContainerInterface => require __DIR__ . '/billing/container.php',
+            source: 'billing',
+        ),
+        static fn(): Psr11Plugin => new Psr11Plugin(
+            static fn(): ContainerInterface => require __DIR__ . '/legacy/container.php',
+            source: 'legacy',
+        ),
+    );
+```
+
+Select a source on each parameter that needs a specific container:
+
+<!-- php-example {"example":"psr-example-08","file":"snippet.php","mode":"class-members","tools":["rector"]} -->
+```php
+use Greenlight\Harness\Service;
+use Psr\Container\ContainerInterface;
+
+public function __construct(
+    #[Service(source: 'billing')]
+    private readonly UserRepository $billingUsers,
+    #[Service('users.repository', source: 'legacy')]
+    private readonly UserRepository $legacyUsers,
+    #[Service(source: 'legacy')]
+    private readonly ContainerInterface $legacyContainer,
+) {}
+```
+
+Without `id:`, the attribute requests the declared parameter type. An explicit
+ID requests that ID from the selected container. Both forms check the returned
+service type.
+
+A source request uses only the selected plugin instance. An unknown source or
+absent service causes an error without a request to another container. Source
+selection also takes precedence over global harness services.
+
+Each named plugin supplies its own `ContainerInterface` harness definition. If
+multiple named definitions match, an unqualified container parameter causes an
+ambiguity error. Use `source:` to select the required container.
+
+Parameters without `source:` retain normal harness and resolver order. Named
+container resolvers still participate in that order. An unqualified explicit
+ID does not select a container.
+
+Source names are case sensitive, nonempty, and unique among plugin instances.
+See [service sources](plugins.md#servicesource) for custom providers and
+resolvers.
 
 ## State between tests
 

--- a/docs/symfony.md
+++ b/docs/symfony.md
@@ -57,9 +57,10 @@ final class RegistrationTest
 }
 ```
 
-Greenlight first resolves constructor parameters from its harness. It then uses
-the Symfony container. Thus, `Doubles`, `TestChannel`, and provider services
-take precedence over container services.
+Without an explicit service source, Greenlight first resolves constructor
+parameters from its harness. It then uses the Symfony container. Thus,
+`Doubles`, `TestChannel`, and provider services take precedence over container
+services.
 
 When neither side can resolve a type, the test fails and reports both misses.
 
@@ -88,6 +89,18 @@ public function __construct(
 
 Greenlight still checks the parameter type. If the named service is not an
 instance of the declared type, the test fails and does not receive the object.
+
+### Select a service source
+
+Pass `source: 'app'` to `SymfonyPlugin` to name this plugin instance. Use
+`#[Service(source: 'app')]` to request a service by type from this source.
+Use `#[Service('mailer.transports.async', source: 'app')]` to select an explicit
+ID in its container.
+
+An explicit source takes precedence over global harness services. A missing
+service fails without a request to another source. Use the same source
+attribute to select this plugin's `KernelInterface` harness service. See
+[service sources](plugins.md#servicesource) for naming and resolution rules.
 
 ### The kernel itself
 

--- a/docs/tempest.md
+++ b/docs/tempest.md
@@ -82,10 +82,11 @@ final class RegistrationTest
 }
 ```
 
-Greenlight first resolves constructor parameters from its harness. It then asks
-fallback-capable service resolvers. Finally, it asks the Tempest container to
-resolve the type. Greenlight always places the terminal Tempest resolver last.
-Registration order and plugin priority do not change this rule.
+Without an explicit service source, Greenlight first resolves constructor
+parameters from its harness. It then asks fallback-capable service resolvers.
+Finally, it asks the Tempest container to resolve the type. Greenlight places
+the terminal Tempest resolver last in this chain. Registration order and
+plugin priority do not change this rule.
 
 Tempest can use discovered initializers and automatic constructor injection. If
 Tempest cannot resolve the type, Greenlight throws `ServiceResolutionFailed`.
@@ -114,6 +115,34 @@ checks that the returned service has this type.
 and parameter attribute to use the same string.
 
 Without `#[Service]`, the bridge calls `$container->get(Storage::class)`.
+
+### Select a service source
+
+Pass `source: 'app'` to `TempestPlugin` to name this plugin instance. Use
+`#[Service(source: 'app')]` to request the default binding for a type from this
+source. Add an ID to select a tagged service:
+
+<!-- php-example {"example":"tempest-example-06","file":"snippet.php","mode":"class-members","tools":["rector"]} -->
+```php
+use Greenlight\Harness\Service;
+
+public function __construct(
+    #[Service('archive', source: 'app')]
+    private readonly Storage $storage,
+) {}
+```
+
+The `source` argument selects the plugin instance. The ID selects the tag.
+The selected plugin calls `$container->get(Storage::class, tag: 'archive')`.
+
+Source names do not remove the single-terminal-resolver limit. Register only
+one Tempest plugin.
+
+An explicit source takes precedence over global harness services and the
+resolver chain. A missing service fails without a request to another source.
+Use the same source attribute to select this plugin's kernel or container
+harness service. See [service sources](plugins.md#servicesource) for naming and
+resolution rules.
 
 ### Kernel and container services
 

--- a/src/Execution/Plugin/WorkerPluginRuntime.php
+++ b/src/Execution/Plugin/WorkerPluginRuntime.php
@@ -9,6 +9,7 @@ use Greenlight\Expect\ExpectationExtension;
 use Greenlight\Harness\HarnessScopes;
 use Greenlight\Harness\ServiceDefinition;
 use Greenlight\Harness\ServiceResolver;
+use Greenlight\Harness\ServiceSource;
 use Greenlight\Harness\TerminalServiceResolver;
 use Greenlight\Plugin\AfterTestSubscriber;
 use Greenlight\Plugin\BeforeTestSubscriber;
@@ -100,8 +101,41 @@ final readonly class WorkerPluginRuntime extends PluginRuntime
 
         Expect::install($this->matching(ExpectationExtension::class));
 
+        $sources = [];
+
+        foreach ($this->ordered(ServiceSource::class) as $plugin) {
+            $source = $plugin->source();
+
+            if ($source === null) {
+                continue;
+            }
+
+            if (isset($sources[$source])) {
+                throw new \InvalidArgumentException(\sprintf('Service source "%s" is already registered.', $source));
+            }
+
+            $sources[$source] = true;
+        }
+
         foreach ($this->ordered(HarnessProvider::class) as $provider) {
-            $definitions = [...$definitions, ...$provider->services()];
+            $source = $provider instanceof ServiceSource ? $provider->source() : null;
+
+            foreach ($provider->services() as $definition) {
+                if ($source !== null && $definition->source !== null && $definition->source !== $source) {
+                    throw new \InvalidArgumentException(\sprintf(
+                        'Service source "%s" defines a service for source "%s". Use the provider source name.',
+                        $source,
+                        $definition->source,
+                    ));
+                }
+
+                $definitions[] = $source === null ? $definition : new ServiceDefinition(
+                    $definition->type,
+                    $definition->scope,
+                    $definition->factory,
+                    $source,
+                );
+            }
         }
 
         $resolvers = $this->ordered(ServiceResolver::class);

--- a/src/Execution/Worker/TestExecutor.php
+++ b/src/Execution/Worker/TestExecutor.php
@@ -17,6 +17,7 @@ use Greenlight\Execution\Plugin\WorkerPluginRuntime;
 use Greenlight\Expect\ExpectationFailed;
 use Greenlight\Expect\ExpectationRuntime;
 use Greenlight\Harness\HarnessScopes;
+use Greenlight\Harness\Service;
 use Greenlight\Harness\ServiceResolutionFailed;
 use Greenlight\Harness\UnresolvableService;
 use Greenlight\Plugin\TestContext;
@@ -391,22 +392,27 @@ final readonly class TestExecutor
             /** @var class-string $serviceType */
             $serviceType = $type->getName();
 
-            if ($serviceType === Attachments::class) {
+            $attributes = \array_map(
+                static fn(\ReflectionAttribute $attribute): object => $attribute->newInstance(),
+                $parameter->getAttributes(),
+            );
+            $hasSource = \array_any(
+                $attributes,
+                static fn(object $attribute): bool => $attribute instanceof Service && $attribute->source !== null,
+            );
+
+            if ($serviceType === Attachments::class && !$hasSource) {
                 $arguments[] = $attachments;
 
                 continue;
             }
 
-            if ($serviceType === Cleanup::class) {
+            if ($serviceType === Cleanup::class && !$hasSource) {
                 $arguments[] = $cleanup;
 
                 continue;
             }
 
-            $attributes = \array_map(
-                static fn(\ReflectionAttribute $attribute): object => $attribute->newInstance(),
-                $parameter->getAttributes(),
-            );
             $arguments[] = $this->scopes->resolve($serviceType, $class, $attributes);
         }
 

--- a/src/Harness/HarnessScopes.php
+++ b/src/Harness/HarnessScopes.php
@@ -5,9 +5,10 @@ declare(strict_types=1);
 namespace Greenlight\Harness;
 
 /**
- * A service definition has precedence over a service resolver. Type names do
- * not use letter case for identity. Greenlight does not dispose objects from
- * a service resolver.
+ * An explicit source limits resolution to that source. Without a source,
+ * service definitions have precedence over service resolvers. Type names do
+ * not use letter case for identity. Greenlight does not dispose services that
+ * a resolver supplies.
  *
  * @internal
  */
@@ -17,6 +18,12 @@ final class HarnessScopes
      * @var array<string, ServiceDefinition>
      */
     private array $definitions = [];
+
+    /** @var array<string, array<string, ServiceDefinition>> */
+    private array $namedDefinitions = [];
+
+    /** @var array<string, ServiceResolver> */
+    private array $namedResolvers = [];
 
     private readonly ScopeContainer $worker;
 
@@ -37,6 +44,20 @@ final class HarnessScopes
         foreach ($definitions as $definition) {
             $key = \strtolower($definition->type);
 
+            if ($definition->source !== null) {
+                if (isset($this->namedDefinitions[$definition->source][$key])) {
+                    throw new \InvalidArgumentException(\sprintf(
+                        'Service source "%s" already defines type "%s".',
+                        $definition->source,
+                        $definition->type,
+                    ));
+                }
+
+                $this->namedDefinitions[$definition->source][$key] = $definition;
+
+                continue;
+            }
+
             if (isset($this->definitions[$key])) {
                 throw new \LogicException(\sprintf(
                     'A harness service for %s is already registered.',
@@ -50,6 +71,16 @@ final class HarnessScopes
         $terminalSeen = false;
 
         foreach ($resolvers as $resolver) {
+            $source = $resolver instanceof ServiceSource ? $resolver->source() : null;
+
+            if ($source !== null) {
+                if (isset($this->namedResolvers[$source])) {
+                    throw new \InvalidArgumentException(\sprintf('Service source "%s" is already registered.', $source));
+                }
+
+                $this->namedResolvers[$source] = $resolver;
+            }
+
             if ($terminalSeen) {
                 throw new \InvalidArgumentException('Place a terminal service resolver last.');
             }
@@ -74,44 +105,130 @@ final class HarnessScopes
      */
     public function resolve(string $type, string $consumer, array $attributes = []): object
     {
+        foreach ($attributes as $attribute) {
+            if ($attribute instanceof Service && $attribute->source !== null) {
+                return $this->resolveFromSource($type, $consumer, $attributes, $attribute, $attribute->source);
+            }
+        }
+
         $definition = $this->definitions[\strtolower($type)] ?? null;
 
-        if ($definition instanceof ServiceDefinition) {
-            if ($definition->scope === Scope::PerClass && !$this->classServicesAllowed) {
-                throw UnresolvableService::perClassServiceInParallelClass($type, $consumer);
+        if ($definition === null) {
+            foreach ($this->namedDefinitions as $definitions) {
+                $candidate = $definitions[\strtolower($type)] ?? null;
+
+                if ($candidate === null) {
+                    continue;
+                }
+
+                if ($definition !== null) {
+                    throw UnresolvableService::ambiguousSource($type, $consumer);
+                }
+
+                $definition = $candidate;
             }
+        }
 
-            $service = $this->containerFor($definition->scope)->get($definition);
-
-            if (!$service instanceof $type) {
-                throw UnresolvableService::factoryTypeMismatch($type, $service);
-            }
-
-            return $service;
+        if ($definition !== null) {
+            return $this->resolveDefinition($definition, $type, $consumer);
         }
 
         foreach ($this->resolvers as $resolver) {
-            $service = $resolver->resolve($type, $attributes);
+            $service = $this->resolveUsing($resolver, $type, $consumer, $attributes);
 
-            if ($service === null) {
-                if ($resolver instanceof TerminalServiceResolver) {
-                    throw new \LogicException(\sprintf(
-                        'Terminal service resolver "%s" returned null.',
-                        $resolver::class,
-                    ));
-                }
-
-                continue;
+            if ($service !== null) {
+                return $service;
             }
-
-            if (!$service instanceof $type) {
-                throw UnresolvableService::resolverTypeMismatch($type, $consumer, $resolver::class, $service);
-            }
-
-            return $service;
         }
 
         throw UnresolvableService::unknownType($type, $consumer, \count($this->resolvers));
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $type
+     * @param non-empty-string $consumer
+     * @param list<object> $attributes
+     * @param non-empty-string $source
+     * @return T
+     * @throws ServiceResolutionFailed
+     */
+    private function resolveFromSource(string $type, string $consumer, array $attributes, Service $selection, string $source): object
+    {
+        $definitions = $this->namedDefinitions[$source] ?? [];
+        $resolver = $this->namedResolvers[$source] ?? null;
+
+        if ($definitions === [] && $resolver === null) {
+            throw UnresolvableService::unknownSource($source, $consumer);
+        }
+
+        $definition = $definitions[\strtolower($type)] ?? null;
+
+        if ($selection->id === null && $definition !== null) {
+            return $this->resolveDefinition($definition, $type, $consumer);
+        }
+
+        if ($resolver !== null) {
+            $service = $this->resolveUsing($resolver, $type, $consumer, $attributes);
+
+            if ($service !== null) {
+                return $service;
+            }
+        }
+
+        throw UnresolvableService::missingSourceService($source, $selection->id ?? $type, $consumer);
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $type
+     * @param non-empty-string $consumer
+     * @return T
+     * @throws UnresolvableService
+     */
+    private function resolveDefinition(ServiceDefinition $definition, string $type, string $consumer): object
+    {
+        if ($definition->scope === Scope::PerClass && !$this->classServicesAllowed) {
+            throw UnresolvableService::perClassServiceInParallelClass($type, $consumer);
+        }
+
+        $service = $this->containerFor($definition->scope)->get($definition);
+
+        if (!$service instanceof $type) {
+            throw UnresolvableService::factoryTypeMismatch($type, $service);
+        }
+
+        return $service;
+    }
+
+    /**
+     * @template T of object
+     * @param class-string<T> $type
+     * @param non-empty-string $consumer
+     * @param list<object> $attributes
+     * @return T|null
+     * @throws ServiceResolutionFailed
+     */
+    private function resolveUsing(ServiceResolver $resolver, string $type, string $consumer, array $attributes): ?object
+    {
+        $service = $resolver->resolve($type, $attributes);
+
+        if ($service === null) {
+            if ($resolver instanceof TerminalServiceResolver) {
+                throw new \LogicException(\sprintf(
+                    'Terminal service resolver "%s" returned null.',
+                    $resolver::class,
+                ));
+            }
+
+            return null;
+        }
+
+        if (!$service instanceof $type) {
+            throw UnresolvableService::resolverTypeMismatch($type, $consumer, $resolver::class, $service);
+        }
+
+        return $service;
     }
 
     public function openClass(bool $allowPerClassServices = true): void

--- a/src/Harness/ScopeContainer.php
+++ b/src/Harness/ScopeContainer.php
@@ -18,7 +18,7 @@ namespace Greenlight\Harness;
 final class ScopeContainer
 {
     /**
-     * @var array<class-string, object>
+     * @var array<string, array<class-string, object>>
      */
     private array $services = [];
 
@@ -30,14 +30,15 @@ final class ScopeContainer
      */
     public function get(ServiceDefinition $definition): object
     {
-        $existing = $this->services[$definition->type] ?? null;
+        $source = $definition->source ?? '';
+        $existing = $this->services[$source][$definition->type] ?? null;
 
         if ($existing !== null) {
             return $existing;
         }
 
         $service = $this->instantiate($definition);
-        $this->services[$definition->type] = $service;
+        $this->services[$source][$definition->type] = $service;
 
         return $service;
     }

--- a/src/Harness/Service.php
+++ b/src/Harness/Service.php
@@ -5,23 +5,31 @@ declare(strict_types=1);
 namespace Greenlight\Harness;
 
 /**
- * Selects a service within its source by ID. Each bridge translates the ID
- * into its container lookup. The resolved service must have the declared
- * parameter type.
+ * Selects a service ID or a named source for a constructor parameter. Each
+ * bridge translates the ID into its container lookup, or uses the default
+ * lookup if the ID is absent. The service must have the declared type.
  */
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
 final readonly class Service
 {
-    /** @var non-empty-string */
-    public string $id;
+    /** @var non-empty-string|null */
+    public ?string $id;
+
+    /** @var non-empty-string|null */
+    public ?string $source;
 
     /** @throws \InvalidArgumentException */
-    public function __construct(string $id)
+    public function __construct(?string $id = null, ?string $source = null)
     {
         if ($id === '') {
             throw new \InvalidArgumentException('Service identifier must not be empty.');
         }
 
+        if ($source === '') {
+            throw new \InvalidArgumentException('Service source must not be empty.');
+        }
+
         $this->id = $id;
+        $this->source = $source;
     }
 }

--- a/src/Harness/ServiceDefinition.php
+++ b/src/Harness/ServiceDefinition.php
@@ -6,7 +6,7 @@ namespace Greenlight\Harness;
 
 /**
  * Defines one harness service. It contains the exact injected type, service
- * scope, and factory.
+ * scope, factory, and optional source name.
  */
 final readonly class ServiceDefinition
 {
@@ -14,6 +14,9 @@ final readonly class ServiceDefinition
      * @var class-string
      */
     public string $type;
+
+    /** @var non-empty-string|null */
+    public ?string $source;
 
     /**
      * @template T of object
@@ -27,11 +30,17 @@ final readonly class ServiceDefinition
         string $type,
         public Scope $scope,
         public \Closure $factory,
+        ?string $source = null,
     ) {
         if ($type === '') {
             throw new \InvalidArgumentException('Harness service type cannot be empty.');
         }
 
+        if ($source === '') {
+            throw new \InvalidArgumentException('Service source must not be empty.');
+        }
+
         $this->type = $type;
+        $this->source = $source;
     }
 }

--- a/src/Harness/ServiceSource.php
+++ b/src/Harness/ServiceSource.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Harness;
+
+/**
+ * Names one source of harness definitions or resolved services. Source names
+ * are case-sensitive. A null name keeps the source unnamed.
+ */
+interface ServiceSource
+{
+    /** @return non-empty-string|null */
+    public function source(): ?string;
+}

--- a/src/Harness/UnresolvableService.php
+++ b/src/Harness/UnresolvableService.php
@@ -19,6 +19,34 @@ final class UnresolvableService extends ServiceResolutionFailed
         parent::__construct($message);
     }
 
+    public static function unknownSource(string $source, string $consumer): self
+    {
+        return new self(\sprintf(
+            'Service source "%s", required by "%s", is not registered. Register the source or change #[Service(source: ...)].',
+            $source,
+            $consumer,
+        ));
+    }
+
+    public static function ambiguousSource(string $type, string $consumer): self
+    {
+        return new self(\sprintf(
+            'Multiple service sources define type "%s", required by "%s". Select a source with #[Service(source: ...)].',
+            $type,
+            $consumer,
+        ));
+    }
+
+    public static function missingSourceService(string $source, string $id, string $consumer): self
+    {
+        return new self(\sprintf(
+            'Service source "%s" cannot supply service "%s", required by "%s". Check the service ID and source name.',
+            $source,
+            $id,
+            $consumer,
+        ));
+    }
+
     public static function unknownType(string $type, string $consumer, int $resolversConsulted = 0): self
     {
         $suffix = $resolversConsulted === 0

--- a/src/Hyperf/HyperfPlugin.php
+++ b/src/Hyperf/HyperfPlugin.php
@@ -9,6 +9,7 @@ use Greenlight\Harness\Service;
 use Greenlight\Harness\ServiceDefinition;
 use Greenlight\Harness\ServiceResolutionFailed;
 use Greenlight\Harness\ServiceResolver;
+use Greenlight\Harness\ServiceSource;
 use Greenlight\Internal\Php\ErrorTrap;
 use Greenlight\Plugin\HarnessProvider;
 use Greenlight\Plugin\TestAttemptRunner;
@@ -34,14 +35,17 @@ use function Hyperf\Coroutine\run;
  * coroutine context for each test attempt.
  *
  * The default worker container lifetime matches a long-running Hyperf worker.
- * `#[Service]` selects an explicit container ID. Isolate external test
+ * `#[Service]` selects a container ID or a named source. Isolate external test
  * resources by `GREENLIGHT_CHANNEL`.
  *
  * Requires `hyperf/framework` and `hyperf/di` 3.2. It also requires Swoole 5
  * or later and the pcntl extension. It does not support Swow.
  */
-final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemptRunner, WorkerBootstrapSubscriber, WorkerRuntimeRunner
+final class HyperfPlugin implements HarnessProvider, ServiceResolver, ServiceSource, TestAttemptRunner, WorkerBootstrapSubscriber, WorkerRuntimeRunner
 {
+    /** @var non-empty-string|null */
+    private readonly ?string $source;
+
     private readonly string $basePath;
 
     private readonly string $containerFile;
@@ -62,6 +66,7 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemp
      * @param null|\Closure(ContainerInterface): void $dispose
      *   Releases project-owned resources when the selected container lifetime
      *   ends. The callback runs inside a coroutine.
+     * @throws \InvalidArgumentException
      */
     public function __construct(
         string $basePath,
@@ -69,9 +74,21 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemp
         private readonly ?\Closure $reset = null,
         private readonly ?\Closure $dispose = null,
         private readonly ?int $hookFlags = null,
+        ?string $source = null,
     ) {
+        if ($source === '') {
+            throw new \InvalidArgumentException('Service source must not be empty.');
+        }
+
+        $this->source = $source;
         $this->basePath = \rtrim($basePath, '/');
         $this->containerFile = $this->basePath . '/config/container.php';
+    }
+
+    #[\Override]
+    public function source(): ?string
+    {
+        return $this->source;
     }
 
     /** @return list<ServiceDefinition> */
@@ -92,10 +109,12 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemp
     public function resolve(string $type, array $attributes): ?object
     {
         $id = $type;
+        $explicit = false;
 
         foreach ($attributes as $attribute) {
             if ($attribute instanceof Service) {
-                $id = $attribute->id;
+                $id = $attribute->id ?? $type;
+                $explicit = true;
             }
         }
 
@@ -103,7 +122,7 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, TestAttemp
             $container = $this->container();
 
             if (!$container->has($id)) {
-                if ($id !== $type) {
+                if ($explicit) {
                     throw HyperfBridgeError::unknownServiceId($id, $type);
                 }
 

--- a/src/Laravel/LaravelPlugin.php
+++ b/src/Laravel/LaravelPlugin.php
@@ -9,6 +9,7 @@ use Greenlight\Harness\Service;
 use Greenlight\Harness\ServiceDefinition;
 use Greenlight\Harness\ServiceResolutionFailed;
 use Greenlight\Harness\ServiceResolver;
+use Greenlight\Harness\ServiceSource;
 use Greenlight\Internal\Php\ErrorTrap;
 use Greenlight\Plugin\AfterTestSubscriber;
 use Greenlight\Plugin\HarnessProvider;
@@ -23,11 +24,14 @@ use Illuminate\Foundation\Bootstrap\RegisterProviders;
  * Boots a Laravel application on first use and resolves bound services.
  * By default, Greenlight releases the application after each test attempt.
  *
- * `#[Service]` selects an explicit binding ID. Isolate external test resources
+ * `#[Service]` selects a binding ID or a named source. Isolate external test resources
  * by `GREENLIGHT_CHANNEL`.
  */
-final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, ServiceResolver
+final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, ServiceResolver, ServiceSource
 {
+    /** @var non-empty-string|null */
+    private readonly ?string $source;
+
     /** @var \Closure(): Application */
     private readonly \Closure $factory;
 
@@ -44,12 +48,19 @@ final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, Servi
      * @param bool $refreshBetweenTests
      *   Set to false only when no service keeps state between tests.
      *   Tests on one worker then share one application without resets.
+     * @throws \InvalidArgumentException
      */
     public function __construct(
         string|\Closure $application,
         private readonly string $env = 'testing',
         private readonly bool $refreshBetweenTests = true,
+        ?string $source = null,
     ) {
+        if ($source === '') {
+            throw new \InvalidArgumentException('Service source must not be empty.');
+        }
+
+        $this->source = $source;
         $this->factory = $application instanceof \Closure
             ? $application
             : static function () use ($application): Application {
@@ -67,6 +78,12 @@ final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, Servi
 
                 return $app;
             };
+    }
+
+    #[\Override]
+    public function source(): ?string
+    {
+        return $this->source;
     }
 
     /**
@@ -93,10 +110,12 @@ final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, Servi
     public function resolve(string $type, array $attributes): ?object
     {
         $id = $type;
+        $explicit = false;
 
         foreach ($attributes as $attribute) {
             if ($attribute instanceof Service) {
-                $id = $attribute->id;
+                $id = $attribute->id ?? $type;
+                $explicit = true;
             }
         }
 
@@ -104,7 +123,7 @@ final class LaravelPlugin implements AfterTestSubscriber, HarnessProvider, Servi
             $app = $this->application();
 
             if (!$app->bound($id)) {
-                if ($id !== $type) {
+                if ($explicit) {
                     throw LaravelBridgeError::unknownServiceId($id, $type);
                 }
 

--- a/src/Psr11/Psr11Plugin.php
+++ b/src/Psr11/Psr11Plugin.php
@@ -9,6 +9,7 @@ use Greenlight\Harness\Service;
 use Greenlight\Harness\ServiceDefinition;
 use Greenlight\Harness\ServiceResolutionFailed;
 use Greenlight\Harness\ServiceResolver;
+use Greenlight\Harness\ServiceSource;
 use Greenlight\Plugin\AfterTestSubscriber;
 use Greenlight\Plugin\HarnessProvider;
 use Greenlight\Plugin\TestContext;
@@ -19,11 +20,14 @@ use Psr\Container\ContainerInterface;
  * Creates a PSR-11 container lazily and resolves its services. By default, the
  * plugin discards the container after each test that uses it.
  *
- * `#[Service]` selects an explicit ID. Isolate external test resources by
+ * `#[Service]` selects a service ID or a named source. Isolate external test resources by
  * `GREENLIGHT_CHANNEL`.
  */
-final class Psr11Plugin implements AfterTestSubscriber, HarnessProvider, ServiceResolver
+final class Psr11Plugin implements AfterTestSubscriber, HarnessProvider, ServiceResolver, ServiceSource
 {
+    /** @var non-empty-string|null */
+    private readonly ?string $source;
+
     private ?ContainerInterface $activeContainer = null;
 
     /**
@@ -34,12 +38,26 @@ final class Psr11Plugin implements AfterTestSubscriber, HarnessProvider, Service
      *   or when services do not keep state.
      * @param (\Closure(ContainerInterface): void)|null $reset
      *   An optional callback that resets the active container after each test.
+     * @throws \InvalidArgumentException
      */
     public function __construct(
         private readonly \Closure $factory,
         private readonly bool $refreshBetweenTests = true,
         private readonly ?\Closure $reset = null,
-    ) {}
+        ?string $source = null,
+    ) {
+        if ($source === '') {
+            throw new \InvalidArgumentException('Service source must not be empty.');
+        }
+
+        $this->source = $source;
+    }
+
+    #[\Override]
+    public function source(): ?string
+    {
+        return $this->source;
+    }
 
     /**
      * @return list<ServiceDefinition>
@@ -98,7 +116,7 @@ final class Psr11Plugin implements AfterTestSubscriber, HarnessProvider, Service
 
         foreach ($attributes as $attribute) {
             if ($attribute instanceof Service) {
-                $id = $attribute->id;
+                $id = $attribute->id ?? $type;
                 $explicit = true;
             }
         }

--- a/src/Symfony/SymfonyPlugin.php
+++ b/src/Symfony/SymfonyPlugin.php
@@ -9,6 +9,7 @@ use Greenlight\Harness\Service;
 use Greenlight\Harness\ServiceDefinition;
 use Greenlight\Harness\ServiceResolutionFailed;
 use Greenlight\Harness\ServiceResolver;
+use Greenlight\Harness\ServiceSource;
 use Greenlight\Plugin\AfterTestSubscriber;
 use Greenlight\Plugin\HarnessProvider;
 use Greenlight\Plugin\TestContext;
@@ -25,11 +26,14 @@ use Symfony\Contracts\Service\ResetInterface;
  * does not disable resets, the container must expose `services_resetter`. If a
  * service keeps state between tests, do not disable resets.
  *
- * `#[Service]` selects an explicit ID instead of a type-based search. Isolate
- * external resources with `GREENLIGHT_CHANNEL`.
+ * `#[Service]` selects a service ID or a named source. Isolate external
+ * resources with `GREENLIGHT_CHANNEL`.
  */
-final class SymfonyPlugin implements AfterTestSubscriber, HarnessProvider, ServiceResolver
+final class SymfonyPlugin implements AfterTestSubscriber, HarnessProvider, ServiceResolver, ServiceSource
 {
+    /** @var non-empty-string|null */
+    private readonly ?string $source;
+
     /**
      * @var \Closure(): KernelInterface
      */
@@ -51,13 +55,20 @@ final class SymfonyPlugin implements AfterTestSubscriber, HarnessProvider, Servi
      *   For a container without stateful services, use false to disable
      *   resets. Tests on one worker then reuse the container without resets.
      *   Symfony service configuration determines which instances are shared.
+     * @throws \InvalidArgumentException
      */
     public function __construct(
         string|\Closure $kernel,
         string $env = 'test',
         bool $debug = false,
         private readonly bool $resetBetweenTests = true,
+        ?string $source = null,
     ) {
+        if ($source === '') {
+            throw new \InvalidArgumentException('Service source must not be empty.');
+        }
+
+        $this->source = $source;
         $this->factory = $kernel instanceof \Closure
             ? $kernel
             : static function () use ($kernel, $env, $debug): KernelInterface {
@@ -67,6 +78,12 @@ final class SymfonyPlugin implements AfterTestSubscriber, HarnessProvider, Servi
 
                 return new $kernel($env, $debug);
             };
+    }
+
+    #[\Override]
+    public function source(): ?string
+    {
+        return $this->source;
     }
 
     /**
@@ -89,10 +106,12 @@ final class SymfonyPlugin implements AfterTestSubscriber, HarnessProvider, Servi
     public function resolve(string $type, array $attributes): ?object
     {
         $id = $type;
+        $explicit = false;
 
         foreach ($attributes as $attribute) {
             if ($attribute instanceof Service) {
-                $id = $attribute->id;
+                $id = $attribute->id ?? $type;
+                $explicit = true;
             }
         }
 
@@ -100,7 +119,7 @@ final class SymfonyPlugin implements AfterTestSubscriber, HarnessProvider, Servi
             $container = $this->container();
 
             if (!$container->has($id)) {
-                if ($id !== $type) {
+                if ($explicit) {
                     throw SymfonyBridgeError::unknownServiceId($id, $type);
                 }
 

--- a/src/Tempest/TempestPlugin.php
+++ b/src/Tempest/TempestPlugin.php
@@ -8,6 +8,7 @@ use Greenlight\Harness\Scope;
 use Greenlight\Harness\Service;
 use Greenlight\Harness\ServiceDefinition;
 use Greenlight\Harness\ServiceResolutionFailed;
+use Greenlight\Harness\ServiceSource;
 use Greenlight\Harness\TerminalServiceResolver;
 use Greenlight\Plugin\AfterTestSubscriber;
 use Greenlight\Plugin\BeforeTestSubscriber;
@@ -34,8 +35,11 @@ use Tempest\Http\Request;
  * a tagged Tempest binding.
  * Isolate external test resources by `GREENLIGHT_CHANNEL`.
  */
-final class TempestPlugin implements AfterTestSubscriber, BeforeTestSubscriber, HarnessProvider, TerminalServiceResolver, WorkerBootstrapSubscriber
+final class TempestPlugin implements AfterTestSubscriber, BeforeTestSubscriber, HarnessProvider, ServiceSource, TerminalServiceResolver, WorkerBootstrapSubscriber
 {
+    /** @var non-empty-string|null */
+    private readonly ?string $source;
+
     private ?FrameworkKernel $kernel = null;
 
     private ?TempestProcessState $processState = null;
@@ -51,6 +55,7 @@ final class TempestPlugin implements AfterTestSubscriber, BeforeTestSubscriber, 
         private readonly string $root,
         private readonly string $environment = 'testing',
         private readonly array $discoveryLocations = [],
+        ?string $source = null,
     ) {
         if ($root === '') {
             throw new \InvalidArgumentException('Tempest application root cannot be empty.');
@@ -59,6 +64,18 @@ final class TempestPlugin implements AfterTestSubscriber, BeforeTestSubscriber, 
         if ($environment === '') {
             throw new \InvalidArgumentException('Tempest environment cannot be empty.');
         }
+
+        if ($source === '') {
+            throw new \InvalidArgumentException('Service source must not be empty.');
+        }
+
+        $this->source = $source;
+    }
+
+    #[\Override]
+    public function source(): ?string
+    {
+        return $this->source;
     }
 
     #[\Override]

--- a/tests/Acceptance/BuiltinServiceSourceRunTest.php
+++ b/tests/Acceptance/BuiltinServiceSourceRunTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Artifact\Attachments;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Test\Cleanup;
+use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\GreenlightCli;
+
+final readonly class BuiltinServiceSourceRunTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function attachmentsWithAnUnknownSourceDoNotUseTheBuiltinService(): void
+    {
+        $this->assertUnknownSource(Attachments::class, 'missing-attachments');
+    }
+
+    #[Test]
+    public function cleanupWithAnUnknownSourceDoesNotUseTheBuiltinService(): void
+    {
+        $this->assertUnknownSource(Cleanup::class, 'missing-cleanup');
+    }
+
+    /** @param class-string $type */
+    private function assertUnknownSource(string $type, string $source): void
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, $source);
+        $project->writeFile('tests/BuiltinSourceTest.php', \sprintf(
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace BuiltinSourceProbe;
+
+            use Greenlight\Attribute\Test;
+            use Greenlight\Expect\Expect;
+            use Greenlight\Harness\Service;
+
+            final readonly class BuiltinSourceTest
+            {
+                public function __construct(#[Service(source: '%s')] private \%s $service) {}
+
+                #[Test]
+                public function receivesTheRequestedService(): void
+                {
+                    Expect::that(\is_object($this->service))->toBeTrue();
+                }
+            }
+
+            PHP,
+            $source,
+            $type,
+        ));
+        $project->configureWithTestFiles(['tests/BuiltinSourceTest.php']);
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=plain', '--workers=1']);
+        $output = $result->output();
+
+        Expect::that($result->exitCode)
+            ->because($output === '' ? 'The built-in source run returned no output.' : $output)
+            ->toBe(1);
+        Expect::that($output)->toContain('1 test, 0 passed, 1 errored');
+        Expect::that($output)->toContain('source "' . $source . '"');
+    }
+}

--- a/tests/Acceptance/Psr11SourceRunTest.php
+++ b/tests/Acceptance/Psr11SourceRunTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\GreenlightCli;
+
+final readonly class Psr11SourceRunTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function namedContainersKeepServicesAndTestStateSeparate(): void
+    {
+        $project = $this->writeProject();
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=plain', '--workers=1']);
+        $output = $result->output();
+
+        Expect::that($result->exitCode)
+            ->because($output === '' ? 'The named PSR-11 source run returned no output.' : $output)
+            ->toBe(0);
+        Expect::that($output)->toContain('2 tests, 2 passed');
+    }
+
+    private function writeProject(): AcceptanceProject
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, 'psr11-sources');
+        $project->writeFile('application.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace Psr11SourceProbe;
+
+            final class Counter
+            {
+                public int $calls = 0;
+
+                public function __construct(public readonly string $source) {}
+            }
+
+            PHP);
+
+        $project->writeFile('tests/ContainerSourcesTest.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace Psr11SourceProbe;
+
+            use Greenlight\Attribute\Test;
+            use Greenlight\Expect\Expect;
+            use Greenlight\Harness\Service;
+            use Psr\Container\ContainerInterface;
+
+            final readonly class ContainerSourcesTest
+            {
+                public function __construct(
+                    #[Service(source: 'billing')] private Counter $billing,
+                    #[Service('application.counter', source: 'legacy')] private Counter $legacy,
+                    #[Service(source: 'billing')] private ContainerInterface $billingContainer,
+                    #[Service(source: 'legacy')] private ContainerInterface $legacyContainer,
+                    #[Service(source: 'billing')] private ContainerInterface $billingContainerAgain,
+                ) {}
+
+                #[Test]
+                public function eachSourceUsesItsOwnServicesAndContainer(): void
+                {
+                    $this->checkFreshSources();
+                }
+
+                #[Test]
+                public function eachSourceStartsFreshForTheNextTestAttempt(): void
+                {
+                    $this->checkFreshSources();
+                }
+
+                private function checkFreshSources(): void
+                {
+                    Expect::that($this->billing->source)->toBe('billing');
+                    Expect::that($this->legacy->source)->toBe('legacy');
+                    Expect::that($this->billingContainer)->not()->toBe($this->legacyContainer);
+                    Expect::that($this->billingContainerAgain)->toBe($this->billingContainer);
+                    Expect::that($this->billingContainer->get(Counter::class))->toBe($this->billing);
+                    Expect::that($this->legacyContainer->get('application.counter'))->toBe($this->legacy);
+                    Expect::that($this->billing->calls)->toBe(0);
+                    Expect::that($this->legacy->calls)->toBe(0);
+
+                    ++$this->billing->calls;
+
+                    Expect::that($this->billing->calls)->toBe(1);
+                    Expect::that($this->legacy->calls)->toBe(0);
+
+                    ++$this->legacy->calls;
+                }
+            }
+
+            PHP);
+
+        $project->writeFile('greenlight.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Config\GreenlightConfig;
+            use Greenlight\Psr11\Psr11Plugin;
+            use Greenlight\Tests\Support\Psr11\ArrayContainer;
+            use Psr\Container\ContainerInterface;
+            use Psr11SourceProbe\Counter;
+
+            require_once __DIR__ . '/application.php';
+            require_once __DIR__ . '/tests/ContainerSourcesTest.php';
+
+            return GreenlightConfig::create()
+                ->paths([__DIR__ . '/tests'])
+                ->workers(1)
+                ->plugins(
+                    static fn(): Psr11Plugin => new Psr11Plugin(
+                        static fn(): ContainerInterface => new ArrayContainer([
+                            Counter::class => new Counter('billing'),
+                            'application.counter' => new Counter('billing'),
+                        ]),
+                        source: 'billing',
+                    ),
+                    static fn(): Psr11Plugin => new Psr11Plugin(
+                        static fn(): ContainerInterface => new ArrayContainer([
+                            Counter::class => new Counter('legacy'),
+                            'application.counter' => new Counter('legacy'),
+                        ]),
+                        source: 'legacy',
+                    ),
+                );
+
+            PHP);
+
+        return $project;
+    }
+}

--- a/tests/Unit/Harness/HarnessSourcesTest.php
+++ b/tests/Unit/Harness/HarnessSourcesTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Harness;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Fake;
+use Greenlight\Expect\Expect;
+use Greenlight\Harness\Disposable;
+use Greenlight\Harness\HarnessScopes;
+use Greenlight\Harness\Scope;
+use Greenlight\Harness\Service;
+use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Harness\ServiceResolver;
+use Greenlight\Harness\ServiceSource;
+use Greenlight\Harness\UnresolvableService;
+
+final readonly class HarnessSourcesTest
+{
+    #[Test]
+    public function oneNamedDefinitionCanSupplyAnUnqualifiedType(): void
+    {
+        $service = new \stdClass();
+        $scopes = new HarnessScopes([
+            new ServiceDefinition(\stdClass::class, Scope::PerWorker, static fn(): \stdClass => $service, 'billing'),
+        ]);
+
+        Expect::that($scopes->resolve(\stdClass::class, 'test'))->toBe($service);
+    }
+
+    #[Test]
+    public function duplicateTypesWithinOneSourceFailRegistration(): void
+    {
+        $definition = new ServiceDefinition(\stdClass::class, Scope::PerWorker, static fn(): \stdClass => new \stdClass(), 'billing');
+
+        Expect::that(static fn(): HarnessScopes => new HarnessScopes([$definition, $definition]))
+            ->toThrow(\InvalidArgumentException::class, matching: '/source "billing" already defines type/');
+    }
+
+    #[Test]
+    public function aMissingNamedDefinitionDoesNotUseAnUnnamedDefinition(): void
+    {
+        $scopes = new HarnessScopes([
+            new ServiceDefinition(\stdClass::class, Scope::PerWorker, static fn(): \stdClass => new \stdClass()),
+            new ServiceDefinition(\ArrayObject::class, Scope::PerWorker, static fn(): \ArrayObject => new \ArrayObject(), 'billing'),
+        ]);
+
+        Expect::that(static fn(): object => $scopes->resolve(\stdClass::class, 'test', [new Service(source: 'billing')]))
+            ->toThrow(UnresolvableService::class, matching: '/source "billing" cannot supply service "stdClass"/');
+    }
+
+    #[Test]
+    public function aSelectedResolverCannotDeclineToAnotherSource(): void
+    {
+        $scopes = new HarnessScopes([], [$this->resolver(null)]);
+
+        Expect::that(static fn(): object => $scopes->resolve(\stdClass::class, 'test', [new Service(source: 'billing')]))
+            ->toThrow(UnresolvableService::class, matching: '/source "billing" cannot supply/');
+    }
+
+    #[Test]
+    public function anExplicitIdUsesTheSelectedResolverBeforeItsTypedDefinition(): void
+    {
+        $resolved = new \stdClass();
+        $scopes = new HarnessScopes([
+            new ServiceDefinition(\stdClass::class, Scope::PerWorker, static fn(): \stdClass => new \stdClass(), 'billing'),
+        ], [$this->resolver($resolved)]);
+
+        Expect::that($scopes->resolve(\stdClass::class, 'test', [new Service('custom', 'billing')]))->toBe($resolved);
+    }
+
+    #[Test]
+    public function aSelectedResolverMustSupplyTheDeclaredType(): void
+    {
+        $scopes = new HarnessScopes([], [$this->resolver(new \ArrayObject())]);
+
+        Expect::that(static fn(): object => $scopes->resolve(\stdClass::class, 'test', [new Service(source: 'billing')]))
+            ->toThrow(UnresolvableService::class, matching: '/which is not that type/');
+    }
+
+    #[Test]
+    public function duplicateResolverSourceNamesFailRegistration(): void
+    {
+        Expect::that(fn(): HarnessScopes => new HarnessScopes([], [$this->resolver(null), $this->resolver(null)]))
+            ->toThrow(\InvalidArgumentException::class, message: 'Service source "billing" is already registered.');
+    }
+
+    #[Test]
+    public function namedPerClassServicesCannotEscapeParallelClassRules(): void
+    {
+        $scopes = new HarnessScopes([
+            new ServiceDefinition(\stdClass::class, Scope::PerClass, static fn(): \stdClass => new \stdClass(), 'billing'),
+        ]);
+        $scopes->openClass(allowPerClassServices: false);
+
+        Expect::that(static fn(): object => $scopes->resolve(\stdClass::class, 'test', [new Service(source: 'billing')]))
+            ->toThrow(UnresolvableService::class, matching: '/AllowParallel/');
+    }
+
+    #[Test]
+    public function namedScopesDisposeInGlobalCreationOrderAndResetTheirCaches(): void
+    {
+        /** @var \ArrayObject<int, string> $calls */
+        $calls = new \ArrayObject();
+        $scopes = new HarnessScopes([
+            new ServiceDefinition(Disposable::class, Scope::PerTest, fn(): Disposable => $this->disposable('global', $calls)),
+            new ServiceDefinition(Disposable::class, Scope::PerTest, fn(): Disposable => $this->disposable('billing', $calls), 'billing'),
+            new ServiceDefinition(Disposable::class, Scope::PerTest, fn(): Disposable => $this->disposable('legacy', $calls), 'legacy'),
+        ]);
+        $scopes->openTest();
+        $first = $scopes->resolve(Disposable::class, 'test', [new Service(source: 'billing')]);
+        $scopes->resolve(Disposable::class, 'test');
+        $scopes->resolve(Disposable::class, 'test', [new Service(source: 'legacy')]);
+
+        Expect::that($scopes->closeTest())->toBe([]);
+        Expect::that($calls->getArrayCopy())->toBe(['legacy', 'global', 'billing']);
+
+        $scopes->openTest();
+        $second = $scopes->resolve(Disposable::class, 'test', [new Service(source: 'billing')]);
+
+        Expect::that($second)->not()->toBe($first);
+        Expect::that($scopes->closeTest())->toBe([]);
+        Expect::that($calls->getArrayCopy())->toBe(['legacy', 'global', 'billing', 'billing']);
+    }
+
+    private function resolver(?object $service): ServiceResolver
+    {
+        return new readonly class ($service) implements Fake, ServiceResolver, ServiceSource {
+            public function __construct(private ?object $service) {}
+
+            #[\Override]
+            public function source(): string
+            {
+                return 'billing';
+            }
+
+            #[\Override]
+            public function resolve(string $type, array $attributes): ?object
+            {
+                return $this->service;
+            }
+        };
+    }
+
+    /** @param \ArrayObject<int, string> $calls */
+    private function disposable(string $name, \ArrayObject $calls): Disposable
+    {
+        return new readonly class ($name, $calls) implements Fake, Disposable {
+            /** @param \ArrayObject<int, string> $calls */
+            public function __construct(private string $name, private \ArrayObject $calls) {}
+
+            #[\Override]
+            public function dispose(): void
+            {
+                $this->calls->append($this->name);
+            }
+        };
+    }
+}

--- a/tests/Unit/Harness/ServiceDefinitionValidationTest.php
+++ b/tests/Unit/Harness/ServiceDefinitionValidationTest.php
@@ -25,4 +25,15 @@ final readonly class ServiceDefinitionValidationTest
                 message: 'Harness service type cannot be empty.',
             );
     }
+
+    #[Test]
+    public function rejectsAnEmptySourceName(): void
+    {
+        Expect::that(static fn(): ServiceDefinition => new ServiceDefinition(
+            \stdClass::class,
+            Scope::PerTest,
+            static fn(): \stdClass => new \stdClass(),
+            source: '',
+        ))->toThrow(\InvalidArgumentException::class, message: 'Service source must not be empty.');
+    }
 }

--- a/tests/Unit/Hyperf/HyperfPluginTest.php
+++ b/tests/Unit/Hyperf/HyperfPluginTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Hyperf;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Harness\Service;
+use Greenlight\Hyperf\HyperfBridgeError;
+use Greenlight\Hyperf\HyperfPlugin;
+use Greenlight\Tests\Support\Psr11\ArrayContainer;
+
+final readonly class HyperfPluginTest
+{
+    #[Test]
+    public function exposesTheConfiguredSource(): void
+    {
+        Expect::that(new HyperfPlugin('/project')->source())->toBeNull();
+        Expect::that(new HyperfPlugin('/project', source: 'application')->source())->toBe('application');
+    }
+
+    #[Test]
+    public function rejectsAnEmptySource(): void
+    {
+        Expect::that(static fn(): HyperfPlugin => new HyperfPlugin('/project', source: ''))
+            ->toThrow(\InvalidArgumentException::class, message: 'Service source must not be empty.');
+    }
+
+    #[Test]
+    public function aServiceWithoutAnIdUsesTheParameterType(): void
+    {
+        $service = new \ArrayObject();
+        $plugin = $this->plugin([\ArrayObject::class => $service]);
+
+        Expect::that($plugin->resolve(\ArrayObject::class, [new Service()]))->toBe($service);
+    }
+
+    #[Test]
+    public function anExplicitIdEqualToTheMissingTypeFails(): void
+    {
+        $plugin = $this->plugin([]);
+
+        Expect::that(static fn(): ?object => $plugin->resolve(\ArrayObject::class, [new Service(\ArrayObject::class)]))
+            ->toThrow(HyperfBridgeError::class, matching: '/no service "ArrayObject"/');
+    }
+
+    #[Test]
+    public function aServiceWithoutAnIdFailsWhenTheTypeIsMissing(): void
+    {
+        $plugin = $this->plugin([]);
+
+        Expect::that(static fn(): ?object => $plugin->resolve(\ArrayObject::class, [new Service()]))
+            ->toThrow(HyperfBridgeError::class, matching: '/no service "ArrayObject"/');
+    }
+
+    #[Test]
+    public function anUnknownTypeWithoutAnAttributeReturnsNull(): void
+    {
+        Expect::that($this->plugin([])->resolve(\ArrayObject::class, []))->toBeNull();
+    }
+
+    /** @param array<string, mixed> $services */
+    private function plugin(array $services): HyperfPlugin
+    {
+        $plugin = new HyperfPlugin('/project');
+        new \ReflectionProperty($plugin, 'activeContainer')->setValue($plugin, new ArrayContainer($services));
+
+        return $plugin;
+    }
+}

--- a/tests/Unit/Laravel/LaravelPluginTest.php
+++ b/tests/Unit/Laravel/LaravelPluginTest.php
@@ -50,6 +50,44 @@ final class LaravelPluginTest
         private readonly Doubles $doubles,
     ) {}
 
+    #[Test]
+    public function exposesTheConfiguredSource(): void
+    {
+        Expect::that(new LaravelPlugin('/project/bootstrap/app.php')->source())->toBeNull();
+        Expect::that(new LaravelPlugin('/project/bootstrap/app.php', source: 'application')->source())->toBe('application');
+    }
+
+    #[Test]
+    public function rejectsAnEmptySource(): void
+    {
+        Expect::that(static fn(): LaravelPlugin => new LaravelPlugin('/project/bootstrap/app.php', source: ''))
+            ->toThrow(\InvalidArgumentException::class, message: 'Service source must not be empty.');
+    }
+
+    #[Test]
+    public function aServiceWithoutAnIdUsesTheParameterType(): void
+    {
+        Expect::that($this->plugin()->resolve(Greeter::class, [new Service()]))->toBeInstanceOf(Greeter::class);
+    }
+
+    #[Test]
+    public function anExplicitIdEqualToTheMissingTypeFails(): void
+    {
+        $plugin = $this->plugin();
+
+        Expect::that(static fn(): ?object => $plugin->resolve(\ArrayObject::class, [new Service(\ArrayObject::class)]))
+            ->toThrow(LaravelBridgeError::class, matching: '/no binding "ArrayObject"/');
+    }
+
+    #[Test]
+    public function aServiceWithoutAnIdFailsWhenTheTypeIsMissing(): void
+    {
+        $plugin = $this->plugin();
+
+        Expect::that(static fn(): ?object => $plugin->resolve(\ArrayObject::class, [new Service()]))
+            ->toThrow(LaravelBridgeError::class, matching: '/no binding "ArrayObject"/');
+    }
+
     /** A failed expectation MUST NOT leak a Laravel application into another test. */
     #[After]
     public function releaseLaravelApplications(): void

--- a/tests/Unit/Plugin/WorkerPluginRuntimeServiceSourceTest.php
+++ b/tests/Unit/Plugin/WorkerPluginRuntimeServiceSourceTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Plugin;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Fake;
+use Greenlight\Execution\Plugin\WorkerPluginRuntime;
+use Greenlight\Expect\Expect;
+use Greenlight\Harness\HarnessScopes;
+use Greenlight\Harness\Scope;
+use Greenlight\Harness\Service;
+use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Harness\ServiceResolutionFailed;
+use Greenlight\Harness\ServiceSource;
+use Greenlight\IntegrationFixture\IntegrationResources;
+use Greenlight\Plugin\HarnessProvider;
+use Greenlight\Plugin\Plugin;
+use Greenlight\Plugin\WorkerBootstrapContext;
+use Greenlight\Psr11\Psr11Plugin;
+use Greenlight\Test\TestChannel;
+use Greenlight\Tests\Support\Psr11\ArrayContainer;
+use Greenlight\Tests\Support\Psr11\Greeter;
+use Greenlight\Tests\Support\ServiceResolverProbe;
+use Psr\Container\ContainerInterface;
+
+final readonly class WorkerPluginRuntimeServiceSourceTest
+{
+    #[Test]
+    public function aSelectedSourceBypassesGlobalServicesAndEarlierResolvers(): void
+    {
+        $selected = new Greeter();
+        $earlier = new ServiceResolverProbe(new Greeter());
+        $global = new Greeter();
+        $scopes = $this->prepare([
+            $earlier,
+            $this->plugin(new ArrayContainer([Greeter::class => $selected]), 'billing'),
+        ], [new ServiceDefinition(Greeter::class, Scope::PerWorker, static fn(): Greeter => $global)]);
+
+        Expect::that($scopes->resolve(Greeter::class, 'test', [new Service(source: 'billing')]))->toBe($selected);
+        Expect::that($earlier->calls)->toBe(0);
+        Expect::that($scopes->resolve(Greeter::class, 'test'))->toBe($global);
+    }
+
+    #[Test]
+    public function aSelectedSourceResolvesAnExplicitIdFromItsOwnContainer(): void
+    {
+        $billing = new Greeter();
+        $legacy = new Greeter();
+        $scopes = $this->prepare([
+            $this->plugin(new ArrayContainer(['application.greeter' => $billing]), 'billing'),
+            $this->plugin(new ArrayContainer(['application.greeter' => $legacy]), 'legacy'),
+        ]);
+
+        Expect::that($scopes->resolve(Greeter::class, 'test', [
+            new Service('application.greeter', source: 'legacy'),
+        ]))->toBe($legacy);
+        Expect::that($scopes->resolve(Greeter::class, 'test', [
+            new Service('application.greeter', source: 'billing'),
+        ]))->toBe($billing);
+    }
+
+    #[Test]
+    public function aSelectedSourceCannotUseAServiceFromAnotherContainer(): void
+    {
+        $scopes = $this->prepare([
+            $this->plugin(new ArrayContainer(['application.greeter' => new Greeter()]), 'billing'),
+            $this->plugin(new ArrayContainer([]), 'legacy'),
+        ]);
+
+        Expect::that(static fn(): object => $scopes->resolve(Greeter::class, 'test', [
+            new Service('application.greeter', source: 'legacy'),
+        ]))->toThrow(ServiceResolutionFailed::class, matching: '/no service "application.greeter"/');
+    }
+
+    #[Test]
+    public function aMissingTypeInTheSelectedSourceDoesNotUseALaterResolver(): void
+    {
+        $later = new ServiceResolverProbe(new Greeter());
+        $scopes = $this->prepare([
+            $this->plugin(new ArrayContainer([]), 'billing'),
+            $later,
+        ]);
+
+        Expect::that(static fn(): object => $scopes->resolve(Greeter::class, 'test', [
+            new Service(source: 'billing'),
+        ]))->toThrow(ServiceResolutionFailed::class);
+        Expect::that($later->calls)->toBe(0);
+    }
+
+    #[Test]
+    public function unqualifiedTypesKeepTheResolverOrderAcrossNamedSources(): void
+    {
+        $billing = new Greeter();
+        $legacy = new Greeter();
+        $scopes = $this->prepare([
+            $this->plugin(new ArrayContainer([Greeter::class => $billing]), 'billing'),
+            $this->plugin(new ArrayContainer([Greeter::class => $legacy]), 'legacy'),
+        ]);
+
+        Expect::that($scopes->resolve(Greeter::class, 'test'))->toBe($billing);
+    }
+
+    #[Test]
+    public function anUnknownSourceDoesNotCallUnrelatedResolvers(): void
+    {
+        $earlier = new ServiceResolverProbe(new Greeter());
+        $scopes = $this->prepare([
+            $earlier,
+            $this->plugin(new ArrayContainer([Greeter::class => new Greeter()]), 'billing'),
+        ]);
+
+        Expect::that(static fn(): object => $scopes->resolve(Greeter::class, 'test', [
+            new Service(source: 'missing'),
+        ]))->toThrow(ServiceResolutionFailed::class, matching: '/source "missing"/');
+        Expect::that($earlier->calls)->toBe(0);
+    }
+
+    #[Test]
+    public function providerSourcesKeepSameTypeDefinitionsAndCachesSeparate(): void
+    {
+        $billing = new \stdClass();
+        $legacy = new \stdClass();
+        $scopes = $this->prepare([
+            $this->provider('billing', $billing),
+            $this->provider('legacy', $legacy),
+        ]);
+
+        Expect::that($scopes->resolve(\stdClass::class, 'test', [new Service(source: 'billing')]))->toBe($billing);
+        Expect::that($scopes->resolve(\stdClass::class, 'test', [new Service(source: 'legacy')]))->toBe($legacy);
+        Expect::that($scopes->resolve(\stdClass::class, 'test', [new Service(source: 'billing')]))->toBe($billing);
+    }
+
+    #[Test]
+    public function sameTypeContainersRequireASource(): void
+    {
+        $billing = new ArrayContainer([]);
+        $legacy = new ArrayContainer([]);
+        $scopes = $this->prepare([
+            $this->plugin($billing, 'billing'),
+            $this->plugin($legacy, 'legacy'),
+        ]);
+        $scopes->openTest();
+
+        Expect::that($scopes->resolve(ContainerInterface::class, 'test', [new Service(source: 'billing')]))->toBe($billing);
+        Expect::that($scopes->resolve(ContainerInterface::class, 'test', [new Service(source: 'legacy')]))->toBe($legacy);
+        Expect::that(static fn(): object => $scopes->resolve(ContainerInterface::class, 'test'))
+            ->toThrow(ServiceResolutionFailed::class, matching: '/source/');
+
+        $scopes->closeTest();
+    }
+
+    #[Test]
+    public function duplicatePluginSourcesFailWorkerPreparation(): void
+    {
+        Expect::that(fn(): HarnessScopes => $this->prepare([
+            $this->plugin(new ArrayContainer([]), 'billing'),
+            $this->plugin(new ArrayContainer([]), 'billing'),
+        ]))->toThrow(\InvalidArgumentException::class, matching: '/source "billing"/');
+    }
+
+    #[Test]
+    public function sourceNamesPreserveCaseAndAcceptZero(): void
+    {
+        $lower = new \stdClass();
+        $upper = new \stdClass();
+        $zero = new \stdClass();
+        $scopes = $this->prepare([
+            $this->provider('billing', $lower),
+            $this->provider('Billing', $upper),
+            $this->provider('0', $zero),
+        ]);
+
+        Expect::that($scopes->resolve(\stdClass::class, 'test', [new Service(source: 'billing')]))->toBe($lower);
+        Expect::that($scopes->resolve(\stdClass::class, 'test', [new Service(source: 'Billing')]))->toBe($upper);
+        Expect::that($scopes->resolve(\stdClass::class, 'test', [new Service(source: '0')]))->toBe($zero);
+    }
+
+    /**
+     * @param list<Plugin> $plugins
+     * @param list<ServiceDefinition> $definitions
+     */
+    private function prepare(array $plugins, array $definitions = []): HarnessScopes
+    {
+        return WorkerPluginRuntime::fromPlugins($plugins)->prepareWorker(
+            new WorkerBootstrapContext('test-worker', new TestChannel(1), new IntegrationResources()),
+            $definitions,
+        );
+    }
+
+    private function plugin(ContainerInterface $container, string $source): Psr11Plugin
+    {
+        return new Psr11Plugin(static fn(): ContainerInterface => $container, source: $source);
+    }
+
+    /** @param non-empty-string $source */
+    private function provider(string $source, \stdClass $service): HarnessProvider
+    {
+        return new readonly class ($source, $service) implements Fake, HarnessProvider, ServiceSource {
+            /** @param non-empty-string $name */
+            public function __construct(private string $name, private \stdClass $service) {}
+
+            #[\Override]
+            public function source(): string
+            {
+                return $this->name;
+            }
+
+            #[\Override]
+            public function services(): array
+            {
+                return [new ServiceDefinition(\stdClass::class, Scope::PerWorker, fn(): \stdClass => $this->service)];
+            }
+        };
+    }
+}

--- a/tests/Unit/Psr11/Psr11PluginTest.php
+++ b/tests/Unit/Psr11/Psr11PluginTest.php
@@ -23,6 +23,51 @@ use Psr\Container\ContainerInterface;
 final readonly class Psr11PluginTest
 {
     #[Test]
+    public function exposesTheConfiguredSource(): void
+    {
+        $factory = static fn(): ContainerInterface => new ArrayContainer([]);
+
+        Expect::that(new Psr11Plugin($factory)->source())->toBeNull();
+        Expect::that(new Psr11Plugin($factory, source: 'application')->source())->toBe('application');
+    }
+
+    #[Test]
+    public function rejectsAnEmptySource(): void
+    {
+        Expect::that(static fn(): Psr11Plugin => new Psr11Plugin(
+            static fn(): ContainerInterface => new ArrayContainer([]),
+            source: '',
+        ))->toThrow(\InvalidArgumentException::class, message: 'Service source must not be empty.');
+    }
+
+    #[Test]
+    public function aServiceWithoutAnIdUsesTheParameterType(): void
+    {
+        $greeter = new Greeter();
+        $plugin = $this->plugin([Greeter::class => $greeter]);
+
+        Expect::that($plugin->resolve(Greeter::class, [new Service()]))->toBe($greeter);
+    }
+
+    #[Test]
+    public function anExplicitIdEqualToTheMissingTypeFails(): void
+    {
+        $plugin = $this->plugin([]);
+
+        Expect::that(static fn(): ?object => $plugin->resolve(\ArrayObject::class, [new Service(\ArrayObject::class)]))
+            ->toThrow(Psr11BridgeError::class, matching: '/no service "ArrayObject"/');
+    }
+
+    #[Test]
+    public function aServiceWithoutAnIdFailsWhenTheTypeIsMissing(): void
+    {
+        $plugin = $this->plugin([]);
+
+        Expect::that(static fn(): ?object => $plugin->resolve(\ArrayObject::class, [new Service()]))
+            ->toThrow(Psr11BridgeError::class, matching: '/no service "ArrayObject"/');
+    }
+
+    #[Test]
     public function resolvesContainerServicesByType(): void
     {
         $greeter = new Greeter();

--- a/tests/Unit/ServiceAttributeTest.php
+++ b/tests/Unit/ServiceAttributeTest.php
@@ -28,4 +28,26 @@ final readonly class ServiceAttributeTest
             ->because('a zero-string service identifier is not empty')
             ->toBe('0');
     }
+
+    #[Test]
+    public function aSourceCanUseTheParameterTypeAsItsIdentifier(): void
+    {
+        $service = new Service(source: 'billing');
+
+        Expect::that($service->id)->toBeNull();
+        Expect::that($service->source)->toBe('billing');
+    }
+
+    #[Test]
+    public function rejectsAnEmptySourceName(): void
+    {
+        Expect::that(static fn(): Service => new Service(source: ''))
+            ->toThrow(\InvalidArgumentException::class, message: 'Service source must not be empty.');
+    }
+
+    #[Test]
+    public function preservesAZeroStringSourceName(): void
+    {
+        Expect::that((new Service(source: '0'))->source)->toBe('0');
+    }
 }

--- a/tests/Unit/Symfony/SymfonyPluginTest.php
+++ b/tests/Unit/Symfony/SymfonyPluginTest.php
@@ -26,6 +26,44 @@ use Symfony\Component\HttpKernel\KernelInterface;
 final class SymfonyPluginTest
 {
     #[Test]
+    public function exposesTheConfiguredSource(): void
+    {
+        Expect::that(new SymfonyPlugin(FixtureKernel::class)->source())->toBeNull();
+        Expect::that(new SymfonyPlugin(FixtureKernel::class, source: 'application')->source())->toBe('application');
+    }
+
+    #[Test]
+    public function rejectsAnEmptySource(): void
+    {
+        Expect::that(static fn(): SymfonyPlugin => new SymfonyPlugin(FixtureKernel::class, source: ''))
+            ->toThrow(\InvalidArgumentException::class, message: 'Service source must not be empty.');
+    }
+
+    #[Test]
+    public function aServiceWithoutAnIdUsesTheParameterType(): void
+    {
+        Expect::that($this->plugin()->resolve(Greeter::class, [new Service()]))->toBeInstanceOf(Greeter::class);
+    }
+
+    #[Test]
+    public function anExplicitIdEqualToTheMissingTypeFails(): void
+    {
+        $plugin = $this->plugin();
+
+        Expect::that(static fn(): ?object => $plugin->resolve(\ArrayObject::class, [new Service(\ArrayObject::class)]))
+            ->toThrow(SymfonyBridgeError::class, matching: '/no service "ArrayObject"/');
+    }
+
+    #[Test]
+    public function aServiceWithoutAnIdFailsWhenTheTypeIsMissing(): void
+    {
+        $plugin = $this->plugin();
+
+        Expect::that(static fn(): ?object => $plugin->resolve(\ArrayObject::class, [new Service()]))
+            ->toThrow(SymfonyBridgeError::class, matching: '/no service "ArrayObject"/');
+    }
+
+    #[Test]
     public function resolvesContainerServicesByType(): void
     {
         $greeter = $this->plugin()->resolve(Greeter::class, []);

--- a/tests/Unit/Tempest/TempestPluginConfigurationTest.php
+++ b/tests/Unit/Tempest/TempestPluginConfigurationTest.php
@@ -17,6 +17,20 @@ use Tempest\Core\Kernel;
 final readonly class TempestPluginConfigurationTest
 {
     #[Test]
+    public function exposesTheConfiguredSource(): void
+    {
+        Expect::that(new TempestPlugin('/project')->source())->toBeNull();
+        Expect::that(new TempestPlugin('/project', source: 'application')->source())->toBe('application');
+    }
+
+    #[Test]
+    public function rejectsAnEmptySource(): void
+    {
+        Expect::that(static fn(): TempestPlugin => new TempestPlugin('/project', source: ''))
+            ->toThrow(\InvalidArgumentException::class, message: 'Service source must not be empty.');
+    }
+
+    #[Test]
     public function exposesTheKernelAndContainerAsPerWorkerServices(): void
     {
         $definitions = new TempestPlugin('/project')->services();

--- a/tests/Unit/Tempest/TempestPluginLifecycleTest.php
+++ b/tests/Unit/Tempest/TempestPluginLifecycleTest.php
@@ -96,6 +96,44 @@ final class TempestPluginLifecycleTest
     }
 
     #[Test]
+    public function aSourceOnlyServiceAttributeUsesTheDefaultBinding(): void
+    {
+        $plugin = $this->plugin(source: 'application');
+        $kernel = $this->kernel($plugin);
+        $expected = new TaggedProbeImplementation();
+        $kernel->container->singleton(TaggedProbe::class, $expected);
+        $kernel->container->singleton(TaggedProbe::class, new TaggedProbeImplementation(), 'archive');
+        $earlier = new ServiceResolverProbe(new TaggedProbeImplementation());
+        $scopes = WorkerPluginRuntime::fromPlugins([$earlier, $plugin])->prepareWorker(
+            new WorkerBootstrapContext('test-worker', new TestChannel(1), new IntegrationResources()),
+            [],
+        );
+
+        Expect::that($scopes->resolve(TaggedProbe::class, 'test', [new Service(source: 'application')]))
+            ->toBe($expected);
+        Expect::that($earlier->calls)->toBe(0);
+    }
+
+    #[Test]
+    public function aServiceIdSelectsATagWithinTheNamedSource(): void
+    {
+        $plugin = $this->plugin(source: 'application');
+        $kernel = $this->kernel($plugin);
+        $expected = new TaggedProbeImplementation();
+        $kernel->container->singleton(TaggedProbe::class, new TaggedProbeImplementation());
+        $kernel->container->singleton(TaggedProbe::class, $expected, 'archive');
+        $earlier = new ServiceResolverProbe(new TaggedProbeImplementation());
+        $scopes = WorkerPluginRuntime::fromPlugins([$earlier, $plugin])->prepareWorker(
+            new WorkerBootstrapContext('test-worker', new TestChannel(1), new IntegrationResources()),
+            [],
+        );
+
+        Expect::that($scopes->resolve(TaggedProbe::class, 'test', [new Service('archive', source: 'application')]))
+            ->toBe($expected);
+        Expect::that($earlier->calls)->toBe(0);
+    }
+
+    #[Test]
     public function fallbackResolverRunsBeforeTerminalTempestResolver(): void
     {
         $answer = new TaggedProbeImplementation();
@@ -211,7 +249,7 @@ final class TempestPluginLifecycleTest
         Expect::that(GenericContainer::instance())->not()->toBe($kernel->container);
     }
 
-    private function plugin(): TempestPlugin
+    private function plugin(?string $source = null): TempestPlugin
     {
         $root = $this->tempDirectory->subdirectory('tempest-plugin-' . ++$this->projectNumber);
         $repository = \dirname(__DIR__, 3);
@@ -232,7 +270,7 @@ final class TempestPluginLifecycleTest
             Fail::because('Expected to link the Tempest test project vendor directory.');
         }
 
-        $plugin = new TempestPlugin($root);
+        $plugin = new TempestPlugin($root, source: $source);
         $this->plugins[] = $plugin;
 
         return $plugin;


### PR DESCRIPTION
Service IDs cannot currently select the container that resolves them. An earlier resolver can supply its own service or fail before the intended container receives the request.

Add optional `source:` names to the Symfony, Laravel, Hyperf, PSR-11, and Tempest plugin instances. Tests can select a source with `#[Service(source: 'billing')]`, or select an ID within it with `#[Service('users.repository', source: 'billing')]`. An explicit source takes precedence over other harness bindings and resolvers. A missing source or service fails without fallback.

Source names also qualify harness definitions and scope caches, so two PSR-11 plugins can supply distinct containers and services of the same type. Existing unqualified lookup keeps its order. Ambiguous named harness types require an explicit source. Tempest uses `Service` for both default and tagged bindings within a named source.

Includes the explicit-ID failure fix from #1830 and updates the integration guides and API reference.
