### PR TITLE
feat(amp): cancel supported waits at test deadlines

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ for the complete model.
 * [Static analysis with PHPStan](docs/phpstan.md)
 * [Test Symfony applications](docs/symfony.md)
 * [Test Laravel applications](docs/laravel.md)
+* [Test Amp applications](docs/amp.md)
 * [Test Hyperf applications](docs/hyperf.md)
 * [Test with PSR-11 containers](docs/psr11.md)
 * [Test PSR-15 applications](docs/psr15.md)

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "php": ">=8.4"
     },
     "require-dev": {
+        "amphp/amp": "^3.1",
         "deptrac/deptrac": "^4.0",
         "ergebnis/composer-normalize": "^2.47",
         "fidry/cpu-core-counter": "^1.3",
@@ -33,6 +34,7 @@
         "psr/http-message": "^2.0",
         "psr/http-server-handler": "^1.0",
         "rector/rector": "^2.5",
+        "revolt/event-loop": "^1.0",
         "symfony/config": "^6.4 || ^7.0 || ^8.0",
         "symfony/dependency-injection": "^6.4 || ^7.0 || ^8.0",
         "symfony/framework-bundle": "^6.4 || ^7.0 || ^8.0",
@@ -42,6 +44,7 @@
         "ext-pcntl": "Scans Hyperf classes before 'HyperfPlugin' starts a worker",
         "ext-pcov": "Collects line coverage quickly",
         "ext-swoole": "Runs 'HyperfPlugin' workers and test attempts in Hyperf coroutines",
+        "amphp/amp": "Enables deadline cancellation through 'AmpPlugin' with Amp 3",
         "fidry/cpu-core-counter": "Improves the 'auto' worker count across platforms and on systems with cgroup limits",
         "hyperf/di": "Scans Hyperf classes and generates AOP proxies for the 'HyperfPlugin' bridge",
         "hyperf/framework": "Provides the Hyperf 3.2 application runtime that 'HyperfPlugin' requires",
@@ -52,6 +55,7 @@
         "psr/http-message": "Provides the PSR-7 request and response interfaces that HttpHarness requires",
         "psr/http-server-handler": "Provides the PSR-15 request handler interface that Psr15Plugin requires",
         "rector/rector": "Converts PHPUnit test classes to Greenlight with the bundled 'PhpUnitToGreenlightRector' rule",
+        "revolt/event-loop": "Shares the application scheduler with 'AmpPlugin'",
         "symfony/framework-bundle": "Enables container service injection into kernel-aware Symfony tests through the 'SymfonyPlugin' bridge",
         "tempest/framework": "Enables discovery, configuration, container injection, and reset-safe tests through the 'TempestPlugin' bridge"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,9 +4,90 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "eb70974e179e5072ba650352a3436999",
+    "content-hash": "c3cf4233cc7a31062648c0a68c5d14b7",
     "packages": [],
     "packages-dev": [
+        {
+            "name": "amphp/amp",
+            "version": "v3.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/amphp/amp.git",
+                "reference": "73c38b323ff8d790abf0f76c56fcc892bda4111a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/amphp/amp/zipball/73c38b323ff8d790abf0f76c56fcc892bda4111a",
+                "reference": "73c38b323ff8d790abf0f76c56fcc892bda4111a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "revolt/event-loop": "^1 || ^0.2"
+            },
+            "require-dev": {
+                "amphp/php-cs-fixer-config": "^2",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.1"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions.php",
+                    "src/Future/functions.php",
+                    "src/Internal/functions.php"
+                ],
+                "psr-4": {
+                    "Amp\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Bob Weinand",
+                    "email": "bobwei9@hotmail.com"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                },
+                {
+                    "name": "Daniel Lowrey",
+                    "email": "rdlowrey@php.net"
+                }
+            ],
+            "description": "A non-blocking concurrency framework for PHP applications.",
+            "homepage": "https://amphp.org/amp",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "awaitable",
+                "concurrency",
+                "event",
+                "event-loop",
+                "future",
+                "non-blocking",
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/amphp/amp/issues",
+                "source": "https://github.com/amphp/amp/tree/v3.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/amphp",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-07-19T17:59:20+00:00"
+        },
         {
             "name": "brick/math",
             "version": "0.18.0",
@@ -5656,6 +5737,78 @@
             "time": "2026-09-02T09:38:46+00:00"
         },
         {
+            "name": "revolt/event-loop",
+            "version": "v1.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/revoltphp/event-loop.git",
+                "reference": "44061cf513e53c6200372fc935ac42271566295d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/44061cf513e53c6200372fc935ac42271566295d",
+                "reference": "44061cf513e53c6200372fc935ac42271566295d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "6.16.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Revolt\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "ceesjank@gmail.com"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Rock-solid event loop for concurrent PHP applications.",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "concurrency",
+                "event",
+                "event-loop",
+                "non-blocking",
+                "scheduler"
+            ],
+            "support": {
+                "issues": "https://github.com/revoltphp/event-loop/issues",
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.9"
+            },
+            "time": "2026-05-16T17:55:38+00:00"
+        },
+        {
             "name": "symfony/cache",
             "version": "v8.1.6",
             "source": {
@@ -9303,5 +9456,5 @@
         "php": ">=8.4"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -233,6 +233,20 @@ deptrac:
       collectors:
         - type: directory
           value: src/Documentation/.*
+    - name: Amp
+      collectors:
+        - type: directory
+          value: src/Amp/.*
+    - name: AmpFramework
+      collectors:
+        - type: classNameRegex
+          value: /^Amp\\/
+        - type: functionName
+          value: ^Amp\\
+    - name: RevoltFramework
+      collectors:
+        - type: classNameRegex
+          value: /^Revolt\\/
     - name: Symfony
       collectors:
         - type: directory
@@ -364,6 +378,9 @@ deptrac:
     PhpStan: [Attribute, Condition, Config, Doubles, Expect, InternalPhp, Test, PhpStanFramework, PhpParserFramework]
     Rector: [Attribute, Condition, Expect, Test, PhpParserFramework, RectorFramework]
     Documentation: []
+    Amp: [Expect, Plugin, Test, AmpFramework, RevoltFramework]
+    AmpFramework: []
+    RevoltFramework: []
     Symfony: [Harness, Plugin, Result, SymfonyFramework]
     Laravel: [Harness, InternalPhp, InternalProcess, Plugin, Result, LaravelFramework]
     Hyperf: [Harness, InternalPhp, Plugin, HyperfFramework, PsrContainerFramework, SwooleFramework, ComposerRuntime]

--- a/docs/amp.md
+++ b/docs/amp.md
@@ -1,0 +1,133 @@
+# Amp applications
+
+`AmpPlugin` connects Greenlight to Amp 3 and Revolt 1. Greenlight keeps these
+packages optional. Install them in the application:
+
+```sh
+composer require --dev amphp/amp:^3.1 revolt/event-loop:^1.0
+```
+
+Register the plugin in `greenlight.php`:
+
+<!-- php-example {"example":"amp-configuration","file":"snippet.php","mode":"file","tools":["rector","phpstan"]} -->
+```php
+use Greenlight\Amp\AmpPlugin;
+use Greenlight\Config\GreenlightConfig;
+
+return GreenlightConfig::create()
+    ->paths(['tests'])
+    ->plugins(static fn(): AmpPlugin => new AmpPlugin());
+```
+
+The plugin uses the application's Revolt event loop. Temporal polling yields
+through Amp so other tasks can progress between observations. The plugin does
+not replace the event-loop driver.
+
+## Supported operations
+
+Use `AmpContext::delay()` for a delay that respects the current deadline.
+Use `AmpContext::await()` to wait for an Amp future with that deadline.
+Pass `AmpContext::cancellation()` to other Amp APIs that accept a cancellation
+token. Get the token where the operation starts.
+
+<!-- php-example {"example":"amp-child-work","file":"snippet.php","mode":"file","tools":["rector","phpstan"]} -->
+```php
+use Greenlight\Amp\AmpContext;
+use Greenlight\Attribute\Test;
+use Greenlight\Attribute\Timeout;
+use Greenlight\Expect\Expect;
+
+final class AsyncTest
+{
+    #[Test]
+    #[Timeout(1.0)]
+    public function receivesTheChildResult(): void
+    {
+        $future = AmpContext::async(static function (): string {
+            AmpContext::delay(0.010);
+
+            return 'ready';
+        });
+
+        Expect::that(AmpContext::await($future))->toBe('ready');
+    }
+}
+```
+
+The effective deadline is the earliest test or active temporal deadline.
+It is an absolute monotonic time. A new token does not restart the budget.
+The executor supplies the test deadline before constructor injection, inside
+the attempt runtime boundary.
+
+A temporal probe can use the same operations. A shorter `within()` limit
+cancels a supported wait inside that probe. The first `consistently()`
+observation uses the test and enclosing limits. Its own period starts after
+the first successful observation.
+
+Greenlight reports deadline cancellation as a failed attempt. Diagnostics
+identify the test limit or temporal expectation limit. `retryOnException()`
+and `toThrow()` do not consume Greenlight deadline or child-scope cancellation. Other Amp
+cancellation retains its normal exception behavior.
+
+## Child work and cleanup
+
+Use `AmpContext::async()` to register child work. Each child receives the
+parent's current absolute deadlines. The child can add a shorter temporal
+limit. A sibling's temporal limit does not affect it.
+
+Before `After` hooks, Greenlight requests cancellation of registered children
+and waits for every child to finish. It then runs deferred cleanup and
+per-test service disposal. A retry starts only after this sequence completes.
+Child work cannot register more children after this shutdown starts.
+
+Use `AmpContext::await()` to handle a registered child's result or error.
+Greenlight reports child errors that this method did not deliver at the join.
+Native `Future::await()` does not record this delivery. If you use native waits,
+handle expected application errors inside the child operation.
+
+Cleanup retains the test deadline. If the deadline has expired, supported
+cleanup waits cancel immediately. Greenlight still calls the remaining hooks,
+cleanup callbacks, and service disposal methods. Earlier failures and cleanup
+diagnostics remain in the result. A successful test body does not cancel the
+cleanup budget.
+
+Each retry has a new deadline and child scope. Tokens retained from a completed
+attempt cannot acquire the next attempt's budget.
+
+`afterTest()` subscribers run after this deadline scope closes. They cannot use
+`AmpContext` operations.
+
+## Limits
+
+Cancellation is cooperative. A cancellation token requests that an operation
+stop. It cannot interrupt blocking I/O, `sleep()`, or uninterrupted computation.
+An operation can also ignore cancellation.
+
+Cancellation of `Future::await()` stops that wait. It does not terminate the
+producer. Registration through `AmpContext::async()` lets Greenlight wait for
+the producer before it releases resources. For application-owned futures,
+arrange producer cancellation and completion explicitly.
+
+Native `Amp\async()`, direct Fibers, and callbacks do not inherit the bridge
+context. Pass a token explicitly if they need the current deadline. Keep their
+lifetimes within the attempt. Greenlight cannot find or stop detached work.
+
+If a registered child ignores cancellation, Greenlight waits for it. With
+process-pool execution, the existing process timeout can stop the worker.
+In-process execution has no separate worker to stop. Use process-pool execution
+for tests that can block. See [timeouts](attributes.md#timeout).
+
+Without `AmpPlugin`, Greenlight uses its synchronous polling clock and elapsed
+time checks.
+
+## Integration basis
+
+Amp provides native cancellation and future waits. Revolt provides the shared
+scheduler. This combination lets the bridge use application scheduling without
+a second Fiber scheduler. See the [Amp documentation](https://amphp.org/amp)
+and [Revolt fundamentals](https://revolt.run/fundamentals).
+
+The implementation follows Amp's source behavior for
+[delay and child scheduling](https://github.com/amphp/amp/blob/v3.1.3/src/functions.php),
+[future waits](https://github.com/amphp/amp/blob/v3.1.3/src/Future.php), and
+[cancellation](https://github.com/amphp/amp/blob/v3.1.3/src/DeferredCancellation.php).

--- a/docs/api-expectations.md
+++ b/docs/api-expectations.md
@@ -39,7 +39,7 @@ PHPDoc:
 - `@throws \BadMethodCallException if no native or registered extension matcher has the requested name`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L85)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L86)
 
 ### `not()`
 
@@ -49,7 +49,7 @@ Negates the next matcher for every value returned by the probe.
 final public function not(): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L41)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L42)
 
 ### `because()`
 
@@ -68,7 +68,7 @@ PHPDoc:
 - `@param non-empty-string $reason`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L59)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L60)
 
 ### `toBe()`
 
@@ -83,7 +83,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L141)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L142)
 
 ### `toEqual()`
 
@@ -99,7 +99,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L158)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L159)
 
 ### `toEqualCanonicalizing()`
 
@@ -117,7 +117,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L177)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L178)
 
 ### `toBeOneOf()`
 
@@ -132,7 +132,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L193)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L194)
 
 ### `toBeIn()`
 
@@ -150,7 +150,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L213)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L214)
 
 ### `toBeInstanceOf()`
 
@@ -164,7 +164,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L231)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L232)
 
 ### `toBeTrue()`
 
@@ -177,7 +177,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L245)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L246)
 
 ### `toBeFalse()`
 
@@ -190,7 +190,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L255)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L256)
 
 ### `toBeNull()`
 
@@ -203,7 +203,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L265)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L266)
 
 ### `toBeArray()`
 
@@ -216,7 +216,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L275)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L276)
 
 ### `toBeString()`
 
@@ -229,7 +229,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L290)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L291)
 
 ### `toBeInt()`
 
@@ -242,7 +242,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L305)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L306)
 
 ### `toBeFloat()`
 
@@ -255,7 +255,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L320)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L321)
 
 ### `toBeBool()`
 
@@ -268,7 +268,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L335)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L336)
 
 ### `toBeCallable()`
 
@@ -281,7 +281,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L350)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L351)
 
 ### `toBeIterable()`
 
@@ -294,7 +294,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L365)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L366)
 
 ### `toContain()`
 
@@ -311,7 +311,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L384)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L385)
 
 ### `toHaveCount()`
 
@@ -327,7 +327,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L433)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L434)
 
 ### `toBeEmpty()`
 
@@ -345,7 +345,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L464)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L465)
 
 ### `toHaveLength()`
 
@@ -362,7 +362,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L491)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L492)
 
 ### `toHaveKey()`
 
@@ -379,7 +379,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L522)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L523)
 
 ### `toContainSubset()`
 
@@ -398,7 +398,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L554)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L555)
 
 ### `toBeGreaterThan()`
 
@@ -411,7 +411,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L584)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L585)
 
 ### `toBeGreaterThanOrEqual()`
 
@@ -424,7 +424,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L598)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L599)
 
 ### `toBeLessThan()`
 
@@ -437,7 +437,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L612)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L613)
 
 ### `toBeLessThanOrEqual()`
 
@@ -450,7 +450,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L626)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L627)
 
 ### `toBeWithin()`
 
@@ -466,7 +466,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L643)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L644)
 
 ### `toMatch()`
 
@@ -480,7 +480,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L670)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L671)
 
 ### `toStartWith()`
 
@@ -493,7 +493,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L686)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L687)
 
 ### `toEndWith()`
 
@@ -506,7 +506,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L700)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L701)
 
 ### `toBeJson()`
 
@@ -522,7 +522,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L717)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L718)
 
 ### `toMatchJson()`
 
@@ -540,7 +540,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L736)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L737)
 
 ### `toThrow()`
 
@@ -579,7 +579,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L795)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L796)
 
 ## `EventuallyExpectation`
 
@@ -614,7 +614,7 @@ PHPDoc:
 - `@throws \BadMethodCallException if no native or registered extension matcher has the requested name`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L85)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L86)
 
 ### `not()`
 
@@ -624,7 +624,7 @@ Negates the next matcher for every value returned by the probe.
 final public function not(): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L41)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L42)
 
 ### `because()`
 
@@ -643,7 +643,7 @@ PHPDoc:
 - `@param non-empty-string $reason`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L59)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L60)
 
 ### `toBe()`
 
@@ -658,7 +658,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L141)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L142)
 
 ### `toEqual()`
 
@@ -674,7 +674,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L158)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L159)
 
 ### `toEqualCanonicalizing()`
 
@@ -692,7 +692,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L177)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L178)
 
 ### `toBeOneOf()`
 
@@ -707,7 +707,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L193)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L194)
 
 ### `toBeIn()`
 
@@ -725,7 +725,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L213)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L214)
 
 ### `toBeInstanceOf()`
 
@@ -739,7 +739,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L231)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L232)
 
 ### `toBeTrue()`
 
@@ -752,7 +752,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L245)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L246)
 
 ### `toBeFalse()`
 
@@ -765,7 +765,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L255)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L256)
 
 ### `toBeNull()`
 
@@ -778,7 +778,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L265)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L266)
 
 ### `toBeArray()`
 
@@ -791,7 +791,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L275)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L276)
 
 ### `toBeString()`
 
@@ -804,7 +804,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L290)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L291)
 
 ### `toBeInt()`
 
@@ -817,7 +817,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L305)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L306)
 
 ### `toBeFloat()`
 
@@ -830,7 +830,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L320)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L321)
 
 ### `toBeBool()`
 
@@ -843,7 +843,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L335)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L336)
 
 ### `toBeCallable()`
 
@@ -856,7 +856,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L350)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L351)
 
 ### `toBeIterable()`
 
@@ -869,7 +869,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L365)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L366)
 
 ### `toContain()`
 
@@ -886,7 +886,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L384)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L385)
 
 ### `toHaveCount()`
 
@@ -902,7 +902,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L433)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L434)
 
 ### `toBeEmpty()`
 
@@ -920,7 +920,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L464)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L465)
 
 ### `toHaveLength()`
 
@@ -937,7 +937,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L491)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L492)
 
 ### `toHaveKey()`
 
@@ -954,7 +954,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L522)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L523)
 
 ### `toContainSubset()`
 
@@ -973,7 +973,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L554)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L555)
 
 ### `toBeGreaterThan()`
 
@@ -986,7 +986,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L584)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L585)
 
 ### `toBeGreaterThanOrEqual()`
 
@@ -999,7 +999,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L598)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L599)
 
 ### `toBeLessThan()`
 
@@ -1012,7 +1012,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L612)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L613)
 
 ### `toBeLessThanOrEqual()`
 
@@ -1025,7 +1025,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L626)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L627)
 
 ### `toBeWithin()`
 
@@ -1041,7 +1041,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L643)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L644)
 
 ### `toMatch()`
 
@@ -1055,7 +1055,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L670)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L671)
 
 ### `toStartWith()`
 
@@ -1068,7 +1068,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L686)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L687)
 
 ### `toEndWith()`
 
@@ -1081,7 +1081,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L700)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L701)
 
 ### `toBeJson()`
 
@@ -1097,7 +1097,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L717)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L718)
 
 ### `toMatchJson()`
 
@@ -1115,7 +1115,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L736)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L737)
 
 ### `toThrow()`
 
@@ -1154,7 +1154,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L795)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L796)
 
 ## `Expect`
 
@@ -1251,7 +1251,7 @@ A failed matcher throws `ExpectationFailed` immediately.
 final class Expectation
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L40)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L41)
 
 PHPDoc:
 
@@ -1276,7 +1276,7 @@ PHPDoc:
 - `@throws \BadMethodCallException if no native or registered extension matcher has the requested name`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L73)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L74)
 
 ### `not()`
 
@@ -1292,7 +1292,7 @@ PHPDoc:
 
 - `@return self<T>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L101)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L102)
 
 ### `because()`
 
@@ -1312,7 +1312,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L121)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L122)
 
 ### `toBe()`
 
@@ -1327,7 +1327,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L141)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L142)
 
 ### `toEqual()`
 
@@ -1343,7 +1343,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L158)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L159)
 
 ### `toEqualCanonicalizing()`
 
@@ -1361,7 +1361,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L177)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L178)
 
 ### `toBeOneOf()`
 
@@ -1376,7 +1376,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L193)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L194)
 
 ### `toBeIn()`
 
@@ -1394,7 +1394,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L213)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L214)
 
 ### `toBeInstanceOf()`
 
@@ -1408,7 +1408,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L231)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L232)
 
 ### `toBeTrue()`
 
@@ -1421,7 +1421,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L245)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L246)
 
 ### `toBeFalse()`
 
@@ -1434,7 +1434,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L255)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L256)
 
 ### `toBeNull()`
 
@@ -1447,7 +1447,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L265)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L266)
 
 ### `toBeArray()`
 
@@ -1460,7 +1460,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L275)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L276)
 
 ### `toBeString()`
 
@@ -1473,7 +1473,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L290)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L291)
 
 ### `toBeInt()`
 
@@ -1486,7 +1486,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L305)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L306)
 
 ### `toBeFloat()`
 
@@ -1499,7 +1499,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L320)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L321)
 
 ### `toBeBool()`
 
@@ -1512,7 +1512,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L335)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L336)
 
 ### `toBeCallable()`
 
@@ -1525,7 +1525,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L350)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L351)
 
 ### `toBeIterable()`
 
@@ -1538,7 +1538,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L365)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L366)
 
 ### `toContain()`
 
@@ -1555,7 +1555,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L384)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L385)
 
 ### `toHaveCount()`
 
@@ -1571,7 +1571,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L433)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L434)
 
 ### `toBeEmpty()`
 
@@ -1589,7 +1589,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L464)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L465)
 
 ### `toHaveLength()`
 
@@ -1606,7 +1606,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L491)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L492)
 
 ### `toHaveKey()`
 
@@ -1623,7 +1623,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L522)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L523)
 
 ### `toContainSubset()`
 
@@ -1642,7 +1642,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L554)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L555)
 
 ### `toBeGreaterThan()`
 
@@ -1655,7 +1655,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L584)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L585)
 
 ### `toBeGreaterThanOrEqual()`
 
@@ -1668,7 +1668,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L598)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L599)
 
 ### `toBeLessThan()`
 
@@ -1681,7 +1681,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L612)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L613)
 
 ### `toBeLessThanOrEqual()`
 
@@ -1694,7 +1694,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L626)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L627)
 
 ### `toBeWithin()`
 
@@ -1710,7 +1710,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L643)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L644)
 
 ### `toMatch()`
 
@@ -1724,7 +1724,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L670)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L671)
 
 ### `toStartWith()`
 
@@ -1737,7 +1737,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L686)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L687)
 
 ### `toEndWith()`
 
@@ -1750,7 +1750,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L700)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L701)
 
 ### `toBeJson()`
 
@@ -1766,7 +1766,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L717)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L718)
 
 ### `toMatchJson()`
 
@@ -1784,7 +1784,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L736)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L737)
 
 ### `toThrow()`
 
@@ -1823,7 +1823,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L795)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L796)
 
 ## `ExpectationExtension`
 
@@ -2048,7 +2048,7 @@ consistent expectations.
 abstract class TemporalExpectation
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L18)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L19)
 
 PHPDoc:
 
@@ -2070,7 +2070,7 @@ PHPDoc:
 - `@throws \BadMethodCallException if no native or registered extension matcher has the requested name`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L85)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L86)
 
 ### `not()`
 
@@ -2080,7 +2080,7 @@ Negates the next matcher for every value returned by the probe.
 final public function not(): static
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L41)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L42)
 
 ### `because()`
 
@@ -2099,7 +2099,7 @@ PHPDoc:
 - `@param non-empty-string $reason`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L59)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/TemporalExpectation.php#L60)
 
 ### `toBe()`
 
@@ -2114,7 +2114,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L141)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L142)
 
 ### `toEqual()`
 
@@ -2130,7 +2130,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L158)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L159)
 
 ### `toEqualCanonicalizing()`
 
@@ -2148,7 +2148,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L177)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L178)
 
 ### `toBeOneOf()`
 
@@ -2163,7 +2163,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L193)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L194)
 
 ### `toBeIn()`
 
@@ -2181,7 +2181,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L213)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L214)
 
 ### `toBeInstanceOf()`
 
@@ -2195,7 +2195,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L231)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L232)
 
 ### `toBeTrue()`
 
@@ -2208,7 +2208,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L245)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L246)
 
 ### `toBeFalse()`
 
@@ -2221,7 +2221,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L255)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L256)
 
 ### `toBeNull()`
 
@@ -2234,7 +2234,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L265)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L266)
 
 ### `toBeArray()`
 
@@ -2247,7 +2247,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L275)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L276)
 
 ### `toBeString()`
 
@@ -2260,7 +2260,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L290)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L291)
 
 ### `toBeInt()`
 
@@ -2273,7 +2273,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L305)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L306)
 
 ### `toBeFloat()`
 
@@ -2286,7 +2286,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L320)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L321)
 
 ### `toBeBool()`
 
@@ -2299,7 +2299,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L335)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L336)
 
 ### `toBeCallable()`
 
@@ -2312,7 +2312,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L350)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L351)
 
 ### `toBeIterable()`
 
@@ -2325,7 +2325,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L365)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L366)
 
 ### `toContain()`
 
@@ -2342,7 +2342,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L384)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L385)
 
 ### `toHaveCount()`
 
@@ -2358,7 +2358,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L433)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L434)
 
 ### `toBeEmpty()`
 
@@ -2376,7 +2376,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L464)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L465)
 
 ### `toHaveLength()`
 
@@ -2393,7 +2393,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L491)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L492)
 
 ### `toHaveKey()`
 
@@ -2410,7 +2410,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L522)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L523)
 
 ### `toContainSubset()`
 
@@ -2429,7 +2429,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L554)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L555)
 
 ### `toBeGreaterThan()`
 
@@ -2442,7 +2442,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L584)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L585)
 
 ### `toBeGreaterThanOrEqual()`
 
@@ -2455,7 +2455,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L598)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L599)
 
 ### `toBeLessThan()`
 
@@ -2468,7 +2468,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L612)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L613)
 
 ### `toBeLessThanOrEqual()`
 
@@ -2481,7 +2481,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L626)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L627)
 
 ### `toBeWithin()`
 
@@ -2497,7 +2497,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L643)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L644)
 
 ### `toMatch()`
 
@@ -2511,7 +2511,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L670)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L671)
 
 ### `toStartWith()`
 
@@ -2524,7 +2524,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L686)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L687)
 
 ### `toEndWith()`
 
@@ -2537,7 +2537,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L700)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L701)
 
 ### `toBeJson()`
 
@@ -2553,7 +2553,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L717)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L718)
 
 ### `toMatchJson()`
 
@@ -2571,7 +2571,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L736)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L737)
 
 ### `toThrow()`
 
@@ -2610,4 +2610,4 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L795)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L796)

--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -2,9 +2,128 @@
 
 # Integration API
 
-This reference lists public integration types for Hyperf, Laravel, PSR standards, Rector, Symfony, and Tempest.
+This reference lists public integration types for Amp, Hyperf, Laravel, PSR standards, Rector, Symfony, and Tempest.
 
 These signatures are the public API.
+
+## `AmpContext`
+
+Namespace: `Greenlight\Amp`
+
+Supplies deadline cancellation and child work for an AmpPlugin test attempt.
+Native Amp operations must receive cancellation explicitly.
+
+```php
+final class AmpContext
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Amp/AmpContext.php#L15)
+
+### `cancellation()`
+
+Returns a native token for the current absolute deadline.
+A child also receives cancellation when the test body ends.
+
+```php
+public static function cancellation(): Cancellation
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Amp/AmpContext.php#L29)
+
+### `delay()`
+
+Yields to Revolt until the delay completes or the current deadline expires.
+
+```php
+public static function delay(float $seconds): void
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Amp/AmpContext.php#L37)
+
+### `await()`
+
+Waits for a future within the current deadline.
+Cancellation stops this wait. It does not stop the future's producer.
+
+```php
+public static function await(Future $future): mixed
+```
+
+PHPDoc:
+
+- `@template T`
+- `@param Future<T> $future`
+- `@return T`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Amp/AmpContext.php#L55)
+
+### `async()`
+
+Starts registered child work with the current temporal deadline.
+Greenlight cancels and joins the child before test cleanup.
+
+```php
+public static function async(\Closure $operation): Future
+```
+
+PHPDoc:
+
+- `@template T`
+- `@param \Closure(): T $operation`
+- `@return Future<T>`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Amp/AmpContext.php#L85)
+
+## `AmpPlugin`
+
+Namespace: `Greenlight\Amp`
+
+Connects test deadlines and temporal polling to the application's Revolt scheduler.
+Requires the optional amphp/amp 3.1 and revolt/event-loop 1.x packages.
+
+```php
+final class AmpPlugin implements TestAttemptLifecycle, TestAttemptRunner
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Amp/AmpPlugin.php#L17)
+
+### `runTestAttempt()`
+
+```php
+public function runTestAttempt(\Closure $attempt): mixed
+```
+
+PHPDoc:
+
+- `@template T`
+- `@param \Closure(): T $attempt`
+- `@return T`
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Amp/AmpPlugin.php#L29)
+
+### `enterTestAttempt()`
+
+```php
+public function enterTestAttempt(?float $deadline): void
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Amp/AmpPlugin.php#L56)
+
+### `leaveTestBody()`
+
+```php
+public function leaveTestBody(): void
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Amp/AmpPlugin.php#L62)
+
+### `leaveTestAttempt()`
+
+```php
+public function leaveTestAttempt(): void
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Amp/AmpPlugin.php#L68)
 
 ## `ContainerLifetime`
 

--- a/docs/api-plugins.md
+++ b/docs/api-plugins.md
@@ -536,6 +536,48 @@ public function transformTerminalResult(TestDefinition $definition, TestResult $
 
 [View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TerminalResultTransformer.php#L25)
 
+## `TestAttemptLifecycle`
+
+Namespace: `Greenlight\Plugin`
+
+Controls asynchronous work across the test body and its cleanup stages.
+Entry uses the monotonic test deadline, before constructor injection.
+If entry fails, the plugin releases all state that entry created.
+
+```php
+interface TestAttemptLifecycle extends Plugin
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestAttemptLifecycle.php#L12)
+
+### `enterTestAttempt()`
+
+```php
+public function enterTestAttempt(?float $deadline): void;
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestAttemptLifecycle.php#L14)
+
+### `leaveTestBody()`
+
+Stops and joins test-body work before After hooks and deferred cleanup.
+
+```php
+public function leaveTestBody(): void;
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestAttemptLifecycle.php#L17)
+
+### `leaveTestAttempt()`
+
+Releases attempt state after deferred cleanup and test-scope disposal.
+
+```php
+public function leaveTestAttempt(): void;
+```
+
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestAttemptLifecycle.php#L20)
+
 ## `TestAttemptRunner`
 
 Namespace: `Greenlight\Plugin`

--- a/docs/api.md
+++ b/docs/api.md
@@ -22,4 +22,4 @@ Use the task guides for workflows and examples. Use these pages for exact signat
 - [Integration fixture API](api-integration-fixtures.md) — This reference lists integration fixture definitions, contexts, resources, and sensitive values.
 - [Plugin API](api-plugins.md) — This reference lists plugin capabilities and lifecycle callback contracts.
 - [Reporter API](api-reporting.md) — This reference lists reporter and output contracts.
-- [Integration API](api-integrations.md) — This reference lists public integration types for Hyperf, Laravel, PSR standards, Rector, Symfony, and Tempest.
+- [Integration API](api-integrations.md) — This reference lists public integration types for Amp, Hyperf, Laravel, PSR standards, Rector, Symfony, and Tempest.

--- a/docs/attributes.md
+++ b/docs/attributes.md
@@ -394,6 +394,10 @@ An `eventually()` or `consistently()` matcher checks the current attempt
 deadline between probe calls. A blocked probe cannot check this deadline.
 Only process-pool execution provides the outer timeout for a blocked probe.
 
+The optional [Amp integration](amp.md) cancels supported asynchronous waits
+during construction, hooks, the body, and cleanup. It uses the existing attempt
+deadline. It joins registered child work before cleanup and retries.
+
 <!-- php-example {"mode":"display","reason":"Uses an ellipsis to omit code that is not relevant to the example."} -->
 ```php
 #[Test]

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -249,10 +249,14 @@ For both temporal chains, `pollEvery()` accepts a finite duration of at least
 0.001 seconds. `within()` and `for()` accept finite durations greater than zero.
 
 Each temporal matcher counts as one expectation. Temporal matchers check the
-test-attempt deadline between probe calls. These checks cannot interrupt a
-blocked probe. With process-pool execution, the orchestrator can stop the
-worker after the timeout grace period. In-process execution has no such
-protection. See [timeouts](attributes.md#timeout).
+test-attempt deadline between probe calls. The optional [Amp integration](amp.md)
+also cancels supported asynchronous waits inside probes. It lets other Amp
+tasks progress between polls.
+
+Deadline checks cannot interrupt blocking I/O or uninterrupted computation.
+With process-pool execution, the orchestrator can stop the worker after the
+timeout grace period. In-process execution has no such protection.
+See [timeouts](attributes.md#timeout).
 
 ## Explicit failures
 

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -627,6 +627,29 @@ the normal retry policy.
 The Hyperf bridge uses this capability to run each attempt in one Swoole
 coroutine. See [Hyperf applications](hyperf.md).
 
+### TestAttemptLifecycle
+
+Worker-side.
+
+This additive capability receives the precise attempt deadline before
+constructor injection. `TestAttemptRunner` keeps its existing callback interface.
+
+`enterTestAttempt(?float $deadline)` opens the scope. The deadline is an absolute
+monotonic time in seconds, or `null` when the test has no time limit.
+Do not restart the timeout budget in this callback.
+
+`leaveTestBody()` runs before `After` hooks, including when construction or the
+body fails. Cancel and join owned child work before this method returns.
+`leaveTestAttempt()` releases the scope after deferred cleanup and service
+disposal. Greenlight calls exit methods in reverse entry order.
+
+If entry fails, release partial state before the exception leaves the method.
+Greenlight closes only the scopes whose entry completed. Exit failures do not
+prevent the remaining scopes from closing.
+
+The [Amp integration](amp.md) uses this capability for native cancellation and
+child lifetimes.
+
 ### RetryDecider
 
 Worker-side.
@@ -879,6 +902,7 @@ Priority applies to these capabilities:
 * `WorkerBootstrapSubscriber`
 * `WorkerRuntimeRunner`
 * `TestAttemptRunner`
+* `TestAttemptLifecycle`
 * `BeforeTestSubscriber`
 * `AfterTestSubscriber`
 * `RetryDecider`

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -47,6 +47,8 @@ parameters:
         - greenlight.tempest-coverage.php
         - rector.php
         - rector.docs.php
+    stubFiles:
+        - tools/phpstan-stubs/amp.stub
     scanFiles:
         - stubs/tempest.stub.php
         - tools/phpstan-stubs/hyperf.php

--- a/src/Amp/AmpAttempt.php
+++ b/src/Amp/AmpAttempt.php
@@ -1,0 +1,199 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Amp;
+
+use Amp\Cancellation;
+use Amp\CancelledException;
+use Amp\DeferredCancellation;
+use Amp\Future;
+use Greenlight\Expect\ExpectationRuntime;
+use Greenlight\Test\CleanupFailed;
+
+/**
+ * Owns one attempt's deadline tokens and explicitly registered child work.
+ * It joins all children before the executor releases test resources.
+ *
+ * @internal
+ */
+final class AmpAttempt
+{
+    private bool $active = false;
+
+    private bool $bodyClosed = false;
+
+    private ?float $deadline = null;
+
+    private readonly DeferredCancellation $childrenCancellation;
+
+    private readonly AmpScopeCancelledError $scopeEnded;
+
+    /** @var list<Future<mixed>> */
+    private array $children = [];
+
+    /** @var array<int, \Throwable> */
+    private array $childFailures = [];
+
+    /** @var array<int, true> */
+    private array $observedChildren = [];
+
+    /** @var \WeakMap<AmpCancellation, null> */
+    private readonly \WeakMap $tokens;
+
+    public function __construct()
+    {
+        $this->childrenCancellation = new DeferredCancellation();
+        $this->scopeEnded = new AmpScopeCancelledError();
+        $this->tokens = new \WeakMap();
+    }
+
+    public function enter(?float $deadline): void
+    {
+        if ($this->active || $this->bodyClosed) {
+            throw AmpBridgeError::overlappingAttempts();
+        }
+
+        $this->deadline = $deadline;
+        $this->active = true;
+    }
+
+    public function assertActive(): void
+    {
+        if (!$this->active) {
+            throw AmpBridgeError::contextUnavailable();
+        }
+    }
+
+    public function childCancellation(): Cancellation
+    {
+        return $this->childrenCancellation->getCancellation();
+    }
+
+    public function cancellation(?float $temporalDeadline, bool $child): Cancellation
+    {
+        $this->assertActive();
+        $testDeadline = $this->deadline !== null
+            && ($temporalDeadline === null || $this->deadline <= $temporalDeadline);
+        $token = new AmpCancellation(
+            $testDeadline ? $this->deadline : $temporalDeadline,
+            $testDeadline,
+            $child ? $this->childrenCancellation->getCancellation() : null,
+        );
+        $this->tokens[$token] = null;
+
+        return $token;
+    }
+
+    /**
+     * @template T
+     *
+     * @param \Closure(): T $operation
+     *
+     * @return Future<T>
+     */
+    public function async(\Closure $operation, ?float $temporalDeadline): Future
+    {
+        $this->assertActive();
+
+        if ($this->bodyClosed) {
+            throw AmpBridgeError::bodyClosed();
+        }
+
+        $index = \count($this->children);
+        $future = \Amp\async(fn() => $this->runChild($operation, $temporalDeadline, $index));
+        $this->children[] = $future->ignore();
+
+        return $future;
+    }
+
+    /** @param Future<mixed> $future */
+    public function observe(Future $future, ?\Throwable $failure): void
+    {
+        $index = \array_search($future, $this->children, true);
+
+        if ($index !== false && $future->isComplete()
+            && (!$failure instanceof \Throwable || ($this->childFailures[$index] ?? null) === $failure)
+        ) {
+            $this->observedChildren[$index] = true;
+        }
+    }
+
+    public function leaveBody(): void
+    {
+        if ($this->bodyClosed) {
+            return;
+        }
+
+        $this->bodyClosed = true;
+        $this->childrenCancellation->cancel($this->scopeEnded);
+        $failures = [];
+
+        foreach ($this->children as $index => $child) {
+            try {
+                $child->await();
+            } catch (\Throwable $threw) {
+                if (!isset($this->observedChildren[$index]) && !$this->isScopeEnd($threw)) {
+                    $failures[] = $threw;
+                }
+            }
+        }
+
+        $this->children = [];
+        $this->childFailures = [];
+        $this->observedChildren = [];
+
+        if (\count($failures) === 1) {
+            throw $failures[0];
+        }
+
+        if ($failures !== []) {
+            throw CleanupFailed::fromFailures($failures);
+        }
+    }
+
+    public function close(): void
+    {
+        try {
+            $this->leaveBody();
+        } finally {
+            foreach ($this->tokens as $token => $_) {
+                $token->close();
+            }
+
+            $this->active = false;
+        }
+    }
+
+    private function isScopeEnd(\Throwable $threw): bool
+    {
+        return $threw instanceof CancelledException && $threw->getPrevious() === $this->scopeEnded;
+    }
+
+    /**
+     * @template T
+     *
+     * @param \Closure(): T $operation
+     *
+     * @return T
+     */
+    private function runChild(\Closure $operation, ?float $temporalDeadline, int $index): mixed
+    {
+        try {
+            return AmpContext::withScope(
+                new AmpScope($this, true),
+                function () use ($operation, $temporalDeadline) {
+                    $this->cancellation($temporalDeadline, true)->throwIfRequested();
+
+                    return $temporalDeadline === null
+                        ? $operation()
+                        : ExpectationRuntime::withDeadline($temporalDeadline, $operation);
+                },
+            );
+        } catch (\Throwable $threw) {
+            $this->childFailures[$index] = $threw;
+
+            throw $threw;
+        }
+    }
+}

--- a/src/Amp/AmpBridgeError.php
+++ b/src/Amp/AmpBridgeError.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Amp;
+
+/**
+ * Reports an unavailable Amp dependency or an invalid attempt context.
+ *
+ * @internal
+ */
+final class AmpBridgeError extends \RuntimeException
+{
+    private function __construct(string $message)
+    {
+        parent::__construct($message);
+    }
+
+    public static function runtimeUnavailable(): self
+    {
+        return new self('AmpPlugin requires amphp/amp ^3.1 and revolt/event-loop ^1.0. Install these packages before you activate the plugin.');
+    }
+
+    public static function contextUnavailable(): self
+    {
+        return new self('AmpContext requires an active AmpPlugin attempt. Create child work with AmpContext::async() or pass a cancellation token explicitly.');
+    }
+
+    public static function overlappingAttempts(): self
+    {
+        return new self('AmpPlugin cannot run overlapping test attempts. Complete the active attempt before you start another attempt.');
+    }
+
+    public static function bodyClosed(): self
+    {
+        return new self('AmpContext::async() cannot create child work after the test body ends. Complete child work before cleanup.');
+    }
+
+}

--- a/src/Amp/AmpCancellation.php
+++ b/src/Amp/AmpCancellation.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Amp;
+
+use Amp\Cancellation;
+use Amp\CancelledException;
+use Amp\CompositeCancellation;
+use Amp\DeferredCancellation;
+use Greenlight\Test\DeadlineExceededError;
+use Revolt\EventLoop;
+
+/**
+ * Converts an absolute deadline to native Amp cancellation.
+ * The token owns its timer and releases it when the token or attempt ends.
+ *
+ * @internal
+ */
+final class AmpCancellation implements Cancellation
+{
+    private readonly DeferredCancellation $source;
+
+    private readonly Cancellation $cancellation;
+
+    private ?string $timer = null;
+
+    /** @var array<string, true> */
+    private array $subscriptions = [];
+
+    public function __construct(
+        private readonly ?float $deadline,
+        private readonly bool $testDeadline,
+        ?Cancellation $scopeEnd,
+    ) {
+        $this->source = new DeferredCancellation();
+        $this->cancellation = $scopeEnd instanceof Cancellation
+            ? new CompositeCancellation($this->source->getCancellation(), $scopeEnd)
+            : $this->source->getCancellation();
+
+        if ($deadline === null) {
+            return;
+        }
+
+        $remaining = $deadline - \hrtime(true) / 1_000_000_000;
+
+        if ($remaining <= 0.0) {
+            $this->expire();
+
+            return;
+        }
+
+        $source = $this->source;
+        $timer = &$this->timer;
+        $this->timer = EventLoop::delay($remaining, static function () use ($source, $testDeadline, &$timer): void {
+            $timer = null;
+            $source->cancel($testDeadline ? DeadlineExceededError::forTest() : DeadlineExceededError::forTemporal());
+        });
+        EventLoop::unreference($this->timer);
+    }
+
+    public function __destruct()
+    {
+        $this->cancelTimer();
+    }
+
+    /** @param \Closure(CancelledException): mixed $callback */
+    #[\Override]
+    public function subscribe(\Closure $callback): string
+    {
+        $this->refresh();
+        $id = $this->cancellation->subscribe($callback);
+        $this->subscriptions[$id] = true;
+
+        if ($this->timer !== null) {
+            EventLoop::reference($this->timer);
+        }
+
+        return $id;
+    }
+
+    #[\Override]
+    public function unsubscribe(string $id): void
+    {
+        $this->cancellation->unsubscribe($id);
+        unset($this->subscriptions[$id]);
+
+        if ($this->subscriptions === [] && $this->timer !== null) {
+            EventLoop::unreference($this->timer);
+        }
+    }
+
+    #[\Override]
+    public function isRequested(): bool
+    {
+        $this->refresh();
+
+        return $this->cancellation->isRequested();
+    }
+
+    #[\Override]
+    public function throwIfRequested(): void
+    {
+        $this->refresh();
+        $this->cancellation->throwIfRequested();
+    }
+
+    public function close(): void
+    {
+        $this->cancelTimer();
+        $this->source->cancel(new AmpScopeCancelledError());
+    }
+
+    private function refresh(): void
+    {
+        if ($this->deadline !== null && \hrtime(true) / 1_000_000_000 >= $this->deadline) {
+            $this->expire();
+        }
+    }
+
+    private function expire(): void
+    {
+        $this->cancelTimer();
+        $this->source->cancel($this->testDeadline ? DeadlineExceededError::forTest() : DeadlineExceededError::forTemporal());
+    }
+
+    private function cancelTimer(): void
+    {
+        if ($this->timer !== null) {
+            EventLoop::cancel($this->timer);
+            $this->timer = null;
+        }
+    }
+}

--- a/src/Amp/AmpContext.php
+++ b/src/Amp/AmpContext.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Amp;
+
+use Amp\Cancellation;
+use Amp\Future;
+use Greenlight\Expect\ExpectationRuntime;
+
+/**
+ * Supplies deadline cancellation and child work for an AmpPlugin test attempt.
+ * Native Amp operations must receive cancellation explicitly.
+ */
+final class AmpContext
+{
+    private static ?AmpScope $mainScope = null;
+
+    /** @var \WeakMap<object, AmpScope>|null */
+    private static ?\WeakMap $fiberScopes = null;
+
+    /** @codeCoverageIgnore */
+    private function __construct() {}
+
+    /**
+     * Returns a native token for the current absolute deadline.
+     * A child also receives cancellation when the test body ends.
+     */
+    public static function cancellation(): Cancellation
+    {
+        $scope = self::scope();
+
+        return $scope->attempt->cancellation(ExpectationRuntime::enclosingDeadline(), $scope->child);
+    }
+
+    /** Yields to Revolt until the delay completes or the current deadline expires. */
+    public static function delay(float $seconds): void
+    {
+        $cancellation = self::cancellation();
+        $cancellation->throwIfRequested();
+        \Amp\delay($seconds, cancellation: $cancellation);
+        $cancellation->throwIfRequested();
+    }
+
+    /**
+     * Waits for a future within the current deadline.
+     * Cancellation stops this wait. It does not stop the future's producer.
+     *
+     * @template T
+     *
+     * @param Future<T> $future
+     *
+     * @return T
+     */
+    public static function await(Future $future): mixed
+    {
+        $scope = self::scope();
+        $cancellation = self::cancellation();
+        $cancellation->throwIfRequested();
+
+        try {
+            $value = $future->await($cancellation);
+        } catch (\Throwable $failure) {
+            $scope->attempt->observe($future, $failure);
+
+            throw $failure;
+        }
+
+        $scope->attempt->observe($future, null);
+        $cancellation->throwIfRequested();
+
+        return $value;
+    }
+
+    /**
+     * Starts registered child work with the current temporal deadline.
+     * Greenlight cancels and joins the child before test cleanup.
+     *
+     * @template T
+     *
+     * @param \Closure(): T $operation
+     *
+     * @return Future<T>
+     */
+    public static function async(\Closure $operation): Future
+    {
+        return self::scope()->attempt->async($operation, ExpectationRuntime::enclosingDeadline());
+    }
+
+    /**
+     * Returns scope-end cancellation for a managed child's temporal polling.
+     *
+     * @internal
+     */
+    public static function pollingCancellation(): ?Cancellation
+    {
+        $fiber = \Fiber::getCurrent();
+        $scope = $fiber instanceof \Fiber ? (self::$fiberScopes[$fiber] ?? null) : self::$mainScope;
+
+        return $scope instanceof AmpScope && $scope->child ? $scope->attempt->childCancellation() : null;
+    }
+
+    /**
+     * Runs an operation in an explicit Amp attempt scope.
+     *
+     * @internal
+     *
+     * @template T
+     *
+     * @param \Closure(): T $operation
+     *
+     * @return T
+     */
+    public static function withScope(AmpScope $scope, \Closure $operation): mixed
+    {
+        $fiber = \Fiber::getCurrent();
+        $scopes = self::$fiberScopes ??= new \WeakMap();
+        $previous = $fiber instanceof \Fiber ? ($scopes[$fiber] ?? null) : self::$mainScope;
+
+        if ($fiber instanceof \Fiber) {
+            $scopes[$fiber] = $scope;
+        } else {
+            self::$mainScope = $scope;
+        }
+
+        try {
+            return $operation();
+        } finally {
+            if (!$fiber instanceof \Fiber) {
+                self::$mainScope = $previous;
+            } elseif ($previous === null) {
+                unset($scopes[$fiber]);
+            } else {
+                $scopes[$fiber] = $previous;
+            }
+        }
+    }
+
+    private static function scope(): AmpScope
+    {
+        $fiber = \Fiber::getCurrent();
+        $scope = $fiber instanceof \Fiber ? (self::$fiberScopes[$fiber] ?? null) : self::$mainScope;
+
+        if (!$scope instanceof AmpScope) {
+            throw AmpBridgeError::contextUnavailable();
+        }
+
+        $scope->attempt->assertActive();
+
+        return $scope;
+    }
+}

--- a/src/Amp/AmpPlugin.php
+++ b/src/Amp/AmpPlugin.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Amp;
+
+use Amp\DeferredCancellation;
+use Greenlight\Expect\ExpectationRuntime;
+use Greenlight\Plugin\TestAttemptLifecycle;
+use Greenlight\Plugin\TestAttemptRunner;
+use Revolt\EventLoop;
+
+/**
+ * Connects test deadlines and temporal polling to the application's Revolt scheduler.
+ * Requires the optional amphp/amp 3.1 and revolt/event-loop 1.x packages.
+ */
+final class AmpPlugin implements TestAttemptLifecycle, TestAttemptRunner
+{
+    private ?AmpAttempt $attempt = null;
+
+    /**
+     * @template T
+     *
+     * @param \Closure(): T $attempt
+     *
+     * @return T
+     */
+    #[\Override]
+    public function runTestAttempt(\Closure $attempt): mixed
+    {
+        if (!\class_exists(DeferredCancellation::class) || !\class_exists(EventLoop::class) || !\function_exists('Amp\\delay')) {
+            throw AmpBridgeError::runtimeUnavailable();
+        }
+
+        if ($this->attempt instanceof AmpAttempt) {
+            throw AmpBridgeError::overlappingAttempts();
+        }
+
+        $this->attempt = $state = new AmpAttempt();
+
+        try {
+            return ExpectationRuntime::withClock(
+                new AmpPollingClock(),
+                static fn(): mixed => AmpContext::withScope(new AmpScope($state, false), $attempt),
+            );
+        } finally {
+            try {
+                $state->close();
+            } finally {
+                $this->attempt = null;
+            }
+        }
+    }
+
+    #[\Override]
+    public function enterTestAttempt(?float $deadline): void
+    {
+        $this->state()->enter($deadline);
+    }
+
+    #[\Override]
+    public function leaveTestBody(): void
+    {
+        $this->state()->leaveBody();
+    }
+
+    #[\Override]
+    public function leaveTestAttempt(): void
+    {
+        $this->state()->close();
+    }
+
+    private function state(): AmpAttempt
+    {
+        return $this->attempt ?? throw AmpBridgeError::contextUnavailable();
+    }
+}

--- a/src/Amp/AmpPollingClock.php
+++ b/src/Amp/AmpPollingClock.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Amp;
+
+use Greenlight\Expect\PollingClock;
+
+/**
+ * Supplies monotonic time and yields to the application's Revolt scheduler.
+ *
+ * @internal
+ */
+final readonly class AmpPollingClock implements PollingClock
+{
+    #[\Override]
+    public function now(): float
+    {
+        return \hrtime(true) / 1_000_000_000;
+    }
+
+    #[\Override]
+    public function sleep(float $seconds): void
+    {
+        if ($seconds > 0.0) {
+            $cancellation = AmpContext::pollingCancellation();
+            $cancellation?->throwIfRequested();
+            \Amp\delay($seconds, cancellation: $cancellation);
+        }
+    }
+}

--- a/src/Amp/AmpScope.php
+++ b/src/Amp/AmpScope.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Amp;
+
+/**
+ * Identifies the attempt and child-work boundary for one managed Fiber.
+ *
+ * @internal
+ */
+final readonly class AmpScope
+{
+    public function __construct(
+        public AmpAttempt $attempt,
+        public bool $child,
+    ) {}
+}

--- a/src/Amp/AmpScopeCancelledError.php
+++ b/src/Amp/AmpScopeCancelledError.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Amp;
+
+use Greenlight\Test\OperationCancelledError;
+
+/**
+ * Indicates that an attempt scope stopped an asynchronous operation.
+ *
+ * @internal
+ */
+final class AmpScopeCancelledError extends OperationCancelledError
+{
+    public function __construct()
+    {
+        parent::__construct('The Amp attempt scope has ended.');
+    }
+}

--- a/src/Execution/Plugin/WorkerPluginRuntime.php
+++ b/src/Execution/Plugin/WorkerPluginRuntime.php
@@ -17,6 +17,7 @@ use Greenlight\Plugin\Plugin;
 use Greenlight\Plugin\PluginDefinition;
 use Greenlight\Plugin\RetryDecider;
 use Greenlight\Plugin\TerminalResultTransformer;
+use Greenlight\Plugin\TestAttemptLifecycle;
 use Greenlight\Plugin\TestAttemptRunner;
 use Greenlight\Plugin\TestContext;
 use Greenlight\Plugin\WorkerBootstrapContext;
@@ -25,6 +26,7 @@ use Greenlight\Plugin\WorkerRuntimeRunner;
 use Greenlight\Result\FailureDetail;
 use Greenlight\Result\TestResult;
 use Greenlight\Result\ThrowableDetail;
+use Greenlight\Test\DeadlineExceededError;
 use Greenlight\Test\RetryPolicy;
 use Greenlight\Test\SkipTest;
 use Greenlight\Test\TestDefinition;
@@ -47,6 +49,7 @@ final readonly class WorkerPluginRuntime extends PluginRuntime
         RetryDecider::class,
         ServiceResolver::class,
         TerminalResultTransformer::class,
+        TestAttemptLifecycle::class,
         TestAttemptRunner::class,
         WorkerBootstrapSubscriber::class,
         WorkerRuntimeRunner::class,
@@ -152,6 +155,64 @@ final readonly class WorkerPluginRuntime extends PluginRuntime
         return $attempt();
     }
 
+    /** @return array{list<TestAttemptLifecycle>, ?\Throwable} */
+    public function enterTestAttempt(?float $deadline): array
+    {
+        $entered = [];
+
+        foreach ($this->ordered(TestAttemptLifecycle::class) as $lifecycle) {
+            try {
+                $lifecycle->enterTestAttempt($deadline);
+            } catch (\Throwable $failure) {
+                return [$entered, $failure];
+            }
+
+            $entered[] = $lifecycle;
+        }
+
+        return [$entered, null];
+    }
+
+    /**
+     * @param list<TestAttemptLifecycle> $entered
+     *
+     * @return list<\Throwable>
+     */
+    public function leaveTestBody(array $entered): array
+    {
+        $failures = [];
+
+        foreach (\array_reverse($entered) as $lifecycle) {
+            try {
+                $lifecycle->leaveTestBody();
+            } catch (\Throwable $failure) {
+                $failures[] = $failure;
+            }
+        }
+
+        return $failures;
+    }
+
+    /**
+     * @param list<TestAttemptLifecycle> $entered
+     *
+     * @return list<\Throwable>
+     */
+    public function leaveTestAttempt(array $entered): array
+    {
+        $failures = [];
+
+        foreach (\array_reverse($entered) as $lifecycle) {
+            try {
+                $lifecycle->leaveTestAttempt();
+            } catch (\Throwable $failure) {
+                $failures[] = $failure;
+            }
+        }
+
+        return $failures;
+    }
+
     /**
      * @throws SkipTest
      * @throws PluginRuntimeError
@@ -164,6 +225,10 @@ final readonly class WorkerPluginRuntime extends PluginRuntime
             } catch (SkipTest $skip) {
                 throw $skip;
             } catch (\Throwable $failure) {
+                if (DeadlineExceededError::find($failure) instanceof DeadlineExceededError) {
+                    throw $failure;
+                }
+
                 throw PluginRuntimeError::hookFailed($subscriber::class, 'beforeTest', $failure);
             }
         }

--- a/src/Execution/Worker/HarnessServiceDisposal.php
+++ b/src/Execution/Worker/HarnessServiceDisposal.php
@@ -9,6 +9,7 @@ use Greenlight\Harness\HarnessScopes;
 use Greenlight\Result\FailureDetail;
 use Greenlight\Result\TestResult;
 use Greenlight\Result\ThrowableDetail;
+use Greenlight\Test\DeadlineExceededError;
 
 /**
  * Applies harness service disposal failures to their test or worker boundary.
@@ -40,6 +41,15 @@ final readonly class HarnessServiceDisposal
 
         if (!$primary instanceof \Throwable) {
             throw new \LogicException('Harness service disposal failure list contains an invalid value.');
+        }
+
+        $deadline = DeadlineExceededError::find($primary);
+
+        if ($deadline instanceof DeadlineExceededError) {
+            return $result->failedByTeardown([
+                new FailureDetail($deadline->getMessage()),
+                ...self::secondaryDetails($failures),
+            ]);
         }
 
         if ($primary instanceof ExpectationFailed) {
@@ -99,6 +109,14 @@ final readonly class HarnessServiceDisposal
         $details = [];
 
         foreach ($failures as $failure) {
+            $deadline = DeadlineExceededError::find($failure);
+
+            if ($deadline instanceof DeadlineExceededError) {
+                $details[] = new FailureDetail($deadline->getMessage());
+
+                continue;
+            }
+
             if ($failure instanceof ExpectationFailed) {
                 $details = [...$details, ...$failure->details];
 

--- a/src/Execution/Worker/TestExecutor.php
+++ b/src/Execution/Worker/TestExecutor.php
@@ -12,7 +12,6 @@ use Greenlight\Discovery\Plan\PlanEntry;
 use Greenlight\Execution\Artifact\ArtifactStore;
 use Greenlight\Execution\Artifact\StagedAttachments;
 use Greenlight\Execution\Artifact\TestArtifactBudget;
-use Greenlight\Execution\Plugin\PluginRuntimeError;
 use Greenlight\Execution\Plugin\WorkerPluginRuntime;
 use Greenlight\Expect\ExpectationFailed;
 use Greenlight\Expect\ExpectationRuntime;
@@ -26,6 +25,7 @@ use Greenlight\Result\TestResult;
 use Greenlight\Result\ThrowableDetail;
 use Greenlight\Test\Cleanup;
 use Greenlight\Test\CleanupFailed;
+use Greenlight\Test\DeadlineExceededError;
 use Greenlight\Test\ExpectationCounter;
 use Greenlight\Test\SkipTest;
 use Greenlight\Test\TestId;
@@ -37,6 +37,7 @@ use Greenlight\Test\TestId;
  * - `beforeTest()` subscribers
  * - `Before` hooks
  * - The test method
+ * - Asynchronous work cleanup
  * - `After` hooks
  * - Deferred cleanup callbacks
  * - Test-scope teardown
@@ -120,13 +121,15 @@ final readonly class TestExecutor
             } catch (\Throwable $threw) {
                 $cause = $threw;
                 $attachments = null;
+                $deadline = DeadlineExceededError::find($threw);
                 $result = new TestResult(
                     $entry->id,
-                    Outcome::Errored,
+                    $deadline instanceof DeadlineExceededError ? Outcome::Failed : Outcome::Errored,
                     0.0,
                     0,
                     $attempt,
-                    error: ThrowableDetail::fromThrowable($threw),
+                    failures: $deadline instanceof DeadlineExceededError ? [new FailureDetail($deadline->getMessage())] : [],
+                    error: $deadline instanceof DeadlineExceededError ? null : ThrowableDetail::fromThrowable($threw),
                 );
             }
 
@@ -195,77 +198,90 @@ final readonly class TestExecutor
         $attachments = $stagedAttachments ?? new UnavailableAttachments();
         $cleanup = new Cleanup();
         $disposalFailures = [];
+        $lifecycles = [];
+        $recordFailure = static function (\Throwable $failure, string $secondaryMessage, bool $classifyExpectation = true) use (&$failures, &$cause, &$error, &$skipReason): void {
+            $primary = !$cause instanceof \Throwable;
+            $deadline = DeadlineExceededError::find($failure);
+
+            if ($primary) {
+                $cause = $failure;
+                $skipReason = null;
+            }
+
+            if ($deadline instanceof DeadlineExceededError) {
+                $failures[] = new FailureDetail($deadline->getMessage());
+            } elseif ($classifyExpectation && $failure instanceof ExpectationFailed) {
+                $failures = [...$failures, ...$failure->details];
+            } elseif ($primary) {
+                $error = ThrowableDetail::fromThrowable($failure);
+            } else {
+                $failures[] = new FailureDetail(\sprintf($secondaryMessage, $failure->getMessage()));
+            }
+        };
         $memoryBefore = \memory_get_usage(true);
         $startedAt = \hrtime(true);
         $capture?->start();
-        ExpectationRuntime::enterAttempt(
-            $execution->timeoutSeconds === null
-                ? null
-                : $startedAt / 1_000_000_000 + $execution->timeoutSeconds,
-        );
+        $deadline = $execution->timeoutSeconds === null
+            ? null
+            : $startedAt / 1_000_000_000 + $execution->timeoutSeconds;
+        ExpectationRuntime::enterAttempt($deadline);
 
         try {
-            $instance = $this->instantiate($definition->class, $attachments, $cleanup);
-            $context = new TestContext($instance, $entry->id, $definition, $this->scopes, $attachments);
-            $instance = null;
-
             try {
+                [$lifecycles, $entryFailure] = $this->plugins->enterTestAttempt($deadline);
+
+                if ($entryFailure instanceof \Throwable) {
+                    throw $entryFailure;
+                }
+
+                $instance = $this->instantiate($definition->class, $attachments, $cleanup);
+                $context = new TestContext($instance, $entry->id, $definition, $this->scopes, $attachments);
+                $instance = null;
                 $this->plugins->beforeTest($context);
+
+                foreach ($this->context->beforeHooks as $hook) {
+                    $hook->invoke($context->instance);
+                }
+
+                $arguments = [];
+
+                if ($entry->id->dataSetKey !== null) {
+                    $arguments = $this->context->argumentsFor(
+                        $definition->dataProvider->method,
+                        $definition->dataProvider->class,
+                        $definition->method,
+                        $entry->id->dataSetKey,
+                    );
+                }
+
+                $this->context->reflection->getMethod($definition->method)->invokeArgs($context->instance, $arguments);
             } catch (SkipTest $skip) {
-                $skipReason = $skip->reason;
-            } catch (PluginRuntimeError $failure) {
-                $cause = $failure;
-                $error = ThrowableDetail::fromThrowable($failure);
-            }
-
-            if ($skipReason === null && !$cause instanceof PluginRuntimeError) {
-                try {
-                    foreach ($this->context->beforeHooks as $hook) {
-                        $hook->invoke($context->instance);
-                    }
-
-                    $arguments = [];
-
-                    if ($entry->id->dataSetKey !== null) {
-                        $arguments = $this->context->argumentsFor(
-                            $definition->dataProvider->method,
-                            $definition->dataProvider->class,
-                            $definition->method,
-                            $entry->id->dataSetKey,
-                        );
-                    }
-
-                    $this->context->reflection->getMethod($definition->method)->invokeArgs($context->instance, $arguments);
-                } catch (SkipTest $skip) {
+                if ($context instanceof TestContext) {
                     $skipReason = $skip->reason;
-                } catch (ExpectationFailed $failed) {
-                    $failures = $failed->details;
-                    $cause = $failed;
-                } catch (\Throwable $threw) {
-                    $cause = $threw;
-                    $error = ThrowableDetail::fromThrowable($threw);
+                } else {
+                    $recordFailure($skip, 'Constructor caused an error: %s');
+                }
+            } catch (\Throwable $threw) {
+                $recordFailure($threw, 'Test body caused an error: %s', $context instanceof TestContext);
+            } finally {
+                foreach ($this->plugins->leaveTestBody($lifecycles) as $failure) {
+                    foreach ($failure instanceof CleanupFailed ? $failure->failures : [$failure] as $childFailure) {
+                        $recordFailure($childFailure, 'Test body cleanup caused an error: %s');
+                    }
                 }
             }
 
-            foreach ($this->context->afterHooks as $hook) {
-                try {
-                    $hook->invoke($context->instance);
-                } catch (\Throwable $threw) {
-                    if (!$cause instanceof \Throwable) {
-                        $cause = $threw;
-                        $skipReason = null;
-
-                        if ($threw instanceof ExpectationFailed) {
-                            $failures = $threw->details;
-                        } else {
-                            $error = ThrowableDetail::fromThrowable($threw);
+            if ($context instanceof TestContext) {
+                foreach ($this->context->afterHooks as $hook) {
+                    try {
+                        $hook->invoke($context->instance);
+                    } catch (\Throwable $threw) {
+                        if ($lifecycles !== [] || !$cause instanceof \Throwable) {
+                            $recordFailure($threw, 'After hook caused an error: %s');
                         }
                     }
                 }
             }
-        } catch (\Throwable $threw) {
-            $cause = $threw;
-            $error = ThrowableDetail::fromThrowable($threw);
         } finally {
             try {
                 $captured = $capture?->stop();
@@ -275,36 +291,18 @@ final readonly class TestExecutor
                         $cleanup->close();
                     } catch (CleanupFailed $cleanupFailed) {
                         foreach ($cleanupFailed->failures as $cleanupFailure) {
-                            if (!$cause instanceof \Throwable) {
-                                $cause = $cleanupFailure;
-                                $skipReason = null;
-
-                                if ($cleanupFailure instanceof ExpectationFailed) {
-                                    $failures = $cleanupFailure->details;
-                                } else {
-                                    $error = ThrowableDetail::fromThrowable($cleanupFailure);
-                                }
-
-                                continue;
-                            }
-
-                            if ($cleanupFailure instanceof ExpectationFailed) {
-                                $failures = [...$failures, ...$cleanupFailure->details];
-
-                                continue;
-                            }
-
-                            $failures[] = new FailureDetail(\sprintf(
-                                'Cleanup callback caused an error: %s',
-                                $cleanupFailure->getMessage(),
-                            ));
+                            $recordFailure($cleanupFailure, 'Cleanup callback caused an error: %s');
                         }
                     }
                 } finally {
                     try {
                         $disposalFailures = $this->scopes->closeTest();
                     } finally {
-                        ExpectationRuntime::leaveAttempt();
+                        try {
+                            $disposalFailures = [...$disposalFailures, ...$this->plugins->leaveTestAttempt($lifecycles)];
+                        } finally {
+                            ExpectationRuntime::leaveAttempt();
+                        }
                     }
                 }
             }

--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -7,6 +7,7 @@ namespace Greenlight\Expect;
 use Greenlight\Internal\Php\ErrorTrap;
 use Greenlight\Result\FailureDetail;
 use Greenlight\Test\ExpectationCounter;
+use Greenlight\Test\OperationCancelledError;
 
 /**
  * A fluent matcher chain for one subject value.
@@ -828,6 +829,12 @@ final class Expectation
         try {
             ($this->subject)();
         } catch (\Throwable $caught) {
+            $cancellation = OperationCancelledError::find($caught);
+
+            if ($cancellation instanceof OperationCancelledError) {
+                throw $caught;
+            }
+
             $thrown = $caught;
         }
 

--- a/src/Expect/TemporalExpectation.php
+++ b/src/Expect/TemporalExpectation.php
@@ -7,6 +7,7 @@ namespace Greenlight\Expect;
 use Greenlight\Result\FailureDetail;
 use Greenlight\Result\SourceLocation;
 use Greenlight\Test\ExpectationCounter;
+use Greenlight\Test\OperationCancelledError;
 
 /**
  * Contains the matcher dispatch and probe operations for eventual and
@@ -139,6 +140,12 @@ abstract class TemporalExpectation
         try {
             $subject = ($this->probe)();
         } catch (\Exception $exception) {
+            $cancellation = OperationCancelledError::find($exception);
+
+            if ($cancellation instanceof OperationCancelledError) {
+                throw $exception;
+            }
+
             if (!\array_any(
                 $retryOnExceptions,
                 static fn(string $type): bool => $exception instanceof $type,

--- a/src/Plugin/TestAttemptLifecycle.php
+++ b/src/Plugin/TestAttemptLifecycle.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Plugin;
+
+/**
+ * Controls asynchronous work across the test body and its cleanup stages.
+ * Entry uses the monotonic test deadline, before constructor injection.
+ * If entry fails, the plugin releases all state that entry created.
+ */
+interface TestAttemptLifecycle extends Plugin
+{
+    public function enterTestAttempt(?float $deadline): void;
+
+    /** Stops and joins test-body work before After hooks and deferred cleanup. */
+    public function leaveTestBody(): void;
+
+    /** Releases attempt state after deferred cleanup and test-scope disposal. */
+    public function leaveTestAttempt(): void;
+}

--- a/src/Test/CleanupFailed.php
+++ b/src/Test/CleanupFailed.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Test;
 
 /**
- * One or more cleanup callbacks failed.
+ * One or more cleanup operations failed.
  *
  * @internal
  */

--- a/src/Test/DeadlineExceededError.php
+++ b/src/Test/DeadlineExceededError.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Test;
+
+/**
+ * Indicates that a test or temporal expectation deadline stopped an asynchronous operation.
+ *
+ * @internal
+ */
+final class DeadlineExceededError extends OperationCancelledError
+{
+    private function __construct(public readonly bool $testDeadline)
+    {
+        parent::__construct($testDeadline
+            ? 'The test time limit stopped an asynchronous operation.'
+            : 'The temporal expectation time limit stopped an asynchronous operation.');
+    }
+
+    public static function forTest(): self
+    {
+        return new self(true);
+    }
+
+    public static function forTemporal(): self
+    {
+        return new self(false);
+    }
+}

--- a/src/Test/ExpectationCounter.php
+++ b/src/Test/ExpectationCounter.php
@@ -16,6 +16,7 @@ namespace Greenlight\Test;
  * The static counter supports the design. Harness service factories do not
  * receive a resolver. Each worker runs one test attempt at a time. The executor
  * controls the reset and read operations.
+ * Suppression applies only to the current Fiber or the main context.
  *
  * @internal
  */
@@ -23,7 +24,12 @@ final class ExpectationCounter
 {
     private static int $count = 0;
 
-    private static int $suppressionDepth = 0;
+    private static int $mainSuppressionDepth = 0;
+
+    /** @var \WeakMap<object, int>|null */
+    private static ?\WeakMap $fiberSuppressionDepths = null;
+
+    private static int $generation = 0;
 
     /** @codeCoverageIgnore */
     private function __construct() {}
@@ -31,18 +37,20 @@ final class ExpectationCounter
     public static function reset(): void
     {
         self::$count = 0;
-        self::$suppressionDepth = 0;
+        self::$mainSuppressionDepth = 0;
+        self::$fiberSuppressionDepths = null;
+        ++self::$generation;
     }
 
     public static function increment(): void
     {
-        if (self::$suppressionDepth === 0) {
+        if (self::suppressionDepth() === 0) {
             ++self::$count;
         }
     }
 
     /**
-     * Runs an operation without a change to the expectation count.
+     * Excludes the current context's expectations from the count during an operation.
      *
      * @internal
      *
@@ -54,12 +62,29 @@ final class ExpectationCounter
      */
     public static function withoutCounting(\Closure $operation): mixed
     {
-        ++self::$suppressionDepth;
+        $fiber = \Fiber::getCurrent();
+        $previous = self::suppressionDepth();
+        $generation = self::$generation;
+        $fiberSuppressionDepths = self::$fiberSuppressionDepths ??= new \WeakMap();
+
+        if (!$fiber instanceof \Fiber) {
+            self::$mainSuppressionDepth = $previous + 1;
+        } else {
+            $fiberSuppressionDepths[$fiber] = $previous + 1;
+        }
 
         try {
             return $operation();
         } finally {
-            --self::$suppressionDepth;
+            if (self::$generation === $generation) {
+                if (!$fiber instanceof \Fiber) {
+                    self::$mainSuppressionDepth = $previous;
+                } elseif ($previous === 0) {
+                    unset($fiberSuppressionDepths[$fiber]);
+                } else {
+                    $fiberSuppressionDepths[$fiber] = $previous;
+                }
+            }
         }
     }
 
@@ -69,5 +94,14 @@ final class ExpectationCounter
     public static function count(): int
     {
         return \max(0, self::$count);
+    }
+
+    private static function suppressionDepth(): int
+    {
+        $fiber = \Fiber::getCurrent();
+
+        return $fiber instanceof \Fiber
+            ? (self::$fiberSuppressionDepths[$fiber] ?? 0)
+            : self::$mainSuppressionDepth;
     }
 }

--- a/src/Test/OperationCancelledError.php
+++ b/src/Test/OperationCancelledError.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Test;
+
+/**
+ * Indicates that Greenlight stopped an operation at a deadline or lifecycle boundary.
+ * Expectation matchers propagate this cancellation through exception wrappers.
+ *
+ * @internal
+ */
+abstract class OperationCancelledError extends \RuntimeException
+{
+    public static function find(\Throwable $failure): ?static
+    {
+        do {
+            if ($failure instanceof static) {
+                return $failure;
+            }
+
+            $failure = $failure->getPrevious();
+        } while ($failure instanceof \Throwable);
+
+        return null;
+    }
+}

--- a/tests/Acceptance/AmpDeadlineRunTest.php
+++ b/tests/Acceptance/AmpDeadlineRunTest.php
@@ -1,0 +1,380 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\DataRow;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\AcceptanceProject;
+use Greenlight\Tests\Support\GreenlightCli;
+use Greenlight\Tests\Support\PhpSubprocess;
+
+final readonly class AmpDeadlineRunTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function synchronousExpectationsWorkWithoutTheOptionalRuntime(): void
+    {
+        $root = \dirname(__DIR__, 2);
+        $result = PhpSubprocess::run($root, ['-r', <<<'PHP'
+            spl_autoload_register(static function (string $class): void {
+                if (str_starts_with($class, 'Greenlight\\')) {
+                    $file = getcwd() . '/src/' . str_replace('\\', '/', substr($class, strlen('Greenlight\\'))) . '.php';
+
+                    if (is_file($file)) {
+                        require $file;
+                    }
+                }
+            });
+
+            Greenlight\Expect\Expect::eventually(static fn(): bool => true)->within(0.010)->toBeTrue();
+
+            try {
+                (new Greenlight\Amp\AmpPlugin())->runTestAttempt(static fn(): bool => true);
+                exit(2);
+            } catch (RuntimeException $failure) {
+                echo $failure->getMessage();
+            }
+            PHP]);
+
+        Expect::that($result->exitCode)->toBe(0);
+        Expect::that($result->output())->toContain('AmpPlugin requires amphp/amp ^3.1 and revolt/event-loop ^1.0.');
+    }
+
+    #[Test]
+    #[DataRow(['constructor'])]
+    #[DataRow(['subscriber'])]
+    #[DataRow(['before'])]
+    #[DataRow(['body'])]
+    #[DataRow(['after'])]
+    #[DataRow(['cleanup'])]
+    #[DataRow(['dispose'])]
+    public function supportedWaitsFailAtTheDeadlineAcrossTheLifecycle(string $phase): void
+    {
+        $project = $this->project('amp-lifecycle-' . $phase, \str_replace('__PHASE__', $phase, <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace AmpLifecycleProbe;
+
+            use Greenlight\Amp\AmpContext;
+            use Greenlight\Attribute\After;
+            use Greenlight\Attribute\Before;
+            use Greenlight\Attribute\Test;
+            use Greenlight\Attribute\Timeout;
+            use Greenlight\Expect\Expect;
+            use Greenlight\Harness\Disposable;
+            use Greenlight\Harness\Scope;
+            use Greenlight\Harness\ServiceDefinition;
+            use Greenlight\Plugin\BeforeTestSubscriber;
+            use Greenlight\Plugin\HarnessProvider;
+            use Greenlight\Plugin\TestContext;
+            use Greenlight\Test\Cleanup;
+
+            final class Trace
+            {
+                public static function record(string $phase): void
+                {
+                    \file_put_contents(__DIR__ . '/../trace', $phase . "\n", FILE_APPEND);
+
+                    if ($phase === '__PHASE__') {
+                        AmpContext::delay(10.0);
+                        \file_put_contents(__DIR__ . '/../trace', "overran\n", FILE_APPEND);
+                    }
+                }
+            }
+
+            final class Resource implements Disposable
+            {
+                public function touch(): void {}
+
+                public function dispose(): void
+                {
+                    Trace::record('dispose');
+                }
+            }
+
+            final class FixturePlugin implements BeforeTestSubscriber, HarnessProvider
+            {
+                public function beforeTest(TestContext $context): void
+                {
+                    Trace::record('subscriber');
+                }
+
+                public function services(): array
+                {
+                    return [new ServiceDefinition(Resource::class, Scope::PerTest, static fn() => new Resource())];
+                }
+            }
+
+            final class DeadlineTest
+            {
+                public function __construct(Cleanup $cleanup, Resource $resource)
+                {
+                    $cleanup->defer(static fn() => Trace::record('cleanup'));
+                    $resource->touch();
+                    Trace::record('constructor');
+                }
+
+                #[Before]
+                public function before(): void
+                {
+                    Trace::record('before');
+                }
+
+                #[After]
+                public function after(): void
+                {
+                    Trace::record('after');
+                }
+
+                #[Test]
+                #[Timeout(0.100)]
+                public function stops(): void
+                {
+                    Trace::record('body');
+                    Expect::that(true)->toBeTrue();
+                }
+            }
+            PHP), 'static fn(): \AmpLifecycleProbe\FixturePlugin => new \AmpLifecycleProbe\FixturePlugin(),');
+
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=plain']);
+
+        $output = $result->output();
+        Expect::that($result->exitCode)->because($output === '' ? 'The subprocess returned no output.' : $output)->toBe(1);
+        Expect::that($result->output())->toContain('1 failed')->not()->toContain('1 errored');
+        Expect::that($result->output())->toContain('test time limit stopped an asynchronous operation');
+        $trace = (string) \file_get_contents($project->path('trace'));
+        Expect::that($trace)->not()->toContain('overran');
+        Expect::that(\substr_count($trace, "cleanup\n"))->toBe(1);
+        Expect::that(\substr_count($trace, "dispose\n"))->toBe(1);
+        Expect::that(\substr_count($trace, "after\n"))->toBe($phase === 'constructor' ? 0 : 1);
+    }
+
+    #[Test]
+    public function aTemporalDeadlineCancelsAProbeWithoutRetryingItsCancellation(): void
+    {
+        $project = $this->project('amp-temporal', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Amp\AmpContext;
+            use Greenlight\Attribute\Test;
+            use Greenlight\Attribute\Timeout;
+            use Greenlight\Expect\Expect;
+
+            final class DeadlineTest
+            {
+                #[Test]
+                #[Timeout(2.0)]
+                public function stopsTheProbe(): void
+                {
+                    Expect::eventually(static function (): bool {
+                        \file_put_contents(__DIR__ . '/../trace', "probe\n", FILE_APPEND);
+                        AmpContext::delay(10.0);
+
+                        return true;
+                    })->retryOnException(\Exception::class)->within(0.050)->toBeTrue();
+                }
+            }
+            PHP);
+
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=plain']);
+
+        Expect::that($result->exitCode)->toBe(1);
+        Expect::that($result->output())->toContain('temporal expectation time limit')->toContain('1 failed');
+        Expect::that($result->output())->not()->toContain('test time limit');
+        Expect::that(\file_get_contents($project->path('trace')))->toBe("probe\n");
+    }
+
+    #[Test]
+    public function retriesJoinChildrenBeforeCleanupAndReceiveAFreshDeadline(): void
+    {
+        $project = $this->project('amp-retry', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Amp\AmpContext;
+            use Greenlight\Attribute\After;
+            use Greenlight\Attribute\Retry;
+            use Greenlight\Attribute\Test;
+            use Greenlight\Attribute\Timeout;
+            use Greenlight\Expect\Expect;
+            use Greenlight\Test\Cleanup;
+
+            final class DeadlineTest
+            {
+                private static int $attempt = 0;
+                private static bool $activeChild = false;
+
+                public function __construct(Cleanup $cleanup)
+                {
+                    ++self::$attempt;
+                    Expect::that(self::$activeChild)->toBeFalse();
+                    self::record('construct');
+                    $cleanup->defer(static fn() => self::record('cleanup'));
+                }
+
+                #[After]
+                public function after(): void
+                {
+                    Expect::that(self::$activeChild)->toBeFalse();
+                    self::record('after');
+                }
+
+                #[Test]
+                #[Retry(1)]
+                #[Timeout(0.150)]
+                public function completesTheSecondAttempt(): void
+                {
+                    if (self::$attempt === 2) {
+                        AmpContext::delay(0.020);
+                        Expect::that(self::$activeChild)->toBeFalse();
+                        self::record('pass');
+
+                        return;
+                    }
+
+                    AmpContext::async(static function (): void {
+                        self::$activeChild = true;
+                        self::record('child');
+
+                        try {
+                            AmpContext::delay(10.0);
+                        } finally {
+                            // This uncancelled wait proves that the join waits for child cleanup.
+                            \Amp\delay(0.020);
+                            self::$activeChild = false;
+                            self::record('joined');
+                        }
+                    });
+                    AmpContext::delay(10.0);
+                }
+
+                private static function record(string $phase): void
+                {
+                    \file_put_contents(__DIR__ . '/../trace', self::$attempt . ':' . $phase . "\n", FILE_APPEND);
+                }
+            }
+            PHP);
+
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=plain']);
+
+        $output = $result->output();
+        Expect::that($result->exitCode)->because($output === '' ? 'The subprocess returned no output.' : $output)->toBe(0);
+        Expect::that($result->output())->toContain('1 passed');
+        Expect::that(\file_get_contents($project->path('trace')))->toBe(
+            "1:construct\n1:child\n1:joined\n1:after\n1:cleanup\n2:construct\n2:pass\n2:after\n2:cleanup\n",
+        );
+    }
+
+    #[Test]
+    public function cleanupCancellationKeepsAnEarlierFailureAndRunsRemainingCallbacks(): void
+    {
+        $project = $this->project('amp-cleanup-failure', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Amp\AmpContext;
+            use Greenlight\Attribute\Test;
+            use Greenlight\Attribute\Timeout;
+            use Greenlight\Expect\Fail;
+            use Greenlight\Test\Cleanup;
+
+            final class DeadlineTest
+            {
+                public function __construct(Cleanup $cleanup)
+                {
+                    $cleanup->defer(static fn() => \file_put_contents(__DIR__ . '/../trace', 'closed'));
+                    $cleanup->defer(static fn() => AmpContext::delay(10.0));
+                }
+
+                #[Test]
+                #[Timeout(0.100)]
+                public function failsBeforeCleanup(): void
+                {
+                    Fail::because('The original assertion failed.');
+                }
+            }
+            PHP);
+
+        $result = GreenlightCli::run($project->directory, ['run', '--reporter=plain']);
+
+        Expect::that($result->exitCode)->toBe(1);
+        Expect::that($result->output())->toContain('The original assertion failed.')
+            ->toContain('test time limit stopped an asynchronous operation')->toContain('1 failed');
+        Expect::that(\file_get_contents($project->path('trace')))->toBe('closed');
+    }
+
+    #[Test]
+    public function processEnforcementStillContainsAChildThatIgnoresCancellation(): void
+    {
+        $project = $this->project('amp-process-timeout', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Amp\AmpContext;
+            use Greenlight\Attribute\Test;
+            use Greenlight\Attribute\Timeout;
+            use Greenlight\Expect\Expect;
+
+            final class DeadlineTest
+            {
+                #[Test]
+                #[Timeout(0.050)]
+                public function blocks(): void
+                {
+                    AmpContext::async(static fn() => \sleep(10));
+                    AmpContext::delay(10.0);
+                }
+
+                #[Test]
+                public function recoversAfterTheBlockedTest(): void
+                {
+                    Expect::that(true)->toBeTrue();
+                }
+            }
+            PHP);
+
+        $result = GreenlightCli::run($project->directory, ['run', '--workers=2', '--reporter=plain']);
+
+        Expect::that($result->exitCode)->toBe(1);
+        Expect::that($result->output())->toContain('exceeded its 0.050-second time limit');
+        Expect::that($result->output())->toContain('1 passed')->toContain('1 failed');
+    }
+
+    private function project(string $name, string $source, string $extraPlugin = ''): AcceptanceProject
+    {
+        $project = AcceptanceProject::create($this->tempDirectory, $name);
+        $project->writeFile('tests/DeadlineTest.php', $source);
+        $project->writeFile('greenlight.php', \str_replace('__EXTRA_PLUGIN__', $extraPlugin, <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            use Greenlight\Amp\AmpPlugin;
+            use Greenlight\Config\GreenlightConfig;
+
+            require_once __DIR__ . '/tests/DeadlineTest.php';
+
+            return GreenlightConfig::create()
+                ->paths([__DIR__ . '/tests'])
+                ->workers(1)
+                ->plugins(
+                    static fn(): AmpPlugin => new AmpPlugin(),
+                    __EXTRA_PLUGIN__
+                );
+            PHP));
+
+        return $project;
+    }
+}

--- a/tests/Unit/Amp/AmpContextTest.php
+++ b/tests/Unit/Amp/AmpContextTest.php
@@ -1,0 +1,471 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Amp;
+
+use Amp\Cancellation;
+use Amp\CancelledException;
+use Amp\DeferredFuture;
+use Greenlight\Amp\AmpBridgeError;
+use Greenlight\Amp\AmpContext;
+use Greenlight\Amp\AmpPlugin;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\ExpectationFailed;
+use Greenlight\Expect\ExpectationRuntime;
+use Greenlight\Test\DeadlineExceededError;
+use Greenlight\Test\ExpectationCounter;
+use Revolt\EventLoop;
+
+final class AmpContextTest
+{
+    #[Test]
+    public function otherFibersProgressDuringTemporalPolling(): void
+    {
+        $ready = false;
+
+        self::attempt(static function () use (&$ready): void {
+            AmpContext::async(static function () use (&$ready): void {
+                AmpContext::delay(0.005);
+                $ready = true;
+            });
+
+            Expect::eventually(static function () use (&$ready): bool {
+                return $ready;
+            })
+                ->pollEvery(0.001)
+                ->within(0.100)
+                ->toBeTrue();
+        });
+
+        Expect::that($ready)->toBeTrue();
+    }
+
+    #[Test]
+    public function registeredChildrenReceiveTheSameShorterTemporalDeadline(): void
+    {
+        $parentDeadline = null;
+        $childDeadline = null;
+        $nestedDeadline = null;
+        $finished = false;
+        $caught = self::capture(static function () use (&$parentDeadline, &$childDeadline, &$nestedDeadline, &$finished): void {
+            self::attempt(static function () use (&$parentDeadline, &$childDeadline, &$nestedDeadline, &$finished): void {
+                Expect::eventually(static function () use (&$parentDeadline, &$childDeadline, &$nestedDeadline, &$finished): bool {
+                    $parentDeadline = ExpectationRuntime::enclosingDeadline();
+
+                    return AmpContext::await(AmpContext::async(static function () use (&$childDeadline, &$nestedDeadline, &$finished): bool {
+                        $childDeadline = ExpectationRuntime::enclosingDeadline();
+                        Expect::eventually(static function () use (&$nestedDeadline): bool {
+                            $nestedDeadline = ExpectationRuntime::enclosingDeadline();
+                            AmpContext::delay(0.500);
+
+                            return true;
+                        })->within(0.500)->toBeTrue();
+                        $finished = true;
+
+                        return true;
+                    }));
+                })
+                    ->retryOnException(\Exception::class)
+                    ->within(0.015)
+                    ->toBeTrue();
+            });
+        });
+
+        $deadline = $caught instanceof \Throwable ? DeadlineExceededError::find($caught) : null;
+        Expect::that($deadline)->toBeInstanceOf(DeadlineExceededError::class);
+        Expect::that($deadline->testDeadline)->toBeFalse();
+        Expect::that($parentDeadline)->not()->toBeNull();
+        Expect::that($childDeadline)->toBe($parentDeadline);
+        Expect::that($nestedDeadline)->toBe($parentDeadline);
+        Expect::that($finished)->toBeFalse();
+        Expect::that(ExpectationRuntime::enclosingDeadline())->toBeNull();
+    }
+
+    #[Test]
+    public function cancellationStopsTheAwaitWithoutTerminatingItsProducer(): void
+    {
+        $producerFinished = false;
+        $finishedWhenWaitStopped = null;
+        $caught = null;
+
+        self::attempt(static function () use (&$producerFinished, &$finishedWhenWaitStopped, &$caught): void {
+            $producer = \Amp\async(static function () use (&$producerFinished): string {
+                \Amp\delay(0.060);
+                $producerFinished = true;
+
+                return 'complete';
+            });
+
+            try {
+                $caught = self::capture(static function () use ($producer): void {
+                    ExpectationRuntime::withDeadline(
+                        \Amp\now() + 0.010,
+                        static function () use ($producer): void {
+                            AmpContext::await($producer);
+                        },
+                    );
+                });
+                $finishedWhenWaitStopped = $producerFinished;
+            } finally {
+                Expect::that($producer->await())->toBe('complete');
+            }
+        });
+
+        $deadline = $caught instanceof \Throwable ? DeadlineExceededError::find($caught) : null;
+        Expect::that($deadline?->testDeadline)->toBeFalse();
+        Expect::that($finishedWhenWaitStopped)->toBeFalse();
+        Expect::that($producerFinished)->toBeTrue();
+    }
+
+    #[Test]
+    public function anUnresolvedFutureStopsAtTheTestDeadline(): void
+    {
+        $caught = self::capture(static function (): void {
+            self::attempt(static function (): void {
+                $pending = new DeferredFuture();
+                AmpContext::await($pending->getFuture());
+            }, seconds: 0.010);
+        });
+
+        $deadline = $caught instanceof \Throwable ? DeadlineExceededError::find($caught) : null;
+        Expect::that($deadline)->toBeInstanceOf(DeadlineExceededError::class);
+        Expect::that($deadline->testDeadline)->toBeTrue();
+    }
+
+    #[Test]
+    public function scopeEndWaitsForRegisteredChildCleanup(): void
+    {
+        $events = [];
+
+        self::attempt(static function () use (&$events): void {
+            $started = new DeferredFuture();
+            AmpContext::async(static function () use ($started, &$events): void {
+                try {
+                    $events[] = 'child started';
+                    $started->complete();
+                    AmpContext::delay(10.000);
+                } finally {
+                    \Amp\delay(0.005);
+                    $events[] = 'child cleanup';
+                }
+            });
+            AmpContext::await($started->getFuture());
+            $events[] = 'body ended';
+        });
+        $events[] = 'attempt returned';
+
+        Expect::that($events)->toBe(['child started', 'body ended', 'child cleanup', 'attempt returned']);
+    }
+
+    #[Test]
+    public function scopeEndInterruptsChildTemporalPolling(): void
+    {
+        $observations = 0;
+        $cleanupCalls = 0;
+
+        self::attempt(static function () use (&$observations, &$cleanupCalls): void {
+            $started = new DeferredFuture();
+            AmpContext::async(static function () use ($started, &$observations, &$cleanupCalls): void {
+                try {
+                    Expect::eventually(static function () use ($started, &$observations): bool {
+                        if (++$observations === 1) {
+                            $started->complete();
+                        }
+
+                        return false;
+                    })
+                        ->pollEvery(0.100)
+                        ->within(0.500)
+                        ->toBeTrue();
+                } finally {
+                    ++$cleanupCalls;
+                }
+            });
+            AmpContext::await($started->getFuture());
+        });
+
+        Expect::that($observations)->toBe(1);
+        Expect::that($cleanupCalls)->toBe(1);
+    }
+
+    #[Test]
+    public function scopeCancellationIsNotRetriedAsAProbeFailure(): void
+    {
+        $observations = 0;
+        $continued = false;
+
+        self::attempt(static function () use (&$observations, &$continued): void {
+            $started = new DeferredFuture();
+            AmpContext::async(static function () use ($started, &$observations, &$continued): void {
+                Expect::eventually(static function () use ($started, &$observations): bool {
+                    if (++$observations === 1) {
+                        $started->complete();
+                    }
+
+                    AmpContext::delay(10.000);
+
+                    return true;
+                })
+                    ->retryOnException(\Exception::class)
+                    ->within(0.500)
+                    ->toBeTrue();
+                $continued = true;
+            });
+            AmpContext::await($started->getFuture());
+        });
+
+        Expect::that($observations)->toBe(1);
+        Expect::that($continued)->toBeFalse();
+    }
+
+    #[Test]
+    public function scopeCancellationCannotPassAToThrowMatcher(): void
+    {
+        $continued = false;
+
+        self::attempt(static function () use (&$continued): void {
+            $started = new DeferredFuture();
+            AmpContext::async(static function () use ($started, &$continued): void {
+                Expect::that(static function () use ($started): void {
+                    $started->complete();
+                    AmpContext::delay(10.000);
+                })->toThrow(\Throwable::class);
+                $continued = true;
+            });
+            AmpContext::await($started->getFuture());
+        });
+
+        Expect::that($continued)->toBeFalse();
+    }
+
+    #[Test]
+    public function temporalProbesPreserveCleanupErrorsThatWrapScopeCancellation(): void
+    {
+        $caught = self::capture(static function (): void {
+            self::attempt(static function (): void {
+                $started = new DeferredFuture();
+                AmpContext::async(static function () use ($started): void {
+                    Expect::eventually(static function () use ($started): bool {
+                        $started->complete();
+
+                        try {
+                            AmpContext::delay(10.000);
+                        } catch (CancelledException $cancelled) {
+                            throw new \RuntimeException('Probe cleanup failed.', $cancelled->getCode(), previous: $cancelled);
+                        }
+
+                        return true;
+                    })
+                        ->retryOnException(\Exception::class)
+                        ->within(0.500)
+                        ->toBeTrue();
+                });
+                AmpContext::await($started->getFuture());
+            });
+        });
+
+        Expect::that($caught)->toBeInstanceOf(\RuntimeException::class);
+        Expect::that($caught->getMessage())->toBe('Probe cleanup failed.');
+        Expect::that($caught->getPrevious())->toBeInstanceOf(CancelledException::class);
+    }
+
+    #[Test]
+    public function suspendedMatcherCallbacksKeepSiblingAssertionsInTheCount(): void
+    {
+        $count = self::attempt(static function (): int {
+            ExpectationCounter::reset();
+            $entered = new DeferredFuture();
+            $release = new DeferredFuture();
+            AmpContext::async(static function () use ($entered, $release): void {
+                AmpContext::await($entered->getFuture());
+                Expect::that('sibling')->toBe('sibling');
+                $release->complete();
+            });
+
+            Expect::eventually(static fn(): \Closure => static fn(): never => throw new \RuntimeException('The operation failed.'))
+                ->within(0.100)
+                ->toThrow(static function (\RuntimeException $error) use ($entered, $release): void {
+                    $entered->complete();
+                    AmpContext::await($release->getFuture());
+                    Expect::that('callback')->toBe('callback');
+                });
+
+            return ExpectationCounter::count();
+        });
+
+        Expect::that($count)->toBe(2);
+    }
+
+    #[Test]
+    public function scopeEndPreservesChildCleanupErrorsThatWrapCancellation(): void
+    {
+        $caught = self::capture(static function (): void {
+            self::attempt(static function (): void {
+                $started = new DeferredFuture();
+                AmpContext::async(static function () use ($started): void {
+                    $started->complete();
+
+                    try {
+                        AmpContext::delay(10.000);
+                    } catch (CancelledException $cancelled) {
+                        throw new \RuntimeException('Child cleanup failed.', $cancelled->getCode(), previous: $cancelled);
+                    }
+                });
+                AmpContext::await($started->getFuture());
+            });
+        });
+
+        Expect::that($caught)->toBeInstanceOf(\RuntimeException::class);
+        Expect::that($caught->getMessage())->toBe('Child cleanup failed.');
+    }
+
+    #[Test]
+    public function aHandledChildFailureDoesNotFailAgainAtScopeEnd(): void
+    {
+        self::attempt(static function (): void {
+            $child = AmpContext::async(static fn(): never => throw new \RuntimeException('The child failed.'));
+
+            Expect::that(static fn(): mixed => AmpContext::await($child))
+                ->toThrow(\RuntimeException::class, message: 'The child failed.');
+        });
+    }
+
+    #[Test]
+    public function unregisteredFibersRequireExplicitCancellationPropagation(): void
+    {
+        self::attempt(static function (): void {
+            $unregistered = \Amp\async(static fn(): Cancellation => AmpContext::cancellation());
+
+            Expect::that(static function () use ($unregistered): void {
+                $unregistered->await();
+            })
+                ->toThrow(AmpBridgeError::class, matching: '/AmpContext requires an active AmpPlugin attempt/');
+
+            $cancellation = AmpContext::cancellation();
+            $explicit = \Amp\async(static function () use ($cancellation): string {
+                \Amp\delay(0.001, cancellation: $cancellation);
+
+                return 'complete';
+            });
+
+            Expect::that(AmpContext::await($explicit))->toBe('complete');
+        });
+    }
+
+    #[Test]
+    public function closedAttemptsCancelRetainedTokensAndRemoveTheirTimers(): void
+    {
+        $plugin = new AmpPlugin();
+        $before = EventLoop::getIdentifiers();
+        $retained = self::attempt(static fn(): Cancellation => AmpContext::cancellation(), $plugin, 0.050);
+
+        Expect::that($retained->isRequested())->toBeTrue();
+        Expect::that(EventLoop::getIdentifiers())->toBe($before);
+
+        self::attempt(static function () use ($retained): void {
+            $fresh = AmpContext::cancellation();
+            AmpContext::delay(0.070);
+            $closed = self::capture(static fn() => $retained->throwIfRequested());
+
+            Expect::that($fresh->isRequested())->toBeFalse();
+            Expect::that($closed)->toBeInstanceOf(CancelledException::class);
+            Expect::that(DeadlineExceededError::find($closed))->toBeNull();
+        }, $plugin);
+
+        Expect::that(EventLoop::getIdentifiers())->toBe($before);
+    }
+
+    #[Test]
+    public function theFinalSynchronousObservationStillRunsAfterTheDeadline(): void
+    {
+        $calls = 0;
+
+        $caught = self::capture(static function () use (&$calls): void {
+            self::attempt(static function () use (&$calls): void {
+                Expect::eventually(static function () use (&$calls): bool {
+                    return ++$calls === 2;
+                })
+                    ->pollEvery(0.100)
+                    ->within(0.010)
+                    ->toBeTrue();
+            });
+        });
+
+        Expect::that($caught)->toBeInstanceOf(ExpectationFailed::class);
+        Expect::that($calls)->toBe(2);
+    }
+
+    #[Test]
+    public function consistencyStartsItsPeriodAfterTheFirstAsyncObservation(): void
+    {
+        $calls = 0;
+        $firstCompletedAt = null;
+        $lastObservedAt = null;
+
+        self::attempt(static function () use (&$calls, &$firstCompletedAt, &$lastObservedAt): void {
+            Expect::consistently(static function () use (&$calls, &$firstCompletedAt, &$lastObservedAt): bool {
+                if (++$calls === 1) {
+                    AmpContext::delay(0.025);
+                    $firstCompletedAt = \Amp\now();
+                }
+
+                $lastObservedAt = \Amp\now();
+
+                return true;
+            })
+                ->pollEvery(0.005)
+                ->for(0.015)
+                ->toBeTrue();
+        });
+
+        Expect::that($calls)->toBeGreaterThan(1);
+        Expect::that(($lastObservedAt ?? 0.0) - ($firstCompletedAt ?? 0.0))->toBeGreaterThanOrEqual(0.015);
+    }
+
+    /**
+     * @template T
+     *
+     * @param \Closure(): T $operation
+     *
+     * @return T
+     */
+    private static function attempt(\Closure $operation, ?AmpPlugin $plugin = null, float $seconds = 1.000): mixed
+    {
+        $plugin ??= new AmpPlugin();
+
+        return $plugin->runTestAttempt(static function () use ($operation, $plugin, $seconds): mixed {
+            $deadline = \Amp\now() + $seconds;
+            ExpectationRuntime::enterAttempt($deadline);
+
+            try {
+                $plugin->enterTestAttempt($deadline);
+
+                try {
+                    return $operation();
+                } finally {
+                    try {
+                        $plugin->leaveTestBody();
+                    } finally {
+                        $plugin->leaveTestAttempt();
+                    }
+                }
+            } finally {
+                ExpectationRuntime::leaveAttempt();
+            }
+        });
+    }
+
+    /** @param \Closure(): void $operation */
+    private static function capture(\Closure $operation): ?\Throwable
+    {
+        try {
+            $operation();
+        } catch (\Throwable $error) {
+            return $error;
+        }
+
+        return null;
+    }
+}

--- a/tests/Unit/Execution/Worker/TestAttemptLifecycleTest.php
+++ b/tests/Unit/Execution/Worker/TestAttemptLifecycleTest.php
@@ -1,0 +1,308 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Execution\Worker;
+
+use Greenlight\Attribute\After;
+use Greenlight\Attribute\Before;
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Discovery\Plan\ExecutionPlan;
+use Greenlight\Discovery\Plan\PlanEntry;
+use Greenlight\Doubles\Fake;
+use Greenlight\Execution\Plugin\WorkerPluginRuntime;
+use Greenlight\Execution\Worker\Worker;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\ExpectationFailed;
+use Greenlight\Expect\ExpectationRuntime;
+use Greenlight\Harness\Disposable;
+use Greenlight\Harness\Scope;
+use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Plugin\BeforeTestSubscriber;
+use Greenlight\Plugin\TestAttemptLifecycle;
+use Greenlight\Plugin\TestAttemptRunner;
+use Greenlight\Plugin\TestContext;
+use Greenlight\Result\FailureDetail;
+use Greenlight\Result\Outcome;
+use Greenlight\Result\TestResult;
+use Greenlight\Test\Cleanup;
+use Greenlight\Test\CleanupFailed;
+use Greenlight\Test\DeadlineExceededError;
+use Greenlight\Test\ExecutionPolicy;
+use Greenlight\Test\SkipTest;
+use Greenlight\Test\TestDefinition;
+use Greenlight\Tests\Support\CollectingEventSink;
+
+final class TestAttemptLifecycleTest
+{
+    #[Test]
+    public function lifecycleBoundariesUseTheTestDeadlineAndPreserveCleanupOrder(): void
+    {
+        $trace = new AttemptLifecycleTrace();
+        $result = $this->run($trace);
+
+        Expect::that($result->outcome)->toBe(Outcome::Passed);
+        Expect::that($trace->events)->toBe([
+            'runner enter', 'enter', 'constructor', 'subscriber', 'before', 'body',
+            'join', 'after', 'cleanup', 'disposal', 'release', 'runner exit',
+        ]);
+        Expect::that($trace->deadline)->not()->toBeNull();
+        Expect::that($trace->deadline)->toBe($trace->expectationDeadline);
+        Expect::that(ExpectationRuntime::deadline())->toBeNull();
+    }
+
+    #[Test]
+    #[DataSet('deadlineStages')]
+    public function wrappedDeadlinesFailEachAttemptStage(string $stage): void
+    {
+        $trace = new AttemptLifecycleTrace([$stage => new \RuntimeException('Operation wrapper.', previous: DeadlineExceededError::forTest())]);
+        $result = $this->run($trace);
+
+        Expect::that($result->outcome)->toBe(Outcome::Failed);
+        Expect::that($result->error)->toBeNull();
+        Expect::that($result->failures[0]->message)->toBe('The test time limit stopped an asynchronous operation.');
+        Expect::that($trace->events)->toContain('join')->toContain('cleanup')->toContain('release')->toContain('runner exit');
+        Expect::that(ExpectationRuntime::deadline())->toBeNull();
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function deadlineStages(): iterable
+    {
+        foreach (['constructor', 'subscriber', 'before', 'body', 'join', 'after', 'cleanup', 'disposal', 'release'] as $stage) {
+            yield $stage => [$stage];
+        }
+    }
+
+    #[Test]
+    public function failedJoinPreservesThePrimaryFailureAndRunsAllCleanupStages(): void
+    {
+        $trace = new AttemptLifecycleTrace([
+            'body' => ExpectationFailed::fromDetail(new FailureDetail('The body failed first.')),
+            'join' => new \RuntimeException('Child operation failed.'),
+            'cleanup' => DeadlineExceededError::forTest(),
+        ]);
+        $result = $this->run($trace);
+
+        Expect::that($result->outcome)->toBe(Outcome::Failed);
+        Expect::that($result->error)->toBeNull();
+        Expect::that(\array_map(static fn(FailureDetail $detail): string => $detail->message, $result->failures))->toBe([
+            'The body failed first.',
+            'Test body cleanup caused an error: Child operation failed.',
+            'The test time limit stopped an asynchronous operation.',
+        ]);
+        Expect::that(\array_slice($trace->events, -6))->toBe(['join', 'after', 'cleanup', 'disposal', 'release', 'runner exit']);
+    }
+
+    #[Test]
+    public function deadlineDuringCleanupPreservesAnEarlierError(): void
+    {
+        $trace = new AttemptLifecycleTrace([
+            'body' => new \LogicException('The body failed first.'),
+            'after' => DeadlineExceededError::forTest(),
+            'disposal' => DeadlineExceededError::forTest(),
+        ]);
+        $result = $this->run($trace);
+
+        Expect::that($result->outcome)->toBe(Outcome::Errored);
+        Expect::that($result->error?->message)->toBe('The body failed first.');
+        Expect::that($result->failures)->toHaveCount(2);
+        Expect::that($result->failures[0]->message)->toBe('The test time limit stopped an asynchronous operation.');
+        Expect::that($result->failures[1]->message)->toBe('The test time limit stopped an asynchronous operation.');
+    }
+
+    #[Test]
+    public function lifecycleAfterFailuresPreserveEarlierBodyFailures(): void
+    {
+        $trace = new AttemptLifecycleTrace([
+            'body' => ExpectationFailed::fromDetail(new FailureDetail('The body failed first.')),
+            'after' => ExpectationFailed::fromDetail(new FailureDetail('The After hook failed.')),
+        ]);
+        $result = $this->run($trace);
+
+        Expect::that($result->outcome)->toBe(Outcome::Failed);
+        Expect::that($result->error)->toBeNull();
+        Expect::that(\array_map(static fn(FailureDetail $detail): string => $detail->message, $result->failures))->toBe([
+            'The body failed first.',
+            'The After hook failed.',
+        ]);
+        Expect::that(\array_slice($trace->events, -6))->toBe(['join', 'after', 'cleanup', 'disposal', 'release', 'runner exit']);
+    }
+
+    #[Test]
+    public function aggregateChildFailuresRetainAllDiagnosticsAndRunCleanup(): void
+    {
+        $trace = new AttemptLifecycleTrace([
+            'body' => new \LogicException('The body failed first.'),
+            'join' => CleanupFailed::fromFailures([
+                ExpectationFailed::fromDetail(new FailureDetail('The first child cleanup failed.')),
+                new \RuntimeException('The second child cleanup failed.'),
+                DeadlineExceededError::forTest(),
+            ]),
+        ]);
+        $result = $this->run($trace);
+
+        Expect::that($result->outcome)->toBe(Outcome::Errored);
+        Expect::that($result->error?->message)->toBe('The body failed first.');
+        Expect::that(\array_map(static fn(FailureDetail $detail): string => $detail->message, $result->failures))->toBe([
+            'The first child cleanup failed.',
+            'Test body cleanup caused an error: The second child cleanup failed.',
+            'The test time limit stopped an asynchronous operation.',
+        ]);
+        Expect::that(\array_slice($trace->events, -6))->toBe(['join', 'after', 'cleanup', 'disposal', 'release', 'runner exit']);
+    }
+
+    #[Test]
+    public function aggregateChildTimeoutKeepsItsFailureClassification(): void
+    {
+        $trace = new AttemptLifecycleTrace([
+            'join' => CleanupFailed::fromFailures([
+                DeadlineExceededError::forTest(),
+                new \RuntimeException('The second child cleanup failed.'),
+            ]),
+        ]);
+        $result = $this->run($trace);
+
+        Expect::that($result->outcome)->toBe(Outcome::Failed);
+        Expect::that($result->error)->toBeNull();
+        Expect::that(\array_map(static fn(FailureDetail $detail): string => $detail->message, $result->failures))->toBe([
+            'The test time limit stopped an asynchronous operation.',
+            'Test body cleanup caused an error: The second child cleanup failed.',
+        ]);
+    }
+
+    #[Test]
+    #[DataSet('constructorSignals')]
+    public function constructorControlSignalsKeepTheirErrorClassification(bool $skip): void
+    {
+        $failure = $skip
+            ? new SkipTest('The constructor stopped.')
+            : ExpectationFailed::fromDetail(new FailureDetail('The constructor stopped.'));
+        $trace = new AttemptLifecycleTrace(['constructor' => $failure]);
+        $result = $this->run($trace);
+
+        Expect::that($result->outcome)->toBe(Outcome::Errored);
+        Expect::that($result->error?->message)->toBe('The constructor stopped.');
+        Expect::that($result->skipReason)->toBeNull();
+        Expect::that($trace->events)->not()->toContain('after');
+    }
+
+    /** @return iterable<string, array{bool}> */
+    public static function constructorSignals(): iterable
+    {
+        yield 'skip' => [true];
+        yield 'expectation' => [false];
+    }
+
+    private function run(AttemptLifecycleTrace $trace): TestResult
+    {
+        $plugins = WorkerPluginRuntime::fromPlugins([new AttemptLifecyclePlugin($trace)]);
+        $definitions = [new ServiceDefinition(AttemptLifecycleTrace::class, Scope::PerTest, static fn(): AttemptLifecycleTrace => $trace)];
+        $plan = new ExecutionPlan([new PlanEntry(new TestDefinition(
+            AttemptLifecycleCase::class,
+            'runs',
+            execution: new ExecutionPolicy(timeoutSeconds: 10.0, noExpectations: true),
+        ))]);
+        $sink = new CollectingEventSink();
+        new Worker($definitions, $plugins)->run($plan, $sink);
+
+        return $sink->results()[0];
+    }
+}
+
+final class AttemptLifecycleTrace implements Disposable, Fake
+{
+    /** @var list<string> */
+    public array $events = [];
+    public ?float $deadline = null;
+    public ?float $expectationDeadline = null;
+
+    /** @param array<string, \Throwable> $failures */
+    public function __construct(private readonly array $failures = []) {}
+
+    public function hit(string $stage): void
+    {
+        $this->events[] = $stage;
+
+        if (isset($this->failures[$stage])) {
+            throw $this->failures[$stage];
+        }
+    }
+
+    #[\Override]
+    public function dispose(): void
+    {
+        $this->hit('disposal');
+    }
+}
+
+final readonly class AttemptLifecycleCase
+{
+    public function __construct(private AttemptLifecycleTrace $trace, Cleanup $cleanup)
+    {
+        $cleanup->defer(function (): void {
+            $this->trace->hit('cleanup');
+        });
+        $this->trace->hit('constructor');
+    }
+
+    #[Before]
+    public function before(): void
+    {
+        $this->trace->hit('before');
+    }
+
+    public function runs(): void
+    {
+        $this->trace->hit('body');
+    }
+
+    #[After]
+    public function after(): void
+    {
+        $this->trace->hit('after');
+    }
+}
+
+final readonly class AttemptLifecyclePlugin implements BeforeTestSubscriber, Fake, TestAttemptLifecycle, TestAttemptRunner
+{
+    public function __construct(private AttemptLifecycleTrace $trace) {}
+
+    #[\Override]
+    public function runTestAttempt(\Closure $attempt): mixed
+    {
+        $this->trace->hit('runner enter');
+
+        try {
+            return $attempt();
+        } finally {
+            $this->trace->hit('runner exit');
+        }
+    }
+
+    #[\Override]
+    public function enterTestAttempt(?float $deadline): void
+    {
+        $this->trace->deadline = $deadline;
+        $this->trace->expectationDeadline = ExpectationRuntime::deadline();
+        $this->trace->hit('enter');
+    }
+
+    #[\Override]
+    public function leaveTestBody(): void
+    {
+        $this->trace->hit('join');
+    }
+
+    #[\Override]
+    public function leaveTestAttempt(): void
+    {
+        $this->trace->hit('release');
+    }
+
+    #[\Override]
+    public function beforeTest(TestContext $context): void
+    {
+        $this->trace->hit('subscriber');
+    }
+}

--- a/tests/Unit/Expect/TemporalCancellationTest.php
+++ b/tests/Unit/Expect/TemporalCancellationTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Expect\ExpectationRuntime;
+use Greenlight\Test\DeadlineExceededError;
+use Greenlight\Tests\Fixture\Expect\FakePollingClock;
+
+final class TemporalCancellationTest
+{
+    #[Test]
+    public function eventuallyDoesNotRetryTestDeadlineCancellation(): void
+    {
+        $clock = new FakePollingClock();
+        $deadline = DeadlineExceededError::forTest();
+        $calls = 0;
+
+        $caught = $this->capture(static function () use ($clock, $deadline, &$calls): void {
+            ExpectationRuntime::withClock($clock, static function () use ($deadline, &$calls): void {
+                Expect::eventually(static function () use ($deadline, &$calls): never {
+                    ++$calls;
+
+                    throw $deadline;
+                })
+                    ->retryOnException(\Exception::class)
+                    ->within(1.000)
+                    ->toBeTrue();
+            });
+        });
+
+        Expect::that($caught)->toBe($deadline);
+        Expect::that($calls)->toBe(1);
+        Expect::that($clock->sleeps)->toBe([]);
+        Expect::that(ExpectationRuntime::enclosingDeadline())->toBeNull();
+    }
+
+    #[Test]
+    public function eventuallyFindsTemporalCancellationInNestedCauses(): void
+    {
+        $clock = new FakePollingClock();
+        $deadline = DeadlineExceededError::forTemporal();
+        $wrapped = new \RuntimeException(
+            'The operation failed.',
+            previous: new \RuntimeException('The wait was canceled.', previous: $deadline),
+        );
+        $calls = 0;
+
+        $caught = $this->capture(static function () use ($clock, $wrapped, &$calls): void {
+            ExpectationRuntime::withClock($clock, static function () use ($wrapped, &$calls): void {
+                Expect::eventually(static function () use ($wrapped, &$calls): never {
+                    ++$calls;
+
+                    throw $wrapped;
+                })
+                    ->retryOnException(\RuntimeException::class)
+                    ->within(1.000)
+                    ->toBeTrue();
+            });
+        });
+
+        Expect::that($caught)->toBe($wrapped);
+        Expect::that($calls)->toBe(1);
+        Expect::that($clock->sleeps)->toBe([]);
+        Expect::that(ExpectationRuntime::enclosingDeadline())->toBeNull();
+    }
+
+    #[Test]
+    public function consistentlyPreservesTheDeadlineCause(): void
+    {
+        $clock = new FakePollingClock();
+        $deadline = DeadlineExceededError::forTest();
+        $wrapped = new \RuntimeException('The wait was canceled.', previous: $deadline);
+
+        $caught = $this->capture(static function () use ($clock, $wrapped): void {
+            ExpectationRuntime::withClock($clock, static function () use ($wrapped): void {
+                Expect::consistently(static fn(): never => throw $wrapped)
+                    ->for(1.000)
+                    ->toBeTrue();
+            });
+        });
+
+        Expect::that($caught)->toBe($wrapped);
+        Expect::that($clock->sleeps)->toBe([]);
+        Expect::that(ExpectationRuntime::enclosingDeadline())->toBeNull();
+    }
+
+    #[Test]
+    public function toThrowDoesNotAcceptDeadlineCancellation(): void
+    {
+        $deadline = DeadlineExceededError::forTest();
+        $wrapped = new \RuntimeException('The wait was canceled.', previous: $deadline);
+
+        $caught = $this->capture(static function () use ($wrapped): void {
+            Expect::that(static fn(): never => throw $wrapped)->toThrow(\Throwable::class);
+        });
+
+        Expect::that($caught)->toBe($wrapped);
+    }
+
+    #[Test]
+    public function temporalToThrowDoesNotAcceptDeadlineCancellation(): void
+    {
+        $clock = new FakePollingClock();
+        $deadline = DeadlineExceededError::forTemporal();
+        $wrapped = new \RuntimeException('The wait was canceled.', previous: $deadline);
+
+        $caught = $this->capture(static function () use ($clock, $wrapped): void {
+            ExpectationRuntime::withClock($clock, static function () use ($wrapped): void {
+                Expect::eventually(static fn(): \Closure => static fn(): never => throw $wrapped)
+                    ->retryOnException(\Exception::class)
+                    ->within(1.000)
+                    ->toThrow(\Throwable::class);
+            });
+        });
+
+        Expect::that($caught)->toBe($wrapped);
+        Expect::that($clock->sleeps)->toBe([]);
+        Expect::that(ExpectationRuntime::enclosingDeadline())->toBeNull();
+    }
+
+    #[Test]
+    public function matcherCallbacksPropagateDeadlineCancellation(): void
+    {
+        $clock = new FakePollingClock();
+        $deadline = DeadlineExceededError::forTemporal();
+        $calls = 0;
+
+        $caught = $this->capture(static function () use ($clock, $deadline, &$calls): void {
+            ExpectationRuntime::withClock($clock, static function () use ($deadline, &$calls): void {
+                Expect::eventually(static fn(): \Closure => static fn(): never => throw new \RuntimeException('The operation failed.'))
+                    ->retryOnException(\Exception::class)
+                    ->within(1.000)
+                    ->toThrow(static function (\RuntimeException $error) use ($deadline, &$calls): void {
+                        ++$calls;
+
+                        throw $deadline;
+                    });
+            });
+        });
+
+        Expect::that($caught)->toBe($deadline);
+        Expect::that($calls)->toBe(1);
+        Expect::that($clock->sleeps)->toBe([]);
+        Expect::that(ExpectationRuntime::enclosingDeadline())->toBeNull();
+    }
+
+    /** @param \Closure(): void $operation */
+    private function capture(\Closure $operation): ?\Throwable
+    {
+        try {
+            $operation();
+        } catch (\Throwable $error) {
+            return $error;
+        }
+
+        return null;
+    }
+}

--- a/tests/Unit/Plugin/TestAttemptLifecycleRuntimeTest.php
+++ b/tests/Unit/Plugin/TestAttemptLifecycleRuntimeTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Plugin;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Fake;
+use Greenlight\Execution\Plugin\WorkerPluginRuntime;
+use Greenlight\Expect\Expect;
+use Greenlight\Plugin\PluginDefinition;
+use Greenlight\Plugin\Prioritized;
+use Greenlight\Plugin\TestAttemptLifecycle;
+
+final class TestAttemptLifecycleRuntimeTest
+{
+    #[Test]
+    public function lifecycleEntryUsesPriorityAndExitReversesTheOrder(): void
+    {
+        /** @var \ArrayObject<int, string> $events */
+        $events = new \ArrayObject();
+        $early = new LifecycleRuntimeProbe($events, 'early', -10);
+        $late = new LifecycleRuntimeProbe($events, 'late', 10);
+        $runtime = WorkerPluginRuntime::fromDefinitions([
+            PluginDefinition::fromFactory(static fn(): LifecycleRuntimeProbe => $late),
+            PluginDefinition::fromFactory(static fn(): LifecycleRuntimeProbe => $early),
+        ]);
+
+        [$entered, $failure] = $runtime->enterTestAttempt(12.5);
+        $bodyFailures = $runtime->leaveTestBody($entered);
+        $releaseFailures = $runtime->leaveTestAttempt($entered);
+
+        Expect::that($failure)->toBeNull();
+        Expect::that($bodyFailures)->toBe([]);
+        Expect::that($releaseFailures)->toBe([]);
+        Expect::that($early->deadline)->toBe(12.5);
+        Expect::that($late->deadline)->toBe(12.5);
+        Expect::that($events->getArrayCopy())->toBe([
+            'early:enter', 'late:enter', 'late:body', 'early:body', 'late:release', 'early:release',
+        ]);
+    }
+
+    #[Test]
+    public function failedEntryReleasesOnlySuccessfulEntries(): void
+    {
+        /** @var \ArrayObject<int, string> $events */
+        $events = new \ArrayObject();
+        $early = new LifecycleRuntimeProbe($events, 'early', -10);
+        $failed = new LifecycleRuntimeProbe($events, 'failed', 0, 'enter');
+        $late = new LifecycleRuntimeProbe($events, 'late', 10);
+        $runtime = WorkerPluginRuntime::fromPlugins([$early, $failed, $late]);
+
+        [$entered, $failure] = $runtime->enterTestAttempt(null);
+        $runtime->leaveTestBody($entered);
+        $runtime->leaveTestAttempt($entered);
+
+        Expect::that($failure?->getMessage())->toBe('Lifecycle operation failed.');
+        Expect::that($events->getArrayCopy())->toBe(['early:enter', 'failed:enter', 'early:body', 'early:release']);
+    }
+
+    #[Test]
+    public function failedExitDoesNotPreventOtherLifecyclesFromExiting(): void
+    {
+        /** @var \ArrayObject<int, string> $events */
+        $events = new \ArrayObject();
+        $early = new LifecycleRuntimeProbe($events, 'early', -10);
+        $late = new LifecycleRuntimeProbe($events, 'late', 10, 'body');
+        $runtime = WorkerPluginRuntime::fromPlugins([$early, $late]);
+
+        [$entered] = $runtime->enterTestAttempt(null);
+        $failures = $runtime->leaveTestBody($entered);
+        $runtime->leaveTestAttempt($entered);
+
+        Expect::that($failures)->toHaveCount(1);
+        Expect::that($events->getArrayCopy())->toBe([
+            'early:enter', 'late:enter', 'late:body', 'early:body', 'late:release', 'early:release',
+        ]);
+    }
+}
+
+final class LifecycleRuntimeProbe implements Fake, Prioritized, TestAttemptLifecycle
+{
+    public ?float $deadline = null;
+
+    /** @param \ArrayObject<int, string> $events */
+    public function __construct(
+        private readonly \ArrayObject $events,
+        private readonly string $name,
+        private readonly int $priority,
+        private readonly ?string $failAt = null,
+    ) {}
+
+    #[\Override]
+    public function priority(): int
+    {
+        return $this->priority;
+    }
+
+    #[\Override]
+    public function enterTestAttempt(?float $deadline): void
+    {
+        $this->deadline = $deadline;
+        $this->record('enter');
+    }
+
+    #[\Override]
+    public function leaveTestBody(): void
+    {
+        $this->record('body');
+    }
+
+    #[\Override]
+    public function leaveTestAttempt(): void
+    {
+        $this->record('release');
+    }
+
+    private function record(string $stage): void
+    {
+        $this->events->append($this->name . ':' . $stage);
+
+        if ($stage === $this->failAt) {
+            throw new \RuntimeException('Lifecycle operation failed.');
+        }
+    }
+}

--- a/tests/Unit/Test/ExpectationCounterTest.php
+++ b/tests/Unit/Test/ExpectationCounterTest.php
@@ -76,4 +76,121 @@ final class ExpectationCounterTest
             ->because('expectation counting MUST resume after an operation error')
             ->toBe(2);
     }
+
+    #[Test]
+    public function suspendedSuppressionDoesNotHideAssertionsInOtherContexts(): void
+    {
+        ExpectationCounter::reset();
+        $fiber = new \Fiber(static function (): void {
+            ExpectationCounter::withoutCounting(static function (): void {
+                Expect::that(true)->toBeTrue();
+                \Fiber::suspend();
+                Expect::that(true)->toBeTrue();
+            });
+            Expect::that(true)->toBeTrue();
+        });
+
+        $fiber->start();
+        $afterSuspension = ExpectationCounter::count();
+        Expect::that(true)->toBeTrue();
+        $sibling = new \Fiber(static function (): void {
+            Expect::that(true)->toBeTrue();
+        });
+        $sibling->start();
+        $afterOtherContexts = ExpectationCounter::count();
+        $fiber->resume();
+        $afterResume = ExpectationCounter::count();
+
+        Expect::that($afterSuspension)->toBe(0);
+        Expect::that($afterOtherContexts)->toBe(2);
+        Expect::that($afterResume)->toBe(3);
+    }
+
+    #[Test]
+    public function mainSuppressionDoesNotApplyToChildFibers(): void
+    {
+        ExpectationCounter::reset();
+
+        ExpectationCounter::withoutCounting(static function (): void {
+            $fiber = new \Fiber(static function (): void {
+                Expect::that(true)->toBeTrue();
+            });
+            $fiber->start();
+            Expect::that(true)->toBeTrue();
+        });
+        $afterSuppression = ExpectationCounter::count();
+        Expect::that(true)->toBeTrue();
+        $afterResume = ExpectationCounter::count();
+
+        Expect::that($afterSuppression)->toBe(1);
+        Expect::that($afterResume)->toBe(2);
+    }
+
+    #[Test]
+    public function nestedFiberSuppressionRestoresCountingAfterAnError(): void
+    {
+        ExpectationCounter::reset();
+        $message = null;
+        $fiber = new \Fiber(static function () use (&$message): void {
+            try {
+                ExpectationCounter::withoutCounting(static function (): void {
+                    Expect::that(true)->toBeTrue();
+                    ExpectationCounter::withoutCounting(static function (): never {
+                        Expect::that(true)->toBeTrue();
+
+                        throw new \RuntimeException('Operation failed.');
+                    });
+                });
+            } catch (\RuntimeException $error) {
+                $message = $error->getMessage();
+            }
+
+            Expect::that(true)->toBeTrue();
+        });
+        $fiber->start();
+        $afterError = ExpectationCounter::count();
+
+        Expect::that($message)->toBe('Operation failed.');
+        Expect::that($afterError)->toBe(1);
+    }
+
+    #[Test]
+    public function resetPreventsOldMainScopesFromRestoringSuppression(): void
+    {
+        ExpectationCounter::reset();
+
+        ExpectationCounter::withoutCounting(static function (): void {
+            ExpectationCounter::withoutCounting(static function (): void {
+                ExpectationCounter::reset();
+                ExpectationCounter::increment();
+            });
+            ExpectationCounter::increment();
+        });
+        ExpectationCounter::increment();
+        $afterReset = ExpectationCounter::count();
+
+        Expect::that($afterReset)->toBe(3);
+    }
+
+    #[Test]
+    public function resetClearsSuppressionInSuspendedFibers(): void
+    {
+        ExpectationCounter::reset();
+        $fiber = new \Fiber(static function (): void {
+            ExpectationCounter::withoutCounting(static function (): void {
+                ExpectationCounter::withoutCounting(static function (): void {
+                    \Fiber::suspend();
+                    ExpectationCounter::increment();
+                });
+                ExpectationCounter::increment();
+            });
+            ExpectationCounter::increment();
+        });
+        $fiber->start();
+        ExpectationCounter::reset();
+        $fiber->resume();
+        $afterReset = ExpectationCounter::count();
+
+        Expect::that($afterReset)->toBe(3);
+    }
 }

--- a/tests/Unit/Test/OperationCancelledErrorTest.php
+++ b/tests/Unit/Test/OperationCancelledErrorTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Test;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Test\DeadlineExceededError;
+use Greenlight\Test\OperationCancelledError;
+
+final class OperationCancelledErrorTest
+{
+    #[Test]
+    public function findsDeadlineCancellationThroughNestedWrappers(): void
+    {
+        $deadline = DeadlineExceededError::forTest();
+        $wrapper = new \RuntimeException('Outer wrapper.', previous: new \LogicException('Inner wrapper.', previous: $deadline));
+
+        Expect::that(OperationCancelledError::find($wrapper))->toBe($deadline);
+        Expect::that(DeadlineExceededError::find($wrapper))->toBe($deadline);
+        Expect::that($deadline->testDeadline)->toBeTrue();
+    }
+
+    #[Test]
+    public function deadlineLookupExcludesOtherOperationCancellation(): void
+    {
+        $scope = new class ('The operation scope ended.') extends OperationCancelledError {};
+        $wrapper = new \RuntimeException('Outer wrapper.', previous: $scope);
+
+        Expect::that(OperationCancelledError::find($wrapper))->toBe($scope);
+        Expect::that(DeadlineExceededError::find($wrapper))->toBeNull();
+        Expect::that(OperationCancelledError::find(new \RuntimeException('Ordinary failure.')))->toBeNull();
+    }
+
+    #[Test]
+    public function temporalDeadlineKeepsItsOwnCauseAndDiagnostic(): void
+    {
+        $deadline = DeadlineExceededError::forTemporal();
+
+        Expect::that($deadline->testDeadline)->toBeFalse();
+        Expect::that($deadline->getMessage())->toBe('The temporal expectation time limit stopped an asynchronous operation.');
+    }
+}

--- a/tools/phpstan-stubs/amp.stub
+++ b/tools/phpstan-stubs/amp.stub
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Amp;
+
+class CancelledException extends \Exception {}
+
+/** @template-covariant T */
+final class Future {}
+
+/** Supplies PHPStan-compatible signatures for the Amp cancellation callback. */
+interface Cancellation
+{
+    /** @param \Closure(CancelledException): mixed $callback */
+    public function subscribe(\Closure $callback): string;
+}
+
+/**
+ * Preserves the child callback's return type through Amp's future.
+ *
+ * @template T
+ *
+ * @param \Closure(mixed...): T $closure
+ * @param mixed ...$args
+ *
+ * @return Future<T>
+ */
+function async(\Closure $closure, mixed ...$args): Future {}

--- a/website/scripts/generate-api-reference.mjs
+++ b/website/scripts/generate-api-reference.mjs
@@ -101,8 +101,9 @@ const sections = [
   {
     id: 'api-integrations',
     title: 'Integration API',
-    description: 'This reference lists public integration types for Hyperf, Laravel, PSR standards, Rector, Symfony, and Tempest.',
+    description: 'This reference lists public integration types for Amp, Hyperf, Laravel, PSR standards, Rector, Symfony, and Tempest.',
     prefixes: [
+      'Greenlight\\Amp\\',
       'Greenlight\\Hyperf\\',
       'Greenlight\\Laravel\\',
       'Greenlight\\PhpStan\\',

--- a/website/src/lib/docs.ts
+++ b/website/src/lib/docs.ts
@@ -62,6 +62,11 @@ export const docSections = [
     title: 'Extend',
     items: [
       {
+        id: 'amp',
+        title: 'Amp',
+        description: 'This guide explains asynchronous deadlines, child work, and cleanup with Amp and Revolt.',
+      },
+      {
         id: 'symfony',
         title: 'Symfony',
         description: 'This guide explains how tests use a kernel and receive container services.',


### PR DESCRIPTION
Depends on #1851 and targets `ben-challis/temporal-deadline-scopes` so this diff contains only the scheduler integration and lifecycle work.

Add an optional Amp 3/Revolt 1 bridge. Supported waits now stop during execution at the existing test or temporal deadline. Temporal polling yields through the application's scheduler. `AmpContext` supplies native cancellation and explicitly registered child work without mandatory runtime dependencies.

Cancel and join registered children before After hooks, resource cleanup, or retries. Preserve primary failures and cleanup diagnostics, classify deadline cancellation as a failed attempt, and keep matcher suppression local to each Fiber. Add lifecycle coverage and document cancellation propagation, wait-versus-producer behavior, and process enforcement for code that does not cooperate.
