### PR TITLE
feat!: use Service for Tempest tag selection

### DIFF
--- a/docs/api-harness.md
+++ b/docs/api-harness.md
@@ -71,15 +71,16 @@ case PerWorker = 'per-worker';
 
 Namespace: `Greenlight\Harness`
 
-Selects a container service ID that differs from the parameter type. The
-resolved service must have the declared type.
+Selects a service within its source by ID. Each bridge translates the ID
+into its container lookup. The resolved service must have the declared
+parameter type.
 
 ```php
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
 final readonly class Service
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/Service.php#L12)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/Service.php#L13)
 
 ### `$id`
 
@@ -91,7 +92,7 @@ PHPDoc:
 
 - `@var non-empty-string`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/Service.php#L15)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/Service.php#L16)
 
 ### `__construct()`
 
@@ -103,7 +104,7 @@ PHPDoc:
 
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/Service.php#L18)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/Service.php#L19)
 
 ## `ServiceDefinition`
 

--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -591,9 +591,9 @@ Boots one Tempest long-running kernel for each worker. Tempest discovery,
 configuration, container reset, deferred tasks, and shutdown events stay
 under kernel control.
 
-The bridge uses the `testing` environment by default. Native `#[Tag]`
-attributes select tagged Tempest bindings. Isolate external test resources
-by `GREENLIGHT_CHANNEL`.
+The bridge uses the `testing` environment by default. `#[Service]` selects
+a tagged Tempest binding.
+Isolate external test resources by `GREENLIGHT_CHANNEL`.
 
 ```php
 final class TempestPlugin implements AfterTestSubscriber, BeforeTestSubscriber, HarnessProvider, TerminalServiceResolver, WorkerBootstrapSubscriber

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -745,6 +745,12 @@ Registered harness services always take precedence. If no service matches,
 Greenlight calls resolvers in registration order. Each call receives the
 declared parameter type and the attribute instances.
 
+The `#[Service]` ID selects a service within its source. Each bridge translates
+this selection into its container lookup. Tempest uses the ID as a tag with
+the declared type. The PSR-11, Symfony, Laravel, and Hyperf bridges use the ID
+as a container key. Each bridge checks the returned service against the
+declared parameter type.
+
 Return `null` when the resolver does not support the type. Greenlight then
 calls the next resolver.
 

--- a/docs/tempest.md
+++ b/docs/tempest.md
@@ -93,19 +93,27 @@ The exception contains the Tempest container exception as its cause.
 
 ### Tagged services
 
-Use the Tempest `#[Tag]` attribute to select a tagged service:
+Replace Tempest `#[Tag]` with `#[Service]` on test constructor parameters.
+
+Use `#[Service]` to select a tagged service:
 
 <!-- php-example {"example":"tempest-example-04","file":"snippet.php","mode":"class-members","tools":["rector"]} -->
 ```php
-use Tempest\Container\Tag;
+use Greenlight\Harness\Service;
 
 public function __construct(
-    #[Tag('archive')] private readonly Storage $storage,
+    #[Service('archive')] private readonly Storage $storage,
 ) {}
 ```
 
-The bridge passes the tag to the Tempest container. The resolved service has
-the declared parameter type.
+The bridge calls `$container->get(Storage::class, tag: 'archive')`. The ID
+selects a tag, and the declared parameter type stays `Storage`. Greenlight
+checks that the returned service has this type.
+
+`Service` accepts only string IDs. For an enum tag, change the Tempest binding
+and parameter attribute to use the same string.
+
+Without `#[Service]`, the bridge calls `$container->get(Storage::class)`.
 
 ### Kernel and container services
 

--- a/src/Harness/Service.php
+++ b/src/Harness/Service.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Greenlight\Harness;
 
 /**
- * Selects a container service ID that differs from the parameter type. The
- * resolved service must have the declared type.
+ * Selects a service within its source by ID. Each bridge translates the ID
+ * into its container lookup. The resolved service must have the declared
+ * parameter type.
  */
 #[\Attribute(\Attribute::TARGET_PARAMETER)]
 final readonly class Service

--- a/src/Tempest/TempestPlugin.php
+++ b/src/Tempest/TempestPlugin.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tempest;
 
 use Greenlight\Harness\Scope;
+use Greenlight\Harness\Service;
 use Greenlight\Harness\ServiceDefinition;
 use Greenlight\Harness\ServiceResolutionFailed;
 use Greenlight\Harness\TerminalServiceResolver;
@@ -17,7 +18,6 @@ use Greenlight\Plugin\WorkerBootstrapSubscriber;
 use Greenlight\Result\TestResult;
 use Tempest\Container\Container;
 use Tempest\Container\GenericContainer;
-use Tempest\Container\Tag;
 use Tempest\Core\FrameworkKernel;
 use Tempest\Core\Kernel;
 use Tempest\Discovery\DiscoveryLocation;
@@ -30,9 +30,9 @@ use Tempest\Http\Request;
  * configuration, container reset, deferred tasks, and shutdown events stay
  * under kernel control.
  *
- * The bridge uses the `testing` environment by default. Native `#[Tag]`
- * attributes select tagged Tempest bindings. Isolate external test resources
- * by `GREENLIGHT_CHANNEL`.
+ * The bridge uses the `testing` environment by default. `#[Service]` selects
+ * a tagged Tempest binding.
+ * Isolate external test resources by `GREENLIGHT_CHANNEL`.
  */
 final class TempestPlugin implements AfterTestSubscriber, BeforeTestSubscriber, HarnessProvider, TerminalServiceResolver, WorkerBootstrapSubscriber
 {
@@ -90,13 +90,13 @@ final class TempestPlugin implements AfterTestSubscriber, BeforeTestSubscriber, 
         $tag = null;
 
         foreach ($attributes as $attribute) {
-            if ($attribute instanceof Tag) {
-                $tag = $attribute->name;
+            if ($attribute instanceof Service) {
+                $tag = $attribute->id;
             }
         }
 
         try {
-            $service = $this->container()->get($type, $tag);
+            $service = $this->container()->get($type, tag: $tag);
         } catch (ServiceResolutionFailed $error) {
             throw $error;
         } catch (\Throwable $cause) {

--- a/stubs/tempest.stub.php
+++ b/stubs/tempest.stub.php
@@ -26,12 +26,6 @@ final class GenericContainer implements Container
     public function reset(): self {}
 }
 
-#[\Attribute]
-final readonly class Tag
-{
-    public function __construct(public string|\UnitEnum $name) {}
-}
-
 namespace Tempest\Core;
 
 use Tempest\Container\Container;

--- a/tests/Acceptance/TempestRunTest.php
+++ b/tests/Acceptance/TempestRunTest.php
@@ -90,6 +90,27 @@ final readonly class TempestRunTest
             }
             PHP);
 
+        $project->writeFile('app/ArchiveGreetingInitializer.php', <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace TempestProbe;
+
+            use Tempest\Container\Container;
+            use Tempest\Container\Initializer;
+            use Tempest\Container\Singleton;
+
+            final readonly class ArchiveGreetingInitializer implements Initializer
+            {
+                #[Singleton(tag: 'archive')]
+                public function initialize(Container $container): GreetingConfig
+                {
+                    return new GreetingConfig('Hello from archive');
+                }
+            }
+            PHP);
+
         $project->writeFile('app/VisitCounter.php', <<<'PHP'
             <?php
 
@@ -162,6 +183,7 @@ final readonly class TempestRunTest
 
             use Greenlight\Attribute\Test;
             use Greenlight\Expect\Expect;
+            use Greenlight\Harness\Service;
             use Tempest\Container\Container;
             use Tempest\Core\Environment;
             use Tempest\Core\Kernel;
@@ -177,6 +199,8 @@ final readonly class TempestRunTest
                     private readonly Kernel $kernel,
                     private readonly Container $container,
                     private readonly Request $request,
+                    private readonly GreetingConfig $defaultGreeting,
+                    #[Service('archive')] private readonly GreetingConfig $serviceGreeting,
                 ) {}
 
                 #[Test]
@@ -191,6 +215,8 @@ final readonly class TempestRunTest
                     Expect::that($this->request->method)->toBe(Method::GET);
                     Expect::that($this->request->uri)->toBe('/');
                     Expect::that($this->counter->count())->toBe(1);
+                    Expect::that($this->defaultGreeting->prefix)->toBe('Hello from testing');
+                    Expect::that($this->serviceGreeting->prefix)->toBe('Hello from archive');
                 }
 
                 #[Test]
@@ -213,6 +239,7 @@ final readonly class TempestRunTest
 
             require_once __DIR__ . '/app/GreetingConfig.php';
             require_once __DIR__ . '/app/Greeter.php';
+            require_once __DIR__ . '/app/ArchiveGreetingInitializer.php';
             require_once __DIR__ . '/app/VisitCounter.php';
             require_once __DIR__ . '/app/LifecycleObserver.php';
             require_once __DIR__ . '/tests/TempestApplicationTest.php';

--- a/tests/Unit/Tempest/TempestPluginLifecycleTest.php
+++ b/tests/Unit/Tempest/TempestPluginLifecycleTest.php
@@ -11,6 +11,8 @@ use Greenlight\Condition\ClassAvailable;
 use Greenlight\Execution\Plugin\WorkerPluginRuntime;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
+use Greenlight\Harness\Service;
+use Greenlight\Harness\ServiceResolutionFailed;
 use Greenlight\IntegrationFixture\IntegrationResources;
 use Greenlight\Plugin\TestContext;
 use Greenlight\Plugin\WorkerBootstrapContext;
@@ -23,7 +25,6 @@ use Greenlight\Test\TestChannel;
 use Greenlight\Tests\Support\PluginLifecycle;
 use Greenlight\Tests\Support\ServiceResolverProbe;
 use Tempest\Container\GenericContainer;
-use Tempest\Container\Tag;
 use Tempest\Core\FrameworkKernel;
 use Tempest\Http\GenericRequest;
 use Tempest\Http\Request;
@@ -53,16 +54,45 @@ final class TempestPluginLifecycleTest
     }
 
     #[Test]
-    public function resolvesATaggedContainerService(): void
+    public function theServiceIdSelectsATagForTheDeclaredType(): void
     {
         $plugin = $this->plugin();
         $kernel = $this->kernel($plugin);
         $expected = new TaggedProbeImplementation();
-        $kernel->container->singleton(TaggedProbe::class, $expected, 'preferred');
+        $kernel->container->singleton(TaggedProbe::class, new TaggedProbeImplementation());
+        $kernel->container->singleton(TaggedProbe::class, $expected, 'archive');
+        $kernel->container->singleton('archive', new TaggedProbeImplementation());
 
-        Expect::that($plugin->resolve(TaggedProbe::class, [new Tag('preferred')]))
-            ->because('the Tempest Tag attribute MUST select the tagged container binding')
-            ->toBe($expected);
+        Expect::that($plugin->resolve(TaggedProbe::class, [new Service('archive')]))->toBe($expected);
+    }
+
+    #[Test]
+    public function aParameterWithoutASelectorUsesTheDefaultBinding(): void
+    {
+        $plugin = $this->plugin();
+        $kernel = $this->kernel($plugin);
+        $expected = new TaggedProbeImplementation();
+        $kernel->container->singleton(TaggedProbe::class, $expected);
+        $kernel->container->singleton(TaggedProbe::class, new TaggedProbeImplementation(), 'archive');
+
+        Expect::that($plugin->resolve(TaggedProbe::class, []))->toBe($expected);
+    }
+
+    #[Test]
+    public function rejectsAServiceTagBindingOfTheWrongType(): void
+    {
+        $plugin = $this->plugin();
+        $kernel = $this->kernel($plugin);
+        $kernel->container->singleton(TaggedProbe::class, new TaggedProbeImplementation());
+        $kernel->container->singleton(TaggedProbe::class, new \stdClass(), 'archive');
+
+        Expect::that(static fn(): object => $plugin->resolve(TaggedProbe::class, [new Service('archive')]))
+            ->toThrow(
+                ServiceResolutionFailed::class,
+                message: 'The Tempest container returned "stdClass" for the parameter type "'
+                    . TaggedProbe::class
+                    . '".',
+            );
     }
 
     #[Test]


### PR DESCRIPTION
Tempest now resolves `#[Service('archive')] Storage $storage` through `$container->get(Storage::class, tag: 'archive')`. The declared parameter type and result-type checks stay in place. Without `Service`, the bridge uses the default Tempest lookup.

This replaces native Tempest `#[Tag]` selection on test constructor parameters. Use `#[Service]` instead. Service IDs remain strings, so enum-tagged bindings must use string tags for this interface.

The shared Service documentation now defines an ID as a selection within its source. Each bridge translates that selection. Other bridges keep their current lookup behavior. The Tempest guide and generated API references describe the change.

Merge this PR before #1853. This branch starts from `main` and does not include the named-source changes.
