### PR TITLE
build(docs): reuse the website build pipeline

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,7 @@
     "api:check": "node --test scripts/generate-api-reference.test.mjs && node scripts/generate-api-reference.mjs --check",
     "api:generate": "node scripts/generate-api-reference.mjs",
     "build": "npm run api:check && npm run test:links && astro build --force && pagefind --site dist --output-subdir _pagefind && node scripts/check-built-site.mjs",
-    "check": "npm run api:check && npm run test:links && astro check && astro build --force && pagefind --site dist --output-subdir _pagefind && node scripts/check-built-site.mjs && npm run test:browser",
+    "check": "astro check && npm run build && npm run test:browser",
     "test:links": "node --test scripts/remark-documentation-links.test.mjs",
     "test:browser": "node --test scripts/docs-navigation.test.mjs",
     "dev": "astro dev",


### PR DESCRIPTION
The website `build` and `check` commands repeat the API check, link tests, Astro build, search index generation, and built-site check. Each pipeline change must update both commands.

Make `check` run Astro type analysis, then the existing `build` command, then the browser tests. The build pipeline now has one definition. All checks remain enabled. Type analysis runs first so a type error stops the command before the build starts.
