### PR TITLE
refactor(hyperf): derive coroutine completion from its result

### DIFF
--- a/.github/fixtures/hyperf-bridge/tests/Cleanup/HyperfCoroutineResultTest.php
+++ b/.github/fixtures/hyperf-bridge/tests/Cleanup/HyperfCoroutineResultTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace HyperfBridgeAcceptance\Cleanup;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Hyperf\ContainerLifetime;
+use Greenlight\Hyperf\HyperfPlugin;
+use Greenlight\IntegrationFixture\IntegrationResources;
+use Greenlight\Plugin\WorkerBootstrapContext;
+use Greenlight\Test\TestChannel;
+
+final readonly class HyperfCoroutineResultTest
+{
+    #[Test]
+    #[DataSet('lifetimes')]
+    public function returnsNullFromACompletedCoroutine(ContainerLifetime $lifetime): void
+    {
+        $plugin = $this->plugin($lifetime);
+
+        $result = $plugin->runWorker(static fn(): mixed => $plugin->runTestAttempt(static fn(): null => null));
+
+        Expect::that($result)->toBeNull();
+    }
+
+    #[Test]
+    #[DataSet('lifetimes')]
+    public function returnsFalseFromACompletedCoroutine(ContainerLifetime $lifetime): void
+    {
+        $plugin = $this->plugin($lifetime);
+
+        $result = $plugin->runWorker(static fn(): mixed => $plugin->runTestAttempt(static fn(): false => false));
+
+        Expect::that($result)->toBeFalse();
+    }
+
+    #[Test]
+    #[DataSet('lifetimes')]
+    public function preservesTheCoroutineFailure(ContainerLifetime $lifetime): void
+    {
+        $plugin = $this->plugin($lifetime);
+        $failure = new \RuntimeException('The coroutine failed.');
+        $caught = null;
+
+        try {
+            $plugin->runWorker(static fn(): mixed => $plugin->runTestAttempt(static fn(): never => throw $failure));
+        } catch (\Throwable $threw) {
+            $caught = $threw;
+        }
+
+        Expect::that($caught)->toBe($failure);
+    }
+
+    /** @return iterable<string, array{ContainerLifetime}> */
+    public static function lifetimes(): iterable
+    {
+        yield 'worker' => [ContainerLifetime::Worker];
+        yield 'attempt' => [ContainerLifetime::TestAttempt];
+    }
+
+    private function plugin(ContainerLifetime $lifetime): HyperfPlugin
+    {
+        $plugin = new HyperfPlugin(\dirname(__DIR__, 2), containerLifetime: $lifetime);
+        $plugin->onWorkerBootstrap(new WorkerBootstrapContext('result-probe', new TestChannel(1), IntegrationResources::empty()));
+
+        return $plugin;
+    }
+}

--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -153,7 +153,7 @@ PHPDoc:
 - `@return T`
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L249)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L247)
 
 ## `LaravelPlugin`
 

--- a/src/Hyperf/HyperfPlugin.php
+++ b/src/Hyperf/HyperfPlugin.php
@@ -215,14 +215,12 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, ServiceSou
         /** @var array{value: T}|array{} $result */
         $result = [];
         $failure = null;
-        $completed = false;
         $flags = $this->hookFlags ?? SWOOLE_HOOK_ALL;
 
         try {
-            $started = run(function () use ($worker, &$result, &$failure, &$completed): void {
+            $started = run(function () use ($worker, &$result, &$failure): void {
                 try {
                     $result = ['value' => $worker()];
-                    $completed = true;
                 } catch (\Throwable $threw) {
                     $failure = $threw;
                 } finally {
@@ -234,7 +232,7 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, ServiceSou
             Runtime::enableCoroutine(0);
         }
 
-        return $this->coroutineResult($started, $completed, $result, $failure);
+        return $this->coroutineResult($started, $result, $failure);
     }
 
     /**
@@ -310,7 +308,6 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, ServiceSou
         /** @var array{value: T}|array{} $result */
         $result = [];
         $failure = null;
-        $completed = false;
         $finished = new Channel(1);
         $coroutineId = SwooleCoroutine::create(function () use (
             $attempt,
@@ -318,12 +315,10 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, ServiceSou
             $finished,
             &$result,
             &$failure,
-            &$completed,
         ): void {
             try {
                 $this->activeContainer = $container;
                 $result = ['value' => $attempt()];
-                $completed = true;
             } catch (\Throwable $threw) {
                 $failure = $threw;
             } finally {
@@ -344,7 +339,7 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, ServiceSou
         $didFinish = $finished->pop();
         $finished->close();
 
-        return $this->coroutineResult($didFinish === true, $completed, $result, $failure);
+        return $this->coroutineResult($didFinish === true, $result, $failure);
     }
 
     /**
@@ -360,11 +355,10 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, ServiceSou
         /** @var array{value: T}|array{} $result */
         $result = [];
         $failure = null;
-        $completed = false;
         $flags = $this->hookFlags ?? SWOOLE_HOOK_ALL;
 
         try {
-            $started = run(function () use ($attempt, &$result, &$failure, &$completed): void {
+            $started = run(function () use ($attempt, &$result, &$failure): void {
                 try {
                     $container = $this->createContainer();
                     $this->rejectReusedContainer($container);
@@ -372,7 +366,6 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, ServiceSou
                     ApplicationContext::setContainer($container);
                     $this->bootApplication($container);
                     $result = ['value' => $attempt()];
-                    $completed = true;
                 } catch (\Throwable $threw) {
                     $failure = $threw;
                 } finally {
@@ -384,7 +377,7 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, ServiceSou
             Runtime::enableCoroutine(0);
         }
 
-        return $this->coroutineResult($started, $completed, $result, $failure);
+        return $this->coroutineResult($started, $result, $failure);
     }
 
     /** @throws ServiceResolutionFailed */
@@ -496,7 +489,7 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, ServiceSou
      * @return T
      * @throws ServiceResolutionFailed
      */
-    private function coroutineResult(bool $started, bool $completed, array $result, ?\Throwable $failure): mixed
+    private function coroutineResult(bool $started, array $result, ?\Throwable $failure): mixed
     {
         if (!$started) {
             throw HyperfBridgeError::coroutineDidNotStart();
@@ -506,7 +499,7 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, ServiceSou
             throw $failure;
         }
 
-        if (!$completed || !\array_key_exists('value', $result)) {
+        if (!\array_key_exists('value', $result)) {
             throw HyperfBridgeError::coroutineDidNotStart();
         }
 


### PR DESCRIPTION
Hyperf keeps coroutine completion in both a Boolean flag and a result array. Every successful runner updates both values, then the common result reader checks both.

Use the existing result key as the completion state. This removes a captured reference and a required update from all three coroutine paths. A present key still permits `null` and `false` return values. Startup and failure checks keep their order.

Add acceptance cases for null results, false results, and the original exception under both container lifetimes. These cases exercise the worker wrapper, worker attempts, and isolated attempts through the real Hyperf runtime.
