### PR TITLE
refactor(cli): build bundled catalogs directly

### DIFF
--- a/src/Cli/Plugin/CommandDispatcher.php
+++ b/src/Cli/Plugin/CommandDispatcher.php
@@ -44,15 +44,12 @@ final readonly class CommandDispatcher
     {
         [$command, $commandIndex] = $this->selectedCommand($argv);
         $command ??= 'run';
-        $bundled = PluginDefinition::fromFactory(
-            fn(): BundledCommands => new BundledCommands($this->console, $this->version, $this->definition),
-        );
 
         try {
-            $catalog = $this->catalog([$bundled]);
+            $catalog = $this->catalog([]);
 
             if (!$catalog->has($command)) {
-                $catalog = $this->catalog([$bundled, ...$this->configuredPlugins($argv, $workingDirectory)]);
+                $catalog = $this->catalog($this->configuredPlugins($argv, $workingDirectory));
             }
         } catch (ConfigFileError|InvalidConfiguration|CommandSetupFailed $error) {
             $this->console->error($error->getMessage(), \in_array('--no-ansi', $argv, true));
@@ -108,7 +105,7 @@ final readonly class CommandDispatcher
      */
     private function catalog(array $plugins): CommandCatalog
     {
-        $definitions = [];
+        $definitions = new BundledCommands($this->console, $this->version, $this->definition)->commands();
 
         foreach ($plugins as $pluginDefinition) {
             if (!$pluginDefinition->supports(CommandProvider::class)) {

--- a/src/Cli/Reporting/ReporterFactory.php
+++ b/src/Cli/Reporting/ReporterFactory.php
@@ -39,17 +39,14 @@ final readonly class ReporterFactory
         $prefix = \rtrim($workingDirectory, '/') . '/';
         $displayedConfig = \str_starts_with($configFile, $prefix) ? \substr($configFile, \strlen($prefix)) : $configFile;
         $header = new RunHeader($version, $displayedConfig, $seed, workerFallback: $workerFallback);
-        $definitions = [];
-        $bundled = PluginDefinition::fromFactory(
-            fn(): BundledReporters => new BundledReporters(
-                $capabilities,
-                $header,
-                $arguments,
-                TerminalRowsResolver::resolve(),
-            ),
-        );
+        $definitions = new BundledReporters(
+            $capabilities,
+            $header,
+            $arguments,
+            TerminalRowsResolver::resolve(),
+        )->reporters();
 
-        foreach ([$bundled, ...$plugins] as $pluginDefinition) {
+        foreach ($plugins as $pluginDefinition) {
             if (!$pluginDefinition->supports(ReporterProvider::class)) {
                 continue;
             }


### PR DESCRIPTION
The CLI wrapped its bundled command and reporter providers in plugin factories. It then used reflection and runtime capability checks to recover providers whose concrete types were already known.

Create the bundled definitions directly and use them to initialize each catalog. Configured plugins still use the existing factory validation, failure handling, and duplicate-name checks. Bundled definitions keep their original order, and built-in commands still avoid loading the project configuration.

This removes an internal factory round trip from command and reporter setup. Public commands, reporter selection, plugin interfaces, and output stay the same.
