### PR TITLE
refactor(config): remove duplicate coverage state and validation

### DIFF
--- a/docs/api-configuration.md
+++ b/docs/api-configuration.md
@@ -245,7 +245,7 @@ final class GreenlightConfig
 public static function create(): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L81)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L78)
 
 ### `paths()`
 
@@ -261,7 +261,7 @@ PHPDoc:
 - `@param non-empty-list<non-empty-string> $tests`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L94)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L91)
 
 ### `suite()`
 
@@ -282,7 +282,7 @@ PHPDoc:
 - `@param callable(SuiteBuilder): mixed $configurator`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L152)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L149)
 
 ### `workers()`
 
@@ -297,7 +297,7 @@ PHPDoc:
 - `@param positive-int|'auto' $count`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L176)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L173)
 
 ### `resourceLimit()`
 
@@ -316,7 +316,7 @@ PHPDoc:
 - `@param positive-int $limit`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L194)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L191)
 
 ### `coverage()`
 
@@ -328,7 +328,7 @@ PHPDoc:
 
 - `@param callable(CoverageBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L218)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L215)
 
 ### `watch()`
 
@@ -340,7 +340,7 @@ PHPDoc:
 
 - `@param callable(WatchBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L231)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L227)
 
 ### `artifacts()`
 
@@ -352,7 +352,7 @@ PHPDoc:
 
 - `@param callable(ArtifactBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L243)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L239)
 
 ### `storage()`
 
@@ -367,7 +367,7 @@ PHPDoc:
 
 - `@param callable(StorageBuilder): mixed $configurator`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L258)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L254)
 
 ### `failOnDeprecation()`
 
@@ -383,7 +383,7 @@ PHPDoc:
 
 - `@see self::ignoreDeprecationsMatching()`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L274)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L270)
 
 ### `failOnNotice()`
 
@@ -393,7 +393,7 @@ Fails an otherwise passed test if captured output contains a notice.
 public function failOnNotice(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L282)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L278)
 
 ### `failOnWarning()`
 
@@ -403,7 +403,7 @@ Fails an otherwise passed test if captured output contains a warning.
 public function failOnWarning(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L290)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L286)
 
 ### `failOnRisky()`
 
@@ -415,7 +415,7 @@ expectations.
 public function failOnRisky(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L302)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L298)
 
 ### `failOnSkipped()`
 
@@ -426,7 +426,7 @@ keeps its skipped outcome and reason.
 public function failOnSkipped(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L313)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L309)
 
 ### `failOnRetriedPass()`
 
@@ -437,7 +437,7 @@ outcome and attempt count.
 public function failOnRetriedPass(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L324)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L320)
 
 ### `ignoreDeprecationsMatching()`
 
@@ -454,7 +454,7 @@ PHPDoc:
 - `@param non-empty-string ...$patterns`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L340)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L336)
 
 ### `plugins()`
 
@@ -467,7 +467,7 @@ PHPDoc:
 - `@param \Closure(): Plugin ...$plugins`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L361)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L357)
 
 ### `failFast()`
 
@@ -475,7 +475,7 @@ PHPDoc:
 public function failFast(bool $enabled = true): self
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L378)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L374)
 
 ### `randomizeOrder()`
 
@@ -490,7 +490,7 @@ PHPDoc:
 - `@param int<0, max>|null $seed`
 - `@throws InvalidConfiguration`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L391)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Config/GreenlightConfig.php#L387)
 
 ## `InvalidConfiguration`
 

--- a/src/Config/CoverageBuilder.php
+++ b/src/Config/CoverageBuilder.php
@@ -126,14 +126,6 @@ final class CoverageBuilder
      */
     public function export(string $format, string $target): self
     {
-        if ($format === '') {
-            throw InvalidConfiguration::emptyCoverageExport();
-        }
-
-        if ($target === '') {
-            throw InvalidConfiguration::emptyCoverageExport();
-        }
-
         $this->exports[] = new CoverageExport($format, $target);
 
         return $this;

--- a/src/Config/GreenlightConfig.php
+++ b/src/Config/GreenlightConfig.php
@@ -25,9 +25,7 @@ final class GreenlightConfig
 
     private WorkerCount $workers;
 
-    private CoverageBuilder $coverage;
-
-    private bool $coverageEnabled = false;
+    private ?CoverageBuilder $coverage = null;
 
     private WatchBuilder $watch;
 
@@ -72,7 +70,6 @@ final class GreenlightConfig
     private function __construct()
     {
         $this->workers = WorkerCount::auto();
-        $this->coverage = new CoverageBuilder();
         $this->watch = new WatchBuilder();
         $this->artifacts = new ArtifactBuilder();
         $this->storage = new StorageBuilder();
@@ -217,10 +214,9 @@ final class GreenlightConfig
      */
     public function coverage(callable $configurator): self
     {
-        $builder = clone $this->coverage;
+        $builder = $this->coverage === null ? new CoverageBuilder() : clone $this->coverage;
         $configurator($builder);
         $this->coverage = clone $builder;
-        $this->coverageEnabled = true;
 
         return $this;
     }
@@ -453,7 +449,7 @@ final class GreenlightConfig
                 artifacts: $this->artifacts->toConfiguration(),
             ),
             order: new OrderConfiguration($this->randomizeOrder, $this->randomSeed),
-            coverage: $this->coverageEnabled ? $this->coverage->toConfiguration() : null,
+            coverage: $this->coverage?->toConfiguration(),
             watch: $this->watch->toConfiguration(),
             storage: $this->storage->toConfiguration(),
         );

--- a/src/Config/GreenlightConfig.php
+++ b/src/Config/GreenlightConfig.php
@@ -214,7 +214,7 @@ final class GreenlightConfig
      */
     public function coverage(callable $configurator): self
     {
-        $builder = $this->coverage === null ? new CoverageBuilder() : clone $this->coverage;
+        $builder = $this->coverage instanceof CoverageBuilder ? clone $this->coverage : new CoverageBuilder();
         $configurator($builder);
         $this->coverage = clone $builder;
 

--- a/tests/Unit/Config/GreenlightConfigTest.php
+++ b/tests/Unit/Config/GreenlightConfigTest.php
@@ -179,6 +179,19 @@ final class GreenlightConfigTest
     }
 
     #[Test]
+    public function anEmptyCoverageConfiguratorEnablesDefaultCoverage(): void
+    {
+        $configuration = GreenlightConfig::create()
+            ->coverage(static function (CoverageBuilder $coverage): void {})
+            ->build();
+
+        Expect::that($configuration->coverage)->toBeInstanceOf(CoverageConfiguration::class);
+        Expect::that($configuration->coverage->includePaths)->toBe([]);
+        Expect::that($configuration->coverage->driver)->toBe(null);
+        Expect::that($configuration->coverage->exports)->toBe([]);
+    }
+
+    #[Test]
     public function rejectedCoverageConfigurationDoesNotEnableCoverage(): void
     {
         $builder = GreenlightConfig::create();


### PR DESCRIPTION
Coverage configuration stored an always-present builder and a separate flag to say whether coverage was enabled. Export configuration also checked empty values before the export value object repeated those checks.

Use a nullable coverage builder as the single record of whether coverage was configured. Create the builder on the first successful configuration call. Keep the existing copies that isolate callbacks and preserve earlier settings after a rejected call.

Let CoverageExport own export validation. The same exception types and messages remain in use. An empty coverage callback still enables the defaults, repeated callbacks retain earlier settings, and rejected callbacks leave the previous configuration intact.
