### PR TITLE
refactor(expect): reuse array comparison for object properties

### DIFF
--- a/src/Expect/Equality.php
+++ b/src/Expect/Equality.php
@@ -194,18 +194,11 @@ final class Equality
                 return true;
             }
 
-            $aProperties = \get_mangled_object_vars($a);
-            $bProperties = \get_mangled_object_vars($b);
-
-            if (\count($aProperties) !== \count($bProperties)) {
-                return false;
-            }
-            return \array_all(
-                $aProperties,
-                static function ($value, $name) use ($bProperties, &$leftObjects, &$rightObjects): bool {
-                    return \array_key_exists($name, $bProperties)
-                        && self::compare($value, $bProperties[$name], $leftObjects, $rightObjects);
-                },
+            return self::compare(
+                \get_mangled_object_vars($a),
+                \get_mangled_object_vars($b),
+                $leftObjects,
+                $rightObjects,
             );
         }
 

--- a/tests/Unit/Expect/ToBeAndToEqualTest.php
+++ b/tests/Unit/Expect/ToBeAndToEqualTest.php
@@ -118,6 +118,15 @@ final class ToBeAndToEqualTest
     }
 
     #[Test]
+    public function toEqualPreservesPropertyNamesWithNullValues(): void
+    {
+        $subject = (object) ['first' => null, 'second' => 2];
+
+        Expect::that($subject)->toEqual((object) ['second' => 2.0, 'first' => null]);
+        Expect::that($subject)->not()->toEqual((object) ['other' => null, 'second' => 2]);
+    }
+
+    #[Test]
     public function toEqualComparesEnumsByIdentity(): void
     {
         Expect::that(Suit::Hearts)->because('toEqual() compares enums by identity')->toEqual(Suit::Hearts);


### PR DESCRIPTION
Deep equality compares both arrays and object properties by key, but the object path repeats the array count, key-presence, and recursive-value checks.

After the existing class and object-identity checks, pass the property maps through the array comparison. This leaves one recursive rule for keyed values and keeps the existing object-cycle maps. Private property keys, property order, numeric values, and null properties retain their meaning.

Add a focused case for equal property maps with null values and different property names. Existing cases cover private properties, cyclic and shared objects, JSON container shapes, and double argument matching.
