### PR TITLE
refactor(execution): remove redundant runtime state

### DIFF
--- a/src/Execution/Plugin/PluginRuntime.php
+++ b/src/Execution/Plugin/PluginRuntime.php
@@ -16,7 +16,7 @@ use Greenlight\Plugin\Prioritized;
 abstract readonly class PluginRuntime
 {
     /**
-     * @var list<array{plugin: Plugin, priority: int, registration: int}>
+     * @var list<Plugin>
      */
     private array $plugins;
 
@@ -38,7 +38,7 @@ abstract readonly class PluginRuntime
             ];
         }
 
-        $this->plugins = $indexed;
+        $this->plugins = $plugins;
 
         \usort(
             $indexed,
@@ -82,9 +82,9 @@ abstract readonly class PluginRuntime
     {
         $matching = [];
 
-        foreach ($this->plugins as $entry) {
-            if ($entry['plugin'] instanceof $capability) {
-                $matching[] = $entry['plugin'];
+        foreach ($this->plugins as $plugin) {
+            if ($plugin instanceof $capability) {
+                $matching[] = $plugin;
             }
         }
 

--- a/src/Execution/Worker/Worker.php
+++ b/src/Execution/Worker/Worker.php
@@ -69,13 +69,12 @@ final readonly class Worker
         $scopes ??= new HarnessScopes($this->definitions);
         $summary = new ResultSummary();
         $drained = false;
-        $stopped = false;
         $remaining = [];
         $leaks = [];
 
         try {
             foreach ($plan->entriesByClass() as $class => $entries) {
-                if ($stopped) {
+                if ($drained) {
                     $remaining = [...$remaining, ...\array_map(static fn(PlanEntry $entry): TestId => $entry->id, $entries)];
 
                     continue;
@@ -138,7 +137,6 @@ final readonly class Worker
                     };
 
                     if ($stopReached !== null) {
-                        $stopped = true;
                         $drained = true;
 
                         if ($index !== $lastIndex) {


### PR DESCRIPTION
The worker stored two booleans that always changed together when a failure limit or drain request stopped an assignment. Use the existing drained state to control the remaining entries and to report the outcome.

The plugin runtime also retained priority and registration metadata in its original-order plugin list. Capability matching only needs the plugin objects. Retain those objects directly and keep the sort metadata local to construction. Priority values are still read once, and priority order and registration order keep their existing meanings.

These changes remove duplicate state without changing worker results, remaining test IDs, plugin ownership, or callback order.
