### PR TITLE
ci(renovate): separate npm and Composer lock file maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,6 +29,18 @@
     ],
     "packageRules": [
         {
+            "description": "Separate npm and Composer lock file maintenance",
+            "matchManagers": [
+                "npm",
+                "composer"
+            ],
+            "matchUpdateTypes": [
+                "lockFileMaintenance"
+            ],
+            "additionalBranchPrefix": "{{manager}}-",
+            "commitMessageSuffix": "({{manager}})"
+        },
+        {
             "description": "Keep TypeScript at version 6 until Astro Check supports the native compiler API",
             "matchManagers": [
                 "npm"


### PR DESCRIPTION
Weekly lock file maintenance currently updates `composer.lock` and `website/package-lock.json` in one pull request.

Add a package rule that gives npm and Composer maintenance separate branch prefixes and PR title suffixes. Each package manager gets its own weekly maintenance PR. Regular dependency update rules remain unchanged.
