### PR TITLE
ci(renovate): enable automerge by default

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,7 @@
         ":semanticCommitScope(deps)"
     ],
     "timezone": "Europe/London",
+    "automerge": true,
     "prConcurrentLimit": 5,
     "customManagers": [
         {


### PR DESCRIPTION
Set `automerge` to `true` in the Renovate configuration so dependency PRs use automerge by default, including major updates and lock file maintenance.

GitHub already permits automerge for this repository. The existing required checks, code-owner review, and squash merge policy still apply.
