### PR TITLE
refactor(phpstan): share method argument lookup

### DIFF
--- a/src/PhpStan/CaptureArgumentReturnTypeExtension.php
+++ b/src/PhpStan/CaptureArgumentReturnTypeExtension.php
@@ -8,7 +8,6 @@ use Greenlight\Doubles\ArgumentCaptor;
 use Greenlight\Doubles\MethodExpectation;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Identifier;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Reflection\ReflectionProvider;
@@ -96,7 +95,7 @@ final readonly class CaptureArgumentReturnTypeExtension implements DynamicMethod
             }
         }
 
-        $argument = $this->argument($call, 'position', 0);
+        $argument = MethodCallArguments::find($call, 'position', 0);
 
         if (!$argument instanceof Arg) {
             return 0;
@@ -108,32 +107,5 @@ final readonly class CaptureArgumentReturnTypeExtension implements DynamicMethod
         ));
 
         return \count($values) === 1 ? $values[0] : null;
-    }
-
-    private function argument(MethodCall $call, string $name, int $position): ?Arg
-    {
-        $nextPosition = 0;
-
-        foreach ($call->getArgs() as $argument) {
-            if ($argument->unpack) {
-                continue;
-            }
-
-            if ($argument->name instanceof Identifier) {
-                if ($argument->name->toString() === $name) {
-                    return $argument;
-                }
-
-                continue;
-            }
-
-            if ($nextPosition === $position) {
-                return $argument;
-            }
-
-            ++$nextPosition;
-        }
-
-        return null;
     }
 }

--- a/src/PhpStan/DoublePlanRule.php
+++ b/src/PhpStan/DoublePlanRule.php
@@ -239,7 +239,7 @@ final readonly class DoublePlanRule implements Rule
             return [];
         }
 
-        $count = $this->argument($call, 'count', 0);
+        $count = MethodCallArguments::find($call, 'count', 0);
 
         if (!$count instanceof Node\Arg) {
             return [];
@@ -294,7 +294,7 @@ final readonly class DoublePlanRule implements Rule
         }
 
         if ($selector === 'andReturnsUsing') {
-            $answer = $this->argument($call, 'answer', 0);
+            $answer = MethodCallArguments::find($call, 'answer', 0);
 
             if (!$answer instanceof Node\Arg) {
                 return [];
@@ -371,7 +371,7 @@ final readonly class DoublePlanRule implements Rule
         }
 
         [$target, $method, $acceptor] = $selected;
-        $positionArgument = $this->argument($call, 'position', 0);
+        $positionArgument = MethodCallArguments::find($call, 'position', 0);
         $positions = $positionArgument instanceof Node\Arg
             ? $scope->getType($positionArgument->value)->getConstantScalarValues()
             : [0];
@@ -452,33 +452,6 @@ final readonly class DoublePlanRule implements Rule
         $acceptor = $this->singleAcceptor($target->getNativeMethod($method)->getVariants());
 
         return $acceptor instanceof ParametersAcceptor ? [$target, $method, $acceptor] : null;
-    }
-
-    private function argument(MethodCall $call, string $name, int $position): ?Node\Arg
-    {
-        $nextPosition = 0;
-
-        foreach ($call->getArgs() as $argument) {
-            if ($argument->unpack) {
-                continue;
-            }
-
-            if ($argument->name instanceof Identifier) {
-                if ($argument->name->toString() === $name) {
-                    return $argument;
-                }
-
-                continue;
-            }
-
-            if ($nextPosition === $position) {
-                return $argument;
-            }
-
-            ++$nextPosition;
-        }
-
-        return null;
     }
 
     /**

--- a/src/PhpStan/DoubleableTypeRule.php
+++ b/src/PhpStan/DoubleableTypeRule.php
@@ -43,7 +43,7 @@ final readonly class DoubleableTypeRule implements Rule
             return [];
         }
 
-        $type = $this->argument($node, 'type', 0);
+        $type = MethodCallArguments::find($node, 'type', 0);
 
         if (!$type instanceof Arg) {
             return [];
@@ -92,33 +92,6 @@ final readonly class DoubleableTypeRule implements Rule
 
         if ($class->isTrait()) {
             return 'it is a trait. Use a class or interface that uses it';
-        }
-
-        return null;
-    }
-
-    private function argument(MethodCall $call, string $name, int $position): ?Arg
-    {
-        $nextPosition = 0;
-
-        foreach ($call->getArgs() as $argument) {
-            if ($argument->unpack) {
-                continue;
-            }
-
-            if ($argument->name instanceof Identifier) {
-                if ($argument->name->toString() === $name) {
-                    return $argument;
-                }
-
-                continue;
-            }
-
-            if ($nextPosition === $position) {
-                return $argument;
-            }
-
-            ++$nextPosition;
         }
 
         return null;

--- a/src/PhpStan/DoublesCallRule.php
+++ b/src/PhpStan/DoublesCallRule.php
@@ -44,8 +44,8 @@ final readonly class DoublesCallRule implements Rule
             return [];
         }
 
-        $double = $this->argument($node, 'double', 0);
-        $method = $this->argument($node, 'method', 1);
+        $double = MethodCallArguments::find($node, 'double', 0);
+        $method = MethodCallArguments::find($node, 'method', 1);
 
         if (!$double instanceof Arg || !$method instanceof Arg) {
             return [];
@@ -80,33 +80,6 @@ final readonly class DoublesCallRule implements Rule
         }
 
         return $errors;
-    }
-
-    private function argument(MethodCall $call, string $name, int $position): ?Arg
-    {
-        $nextPosition = 0;
-
-        foreach ($call->getArgs() as $argument) {
-            if ($argument->unpack) {
-                continue;
-            }
-
-            if ($argument->name instanceof Identifier) {
-                if ($argument->name->toString() === $name) {
-                    return $argument;
-                }
-
-                continue;
-            }
-
-            if ($nextPosition === $position) {
-                return $argument;
-            }
-
-            ++$nextPosition;
-        }
-
-        return null;
     }
 
     private function error(string $method, string $type, int $line): IdentifierRuleError

--- a/src/PhpStan/DoublesCallsToReturnTypeExtension.php
+++ b/src/PhpStan/DoublesCallsToReturnTypeExtension.php
@@ -7,7 +7,6 @@ namespace Greenlight\PhpStan;
 use Greenlight\Doubles\Doubles;
 use PhpParser\Node\Arg;
 use PhpParser\Node\Expr\MethodCall;
-use PhpParser\Node\Identifier;
 use PHPStan\Analyser\Scope;
 use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\Accessory\AccessoryArrayListType;
@@ -40,8 +39,8 @@ final readonly class DoublesCallsToReturnTypeExtension implements DynamicMethodR
     #[\Override]
     public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
     {
-        $double = $this->argument($methodCall, 'double', 0);
-        $method = $this->argument($methodCall, 'method', 1);
+        $double = MethodCallArguments::find($methodCall, 'double', 0);
+        $method = MethodCallArguments::find($methodCall, 'method', 1);
 
         if (!$double instanceof Arg || !$method instanceof Arg) {
             return null;
@@ -92,32 +91,5 @@ final readonly class DoublesCallsToReturnTypeExtension implements DynamicMethodR
         );
 
         return TypeCombinator::intersect($calls, new AccessoryArrayListType());
-    }
-
-    private function argument(MethodCall $call, string $name, int $position): ?Arg
-    {
-        $nextPosition = 0;
-
-        foreach ($call->getArgs() as $argument) {
-            if ($argument->unpack) {
-                continue;
-            }
-
-            if ($argument->name instanceof Identifier) {
-                if ($argument->name->toString() === $name) {
-                    return $argument;
-                }
-
-                continue;
-            }
-
-            if ($nextPosition === $position) {
-                return $argument;
-            }
-
-            ++$nextPosition;
-        }
-
-        return null;
     }
 }

--- a/src/PhpStan/ExpectationArgumentRule.php
+++ b/src/PhpStan/ExpectationArgumentRule.php
@@ -62,7 +62,7 @@ final class ExpectationArgumentRule implements Rule
      */
     private function reasonErrors(MethodCall $call, Scope $scope): array
     {
-        $argument = $this->argument($call, 'reason', 0);
+        $argument = MethodCallArguments::find($call, 'reason', 0);
 
         if (!$argument instanceof Arg) {
             return [];
@@ -94,7 +94,7 @@ final class ExpectationArgumentRule implements Rule
         string $name,
         int $position,
     ): array {
-        $argument = $this->argument($call, $name, $position);
+        $argument = MethodCallArguments::find($call, $name, $position);
 
         if (!$argument instanceof Arg) {
             return [];
@@ -125,7 +125,7 @@ final class ExpectationArgumentRule implements Rule
      */
     private function jsonErrors(MethodCall $call, Scope $scope): array
     {
-        $argument = $this->argument($call, 'expected', 0);
+        $argument = MethodCallArguments::find($call, 'expected', 0);
 
         if (!$argument instanceof Arg) {
             return [];
@@ -145,33 +145,6 @@ final class ExpectationArgumentRule implements Rule
         return [];
     }
 
-    private function argument(MethodCall $call, string $name, int $position): ?Arg
-    {
-        $nextPosition = 0;
-
-        foreach ($call->getArgs() as $argument) {
-            if ($argument->unpack) {
-                continue;
-            }
-
-            if ($argument->name instanceof Identifier) {
-                if ($argument->name->toString() === $name) {
-                    return $argument;
-                }
-
-                continue;
-            }
-
-            if ($nextPosition === $position) {
-                return $argument;
-            }
-
-            ++$nextPosition;
-        }
-
-        return null;
-    }
-
     private function isExpectation(Type $receiver): bool
     {
         return \array_any(
@@ -179,5 +152,4 @@ final class ExpectationArgumentRule implements Rule
             static fn(string $class): bool => new ObjectType($class)->isSuperTypeOf($receiver)->yes(),
         );
     }
-
 }

--- a/src/PhpStan/FloatArgumentRule.php
+++ b/src/PhpStan/FloatArgumentRule.php
@@ -152,7 +152,7 @@ final class FloatArgumentRule implements Rule
                 continue;
             }
 
-            $argument = $this->argument($node, $constraint['argument'], $constraint['position']);
+            $argument = MethodCallArguments::find($node, $constraint['argument'], $constraint['position']);
 
             if (!$argument instanceof Arg) {
                 return [];
@@ -226,33 +226,6 @@ final class FloatArgumentRule implements Rule
     private function belowMaximum(float $value, ?float $maximum, bool $inclusive): bool
     {
         return $maximum === null || ($inclusive ? $value <= $maximum : $value < $maximum);
-    }
-
-    private function argument(MethodCall $call, string $name, int $position): ?Arg
-    {
-        $nextPosition = 0;
-
-        foreach ($call->getArgs() as $argument) {
-            if ($argument->unpack) {
-                continue;
-            }
-
-            if ($argument->name instanceof Identifier) {
-                if ($argument->name->toString() === $name) {
-                    return $argument;
-                }
-
-                continue;
-            }
-
-            if ($nextPosition === $position) {
-                return $argument;
-            }
-
-            ++$nextPosition;
-        }
-
-        return null;
     }
 
     private function error(string $message, string $identifier, int $line): IdentifierRuleError

--- a/src/PhpStan/MethodCallArguments.php
+++ b/src/PhpStan/MethodCallArguments.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\PhpStan;
+
+use Greenlight\Attribute\CoverageIgnore;
+use PhpParser\Node\Arg;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Identifier;
+
+/**
+ * Finds an explicit method argument by name or position.
+ *
+ * @internal
+ */
+final class MethodCallArguments
+{
+    #[CoverageIgnore]
+    private function __construct() {}
+
+    public static function find(MethodCall $call, string $name, int $position): ?Arg
+    {
+        $nextPosition = 0;
+
+        foreach ($call->getArgs() as $argument) {
+            if ($argument->unpack) {
+                continue;
+            }
+
+            if ($argument->name instanceof Identifier) {
+                if ($argument->name->toString() === $name) {
+                    return $argument;
+                }
+
+                continue;
+            }
+
+            if ($nextPosition === $position) {
+                return $argument;
+            }
+
+            ++$nextPosition;
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
Seven PHPStan rules and return-type extensions each carried the same method-argument lookup. A change to named or positional argument handling required the same edit in seven places.

Move the identical lookup into one internal `MethodCallArguments::find()` helper. The callers retain their validation and type-inference decisions, including the capture-position check that keeps unpacked arguments unresolved. This gives the shared parser behavior one owner without changing diagnostics, defaults, public interfaces, or dependencies.
