### PR TITLE
test(rector): batch acceptance test conversions

### DIFF
--- a/tests/Acceptance/RectorArgumentOrderTest.php
+++ b/tests/Acceptance/RectorArgumentOrderTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Greenlight\Tests\Acceptance;
 
-use Greenlight\Attribute\DataSet;
 use Greenlight\Attribute\RequiresResource;
 use Greenlight\Attribute\Test;
 use Greenlight\Expect\Expect;
@@ -17,13 +16,21 @@ final readonly class RectorArgumentOrderTest
     public function __construct(private TemporaryDirectory $workspace) {}
 
     #[Test]
-    #[DataSet('assertionsWhoseArgumentsCanAffectEachOther')]
-    public function keepsClassesWhoseAssertionArgumentsCanAffectEachOther(string $assertion): void
+    public function keepsClassesWhoseAssertionArgumentsCanAffectEachOther(): void
     {
-        $source = $this->source($assertion);
-        $probe = RectorProbe::convert($this->workspace, $source, name: 'assertion-order');
+        $cases = [];
 
-        Expect::that($probe->code)->toBe($source);
+        foreach (self::assertionsWhoseArgumentsCanAffectEachOther() as $caseName => [$assertion]) {
+            $cases[$caseName] = $this->source($assertion);
+        }
+
+        $probes = RectorProbe::convertBatch($this->workspace, $cases, name: 'assertion-order');
+
+        foreach ($probes as $caseName => $probe) {
+            Expect::that($probe->code)
+                ->because('Assertion argument order case: ' . $caseName . '.')
+                ->toBe($cases[$caseName]);
+        }
     }
 
     #[Test]

--- a/tests/Acceptance/RectorMigrationRunTest.php
+++ b/tests/Acceptance/RectorMigrationRunTest.php
@@ -159,13 +159,119 @@ final readonly class RectorMigrationRunTest
 
     PHP_WRAP;
 
+    private const string INLINE_ROWS = <<<'PHP_WRAP'
+    <?php
+
+    declare(strict_types=1);
+
+    namespace App\Tests;
+
+    use PHPUnit\Framework\Attributes\TestWith;
+    use PHPUnit\Framework\TestCase;
+
+    final class ProbeTest extends TestCase
+    {
+        #[TestWith([1])]
+        #[TestWith([2])]
+        public function testRows(int $value): void
+        {
+            $this->assertGreaterThan(0, $value);
+        }
+    }
+
+    PHP_WRAP;
+
+    private const string SUPPORTED_ASSERTIONS = <<<'PHP_WRAP'
+    <?php
+
+    declare(strict_types=1);
+
+    namespace App\Tests;
+
+    use PHPUnit\Framework\TestCase;
+
+    final class ProbeTest extends TestCase
+    {
+        public function testAssertions(): void
+        {
+            $this->assertSame(1, 1);
+            $this->assertNotSame(1, '1');
+            $this->assertEquals(['a' => 1], ['a' => 1]);
+            $this->assertNotEquals(['a' => 1], ['a' => 2]);
+            $this->assertEqualsCanonicalizing([1, 2], [2, 1]);
+            $this->assertNotEqualsCanonicalizing([1, 2], [1, 3]);
+            $this->assertEqualsWithDelta(0.3, 0.1 + 0.2, 0.001);
+            $this->assertTrue(true);
+            $this->assertNotTrue(1);
+            $this->assertFalse(false);
+            $this->assertNotFalse(0);
+            $this->assertNull(null);
+            $this->assertNotNull(false);
+            $this->assertInstanceOf(\stdClass::class, new \stdClass());
+            $this->assertNotInstanceOf(\stdClass::class, new \ArrayObject());
+            $this->assertCount(2, [1, 2]);
+            $this->assertNotCount(1, [1, 2]);
+            $this->assertGreaterThan(1, 2);
+            $this->assertGreaterThanOrEqual(2, 2);
+            $this->assertLessThan(2, 1);
+            $this->assertLessThanOrEqual(1, 1);
+            $this->assertIsArray([]);
+            $this->assertIsNotArray(new \ArrayObject());
+            $this->assertIsString('');
+            $this->assertIsNotString(1);
+            $this->assertIsInt(1);
+            $this->assertIsNotInt(1.0);
+            $this->assertIsFloat(1.0);
+            $this->assertIsNotFloat(1);
+            $this->assertIsBool(true);
+            $this->assertIsNotBool(1);
+            $this->assertIsCallable(static fn(): null => null);
+            $this->assertIsNotCallable(null);
+            $this->assertIsIterable([]);
+            $this->assertIsNotIterable(1);
+            $this->assertContains(1, [1]);
+            $this->assertNotContains(2, [1]);
+            $this->assertStringContainsString('ell', 'hello');
+            $this->assertStringNotContainsString('bye', 'hello');
+            $this->assertArrayHasKey('a', ['a' => 1]);
+            $this->assertArrayNotHasKey('b', ['a' => 1]);
+            $this->assertMatchesRegularExpression('/ell/', 'hello');
+            $this->assertDoesNotMatchRegularExpression('/bye/', 'hello');
+            $this->assertStringStartsWith('hel', 'hello');
+            $this->assertStringStartsNotWith('bye', 'hello');
+            $this->assertStringEndsWith('llo', 'hello');
+            $this->assertStringEndsNotWith('bye', 'hello');
+            $this->assertJson('{"a":1}');
+            $this->assertJsonStringEqualsJsonString('{"a":1}', '{"a":1}');
+        }
+    }
+
+    PHP_WRAP;
+
     public function __construct(private TemporaryDirectory $tempDirectory) {}
 
     #[Test]
-    public function convertsAPhpUnitClassAndTheResultRunsGreen(): void
+    public function convertsSupportedPhpUnitClassesAndTheResultsRunGreen(): void
     {
-        $probe = RectorProbe::convert($this->tempDirectory, self::CONVERTIBLE, name: 'converts');
+        $probes = RectorProbe::convertBatch(
+            $this->tempDirectory,
+            [
+                'class conversion' => self::CONVERTIBLE,
+                'exception message pattern' => self::MATCHED_EXCEPTION,
+                'inline data rows' => self::INLINE_ROWS,
+                'supported assertions' => self::SUPPORTED_ASSERTIONS,
+            ],
+            name: 'supported-migrations',
+        );
 
+        $this->assertClassConversion($probes['class conversion']);
+        $this->assertExceptionMessagePattern($probes['exception message pattern']);
+        $this->assertInlineDataRows($probes['inline data rows']);
+        $this->assertSupportedAssertions($probes['supported assertions']);
+    }
+
+    private function assertClassConversion(RectorProbe $probe): void
+    {
         Expect::that($probe->changed)->toBeTrue();
         Expect::that($probe->code)->not()->toContain('extends TestCase')
             ->toContain('#[\Greenlight\Attribute\Test]')
@@ -192,11 +298,8 @@ final readonly class RectorMigrationRunTest
             ->toContain('no smtp server');
     }
 
-    #[Test]
-    public function preservesExceptionMessagePatternsAndTheResultRunsGreen(): void
+    private function assertExceptionMessagePattern(RectorProbe $probe): void
     {
-        $probe = RectorProbe::convert($this->tempDirectory, self::MATCHED_EXCEPTION, name: 'exception-message-pattern');
-
         Expect::that($probe->changed)
             ->because('the exception test MUST be convertible')
             ->toBeTrue();
@@ -559,35 +662,8 @@ final readonly class RectorMigrationRunTest
             ->not()->toContain('values must match');
     }
 
-    #[Test]
-    public function preservesEachInlineDataRow(): void
+    private function assertInlineDataRows(RectorProbe $probe): void
     {
-        $probe = RectorProbe::convert(
-            $this->tempDirectory,
-            <<<'PHP_WRAP'
-            <?php
-
-            declare(strict_types=1);
-
-            namespace App\Tests;
-
-            use PHPUnit\Framework\Attributes\TestWith;
-            use PHPUnit\Framework\TestCase;
-
-            final class ProbeTest extends TestCase
-            {
-                #[TestWith([1])]
-                #[TestWith([2])]
-                public function testRows(int $value): void
-                {
-                    $this->assertGreaterThan(0, $value);
-                }
-            }
-
-            PHP_WRAP,
-            name: 'inline-rows',
-        );
-
         Expect::that($probe->changed)->toBeTrue();
         Expect::that(\substr_count($probe->code, '#[\Greenlight\Attribute\DataRow'))->toBe(2);
         Expect::that($probe->code)->toContain('#[\Greenlight\Attribute\DataRow([1])]')
@@ -599,80 +675,8 @@ final readonly class RectorMigrationRunTest
         Expect::that($run->stdout)->toContain('2 tests, 2 passed');
     }
 
-    #[Test]
-    public function convertsEverySupportedAssertionAndTheResultRunsGreen(): void
+    private function assertSupportedAssertions(RectorProbe $probe): void
     {
-        $probe = RectorProbe::convert(
-            $this->tempDirectory,
-            <<<'PHP_WRAP'
-            <?php
-
-            declare(strict_types=1);
-
-            namespace App\Tests;
-
-            use PHPUnit\Framework\TestCase;
-
-            final class ProbeTest extends TestCase
-            {
-                public function testAssertions(): void
-                {
-                    $this->assertSame(1, 1);
-                    $this->assertNotSame(1, '1');
-                    $this->assertEquals(['a' => 1], ['a' => 1]);
-                    $this->assertNotEquals(['a' => 1], ['a' => 2]);
-                    $this->assertEqualsCanonicalizing([1, 2], [2, 1]);
-                    $this->assertNotEqualsCanonicalizing([1, 2], [1, 3]);
-                    $this->assertEqualsWithDelta(0.3, 0.1 + 0.2, 0.001);
-                    $this->assertTrue(true);
-                    $this->assertNotTrue(1);
-                    $this->assertFalse(false);
-                    $this->assertNotFalse(0);
-                    $this->assertNull(null);
-                    $this->assertNotNull(false);
-                    $this->assertInstanceOf(\stdClass::class, new \stdClass());
-                    $this->assertNotInstanceOf(\stdClass::class, new \ArrayObject());
-                    $this->assertCount(2, [1, 2]);
-                    $this->assertNotCount(1, [1, 2]);
-                    $this->assertGreaterThan(1, 2);
-                    $this->assertGreaterThanOrEqual(2, 2);
-                    $this->assertLessThan(2, 1);
-                    $this->assertLessThanOrEqual(1, 1);
-                    $this->assertIsArray([]);
-                    $this->assertIsNotArray(new \ArrayObject());
-                    $this->assertIsString('');
-                    $this->assertIsNotString(1);
-                    $this->assertIsInt(1);
-                    $this->assertIsNotInt(1.0);
-                    $this->assertIsFloat(1.0);
-                    $this->assertIsNotFloat(1);
-                    $this->assertIsBool(true);
-                    $this->assertIsNotBool(1);
-                    $this->assertIsCallable(static fn(): null => null);
-                    $this->assertIsNotCallable(null);
-                    $this->assertIsIterable([]);
-                    $this->assertIsNotIterable(1);
-                    $this->assertContains(1, [1]);
-                    $this->assertNotContains(2, [1]);
-                    $this->assertStringContainsString('ell', 'hello');
-                    $this->assertStringNotContainsString('bye', 'hello');
-                    $this->assertArrayHasKey('a', ['a' => 1]);
-                    $this->assertArrayNotHasKey('b', ['a' => 1]);
-                    $this->assertMatchesRegularExpression('/ell/', 'hello');
-                    $this->assertDoesNotMatchRegularExpression('/bye/', 'hello');
-                    $this->assertStringStartsWith('hel', 'hello');
-                    $this->assertStringStartsNotWith('bye', 'hello');
-                    $this->assertStringEndsWith('llo', 'hello');
-                    $this->assertStringEndsNotWith('bye', 'hello');
-                    $this->assertJson('{"a":1}');
-                    $this->assertJsonStringEqualsJsonString('{"a":1}', '{"a":1}');
-                }
-            }
-
-            PHP_WRAP,
-            name: 'assertions',
-        );
-
         Expect::that($probe->changed)->toBeTrue();
         Expect::that($probe->code)->not()->toContain('->assert')
             ->not()->toContain('::assert');
@@ -682,5 +686,4 @@ final readonly class RectorMigrationRunTest
         Expect::that($run->exitCode)->toBe(0);
         Expect::that($run->stdout)->toContain('1 test, 1 passed');
     }
-
 }


### PR DESCRIPTION
These acceptance classes started Rector once per case, which repeated the same process startup and analysis setup. Batch the seven argument-order rejection cases and the four default migration cases with the existing `RectorProbe::convertBatch()` helper. Rector starts fall from 13 to 4.

Keep all 48 expectations and all five converted-fixture runs. Each rejection case has a named failure message, and each migration case has a separate assertion helper. The configured assertion-message case retains its own Rector run.

Local timings on PHP 8.4.14, using the median of three runs with one worker and seed 42:

| Class | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| `RectorArgumentOrderTest` | 17.403s | 3.786s | 78% |
| `RectorMigrationRunTest` | 11.799s | 4.693s | 60% |
| Combined run | 28.183s | 8.372s | 70% |
