### PR TITLE
refactor(reporting): share risky test guidance formatting

### DIFF
--- a/src/Reporting/PlainReporter.php
+++ b/src/Reporting/PlainReporter.php
@@ -173,13 +173,7 @@ final class PlainReporter implements Reporter
         $this->output->write($this->slowTests->render($this->style));
 
         if ($this->risky !== []) {
-            $this->output->write(\sprintf(
-                "\nRisky tests: %d\n"
-                . "These tests passed without a verified expectation.\n"
-                . "Add #[NoExpectations] to accept this result. Use --fail-on-risky to fail the run.\n%s\n",
-                \count($this->risky),
-                \implode("\n", \array_map(static fn(string $id): string => '  ' . $id, $this->risky)),
-            ));
+            $this->output->write(SummaryFormat::risky($this->risky));
         }
     }
 

--- a/src/Reporting/SummaryFormat.php
+++ b/src/Reporting/SummaryFormat.php
@@ -117,6 +117,20 @@ final class SummaryFormat
         return \implode("\n", $lines) . "\n";
     }
 
+    /**
+     * @param non-empty-list<non-empty-string> $risky
+     */
+    public static function risky(array $risky): string
+    {
+        return \sprintf(
+            "\nRisky tests: %d\n"
+            . "These tests passed without a verified expectation.\n"
+            . "Add #[NoExpectations] to accept this result. Use --fail-on-risky to fail the run.\n%s\n",
+            \count($risky),
+            \implode("\n", \array_map(static fn(string $id): string => '  ' . $id, $risky)),
+        );
+    }
+
     public static function coverage(float $percentage, int $coveredLines, int $executableLines, Style $style): string
     {
         return \sprintf(

--- a/src/Reporting/TtyReporter.php
+++ b/src/Reporting/TtyReporter.php
@@ -300,13 +300,7 @@ final class TtyReporter implements Reporter, Ticking
         }
 
         if ($this->risky !== []) {
-            $this->output->write(\sprintf(
-                "\nRisky tests: %d\n"
-                . "These tests passed without a verified expectation.\n"
-                . "Add #[NoExpectations] to accept this result. Use --fail-on-risky to fail the run.\n%s\n",
-                \count($this->risky),
-                \implode("\n", \array_map(static fn(string $id): string => '  ' . $id, $this->risky)),
-            ));
+            $this->output->write(SummaryFormat::risky($this->risky));
         }
     }
 


### PR DESCRIPTION
The plain and TTY reporters each built the same risky-test guidance block. A text change required two edits, although both formats use the same wording and layout.

Move this formatter into the existing `SummaryFormat` class. Each reporter retains its result selection, emission guard, and output order. The existing exact-output assertions for both reporters continue to cover the guidance text and the exclusion of failed risky tests.
