### PR TITLE
refactor(hyperf): share coroutine runtime cleanup

### DIFF
--- a/.github/fixtures/hyperf-bridge/tests/Cleanup/HyperfCoroutineResultTest.php
+++ b/.github/fixtures/hyperf-bridge/tests/Cleanup/HyperfCoroutineResultTest.php
@@ -12,6 +12,7 @@ use Greenlight\Hyperf\HyperfPlugin;
 use Greenlight\IntegrationFixture\IntegrationResources;
 use Greenlight\Plugin\WorkerBootstrapContext;
 use Greenlight\Test\TestChannel;
+use Hyperf\Coroutine\Coroutine;
 
 final readonly class HyperfCoroutineResultTest
 {
@@ -51,6 +52,34 @@ final readonly class HyperfCoroutineResultTest
             $caught = $threw;
         }
 
+        Expect::that($caught)->toBe($failure);
+    }
+
+    #[Test]
+    #[DataSet('lifetimes')]
+    public function aCoroutineFailureStillDisposesInsideTheRuntime(ContainerLifetime $lifetime): void
+    {
+        $failure = new \RuntimeException('The coroutine failed.');
+        $disposedInCoroutine = false;
+        $plugin = new HyperfPlugin(
+            \dirname(__DIR__, 2),
+            containerLifetime: $lifetime,
+            dispose: static function () use (&$disposedInCoroutine): never {
+                $disposedInCoroutine = Coroutine::inCoroutine();
+
+                throw new \RuntimeException('The disposal failed.');
+            },
+        );
+        $plugin->onWorkerBootstrap(new WorkerBootstrapContext('cleanup-result-probe', new TestChannel(1), IntegrationResources::empty()));
+        $caught = null;
+
+        try {
+            $plugin->runWorker(static fn(): mixed => $plugin->runTestAttempt(static fn(): never => throw $failure));
+        } catch (\Throwable $threw) {
+            $caught = $threw;
+        }
+
+        Expect::that($disposedInCoroutine)->toBeTrue();
         Expect::that($caught)->toBe($failure);
     }
 

--- a/docs/api-integrations.md
+++ b/docs/api-integrations.md
@@ -153,7 +153,7 @@ PHPDoc:
 - `@return T`
 - `@throws ServiceResolutionFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L247)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Hyperf/HyperfPlugin.php#L227)
 
 ## `LaravelPlugin`
 

--- a/src/Hyperf/HyperfPlugin.php
+++ b/src/Hyperf/HyperfPlugin.php
@@ -212,27 +212,7 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, ServiceSou
             throw HyperfBridgeError::workerContainerUnavailable();
         }
 
-        /** @var array{value: T}|array{} $result */
-        $result = [];
-        $failure = null;
-        $flags = $this->hookFlags ?? SWOOLE_HOOK_ALL;
-
-        try {
-            $started = run(function () use ($worker, &$result, &$failure): void {
-                try {
-                    $result = ['value' => $worker()];
-                } catch (\Throwable $threw) {
-                    $failure = $threw;
-                } finally {
-                    $this->captureCleanup($failure, $this->disposeWorkerContainer(...));
-                    $this->captureRuntimeCleanup($failure);
-                }
-            }, $flags);
-        } finally {
-            Runtime::enableCoroutine(0);
-        }
-
-        return $this->coroutineResult($started, $result, $failure);
+        return $this->runRuntime($worker, $this->disposeWorkerContainer(...));
     }
 
     /**
@@ -254,7 +234,15 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, ServiceSou
             return $this->runWorkerAttempt($attempt);
         }
 
-        return $this->runIsolatedAttempt($attempt);
+        return $this->runRuntime(function () use ($attempt): mixed {
+            $container = $this->createContainer();
+            $this->rejectReusedContainer($container);
+            $this->activeContainer = $container;
+            ApplicationContext::setContainer($container);
+            $this->bootApplication($container);
+
+            return $attempt();
+        }, $this->disposeAttemptContainer(...));
     }
 
     /** @throws ServiceResolutionFailed */
@@ -346,12 +334,13 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, ServiceSou
     /**
      * @template T
      *
-     * @param \Closure(): T $attempt
+     * @param \Closure(): T $callback
+     * @param \Closure(): void $dispose
      *
      * @return T
      * @throws ServiceResolutionFailed
      */
-    private function runIsolatedAttempt(\Closure $attempt): mixed
+    private function runRuntime(\Closure $callback, \Closure $dispose): mixed
     {
         /** @var array{value: T}|array{} $result */
         $result = [];
@@ -359,18 +348,13 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, ServiceSou
         $flags = $this->hookFlags ?? SWOOLE_HOOK_ALL;
 
         try {
-            $started = run(function () use ($attempt, &$result, &$failure): void {
+            $started = run(function () use ($callback, $dispose, &$result, &$failure): void {
                 try {
-                    $container = $this->createContainer();
-                    $this->rejectReusedContainer($container);
-                    $this->activeContainer = $container;
-                    ApplicationContext::setContainer($container);
-                    $this->bootApplication($container);
-                    $result = ['value' => $attempt()];
+                    $result = ['value' => $callback()];
                 } catch (\Throwable $threw) {
                     $failure = $threw;
                 } finally {
-                    $this->captureCleanup($failure, $this->disposeAttemptContainer(...));
+                    $this->captureCleanup($failure, $dispose);
                     $this->captureRuntimeCleanup($failure);
                 }
             }, $flags);


### PR DESCRIPTION
The worker and per-attempt container lifetimes duplicated the coroutine result, failure, and cleanup protocol. A change to disposal order or hook reset had to update both paths.

Use one private runtime method for both lifetimes. Each caller still owns container preparation and supplies its disposal callback. The shared method preserves the first failure, runs disposal and runtime cleanup inside the coroutine, and disables coroutine hooks after it ends.

Extend the isolated Hyperf fixture to check that both lifetimes dispose inside the runtime when the test and disposal both fail. The original test failure remains the reported failure.
