### PR TITLE
docs: clarify plugin and bridge lifecycle boundaries

### DIFF
--- a/docs/hyperf.md
+++ b/docs/hyperf.md
@@ -112,7 +112,7 @@ container.
 
 ## Test-attempt container lifecycle
 
-The isolated mode uses this lifecycle for each attempt:
+`ContainerLifetime::TestAttempt` uses this lifecycle for each attempt:
 
 1. Start one root Swoole coroutine.
 2. Load `config/container.php` and activate its new container.
@@ -203,13 +203,17 @@ new HyperfPlugin(
 The reset callback runs after Greenlight closes its per-test service scope. It
 runs inside the test coroutine in both modes.
 
-The disposal callback runs before Greenlight discards its container. In worker
-mode, it runs once when the worker exits. In test-attempt mode, the reset
-callback runs first. Greenlight calls disposal even if reset throws. If either
-callback throws, the attempt has an error.
+The disposal callback runs before Greenlight discards its container.
+In worker mode, it runs once after the worker finishes its assignments.
+A disposal failure stops the worker runtime and fails the run.
 
-The first throwable remains the cause. Greenlight still removes access to the container, clears the coroutine
-runtime, and ends the coroutine.
+In test-attempt mode, the reset callback runs first. Greenlight calls disposal
+even if reset throws. A failure from either callback gives the attempt an error.
+A reset failure in worker mode also gives the attempt an error.
+
+The first throwable remains the cause. At the end of the container lifetime,
+Greenlight still removes container access, clears the coroutine runtime, and
+ends the root coroutine.
 
 The bridge does not reset application static properties or global variables.
 Reset these values in an `#[After]` hook or the `reset:` callback.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -5,8 +5,8 @@ plugin to `GreenlightConfig::plugins()` in `greenlight.php`. Give each factory
 its concrete plugin class as the return type. Return a new instance each time
 Greenlight calls the factory.
 
-Plugin capabilities run either in the orchestrator or in workers. Each
-capability section below names its side.
+Plugin capabilities run in the command process, the orchestrator, or workers.
+Each capability section below names its owner.
 
 <!-- php-example {"example":"plugins-example-01","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
@@ -24,13 +24,13 @@ Greenlight creates plugin instances only for an owner that uses one of their
 capabilities. It creates one command-owned instance for each factory that
 has `CommandProvider`, `ReporterProvider`, `WatchSource`,
 `CoverageMapTransformer`, or `RunAcceptancePolicy`. Command dispatch,
-reporter setup, watch polling, coverage finishing, and run policy evaluation
+reporter setup, watch polling, coverage completion, and run policy evaluation
 own separate instances. It creates one
 run-owned orchestrator instance for each factory that has a run capability. It
 creates one worker instance for each factory that has a worker capability and
 for each physical worker.
 
-A plugin that has capabilities on both sides gets one instance on each side.
+A plugin with several owners gets a separate instance for each owner.
 The instances are separate with one in-process worker and with parallel
 workers. Capabilities with the same owner and lifetime use the same instance.
 A plugin that has `ReporterProvider` and a run capability gets separate command
@@ -275,7 +275,7 @@ return GreenlightConfig::create()
 
 The transformer receives a `CoverageMap` with sorted `FileCoverage` values.
 Return a `CoverageMap`. A transformer or plugin-factory error stops coverage
-finishing and the command fails. Watch reruns do not write coverage and do not
+completion and the command fails. Watch reruns do not write coverage and do not
 apply these transformers.
 
 ### AttachmentRetentionDecider
@@ -659,7 +659,7 @@ public function transformTerminalResult(TestDefinition $definition, TestResult $
 ```
 
 Greenlight calls a terminal-result transformer one time after the last attempt.
-The test scope is closed. The worker has not yet closed the class scope or
+The test scope has closed. The worker has not yet closed the class scope or
 published `TestFinished`.
 
 The transformer receives the test definition and the result that remains after
@@ -686,10 +686,12 @@ stream contains run, worker, class, and test events.
 
 Run subscribers cannot change results across the process boundary. Integration
 fixture provisioning completes before `RunStarted`.
-`RunFinished` is delivered before fixture teardown begins. If a run subscriber
-throws, the run fails and fixtures are still torn down.
+Greenlight sends `RunFinished` before fixture teardown begins. If a run
+subscriber throws, the run fails and Greenlight still runs fixture teardown.
 
 ### HarnessProvider
+
+Worker-side.
 
 <!-- php-example {"example":"plugins-example-11","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
@@ -709,7 +711,7 @@ final class DatabaseProvider implements HarnessProvider
 
 Harness providers supply services to test constructors.
 
-Services can be scoped as `PerTest`, `PerClass`, or `PerWorker`.
+Give each service a `PerTest`, `PerClass`, or `PerWorker` scope.
 `PerWorker` means the physical worker lifetime. It does not mean the
 orchestrator-owned integration fixture lifetime. Services are lazy. Greenlight
 constructs a service only when a test uses it.
@@ -732,7 +734,7 @@ failure and adds each disposal failure to the diagnostic.
 
 ### ServiceResolver
 
-In `Greenlight\Harness`.
+In `Greenlight\Harness`. Worker-side.
 
 <!-- php-example {"mode":"display","reason":"Shows one method signature without its interface declaration."} -->
 ```php
@@ -831,7 +833,7 @@ their constructors. See the [multiple PSR-11 containers example](psr11.md#multip
 
 ### ExpectationExtension
 
-In `Greenlight\Expect`.
+In `Greenlight\Expect`. Worker-side during test execution.
 
 <!-- php-example {"example":"plugins-example-13","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
@@ -964,6 +966,9 @@ implement both capabilities run their callbacks in the exact reverse order.
 Greenlight runs all after-test subscribers. It also runs them when a
 before-test subscriber stops the attempt.
 
-Greenlight reports all plugin failures. A command-side failure stops the
-command. A worker-side failure causes an error for the affected test and names
-the plugin. An orchestrator-side failure causes the run to fail.
+Greenlight reports plugin failures at the affected lifecycle boundary.
+A command-side or orchestrator-side failure fails the run or command.
+A test-attempt failure gives the affected test an error and names the plugin.
+Worker bootstrap and runtime failures stop the worker. They do not always
+have an active test to receive an error. Each capability section describes
+its error behavior.

--- a/docs/psr11.md
+++ b/docs/psr11.md
@@ -155,7 +155,8 @@ resolvers.
 ## State between tests
 
 By default, the bridge discards the active container after each test attempt.
-The next test creates a new container from the factory.
+The next service request calls the factory again. Return a new container from
+each factory call to keep container state separate between attempts.
 
 Use `reset:` to reset container state before the bridge discards the container:
 

--- a/docs/psr15.md
+++ b/docs/psr15.md
@@ -78,7 +78,9 @@ This bootstrap file returns the handler that the plugin factory expects.
 `Psr15Plugin` does not supply container services to test constructors.
 
 If tests need application services, also register the
-[PSR-11 bridge](psr11.md).
+[PSR-11 bridge](psr11.md). The two plugins call separate factories. Registration
+alone does not make them share a container. A service from the PSR-11 factory
+can therefore be a different instance from the service that handles a request.
 
 ## Send requests
 


### PR DESCRIPTION
Plugin capabilities execute in several owners, and the guides blurred their failure boundaries. Clarify command, orchestrator, worker, and test-attempt ownership. Explain that Hyperf worker disposal occurs after its assignment loop, so its failure affects the worker runtime. Explain that PSR-11 factories need to create new containers for fresh state and that PSR-11 and PSR-15 factories do not share a container automatically.

The lifecycle corrections follow `HyperfPlugin::runWorker()`, `runWorkerAttempt()`, `runIsolatedAttempt()`, and the independent factories in `Psr11Plugin` and `Psr15Plugin`. The existing worker-runtime and worker-disposal acceptance tests cover the distinction between worker failures and test results.
