### PR TITLE
refactor(plugin): let harness scopes validate services

### DIFF
--- a/docs/api-plugins.md
+++ b/docs/api-plugins.md
@@ -575,7 +575,7 @@ for a per-test service then throws. Other service scopes remain available.
 final readonly class TestContext
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L22)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L21)
 
 ### `$attachments`
 
@@ -583,7 +583,7 @@ final readonly class TestContext
 public Attachments $attachments;
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L24)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L23)
 
 ### `$instance`
 
@@ -591,7 +591,7 @@ public Attachments $attachments;
 public object $instance
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L28)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L27)
 
 ### `$id`
 
@@ -599,7 +599,7 @@ public object $instance
 public TestId $id
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L29)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L28)
 
 ### `$definition`
 
@@ -607,7 +607,7 @@ public TestId $id
 public TestDefinition $definition
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L30)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L29)
 
 ### `service()`
 
@@ -622,7 +622,7 @@ PHPDoc:
 - `@return T`
 - `@throws ServiceResolutionFailed when a service resolver cannot supply a valid service`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L46)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L45)
 
 ### `skip()`
 
@@ -638,7 +638,7 @@ PHPDoc:
 - `@param non-empty-string $reason`
 - `@throws SkipTest`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L65)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/TestContext.php#L58)
 
 ## `TestPlan`
 

--- a/src/Plugin/TestContext.php
+++ b/src/Plugin/TestContext.php
@@ -8,7 +8,6 @@ use Greenlight\Artifact\Attachments;
 use Greenlight\Artifact\UnavailableAttachments;
 use Greenlight\Harness\HarnessScopes;
 use Greenlight\Harness\ServiceResolutionFailed;
-use Greenlight\Harness\UnresolvableService;
 use Greenlight\Test\SkipTest;
 use Greenlight\Test\TestDefinition;
 use Greenlight\Test\TestId;
@@ -45,13 +44,7 @@ final readonly class TestContext
      */
     public function service(string $type): object
     {
-        $service = $this->scopes->resolve($type, 'plugin context for ' . $this->definition->class);
-
-        if (!$service instanceof $type) {
-            throw UnresolvableService::unknownType($type, 'plugin context for ' . $this->definition->class);
-        }
-
-        return $service;
+        return $this->scopes->resolve($type, 'plugin context for ' . $this->definition->class);
     }
 
     /**

--- a/tests/Unit/Plugin/TestContextTest.php
+++ b/tests/Unit/Plugin/TestContextTest.php
@@ -58,7 +58,7 @@ final class TestContextTest
     {
         $resolver = new class implements ServiceResolver {
             #[\Override]
-            public function resolve(string $type, array $attributes): ?object
+            public function resolve(string $type, array $attributes): object
             {
                 return new \stdClass();
             }

--- a/tests/Unit/Plugin/TestContextTest.php
+++ b/tests/Unit/Plugin/TestContextTest.php
@@ -10,6 +10,7 @@ use Greenlight\Expect\Expect;
 use Greenlight\Harness\HarnessScopes;
 use Greenlight\Harness\Scope;
 use Greenlight\Harness\ServiceDefinition;
+use Greenlight\Harness\ServiceResolver;
 use Greenlight\Harness\UnresolvableService;
 use Greenlight\Plugin\TestContext;
 use Greenlight\Test\SkipTest;
@@ -49,6 +50,30 @@ final class TestContextTest
                 UnresolvableService::class,
                 message: 'No harness service is registered for type "ArrayObject", required by "plugin context for Fixture\\PluginTest". '
                 . 'Constructor injection resolves exact types only.',
+            );
+    }
+
+    #[Test]
+    public function servicePreservesTheHarnessTypeMismatch(): void
+    {
+        $resolver = new class implements ServiceResolver {
+            #[\Override]
+            public function resolve(string $type, array $attributes): ?object
+            {
+                return new \stdClass();
+            }
+        };
+        $context = $this->context(new HarnessScopes(resolvers: [$resolver]));
+
+        Expect::that(static fn(): object => $context->service(\ArrayObject::class))
+            ->toThrow(
+                UnresolvableService::class,
+                message: UnresolvableService::resolverTypeMismatch(
+                    \ArrayObject::class,
+                    'plugin context for Fixture\\PluginTest',
+                    $resolver::class,
+                    new \stdClass(),
+                )->getMessage(),
             );
     }
 


### PR DESCRIPTION
`TestContext::service()` checked each resolved object after `HarnessScopes` had already checked its type. That second guard could not run: the final scopes class returns the requested type or throws the applicable resolution error.

Delegate directly to `HarnessScopes`. This keeps type enforcement and diagnostics with the service owner and removes an unreachable fallback from the plugin context. Add a focused assertion that a resolver type mismatch reaches the plugin caller with its context intact.
