### PR TITLE
docs: clarify execution limits and data provider lifecycle

### DIFF
--- a/docs/api-attributes.md
+++ b/docs/api-attributes.md
@@ -128,15 +128,16 @@ PHPDoc:
 
 Namespace: `Greenlight\Attribute`
 
-References a pure public static data provider. The provider runs during
-discovery.
+References a pure public static data provider. Greenlight evaluates the
+provider during discovery and again in the worker for each class assignment.
+Return the same data for the same inputs. Do not change external state.
 
 ```php
 #[\Attribute(\Attribute::TARGET_METHOD)]
 final readonly class DataSet
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataSet.php#L12)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataSet.php#L13)
 
 ### `$provider`
 
@@ -148,7 +149,7 @@ PHPDoc:
 
 - `@var non-empty-string`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataSet.php#L17)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataSet.php#L18)
 
 ### `$providerClass`
 
@@ -160,7 +161,7 @@ PHPDoc:
 
 - `@var class-string|null`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataSet.php#L22)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataSet.php#L23)
 
 ### `__construct()`
 
@@ -178,7 +179,7 @@ PHPDoc:
 - `@param non-empty-string|null $method`
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataSet.php#L34)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/DataSet.php#L35)
 
 ## `Group`
 
@@ -223,14 +224,15 @@ PHPDoc:
 
 Namespace: `Greenlight\Attribute`
 
-Greenlight assigns a new worker to each selected test.
+Assigns a fresh worker process to each selected test during process-pool
+execution. In-process execution does not provide process isolation.
 
 ```php
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS)]
 final readonly class Isolated
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Isolated.php#L11)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Isolated.php#L12)
 
 This type does not declare public members.
 
@@ -474,12 +476,15 @@ number of seconds. Greenlight checks elapsed time after per-test service
 disposal. This check does not interrupt PHP code that is still running.
 A class attribute applies the limit to each test in the class.
 
+During process-pool execution, the orchestrator also stops a blocked worker
+after the timeout grace period. In-process execution has no such interrupt.
+
 ```php
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS)]
 final readonly class Timeout
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Timeout.php#L14)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Timeout.php#L17)
 
 ### `$seconds`
 
@@ -487,7 +492,7 @@ final readonly class Timeout
 public float $seconds
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Timeout.php#L20)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Timeout.php#L23)
 
 ### `__construct()`
 
@@ -501,7 +506,7 @@ PHPDoc:
 
 - `@throws \InvalidArgumentException`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Timeout.php#L19)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Attribute/Timeout.php#L22)
 
 ## `ClassAvailable`
 

--- a/src/Attribute/DataSet.php
+++ b/src/Attribute/DataSet.php
@@ -5,8 +5,9 @@ declare(strict_types=1);
 namespace Greenlight\Attribute;
 
 /**
- * References a pure public static data provider. The provider runs during
- * discovery.
+ * References a pure public static data provider. Greenlight evaluates the
+ * provider during discovery and again in the worker for each class assignment.
+ * Return the same data for the same inputs. Do not change external state.
  */
 #[\Attribute(\Attribute::TARGET_METHOD)]
 final readonly class DataSet

--- a/src/Attribute/Isolated.php
+++ b/src/Attribute/Isolated.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 namespace Greenlight\Attribute;
 
 /**
- * Greenlight assigns a new worker to each selected test.
+ * Assigns a fresh worker process to each selected test during process-pool
+ * execution. In-process execution does not provide process isolation.
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS)]
 final readonly class Isolated {}

--- a/src/Attribute/Timeout.php
+++ b/src/Attribute/Timeout.php
@@ -9,6 +9,9 @@ namespace Greenlight\Attribute;
  * number of seconds. Greenlight checks elapsed time after per-test service
  * disposal. This check does not interrupt PHP code that is still running.
  * A class attribute applies the limit to each test in the class.
+ *
+ * During process-pool execution, the orchestrator also stops a blocked worker
+ * after the timeout grace period. In-process execution has no such interrupt.
  */
 #[\Attribute(\Attribute::TARGET_METHOD | \Attribute::TARGET_CLASS)]
 final readonly class Timeout

--- a/src/Cli/Input/Definition.php
+++ b/src/Cli/Input/Definition.php
@@ -61,10 +61,14 @@ final readonly class Definition
 
         Options:
           --config=<path>    Use this configuration file instead of ./greenlight.php
-          --workers=<n|auto> Set the worker process count
+          --workers=<n|auto> Set the worker count. The built-in default is auto.
+                             auto uses the detected CPU count. A count of 1 runs
+                             tests in the command process without process isolation.
           --resource-limit=<name>=<n>
                              Set a named resource limit. You can repeat this option.
-          --bail[=<n>]       Stop after <n> failed or errored tests (default 1)
+          --bail[=<n>]       Stop new work after <n> failed or errored tests.
+                             Without <n>, this option uses a limit of 1.
+                             Active assignments can finish after the limit.
           --suite=<name>     Select a named suite. You can repeat this option.
           --suite-tag=<tag>  Select suites with this tag. You can repeat this option.
           --group=<name>     Run only this group. You can repeat this option.
@@ -94,7 +98,8 @@ final readonly class Definition
                              A failed iteration fails the command.
           --repeat-until-failure  Repeat until an iteration fails, up to
                              --repeat times (default at most 100)
-                             Do not use repeat modes with JUnit output or coverage.
+                             Do not use repeat modes with JUnit output, coverage,
+                             or --watch.
           --shard=<n>/<m>    Run shard n of m. Shards are disjoint and contain
                              whole classes. They are stable across machines and
                              need no coordination.

--- a/src/Test/DataSet/DataSetError.php
+++ b/src/Test/DataSet/DataSetError.php
@@ -87,7 +87,7 @@ final class DataSetError extends \RuntimeException
     public static function providerTooSlow(string $class, string $provider, float $budgetSeconds): self
     {
         return new self(\sprintf(
-            'Data-set provider %s::%s() exceeded the %.3f-second discovery time budget. Providers run during plan creation. Keep them pure and fast.',
+            'Data-set provider %s::%s() exceeded the %.3f-second provider time budget. Providers run during discovery and execution. Keep them pure and fast.',
             $class,
             $provider,
             $budgetSeconds,

--- a/tests/Unit/Test/DataSet/DataSetErrorTest.php
+++ b/tests/Unit/Test/DataSet/DataSetErrorTest.php
@@ -34,7 +34,7 @@ final class DataSetErrorTest
             'Test method App\ExampleTest::checksValue() references data-set provider App\Rows::values(). Declare the provider as public and static.',
             'Data-set provider App\Rows::values() returned string. Return an iterable from the provider.',
             'Data-set provider App\ExampleTest::rows() threw RuntimeException: provider failed',
-            'Data-set provider App\Rows::values() exceeded the 0.125-second discovery time budget. Providers run during plan creation. Keep them pure and fast.',
+            'Data-set provider App\Rows::values() exceeded the 0.125-second provider time budget. Providers run during discovery and execution. Keep them pure and fast.',
             'Data-set provider App\Rows::values() produced no data sets. Produce at least one data set.',
             'Data-set provider App\Rows::values() produced a key of type float. Use string or integer keys.',
             'Data sets for App\ExampleTest::checksValue() contain key "same" more than once. Use each key only once for the test method.',

--- a/tests/Unit/Test/DataSet/DataSetExpansionTest.php
+++ b/tests/Unit/Test/DataSet/DataSetExpansionTest.php
@@ -265,7 +265,7 @@ final class DataSetExpansionTest
             ->toThrow(
                 DataSetError::class,
                 message: 'Data-set provider ' . ProviderKeysTest::class . '::stringKeys() '
-                    . 'exceeded the 5.000-second discovery time budget. Providers run during plan creation. '
+                    . 'exceeded the 5.000-second provider time budget. Providers run during discovery and execution. '
                     . 'Keep them pure and fast.',
             );
     }


### PR DESCRIPTION
The attribute reference currently promises a new process for every isolated test, describes data providers only at discovery, and omits hard timeout containment. The CLI help also leaves the one-worker mode and the optional bail threshold unclear.

Clarify that process isolation and hard timeout containment require the process pool, and that workers evaluate data providers again for each class assignment. Explain the automatic worker count, the in-process single-worker mode, active work after a bail threshold, and the repeat/watch restriction. Regenerate the attribute reference from its PHPDoc sources.

Describe a slow data provider's limit as a provider time budget, since the same diagnostic can occur during discovery or worker execution. Update the exact expected messages to match the corrected wording.

These corrections follow `RunSession::adapter()`, `ClassContext::argumentsFor()`, `Orchestrator::enforceTimeouts()`, `CliOverrides::fromArguments()`, and `RunCommand::run()`. They align the API reference and command help with the existing execution behavior and attribute guide.
