### PR TITLE
refactor(phpstan): reuse method argument lookup

### DIFF
--- a/src/PhpStan/ToThrowCallbackRule.php
+++ b/src/PhpStan/ToThrowCallbackRule.php
@@ -53,7 +53,7 @@ final class ToThrowCallbackRule implements Rule
             return [];
         }
 
-        $argument = $this->throwableArgument($node);
+        $argument = MethodCallArguments::find($node, 'throwable', 0);
 
         if (!$argument instanceof Arg) {
             return [];
@@ -74,27 +74,6 @@ final class ToThrowCallbackRule implements Rule
         }
 
         return [];
-    }
-
-    private function throwableArgument(MethodCall $call): ?Arg
-    {
-        foreach ($call->getArgs() as $argument) {
-            if ($argument->unpack) {
-                continue;
-            }
-
-            if ($argument->name instanceof Identifier) {
-                if ($argument->name->toString() === 'throwable') {
-                    return $argument;
-                }
-
-                continue;
-            }
-
-            return $argument;
-        }
-
-        return null;
     }
 
     private function callbackError(CallableParametersAcceptor $callback, int $line): ?IdentifierRuleError


### PR DESCRIPTION
The throwable callback rule had its own argument scan even though the PHPStan module already provides the same lookup in `MethodCallArguments`.

Use the shared lookup for the `throwable` argument and remove the private scan. Named arguments, the first positional argument, and unpack handling keep the same behavior. Future argument lookup changes now have one maintained implementation.
