### PR TITLE
docs: clarify execution and coverage ownership

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,11 @@ Greenlight discovers each test class once and creates an execution plan.
 Workers request assignments when they have capacity.
 
 The orchestrator controls resource limits, worker replacement, event checks,
-and reports. It also stores test durations to improve the order of later runs.
+and result delivery to reporters. The CLI stores test durations to improve the
+order of later runs.
+
+With one configured or detected worker, the CLI runs tests in its own process.
+This mode has no worker-process isolation or hard timeout enforcement.
 
 Greenlight normally schedules complete test classes. It schedules each
 `#[Isolated]` test separately. Add `#[AllowParallel]` to split an independent

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -54,10 +54,10 @@ containment, summary totals, artifact publication, and worker coverage
 aggregation. Workers execute their plan sections in sequence and send each
 result immediately.
 
-Each adapter returns a coverage map in its execution outcome. The CLI coverage
-session can merge this map with command-process and relayed subprocess
-coverage. Command-side coverage plugins transform the merged map. The CLI
-writes exports and evaluates coverage gates.
+The execution outcome contains a coverage map when the adapter collects
+coverage. The CLI coverage session can merge this map with command-process and
+relayed subprocess coverage. Command-side coverage plugins transform the merged
+map. The CLI writes exports and evaluates coverage gates.
 
 ## Module map
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -34,6 +34,9 @@ flowchart LR
 ```
 
 The CLI resolves the configuration once and selects one execution adapter.
+It selects `InProcessExecution` when the worker count is one or the worker
+entry point is unavailable. Otherwise, it selects `ProcessPoolExecution`.
+
 The run coordinator uses discovery to produce an immutable execution plan.
 It controls plan order, run resources, and run lifecycle events. The selected
 adapter executes the plan and returns one outcome. Reporters consume the events
@@ -117,8 +120,8 @@ Public contract modules do not depend on discovery or integration implementation
 `Plugin` depends on public reporting contracts. `Internal/Event` depends on
 `Event` to encode and decode events. Other internal utility modules do not
 depend on public contract modules.
-Reporters **MUST NOT** control execution. Optional integrations **MUST NOT**
-become runtime package dependencies.
+Keep execution control out of reporters. Do not add optional integrations as
+runtime package dependencies.
 
 ## Module interfaces
 
@@ -162,8 +165,8 @@ one run-owned orchestrator instance for each applicable factory. It creates one
 worker-owned instance for each applicable factory and physical worker.
 
 Immutable plugin definitions cross process seams. Plugin instances do not.
-Plugins **SHOULD NOT** depend on orchestrator classes or protocol implementation
-classes.
+We recommend that plugins avoid dependencies on orchestrator classes and
+protocol implementation classes.
 
 ### Output
 
@@ -174,6 +177,10 @@ output shape, read [compatibility](compatibility.md).
 The internal event codec owns event tags, tagged payload validation, and event
 construction. It also owns JSONL encoding and decoding. The worker protocol,
 JSONL reporter, and `profile:report` use this codec through their own seams.
+
+The CLI collects failed test IDs and class durations through `FailedTestsTap`.
+`RunSession` saves these values through `RunState` for later selection and
+class order. The orchestrator receives duration data but does not save it.
 
 ## Architectural invariants
 

--- a/docs/architecture/coverage-json.md
+++ b/docs/architecture/coverage-json.md
@@ -171,7 +171,9 @@ The format stores covered and uncovered line sets, not hit counts.
 The format excludes lines that the coverage driver identifies as dead or
 unreachable code. These lines do not appear in `covered` or `uncovered`.
 
-A line has coverage if one or more tests in the run executed it.
+A line has coverage if the driver recorded its execution during collection.
+The CLI can merge worker coverage with command-process and relayed subprocess
+coverage. Thus, covered lines can include code outside test bodies.
 
 The line lists supply the `percentage` values and the `totals` object.
 `import()` calculates these values again and ignores the stored values.

--- a/docs/architecture/coverage-json.md
+++ b/docs/architecture/coverage-json.md
@@ -6,7 +6,7 @@ export. `JsonExporter::import()` imports it.
 The coverage difference command also uses this format:
 
 ```sh id="x3l9w8"
-greenlight coverage:diff --baseline=baseline.json --current=current.json
+vendor/bin/greenlight coverage:diff --baseline=baseline.json --current=current.json
 ```
 
 Without root options, both input documents **MUST** use absolute file-path keys.
@@ -132,7 +132,7 @@ miss.
 The coverage merge command reads two or more coverage documents:
 
 ```sh id="merge-coverage-json"
-greenlight coverage:merge \
+vendor/bin/greenlight coverage:merge \
     --input=shard-1.json \
     --input=shard-2.json \
     --export=json=coverage.json

--- a/docs/architecture/orchestrator-integration-fixtures.md
+++ b/docs/architecture/orchestrator-integration-fixtures.md
@@ -1,8 +1,8 @@
 # Orchestrator-owned integration fixtures
 
 Greenlight provisions external test infrastructure in the orchestrator. It
-sends each worker only the connection data for that worker's channel and tears
-the infrastructure down when the run ends.
+sends each worker only the connection data for that worker's channel.
+It removes the infrastructure when the run ends.
 
 ## Ownership and lifetime
 
@@ -50,9 +50,9 @@ channel's overlay before it sends them to a worker.
 ## Resource transport
 
 `FixtureResource` accepts JSON-safe nulls, booleans, finite numbers, UTF-8
-strings, lists, and maps. Map keys must be non-empty UTF-8 strings. Lists and
-maps can have a maximum nesting depth of 16. Greenlight rejects a complete
-channel payload larger than 1 MiB.
+strings, lists, and maps. Map keys must be non-empty UTF-8 strings. Values can
+contain up to 16 nested lists or maps below the top-level map. Greenlight
+rejects a complete channel payload larger than 1 MiB.
 
 Store credentials in the separate secrets map. Worker code receives each secret
 as a `SensitiveValue` and must call `reveal()` to read it. Object dumps and

--- a/docs/architecture/worker-lifecycle.md
+++ b/docs/architecture/worker-lifecycle.md
@@ -1,8 +1,12 @@
 # Worker lifecycle and wire protocol
 
 Greenlight's orchestrator and workers exchange framed JSON messages over a
-local socket. The protocol is internal and may change between releases. Its
-details are useful when debugging parallel runs.
+local socket. The protocol is internal and can change between releases. Use
+these details to diagnose parallel runs.
+
+This page describes the process pool. With one configured or detected worker,
+the CLI uses an in-process adapter. That adapter has no worker sockets,
+worker-process isolation, or separate process to enforce hard timeouts.
 
 ## Transport ownership
 
@@ -374,7 +378,7 @@ and teardown callbacks.
 ## Isolated tests
 
 The orchestrator queues `#[Isolated]` entries separately. Only a fresh worker
-may take an isolated entry, and only after the pooled queue is empty. After
+can take an isolated entry, and only after the pooled queue is empty. After
 `done`, the orchestrator sends `drain` and lets the process exit instead of
 returning it to the pool. Any global state changed by the test dies with the
 worker. An isolated entry still waits for its required resources.
@@ -409,8 +413,10 @@ The allocator gives out the lowest free number and returns it when a worker
 retires. A replacement can use a released channel.
 
 At most the initial worker target channels are live at once. Concurrent tests
-never share a channel. Per-channel databases, port ranges, and temporary
-directories can therefore use the number safely. The
+in one run never share a channel. Different runs can use the same channel
+numbers. If runs can overlap, give each run separate resources.
+Per-channel databases, port ranges, and temporary directories can then use
+the number safely. The
 [README](../../README.md) describes the user-facing contract.
 
 Integration fixtures use the same channel pool. Greenlight merges shared values


### PR DESCRIPTION
The README assigns saved class durations to the orchestrator, and the architecture pages leave some process boundaries unclear. The coverage format also describes covered lines as test execution only.

Explain how the CLI selects in-process execution, stores failed test IDs and class durations, and merges command-process and relayed subprocess coverage. `RunSession::adapter()`, `RunSession::persist()`, `FailedTestsTap`, and `CoverageSession::finish()` establish these boundaries. Keep the worker-pool isolation and hard-timeout guarantees specific to that execution mode.

Use the Composer-installed `vendor/bin/greenlight` path in the coverage commands, as in the README installation steps. The examples no longer depend on a separate shell PATH setup.

Clarify that channel numbers are unique within one run and that fixture values can contain 16 nested containers below the top-level map. These details match `ChannelAllocator` and `FixtureResource::validateValue()`. Use direct contributor instructions while preserving formal protocol requirements and format versions.
