### PR TITLE
docs: use direct runtime and test support instructions

### DIFF
--- a/src/Cli/Coverage/CoverageSession.php
+++ b/src/Cli/Coverage/CoverageSession.php
@@ -91,7 +91,7 @@ final class CoverageSession
             try {
                 $this->collector?->stop();
             } catch (\Throwable) {
-                // A cleanup failure MUST not replace the run failure.
+                // Preserve the run failure if cleanup also fails.
             }
         }
 
@@ -102,7 +102,7 @@ final class CoverageSession
             try {
                 $shared->drain();
             } catch (\Throwable) {
-                // A cleanup failure MUST not replace the run failure.
+                // Preserve the run failure if cleanup also fails.
             }
         }
     }

--- a/src/Coverage/Collection/Driver/CoverageDriver.php
+++ b/src/Coverage/Collection/Driver/CoverageDriver.php
@@ -7,9 +7,11 @@ namespace Greenlight\Coverage\Collection\Driver;
 use Greenlight\Coverage\Collection\RawCoverage;
 
 /**
- * isAvailable() MUST return true before a selector constructs an
- * implementation. Each implementation MUST have a constructor with no
- * arguments. Thus, a selector can create it from its class name.
+ * Collects raw coverage through one installed extension.
+ *
+ * Call isAvailable() before construction. Construct the driver only if it
+ * returns true. Give each implementation a constructor with no required
+ * arguments so that a selector can create it from its class name.
  *
  * @internal
  */

--- a/src/Coverage/Collection/Driver/CoverageDriver.php
+++ b/src/Coverage/Collection/Driver/CoverageDriver.php
@@ -7,11 +7,11 @@ namespace Greenlight\Coverage\Collection\Driver;
 use Greenlight\Coverage\Collection\RawCoverage;
 
 /**
- * Collects raw coverage through one installed extension.
+ * Collects raw line coverage.
  *
- * Call isAvailable() before construction. Construct the driver only if it
- * returns true. Give each implementation a constructor with no required
- * arguments so that a selector can create it from its class name.
+ * A selector calls isAvailable() before construction. It constructs a driver
+ * only when this method returns true. Give each implementation a constructor
+ * with no required arguments so a selector can create it from its class name.
  *
  * @internal
  */

--- a/src/Execution/ProcessPool/Orchestrator/Orchestrator.php
+++ b/src/Execution/ProcessPool/Orchestrator/Orchestrator.php
@@ -587,8 +587,8 @@ final class Orchestrator
 
         foreach ($this->handles as $handle) {
             if ($handle->isActive() && $handle->ready && $handle->assigned === null) {
-                // Every initial worker is fresh, so once pooled work is gone
-                // it may take an isolated unit.
+                // Each initial worker is fresh. It can take an isolated unit
+                // after the pooled queue is empty.
                 $this->assignNext($handle, $sink);
             }
         }

--- a/src/Plugin/PluginDefinition.php
+++ b/src/Plugin/PluginDefinition.php
@@ -13,7 +13,7 @@ final readonly class PluginDefinition
 {
     /**
      * @param class-string<Plugin> $pluginClass
-     * @param \Closure(): Plugin $factory The factory MUST return a new plugin
+     * @param \Closure(): Plugin $factory Return a new plugin
      *   instance on each call.
      */
     private function __construct(

--- a/src/Reporting/JUnitReporter.php
+++ b/src/Reporting/JUnitReporter.php
@@ -297,7 +297,7 @@ final class JUnitReporter implements Reporter
                 $file = $reflected;
             }
         } catch (\Throwable) {
-            // An autoloader error MUST NOT stop report generation.
+            // Continue report generation if an autoloader fails.
         }
 
         return $this->sourceFilesByClassAndMethod[$class][$method] = $file;

--- a/src/Test/DataSet/DataSetExpander.php
+++ b/src/Test/DataSet/DataSetExpander.php
@@ -11,10 +11,9 @@ use Greenlight\Internal\Php\ErrorTrap;
  * Invokes a #[DataSet] provider when Greenlight makes the execution plan.
  * It makes one stable string key for each data set.
  *
- * Discovery executes only data providers. Providers MUST be pure. For the
- * same inputs, a provider MUST supply the same data. A provider MUST NOT
- * change external state. Greenlight checks the time budget between rows and
- * after iteration. The budget cannot interrupt a blocked provider.
+ * Keep data providers pure. Return the same data for the same inputs.
+ * Do not change external state. Greenlight checks the time budget between
+ * rows and after iteration. The budget cannot interrupt a blocked provider.
  *
  * Greenlight does not change a printable string key. It converts an integer
  * key to "#<value>". For an empty or nonprintable string key, it uses the

--- a/src/Test/DataSet/DataSetExpander.php
+++ b/src/Test/DataSet/DataSetExpander.php
@@ -8,7 +8,7 @@ use Greenlight\Attribute\DataRow;
 use Greenlight\Internal\Php\ErrorTrap;
 
 /**
- * Invokes a #[DataSet] provider when Greenlight makes the execution plan.
+ * Expands #[DataSet] providers during discovery and worker execution.
  * It makes one stable string key for each data set.
  *
  * Keep data providers pure. Return the same data for the same inputs.

--- a/tests/Support/JsonlEvents.php
+++ b/tests/Support/JsonlEvents.php
@@ -10,8 +10,8 @@ use Greenlight\Event\WorkerSpawned;
 use Greenlight\Internal\Event\EventCodec;
 
 /**
- * Reads JSONL only from standard output. Each nonempty line MUST contain a
- * supported envelope. It MUST also contain a known event tag and payload.
+ * Reads JSONL only from standard output. Each nonempty line requires a
+ * supported envelope with a known event tag and a valid payload.
  */
 final class JsonlEvents
 {

--- a/tests/Support/Subprocess.php
+++ b/tests/Support/Subprocess.php
@@ -7,9 +7,9 @@ namespace Greenlight\Tests\Support;
 use Greenlight\Internal\Php\ErrorTrap;
 
 /**
- * The caller of start() owns the active process handle. After start() returns,
- * the caller MUST immediately guarantee that terminate() will run. After
- * wait() collects the result, terminate() has no effect.
+ * The caller of start() owns the active process handle. Immediately after
+ * start() returns, use a finally block to call terminate(). After wait()
+ * collects the result, terminate() has no effect.
  */
 final class Subprocess
 {


### PR DESCRIPTION
Runtime comments and test support documentation use uppercase requirement terms for ordinary contributor instructions. Some statements also obscure the actual constraint: coverage drivers can have optional constructor arguments, and discovery executes attribute constructors as well as data providers.

Use direct instructions for provider purity, plugin factory lifetime, subprocess cleanup, and error handling. Describe coverage drivers as callable without required constructor arguments, consistent with the optional runtime arguments in `PcovDriver` and `XdebugDriver`. Remove the overbroad claim that discovery executes only data providers.

The cleanup guidance follows the existing catch/finally paths. JSONL support still requires the same envelope, event tag, and payload. Protocol definitions, executable assertions, and fixture text keep their existing meaning.
