### PR TITLE
docs: make test examples and tool setup explicit

### DIFF
--- a/docs/attachments.md
+++ b/docs/attachments.md
@@ -8,31 +8,42 @@ text, bytes, or files that already exist.
 
 Ask for `Greenlight\Artifact\Attachments` through constructor injection:
 
-<!-- php-example {"example":"attachments-example-01","file":"snippet.php","mode":"file","tools":["rector"]} -->
+<!-- php-example {"example":"attachments-example-01","file":"snippet.php","mode":"file","tools":["phpstan","rector"]} -->
 ```php
+use Greenlight\Attribute\NoExpectations;
 use Greenlight\Attribute\Test;
-use Greenlight\Artifact\AttachmentRetention;
 use Greenlight\Artifact\Attachments;
+use Greenlight\Sandbox\TemporaryDirectory;
 
-final readonly class CheckoutTest
+final readonly class DiagnosticAttachmentsTest
 {
-    public function __construct(private Attachments $attachments) {}
+    public function __construct(
+        private Attachments $attachments,
+        private TemporaryDirectory $temporary,
+    ) {}
 
     #[Test]
-    public function submitsAnOrder(): void
+    #[NoExpectations]
+    public function recordsDiagnosticData(): void
     {
-        $response = $this->client->post('/orders');
-
         $this->attachments->value('response.json', [
-            'status' => $response->status(),
-            'headers' => $response->headers(),
+            'status' => 202,
+            'requestId' => 'request-123',
         ]);
-        $this->attachments->text('subprocess.log', $this->process->output());
-        $this->attachments->bytes('trace.bin', $this->trace);
-        $this->attachments->file('screenshot.png', $this->screenshotPath);
+        $this->attachments->text('application.log', 'Order accepted.');
+        $this->attachments->bytes('trace.bin', "\x00\x01");
+
+        $source = $this->temporary->path() . '/export.csv';
+        \file_put_contents($source, "id,status\n123,accepted\n");
+        $this->attachments->file('export.csv', $source);
     }
 }
 ```
+
+This example uses fixed diagnostic values. Replace them with values from the
+system under test. The test has no expectations because it only demonstrates
+attachment creation. The default retention policy discards these attachments
+when the test passes.
 
 `value()` encodes its value as JSON. `text()` and `bytes()` accept an optional
 media type. `file()` copies a regular file and detects its media type when
@@ -47,14 +58,16 @@ do not change the attachment.
 
 By default, Greenlight retains attachments when the final result fails or has
 an error. It also retains them when the transformation log contains an earlier
-failed or errored outcome. Thus, a plugin cannot discard failure evidence only
-by changing the outcome to passed or skipped.
+failed or errored outcome. A change to passed or skipped therefore preserves
+failure evidence.
 
 To retain an attachment from a result without failure evidence, set its
 retention to `AttachmentRetention::Always`:
 
-<!-- php-example {"example":"attachments-example-02","file":"snippet.php","mode":"statements","tools":["rector"]} -->
+<!-- php-example {"example":"attachments-example-02","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
+use Greenlight\Artifact\AttachmentRetention;
+
 $attachments->text(
     'timing.txt',
     $timing,
@@ -76,6 +89,7 @@ create an empty directory. Change the parent directory in `greenlight.php`:
 <!-- php-example {"example":"attachments-example-03","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Config\ArtifactBuilder;
+use Greenlight\Config\GreenlightConfig;
 
 return GreenlightConfig::create()
     ->artifacts(fn (ArtifactBuilder $artifacts) => $artifacts
@@ -88,12 +102,13 @@ Use `--artifacts-dir` to override it for one run:
 vendor/bin/greenlight run --artifacts-dir=build/ci-evidence
 ```
 
-Completed run retention is disabled by default. Configure one or more limits
-to remove old Greenlight run directories after a run completes:
+By default, Greenlight does not remove completed run directories. Configure
+one or more limits to remove old directories after a run completes:
 
 <!-- php-example {"example":"attachments-example-04","file":"snippet.php","mode":"file","tools":["rector"]} -->
 ```php
 use Greenlight\Config\ArtifactBuilder;
+use Greenlight\Config\GreenlightConfig;
 
 return GreenlightConfig::create()
     ->artifacts(fn (ArtifactBuilder $artifacts) => $artifacts

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -52,8 +52,8 @@ When the matcher fails, the failure message puts the reason after the word
 Expected false to be true because a refund requires an open order.
 ```
 
-The reason must not be empty. Temporal expectation chains also accept
-`because()`.
+Greenlight applies PHP's `trim()` to the reason. The result must not be empty.
+Temporal expectation chains also accept `because()`.
 
 ## Matcher reference
 

--- a/docs/migrating-from-phpunit.md
+++ b/docs/migrating-from-phpunit.md
@@ -92,6 +92,18 @@ The rule removes coverage metadata attributes, for example `#[CoversClass]`,
 because coverage configuration belongs in `greenlight.php`. It also removes
 use metadata, `#[TestDox]`, and `#[DisableReturnValueGenerationForTestDoubles]`.
 
+Preview the proposed changes:
+
+```sh
+vendor/bin/rector process --dry-run
+```
+
+Apply the changes after you review the preview:
+
+```sh
+vendor/bin/rector process
+```
+
 Rector's printer also reflows each converted class. Run your code-style fixer
 after the conversion. If no test depends on `#[Isolated]`, run the suite one
 time with `--workers=1` before you enable parallel workers. Otherwise, start
@@ -275,8 +287,9 @@ Expect::that($captor->value())->toBeInstanceOf(Order::class);
 If the collaborator must return a value, use a mock with explicit
 expectations.
 
-`spy(Type::class)` records calls only for methods that return nothing. A spy
-does not create a return value.
+`spy(Type::class)` records calls to methods declared `void` or without a native
+return type. These calls return `null`. A call with another native return type
+fails the test.
 
 Read records with `$this->doubles->callsTo($spy, 'method')`. Check the records
 with `Expect`.

--- a/docs/phpstan.md
+++ b/docs/phpstan.md
@@ -28,6 +28,10 @@ parameters:
 Use `configFiles` only for custom matcher checks. The data-provider and native
 matcher rules work without it.
 
+If you use [phpstan/extension-installer](https://github.com/phpstan/extension-installer),
+it registers the include for you. Set only the `greenlight.configFiles`
+parameter for custom matcher checks.
+
 ## Double checks
 
 The extension checks a constant method name in `Doubles::callsTo()` against the
@@ -91,10 +95,6 @@ Coverage errors use `greenlight.coverageBuilderArgument.*`. Expectation errors
 use `greenlight.expectationArgument.tolerance` and
 `greenlight.expectationArgument.duration`. Greenlight checks unresolved values
 at run time.
-
-If you use [phpstan/extension-installer](https://github.com/phpstan/extension-installer),
-it registers the include for you. Set only the `greenlight.configFiles`
-parameter.
 
 ## Native matcher constraints
 
@@ -279,7 +279,7 @@ use:
 * `toMatch()` and the `matching:` argument of `toThrow()` require a valid
   regular expression.
 * The expected value for `toMatchJson()` must contain valid JSON.
-* A constant `because()` reason must contain a non-whitespace character.
+* A constant `because()` reason must not be empty after PHP's `trim()` operation.
 
 Errors have identifiers under `greenlight.expectationArgument.*` (`pattern`,
 `json`, `reason`). PHPStan checks constant values before run time. Greenlight

--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -89,17 +89,36 @@ Each mock method with a native non-`void` return type needs an explicit
 response. A method declared `void` or without a native return type needs no
 response and returns `null`. PHPDoc return tags do not change this rule.
 
+The following examples show separate response plans.
+
+Return one value for every matched call:
+
 <!-- php-example {"example":"test-doubles-example-03","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php
 $plan->expects('nextId')->andReturns('id-1');
+```
 
+Return successive values for two calls:
+
+<!-- php-example {"example":"test-doubles-response-sequence","file":"snippet.php","mode":"statements","tools":["rector"]} -->
+```php
 $plan->expects('nextId')
     ->times(2)
     ->andReturnsSequence('id-1', 'id-2');
+```
 
+Calculate the response from the call arguments:
+
+<!-- php-example {"example":"test-doubles-response-callback","file":"snippet.php","mode":"statements","tools":["rector"]} -->
+```php
 $plan->expects('convert')
     ->andReturnsUsing(fn (int $value): int => $value * 2);
+```
 
+Throw an exception:
+
+<!-- php-example {"example":"test-doubles-response-throwable","file":"snippet.php","mode":"statements","tools":["rector"]} -->
+```php
 $plan->expects('load')
     ->andThrows(new NotFound('Missing record.'));
 ```


### PR DESCRIPTION
Several examples omit the information needed to follow them correctly. Replace the attachment test's undefined properties with injected services and fixed diagnostic data, and explain its retention behavior. Keep each mock response plan separate so the first unbounded `nextId` expectation cannot consume calls meant for the sequence example.

Add the Rector preview and apply commands to the migration sequence. State the exact native return types that spies support, move PHPStan extension-installer setup beside the include instructions, and describe `because()` whitespace handling.

The examples follow the `Attachments` and `TemporaryDirectory` APIs, mock expectation matching order, and `Expectation::because()`. The attachment example now opts into PHPStan as well as Rector through the existing documentation example checks.
