### PR TITLE
fix(expect): escape canonical object property keys

### DIFF
--- a/src/Expect/Equality.php
+++ b/src/Expect/Equality.php
@@ -109,7 +109,7 @@ final class Equality
             \ksort($properties, \SORT_STRING);
 
             foreach ($properties as $name => $item) {
-                $parts[] = $name . '=>' . self::sortKey($item, $seen);
+                $parts[] = \var_export($name, true) . '=>' . self::sortKey($item, $seen);
             }
 
             return $value::class . '{' . \implode(',', $parts) . '}';

--- a/tests/Unit/Expect/CanonicalPropertyKeyCollisionTest.php
+++ b/tests/Unit/Expect/CanonicalPropertyKeyCollisionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+
+final class CanonicalPropertyKeyCollisionTest
+{
+    #[Test]
+    public function canonicalEqualityDistinguishesPropertyNamesFromPropertyValues(): void
+    {
+        $first = (object) ['a' => null, 'b' => null];
+        $second = (object) ['a=>null:NULL,b' => null];
+
+        Expect::that([$first, $second])->toEqualCanonicalizing([$second, $first]);
+        Expect::that([$first, $first])->not()->toEqualCanonicalizing([$first, $second]);
+    }
+
+    #[Test]
+    public function canonicalEqualityPreservesQuotesAndBackslashesInPropertyNames(): void
+    {
+        $first = (object) ["a'" => null, 'b\\' => null];
+        $second = (object) ["a'=>null:NULL,b\\" => null];
+
+        Expect::that([$first, $second])->toEqualCanonicalizing([$second, $first]);
+    }
+}


### PR DESCRIPTION
Canonical equality can reject a list that contains the same objects in a different order when a property name contains the sort-key delimiters. For example, `(object) ['a' => null, 'b' => null]` and `(object) ['a=>null:NULL,b' => null]` currently produce the same key. Their original order then survives sorting, so reversing the list fails `toEqualCanonicalizing()`.

Quote and escape object property names when constructing their sort keys, matching the existing treatment of array keys. This keeps property names separate from encoded property values. Two regressions cover delimiter collisions, quotes and backslashes, and rejection of a different object multiset. Both regressions failed before the change and now pass.

The required Composer static checks, full suite and documentation check passed. The suite reported 3,537 passed tests, 19 environment-dependent skips and 9,031 expectations. The focused regressions also passed after rebasing onto current main.
