### PR TITLE
fix(coverage): ignore literal string braces in exclusions

### DIFF
--- a/src/Coverage/Ignore/IgnoreScanner.php
+++ b/src/Coverage/Ignore/IgnoreScanner.php
@@ -198,8 +198,8 @@ final readonly class IgnoreScanner
      * Finds the line range from a declaration keyword to its final character.
      *
      * The final character is the related final brace. For a signature
-     * without a body, it is the final semicolon. Strings and comments are
-     * single tokens. Thus, braces in them do not affect the count.
+     * without a body, it is the final semicolon. Only PHP brace tokens and
+     * interpolation boundaries affect the brace count.
      *
      * @param list<\PhpToken> $tokens
      *
@@ -218,9 +218,9 @@ final readonly class IgnoreScanner
                 return [$first, $token->line];
             }
 
-            if ($token->text === '{' || $token->is([\T_CURLY_OPEN, \T_DOLLAR_OPEN_CURLY_BRACES])) {
+            if ($token->is([\ord('{'), \T_CURLY_OPEN, \T_DOLLAR_OPEN_CURLY_BRACES])) {
                 $depth++;
-            } elseif ($token->text === '}' && --$depth === 0) {
+            } elseif ($token->is(\ord('}')) && --$depth === 0) {
                 return [$first, $token->line];
             }
         }

--- a/tests/Unit/Coverage/Ignore/IgnoreScannerStringBraceTest.php
+++ b/tests/Unit/Coverage/Ignore/IgnoreScannerStringBraceTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Coverage\Ignore;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Coverage\CoverageMap;
+use Greenlight\Coverage\FileCoverage;
+use Greenlight\Coverage\Ignore\IgnoreFilter;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+
+final readonly class IgnoreScannerStringBraceTest
+{
+    public function __construct(private TemporaryDirectory $temporaryDirectory) {}
+
+    #[Test]
+    #[DataSet('strings')]
+    public function stringBracesDoNotChangeTheIgnoredDeclaration(string $expression): void
+    {
+        $source = <<<'PHP'
+            <?php
+            /** @codeCoverageIgnore */
+            function ignored(string $name): string
+            {
+                $text = EXPRESSION;
+                return $text;
+            }
+            function kept(): int
+            {
+                return 1;
+            }
+            PHP;
+        $path = $this->temporaryDirectory->path() . '/strings.php';
+        \file_put_contents($path, \str_replace('EXPRESSION', $expression, $source));
+
+        $map = new CoverageMap([new FileCoverage($path, [], [5, 6, 10])]);
+        $filtered = new IgnoreFilter()->apply($map);
+
+        Expect::that($filtered->files()[$path] ?? null)->toBeInstanceOf(FileCoverage::class);
+        Expect::that($filtered->files()[$path]->uncoveredLines)->toBe([10]);
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function strings(): iterable
+    {
+        yield 'closing brace before a variable' => ['"}$name"'];
+        yield 'closing brace after a variable' => ['"{$name}}"'];
+        yield 'opening brace after a variable' => ['"{$name}{"'];
+    }
+}


### PR DESCRIPTION
Coverage exclusions can end at a literal closing brace inside an interpolated string, or extend into the next function after a literal opening brace. This changes coverage totals and can hide unrelated uncovered code.

Count PHP brace tokens and interpolation boundaries when locating the end of an ignored declaration. Three regression cases previously retained an ignored uncovered line or removed the following function from coverage; each now keeps only the following function's uncovered line. The focused cases pass with six expectations. The full local suite passed with 3,538 tests and 19 environment-dependent skips, and the required static and documentation checks passed.
