### PR TITLE
fix(hyperf): tolerate concurrent scan directory creation

### DIFF
--- a/src/Hyperf/HyperfPlugin.php
+++ b/src/Hyperf/HyperfPlugin.php
@@ -264,6 +264,7 @@ final class HyperfPlugin implements HarnessProvider, ServiceResolver, ServiceSou
 
         if (!\is_dir($runtimeDirectory)
             && !ErrorTrap::run(static fn() => \mkdir($runtimeDirectory, 0o755, true), $warning)
+            && !\is_dir($runtimeDirectory)
         ) {
             throw HyperfBridgeError::scanLockUnavailable($runtimeDirectory . '/greenlight.scan.lock');
         }

--- a/tests/Unit/Hyperf/HyperfScanDirectoryRaceTest.php
+++ b/tests/Unit/Hyperf/HyperfScanDirectoryRaceTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Hyperf;
+
+use Greenlight\Attribute\DataRow;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\PhpSubprocess;
+
+final readonly class HyperfScanDirectoryRaceTest
+{
+    #[Test]
+    #[DataRow([true, 0, 'Class scan completed.'])]
+    #[DataRow([false, 1, 'HyperfPlugin cannot open scan lock'])]
+    public function aConcurrentDirectoryCreationDoesNotPreventTheClassScan(bool $created, int $exitCode, string $output): void
+    {
+        $result = PhpSubprocess::run(\dirname(__DIR__, 3), ['-r', <<<'PHP'
+        namespace Hyperf\Di {
+            final class ClassLoader
+            {
+                public static function init(): void
+                {
+                    echo 'Class scan completed.';
+                }
+            }
+        }
+
+        namespace {
+            require 'vendor/autoload.php';
+
+            final class ConcurrentDirectory
+            {
+                public $context;
+                private static bool $exists = false;
+
+                public function url_stat(string $path, int $flags): array|false
+                {
+                    return self::$exists ? ['mode' => 0040777] : false;
+                }
+
+                public function mkdir(string $path, int $mode, int $options): bool
+                {
+                    self::$exists = $_SERVER['argv'][1] === 'created';
+
+                    return false;
+                }
+
+                public function stream_open(string $path, string $mode, int $options, ?string &$openedPath): bool
+                {
+                    return true;
+                }
+
+                public function stream_lock(int $operation): bool
+                {
+                    return true;
+                }
+            }
+
+            stream_wrapper_register('concurrent-directory', ConcurrentDirectory::class);
+            $plugin = new \Greenlight\Hyperf\HyperfPlugin('concurrent-directory://application');
+
+            try {
+                new \ReflectionMethod($plugin, 'initializeClassLoader')->invoke($plugin, 'concurrent-directory://application');
+            } catch (\Greenlight\Hyperf\HyperfBridgeError $error) {
+                echo $error->getMessage();
+                exit(1);
+            }
+        }
+        PHP, $created ? 'created' : 'missing']);
+
+        Expect::that($result->exitCode)->toBe($exitCode);
+        Expect::that($result->stdout)->toContain($output);
+        Expect::that($result->stderr)->toBe('');
+    }
+}


### PR DESCRIPTION
Parallel Hyperf workers can both observe a missing runtime/container directory before one creates it. The second worker then treats mkdir returning false as a fatal scan-lock failure, even though the directory is ready. A 24-worker reproduction failed 30 of 480 starts before this change and none of 480 after it.

Recheck whether the directory exists after a failed creation attempt. A deterministic regression covers concurrent creation and a directory that remains unavailable. The existing scan lock still serializes the class scan.
