### PR TITLE
fix(execution): restore capture state after output callback failures

### DIFF
--- a/src/Execution/Worker/OutputCapture.php
+++ b/src/Execution/Worker/OutputCapture.php
@@ -113,23 +113,36 @@ final class OutputCapture
 
         $level = $this->bufferLevel;
         $this->bufferLevel = null;
+        $failure = null;
 
-        while (\ob_get_level() > $level) {
-            $previousLevel = \ob_get_level();
-            $removed = ErrorTrap::run(static fn() => \ob_end_flush());
+        try {
+            while (\ob_get_level() > $level) {
+                $previousLevel = \ob_get_level();
 
-            if (!$removed || \ob_get_level() >= $previousLevel) {
+                try {
+                    $removed = ErrorTrap::run(static fn() => \ob_end_flush());
+                } catch (\Throwable $error) {
+                    $failure ??= $error;
+                    $removed = \ob_get_level() < $previousLevel;
+                }
+
+                if (!$removed || \ob_get_level() >= $previousLevel) {
+                    throw $failure ?? CaptureError::nestedBufferCannotBeRemoved();
+                }
+            }
+
+            if ($failure instanceof \Throwable) {
+                throw $failure;
+            }
+        } finally {
+            try {
+                if (!$this->bufferClosed && \ob_get_level() === $level) {
+                    \ob_end_clean();
+                }
+            } finally {
                 $this->restoreErrorHandler();
-
-                throw CaptureError::nestedBufferCannotBeRemoved();
             }
         }
-
-        if (!$this->bufferClosed && \ob_get_level() === $level) {
-            \ob_end_clean();
-        }
-
-        $this->restoreErrorHandler();
 
         $scrubbedStdout = Utf8::scrub($this->stdout);
         $boundedStdout = Utf8::headBytes($scrubbedStdout, $this->maxStdoutBytes);
@@ -151,8 +164,8 @@ final class OutputCapture
 
     /**
      * Keeps the first part within the size limit. It returns an empty string to
-     * stop propagation. This callback MUST NOT throw because an output-handler
-     * exception is fatal.
+     * stop propagation. Do not throw from this callback.
+     * An output-handler exception is fatal.
      */
     private function appendChunk(string $chunk): string
     {

--- a/tests/Unit/Execution/Worker/Capture/OutputCaptureCallbackFailureTest.php
+++ b/tests/Unit/Execution/Worker/Capture/OutputCaptureCallbackFailureTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Execution\Worker\Capture;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Execution\Worker\OutputCapture;
+use Greenlight\Expect\Expect;
+
+final readonly class OutputCaptureCallbackFailureTest
+{
+    #[Test]
+    public function aCallbackFailureStillClosesBuffersAndRestoresTheErrorHandler(): void
+    {
+        $baseline = \ob_get_level();
+        $messages = [];
+        $handler = static function (int $severity, string $message) use (&$messages): bool {
+            $messages[] = $message;
+
+            return true;
+        };
+        $previous = \set_error_handler($handler);
+        $capture = new OutputCapture();
+        $capture->start();
+        $first = new \RuntimeException('The inner output callback failed.');
+        $second = new \RuntimeException('The outer output callback failed.');
+        \ob_start(static function (string $buffer, int $phase) use ($second): string {
+            if (($phase & \PHP_OUTPUT_HANDLER_CLEAN) !== 0) {
+                return '';
+            }
+
+            throw $second;
+        });
+        \ob_start(static function (string $buffer, int $phase) use ($first): string {
+            if (($phase & \PHP_OUTPUT_HANDLER_CLEAN) !== 0) {
+                return '';
+            }
+
+            throw $first;
+        });
+
+        try {
+            Expect::that($capture->stop(...))
+                ->because('capture cleanup MUST preserve the first callback failure')
+                ->toThrow($first);
+            $levelAfterStop = \ob_get_level();
+            \trigger_error('After capture.', \E_USER_NOTICE);
+        } finally {
+            while (\ob_get_level() > $baseline) {
+                \ob_end_clean();
+            }
+
+            do {
+                $active = \set_error_handler(static fn(): bool => true);
+                \restore_error_handler();
+
+                if ($active !== $previous) {
+                    \restore_error_handler();
+                }
+            } while ($active !== $previous);
+        }
+
+        Expect::that($levelAfterStop)
+            ->because('a callback failure MUST NOT leave capture buffers active')
+            ->toBe($baseline);
+        Expect::that($messages)
+            ->because('the previous error handler MUST receive later diagnostics')
+            ->toBe(['After capture.']);
+
+        $capture->start();
+        echo 'Next capture.';
+        $captured = $capture->stop();
+
+        Expect::that($captured->stdout)->toBe('Next capture.');
+    }
+}


### PR DESCRIPTION
An exception from a nested user output-buffer callback stops capture cleanup early. The next test can inherit Greenlight's output buffer and error handler. A baseline reproduction leaves one extra buffer and prevents a later notice from reaching the caller's handler.

Continue closing removable nested buffers after a callback failure, preserve the first exception, and restore the capture buffer and handler in finally blocks. The regression uses two throwing callbacks and checks the original exception, the buffer baseline, delivery of a later notice, and capture reuse. The same reproduction now leaves no extra buffer and restores the caller's handler.
