### PR TITLE
perf(execution): bound transient worker diagnostic memory

### DIFF
--- a/src/Execution/ProcessPool/Orchestrator/WorkerHandle.php
+++ b/src/Execution/ProcessPool/Orchestrator/WorkerHandle.php
@@ -159,27 +159,29 @@ final class WorkerHandle
                 }
 
                 \stream_set_blocking($pipe, false);
-                $bytes = \stream_get_contents($pipe);
+                do {
+                    $bytes = \stream_get_contents($pipe, self::MAX_DIAGNOSTIC_BYTES);
 
-                if (!\is_string($bytes)) {
-                    continue;
-                }
+                    if (!\is_string($bytes)) {
+                        break;
+                    }
 
-                [$complete, $this->diagnosticCarry[$index]] = $this->completeUtf8Prefix(
-                    $this->diagnosticCarry[$index] . $bytes,
-                );
-
-                if (\feof($pipe) && $this->diagnosticCarry[$index] !== '') {
-                    $complete .= $this->diagnosticCarry[$index];
-                    $this->diagnosticCarry[$index] = '';
-                }
-
-                if ($complete !== '') {
-                    $this->diagnostics = Utf8::tailBytes(
-                        $this->diagnostics . $complete,
-                        self::MAX_DIAGNOSTIC_BYTES,
+                    [$complete, $this->diagnosticCarry[$index]] = $this->completeUtf8Prefix(
+                        $this->diagnosticCarry[$index] . $bytes,
                     );
-                }
+
+                    if (\feof($pipe) && $this->diagnosticCarry[$index] !== '') {
+                        $complete .= $this->diagnosticCarry[$index];
+                        $this->diagnosticCarry[$index] = '';
+                    }
+
+                    if ($complete !== '') {
+                        $this->diagnostics = Utf8::tailBytes(
+                            $this->diagnostics . $complete,
+                            self::MAX_DIAGNOSTIC_BYTES,
+                        );
+                    }
+                } while ($bytes !== '' && !\feof($pipe));
             }
         });
     }
@@ -199,8 +201,8 @@ final class WorkerHandle
             $prefix = \substr($value, 0, -$carryBytes);
             $carry = \substr($value, -$carryBytes);
 
-            if (\preg_match('//u', $prefix) === 1 && $this->isIncompleteUtf8Suffix($carry)) {
-                return [$prefix, $carry];
+            if ($this->isIncompleteUtf8Suffix($carry)) {
+                return [Utf8::scrub($prefix), $carry];
             }
         }
 

--- a/tests/Unit/Execution/ProcessPool/Orchestrator/WorkerHandleLargeDiagnosticsTest.php
+++ b/tests/Unit/Execution/ProcessPool/Orchestrator/WorkerHandleLargeDiagnosticsTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Execution\ProcessPool\Orchestrator;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Execution\ProcessPool\Orchestrator\WorkerHandle;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\ConnectedStreamPair;
+use Greenlight\Tests\Support\MemoryStream;
+
+final readonly class WorkerHandleLargeDiagnosticsTest
+{
+    #[Test]
+    public function malformedBytesPreserveTheNextSplitUnicodeCharacter(): void
+    {
+        [$reader, $writer] = ConnectedStreamPair::open();
+        $process = MemoryStream::open();
+        $stderr = MemoryStream::open();
+
+        try {
+            $handle = new WorkerHandle('worker-1', 1, $process, $reader, $stderr);
+            \fwrite($writer, "\xFF\xE2");
+            $handle->drainPipes();
+            \fwrite($writer, "\x82\xAC");
+            $handle->drainPipes();
+
+            Expect::that($handle->diagnostics)
+                ->because('malformed bytes MUST NOT replace a later complete Unicode character')
+                ->toBe("\u{FFFD}\u{20AC}");
+        } finally {
+            MemoryStream::close($reader, $writer, $process, $stderr);
+        }
+    }
+
+    #[Test]
+    public function aLargeReadPreservesUnicodeAndTheFinalDiagnosticTail(): void
+    {
+        $tail = "\u{20AC}" . \str_repeat('y', 65_530) . "\u{FFFD}";
+        $process = MemoryStream::open();
+        $stdout = MemoryStream::open(\str_repeat('x', 131_070) . "\xFF\u{20AC}" . \str_repeat('y', 65_530) . "\xE2");
+        $stderr = MemoryStream::open();
+
+        try {
+            $handle = new WorkerHandle('worker-1', 1, $process, $stdout, $stderr);
+            $handle->drainPipes();
+
+            Expect::that($handle->diagnostics)
+                ->because('a large pipe read MUST preserve the complete final Unicode tail')
+                ->toBe($tail);
+
+            $handle->drainPipes();
+
+            Expect::that($handle->diagnostics)
+                ->because('another drain at EOF MUST NOT duplicate diagnostic bytes')
+                ->toBe($tail);
+        } finally {
+            MemoryStream::close($process, $stdout, $stderr);
+        }
+    }
+}

--- a/tools/worker-diagnostics-benchmark.php
+++ b/tools/worker-diagnostics-benchmark.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tools;
 
 use Greenlight\Execution\ProcessPool\Orchestrator\NativeWorkerTransport;
+use Greenlight\Execution\ProcessPool\Orchestrator\WorkerHandle;
 use Greenlight\Execution\ProcessPool\Orchestrator\WorkerTransportEventKind;
 
 require __DIR__ . '/../vendor/autoload.php';
@@ -45,6 +46,53 @@ foreach (['STDOUT', 'STDERR'] as $stream) {
             );
         } finally {
             $transport->close();
+        }
+    }
+}
+
+// Measure transient memory with a diagnostic burst that exceeds pipe capacity.
+foreach ([8, 64] as $mebibytes) {
+    for ($sample = 1; $sample <= 3; ++$sample) {
+        $stdout = \tmpfile();
+        $empty = \fopen('php://memory', 'w+');
+
+        if ($stdout === false || $empty === false) {
+            throw new \RuntimeException('The diagnostic benchmark did not open its streams.');
+        }
+
+        try {
+            $chunk = \str_repeat('x', 1024 * 1024);
+
+            for ($index = 0; $index < $mebibytes; ++$index) {
+                if (\fwrite($stdout, $chunk) !== \strlen($chunk)) {
+                    throw new \RuntimeException('The diagnostic benchmark did not write its input.');
+                }
+            }
+
+            \rewind($stdout);
+            $handle = new WorkerHandle('diagnostic-burst', 1, $empty, $stdout, $empty);
+            \memory_reset_peak_usage();
+            $memoryBefore = \memory_get_usage();
+            $startedAt = \hrtime(true);
+            $handle->drainPipes();
+            $seconds = (\hrtime(true) - $startedAt) / 1_000_000_000;
+            $additionalPeakBytes = \memory_get_peak_usage() - $memoryBefore;
+
+            if ($handle->diagnostics !== \str_repeat('x', 65_536)) {
+                throw new \RuntimeException('The diagnostic benchmark did not retain the expected tail.');
+            }
+
+            \printf(
+                "BURST sample=%d bytes=%d seconds=%.6f additional_peak_bytes=%d retained=%d\n",
+                $sample,
+                $mebibytes * 1024 * 1024,
+                $seconds,
+                $additionalPeakBytes,
+                \strlen($handle->diagnostics),
+            );
+        } finally {
+            \fclose($stdout);
+            \fclose($empty);
         }
     }
 }


### PR DESCRIPTION
Worker diagnostics retain a 64 KiB tail, but the old unbounded stream read temporarily allocates the whole available burst. Read at most 64 KiB at a time while draining the available output. The final diagnostic tail and stdout-before-stderr order remain unchanged.

The existing diagnostic benchmark now measures disk-backed bursts as well as native pipe throughput. With PHP 8.4.14 and XDEBUG_MODE=off, three samples of a 64 MiB burst each reduced additional peak allocation from 67,216,992 bytes to 353,864 bytes, about 99.47%. An 8 MiB burst fell from 8,496,736 bytes to the same 353,864 bytes. All samples retained exactly 65,536 bytes. Run `XDEBUG_MODE=off php tools/worker-diagnostics-benchmark.php` to reproduce these measurements. Extra loop calls can add overhead for small bursts; shared-machine timings do not establish a stable CPU speedup.

Keep an incomplete valid UTF-8 suffix even when earlier bytes in the chunk are malformed. Previously, reads containing FF E2 followed by 82 AC produced four replacement characters instead of one replacement character and a euro sign. The regressions cover this two-read boundary, a large final Unicode tail, and repeated EOF reads. Existing native stdout/stderr tests cover pipe progress.
