### PR TITLE
test: make regression checks observe their intended behavior

### DIFF
--- a/tests/Unit/Cli/Reporting/ReporterCatalogTest.php
+++ b/tests/Unit/Cli/Reporting/ReporterCatalogTest.php
@@ -47,14 +47,16 @@ final class ReporterCatalogTest
     public function duplicateNamesFailBeforeAFactoryRuns(): void
     {
         $calls = 0;
-        $definition = static fn(): ReporterDefinition => new ReporterDefinition(
-            'plain',
-            static function (Output $output) use (&$calls): Reporter {
-                $calls++;
+        $definition = static function () use (&$calls): ReporterDefinition {
+            return new ReporterDefinition(
+                'plain',
+                static function (Output $output) use (&$calls): Reporter {
+                    $calls++;
 
-                return new RecordingReporter();
-            },
-        );
+                    return new RecordingReporter();
+                },
+            );
+        };
 
         Expect::that(static fn() => new ReporterCatalog([$definition(), $definition()]))
             ->toThrow(ReporterSetupFailed::class, '/Reporter name "plain" is registered more than one time\./');

--- a/tests/Unit/Discovery/DiscoveryCacheTest.php
+++ b/tests/Unit/Discovery/DiscoveryCacheTest.php
@@ -11,7 +11,6 @@ use Greenlight\Discovery\TestDiscoverer;
 use Greenlight\Expect\Expect;
 use Greenlight\Expect\Fail;
 use Greenlight\Sandbox\Autoloaders;
-use Greenlight\Sandbox\EnvironmentVariables;
 use Greenlight\Sandbox\StreamWrappers;
 use Greenlight\Tests\Fixture\Filesystem\StatableFileStream;
 use Greenlight\Tests\Support\DiscoveryCachePath;
@@ -22,7 +21,6 @@ final readonly class DiscoveryCacheTest
 
     public function __construct(
         private Autoloaders $autoloaders,
-        private EnvironmentVariables $environment,
         private StreamWrappers $streamWrappers,
     ) {}
 
@@ -325,11 +323,12 @@ final readonly class DiscoveryCacheTest
     }
 
     #[Test]
-    public function persistToAMissingDirectoryIsASilentNoOp(): void
+    public function persistCreatesAMissingCacheDirectory(): void
     {
         $className = 'MissingDirProbeTest';
         $directory = $this->writeFixture($className);
         $missingDirectory = \sys_get_temp_dir() . '/greenlight-missing-' . \bin2hex(\random_bytes(6));
+        $cacheFile = $missingDirectory . '/' . \basename(DiscoveryCachePath::forDirectories([$directory]));
 
         $this->autoloaders->register(static function (string $class) use ($directory, $className): void {
             if ($class === 'GreenlightDiscoCache\\' . $className) {
@@ -337,13 +336,25 @@ final readonly class DiscoveryCacheTest
             }
         });
 
-        $this->environment->set('TMPDIR', $missingDirectory);
-
         try {
-            new TestDiscoverer()->discover([$directory], cache: DiscoveryCache::forDirectories([$directory]));
+            new TestDiscoverer()->discover(
+                [$directory],
+                cache: DiscoveryCache::forDirectories([$directory], $missingDirectory),
+            );
 
-            Expect::that(\is_dir($missingDirectory))->toBeFalse();
+            Expect::that(\is_file($cacheFile))->toBeTrue();
+            $source = \realpath($directory . '/' . $className . '.php');
+
+            if ($source === false) {
+                Fail::because('The discovery source fixture is unavailable.');
+            }
+
+            Expect::that(DiscoveryCache::forDirectories([$directory], $missingDirectory)
+                ->lookup($source))
+                ->toHaveCount(2);
         } finally {
+            @\unlink($cacheFile);
+            @\rmdir($missingDirectory);
             @\unlink($directory . '/' . $className . '.php');
             @\rmdir($directory);
         }


### PR DESCRIPTION
Two regression checks could pass without observing the behavior they describe.

The duplicate-reporter check captured its counter by value in an outer arrow function. Factory calls changed a separate counter, so the final assertion still saw zero. Capture the shared counter by reference at both closure boundaries.

The discovery-cache check changed `TMPDIR` after PHP had cached the system temporary directory. It wrote to the normal cache location and only checked that the unused directory was absent. Pass the missing cache directory explicitly, verify that the cache file is created, and reload its two discovered tests. Remove the cache file during cleanup.

Controlled mutations demonstrate both gaps: the old tests pass when a duplicate reporter factory runs early or when cache persistence refuses to create a directory. The corrected tests fail for those mutations and pass with the current production code. The focused run passes all 18 tests with 46 expectations.
