### PR TITLE
perf(test): index exact test IDs for selection

### DIFF
--- a/src/Test/TestSelection.php
+++ b/src/Test/TestSelection.php
@@ -13,12 +13,17 @@ use Greenlight\Internal\Text\Wildcard;
  */
 final readonly class TestSelection
 {
+    /** @var array<array-key, true> */
+    private array $exactIds;
+
     /** @param array{int, int}|null $shard A 1-based shard index and total shard count. */
     public function __construct(
         public TestInclusions $include = new TestInclusions(),
         public TestExclusions $exclude = new TestExclusions(),
         public ?array $shard = null,
-    ) {}
+    ) {
+        $this->exactIds = \array_fill_keys($include->exactIds, true);
+    }
 
     /** @param list<non-empty-string> $ids */
     public function withExactIds(array $ids): self
@@ -72,7 +77,7 @@ final readonly class TestSelection
             return true;
         }
 
-        if (\in_array($renderedId, $this->include->exactIds, true)) {
+        if (isset($this->exactIds[$renderedId])) {
             return true;
         }
 

--- a/tests/Unit/Test/ExactIdSelectionCopyTest.php
+++ b/tests/Unit/Test/ExactIdSelectionCopyTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Test;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Test\TestInclusions;
+use Greenlight\Test\TestSelection;
+
+final class ExactIdSelectionCopyTest
+{
+    #[Test]
+    public function exactIdCopiesReplaceMembershipAndPreservePatterns(): void
+    {
+        $original = new TestSelection(include: new TestInclusions(
+            idPatterns: ['*::pattern'],
+            exactIds: ['App\\ExampleTest::first'],
+        ));
+        $replacement = $original->withExactIds(['App\\ExampleTest::second']);
+        $filtered = $replacement->withExcludedPaths(['/project/generated']);
+
+        Expect::that($original->acceptsId('App\\ExampleTest::first'))->toBeTrue();
+        Expect::that($original->acceptsId('App\\ExampleTest::second'))->toBeFalse();
+        Expect::that($filtered->acceptsId('App\\ExampleTest::first'))->toBeFalse();
+        Expect::that($filtered->acceptsId('App\\ExampleTest::second'))->toBeTrue();
+        Expect::that($filtered->acceptsId('App\\ExampleTest::pattern'))->toBeTrue();
+        Expect::that($filtered->acceptsId('app\\ExampleTest::second'))->toBeFalse();
+    }
+}

--- a/tools/benchmark-test-selection.php
+++ b/tools/benchmark-test-selection.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tools;
+
+/**
+ * Measures exact test ID selection for a failed-test rerun.
+ * Run: php tools/benchmark-test-selection.php [test-count] [failed-count]
+ * Each workload uses seven samples and includes selection construction.
+ * Compare equal counts with the same PHP settings on an idle machine.
+ */
+
+require \dirname(__DIR__) . '/vendor/autoload.php';
+
+use Greenlight\Test\TestInclusions;
+use Greenlight\Test\TestSelection;
+
+$testCount = \filter_var($argv[1] ?? '20000', \FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+$failedCount = \filter_var($argv[2] ?? '10000', \FILTER_VALIDATE_INT, ['options' => ['min_range' => 1]]);
+
+if (!\is_int($testCount) || !\is_int($failedCount) || $failedCount > $testCount) {
+    throw new \InvalidArgumentException('Supply positive test and failed counts. The failed count must not exceed the test count.');
+}
+
+$ids = [];
+
+for ($test = 0; $test < $testCount; ++$test) {
+    $ids[] = 'App\\ExampleTest::case' . $test;
+}
+
+$failed = \array_slice($ids, 0, $failedCount);
+$samples = [];
+
+for ($sample = 0; $sample < 7; ++$sample) {
+    $memoryBefore = \memory_get_usage();
+    $startedAt = \hrtime(true);
+    $selection = new TestSelection(include: new TestInclusions(exactIds: $failed));
+    $selected = 0;
+
+    foreach ($ids as $id) {
+        if ($selection->acceptsId($id)) {
+            ++$selected;
+        }
+    }
+
+    $samples[] = [
+        'milliseconds' => (\hrtime(true) - $startedAt) / 1_000_000,
+        'retainedBytes' => \memory_get_usage() - $memoryBefore,
+    ];
+
+    if ($selected !== $failedCount) {
+        throw new \LogicException('The selection accepted an incorrect test count.');
+    }
+
+    unset($selection);
+}
+
+echo \json_encode([
+    'php' => \PHP_VERSION,
+    'testCount' => $testCount,
+    'failedCount' => $failedCount,
+    'samples' => $samples,
+], \JSON_THROW_ON_ERROR | \JSON_PRETTY_PRINT), "\n";


### PR DESCRIPTION
Failed-test reruns and repeated `--test-id` selections scan every requested exact ID for every discovered candidate. Build an immutable membership index once per `TestSelection`, then use it for exact-ID lookups. The public inclusion list, case-sensitive exact matches, pattern unions and selection copies keep their behavior.

The included `tools/benchmark-test-selection.php` measures selection construction and filtering over seven samples and checks the accepted count. With 20,000 candidate IDs on PHP 8.4.14, the median for 10,000 exact IDs fell from 1,339.347 ms to 3.485 ms. Retained memory increased by 655,432 bytes. With only 10 exact IDs, the median fell from 6.305 ms to 4.422 ms with 712 additional bytes. These are selection-only measurements with Xdebug and tracing disabled. Other audit checks were active, so the absolute times reflect host contention. The change removes the repeated linear scan; it does not claim the same speedup for a complete test run.

A focused regression confirms that copied selections replace exact membership, retain pattern unions and preserve case sensitivity. The required Composer static checks and documentation check passed. The full suite passed with 3,536 passed tests, 19 environment-dependent skips and 9,034 expectations.
