### PR TITLE
fix(doubles): isolate reference values and generated results

### DIFF
--- a/docs/test-doubles.md
+++ b/docs/test-doubles.md
@@ -220,7 +220,10 @@ If a plan must capture more than one argument, put an explicit
 
 ## Spy calls
 
-`callsTo()` returns argument lists in call order:
+`callsTo()` returns argument lists in call order. It copies each top-level
+argument value at the start of the call. Later assignments to a reference
+parameter do not change earlier recordings. Objects keep their identity.
+Greenlight does not clone them.
 
 <!-- php-example {"example":"test-doubles-example-09","file":"snippet.php","mode":"statements","tools":["rector"]} -->
 ```php

--- a/src/Doubles/CallHandler.php
+++ b/src/Doubles/CallHandler.php
@@ -45,7 +45,11 @@ final readonly class CallHandler
         $this->contracts->get($this->state->type, $method)
             ->assertCallArgumentCount(\count($arguments));
 
-        $positionalArguments = \array_values($arguments);
+        $positionalArguments = \array_map(
+            static fn(mixed $argument): mixed => $argument,
+            \array_values($arguments),
+        );
+
         $this->state->recordedCalls[$method][] = $positionalArguments;
 
         return match ($this->state->kind) {

--- a/src/Doubles/ProxyGenerator.php
+++ b/src/Doubles/ProxyGenerator.php
@@ -258,9 +258,18 @@ final readonly class ProxyGenerator
                     $method->getDeclaringClass()->name,
                     $method->name,
                 );
+        } elseif (!$method->returnsReference()) {
+            $body = '        return ' . $invoke . "\n";
         } else {
-            $body = '        $__greenlightResult = ' . $invoke . "\n"
-                . "        return \$__greenlightResult;\n";
+            $resultName = '__greenlightResult';
+            $parameters = $method->getParameters();
+
+            while (\array_any($parameters, static fn(\ReflectionParameter $parameter): bool => $parameter->name === $resultName)) {
+                $resultName .= '_';
+            }
+
+            $body = '        $' . $resultName . ' = ' . $invoke . "\n"
+                . '        return $' . $resultName . ";\n";
         }
 
         return \sprintf(

--- a/tests/Fixture/Doubles/ResultParameterCollision.php
+++ b/tests/Fixture/Doubles/ResultParameterCollision.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Doubles;
+
+interface ResultParameterCollision
+{
+    public function result(string &$__greenlightResult, string &$__greenlightResult_): int;
+
+    public function &reference(string &$__greenlightResult): string;
+}

--- a/tests/Unit/Doubles/ReferenceValueIsolationTest.php
+++ b/tests/Unit/Doubles/ReferenceValueIsolationTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Doubles;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Doubles\Doubles;
+use Greenlight\Doubles\MockPlan;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Fixture\Doubles\ResultParameterCollision;
+use Greenlight\Tests\Fixture\Doubles\VariadicReference;
+use Greenlight\Tests\Fixture\Doubles\Wide;
+
+final readonly class ReferenceValueIsolationTest
+{
+    public function __construct(private Doubles $doubles) {}
+
+    #[Test]
+    public function recordedCallsKeepReferenceValuesFromEachCall(): void
+    {
+        $spy = $this->doubles->spy(Wide::class);
+        $items = ['first'];
+        $spy->byReference($items);
+        $items = ['second'];
+        $spy->byReference($items);
+        $items = ['later'];
+
+        Expect::that($this->doubles->callsTo($spy, 'byReference'))->toBe([[['first']], [['second']]]);
+        Expect::that($items)->toBe(['later']);
+    }
+
+    #[Test]
+    public function recordedVariadicReferencesKeepTheirValuesBeforeTheCallback(): void
+    {
+        $mock = $this->doubles->mock(VariadicReference::class, static function (MockPlan $plan): void {
+            $plan->expects('mutate')->andReturnsUsing(static function (string &...$values): void {
+                foreach ($values as &$value) {
+                    $value .= ' changed';
+                }
+            });
+        });
+        $first = 'first';
+        $second = 'second';
+
+        $mock->mutate($first, second: $second);
+
+        Expect::that($this->doubles->callsTo($mock, 'mutate'))->toBe([['first', 'second']]);
+        Expect::that($first)->toBe('first changed');
+        Expect::that($second)->toBe('second changed');
+    }
+
+    #[Test]
+    public function recordedReferenceValuesPreserveObjectIdentity(): void
+    {
+        $spy = $this->doubles->spy(Wide::class);
+        $object = new \stdClass();
+        $items = [$object];
+        $spy->byReference($items);
+        $items = [];
+
+        Expect::that($this->doubles->callsTo($spy, 'byReference'))->toBe([[[$object]]]);
+        Expect::that($items)->toBe([]);
+    }
+
+    #[Test]
+    public function returnValuesDoNotOverwriteReferenceParametersWithGeneratedNames(): void
+    {
+        $mock = $this->doubles->mock(ResultParameterCollision::class, static function (MockPlan $plan): void {
+            $plan->expects('result')->andReturns(42);
+        });
+        $first = 'first';
+        $second = 'second';
+
+        Expect::that($mock->result($first, $second))->toBe(42);
+        Expect::that($first)->toBe('first');
+        Expect::that($second)->toBe('second');
+    }
+
+    #[Test]
+    public function referenceReturnsStaySeparateFromReferenceParameters(): void
+    {
+        $mock = $this->doubles->mock(ResultParameterCollision::class, static function (MockPlan $plan): void {
+            $plan->expects('reference')->andReturns('answer');
+        });
+        $input = 'input';
+        $result = &$mock->reference($input);
+        $result = 'changed result';
+
+        Expect::that($input)->toBe('input');
+        Expect::that($result)->toBe('changed result');
+    }
+}


### PR DESCRIPTION
Double calls can corrupt caller values and recorded call history when a method uses reference parameters. `array_values()` preserves references, so assigning to a caller variable after a spy call rewrites that earlier recording. Also, a generated value-returning method assigns its answer to `$__greenlightResult`. A reference parameter with that name is overwritten with the answer, even when the configured callback does not mutate it.

Copy top-level argument values for call history while passing the original references to configured callbacks. Objects retain their identity. Return ordinary values directly, and choose an unused local variable for methods that return by reference. The guide describes these recording semantics.

The reproducer previously changed a recorded `['original']` argument to `['original', 'later']` and overwrote a string reference with the integer return value `42`. Both values now stay unchanged. Five focused regressions pass with 15 expectations, covering repeated records, named variadic callbacks, object identity and generated-name collisions. Composer static analysis, the complete suite (3,540 passed, 19 skipped, 9,043 expectations), and the documentation check pass.
