### PR TITLE
fix(plugin): resolve factory return type identity

### DIFF
--- a/src/Plugin/PluginDefinition.php
+++ b/src/Plugin/PluginDefinition.php
@@ -26,7 +26,8 @@ final readonly class PluginDefinition
      */
     public static function fromFactory(\Closure $factory): self
     {
-        $returnType = new \ReflectionFunction($factory)->getReturnType();
+        $reflection = new \ReflectionFunction($factory);
+        $returnType = $reflection->getReturnType();
 
         if (!$returnType instanceof \ReflectionNamedType
             || $returnType->isBuiltin()
@@ -39,12 +40,23 @@ final readonly class PluginDefinition
 
         $pluginClass = $returnType->getName();
 
-        if (!\class_exists($pluginClass) || new \ReflectionClass($pluginClass)->isAbstract()) {
+        if ($pluginClass === 'self') {
+            $pluginClass = $reflection->getClosureScopeClass()->name ?? $pluginClass;
+        } elseif ($pluginClass === 'parent') {
+            $parent = $reflection->getClosureScopeClass()?->getParentClass();
+            $pluginClass = $parent instanceof \ReflectionClass ? $parent->name : $pluginClass;
+        }
+
+        $pluginType = \class_exists($pluginClass) ? new \ReflectionClass($pluginClass) : null;
+
+        if (!$pluginType instanceof \ReflectionClass || $pluginType->isAbstract()) {
             throw new \InvalidArgumentException(\sprintf(
                 'Plugin factory return type "%s" must be a concrete class.',
                 $pluginClass,
             ));
         }
+
+        $pluginClass = $pluginType->name;
 
         if (!\is_a($pluginClass, Plugin::class, true)) {
             throw new \InvalidArgumentException(\sprintf(

--- a/tests/Fixture/Plugins/FactoryIdentityChildPlugin.php
+++ b/tests/Fixture/Plugins/FactoryIdentityChildPlugin.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Plugins;
+
+final class FactoryIdentityChildPlugin extends FactoryIdentityPlugin
+{
+    /** @return \Closure(): parent */
+    public static function parentFactory(): \Closure
+    {
+        return static fn(): parent => new parent();
+    }
+}

--- a/tests/Fixture/Plugins/FactoryIdentityPlugin.php
+++ b/tests/Fixture/Plugins/FactoryIdentityPlugin.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Fixture\Plugins;
+
+use Greenlight\Doubles\Fake;
+use Greenlight\Plugin\Plugin;
+
+class FactoryIdentityPlugin implements Fake, Plugin
+{
+    /** @return \Closure(): self */
+    public static function scopedFactory(): \Closure
+    {
+        return static fn(): self => new self();
+    }
+}

--- a/tests/Unit/Plugin/PluginFactoryTypeIdentityTest.php
+++ b/tests/Unit/Plugin/PluginFactoryTypeIdentityTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Plugin;
+
+use Greenlight\Attribute\DataRow;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Plugin\Plugin;
+use Greenlight\Plugin\PluginDefinition;
+use Greenlight\Tests\Fixture\Plugins\FactoryIdentityChildPlugin;
+use Greenlight\Tests\Fixture\Plugins\FactoryIdentityPlugin;
+
+final class PluginFactoryTypeIdentityTest
+{
+    #[Test]
+    #[DataRow(['case'])]
+    #[DataRow(['alias'])]
+    public function factoryReturnNamesResolveToTheirDeclaredClass(string $form): void
+    {
+        $declaredType = new \ReflectionClass(FactoryIdentityPlugin::class);
+        $name = \strtolower($declaredType->name);
+
+        if ($form === 'alias') {
+            $name = __NAMESPACE__ . '\\FactoryIdentityAlias';
+            \class_alias(FactoryIdentityPlugin::class, $name);
+        }
+
+        /** @var \Closure(): Plugin $factory */
+        $factory = eval(\sprintf(
+            'return static fn(): \\%s => new \\%s();',
+            $name,
+            FactoryIdentityPlugin::class,
+        ));
+        $definition = PluginDefinition::fromFactory($factory);
+
+        Expect::that($definition->create())->toBeInstanceOf(FactoryIdentityPlugin::class);
+        Expect::that($definition->pluginClass)->toBe(FactoryIdentityPlugin::class);
+    }
+
+    #[Test]
+    public function selfReturnTypesUseTheFactoryClosureScope(): void
+    {
+        $definition = PluginDefinition::fromFactory(FactoryIdentityPlugin::scopedFactory());
+
+        Expect::that($definition->pluginClass)->toBe(FactoryIdentityPlugin::class);
+        Expect::that($definition->create())->toBeInstanceOf(FactoryIdentityPlugin::class);
+    }
+
+    #[Test]
+    public function parentReturnTypesUseTheParentOfTheFactoryClosureScope(): void
+    {
+        $definition = PluginDefinition::fromFactory(FactoryIdentityChildPlugin::parentFactory());
+
+        Expect::that($definition->pluginClass)->toBe(FactoryIdentityPlugin::class);
+        Expect::that($definition->create())->toBeInstanceOf(FactoryIdentityPlugin::class);
+    }
+}


### PR DESCRIPTION
Plugin factories can fail even when their native return type accepts the concrete plugin instance. A class alias or different class-name case is stored literally and then compared with the canonical runtime class name. `self` and `parent` return types are also rejected because their closure scope is not resolved.

Resolve `self` and `parent` through the factory closure's lexical class and store the reflected canonical class name. Exact-class validation remains in place, so a factory that declares a concrete base plugin and returns a subclass is still rejected. Factory instances are created through the configured closure as before.

The four new cases all errored before this change. They now pass alongside the five existing factory tests, with 14 expectations in total. Composer static analysis, the complete suite (3,539 passed, 19 skipped, 9,036 expectations), and the documentation check pass.
