### PR TITLE
fix(rector): preserve skips with empty reasons

### DIFF
--- a/src/Rector/PhpUnitToGreenlightRector.php
+++ b/src/Rector/PhpUnitToGreenlightRector.php
@@ -811,7 +811,10 @@ final class PhpUnitToGreenlightRector extends AbstractRector implements Configur
         if ($name === self::MARK_TEST_SKIPPED) {
             $arguments = $this->positionalArgs($call->args);
 
-            return $arguments !== null && \count($arguments) <= 1;
+            return $arguments !== null && \count($arguments) <= 1
+                && ($arguments === []
+                    || $arguments[0]->value instanceof String_
+                    || $this->getType($arguments[0]->value)->isNonEmptyString()->yes());
         }
 
         if (\in_array($name, self::EXPECT_EXCEPTION_METHODS, true) || $name === self::EXPECT_NO_ASSERTIONS) {
@@ -1233,7 +1236,9 @@ final class PhpUnitToGreenlightRector extends AbstractRector implements Configur
 
         if ($allowInstanceApi && $name === self::MARK_TEST_SKIPPED) {
             // SkipTest requires a non-empty reason. The PHPUnit argument is optional.
-            $reason = $arguments === [] ? [new Arg(new String_('Skipped.'))] : $arguments;
+            $emptyReason = $arguments === []
+                || ($arguments[0]->value instanceof String_ && $arguments[0]->value->value === '');
+            $reason = $emptyReason ? [new Arg(new String_('Skipped.'))] : $arguments;
 
             return new Throw_(new New_(new FullyQualified(SkipTest::class), $reason));
         }

--- a/tests/Acceptance/RectorEmptySkipReasonTest.php
+++ b/tests/Acceptance/RectorEmptySkipReasonTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\RectorProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class RectorEmptySkipReasonTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function anEmptyLiteralReasonRemainsASkipAfterMigration(): void
+    {
+        $probe = RectorProbe::convert($this->tempDirectory, <<<'PHP_WRAP'
+        <?php
+
+        declare(strict_types=1);
+
+        final class ProbeTest extends \PHPUnit\Framework\TestCase
+        {
+            public function testSkips(): void
+            {
+                $this->markTestSkipped('');
+            }
+        }
+        PHP_WRAP);
+
+        Expect::that($probe->changed)->toBeTrue();
+        $run = $probe->runConvertedTests();
+
+        Expect::that($run->exitCode)->because('The converted test must remain skipped.')->toBe(0);
+        Expect::that($run->stdout)->toContain('1 skipped');
+    }
+
+    #[Test]
+    public function aPossiblyEmptyDynamicReasonPreservesTheOriginalClass(): void
+    {
+        $source = <<<'PHP_WRAP'
+        <?php
+
+        declare(strict_types=1);
+
+        final class ProbeTest extends \PHPUnit\Framework\TestCase
+        {
+            public function testSkips(): void
+            {
+                $this->markTestSkipped($this->reason());
+            }
+
+            private function reason(): string
+            {
+                return '';
+            }
+        }
+        PHP_WRAP;
+        $probe = RectorProbe::convert($this->tempDirectory, $source);
+
+        Expect::that($probe->code)->toBe($source);
+    }
+
+    #[Test]
+    public function aKnownNonEmptyDynamicReasonStillConverts(): void
+    {
+        $probe = RectorProbe::convert($this->tempDirectory, <<<'PHP_WRAP'
+        <?php
+
+        declare(strict_types=1);
+
+        final class ProbeTest extends \PHPUnit\Framework\TestCase
+        {
+            public function testSkips(): void
+            {
+                $reason = 'Skipped dynamically.';
+                $this->markTestSkipped($reason);
+            }
+        }
+        PHP_WRAP);
+
+        Expect::that($probe->changed)->toBeTrue();
+        $run = $probe->runConvertedTests();
+
+        Expect::that($run->exitCode)->because('The converted test must remain skipped.')->toBe(0);
+        Expect::that($run->stdout)->toContain('1 skipped')->toContain('Skipped dynamically.');
+    }
+}


### PR DESCRIPTION
PHPUnit accepts an empty skip reason, but migrating markTestSkipped('') creates SkipTest(''), which raises InvalidArgumentException instead of skipping. The new regression reproduces that failure by running the converted test suite.

Use the existing default reason for an empty literal. Leave the class unchanged when a dynamic reason may be empty, and continue converting reasons proven to be nonempty. This keeps expression evaluation unchanged and avoids converting valid skips into errors. Three focused cases cover the empty literal, an uncertain dynamic value, and a known nonempty dynamic value.
