### PR TITLE
fix(cli): make interruption notices easier to see

### DIFF
--- a/src/Cli/Run/RunSession.php
+++ b/src/Cli/Run/RunSession.php
@@ -141,7 +141,9 @@ final readonly class RunSession
                 $this->console->error($error->getMessage(), $this->arguments->has('no-ansi'));
                 $interruptSignal = $this->shutdown->signal();
                 if ($interruptSignal !== null) {
-                    $this->console->err("Interrupted. Integration fixture teardown was attempted before exit.\n");
+                    $this->console->err("\n" . $this->console->stderrStyle($this->arguments->has('no-ansi'))->warn(
+                        'Interrupted. Integration fixture teardown was attempted before exit.',
+                    ) . "\n");
                 }
 
                 return $interruptSignal === null
@@ -161,7 +163,9 @@ final readonly class RunSession
         }
         $interruptSignal = $this->shutdown->signal();
         if ($interruptSignal !== null) {
-            $this->console->err("Interrupted. The summary includes only tests that finished before shutdown.\n");
+            $this->console->err("\n" . $this->console->stderrStyle($this->arguments->has('no-ansi'))->warn(
+                'Interrupted. The summary includes only tests that finished before shutdown.',
+            ) . "\n");
 
             return CommandResult::interrupted($interruptSignal);
         }

--- a/tests/Acceptance/InterruptionTest.php
+++ b/tests/Acceptance/InterruptionTest.php
@@ -113,6 +113,11 @@ final readonly class InterruptionTest
                 ->toContain($diagnostic);
         }
 
+        Expect::that($result->stderr)
+            ->because('Interruption diagnostics MUST remain plain when standard error is a pipe.')
+            ->not()
+            ->toContain("\x1b[");
+
         $workerPids = $this->spawnedWorkerPids($events);
         Expect::that($workerPids)
             ->because('The interrupted run MUST start at least one worker.')
@@ -147,14 +152,14 @@ final readonly class InterruptionTest
     {
         yield 'successful cleanup' => [
             false,
-            ['Interrupted'],
+            ["\nInterrupted. The summary includes only tests that finished before shutdown."],
         ];
         yield 'failed cleanup' => [
             true,
             [
                 'Integration fixture teardown failed.',
                 'intentional fixture cleanup failure',
-                'Interrupted. Integration fixture teardown was attempted before exit.',
+                "\n\nInterrupted. Integration fixture teardown was attempted before exit.",
             ],
         ];
     }


### PR DESCRIPTION
Interruption notices appear directly below the run summary or cleanup error, which makes them easy to miss.

Add a blank line before both notices and use the existing yellow warning style. Respect terminal color settings, including `--no-ansi` and `NO_COLOR`.
