### PR TITLE
feat(cli): add color to help output

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1196,7 +1196,7 @@ In interactive output, prints a permanent line for every completed class.
 
 ### `--ansi`
 
-Enables colors in append-only reporter output. It does not enable the live
+Enables colors in help and append-only reporter output. It does not enable the live
 progress window.
 
 ### `--no-ansi`
@@ -1211,7 +1211,10 @@ A truthy `CI` environment variable has the same effect.
 
 ### -h, --help
 
-Shows help.
+Shows help. Terminal output uses colors for the title, section headings,
+commands, and option labels. Piped output uses plain text by default.
+Use `--ansi` to enable colors.
+`NO_COLOR` and `--no-ansi` disable help colors.
 
 ### -V, --version
 

--- a/src/Cli/Input/Definition.php
+++ b/src/Cli/Input/Definition.php
@@ -115,7 +115,7 @@ final readonly class Definition
           --detect-leaks     Verify collection of each test instance. Leaks fail the run.
           --verbose          Print a permanent line per completed class in
                              interactive output
-          --ansi             Enable colors in append-only reporter output.
+          --ansi             Enable colors in help and append-only reporter output.
           --no-ansi          Disable colors and the live progress window.
                              Use plain append-only output.
           --fail-on-deprecation  Fail passed tests that captured a deprecation.

--- a/src/Cli/Output/Console.php
+++ b/src/Cli/Output/Console.php
@@ -58,9 +58,9 @@ final readonly class Console
         );
     }
 
-    public function stdoutStyle(bool $noAnsi): Style
+    public function stdoutStyle(bool $noAnsi, bool $ansi = false): Style
     {
-        return new Style($this->capabilities($noAnsi)->color);
+        return new Style($this->capabilities($noAnsi, $ansi)->color);
     }
 
     public function stderrStyle(bool $noAnsi): Style

--- a/src/Cli/Output/HelpFormatter.php
+++ b/src/Cli/Output/HelpFormatter.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Cli\Output;
+
+use Greenlight\Reporting\Style;
+
+/**
+ * Styles help text without changes to its content or spacing.
+ * Headings have no indentation. Entry labels start after two spaces.
+ *
+ * @internal
+ */
+final readonly class HelpFormatter
+{
+    public function __construct(private Style $style) {}
+
+    public function format(string $text): string
+    {
+        return \implode("\n", \array_map($this->formatLine(...), \explode("\n", $text)));
+    }
+
+    private function formatLine(string $line): string
+    {
+        if ($line === 'Greenlight') {
+            return $this->style->ok($line);
+        }
+
+        if ($line !== '' && $line[0] !== ' ' && \str_ends_with($line, ':')) {
+            return $this->style->heading($line);
+        }
+
+        if (\preg_match('/^  ([^\s,]+(?:, --\S+)?)/', $line, $matches) === 1) {
+            return '  ' . $this->style->label($matches[1]) . \substr($line, \strlen($matches[0]));
+        }
+
+        return $line;
+    }
+}

--- a/src/Cli/Plugin/BundledCommands.php
+++ b/src/Cli/Plugin/BundledCommands.php
@@ -13,6 +13,7 @@ use Greenlight\Cli\Command\ProfileReportCommand;
 use Greenlight\Cli\Input\CliError;
 use Greenlight\Cli\Input\Definition;
 use Greenlight\Cli\Output\Console;
+use Greenlight\Cli\Output\HelpFormatter;
 use Greenlight\Cli\Run\ArtifactsPruneCommand;
 use Greenlight\Cli\Run\RunCommand;
 use Greenlight\Coverage\CoverageError;
@@ -75,7 +76,8 @@ final readonly class BundledCommands implements CommandProvider
         }
 
         if ($arguments->has('help')) {
-            $this->console->out(Definition::HELP . "\n");
+            $style = $this->console->stdoutStyle($arguments->has('no-ansi'), $arguments->has('ansi'));
+            $this->console->out(new HelpFormatter($style)->format(Definition::HELP) . "\n");
 
             return CommandResult::success();
         }

--- a/src/Reporting/Style.php
+++ b/src/Reporting/Style.php
@@ -40,6 +40,16 @@ final readonly class Style
         return $this->paint($text, '2');
     }
 
+    public function heading(string $text): string
+    {
+        return $this->paint($text, '1;33');
+    }
+
+    public function label(string $text): string
+    {
+        return $this->paint($text, '36');
+    }
+
     public function duration(float $seconds): string
     {
         $text = \sprintf('%.3fs', $seconds);

--- a/tests/Acceptance/HelpOutputTest.php
+++ b/tests/Acceptance/HelpOutputTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\GreenlightCli;
+
+final class HelpOutputTest
+{
+    #[Test]
+    #[DataSet('helpOptions')]
+    public function ansiHighlightsHelpLabelsWithoutChangingTheText(string $helpOption): void
+    {
+        $root = \dirname(__DIR__, 2);
+        $plain = GreenlightCli::run($root, [$helpOption], ['NO_COLOR' => '', 'CI' => 'false']);
+        $colored = GreenlightCli::run($root, [$helpOption, '--ansi'], ['NO_COLOR' => '', 'CI' => 'true']);
+
+        Expect::that($plain->exitCode)->toBe(0);
+        Expect::that($plain->stdout)->toStartWith('Greenlight')->not()->toContain("\x1b[");
+        Expect::that($plain->stderr)->toBe('');
+        Expect::that($colored->exitCode)->toBe(0);
+        Expect::that($colored->stderr)->toBe('');
+        Expect::that(\preg_replace('/\x1b\[[0-9;]*m/', '', $colored->stdout))
+            ->because('color preserves the help text and its spacing')
+            ->toBe($plain->stdout);
+        Expect::that($colored->stdout)
+            ->toMatch('/\x1b\[[0-9;]+mGreenlight\x1b\[[0-9;]+m/')
+            ->toMatch('/\x1b\[[0-9;]+mUsage:\x1b\[[0-9;]+m/')
+            ->toMatch('/\x1b\[[0-9;]+mCommands:\x1b\[[0-9;]+m/')
+            ->toMatch('/\x1b\[[0-9;]+mOptions:\x1b\[[0-9;]+m/')
+            ->toMatch('/\x1b\[[0-9;]+mrun\x1b\[[0-9;]+m +Find and run tests/')
+            ->toMatch('/\x1b\[[0-9;]+mcoverage:merge\x1b\[[0-9;]+m +Merge coverage/')
+            ->toMatch('/\x1b\[[0-9;]+m--config=<path>\x1b\[[0-9;]+m +Use this configuration/')
+            ->toMatch('/\x1b\[[0-9;]+m-h, --help\x1b\[[0-9;]+m +Show this help/')
+            ->toMatch('/\x1b\[[0-9;]+m-V, --version\x1b\[[0-9;]+m +Show the version/');
+    }
+
+    /**
+     * @param list<string> $arguments
+     * @param array<string, string> $environment
+     */
+    #[Test]
+    #[DataSet('colorOverrides')]
+    public function colorOverridesKeepHelpEscapeFree(array $arguments, array $environment): void
+    {
+        $root = \dirname(__DIR__, 2);
+        $plain = GreenlightCli::run($root, ['--help'], ['NO_COLOR' => '', 'CI' => 'false']);
+        $result = GreenlightCli::run($root, $arguments, $environment);
+
+        Expect::that($result->exitCode)->toBe(0);
+        Expect::that($result->stdout)->toBe($plain->stdout)->not()->toContain("\x1b[");
+        Expect::that($result->stderr)->toBe('');
+    }
+
+    /** @return iterable<string, array{string}> */
+    public static function helpOptions(): iterable
+    {
+        yield 'long help option' => ['--help'];
+        yield 'short help option' => ['-h'];
+    }
+
+    /** @return iterable<string, array{list<string>, array<string, string>}> */
+    public static function colorOverrides(): iterable
+    {
+        yield 'no ANSI after ANSI' => [
+            ['--help', '--ansi', '--no-ansi'],
+            ['NO_COLOR' => '', 'CI' => 'false'],
+        ];
+        yield 'no ANSI before ANSI' => [
+            ['-h', '--no-ansi', '--ansi'],
+            ['NO_COLOR' => '', 'CI' => 'false'],
+        ];
+        yield 'NO_COLOR enabled' => [
+            ['--help', '--ansi'],
+            ['NO_COLOR' => '1', 'CI' => 'false'],
+        ];
+        yield 'NO_COLOR set to zero' => [
+            ['-h', '--ansi'],
+            ['NO_COLOR' => '0', 'CI' => 'false'],
+        ];
+    }
+}


### PR DESCRIPTION
## What

`--help` now uses a green title, bold yellow headings, and cyan command and option labels. Help uses the existing terminal detection and respects `--ansi`, `--no-ansi`, and `NO_COLOR`.

## Why

Plain help text makes commands and options hard to find. Color separates labels from descriptions and makes each section easier to scan.
