### PR TITLE
refactor(execution): unify attempt attachment finalization

### DIFF
--- a/src/Execution/Worker/TestExecutor.php
+++ b/src/Execution/Worker/TestExecutor.php
@@ -115,7 +115,7 @@ final readonly class TestExecutor
             }
 
             try {
-                [$result, $cause, $attachments] = $this->runTestAttempt(
+                [$result, $cause, $attachments] = $this->plugins->runTestAttempt(
                     fn(): array => $this->attempt($entry, $attempt, $artifactBudget),
                 );
             } catch (\Throwable $threw) {
@@ -135,41 +135,23 @@ final readonly class TestExecutor
                 $result = $result->withAttachments($attachments->collected());
             }
 
-            if ($result->outcome->isSuccessful()) {
-                $sealed = $attachments?->seal() ?? [];
+            $retry = false;
 
-                return $result->withAttachments([...$retainedAttachments, ...$sealed]);
-            }
-
-            try {
-                $retry = $this->plugins->shouldRetry($definition->retry, $result, $attempt, $cause);
-            } catch (\Throwable $threw) {
-                $result = $result->erroredBy(ThrowableDetail::fromThrowable($threw));
-                $sealed = $attachments?->seal() ?? [];
-
-                return $result->withAttachments([...$retainedAttachments, ...$sealed]);
+            if (!$result->outcome->isSuccessful()) {
+                try {
+                    $retry = $this->plugins->shouldRetry($definition->retry, $result, $attempt, $cause);
+                } catch (\Throwable $threw) {
+                    $result = $result->erroredBy(ThrowableDetail::fromThrowable($threw));
+                }
             }
 
             $sealed = $attachments?->seal() ?? [];
+            $retainedAttachments = [...$retainedAttachments, ...$sealed];
 
             if (!$retry) {
-                return $result->withAttachments([...$retainedAttachments, ...$sealed]);
+                return $result->withAttachments($retainedAttachments);
             }
-
-            $retainedAttachments = [...$retainedAttachments, ...$sealed];
         } while (true);
-    }
-
-    /**
-     * @template T
-     *
-     * @param \Closure(): T $attempt
-     *
-     * @return T
-     */
-    private function runTestAttempt(\Closure $attempt): mixed
-    {
-        return $this->plugins->runTestAttempt($attempt);
     }
 
     /**

--- a/tests/Acceptance/AttachmentRunTest.php
+++ b/tests/Acceptance/AttachmentRunTest.php
@@ -8,6 +8,7 @@ use Greenlight\Attribute\Test;
 use Greenlight\Event\RunStarted;
 use Greenlight\Event\TestFinished;
 use Greenlight\Expect\Expect;
+use Greenlight\Result\Outcome;
 use Greenlight\Result\TestResult;
 use Greenlight\Sandbox\TemporaryDirectory;
 use Greenlight\Tests\Support\AcceptanceProject;
@@ -79,7 +80,9 @@ final readonly class AttachmentRunTest
         Expect::that($results['retainsTheFailedRetryAttempt']->attachments[0]->attempt)->toBe(1);
         Expect::that($results['becomesErroredDuringClassTeardown']->outcome->isSuccessful())->toBeFalse();
         Expect::that($results['becomesErroredDuringClassTeardown']->attachments)->toHaveCount(1);
-        Expect::that($results['retryDeciderThrows']->outcome->isSuccessful())->toBeFalse();
+        Expect::that($results['retryDeciderThrows']->outcome)->toBe(Outcome::Errored);
+        Expect::that($results['retryDeciderThrows']->error?->message)->toBe('retry decider failed');
+        Expect::that($results['retryDeciderThrows']->attempts)->toBe(1);
         Expect::that($results['retryDeciderThrows']->attachments)->toHaveCount(2);
 
         foreach ($results as $testResult) {


### PR DESCRIPTION
Test execution repeats attachment finalization for a successful attempt, a failed retry decision, and a result that needs no retry. Each path seals the same attachment store and combines evidence from previous attempts.

Use one finalization path after the retry decision. Successful results still bypass retry deciders. A decider exception still produces an error result and retains its evidence. Call the plugin runtime directly to remove a private method that only forwards the attempt callback.

The existing sequential and process-pool attachment scenarios now also assert the exact error, message, and attempt count when a retry decider throws.
