### PR TITLE
docs: align website examples with runner behavior

### DIFF
--- a/website/src/components/RunPreview.astro
+++ b/website/src/components/RunPreview.astro
@@ -1,3 +1,7 @@
+---
+import { version } from '../../../composer.json';
+---
+
 <figure class="run-preview" aria-label="Example Greenlight test run">
   <figcaption class="run-preview__bar">
     <code><span aria-hidden="true">›</span> vendor/bin/greenlight</code>
@@ -9,7 +13,7 @@
 
   <div class="run-preview__body">
     <div class="run-preview__meta">
-      <strong>Greenlight <span>1.0.0</span></strong>
+      <strong>Greenlight <span>{version}</span></strong>
       <code>PHP 8.4.14 · configuration: greenlight.php · workers: 11</code>
     </div>
 

--- a/website/src/components/TerminalOutput.astro
+++ b/website/src/components/TerminalOutput.astro
@@ -1,4 +1,6 @@
 ---
+import { version } from '../../../composer.json';
+
 type Tone = 'command' | 'muted' | 'prompt' | 'success' | 'warning';
 
 interface Part {
@@ -14,7 +16,7 @@ const lines: Part[][] = [
   [],
   [
     { text: 'Greenlight', tone: 'success' },
-    { text: ' 1.0.0' },
+    { text: ` ${version}` },
   ],
   [
     { text: 'PHP 8.4.14 | configuration: greenlight.php | workers: 11 | ' },

--- a/website/src/components/WorkerFlow.astro
+++ b/website/src/components/WorkerFlow.astro
@@ -1,7 +1,7 @@
 <figure class="worker-flow" aria-labelledby="worker-flow-caption">
   <figcaption id="worker-flow-caption" class="worker-flow__caption">
     <span>Execution plan</span>
-    <strong>Classes run independently. One report combines their results.</strong>
+    <strong>Workers execute test classes. One report combines their results.</strong>
   </figcaption>
 
   <div class="worker-flow__stage" aria-hidden="true">

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -100,7 +100,7 @@ final class PriceTest
           <span>02</span>
           <div>
             <h3>Assign work to available workers</h3>
-            <p>The orchestrator assigns one scheduling unit to each available worker. Saved run state puts previously failed classes first. Without randomized order, saved durations put known slow classes next.</p>
+            <p>The orchestrator assigns one scheduling unit to each available worker. Without randomized order, saved run state puts previously failed classes first and known slow classes next.</p>
           </div>
         </li>
         <li>

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -67,6 +67,7 @@ final class PriceTest
         <h2>Tests stay plain PHP.</h2>
         <p>
           Use ordinary classes, native attributes, and typed expectations.
+          This example uses a <code>Price</code> class from the application under test.
         </p>
         <a class="text-link" href={sitePath('docs/getting-started/')}>Write your first test</a>
       </div>
@@ -99,7 +100,7 @@ final class PriceTest
           <span>02</span>
           <div>
             <h3>Assign work to available workers</h3>
-            <p>The orchestrator assigns one scheduling unit to each available worker. Greenlight starts known slow classes and previously failed classes early.</p>
+            <p>The orchestrator assigns one scheduling unit to each available worker. Saved run state puts previously failed classes first. Without randomized order, saved durations put known slow classes next.</p>
           </div>
         </li>
         <li>


### PR DESCRIPTION
The website terminal previews hardcode Greenlight 1.0.0. Read the version from `composer.json` so both previews show the declared package version after each release.

Clarify that the `Price` example uses an application class. Describe workers without implying that test classes cannot share external state. Explain that saved failures and durations affect order only when randomization is off. These statements follow `RunCommand`, `PlanOrder`, and `RunCoordinator`.
