### PR TITLE
refactor(expect): inline fixed duration checks

### DIFF
--- a/docs/api-expectations.md
+++ b/docs/api-expectations.md
@@ -2022,7 +2022,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws \InvalidArgumentException if a type does not extend Exception`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingEventually.php#L78)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingEventually.php#L84)
 
 ### `within()`
 
@@ -2035,7 +2035,7 @@ PHPDoc:
 - `@return EventuallyExpectation<T>`
 - `@throws \InvalidArgumentException if the duration is not finite or is not positive`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingEventually.php#L95)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/PendingEventually.php#L101)
 
 ## `TemporalExpectation`
 

--- a/src/Expect/PendingEventually.php
+++ b/src/Expect/PendingEventually.php
@@ -62,7 +62,13 @@ final class PendingEventually
      */
     public function pollEvery(float $seconds): self
     {
-        $this->requireDuration($seconds, 'Polling interval', minimum: 0.001, inclusive: true);
+        if (!\is_finite($seconds) || $seconds < 0.001) {
+            throw new \InvalidArgumentException(\sprintf(
+                'Set Polling interval to a finite value of at least %.3f seconds.',
+                0.001,
+            ));
+        }
+
         $this->intervalSeconds = $seconds;
 
         return $this;
@@ -94,7 +100,12 @@ final class PendingEventually
      */
     public function within(float $seconds): EventuallyExpectation
     {
-        $this->requireDuration($seconds, 'Eventually duration');
+        if (!\is_finite($seconds) || $seconds <= 0.0) {
+            throw new \InvalidArgumentException(\sprintf(
+                'Set Eventually duration to a finite value greater than %.3f seconds.',
+                0.0,
+            ));
+        }
 
         return EventuallyExpectation::create(
             $this->probe,
@@ -106,25 +117,6 @@ final class PendingEventually
             $this->renderer,
             $this->extensions,
         );
-    }
-
-    private function requireDuration(
-        float $seconds,
-        string $label,
-        float $minimum = 0.0,
-        bool $inclusive = false,
-    ): void {
-        if (!\is_finite($seconds) || ($inclusive ? $seconds < $minimum : $seconds <= $minimum)) {
-            $constraint = $inclusive
-                ? \sprintf('of at least %.3f seconds', $minimum)
-                : \sprintf('greater than %.3f seconds', $minimum);
-
-            throw new \InvalidArgumentException(\sprintf(
-                'Set %s to a finite value %s.',
-                $label,
-                $constraint,
-            ));
-        }
     }
 
     /**


### PR DESCRIPTION
The eventual expectation builder sent two fixed duration rules through a private validator with labels, optional minimums, and an inclusive flag. A reader had to resolve those options to find the bounds for each public method.

Put each finite-value and boundary check in the method that owns it, as the consistency builder already does. This removes the generic validator and its conditional message construction. Poll intervals still accept 0.001 seconds, wait durations remain strictly positive, and the exception type and formatted diagnostics stay the same.

Refresh the generated API reference so its source links follow the moved methods.

The source change is independent of #1851, which adjusts deadline composition. Their PHP changes combine cleanly. Both shift the same generated reference links, so regenerate that reference from the combined source when incorporating the later change.
