### PR TITLE
docs: clarify public report field semantics

### DIFF
--- a/docs/architecture/coverage-json.md
+++ b/docs/architecture/coverage-json.md
@@ -70,10 +70,19 @@ comparison.
 Supply both root options. Each file key **MUST** be below the selected root.
 Normalization does not change the documents.
 
-`files` is always an object. This rule also applies to an empty report:
+`files` is always an object. An empty report has an empty `files` object:
 
 ```json id="g6nqcx"
-{}
+{
+    "v": 1,
+    "files": {},
+    "totals": {
+        "files": 0,
+        "coveredLines": 0,
+        "executableLines": 0,
+        "percentage": 100
+    }
+}
 ```
 
 ### files.*.covered
@@ -183,7 +192,8 @@ The file uses UTF-8 JSON, unescaped slashes, and a newline at its end.
 
 ## Versions
 
-Version `1` **MAY** receive additive fields.
+Version `1` **MAY** receive optional fields at the top level, in `totals`, or
+in each file entry. New required fields need a new version.
 
 Readers **MUST** ignore unknown keys.
 

--- a/docs/architecture/jsonl.md
+++ b/docs/architecture/jsonl.md
@@ -158,11 +158,15 @@ one of these four values.
 
 ### durationSeconds
 
-The test duration in seconds.
+For a result from a test attempt, the final attempt's duration in seconds.
+This value includes test construction, hooks, cleanup, and per-test service
+disposal. It excludes earlier retry attempts and `afterTest()` subscribers.
 
 ### memoryDeltaBytes
 
-The memory delta for the test, in bytes.
+For a result from a test attempt, the change in allocated PHP memory during the
+final attempt, in bytes. Greenlight measures it with `memory_get_usage(true)`.
+The value can be negative. It is not peak memory use.
 
 ### attempts
 
@@ -278,8 +282,9 @@ An `eventually()` or `consistently()` matcher counts once. Calls to its probe do
 not count separately.
 
 Greenlight takes this count after the final attempt's cleanup and per-test
-service disposal. Cleanup can therefore add expectations after the test body
-fails, errors, or skips. Earlier retry attempts do not contribute to this count.
+service disposal, before `afterTest()` subscribers. Cleanup can therefore add
+expectations after the test body fails, errors, or skips. Earlier retry attempts
+do not contribute to this count.
 
 ### attachments
 

--- a/docs/architecture/test-manifest.md
+++ b/docs/architecture/test-manifest.md
@@ -28,10 +28,14 @@ Each test entry has these identity and source fields:
 - `class`: The test class.
 - `method`: The test method.
 - `dataSetKey`: The normalized data-set key, or `null`.
-- `source.file`: The absolute declaring file.
+- `source.file`: The absolute path of the file that declares the test method.
 - `source.line`: The test method declaration line.
 - `groups`: All groups declared for the test, sorted by name.
-- `suites`: Each configured suite whose path contains the test class file.
+- `suites`: Each configured suite whose path contains the test class file,
+  sorted by name.
+
+For an inherited method, `source` identifies the parent method's declaration.
+Suite membership uses the test class file, which can be different.
 
 A labeled data row or provider key keeps its printable label in `dataSetKey`.
 An integer key uses `#<value>`. Greenlight hashes an empty or nonprintable key.
@@ -41,12 +45,18 @@ test entry.
 
 Each entry also contains this execution metadata:
 
-- `skip.present` and `skip.condition`
-- `retry.additionalAttempts` and `retry.onlyOn`
-- `timeoutSeconds`
-- `captureOutput` and `noExpectations`
-- `resources`
-- `isolated` and `allowParallel`
+| Field | Meaning |
+| --- | --- |
+| `skip.present` | Whether the test has a skip reason or condition. Discovery does not evaluate the condition. |
+| `skip.condition` | The skip condition class, or `null`. |
+| `retry.additionalAttempts` | The configured number of retries, or `0` when none is configured. |
+| `retry.onlyOn` | The exception class that restricts retries, or `null`. |
+| `timeoutSeconds` | The test time budget in seconds, or `null` when no budget is configured. |
+| `captureOutput` | Whether output capture is enabled for the test. |
+| `noExpectations` | Whether the test permits zero expectations. |
+| `resources` | The required resource names, sorted by name. |
+| `isolated` | Whether the test requires a fresh worker process in a process-pool run. |
+| `allowParallel` | Whether each selected test or data set forms a separate pooled scheduling unit. |
 
 The manifest does not contain skip reasons or condition arguments. It also
 does not contain closures, plugin instances, or internal wire payloads.


### PR DESCRIPTION
The report references leave several fields open to interpretation. The coverage page also shows an empty object where readers need a complete empty report.

Show the complete empty coverage document and clarify that optional additions can keep version 1. Define test-manifest execution fields and inherited method locations. Explain that normal JSONL duration and memory values describe the final test attempt, and that the expectation count is captured before `afterTest()`.

These corrections follow `JsonExporter::export()`, `TestManifest::test()`, and `TestExecutor::attempt()`. The existing serializers and schema contracts stay unchanged.
