### PR TITLE
refactor(coverage): track only the active session collector

### DIFF
--- a/src/Cli/Coverage/CoverageSession.php
+++ b/src/Cli/Coverage/CoverageSession.php
@@ -19,8 +19,6 @@ final class CoverageSession
 {
     private ?CoverageCollector $collector = null;
 
-    private bool $collecting = false;
-
     private ?SharedCoverageDirectory $shared = null;
 
     private function __construct() {}
@@ -41,11 +39,11 @@ final class CoverageSession
 
         try {
             if ($collectProcess) {
-                $session->collector = CoverageCollector::create($settings);
+                $collector = CoverageCollector::create($settings);
 
-                if ($session->collector instanceof CoverageCollector) {
-                    $session->collector->start();
-                    $session->collecting = true;
+                if ($collector instanceof CoverageCollector) {
+                    $collector->start();
+                    $session->collector = $collector;
                 }
             }
 
@@ -61,11 +59,12 @@ final class CoverageSession
 
     public function finish(?CoverageMap $coverage): ?CoverageMap
     {
-        if ($this->collecting) {
-            $this->collecting = false;
-            $collected = $this->collector?->stop();
+        if ($this->collector instanceof CoverageCollector) {
+            $collector = $this->collector;
+            $this->collector = null;
+            $collected = $collector->stop();
 
-            if ($collected instanceof CoverageMap && !$collected->isEmpty()) {
+            if (!$collected->isEmpty()) {
                 $coverage = $coverage instanceof CoverageMap ? $coverage->merge($collected) : $collected;
             }
         }
@@ -85,11 +84,12 @@ final class CoverageSession
 
     public function close(): void
     {
-        if ($this->collecting) {
-            $this->collecting = false;
+        if ($this->collector instanceof CoverageCollector) {
+            $collector = $this->collector;
+            $this->collector = null;
 
             try {
-                $this->collector?->stop();
+                $collector->stop();
             } catch (\Throwable) {
                 // Preserve the run failure if cleanup also fails.
             }


### PR DESCRIPTION
The coverage session stores both a collector and a flag that says whether it is active. Each completion and cleanup path must keep those values in step.

Use the nullable collector as the active resource. Retain it after collection starts, then clear it before collection stops. This follows the existing ownership rule for the shared coverage directory and removes the separate flag and nullable stop calls.

Start failures, coverage merging, and cleanup error handling keep their existing behavior. The public interface and coverage output stay the same.
