### PR TITLE
docs(api): clarify service and fixture contracts

### DIFF
--- a/docs/api-harness.md
+++ b/docs/api-harness.md
@@ -209,9 +209,12 @@ This type does not declare public members.
 
 Namespace: `Greenlight\Harness`
 
-Greenlight calls service resolvers in registration order. A null result asks
-Greenlight to call the next resolver. An object must have the requested
-type. A `ServiceResolutionFailed` exception stops resolution.
+Greenlight calls service resolvers with lower priorities first. Equal
+priorities use registration order. A terminal resolver runs after all other
+resolvers, regardless of priority.
+
+A null result asks Greenlight to call the next resolver. An object must have
+the requested type. A `ServiceResolutionFailed` exception stops resolution.
 
 Objects from a service resolver do not belong to a harness service scope.
 Greenlight does not dispose them. The source of an object controls its
@@ -221,7 +224,7 @@ lifetime.
 interface ServiceResolver
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolver.php#L16)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolver.php#L19)
 
 ### `resolve()`
 
@@ -235,7 +238,7 @@ PHPDoc:
 - `@param list<object> $attributes`
 - `@throws ServiceResolutionFailed when the resolver handles the request but cannot supply a valid service`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolver.php#L23)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolver.php#L26)
 
 ## `ServiceSource`
 
@@ -289,4 +292,4 @@ PHPDoc:
 - `@param list<object> $attributes`
 - `@throws ServiceResolutionFailed when the resolver handles the request but cannot supply a valid service`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolver.php#L23)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Harness/ServiceResolver.php#L26)

--- a/docs/api-integration-fixtures.md
+++ b/docs/api-integration-fixtures.md
@@ -209,6 +209,9 @@ PHPDoc:
 
 ### `configuredWorkers()`
 
+Returns the worker limit for the selected execution adapter.
+In-process execution returns one, including a fallback from process-pool execution.
+
 ```php
 public function configuredWorkers(): int;
 ```
@@ -217,7 +220,7 @@ PHPDoc:
 
 - `@return positive-int`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/IntegrationFixtureContext.php#L21)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/IntegrationFixtureContext.php#L24)
 
 ### `channels()`
 
@@ -231,7 +234,7 @@ PHPDoc:
 
 - `@return non-empty-list<positive-int>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/IntegrationFixtureContext.php#L28)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/IntegrationFixtureContext.php#L31)
 
 ### `shard()`
 
@@ -243,7 +246,7 @@ PHPDoc:
 
 - `@return array{int, int}|null one-based shard index and shard count`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/IntegrationFixtureContext.php#L33)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/IntegrationFixtureContext.php#L36)
 
 ### `dependency()`
 
@@ -258,7 +261,7 @@ PHPDoc:
 - `@throws \LogicException when the fixture does not declare the dependency`
 - `@throws \OutOfBoundsException when the channel is not part of this run`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/IntegrationFixtureContext.php#L41)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/IntegrationFixtureContext.php#L44)
 
 ### `defer()`
 
@@ -273,7 +276,7 @@ PHPDoc:
 
 - `@param \Closure(): void $cleanup`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/IntegrationFixtureContext.php#L49)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/IntegrationFixtureContext.php#L52)
 
 ### `expose()`
 
@@ -289,7 +292,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when a channel is not part of this run`
 - `@throws \LogicException when the provisioner publishes resources more than once`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/IntegrationFixtureContext.php#L58)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/IntegrationFixture/IntegrationFixtureContext.php#L61)
 
 ## `IntegrationFixtureDefinition`
 

--- a/docs/api-plugins.md
+++ b/docs/api-plugins.md
@@ -307,13 +307,14 @@ Namespace: `Greenlight\Plugin`
 Adds harness services to the worker registry.
 
 Greenlight adds built-in services before `services()` results. A duplicate
-type causes a configuration error.
+type in the same source causes a configuration error. Unnamed definitions
+share one source. Different named sources can define the same type.
 
 ```php
 interface HarnessProvider extends Plugin
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/HarnessProvider.php#L15)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/HarnessProvider.php#L16)
 
 ### `services()`
 
@@ -325,7 +326,7 @@ PHPDoc:
 
 - `@return list<ServiceDefinition>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/HarnessProvider.php#L20)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Plugin/HarnessProvider.php#L21)
 
 ## `IntegrationFixtureProvider`
 

--- a/src/Harness/ServiceResolver.php
+++ b/src/Harness/ServiceResolver.php
@@ -5,9 +5,12 @@ declare(strict_types=1);
 namespace Greenlight\Harness;
 
 /**
- * Greenlight calls service resolvers in registration order. A null result asks
- * Greenlight to call the next resolver. An object must have the requested
- * type. A `ServiceResolutionFailed` exception stops resolution.
+ * Greenlight calls service resolvers with lower priorities first. Equal
+ * priorities use registration order. A terminal resolver runs after all other
+ * resolvers, regardless of priority.
+ *
+ * A null result asks Greenlight to call the next resolver. An object must have
+ * the requested type. A `ServiceResolutionFailed` exception stops resolution.
  *
  * Objects from a service resolver do not belong to a harness service scope.
  * Greenlight does not dispose them. The source of an object controls its

--- a/src/IntegrationFixture/IntegrationFixtureContext.php
+++ b/src/IntegrationFixture/IntegrationFixtureContext.php
@@ -16,6 +16,9 @@ interface IntegrationFixtureContext
     public function runId(): string;
 
     /**
+     * Returns the worker limit for the selected execution adapter.
+     * In-process execution returns one, including a fallback from process-pool execution.
+     *
      * @return positive-int
      */
     public function configuredWorkers(): int;

--- a/src/Plugin/HarnessProvider.php
+++ b/src/Plugin/HarnessProvider.php
@@ -10,7 +10,8 @@ use Greenlight\Harness\ServiceDefinition;
  * Adds harness services to the worker registry.
  *
  * Greenlight adds built-in services before `services()` results. A duplicate
- * type causes a configuration error.
+ * type in the same source causes a configuration error. Unnamed definitions
+ * share one source. Different named sources can define the same type.
  */
 interface HarnessProvider extends Plugin
 {


### PR DESCRIPTION
The API reference describes service resolvers as registration ordered and rejects duplicate service types without explaining named sources. It also omits the execution-adapter meaning of the fixture worker limit.

Correct the maintained PHPDoc and regenerate the three API pages. Resolver order now includes priority and the terminal-resolver exception. Provider documentation permits one type in different named sources. Fixture documentation explains that in-process execution reports one worker, including process-pool fallback.

These corrections follow `PluginRuntime` ordering, `WorkerPluginRuntime::prepareWorker()`, `HarnessScopes` source maps, and the topology values from both execution adapters. No runtime behavior changes.
