### PR TITLE
docs: clarify execution adapters and temporal deadlines

### DIFF
--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,7 +1,8 @@
 # Architecture
 
-Discovery, process control, schedules, recovery, and reports are internal. Test
-authors use a small public interface.
+Discovery, process control, scheduling, and recovery are internal. Test authors
+and integrations use the documented public interfaces, including versioned
+reports.
 
 This page gives contributors an architecture summary. The user documentation
 explains user-visible behavior. The pages in this directory describe module
@@ -113,8 +114,8 @@ public.
 | `Documentation` | Build-time validation of documentation examples | Nothing |
 | `PhpStan`, `Rector`, `Symfony`, `Laravel`, `Hyperf`, `Psr11`, `Psr15`, `Tempest` | Optional adapters for external tools and frameworks | Their Greenlight interfaces and development-only frameworks |
 
-Dependencies point from modules near the bottom of the table to modules near
-the top. Modules near the top do not depend on the `Execution` or `Cli` modules.
+The table groups responsibilities. Its row order does not define dependency
+rules. Use `deptrac.yaml` for the complete permitted dependencies.
 
 Public contract modules do not depend on discovery or integration implementations.
 `Plugin` depends on public reporting contracts. `Internal/Event` depends on
@@ -164,7 +165,9 @@ run-policy evaluation own separate command-side instances. Greenlight creates
 one run-owned orchestrator instance for each applicable factory. It creates one
 worker-owned instance for each applicable factory and physical worker.
 
-Immutable plugin definitions cross process seams. Plugin instances do not.
+Process-pool workers reload plugin definitions from the configuration file
+during bootstrap. They create their own plugin instances. Neither factory
+closures nor plugin instances cross the worker protocol.
 We recommend that plugins avoid dependencies on orchestrator classes and
 protocol implementation classes.
 

--- a/docs/architecture/orchestrator-integration-fixtures.md
+++ b/docs/architecture/orchestrator-integration-fixtures.md
@@ -1,8 +1,8 @@
 # Orchestrator-owned integration fixtures
 
-Greenlight provisions external test infrastructure in the orchestrator. It
-sends each worker only the connection data for that worker's channel.
-It removes the infrastructure when the run ends.
+Greenlight provisions external test infrastructure in the run coordinator. It
+gives each worker the shared resources and the resources for that worker's
+channel. It runs registered cleanup callbacks when the run ends.
 
 ## Ownership and lifetime
 
@@ -33,11 +33,14 @@ before it provisions anything, then provisions dependencies first.
 Fixture IDs are non-empty UTF-8 strings. They cannot use integer strings
 because PHP converts those map keys to integers.
 
-`IntegrationFixtureContext::configuredWorkers()` returns the configured worker
-ceiling. `IntegrationFixtureContext::channels()` returns the consecutive channel
-numbers that the selected plan can use. Selected work and resource capacity can
-reduce the number of channels below the ceiling. Create overlays only for these
-numbers. Replacement workers reuse released numbers.
+`IntegrationFixtureContext::configuredWorkers()` returns the worker limit for
+the selected execution adapter. In-process execution returns `1`, including a
+fallback from process-pool execution.
+
+`IntegrationFixtureContext::channels()` returns the consecutive channel numbers
+that the selected plan can use. Selected work and resource capacity can reduce
+the number of channels below the limit. Create overlays only for these numbers.
+Replacement workers reuse released numbers.
 
 Call `IntegrationFixtureContext::defer()` as soon as the provisioner acquires a
 resource. The callback will then run even if the rest of the provisioner fails.
@@ -58,9 +61,11 @@ Store credentials in the separate secrets map. Worker code receives each secret
 as a `SensitiveValue` and must call `reveal()` to read it. Object dumps and
 exports redact the value.
 
-Greenlight sends resources through the authenticated local worker protocol. It
-does not put them in environment variables, command arguments, stdout, or
-stderr. A worker receives only its own channel overlay.
+In a process-pool run, Greenlight sends resources through the authenticated
+local worker protocol. It does not put them in environment variables, command
+arguments, stdout, or stderr. A worker receives only its own channel overlay.
+In-process execution uses the shared resources and the overlay for channel `1`
+directly.
 
 ## Worker bootstrap
 

--- a/docs/architecture/temporal-expectations.md
+++ b/docs/architecture/temporal-expectations.md
@@ -17,9 +17,9 @@ The temporal matcher increments the counter one time.
 The `@mixin Expectation<T>` declaration supplies the native matcher methods to
 the API-reference generator.
 
-Native matcher methods are not reflection-visible on `TemporalExpectation`.
-This is an intentional interface change. Code that reflects matcher methods
-MUST use `Expectation` as its source.
+Native matcher methods are not visible through reflection on
+`TemporalExpectation`. To inspect native matcher methods, use `Expectation`
+as the reflection source.
 
 The PHPStan extension supplies the native methods on temporal chains. The IDE
 helper supplies the same methods as annotations. Thus, normal temporal matcher
@@ -39,14 +39,15 @@ The poll operation uses a monotonic clock. `SystemPollingClock` reads
 `hrtime(true)` and waits with `usleep()`. Unit tests use `FakePollingClock`.
 
 The default poll interval is 25ms. `pollEvery()` accepts finite intervals of at
-least 1ms. A duration for `within()` or `for()` **MUST** be finite and more
-than zero.
+least 1ms. For `within()` or `for()`, use a finite duration greater than zero.
 
-Both methods call the probe immediately. They then wait for the configured fixed
-interval and call the probe again. Probe calls never overlap.
+Both methods start with an immediate probe call. If the test deadline has
+already expired, `eventually()` fails before that call. Between calls, the
+methods wait for the configured fixed interval. Probe calls never overlap.
 
-`eventually()` sets its deadline before the first call and returns after the
-first match. `consistently()` requires its first call to match, starts its
+`eventually()` sets its deadline before the first call. It accepts a match only
+when the observation finishes at or before that deadline.
+`consistently()` requires its first call to match, starts its
 stability period after that call, and fails on the first mismatch.
 The next wait ends at the applicable deadline if a full interval would exceed
 it. Greenlight then calls the probe again. An earlier probe call that reaches
@@ -74,8 +75,8 @@ finish. This rule includes tests that use a temporal expectation. Without
 PCNTL, the operating system's default immediate termination behavior can stop
 the active test.
 
-`retryOnException()` accepts only `Exception` subclasses, which excludes
-`Error`, `Throwable`, and other broader types.
+`retryOnException()` accepts `Exception::class` and its subclasses. It rejects
+`Error`, `Throwable`, and unrelated types.
 
 ## Failures
 

--- a/docs/architecture/temporal-expectations.md
+++ b/docs/architecture/temporal-expectations.md
@@ -18,8 +18,8 @@ The `@mixin Expectation<T>` declaration supplies the native matcher methods to
 the API-reference generator.
 
 Native matcher methods are not visible through reflection on
-`TemporalExpectation`. To inspect native matcher methods, use `Expectation`
-as the reflection source.
+`TemporalExpectation`. Code that reflects native matcher methods MUST use
+`Expectation` as its source.
 
 The PHPStan extension supplies the native methods on temporal chains. The IDE
 helper supplies the same methods as annotations. Thus, normal temporal matcher
@@ -39,7 +39,8 @@ The poll operation uses a monotonic clock. `SystemPollingClock` reads
 `hrtime(true)` and waits with `usleep()`. Unit tests use `FakePollingClock`.
 
 The default poll interval is 25ms. `pollEvery()` accepts finite intervals of at
-least 1ms. For `within()` or `for()`, use a finite duration greater than zero.
+least 1ms. A duration for `within()` or `for()` **MUST** be finite and greater
+than zero.
 
 Both methods start with an immediate probe call. If the test deadline has
 already expired, `eventually()` fails before that call. Between calls, the

--- a/docs/architecture/worker-lifecycle.md
+++ b/docs/architecture/worker-lifecycle.md
@@ -170,6 +170,7 @@ concurrency.
 
 Workers reload plugin definitions from the configuration file during `bootstrap`.
 They then build their plugin instances and harness registries.
+
 They reuse them for later assignments. One physical worker constructs each
 configured worker-side plugin one time. A replacement worker constructs new
 instances. Per-worker harness services therefore live for the physical worker's

--- a/docs/architecture/worker-lifecycle.md
+++ b/docs/architecture/worker-lifecycle.md
@@ -5,7 +5,8 @@ local socket. The protocol is internal and can change between releases. Use
 these details to diagnose parallel runs.
 
 This page describes the process pool. With one configured or detected worker,
-the CLI uses an in-process adapter. That adapter has no worker sockets,
+the CLI uses an in-process adapter. It also selects that adapter when the
+worker entry point is unavailable. That adapter has no worker sockets,
 worker-process isolation, or separate process to enforce hard timeouts.
 
 ## Transport ownership
@@ -167,7 +168,8 @@ workers when the queued scheduling units and their resource limits prove that
 more workers cannot run concurrently. This bound does not remove achievable
 concurrency.
 
-Workers build their plugin instances and harness registries during `bootstrap`.
+Workers reload plugin definitions from the configuration file during `bootstrap`.
+They then build their plugin instances and harness registries.
 They reuse them for later assignments. One physical worker constructs each
 configured worker-side plugin one time. A replacement worker constructs new
 instances. Per-worker harness services therefore live for the physical worker's
@@ -405,9 +407,10 @@ variable. The channel pool runs from `1` through the initial worker target.
 Queue size and resource capacity can reduce this target below the configured
 worker count.
 
-`IntegrationFixtureContext::configuredWorkers()` returns the configured worker
-ceiling. `IntegrationFixtureContext::channels()` returns the consecutive channel
-numbers that this selected plan can use.
+`IntegrationFixtureContext::configuredWorkers()` returns the worker limit for
+the selected execution adapter. It returns `1` for in-process execution.
+`IntegrationFixtureContext::channels()` returns the consecutive channel numbers
+that this selected plan can use.
 
 The allocator gives out the lowest free number and returns it when a worker
 retires. A replacement can use a released channel.


### PR DESCRIPTION
The architecture overview says plugin definitions cross process boundaries and presents its module table as a dependency order. The fixture pages also describe the configured worker ceiling without the in-process fallback.

Describe configuration reload during worker bootstrap, identify `deptrac.yaml` as the complete dependency source, and explain the selected adapter's worker limit and channel resources. Clarify temporal reflection guidance and deadline behavior while preserving formal requirement terms.

The corrections follow `WorkerProcess` bootstrap, `RunSession::adapter()`, `InProcessExecution::topology()`, `RunCoordinator`, and the temporal matcher loops. They describe current behavior and preserve the formal worker protocol requirements.
