### PR TITLE
docs: clarify contributor checks and example metadata

### DIFF
--- a/.github/fixtures/hyperf-bridge/greenlight.php
+++ b/.github/fixtures/hyperf-bridge/greenlight.php
@@ -21,7 +21,7 @@ $probe = static function (ContainerInterface $container): DisposalProbe {
     $service = $container->get(DisposalProbe::class);
 
     if (!$service instanceof DisposalProbe) {
-        throw new \RuntimeException('The Hyperf container MUST return DisposalProbe.');
+        throw new \RuntimeException('The Hyperf container must return a DisposalProbe instance.');
     }
 
     return $service;

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,8 +641,8 @@ jobs:
         with:
           persist-credentials: false
 
-      # Require both artifacts before the single Codecov upload. A canceled run
-      # MUST NOT publish a report that contains only the Tempest bridge.
+      # Require both artifacts before the single Codecov upload. Do not publish
+      # a report that contains only the Tempest bridge after a canceled run.
       - name: "Download full-suite coverage"
         uses: "actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c" # v8.0.1
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,9 +46,9 @@ explains the metadata required for PHP code fences in `README.md` and `docs/`.
 ## Technical prose
 
 Use the [technical writing standard](docs/architecture/technical-writing.md)
-for all repository-owned technical prose. The policy uses Simplified Technical English principles
-for documentation, PHPDoc, comments, contributor material, accessibility text,
-diagnostics, CLI help, and human-readable output.
+for all repository-owned technical prose. The policy uses Simplified Technical
+English principles for documentation, PHPDoc, comments, contributor material,
+accessibility text, diagnostics, CLI help, and human-readable output.
 
 Write direct instructions for requirements. Identify recommendations and options
 clearly. Preserve normative terms in formal specifications and protocol rules.
@@ -81,18 +81,21 @@ Replace `<test-id>` with the test ID to run.
 
 Run:
 
-```bash
+```sh
 composer static-analysis
 composer tests
 make docs-check
 ```
 
-All three commands must pass before you push. CI also runs these checks across
-its supported environments.
+All three commands must pass before you push. The
+[CI workflow](.github/workflows/ci.yml) defines the PHP and documentation jobs.
 
 The Composer CI commands use one shared local slot by default. The slot applies
-across Git worktrees. Set `GREENLIGHT_LOCAL_CI_MAX_PARALLELISM` to a positive
-integer to permit more concurrent commands. Hosted CI does not use this limit.
+across Git worktrees. Set `GREENLIGHT_LOCAL_CI_MAX_PARALLELISM` to an integer
+from `1` to `64` to select the maximum number of concurrent commands. The lock
+does not apply when the `CI` environment variable is truthy. An unset or empty
+value, `0`, `false`, `no`, or `off` is false. Comparisons ignore case and
+surrounding whitespace.
 
 ## Commits and pull requests
 
@@ -163,7 +166,7 @@ this directory. Greenlight does not execute its contents.
 
 If completion for `PHPStan\` symbols is absent, run:
 
-```bash
+```sh
 composer phpstan:stubs
 ```
 

--- a/docs/architecture/documentation-php-examples.md
+++ b/docs/architecture/documentation-php-examples.md
@@ -13,8 +13,8 @@ The generated workspace is in `build/docs-php`. Do not commit its contents.
 
 ## Select an example
 
-Put one metadata comment immediately before a PHP fence. The comment is JSON so
-that invalid and unknown fields cause an error.
+Put one metadata comment immediately before a PHP fence. The comment contains
+JSON metadata. The extractor rejects invalid JSON and unknown fields.
 
 ```html
 <!-- php-example {"example":"getting-started","file":"src/Greeter.php","mode":"file","tools":["phpstan","rector"]} -->
@@ -30,8 +30,9 @@ Do not use an absolute path or a parent path. Do not derive this value from
 the position of the fence. Stable names keep diagnostics and tool caches
 useful when prose moves.
 
-`tools` can contain `phpstan`, `rector`, both tools, or no tools. Every selected
-example is checked for PHP syntax before these tools run.
+Set `tools` to a list with `phpstan`, `rector`, or both. Use `"tools":[]` to
+check PHP syntax only. Every selected example passes through the PHP syntax
+check before the selected tools run.
 
 ## Choose a mode
 


### PR DESCRIPTION
The contributor guide permits any positive local CI parallelism value, but the command rejects values above 64. It also describes the lock bypass as hosted CI behavior, although the implementation checks the `CI` environment value.

Document the accepted range and bypass values. Clarify the required PHP-example metadata and the empty tools list for syntax-only checks. Use natural language in the Hyperf fixture diagnostic and the coverage-upload comment without changing their requirements or workflow behavior.

The corrections follow `tools/local-ci-lock.php` and the documentation example extractor. The diagnostic still covers the same service type failure. Existing contributor check requirements and formal specification language remain unchanged.
