### PR TITLE
docs: correct test fixture behavior explanations

### DIFF
--- a/tests/Support/ProcessResult.php
+++ b/tests/Support/ProcessResult.php
@@ -6,7 +6,7 @@ namespace Greenlight\Tests\Support;
 
 /**
  * output() and outputLines() combine standard output and standard error in that
- * order. stdoutLines() excludes extension messages from standard error.
+ * order. stdoutLines() returns lines from standard output only.
  */
 final readonly class ProcessResult
 {

--- a/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorTest.php
+++ b/tests/Unit/Execution/ProcessPool/Orchestrator/OrchestratorTest.php
@@ -164,10 +164,10 @@ final class OrchestratorTest
     #[Timeout(30.0)]
     public function aConnectedWorkerThatGoesSilentBeforeStartingItsAssignmentFailsTheRun(): void
     {
-        // A worker that completes the hello handshake, receives bootstrap,
-        // then goes silent without ever reporting Ready.
-        // No test is in flight, so per-test timeouts never fire, and the channel
-        // stays open, so crash detection never fires either.
+        // The script sends hello and keeps its socket open.
+        // It never reads bootstrap or sends Ready.
+        // No test has started, so test timeouts do not apply.
+        // The open socket prevents disconnect detection.
         $script = <<<'PHP'
             [, , $address, $workerId, $token] = $argv;
             $socket = stream_socket_client($address);

--- a/tests/Unit/Sandbox/TemporaryDirectoryTest.php
+++ b/tests/Unit/Sandbox/TemporaryDirectoryTest.php
@@ -21,8 +21,8 @@ final class TemporaryDirectoryTest
     #[Test]
     public function nothingExistsOnDiskBeforeFirstUse(): void
     {
-        // path() is the only method that accesses the disk. Construction does
-        // not create a directory for disposal.
+        // Construction does not create a directory.
+        // Before first use, dispose() has no filesystem effect.
         $directory = new TemporaryDirectory();
 
         Expect::that(static function () use ($directory): void {


### PR DESCRIPTION
Several test comments describe more behavior than their fixtures provide. State that `TemporaryDirectory` construction and unused disposal have no filesystem effect, rather than claiming that only `path()` accesses the disk. The class also accesses the filesystem in `subdirectory()` and disposal after use.

Describe the silent-worker script as sending `hello` without reading bootstrap or sending `Ready`. Explain why its open socket and lack of an active test require the progress deadline. Clarify that `ProcessResult::stdoutLines()` returns standard output only, with no message-specific filter. The comments now follow the fixture scripts and helper implementations.
