### PR TITLE
fix(phpstan): respect case-insensitive expectation modifiers

### DIFF
--- a/src/PhpStan/ExpectationTypeSpecifyingExtension.php
+++ b/src/PhpStan/ExpectationTypeSpecifyingExtension.php
@@ -111,7 +111,7 @@ final class ExpectationTypeSpecifyingExtension implements MethodTypeSpecifyingEx
             || !$receiver->class instanceof Name
             || !$receiver->name instanceof Identifier
             || $scope->resolveName($receiver->class) !== Expect::class
-            || $receiver->name->toString() !== 'that'
+            || $receiver->name->toLowerString() !== 'that'
         ) {
             return null;
         }
@@ -152,7 +152,7 @@ final class ExpectationTypeSpecifyingExtension implements MethodTypeSpecifyingEx
                 return null;
             }
 
-            $method = $receiver->name->toString();
+            $method = $receiver->name->toLowerString();
 
             if ($method === 'not') {
                 return true;

--- a/tests/Acceptance/PhpStanExpectationNarrowingCallShapeTest.php
+++ b/tests/Acceptance/PhpStanExpectationNarrowingCallShapeTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\PhpStanProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class PhpStanExpectationNarrowingCallShapeTest
+{
+    public function __construct(private TemporaryDirectory $temporaryDirectory) {}
+
+    #[Test]
+    public function uppercaseFactoryAndModifiersKeepSoundSubjectTypes(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->temporaryDirectory,
+            <<<'PHP'
+            <?php
+
+            use Greenlight\Expect\Expect;
+
+            function acceptInt(int $value): void {}
+            function acceptString(string $value): void {}
+
+            function uppercaseNegation(int|string $value): void
+            {
+                Expect::that($value)->NOT()->BECAUSE('The value must be an integer.')->toBeString();
+                acceptInt($value);
+            }
+
+            function uppercaseFactory(int|string $value): void
+            {
+                Expect::THAT($value)->toBeString();
+                acceptString($value);
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            use Greenlight\Expect\Expect;
+
+            function requireString(string $value): void {}
+
+            function negatedString(int|string $value): void
+            {
+                Expect::that($value)->NOT()->toBeString();
+                requireString($value);
+            }
+            PHP,
+        );
+
+        Expect::that($probe->exitCode)->toBe(1);
+        Expect::that(\count($probe->errors))->because('PHPStan messages: ' . $probe->messages())->toBe(1);
+        Expect::that($probe->goodPassed)->because('PHPStan messages: ' . \implode("\n", $probe->goodErrors))->toBeTrue();
+        Expect::that($probe->messages())->toContain('expects string, int given');
+    }
+}


### PR DESCRIPTION
PHP method names are case-insensitive. The PHPStan extension treated `NOT()` as a positive assertion and did not narrow the subject after `THAT()`. As a result, a valid integer use after `Expect::that($value)->NOT()->toBeString()` received a false type error, while an unsafe string use passed analysis.

Normalize the factory and chain modifier names before PHPStan determines the assertion direction. The regression probe checks valid uppercase calls and requires PHPStan to reject the unsafe string call. It failed before the change and passes with the fix; the focused expectation suite passes 3 tests with 19 expectations. Focused PHPStan and code style checks pass, and the documentation check passes. Full Composer checks run in GitHub CI.
