### PR TITLE
perf(execution): bound UTF-8 conversion for large captured writes

### DIFF
--- a/src/Execution/Worker/OutputCapture.php
+++ b/src/Execution/Worker/OutputCapture.php
@@ -179,7 +179,10 @@ final class OutputCapture
             return '';
         }
 
-        $this->stdout = Utf8::headBytes($this->stdout . $chunk, $this->maxStdoutBytes);
+        // Four invalid bytes can become one three-byte replacement character.
+        // Retain enough raw bytes to fill the limit and complete a cut character.
+        $prefix = \substr($chunk, 0, 2 * $this->maxStdoutBytes + 3);
+        $this->stdout = Utf8::headBytes($this->stdout . $prefix, $this->maxStdoutBytes);
         $this->stdoutTruncated = true;
 
         return '';

--- a/tests/Unit/Execution/Worker/Capture/OutputCaptureLargeChunkTest.php
+++ b/tests/Unit/Execution/Worker/Capture/OutputCaptureLargeChunkTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Execution\Worker\Capture;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Execution\Worker\OutputCapture;
+use Greenlight\Expect\Expect;
+
+final readonly class OutputCaptureLargeChunkTest
+{
+    #[Test]
+    #[DataSet('chunks')]
+    public function aLargeWritePreservesTheNormalizedPrefix(string $prefix, string $chunk, string $expected): void
+    {
+        $capture = new OutputCapture(maxStdoutBytes: 12);
+        $capture->start();
+        echo $prefix;
+        echo $chunk . \str_repeat('x', 65_536);
+        $output = $capture->stop();
+
+        Expect::that($output->stdout)->toBe($expected);
+        Expect::that($output->stdoutTruncated)->toBeTrue();
+    }
+
+    /** @return iterable<string, array{string, string, string}> */
+    public static function chunks(): iterable
+    {
+        yield 'ASCII head' => ['head ', 'tail has more bytes', 'head tail ha'];
+        yield 'complete four-byte character at the bound' => ['abcdefgh', "\u{1F600}", "abcdefgh\u{1F600}"];
+        yield 'four-byte character beyond the bound' => ['abcdefghi', "\u{1F600}", 'abcdefghi'];
+        yield 'four-byte character split across writes' => ["abcdefgh\xF0", "\x9F\x98\x80", "abcdefgh\u{1F600}"];
+        yield 'invalid four-byte sequences contract' => ['', \str_repeat("\xF4\x90\x80\x80", 10), \str_repeat("\u{FFFD}", 4)];
+        yield 'invalid bytes expand' => ['head ', \str_repeat("\xFF", 10), "head \u{FFFD}\u{FFFD}"];
+    }
+}

--- a/tools/output-capture-benchmark.php
+++ b/tools/output-capture-benchmark.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tools;
 
 /**
- * Measures output capture for repeated four-byte writes up to the default limit.
+ * Measures output capture for small writes and large writes beyond the default limit.
  * Run on an idle machine with Xdebug disabled. Compare the same command at each revision.
  * Each shape has one warmup and five measured samples. Every sample checks the captured bytes.
  *
@@ -42,4 +42,40 @@ foreach ([16_384, 65_536, 262_144] as $writes) {
 
     \sort($samples);
     \printf("%d writes, %d bytes: median %.6f seconds\n", $writes, $writes * 4, $samples[2]);
+}
+
+foreach (['ascii' => 'x', 'malformed' => "\xFF"] as $shape => $byte) {
+    $payload = \str_repeat($byte, 16 * 1024 * 1024);
+    $expected = $shape === 'ascii'
+        ? \str_repeat('x', 1_048_576)
+        : \str_repeat("\u{FFFD}", 349_525);
+    $samples = [];
+    $peaks = [];
+
+    for ($round = 0; $round < 6; ++$round) {
+        $capture = new OutputCapture();
+        \memory_reset_peak_usage();
+        $baseline = \memory_get_usage();
+        $started = \hrtime(true);
+        $capture->start();
+        echo $payload;
+        $output = $capture->stop();
+        $elapsed = (\hrtime(true) - $started) / 1_000_000_000;
+        $extraPeakBytes = \memory_get_peak_usage() - $baseline;
+
+        if ($output->stdout !== $expected || !$output->stdoutTruncated) {
+            throw new \RuntimeException('Output capture did not preserve the bounded benchmark output.');
+        }
+
+        if ($round > 0) {
+            $samples[] = $elapsed;
+            $peaks[] = $extraPeakBytes;
+        }
+
+        unset($capture, $output);
+    }
+
+    \sort($samples);
+    \sort($peaks);
+    \printf("16 MiB %s write: median %.6f seconds, %d extra peak bytes\n", $shape, $samples[2], $peaks[2]);
 }

--- a/tools/output-capture-benchmark.php
+++ b/tools/output-capture-benchmark.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Greenlight\Tools;
 
 /**
- * Measures output capture for small writes and large writes beyond the default limit.
+ * Measures output capture for repeated four-byte writes up to the default limit.
  * Run on an idle machine with Xdebug disabled. Compare the same command at each revision.
  * Each shape has one warmup and five measured samples. Every sample checks the captured bytes.
  *
@@ -42,40 +42,4 @@ foreach ([16_384, 65_536, 262_144] as $writes) {
 
     \sort($samples);
     \printf("%d writes, %d bytes: median %.6f seconds\n", $writes, $writes * 4, $samples[2]);
-}
-
-foreach (['ascii' => 'x', 'malformed' => "\xFF"] as $shape => $byte) {
-    $payload = \str_repeat($byte, 16 * 1024 * 1024);
-    $expected = $shape === 'ascii'
-        ? \str_repeat('x', 1_048_576)
-        : \str_repeat("\u{FFFD}", 349_525);
-    $samples = [];
-    $peaks = [];
-
-    for ($round = 0; $round < 6; ++$round) {
-        $capture = new OutputCapture();
-        \memory_reset_peak_usage();
-        $baseline = \memory_get_usage();
-        $started = \hrtime(true);
-        $capture->start();
-        echo $payload;
-        $output = $capture->stop();
-        $elapsed = (\hrtime(true) - $started) / 1_000_000_000;
-        $extraPeakBytes = \memory_get_peak_usage() - $baseline;
-
-        if ($output->stdout !== $expected || !$output->stdoutTruncated) {
-            throw new \RuntimeException('Output capture did not preserve the bounded benchmark output.');
-        }
-
-        if ($round > 0) {
-            $samples[] = $elapsed;
-            $peaks[] = $extraPeakBytes;
-        }
-
-        unset($capture, $output);
-    }
-
-    \sort($samples);
-    \sort($peaks);
-    \printf("16 MiB %s write: median %.6f seconds, %d extra peak bytes\n", $shape, $samples[2], $peaks[2]);
 }


### PR DESCRIPTION
A single large stdout write made output capture normalize the entire write before it retained the configured prefix. Malformed UTF-8 amplified the discarded input through JSON conversion, so a 1 MiB capture limit did not bound that conversion work.

Limit the raw prefix passed to UTF-8 conversion. The prefix leaves room for invalid four-byte sequences that contract to a replacement character and for a complete character at the capture boundary. Six focused cases cover ASCII, complete and split Unicode characters, invalid sequences that contract, and invalid bytes that expand. The 36 output-capture cases pass with 84 expectations, and the full Composer static checks pass.

A one-off local benchmark covered single 16 MiB ASCII and malformed writes. With PHP 8.4.14 and Xdebug disabled, the median of five measured samples after one warmup changed from 0.295324 s and 184,616,032 extra peak bytes to 0.041632 s and 54,609,016 bytes for malformed input. ASCII changed from 0.010122 s to 0.003893 s; its extra peak increased from 34,640,944 to 36,754,504 bytes because of the bounded prefix copy. Each sample checked the exact retained bytes and truncation flag. PHP still buffers the incoming write, so this does not make total memory use independent of write size.
