### PR TITLE
fix(sandbox): resolve newly created temporary roots

### DIFF
--- a/docs/api-sandboxes.md
+++ b/docs/api-sandboxes.md
@@ -209,7 +209,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException`
 - `@throws TemporaryDirectoryError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/TemporaryDirectory.php#L60)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/TemporaryDirectory.php#L70)
 
 ### `dispose()`
 
@@ -221,7 +221,7 @@ PHPDoc:
 
 - `@throws TemporaryDirectoryError`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/TemporaryDirectory.php#L108)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Sandbox/TemporaryDirectory.php#L118)
 
 ## `TemporaryDirectoryError`
 

--- a/src/Sandbox/TemporaryDirectory.php
+++ b/src/Sandbox/TemporaryDirectory.php
@@ -42,6 +42,16 @@ final class TemporaryDirectory implements Disposable
                 throw TemporaryDirectoryError::rootCreationFailed($path, $warning);
             }
 
+            if ($resolvedTemporaryRoot === false) {
+                $resolvedPath = ErrorTrap::run(static fn() => \realpath($path), $warning);
+
+                if ($resolvedPath === false) {
+                    throw TemporaryDirectoryError::rootCreationFailed($path, $warning);
+                }
+
+                $path = $resolvedPath;
+            }
+
             $this->path = $path;
         }
 

--- a/tests/Unit/Sandbox/TemporaryDirectoryRelativeRootTest.php
+++ b/tests/Unit/Sandbox/TemporaryDirectoryRelativeRootTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Sandbox;
+
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+
+final readonly class TemporaryDirectoryRelativeRootTest
+{
+    public function __construct(private TemporaryDirectory $workspace) {}
+
+    #[Test]
+    public function disposalFindsANewRelativeRootAfterTheWorkingDirectoryChanges(): void
+    {
+        $originalDirectory = \getcwd();
+        Expect::that($originalDirectory)->toBeString();
+        $firstDirectory = $this->workspace->subdirectory('first');
+        $secondDirectory = $this->workspace->subdirectory('second');
+
+        try {
+            \chdir($firstDirectory);
+            $directory = new TemporaryDirectory('new-root');
+            $path = $directory->path();
+            $absolutePath = \realpath($path);
+            Expect::that($absolutePath)->toBeString();
+            \file_put_contents($path . '/sentinel.txt', 'temporary data');
+
+            \chdir($secondDirectory);
+            $directory->dispose();
+
+            Expect::that(\file_exists($absolutePath))->toBeFalse();
+            Expect::that($path)->toBe($absolutePath);
+        } finally {
+            \chdir($originalDirectory);
+        }
+    }
+}


### PR DESCRIPTION
When a configured temporary root did not exist and used a relative path, `TemporaryDirectory::path()` kept that relative path after recursive creation. A later change to the working directory made `dispose()` look in the wrong location and leave the temporary directory and its files behind.

Resolve the created directory before storing its path when the initial root lookup fails. Existing roots keep the current path lookup cost. The regression creates a new relative root, changes the working directory, and checks both removal and the returned absolute path. It fails on the original code and passes with this change. The directory suite passes 32 tests with 60 expectations using two workers; focused PHPStan and code style checks also pass. Full Composer and documentation checks run in GitHub CI.
