### PR TITLE
fix(expect): reject infinite tolerance subjects

### DIFF
--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -655,7 +655,7 @@ final class Expectation
         );
 
         return $this->verify(
-            $subject >= $of - $delta && $subject <= $of + $delta,
+            \is_finite($subject) && $subject >= $of - $delta && $subject <= $of + $delta,
             'to be ' . $bounds,
             $bounds,
         );

--- a/tests/Unit/Expect/NonFiniteToleranceSubjectTest.php
+++ b/tests/Unit/Expect/NonFiniteToleranceSubjectTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+
+final class NonFiniteToleranceSubjectTest
+{
+    #[Test]
+    #[DataSet('nonFiniteSubjects')]
+    public function aNonFiniteSubjectCannotBeWithinAFiniteTolerance(float $subject, float $delta, float $of): void
+    {
+        Expect::that($subject)->not()->toBeWithin($delta, $of);
+    }
+
+    #[Test]
+    public function finiteSubjectsStillMatchWhenAToleranceBoundaryOverflows(): void
+    {
+        Expect::that(\PHP_FLOAT_MAX)->toBeWithin(\PHP_FLOAT_MAX, \PHP_FLOAT_MAX);
+        Expect::that(-\PHP_FLOAT_MAX)->toBeWithin(\PHP_FLOAT_MAX, -\PHP_FLOAT_MAX);
+        Expect::that(0.0)->toBeWithin(\PHP_FLOAT_MAX, \PHP_FLOAT_MAX);
+        Expect::that(0.0)->toBeWithin(\PHP_FLOAT_MAX, -\PHP_FLOAT_MAX);
+    }
+
+    /** @return iterable<string, array{float, float, float}> */
+    public static function nonFiniteSubjects(): iterable
+    {
+        yield 'upper boundary overflow' => [\INF, \PHP_FLOAT_MAX, \PHP_FLOAT_MAX];
+        yield 'lower boundary overflow' => [-\INF, \PHP_FLOAT_MAX, -\PHP_FLOAT_MAX];
+        yield 'positive infinity reference' => [\INF, 0.0, \INF];
+        yield 'negative infinity reference' => [-\INF, 0.0, -\INF];
+        yield 'not a number' => [\NAN, 0.0, 1.0];
+    }
+}


### PR DESCRIPTION
`toBeWithin()` accepted infinite subjects when a finite tolerance boundary overflowed to infinity. It also accepted an infinite subject against the same infinite reference with a zero tolerance. These values cannot have an absolute difference within a finite tolerance.

Require the subject to be finite before checking the inclusive bounds. The new regression cases failed in four places before the fix and pass afterward, together with the existing numeric matcher cases (32 tests). Finite subjects remain accepted when a calculated boundary overflows. Static analysis and documentation checks pass; the full Composer suite is running through the shared local CI queue.
