### PR TITLE
fix(artifacts): preserve recovery order for large attachment sets

### DIFF
--- a/src/Execution/Artifact/ArtifactStore.php
+++ b/src/Execution/Artifact/ArtifactStore.php
@@ -492,8 +492,11 @@ final class ArtifactStore
 
         \usort(
             $attachments,
-            static fn(StagedAttachment $a, StagedAttachment $b): int =>
-                [$a->attempt, $a->storageKey] <=> [$b->attempt, $b->storageKey],
+            static function (StagedAttachment $a, StagedAttachment $b): int {
+                $attemptOrder = $a->attempt <=> $b->attempt;
+
+                return $attemptOrder !== 0 ? $attemptOrder : \strnatcmp($a->storageKey, $b->storageKey);
+            },
         );
 
         return $attachments === [] ? $result : $this->publish($result->withAttachments($attachments));

--- a/tests/Unit/Execution/Artifact/ArtifactRecoveryOrderTest.php
+++ b/tests/Unit/Execution/Artifact/ArtifactRecoveryOrderTest.php
@@ -56,4 +56,34 @@ final readonly class ArtifactRecoveryOrderTest
                 [10, 'tenth.txt'],
             ]);
     }
+
+    #[Test]
+    public function recoveredAttachmentsKeepCreationOrderBeyondTwoDigits(): void
+    {
+        $root = $this->tempDirectory->subdirectory('recovery-sequence');
+        $store = ArtifactStore::open(
+            new ArtifactConfiguration($root, maxAttachmentsPerTest: 101),
+            $root,
+            'run-sequence',
+        );
+        $this->cleanup->defer($store->cleanup(...));
+        $id = new TestId('Example\EvidenceTest', 'crashesWithManyAttachments');
+        $attempt = $store->forAttempt($id, 1, new TestArtifactBudget());
+        $expectedNames = [];
+
+        for ($sequence = 1; $sequence <= 101; ++$sequence) {
+            $name = 'evidence-' . $sequence . '.txt';
+            $attempt->text($name, 'evidence');
+            $expectedNames[] = $name;
+        }
+
+        $recovered = $store->recover(new TestResult($id, Outcome::Errored, 0.0, 0));
+
+        Expect::that(\array_map(
+            static fn($attachment): string => $attachment->name,
+            $recovered->attachments,
+        ))
+            ->because('crash recovery must preserve attachment creation order within each attempt')
+            ->toBe($expectedNames);
+    }
 }


### PR DESCRIPTION
Crash recovery sorted attachment storage keys as text. The sequence in each key has a minimum width of two digits, so a test configured for more than 99 attachments recovered attachment 100 before attachment 11. Normal publication retained creation order.

Compare attempts numerically, then compare storage keys in natural order. This preserves attachment creation order within each attempt without a storage format change. A regression stages 101 attachments and compares every recovered name with its creation order. It fails on the original comparator and passes with the fix; all eight artifact-recovery cases pass with 13 expectations.
