### PR TITLE
test(cli): reuse passing acceptance project fixtures

### DIFF
--- a/tests/Acceptance/RepeatOutputCompatibilityTest.php
+++ b/tests/Acceptance/RepeatOutputCompatibilityTest.php
@@ -19,7 +19,7 @@ final readonly class RepeatOutputCompatibilityTest
     #[DataSet('repeatOptions')]
     public function repeatRejectsJUnitOutput(string $repeatOption): void
     {
-        $project = $this->writeProject('repeat-junit');
+        $project = AcceptanceProject::createWithOnePassingTest($this->tempDirectory, 'repeat-junit');
         $result = GreenlightCli::run($project->directory, [
             'run',
             '--reporter=junit',
@@ -42,7 +42,7 @@ final readonly class RepeatOutputCompatibilityTest
     #[Test]
     public function repeatRejectsAFileJUnitReporterBeforeItCreatesTheFile(): void
     {
-        $project = $this->writeProject('repeat-file-junit');
+        $project = AcceptanceProject::createWithOnePassingTest($this->tempDirectory, 'repeat-file-junit');
         $report = $project->path('reports/junit.xml');
         $result = GreenlightCli::run($project->directory, [
             'run',
@@ -64,7 +64,7 @@ final readonly class RepeatOutputCompatibilityTest
     #[Test]
     public function oneRequestedRunKeepsJUnitOutputAvailable(): void
     {
-        $project = $this->writeProject('single-junit');
+        $project = AcceptanceProject::createWithOnePassingTest($this->tempDirectory, 'single-junit');
         $result = GreenlightCli::run($project->directory, [
             'run',
             '--reporter=junit',
@@ -86,7 +86,7 @@ final readonly class RepeatOutputCompatibilityTest
     #[DataSet('coverageConfigurations')]
     public function repeatRejectsEnabledCoverage(string $coverageConfiguration, string $repeatOption): void
     {
-        $project = $this->writeProject('repeat-coverage');
+        $project = AcceptanceProject::createWithOnePassingTest($this->tempDirectory, 'repeat-coverage');
         $project->writeFile('greenlight.php', \sprintf(
             <<<'PHP'
             <?php
@@ -95,7 +95,7 @@ final readonly class RepeatOutputCompatibilityTest
 
             use Greenlight\Config\GreenlightConfig;
 
-            require_once __DIR__ . '/tests/ProbeTest.php';
+            require_once __DIR__ . '/tests/PassingTest.php';
 
             return GreenlightConfig::create()
                 ->paths([__DIR__ . '/tests'])
@@ -127,7 +127,7 @@ final readonly class RepeatOutputCompatibilityTest
     #[Test]
     public function repeatKeepsAValidJsonlEventStream(): void
     {
-        $project = $this->writeProject('repeat-jsonl');
+        $project = AcceptanceProject::createWithOnePassingTest($this->tempDirectory, 'repeat-jsonl');
         $result = GreenlightCli::run($project->directory, [
             'run',
             '--reporter=jsonl',
@@ -160,7 +160,7 @@ final readonly class RepeatOutputCompatibilityTest
     #[Test]
     public function repeatKeepsAValidJsonlFileAndStatusOnStandardOutput(): void
     {
-        $project = $this->writeProject('repeat-file-jsonl');
+        $project = AcceptanceProject::createWithOnePassingTest($this->tempDirectory, 'repeat-file-jsonl');
         $report = $project->path('reports/events.jsonl');
         $result = GreenlightCli::run($project->directory, [
             'run',
@@ -205,28 +205,5 @@ final readonly class RepeatOutputCompatibilityTest
         yield 'repeat until failure with collection without exports' => ['', '--repeat-until-failure'];
         yield 'fixed repeat with a coverage export' => ["->export('json', 'coverage.json')", '--repeat=2'];
         yield 'repeat until failure with a coverage export' => ["->export('json', 'coverage.json')", '--repeat-until-failure'];
-    }
-
-    private function writeProject(string $name): AcceptanceProject
-    {
-        $project = AcceptanceProject::create($this->tempDirectory, $name);
-        $project->writeFile('tests/ProbeTest.php', <<<'PHP'
-            <?php
-
-            declare(strict_types=1);
-
-            namespace RepeatOutputCompatibilityProbe;
-
-            use Greenlight\Attribute\Test;
-
-            final class ProbeTest
-            {
-                #[Test]
-                public function passes(): void {}
-            }
-            PHP);
-        $project->configureWithTestFiles(['tests/ProbeTest.php']);
-
-        return $project;
     }
 }

--- a/tests/Acceptance/RepeatSingleIterationTest.php
+++ b/tests/Acceptance/RepeatSingleIterationTest.php
@@ -17,23 +17,7 @@ final readonly class RepeatSingleIterationTest
     #[Test]
     public function oneIterationUsesTheStandardRunOutput(): void
     {
-        $project = AcceptanceProject::create($this->tempDirectory, 'repeat-single-iteration');
-        $project->writeFile('tests/ProbeTest.php', <<<'PHP'
-            <?php
-
-            declare(strict_types=1);
-
-            namespace RepeatSingleIterationProbe;
-
-            use Greenlight\Attribute\Test;
-
-            final class ProbeTest
-            {
-                #[Test]
-                public function passes(): void {}
-            }
-            PHP);
-        $project->configureWithTestFiles(['tests/ProbeTest.php']);
+        $project = AcceptanceProject::createWithOnePassingTest($this->tempDirectory, 'repeat-single-iteration');
 
         $result = GreenlightCli::run($project->directory, [
             'run',

--- a/tests/Acceptance/WatchJsonlOutputTest.php
+++ b/tests/Acceptance/WatchJsonlOutputTest.php
@@ -20,21 +20,7 @@ final readonly class WatchJsonlOutputTest
     #[DataSet('outputTargets')]
     public function watchKeepsStatusOutsideTheJsonlEventStream(bool $fileOutput): void
     {
-        $project = AcceptanceProject::create($this->directory, 'watch-jsonl');
-        $project->writeFile('tests/ProbeTest.php', <<<'PHP'
-            <?php
-
-            namespace WatchJsonlProbe;
-
-            use Greenlight\Attribute\Test;
-
-            final class ProbeTest
-            {
-                #[Test]
-                public function passes(): void {}
-            }
-            PHP);
-        $project->configureWithTestFiles(['tests/ProbeTest.php']);
+        $project = AcceptanceProject::createWithOnePassingTest($this->directory, 'watch-jsonl');
         $reporter = $fileOutput ? '--reporter=jsonl=events.jsonl' : '--reporter=jsonl';
         $ready = $fileOutput ? 'Waiting for changes' : 'run-finished';
         $process = GreenlightCli::start($project->directory, ['run', '--watch', $reporter, '--workers=1']);


### PR DESCRIPTION
The repeat and JSONL watch tests each wrote a no-op passing PHP class and its configuration, even though `AcceptanceProject` already owns this setup.

Use `AcceptanceProject::createWithOnePassingTest()` in the three output-focused test classes and remove the repeat compatibility test's duplicate project factory. The coverage-specific configuration now requires the shared fixture's filename. This gives the fixture one maintained source and keeps each test focused on its output contract.

The shared helper preserves one empty passing test, a separate temporary project, and the one-worker default. Every command, option, assertion, and watch synchronization step remains in place. These tests do not depend on the fixture's class name or namespace.
