### PR TITLE
build(docs): select API sections by namespace prefix

### DIFF
--- a/website/scripts/generate-api-reference.mjs
+++ b/website/scripts/generate-api-reference.mjs
@@ -172,12 +172,9 @@ const assigned = new Set();
 const generated = new Map();
 
 for (const section of sections) {
-  const types = publicTypes.filter((type) => {
-    const matchesPrefix = section.prefixes.some((prefix) => type.name.startsWith(prefix));
-    const matchesName = section.names?.includes(type.name) ?? false;
-
-    return matchesPrefix || matchesName;
-  });
+  const types = publicTypes.filter((type) =>
+    section.prefixes.some((prefix) => type.name.startsWith(prefix)),
+  );
   const shortNameCounts = new Map();
 
   for (const type of types) {


### PR DESCRIPTION
The API generator checked both namespace prefixes and individual type names when it assigned types to sections. Every section in its private configuration uses namespace prefixes, and the script has no way to supply individual names.

Select types directly by prefix. This removes an unused matching mode and makes the assignment rule explicit while preserving the generated pages and section order.
