### PR TITLE
fix(expect): reject unsupported cyclic array traversal

### DIFF
--- a/docs/api-expectations.md
+++ b/docs/api-expectations.md
@@ -83,7 +83,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L141)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L142)
 
 ### `toEqual()`
 
@@ -98,8 +98,9 @@ PHPDoc:
 
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
+- `@throws \InvalidArgumentException when the comparison follows a cyclic array`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L158)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L160)
 
 ### `toEqualCanonicalizing()`
 
@@ -107,9 +108,6 @@ Uses the `toEqual()` rules but ignores list-element order. Canonicalization
 recurses through array values. It does not inspect object properties.
 Thus, lists in object properties keep their order. Associative arrays
 keep their keys.
-
-Cyclic arrays cannot be normalized or used to order list elements.
-Use `toEqual()` to compare these arrays without reordering.
 
 ```php
 public function toEqualCanonicalizing(mixed $expected): Expectation
@@ -119,9 +117,9 @@ PHPDoc:
 
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
-- `@throws \InvalidArgumentException when canonicalization encounters a cyclic array`
+- `@throws \InvalidArgumentException when an array selected for comparison or ordering contains a cycle`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L181)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L180)
 
 ### `toBeOneOf()`
 
@@ -136,7 +134,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L197)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L196)
 
 ### `toBeIn()`
 
@@ -154,7 +152,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L217)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L216)
 
 ### `toBeInstanceOf()`
 
@@ -168,7 +166,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L235)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L234)
 
 ### `toBeTrue()`
 
@@ -181,7 +179,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L249)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L248)
 
 ### `toBeFalse()`
 
@@ -194,7 +192,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L259)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L258)
 
 ### `toBeNull()`
 
@@ -207,7 +205,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L269)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L268)
 
 ### `toBeArray()`
 
@@ -220,7 +218,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L279)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L278)
 
 ### `toBeString()`
 
@@ -233,7 +231,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L294)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L293)
 
 ### `toBeInt()`
 
@@ -246,7 +244,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L309)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L308)
 
 ### `toBeFloat()`
 
@@ -259,7 +257,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L324)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L323)
 
 ### `toBeBool()`
 
@@ -272,7 +270,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L339)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L338)
 
 ### `toBeCallable()`
 
@@ -285,7 +283,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L354)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L353)
 
 ### `toBeIterable()`
 
@@ -298,7 +296,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L369)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L368)
 
 ### `toContain()`
 
@@ -315,7 +313,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L388)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L387)
 
 ### `toHaveCount()`
 
@@ -331,7 +329,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L437)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L436)
 
 ### `toBeEmpty()`
 
@@ -349,7 +347,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L468)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L467)
 
 ### `toHaveLength()`
 
@@ -366,7 +364,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L495)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L494)
 
 ### `toHaveKey()`
 
@@ -383,7 +381,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L526)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L525)
 
 ### `toContainSubset()`
 
@@ -402,7 +400,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L558)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L557)
 
 ### `toBeGreaterThan()`
 
@@ -415,7 +413,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L588)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L587)
 
 ### `toBeGreaterThanOrEqual()`
 
@@ -428,7 +426,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L602)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L601)
 
 ### `toBeLessThan()`
 
@@ -441,7 +439,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L616)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L615)
 
 ### `toBeLessThanOrEqual()`
 
@@ -454,7 +452,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L630)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L629)
 
 ### `toBeWithin()`
 
@@ -470,7 +468,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L647)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L646)
 
 ### `toMatch()`
 
@@ -484,7 +482,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L674)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L673)
 
 ### `toStartWith()`
 
@@ -497,7 +495,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L690)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L689)
 
 ### `toEndWith()`
 
@@ -510,7 +508,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L704)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L703)
 
 ### `toBeJson()`
 
@@ -526,7 +524,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L721)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L720)
 
 ### `toMatchJson()`
 
@@ -544,7 +542,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L740)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L739)
 
 ### `toThrow()`
 
@@ -583,7 +581,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L799)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L798)
 
 ## `EventuallyExpectation`
 
@@ -662,7 +660,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L141)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L142)
 
 ### `toEqual()`
 
@@ -677,8 +675,9 @@ PHPDoc:
 
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
+- `@throws \InvalidArgumentException when the comparison follows a cyclic array`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L158)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L160)
 
 ### `toEqualCanonicalizing()`
 
@@ -686,9 +685,6 @@ Uses the `toEqual()` rules but ignores list-element order. Canonicalization
 recurses through array values. It does not inspect object properties.
 Thus, lists in object properties keep their order. Associative arrays
 keep their keys.
-
-Cyclic arrays cannot be normalized or used to order list elements.
-Use `toEqual()` to compare these arrays without reordering.
 
 ```php
 public function toEqualCanonicalizing(mixed $expected): Expectation
@@ -698,9 +694,9 @@ PHPDoc:
 
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
-- `@throws \InvalidArgumentException when canonicalization encounters a cyclic array`
+- `@throws \InvalidArgumentException when an array selected for comparison or ordering contains a cycle`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L181)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L180)
 
 ### `toBeOneOf()`
 
@@ -715,7 +711,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L197)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L196)
 
 ### `toBeIn()`
 
@@ -733,7 +729,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L217)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L216)
 
 ### `toBeInstanceOf()`
 
@@ -747,7 +743,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L235)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L234)
 
 ### `toBeTrue()`
 
@@ -760,7 +756,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L249)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L248)
 
 ### `toBeFalse()`
 
@@ -773,7 +769,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L259)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L258)
 
 ### `toBeNull()`
 
@@ -786,7 +782,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L269)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L268)
 
 ### `toBeArray()`
 
@@ -799,7 +795,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L279)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L278)
 
 ### `toBeString()`
 
@@ -812,7 +808,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L294)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L293)
 
 ### `toBeInt()`
 
@@ -825,7 +821,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L309)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L308)
 
 ### `toBeFloat()`
 
@@ -838,7 +834,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L324)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L323)
 
 ### `toBeBool()`
 
@@ -851,7 +847,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L339)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L338)
 
 ### `toBeCallable()`
 
@@ -864,7 +860,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L354)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L353)
 
 ### `toBeIterable()`
 
@@ -877,7 +873,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L369)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L368)
 
 ### `toContain()`
 
@@ -894,7 +890,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L388)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L387)
 
 ### `toHaveCount()`
 
@@ -910,7 +906,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L437)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L436)
 
 ### `toBeEmpty()`
 
@@ -928,7 +924,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L468)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L467)
 
 ### `toHaveLength()`
 
@@ -945,7 +941,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L495)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L494)
 
 ### `toHaveKey()`
 
@@ -962,7 +958,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L526)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L525)
 
 ### `toContainSubset()`
 
@@ -981,7 +977,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L558)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L557)
 
 ### `toBeGreaterThan()`
 
@@ -994,7 +990,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L588)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L587)
 
 ### `toBeGreaterThanOrEqual()`
 
@@ -1007,7 +1003,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L602)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L601)
 
 ### `toBeLessThan()`
 
@@ -1020,7 +1016,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L616)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L615)
 
 ### `toBeLessThanOrEqual()`
 
@@ -1033,7 +1029,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L630)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L629)
 
 ### `toBeWithin()`
 
@@ -1049,7 +1045,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L647)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L646)
 
 ### `toMatch()`
 
@@ -1063,7 +1059,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L674)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L673)
 
 ### `toStartWith()`
 
@@ -1076,7 +1072,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L690)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L689)
 
 ### `toEndWith()`
 
@@ -1089,7 +1085,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L704)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L703)
 
 ### `toBeJson()`
 
@@ -1105,7 +1101,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L721)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L720)
 
 ### `toMatchJson()`
 
@@ -1123,7 +1119,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L740)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L739)
 
 ### `toThrow()`
 
@@ -1162,7 +1158,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L799)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L798)
 
 ## `Expect`
 
@@ -1244,7 +1240,8 @@ A failed matcher throws `ExpectationFailed` immediately.
   equal `1`.
 
 - Arrays are equal when they contain the same keys and recursively equal
-  values. Key order has no effect.
+  values. Key order has no effect. Cyclic arrays are unsupported. When the
+  comparison follows a cycle, it raises `InvalidArgumentException`.
 
 - Enum cases, closures, and resources use identity.
 
@@ -1253,13 +1250,13 @@ A failed matcher throws `ExpectationFailed` immediately.
 
 - Other objects are equal when they have the same class and recursively
   equal properties. This rule includes private and inherited properties.
-  The comparison safely processes cyclic structures.
+  The comparison safely processes cyclic object structures.
 
 ```php
 final class Expectation
 ```
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L40)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L41)
 
 PHPDoc:
 
@@ -1284,7 +1281,7 @@ PHPDoc:
 - `@throws \BadMethodCallException if no native or registered extension matcher has the requested name`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L73)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L74)
 
 ### `not()`
 
@@ -1300,7 +1297,7 @@ PHPDoc:
 
 - `@return self<T>`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L101)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L102)
 
 ### `because()`
 
@@ -1320,7 +1317,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L121)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L122)
 
 ### `toBe()`
 
@@ -1335,7 +1332,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L141)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L142)
 
 ### `toEqual()`
 
@@ -1350,8 +1347,9 @@ PHPDoc:
 
 - `@return self<T>`
 - `@throws ExpectationFailed`
+- `@throws \InvalidArgumentException when the comparison follows a cyclic array`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L158)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L160)
 
 ### `toEqualCanonicalizing()`
 
@@ -1359,9 +1357,6 @@ Uses the `toEqual()` rules but ignores list-element order. Canonicalization
 recurses through array values. It does not inspect object properties.
 Thus, lists in object properties keep their order. Associative arrays
 keep their keys.
-
-Cyclic arrays cannot be normalized or used to order list elements.
-Use `toEqual()` to compare these arrays without reordering.
 
 ```php
 public function toEqualCanonicalizing(mixed $expected): self
@@ -1371,9 +1366,9 @@ PHPDoc:
 
 - `@return self<T>`
 - `@throws ExpectationFailed`
-- `@throws \InvalidArgumentException when canonicalization encounters a cyclic array`
+- `@throws \InvalidArgumentException when an array selected for comparison or ordering contains a cycle`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L181)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L180)
 
 ### `toBeOneOf()`
 
@@ -1388,7 +1383,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L197)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L196)
 
 ### `toBeIn()`
 
@@ -1406,7 +1401,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L217)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L216)
 
 ### `toBeInstanceOf()`
 
@@ -1420,7 +1415,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L235)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L234)
 
 ### `toBeTrue()`
 
@@ -1433,7 +1428,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L249)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L248)
 
 ### `toBeFalse()`
 
@@ -1446,7 +1441,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L259)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L258)
 
 ### `toBeNull()`
 
@@ -1459,7 +1454,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L269)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L268)
 
 ### `toBeArray()`
 
@@ -1472,7 +1467,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L279)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L278)
 
 ### `toBeString()`
 
@@ -1485,7 +1480,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L294)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L293)
 
 ### `toBeInt()`
 
@@ -1498,7 +1493,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L309)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L308)
 
 ### `toBeFloat()`
 
@@ -1511,7 +1506,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L324)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L323)
 
 ### `toBeBool()`
 
@@ -1524,7 +1519,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L339)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L338)
 
 ### `toBeCallable()`
 
@@ -1537,7 +1532,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L354)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L353)
 
 ### `toBeIterable()`
 
@@ -1550,7 +1545,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L369)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L368)
 
 ### `toContain()`
 
@@ -1567,7 +1562,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L388)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L387)
 
 ### `toHaveCount()`
 
@@ -1583,7 +1578,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L437)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L436)
 
 ### `toBeEmpty()`
 
@@ -1601,7 +1596,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L468)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L467)
 
 ### `toHaveLength()`
 
@@ -1618,7 +1613,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L495)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L494)
 
 ### `toHaveKey()`
 
@@ -1635,7 +1630,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L526)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L525)
 
 ### `toContainSubset()`
 
@@ -1654,7 +1649,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L558)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L557)
 
 ### `toBeGreaterThan()`
 
@@ -1667,7 +1662,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L588)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L587)
 
 ### `toBeGreaterThanOrEqual()`
 
@@ -1680,7 +1675,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L602)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L601)
 
 ### `toBeLessThan()`
 
@@ -1693,7 +1688,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L616)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L615)
 
 ### `toBeLessThanOrEqual()`
 
@@ -1706,7 +1701,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L630)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L629)
 
 ### `toBeWithin()`
 
@@ -1722,7 +1717,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L647)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L646)
 
 ### `toMatch()`
 
@@ -1736,7 +1731,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L674)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L673)
 
 ### `toStartWith()`
 
@@ -1749,7 +1744,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L690)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L689)
 
 ### `toEndWith()`
 
@@ -1762,7 +1757,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L704)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L703)
 
 ### `toBeJson()`
 
@@ -1778,7 +1773,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L721)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L720)
 
 ### `toMatchJson()`
 
@@ -1796,7 +1791,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L740)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L739)
 
 ### `toThrow()`
 
@@ -1835,7 +1830,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L799)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L798)
 
 ## `ExpectationExtension`
 
@@ -2126,7 +2121,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L141)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L142)
 
 ### `toEqual()`
 
@@ -2141,8 +2136,9 @@ PHPDoc:
 
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
+- `@throws \InvalidArgumentException when the comparison follows a cyclic array`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L158)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L160)
 
 ### `toEqualCanonicalizing()`
 
@@ -2150,9 +2146,6 @@ Uses the `toEqual()` rules but ignores list-element order. Canonicalization
 recurses through array values. It does not inspect object properties.
 Thus, lists in object properties keep their order. Associative arrays
 keep their keys.
-
-Cyclic arrays cannot be normalized or used to order list elements.
-Use `toEqual()` to compare these arrays without reordering.
 
 ```php
 public function toEqualCanonicalizing(mixed $expected): Expectation
@@ -2162,9 +2155,9 @@ PHPDoc:
 
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
-- `@throws \InvalidArgumentException when canonicalization encounters a cyclic array`
+- `@throws \InvalidArgumentException when an array selected for comparison or ordering contains a cycle`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L181)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L180)
 
 ### `toBeOneOf()`
 
@@ -2179,7 +2172,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L197)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L196)
 
 ### `toBeIn()`
 
@@ -2197,7 +2190,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L217)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L216)
 
 ### `toBeInstanceOf()`
 
@@ -2211,7 +2204,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L235)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L234)
 
 ### `toBeTrue()`
 
@@ -2224,7 +2217,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L249)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L248)
 
 ### `toBeFalse()`
 
@@ -2237,7 +2230,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L259)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L258)
 
 ### `toBeNull()`
 
@@ -2250,7 +2243,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L269)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L268)
 
 ### `toBeArray()`
 
@@ -2263,7 +2256,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L279)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L278)
 
 ### `toBeString()`
 
@@ -2276,7 +2269,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L294)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L293)
 
 ### `toBeInt()`
 
@@ -2289,7 +2282,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L309)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L308)
 
 ### `toBeFloat()`
 
@@ -2302,7 +2295,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L324)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L323)
 
 ### `toBeBool()`
 
@@ -2315,7 +2308,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L339)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L338)
 
 ### `toBeCallable()`
 
@@ -2328,7 +2321,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L354)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L353)
 
 ### `toBeIterable()`
 
@@ -2341,7 +2334,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L369)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L368)
 
 ### `toContain()`
 
@@ -2358,7 +2351,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L388)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L387)
 
 ### `toHaveCount()`
 
@@ -2374,7 +2367,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L437)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L436)
 
 ### `toBeEmpty()`
 
@@ -2392,7 +2385,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L468)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L467)
 
 ### `toHaveLength()`
 
@@ -2409,7 +2402,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L495)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L494)
 
 ### `toHaveKey()`
 
@@ -2426,7 +2419,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L526)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L525)
 
 ### `toContainSubset()`
 
@@ -2445,7 +2438,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L558)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L557)
 
 ### `toBeGreaterThan()`
 
@@ -2458,7 +2451,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L588)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L587)
 
 ### `toBeGreaterThanOrEqual()`
 
@@ -2471,7 +2464,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L602)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L601)
 
 ### `toBeLessThan()`
 
@@ -2484,7 +2477,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L616)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L615)
 
 ### `toBeLessThanOrEqual()`
 
@@ -2497,7 +2490,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L630)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L629)
 
 ### `toBeWithin()`
 
@@ -2513,7 +2506,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L647)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L646)
 
 ### `toMatch()`
 
@@ -2527,7 +2520,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L674)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L673)
 
 ### `toStartWith()`
 
@@ -2540,7 +2533,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L690)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L689)
 
 ### `toEndWith()`
 
@@ -2553,7 +2546,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L704)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L703)
 
 ### `toBeJson()`
 
@@ -2569,7 +2562,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L721)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L720)
 
 ### `toMatchJson()`
 
@@ -2587,7 +2580,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L740)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L739)
 
 ### `toThrow()`
 
@@ -2626,4 +2619,4 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L799)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L798)

--- a/docs/api-expectations.md
+++ b/docs/api-expectations.md
@@ -108,6 +108,9 @@ recurses through array values. It does not inspect object properties.
 Thus, lists in object properties keep their order. Associative arrays
 keep their keys.
 
+Cyclic arrays cannot be normalized or used to order list elements.
+Use `toEqual()` to compare these arrays without reordering.
+
 ```php
 public function toEqualCanonicalizing(mixed $expected): Expectation
 ```
@@ -116,8 +119,9 @@ PHPDoc:
 
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
+- `@throws \InvalidArgumentException when canonicalization encounters a cyclic array`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L177)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L181)
 
 ### `toBeOneOf()`
 
@@ -132,7 +136,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L193)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L197)
 
 ### `toBeIn()`
 
@@ -150,7 +154,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L213)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L217)
 
 ### `toBeInstanceOf()`
 
@@ -164,7 +168,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L231)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L235)
 
 ### `toBeTrue()`
 
@@ -177,7 +181,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L245)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L249)
 
 ### `toBeFalse()`
 
@@ -190,7 +194,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L255)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L259)
 
 ### `toBeNull()`
 
@@ -203,7 +207,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L265)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L269)
 
 ### `toBeArray()`
 
@@ -216,7 +220,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L275)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L279)
 
 ### `toBeString()`
 
@@ -229,7 +233,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L290)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L294)
 
 ### `toBeInt()`
 
@@ -242,7 +246,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L305)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L309)
 
 ### `toBeFloat()`
 
@@ -255,7 +259,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L320)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L324)
 
 ### `toBeBool()`
 
@@ -268,7 +272,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L335)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L339)
 
 ### `toBeCallable()`
 
@@ -281,7 +285,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L350)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L354)
 
 ### `toBeIterable()`
 
@@ -294,7 +298,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L365)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L369)
 
 ### `toContain()`
 
@@ -311,7 +315,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L384)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L388)
 
 ### `toHaveCount()`
 
@@ -327,7 +331,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L433)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L437)
 
 ### `toBeEmpty()`
 
@@ -345,7 +349,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L464)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L468)
 
 ### `toHaveLength()`
 
@@ -362,7 +366,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L491)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L495)
 
 ### `toHaveKey()`
 
@@ -379,7 +383,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L522)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L526)
 
 ### `toContainSubset()`
 
@@ -398,7 +402,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L554)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L558)
 
 ### `toBeGreaterThan()`
 
@@ -411,7 +415,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L584)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L588)
 
 ### `toBeGreaterThanOrEqual()`
 
@@ -424,7 +428,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L598)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L602)
 
 ### `toBeLessThan()`
 
@@ -437,7 +441,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L612)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L616)
 
 ### `toBeLessThanOrEqual()`
 
@@ -450,7 +454,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L626)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L630)
 
 ### `toBeWithin()`
 
@@ -466,7 +470,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L643)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L647)
 
 ### `toMatch()`
 
@@ -480,7 +484,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L670)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L674)
 
 ### `toStartWith()`
 
@@ -493,7 +497,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L686)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L690)
 
 ### `toEndWith()`
 
@@ -506,7 +510,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L700)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L704)
 
 ### `toBeJson()`
 
@@ -522,7 +526,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L717)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L721)
 
 ### `toMatchJson()`
 
@@ -540,7 +544,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L736)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L740)
 
 ### `toThrow()`
 
@@ -579,7 +583,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L795)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L799)
 
 ## `EventuallyExpectation`
 
@@ -683,6 +687,9 @@ recurses through array values. It does not inspect object properties.
 Thus, lists in object properties keep their order. Associative arrays
 keep their keys.
 
+Cyclic arrays cannot be normalized or used to order list elements.
+Use `toEqual()` to compare these arrays without reordering.
+
 ```php
 public function toEqualCanonicalizing(mixed $expected): Expectation
 ```
@@ -691,8 +698,9 @@ PHPDoc:
 
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
+- `@throws \InvalidArgumentException when canonicalization encounters a cyclic array`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L177)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L181)
 
 ### `toBeOneOf()`
 
@@ -707,7 +715,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L193)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L197)
 
 ### `toBeIn()`
 
@@ -725,7 +733,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L213)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L217)
 
 ### `toBeInstanceOf()`
 
@@ -739,7 +747,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L231)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L235)
 
 ### `toBeTrue()`
 
@@ -752,7 +760,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L245)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L249)
 
 ### `toBeFalse()`
 
@@ -765,7 +773,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L255)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L259)
 
 ### `toBeNull()`
 
@@ -778,7 +786,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L265)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L269)
 
 ### `toBeArray()`
 
@@ -791,7 +799,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L275)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L279)
 
 ### `toBeString()`
 
@@ -804,7 +812,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L290)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L294)
 
 ### `toBeInt()`
 
@@ -817,7 +825,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L305)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L309)
 
 ### `toBeFloat()`
 
@@ -830,7 +838,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L320)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L324)
 
 ### `toBeBool()`
 
@@ -843,7 +851,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L335)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L339)
 
 ### `toBeCallable()`
 
@@ -856,7 +864,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L350)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L354)
 
 ### `toBeIterable()`
 
@@ -869,7 +877,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L365)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L369)
 
 ### `toContain()`
 
@@ -886,7 +894,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L384)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L388)
 
 ### `toHaveCount()`
 
@@ -902,7 +910,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L433)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L437)
 
 ### `toBeEmpty()`
 
@@ -920,7 +928,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L464)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L468)
 
 ### `toHaveLength()`
 
@@ -937,7 +945,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L491)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L495)
 
 ### `toHaveKey()`
 
@@ -954,7 +962,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L522)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L526)
 
 ### `toContainSubset()`
 
@@ -973,7 +981,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L554)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L558)
 
 ### `toBeGreaterThan()`
 
@@ -986,7 +994,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L584)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L588)
 
 ### `toBeGreaterThanOrEqual()`
 
@@ -999,7 +1007,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L598)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L602)
 
 ### `toBeLessThan()`
 
@@ -1012,7 +1020,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L612)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L616)
 
 ### `toBeLessThanOrEqual()`
 
@@ -1025,7 +1033,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L626)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L630)
 
 ### `toBeWithin()`
 
@@ -1041,7 +1049,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L643)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L647)
 
 ### `toMatch()`
 
@@ -1055,7 +1063,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L670)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L674)
 
 ### `toStartWith()`
 
@@ -1068,7 +1076,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L686)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L690)
 
 ### `toEndWith()`
 
@@ -1081,7 +1089,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L700)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L704)
 
 ### `toBeJson()`
 
@@ -1097,7 +1105,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L717)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L721)
 
 ### `toMatchJson()`
 
@@ -1115,7 +1123,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L736)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L740)
 
 ### `toThrow()`
 
@@ -1154,7 +1162,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L795)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L799)
 
 ## `Expect`
 
@@ -1352,6 +1360,9 @@ recurses through array values. It does not inspect object properties.
 Thus, lists in object properties keep their order. Associative arrays
 keep their keys.
 
+Cyclic arrays cannot be normalized or used to order list elements.
+Use `toEqual()` to compare these arrays without reordering.
+
 ```php
 public function toEqualCanonicalizing(mixed $expected): self
 ```
@@ -1360,8 +1371,9 @@ PHPDoc:
 
 - `@return self<T>`
 - `@throws ExpectationFailed`
+- `@throws \InvalidArgumentException when canonicalization encounters a cyclic array`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L177)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L181)
 
 ### `toBeOneOf()`
 
@@ -1376,7 +1388,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L193)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L197)
 
 ### `toBeIn()`
 
@@ -1394,7 +1406,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L213)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L217)
 
 ### `toBeInstanceOf()`
 
@@ -1408,7 +1420,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L231)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L235)
 
 ### `toBeTrue()`
 
@@ -1421,7 +1433,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L245)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L249)
 
 ### `toBeFalse()`
 
@@ -1434,7 +1446,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L255)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L259)
 
 ### `toBeNull()`
 
@@ -1447,7 +1459,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L265)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L269)
 
 ### `toBeArray()`
 
@@ -1460,7 +1472,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L275)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L279)
 
 ### `toBeString()`
 
@@ -1473,7 +1485,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L290)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L294)
 
 ### `toBeInt()`
 
@@ -1486,7 +1498,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L305)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L309)
 
 ### `toBeFloat()`
 
@@ -1499,7 +1511,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L320)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L324)
 
 ### `toBeBool()`
 
@@ -1512,7 +1524,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L335)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L339)
 
 ### `toBeCallable()`
 
@@ -1525,7 +1537,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L350)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L354)
 
 ### `toBeIterable()`
 
@@ -1538,7 +1550,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L365)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L369)
 
 ### `toContain()`
 
@@ -1555,7 +1567,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L384)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L388)
 
 ### `toHaveCount()`
 
@@ -1571,7 +1583,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L433)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L437)
 
 ### `toBeEmpty()`
 
@@ -1589,7 +1601,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L464)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L468)
 
 ### `toHaveLength()`
 
@@ -1606,7 +1618,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L491)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L495)
 
 ### `toHaveKey()`
 
@@ -1623,7 +1635,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L522)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L526)
 
 ### `toContainSubset()`
 
@@ -1642,7 +1654,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L554)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L558)
 
 ### `toBeGreaterThan()`
 
@@ -1655,7 +1667,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L584)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L588)
 
 ### `toBeGreaterThanOrEqual()`
 
@@ -1668,7 +1680,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L598)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L602)
 
 ### `toBeLessThan()`
 
@@ -1681,7 +1693,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L612)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L616)
 
 ### `toBeLessThanOrEqual()`
 
@@ -1694,7 +1706,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L626)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L630)
 
 ### `toBeWithin()`
 
@@ -1710,7 +1722,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L643)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L647)
 
 ### `toMatch()`
 
@@ -1724,7 +1736,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L670)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L674)
 
 ### `toStartWith()`
 
@@ -1737,7 +1749,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L686)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L690)
 
 ### `toEndWith()`
 
@@ -1750,7 +1762,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L700)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L704)
 
 ### `toBeJson()`
 
@@ -1766,7 +1778,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L717)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L721)
 
 ### `toMatchJson()`
 
@@ -1784,7 +1796,7 @@ PHPDoc:
 - `@return self<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L736)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L740)
 
 ### `toThrow()`
 
@@ -1823,7 +1835,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L795)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L799)
 
 ## `ExpectationExtension`
 
@@ -2139,6 +2151,9 @@ recurses through array values. It does not inspect object properties.
 Thus, lists in object properties keep their order. Associative arrays
 keep their keys.
 
+Cyclic arrays cannot be normalized or used to order list elements.
+Use `toEqual()` to compare these arrays without reordering.
+
 ```php
 public function toEqualCanonicalizing(mixed $expected): Expectation
 ```
@@ -2147,8 +2162,9 @@ PHPDoc:
 
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
+- `@throws \InvalidArgumentException when canonicalization encounters a cyclic array`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L177)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L181)
 
 ### `toBeOneOf()`
 
@@ -2163,7 +2179,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L193)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L197)
 
 ### `toBeIn()`
 
@@ -2181,7 +2197,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L213)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L217)
 
 ### `toBeInstanceOf()`
 
@@ -2195,7 +2211,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L231)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L235)
 
 ### `toBeTrue()`
 
@@ -2208,7 +2224,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L245)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L249)
 
 ### `toBeFalse()`
 
@@ -2221,7 +2237,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L255)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L259)
 
 ### `toBeNull()`
 
@@ -2234,7 +2250,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L265)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L269)
 
 ### `toBeArray()`
 
@@ -2247,7 +2263,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L275)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L279)
 
 ### `toBeString()`
 
@@ -2260,7 +2276,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L290)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L294)
 
 ### `toBeInt()`
 
@@ -2273,7 +2289,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L305)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L309)
 
 ### `toBeFloat()`
 
@@ -2286,7 +2302,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L320)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L324)
 
 ### `toBeBool()`
 
@@ -2299,7 +2315,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L335)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L339)
 
 ### `toBeCallable()`
 
@@ -2312,7 +2328,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L350)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L354)
 
 ### `toBeIterable()`
 
@@ -2325,7 +2341,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L365)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L369)
 
 ### `toContain()`
 
@@ -2342,7 +2358,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L384)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L388)
 
 ### `toHaveCount()`
 
@@ -2358,7 +2374,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L433)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L437)
 
 ### `toBeEmpty()`
 
@@ -2376,7 +2392,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L464)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L468)
 
 ### `toHaveLength()`
 
@@ -2393,7 +2409,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L491)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L495)
 
 ### `toHaveKey()`
 
@@ -2410,7 +2426,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L522)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L526)
 
 ### `toContainSubset()`
 
@@ -2429,7 +2445,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L554)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L558)
 
 ### `toBeGreaterThan()`
 
@@ -2442,7 +2458,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L584)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L588)
 
 ### `toBeGreaterThanOrEqual()`
 
@@ -2455,7 +2471,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L598)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L602)
 
 ### `toBeLessThan()`
 
@@ -2468,7 +2484,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L612)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L616)
 
 ### `toBeLessThanOrEqual()`
 
@@ -2481,7 +2497,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L626)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L630)
 
 ### `toBeWithin()`
 
@@ -2497,7 +2513,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L643)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L647)
 
 ### `toMatch()`
 
@@ -2511,7 +2527,7 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L670)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L674)
 
 ### `toStartWith()`
 
@@ -2524,7 +2540,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L686)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L690)
 
 ### `toEndWith()`
 
@@ -2537,7 +2553,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L700)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L704)
 
 ### `toBeJson()`
 
@@ -2553,7 +2569,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L717)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L721)
 
 ### `toMatchJson()`
 
@@ -2571,7 +2587,7 @@ PHPDoc:
 - `@return Expectation<T>`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L736)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L740)
 
 ### `toThrow()`
 
@@ -2610,4 +2626,4 @@ PHPDoc:
 - `@throws \InvalidArgumentException when the match pattern is not a valid regular expression`
 - `@throws ExpectationFailed`
 
-[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L795)
+[View source](https://github.com/ben-challis/greenlight/blob/main/src/Expect/Expectation.php#L799)

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -71,11 +71,17 @@ The reason must not be empty. Temporal expectation chains also accept
 
 `toEqual()` compares integers and floats by numeric value. It compares other
 scalars strictly. It compares arrays by key and recursively equal values.
+Array comparisons can follow cyclic references without exhausting the worker.
 Objects must have the same class and recursively equal properties. This rule
 includes private properties.
 
 Object comparisons distinguish shared objects from equal copies. They also
 require equal cycle shapes.
+
+Canonicalizing equality throws `InvalidArgumentException` when it encounters a
+cyclic array while normalizing array values or ordering list elements. Use
+`toEqual()` to compare these arrays without reordering. Shared references to
+acyclic arrays remain supported.
 
 Enum cases compare by identity.
 `DateTimeInterface` values compare by instant at microsecond precision.

--- a/docs/expectations.md
+++ b/docs/expectations.md
@@ -71,17 +71,15 @@ The reason must not be empty. Temporal expectation chains also accept
 
 `toEqual()` compares integers and floats by numeric value. It compares other
 scalars strictly. It compares arrays by key and recursively equal values.
-Array comparisons can follow cyclic references without exhausting the worker.
 Objects must have the same class and recursively equal properties. This rule
 includes private properties.
 
 Object comparisons distinguish shared objects from equal copies. They also
 require equal cycle shapes.
 
-Canonicalizing equality throws `InvalidArgumentException` when it encounters a
-cyclic array while normalizing array values or ordering list elements. Use
-`toEqual()` to compare these arrays without reordering. Shared references to
-acyclic arrays remain supported.
+Both equality matchers report unsupported cyclic array traversal with
+`InvalidArgumentException`. Compare selected acyclic values instead.
+Object cycles and shared references to acyclic arrays remain supported.
 
 Enum cases compare by identity.
 `DateTimeInterface` values compare by instant at microsecond precision.

--- a/src/Expect/Equality.php
+++ b/src/Expect/Equality.php
@@ -4,9 +4,13 @@ declare(strict_types=1);
 
 namespace Greenlight\Expect;
 
+use Greenlight\Internal\Php\ErrorTrap;
+
 /** @internal */
 final class Equality
 {
+    private const int ARRAY_CYCLE_CHECK_DEPTH = 64;
+
     /** @codeCoverageIgnore */
     private function __construct() {}
 
@@ -14,9 +18,8 @@ final class Equality
     {
         $leftObjects = [];
         $rightObjects = [];
-        $arrayPairs = [];
 
-        return self::compare($a, $b, $leftObjects, $rightObjects, $arrayPairs);
+        return self::compare($a, $b, $leftObjects, $rightObjects);
     }
 
     /**
@@ -27,36 +30,26 @@ final class Equality
      */
     public static function equalsCanonicalizing(mixed $a, mixed $b): bool
     {
+        self::requireAcyclicArrays($a);
+        self::requireAcyclicArrays($b);
         $leftObjects = [];
         $rightObjects = [];
-        $arrayPairs = [];
 
-        return self::compare(
-            self::canonicalize($a, []),
-            self::canonicalize($b, []),
-            $leftObjects,
-            $rightObjects,
-            $arrayPairs,
-        );
+        return self::compare(self::canonicalize($a), self::canonicalize($b), $leftObjects, $rightObjects);
     }
 
-    /** @param array<string, true> $seenArrays Array references in the current path */
-    private static function canonicalize(mixed $value, array $seenArrays): mixed
+    private static function canonicalize(mixed $value): mixed
     {
         if (!\is_array($value)) {
             return $value;
         }
 
-        $canonical = [];
-
-        foreach ($value as $key => $item) {
-            $canonical[$key] = self::canonicalize($item, self::canonicalArrayStack($value, $key, $seenArrays));
-        }
+        $canonical = \array_map(self::canonicalize(...), $value);
 
         if (\array_is_list($canonical)) {
             // Compute each key one time for each element. A comparator
             // serializes both operands again for each comparison.
-            $keys = \array_map(static fn(mixed $item): string => self::sortKey($item, [], []), $canonical);
+            $keys = \array_map(static fn(mixed $item): string => self::sortKey($item, []), $canonical);
             \asort($keys, \SORT_STRING);
             $canonical = \array_map(static fn(int $index): mixed => $canonical[$index], \array_keys($keys));
         }
@@ -71,20 +64,15 @@ final class Equality
      *
      * @param list<int> $seen Object IDs already in the conversion stack. This
      *   list stops cycles.
-     * @param array<string, true> $seenArrays Array reference IDs in the conversion stack
      */
-    private static function sortKey(mixed $value, array $seen, array $seenArrays): string
+    private static function sortKey(mixed $value, array $seen): string
     {
         if (\is_array($value)) {
             $parts = [];
             \ksort($value, \SORT_STRING);
 
             foreach ($value as $key => $item) {
-                $parts[] = \var_export($key, true) . '=>' . self::sortKey(
-                    $item,
-                    $seen,
-                    self::canonicalArrayStack($value, $key, $seenArrays),
-                );
+                $parts[] = \var_export($key, true) . '=>' . self::sortKey($item, $seen);
             }
 
             return '[' . \implode(',', $parts) . ']';
@@ -124,10 +112,11 @@ final class Equality
             $seen[] = $id;
             $parts = [];
             $properties = \get_mangled_object_vars($value);
+            self::requireAcyclicArrays($properties);
             \ksort($properties, \SORT_STRING);
 
             foreach ($properties as $name => $item) {
-                $parts[] = \var_export($name, true) . '=>' . self::sortKey($item, $seen, $seenArrays);
+                $parts[] = \var_export($name, true) . '=>' . self::sortKey($item, $seen);
             }
 
             return $value::class . '{' . \implode(',', $parts) . '}';
@@ -145,16 +134,13 @@ final class Equality
      *   to the right value
      * @param array<int, int> $rightObjects Object mappings from the right value
      *   to the left value
-     * @param array<string, true> $arrayPairs Array position pairs already compared
      */
     private static function compare(
         mixed $a,
         mixed $b,
         array &$leftObjects,
         array &$rightObjects,
-        array &$arrayPairs,
-        string $leftArrayPath = '',
-        string $rightArrayPath = '',
+        int $arrayDepth = 0,
     ): bool {
         if ((\is_int($a) || \is_float($a)) && (\is_int($b) || \is_float($b))) {
             if (\is_int($a) && \is_int($b)) {
@@ -176,35 +162,27 @@ final class Equality
                 return false;
             }
 
-            if ($leftArrayPath !== '' && $rightArrayPath !== '') {
-                $pair = \strlen($leftArrayPath) . ':' . $leftArrayPath . $rightArrayPath;
-
-                if (isset($arrayPairs[$pair])) {
-                    return true;
-                }
-
-                $arrayPairs[$pair] = true;
+            if ($arrayDepth === self::ARRAY_CYCLE_CHECK_DEPTH) {
+                self::requireAcyclicArrays($a);
+                self::requireAcyclicArrays($b);
+                $arrayDepth = -1;
             }
 
-            foreach ($a as $key => $value) {
-                if (!\array_key_exists($key, $b)) {
-                    return false;
-                }
+            $nextArrayDepth = $arrayDepth < 0 ? -1 : $arrayDepth + 1;
 
-                if (!self::compare(
-                    $value,
-                    $b[$key],
-                    $leftObjects,
-                    $rightObjects,
-                    $arrayPairs,
-                    self::arrayPath($a, $key, $leftArrayPath),
-                    self::arrayPath($b, $key, $rightArrayPath),
-                )) {
-                    return false;
-                }
-            }
-
-            return true;
+            return \array_all(
+                $a,
+                static function ($value, $key) use ($b, &$leftObjects, &$rightObjects, $nextArrayDepth): bool {
+                    return \array_key_exists($key, $b)
+                        && self::compare(
+                            $value,
+                            $b[$key],
+                            $leftObjects,
+                            $rightObjects,
+                            $nextArrayDepth,
+                        );
+                },
+            );
         }
 
         if ($a instanceof \UnitEnum || $b instanceof \UnitEnum) {
@@ -244,55 +222,27 @@ final class Equality
                 \get_mangled_object_vars($b),
                 $leftObjects,
                 $rightObjects,
-                $arrayPairs,
             );
         }
 
         return $a === $b;
     }
 
-    /** @param array<mixed> $array */
-    private static function arrayPath(array $array, int|string $key, string $parent): string
+    private static function requireAcyclicArrays(mixed $value): void
     {
-        if (!\is_array($array[$key])) {
-            return $parent;
+        if (!\is_array($value)) {
+            return;
         }
 
-        $reference = \ReflectionReference::fromArrayElement($array, $key);
+        // Native traversal sees cycles even after PHP unwraps their reference
+        // containers. Delay ordinary comparisons so early mismatches do not
+        // scan an otherwise unused array graph. A checked subtree stays checked.
+        ErrorTrap::run(static fn(): int => \count($value, \COUNT_RECURSIVE), $warning);
 
-        // Value edges between reference edges need a stable position too.
-        // The two graphs can reach their back edges at different depths.
-        if ($reference instanceof \ReflectionReference) {
-            return 'reference:' . $reference->getId();
-        }
-
-        return $parent === '' ? '' : $parent . \serialize($key);
-    }
-
-    /**
-     * @param array<mixed> $array
-     * @param array<string, true> $seen
-     *
-     * @return array<string, true>
-     */
-    private static function canonicalArrayStack(array $array, int|string $key, array $seen): array
-    {
-        $reference = \is_array($array[$key]) ? \ReflectionReference::fromArrayElement($array, $key) : null;
-
-        if (!$reference instanceof \ReflectionReference) {
-            return $seen;
-        }
-
-        $id = $reference->getId();
-
-        if (isset($seen[$id])) {
+        if ($warning !== null) {
             throw new \InvalidArgumentException(
-                'toEqualCanonicalizing() cannot order cyclic arrays. Use toEqual() to compare them without reordering.',
+                'Equality matchers do not support cyclic arrays. Compare selected acyclic values instead.',
             );
         }
-
-        $seen[$id] = true;
-
-        return $seen;
     }
 }

--- a/src/Expect/Equality.php
+++ b/src/Expect/Equality.php
@@ -30,62 +30,35 @@ final class Equality
         $leftObjects = [];
         $rightObjects = [];
         $arrayPairs = [];
-        $leftArrays = [];
-        $rightArrays = [];
 
         return self::compare(
-            self::canonicalize($a, $leftArrays),
-            self::canonicalize($b, $rightArrays),
+            self::canonicalize($a, []),
+            self::canonicalize($b, []),
             $leftObjects,
             $rightObjects,
             $arrayPairs,
         );
     }
 
-    /** @param array<string, array<mixed>> $arrays Canonical array reference targets */
-    private static function canonicalize(mixed $value, array &$arrays): mixed
+    /** @param array<string, true> $seenArrays Array references in the current path */
+    private static function canonicalize(mixed $value, array $seenArrays): mixed
     {
         if (!\is_array($value)) {
             return $value;
         }
 
-        return self::canonicalizeArray($value, $arrays);
-    }
-
-    /**
-     * @param array<mixed> $value
-     * @param array<string, array<mixed>> $arrays
-     *
-     * @return array<mixed>
-     */
-    private static function canonicalizeArray(array $value, array &$arrays): array
-    {
         $canonical = [];
 
         foreach ($value as $key => $item) {
-            $reference = \is_array($item) ? \ReflectionReference::fromArrayElement($value, $key) : null;
-
-            if (\is_array($item) && $reference !== null) {
-                $id = $reference->getId();
-
-                if (!\array_key_exists($id, $arrays)) {
-                    // Register the target before following a reference back to it.
-                    $arrays[$id] = [];
-                    $arrays[$id] = self::canonicalizeArray($item, $arrays);
-                }
-
-                $canonical[$key] = &$arrays[$id];
-            } else {
-                $canonical[$key] = self::canonicalize($item, $arrays);
-            }
+            $canonical[$key] = self::canonicalize($item, self::canonicalArrayStack($value, $key, $seenArrays));
         }
 
         if (\array_is_list($canonical)) {
             // Compute each key one time for each element. A comparator
             // serializes both operands again for each comparison.
             $keys = \array_map(static fn(mixed $item): string => self::sortKey($item, [], []), $canonical);
-            \uksort($canonical, static fn(int $left, int $right): int => \strcmp($keys[$left], $keys[$right]));
-            $canonical = \array_values($canonical);
+            \asort($keys, \SORT_STRING);
+            $canonical = \array_map(static fn(int $index): mixed => $canonical[$index], \array_keys($keys));
         }
 
         return $canonical;
@@ -98,7 +71,7 @@ final class Equality
      *
      * @param list<int> $seen Object IDs already in the conversion stack. This
      *   list stops cycles.
-     * @param list<string> $seenArrays Array reference IDs in the conversion stack
+     * @param array<string, true> $seenArrays Array reference IDs in the conversion stack
      */
     private static function sortKey(mixed $value, array $seen, array $seenArrays): string
     {
@@ -107,19 +80,10 @@ final class Equality
             \ksort($value, \SORT_STRING);
 
             foreach ($value as $key => $item) {
-                $arrayId = \is_array($item) ? \ReflectionReference::fromArrayElement($value, $key)?->getId() : null;
-                $keyPrefix = \var_export($key, true) . '=>';
-
-                if ($arrayId !== null && \in_array($arrayId, $seenArrays, true)) {
-                    $parts[] = $keyPrefix . '[...]';
-
-                    continue;
-                }
-
-                $parts[] = $keyPrefix . self::sortKey(
+                $parts[] = \var_export($key, true) . '=>' . self::sortKey(
                     $item,
                     $seen,
-                    $arrayId === null ? $seenArrays : [...$seenArrays, $arrayId],
+                    self::canonicalArrayStack($value, $key, $seenArrays),
                 );
             }
 
@@ -181,7 +145,7 @@ final class Equality
      *   to the right value
      * @param array<int, int> $rightObjects Object mappings from the right value
      *   to the left value
-     * @param array<string, true> $arrayPairs Array reference pairs already compared
+     * @param array<string, true> $arrayPairs Array position pairs already compared
      */
     private static function compare(
         mixed $a,
@@ -189,6 +153,8 @@ final class Equality
         array &$leftObjects,
         array &$rightObjects,
         array &$arrayPairs,
+        string $leftArrayPath = '',
+        string $rightArrayPath = '',
     ): bool {
         if ((\is_int($a) || \is_float($a)) && (\is_int($b) || \is_float($b))) {
             if (\is_int($a) && \is_int($b)) {
@@ -210,27 +176,30 @@ final class Equality
                 return false;
             }
 
+            if ($leftArrayPath !== '' && $rightArrayPath !== '') {
+                $pair = \strlen($leftArrayPath) . ':' . $leftArrayPath . $rightArrayPath;
+
+                if (isset($arrayPairs[$pair])) {
+                    return true;
+                }
+
+                $arrayPairs[$pair] = true;
+            }
+
             foreach ($a as $key => $value) {
                 if (!\array_key_exists($key, $b)) {
                     return false;
                 }
 
-                if (\is_array($value) && \is_array($b[$key])) {
-                    $leftReference = \ReflectionReference::fromArrayElement($a, $key);
-                    $rightReference = \ReflectionReference::fromArrayElement($b, $key);
-
-                    if ($leftReference !== null && $rightReference !== null) {
-                        $pair = $leftReference->getId() . $rightReference->getId();
-
-                        if (isset($arrayPairs[$pair])) {
-                            continue;
-                        }
-
-                        $arrayPairs[$pair] = true;
-                    }
-                }
-
-                if (!self::compare($value, $b[$key], $leftObjects, $rightObjects, $arrayPairs)) {
+                if (!self::compare(
+                    $value,
+                    $b[$key],
+                    $leftObjects,
+                    $rightObjects,
+                    $arrayPairs,
+                    self::arrayPath($a, $key, $leftArrayPath),
+                    self::arrayPath($b, $key, $rightArrayPath),
+                )) {
                     return false;
                 }
             }
@@ -280,5 +249,50 @@ final class Equality
         }
 
         return $a === $b;
+    }
+
+    /** @param array<mixed> $array */
+    private static function arrayPath(array $array, int|string $key, string $parent): string
+    {
+        if (!\is_array($array[$key])) {
+            return $parent;
+        }
+
+        $reference = \ReflectionReference::fromArrayElement($array, $key);
+
+        // Value edges between reference edges need a stable position too.
+        // The two graphs can reach their back edges at different depths.
+        if ($reference instanceof \ReflectionReference) {
+            return 'reference:' . $reference->getId();
+        }
+
+        return $parent === '' ? '' : $parent . \serialize($key);
+    }
+
+    /**
+     * @param array<mixed> $array
+     * @param array<string, true> $seen
+     *
+     * @return array<string, true>
+     */
+    private static function canonicalArrayStack(array $array, int|string $key, array $seen): array
+    {
+        $reference = \is_array($array[$key]) ? \ReflectionReference::fromArrayElement($array, $key) : null;
+
+        if (!$reference instanceof \ReflectionReference) {
+            return $seen;
+        }
+
+        $id = $reference->getId();
+
+        if (isset($seen[$id])) {
+            throw new \InvalidArgumentException(
+                'toEqualCanonicalizing() cannot order cyclic arrays. Use toEqual() to compare them without reordering.',
+            );
+        }
+
+        $seen[$id] = true;
+
+        return $seen;
     }
 }

--- a/src/Expect/Equality.php
+++ b/src/Expect/Equality.php
@@ -14,8 +14,9 @@ final class Equality
     {
         $leftObjects = [];
         $rightObjects = [];
+        $arrayPairs = [];
 
-        return self::compare($a, $b, $leftObjects, $rightObjects);
+        return self::compare($a, $b, $leftObjects, $rightObjects, $arrayPairs);
     }
 
     /**
@@ -28,24 +29,63 @@ final class Equality
     {
         $leftObjects = [];
         $rightObjects = [];
+        $arrayPairs = [];
+        $leftArrays = [];
+        $rightArrays = [];
 
-        return self::compare(self::canonicalize($a), self::canonicalize($b), $leftObjects, $rightObjects);
+        return self::compare(
+            self::canonicalize($a, $leftArrays),
+            self::canonicalize($b, $rightArrays),
+            $leftObjects,
+            $rightObjects,
+            $arrayPairs,
+        );
     }
 
-    private static function canonicalize(mixed $value): mixed
+    /** @param array<string, array<mixed>> $arrays Canonical array reference targets */
+    private static function canonicalize(mixed $value, array &$arrays): mixed
     {
         if (!\is_array($value)) {
             return $value;
         }
 
-        $canonical = \array_map(self::canonicalize(...), $value);
+        return self::canonicalizeArray($value, $arrays);
+    }
+
+    /**
+     * @param array<mixed> $value
+     * @param array<string, array<mixed>> $arrays
+     *
+     * @return array<mixed>
+     */
+    private static function canonicalizeArray(array $value, array &$arrays): array
+    {
+        $canonical = [];
+
+        foreach ($value as $key => $item) {
+            $reference = \is_array($item) ? \ReflectionReference::fromArrayElement($value, $key) : null;
+
+            if (\is_array($item) && $reference !== null) {
+                $id = $reference->getId();
+
+                if (!\array_key_exists($id, $arrays)) {
+                    // Register the target before following a reference back to it.
+                    $arrays[$id] = [];
+                    $arrays[$id] = self::canonicalizeArray($item, $arrays);
+                }
+
+                $canonical[$key] = &$arrays[$id];
+            } else {
+                $canonical[$key] = self::canonicalize($item, $arrays);
+            }
+        }
 
         if (\array_is_list($canonical)) {
             // Compute each key one time for each element. A comparator
             // serializes both operands again for each comparison.
-            $keys = \array_map(static fn(mixed $item): string => self::sortKey($item, []), $canonical);
-            \asort($keys, \SORT_STRING);
-            $canonical = \array_map(static fn(int $index): mixed => $canonical[$index], \array_keys($keys));
+            $keys = \array_map(static fn(mixed $item): string => self::sortKey($item, [], []), $canonical);
+            \uksort($canonical, static fn(int $left, int $right): int => \strcmp($keys[$left], $keys[$right]));
+            $canonical = \array_values($canonical);
         }
 
         return $canonical;
@@ -58,15 +98,29 @@ final class Equality
      *
      * @param list<int> $seen Object IDs already in the conversion stack. This
      *   list stops cycles.
+     * @param list<string> $seenArrays Array reference IDs in the conversion stack
      */
-    private static function sortKey(mixed $value, array $seen): string
+    private static function sortKey(mixed $value, array $seen, array $seenArrays): string
     {
         if (\is_array($value)) {
             $parts = [];
             \ksort($value, \SORT_STRING);
 
             foreach ($value as $key => $item) {
-                $parts[] = \var_export($key, true) . '=>' . self::sortKey($item, $seen);
+                $arrayId = \is_array($item) ? \ReflectionReference::fromArrayElement($value, $key)?->getId() : null;
+                $keyPrefix = \var_export($key, true) . '=>';
+
+                if ($arrayId !== null && \in_array($arrayId, $seenArrays, true)) {
+                    $parts[] = $keyPrefix . '[...]';
+
+                    continue;
+                }
+
+                $parts[] = $keyPrefix . self::sortKey(
+                    $item,
+                    $seen,
+                    $arrayId === null ? $seenArrays : [...$seenArrays, $arrayId],
+                );
             }
 
             return '[' . \implode(',', $parts) . ']';
@@ -109,7 +163,7 @@ final class Equality
             \ksort($properties, \SORT_STRING);
 
             foreach ($properties as $name => $item) {
-                $parts[] = \var_export($name, true) . '=>' . self::sortKey($item, $seen);
+                $parts[] = \var_export($name, true) . '=>' . self::sortKey($item, $seen, $seenArrays);
             }
 
             return $value::class . '{' . \implode(',', $parts) . '}';
@@ -127,12 +181,14 @@ final class Equality
      *   to the right value
      * @param array<int, int> $rightObjects Object mappings from the right value
      *   to the left value
+     * @param array<string, true> $arrayPairs Array reference pairs already compared
      */
     private static function compare(
         mixed $a,
         mixed $b,
         array &$leftObjects,
         array &$rightObjects,
+        array &$arrayPairs,
     ): bool {
         if ((\is_int($a) || \is_float($a)) && (\is_int($b) || \is_float($b))) {
             if (\is_int($a) && \is_int($b)) {
@@ -153,13 +209,33 @@ final class Equality
             if (\count($a) !== \count($b)) {
                 return false;
             }
-            return \array_all(
-                $a,
-                static function ($value, $key) use ($b, &$leftObjects, &$rightObjects): bool {
-                    return \array_key_exists($key, $b)
-                        && self::compare($value, $b[$key], $leftObjects, $rightObjects);
-                },
-            );
+
+            foreach ($a as $key => $value) {
+                if (!\array_key_exists($key, $b)) {
+                    return false;
+                }
+
+                if (\is_array($value) && \is_array($b[$key])) {
+                    $leftReference = \ReflectionReference::fromArrayElement($a, $key);
+                    $rightReference = \ReflectionReference::fromArrayElement($b, $key);
+
+                    if ($leftReference !== null && $rightReference !== null) {
+                        $pair = $leftReference->getId() . $rightReference->getId();
+
+                        if (isset($arrayPairs[$pair])) {
+                            continue;
+                        }
+
+                        $arrayPairs[$pair] = true;
+                    }
+                }
+
+                if (!self::compare($value, $b[$key], $leftObjects, $rightObjects, $arrayPairs)) {
+                    return false;
+                }
+            }
+
+            return true;
         }
 
         if ($a instanceof \UnitEnum || $b instanceof \UnitEnum) {
@@ -199,6 +275,7 @@ final class Equality
                 \get_mangled_object_vars($b),
                 $leftObjects,
                 $rightObjects,
+                $arrayPairs,
             );
         }
 

--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -24,7 +24,8 @@ use Greenlight\Test\ExpectationCounter;
  *   equal `1`.
  *
  * - Arrays are equal when they contain the same keys and recursively equal
- *   values. Key order has no effect.
+ *   values. Key order has no effect. Cyclic arrays are unsupported. When the
+ *   comparison follows a cycle, it raises `InvalidArgumentException`.
  *
  * - Enum cases, closures, and resources use identity.
  *
@@ -33,7 +34,7 @@ use Greenlight\Test\ExpectationCounter;
  *
  * - Other objects are equal when they have the same class and recursively
  *   equal properties. This rule includes private and inherited properties.
- *   The comparison safely processes cyclic structures.
+ *   The comparison safely processes cyclic object structures.
  *
  * @template T
  */
@@ -154,6 +155,7 @@ final class Expectation
      * @return self<T>
      *
      * @throws ExpectationFailed
+     * @throws \InvalidArgumentException when the comparison follows a cyclic array
      */
     public function toEqual(mixed $expected): self
     {
@@ -170,13 +172,10 @@ final class Expectation
      * Thus, lists in object properties keep their order. Associative arrays
      * keep their keys.
      *
-     * Cyclic arrays cannot be normalized or used to order list elements.
-     * Use `toEqual()` to compare these arrays without reordering.
-     *
      * @return self<T>
      *
      * @throws ExpectationFailed
-     * @throws \InvalidArgumentException when canonicalization encounters a cyclic array
+     * @throws \InvalidArgumentException when an array selected for comparison or ordering contains a cycle
      */
     public function toEqualCanonicalizing(mixed $expected): self
     {

--- a/src/Expect/Expectation.php
+++ b/src/Expect/Expectation.php
@@ -170,9 +170,13 @@ final class Expectation
      * Thus, lists in object properties keep their order. Associative arrays
      * keep their keys.
      *
+     * Cyclic arrays cannot be normalized or used to order list elements.
+     * Use `toEqual()` to compare these arrays without reordering.
+     *
      * @return self<T>
      *
      * @throws ExpectationFailed
+     * @throws \InvalidArgumentException when canonicalization encounters a cyclic array
      */
     public function toEqualCanonicalizing(mixed $expected): self
     {

--- a/tests/Unit/Expect/CyclicArrayEqualityTest.php
+++ b/tests/Unit/Expect/CyclicArrayEqualityTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\Expect;
+
+use Greenlight\Attribute\DataRow;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Tests\Support\PhpSubprocess;
+
+final class CyclicArrayEqualityTest
+{
+    #[Test]
+    #[DataRow(['toEqual'], label: 'deep equality')]
+    #[DataRow(['toEqualCanonicalizing'], label: 'canonical equality')]
+    public function cyclicArraysCompareWithoutExhaustingTheProcess(string $method): void
+    {
+        $root = \dirname(__DIR__, 3);
+        $result = PhpSubprocess::run($root, [
+            '-n',
+            '-d',
+            'memory_limit=32M',
+            '-d',
+            'max_execution_time=2',
+            '-r',
+            <<<'PHP'
+            require $argv[1];
+
+            use Greenlight\Expect\Expect;
+
+            $method = $argv[2];
+            $left = [];
+            $left['self'] = &$left;
+            $left['value'] = 1;
+            $right = ['value' => 1.0];
+            $right['self'] = &$right;
+            Expect::that($left)->{$method}($right);
+
+            $right['value'] = 2;
+            Expect::that($left)->not()->{$method}($right);
+            Expect::that($right)->not()->{$method}($left);
+            $right['value'] = 1;
+            Expect::that((object) ['items' => $left])->{$method}((object) ['items' => $right]);
+
+            $first = ['value' => 1];
+            $second = ['value' => 2];
+            $first['next'] = &$second;
+            $second['next'] = &$first;
+            $otherFirst = ['value' => 1.0];
+            $otherSecond = ['value' => 2.0];
+            $otherFirst['next'] = &$otherSecond;
+            $otherSecond['next'] = &$otherFirst;
+            Expect::that($first)->{$method}($otherFirst);
+
+            $shared = ['value' => 1];
+            $aliases = [&$shared, &$shared];
+            Expect::that($aliases)->{$method}([['value' => 1], ['value' => 1]]);
+
+            if ($method === 'toEqualCanonicalizing') {
+                $left = [2, 1];
+                $left[] = &$left;
+                $right = [];
+                $right[] = &$right;
+                $right[] = 1;
+                $right[] = 2;
+                Expect::that($left)->toEqualCanonicalizing($right);
+                Expect::that([$first, $second])->toEqualCanonicalizing([$otherSecond, $otherFirst]);
+                Expect::that(array_slice($left, 0, 2))->toBe([2, 1]);
+                Expect::that(array_slice($right, 1))->toBe([1, 2]);
+            }
+
+            fwrite(STDOUT, 'matched');
+            PHP,
+            $root . '/vendor/autoload.php',
+            $method,
+        ]);
+
+        Expect::that($result->exitCode)
+            ->because('cyclic array equality MUST terminate within the bounded child process')
+            ->toBe(0);
+        Expect::that($result->stdout)->toBe('matched');
+        Expect::that($result->stderr)->toBe('');
+    }
+}

--- a/tests/Unit/Expect/CyclicArrayEqualityTest.php
+++ b/tests/Unit/Expect/CyclicArrayEqualityTest.php
@@ -30,16 +30,29 @@ final class CyclicArrayEqualityTest
             use Greenlight\Expect\Expect;
 
             $method = $argv[2];
+            $compare = static function ($left, $right, bool $equal = true) use ($method): void {
+                if ($method === 'toEqualCanonicalizing') {
+                    Expect::that(static fn() => Expect::that($left)->toEqualCanonicalizing($right))
+                        ->toThrow(InvalidArgumentException::class, message:
+                            'toEqualCanonicalizing() cannot order cyclic arrays. Use toEqual() to compare them without reordering.');
+                    return;
+                }
+                $expectation = Expect::that($left);
+                if (!$equal) {
+                    $expectation->not();
+                }
+                $expectation->toEqual($right);
+            };
             $left = [];
             $left['self'] = &$left;
             $left['value'] = 1;
             $right = ['value' => 1.0];
             $right['self'] = &$right;
-            Expect::that($left)->{$method}($right);
+            $compare($left, $right);
 
             $right['value'] = 2;
-            Expect::that($left)->not()->{$method}($right);
-            Expect::that($right)->not()->{$method}($left);
+            $compare($left, $right, false);
+            $compare($right, $left, false);
             $right['value'] = 1;
             Expect::that((object) ['items' => $left])->{$method}((object) ['items' => $right]);
 
@@ -51,7 +64,23 @@ final class CyclicArrayEqualityTest
             $otherSecond = ['value' => 2.0];
             $otherFirst['next'] = &$otherSecond;
             $otherSecond['next'] = &$otherFirst;
-            Expect::that($first)->{$method}($otherFirst);
+            $compare($first, $otherFirst);
+
+            $shiftedLeft = [];
+            $shiftedLeft['next'] = ['next' => &$shiftedLeft];
+            $shiftedRight = [];
+            $shiftedRight['next'] = &$target;
+            $target = ['next' => $shiftedRight];
+            $compare($shiftedLeft, $shiftedRight);
+            $compare($shiftedRight, $shiftedLeft);
+
+            $shiftedLeft['value'] = 1;
+            $shiftedLeft['next']['value'] = 2;
+            $shiftedRight['value'] = 1;
+            $target['value'] = 3;
+            $target['next'] = $shiftedRight;
+            $compare($shiftedLeft, $shiftedRight, false);
+            $compare($shiftedRight, $shiftedLeft, false);
 
             $shared = ['value' => 1];
             $aliases = [&$shared, &$shared];
@@ -64,8 +93,9 @@ final class CyclicArrayEqualityTest
                 $right[] = &$right;
                 $right[] = 1;
                 $right[] = 2;
-                Expect::that($left)->toEqualCanonicalizing($right);
-                Expect::that([$first, $second])->toEqualCanonicalizing([$otherSecond, $otherFirst]);
+                $compare($left, $right);
+                $compare([$first, $second], [$otherSecond, $otherFirst]);
+                $compare([(object) ['items' => $first]], [(object) ['items' => $otherFirst]]);
                 Expect::that(array_slice($left, 0, 2))->toBe([2, 1]);
                 Expect::that(array_slice($right, 1))->toBe([1, 2]);
             }

--- a/tests/Unit/Expect/CyclicArrayEqualityTest.php
+++ b/tests/Unit/Expect/CyclicArrayEqualityTest.php
@@ -14,7 +14,7 @@ final class CyclicArrayEqualityTest
     #[Test]
     #[DataRow(['toEqual'], label: 'deep equality')]
     #[DataRow(['toEqualCanonicalizing'], label: 'canonical equality')]
-    public function cyclicArraysCompareWithoutExhaustingTheProcess(string $method): void
+    public function cyclicArraysFailExplicitlyWithoutExhaustingTheProcess(string $method): void
     {
         $root = \dirname(__DIR__, 3);
         $result = PhpSubprocess::run($root, [
@@ -30,75 +30,81 @@ final class CyclicArrayEqualityTest
             use Greenlight\Expect\Expect;
 
             $method = $argv[2];
-            $compare = static function ($left, $right, bool $equal = true) use ($method): void {
-                if ($method === 'toEqualCanonicalizing') {
-                    Expect::that(static fn() => Expect::that($left)->toEqualCanonicalizing($right))
-                        ->toThrow(InvalidArgumentException::class, message:
-                            'toEqualCanonicalizing() cannot order cyclic arrays. Use toEqual() to compare them without reordering.');
-                    return;
-                }
-                $expectation = Expect::that($left);
-                if (!$equal) {
-                    $expectation->not();
-                }
-                $expectation->toEqual($right);
+            $reject = static function ($left, $right) use ($method): void {
+                Expect::that(static fn() => Expect::that($left)->{$method}($right))
+                    ->toThrow(InvalidArgumentException::class, message:
+                        'Equality matchers do not support cyclic arrays. Compare selected acyclic values instead.');
             };
-            $left = [];
-            $left['self'] = &$left;
-            $left['value'] = 1;
-            $right = ['value' => 1.0];
-            $right['self'] = &$right;
-            $compare($left, $right);
+            $factories = [
+                static function (): array {
+                    $left = [];
+                    $left['self'] = &$left;
+                    $left['value'] = 1;
+                    $right = ['value' => 1];
+                    $right['self'] = &$right;
+                    return [$left, $right];
+                },
+                static function (): array {
+                    $left = [];
+                    $left['next'] = ['next' => &$left];
+                    $right = [];
+                    $right['next'] = &$target;
+                    $target = ['next' => $right];
+                    return [$left, $right];
+                },
+                static function (): array {
+                    $first = [];
+                    $second = [];
+                    $first[] = &$second;
+                    $first[] = [1];
+                    $second[] = &$first;
+                    $second[] = [2];
+                    return [[$first, $second], [$second, $first]];
+                },
+            ];
 
-            $right['value'] = 2;
-            $compare($left, $right, false);
-            $compare($right, $left, false);
-            $right['value'] = 1;
-            Expect::that((object) ['items' => $left])->{$method}((object) ['items' => $right]);
-
-            $first = ['value' => 1];
-            $second = ['value' => 2];
-            $first['next'] = &$second;
-            $second['next'] = &$first;
-            $otherFirst = ['value' => 1.0];
-            $otherSecond = ['value' => 2.0];
-            $otherFirst['next'] = &$otherSecond;
-            $otherSecond['next'] = &$otherFirst;
-            $compare($first, $otherFirst);
-
-            $shiftedLeft = [];
-            $shiftedLeft['next'] = ['next' => &$shiftedLeft];
-            $shiftedRight = [];
-            $shiftedRight['next'] = &$target;
-            $target = ['next' => $shiftedRight];
-            $compare($shiftedLeft, $shiftedRight);
-            $compare($shiftedRight, $shiftedLeft);
-
-            $shiftedLeft['value'] = 1;
-            $shiftedLeft['next']['value'] = 2;
-            $shiftedRight['value'] = 1;
-            $target['value'] = 3;
-            $target['next'] = $shiftedRight;
-            $compare($shiftedLeft, $shiftedRight, false);
-            $compare($shiftedRight, $shiftedLeft, false);
-
-            $shared = ['value' => 1];
-            $aliases = [&$shared, &$shared];
-            Expect::that($aliases)->{$method}([['value' => 1], ['value' => 1]]);
-
-            if ($method === 'toEqualCanonicalizing') {
-                $left = [2, 1];
-                $left[] = &$left;
-                $right = [];
-                $right[] = &$right;
-                $right[] = 1;
-                $right[] = 2;
-                $compare($left, $right);
-                $compare([$first, $second], [$otherSecond, $otherFirst]);
-                $compare([(object) ['items' => $first]], [(object) ['items' => $otherFirst]]);
-                Expect::that(array_slice($left, 0, 2))->toBe([2, 1]);
-                Expect::that(array_slice($right, 1))->toBe([1, 2]);
+            foreach ($factories as $make) {
+                [$left, $right] = $make();
+                $reject($left, $right);
+                $reject($right, $left);
+                $reject((object) ['items' => $left], (object) ['items' => $right]);
+                if ($method === 'toEqualCanonicalizing') {
+                    $object = (object) ['items' => $left];
+                    $reject([$object], [$object]);
+                }
             }
+
+            $shared = [2, 1];
+            $aliases = [&$shared, &$shared];
+            Expect::that($aliases)->{$method}([[2, 1], [2, 1]]);
+            Expect::that($shared)->toBe([2, 1]);
+
+            $deep = ['leaf'];
+            for ($depth = 0; $depth < 100; ++$depth) {
+                $deep = [$deep];
+            }
+            Expect::that($deep)->{$method}($deep);
+
+            $leftObject = new stdClass();
+            $leftObject->self = $leftObject;
+            $rightObject = new stdClass();
+            $rightObject->self = $rightObject;
+            Expect::that([$leftObject])->{$method}([$rightObject]);
+
+            $mixedGraph = static function (): object {
+                $array = [];
+                $node = new stdClass();
+                $array[] = $node;
+                $node->items = [&$array];
+                return (object) ['items' => [&$array]];
+            };
+            Expect::that([$mixedGraph()])->{$method}([$mixedGraph()]);
+
+            $object = new class implements Countable {
+                public function count(): int { throw new LogicException('Do not invoke user code.'); }
+                public function __serialize(): array { throw new LogicException('Do not invoke user code.'); }
+            };
+            Expect::that([$object])->{$method}([$object]);
 
             fwrite(STDOUT, 'matched');
             PHP,
@@ -107,7 +113,7 @@ final class CyclicArrayEqualityTest
         ]);
 
         Expect::that($result->exitCode)
-            ->because('cyclic array equality MUST terminate within the bounded child process')
+            ->because('cyclic array diagnostics MUST terminate within the bounded child process')
             ->toBe(0);
         Expect::that($result->stdout)->toBe('matched');
         Expect::that($result->stderr)->toBe('');


### PR DESCRIPTION
Comparing self-referential arrays with `toEqual()` or `toEqualCanonicalizing()` could exhaust the worker's memory. Existing cycle protection covered objects. Array comparison, canonicalization, and sort-key generation could follow cyclic array references without a limit. Both public matchers failed in child processes limited to 32 MB before this change.

Both matchers now report unsupported cyclic array traversal with a clear `InvalidArgumentException` and guidance to compare selected acyclic values. PHP's native recursive count detects cycles even when PHP has removed their reference wrappers. It does not invoke `Countable`, serialization, or other user hooks. Supported object cycles and shared references to acyclic arrays retain their behavior. The public PHPDoc, guide, and generated API reference state the limit.

Ordinary equality checks array subtrees after 64 consecutive array levels and reuses a successful check below that point. This preserves shallow count and early value mismatches. Canonical equality checks arrays before normalization and object sort-key generation, which already traverse their inputs. The depth threshold limits comparison recursion before the check; it does not bound the cost of the native scan.

The bounded subprocess regressions cover self and mutual cycles, shifted reference edges in both operand orders, cyclic arrays inside objects, reference wrappers that disappear after a factory returns, deep acyclic inputs, shared acyclic references, and supported object cycles. Independent compatibility probes checked 31 cases without changed results or input mutation.

The guard adds a measured cost. Nine warmed baseline/candidate process pairs on PHP 8.4.14, arm64, with extensions and JIT disabled measured equal flat arrays about 9 to 11% slower. A shallow 10,000-element early mismatch changed from 0.241 to 0.263 microseconds. A shared array graph with 18 duplicated-reference levels below 64 array wrappers changed from 12.081 microseconds to 4.719 milliseconds for an early mismatch. Native traversal revisits shared paths, so compact, deeply nested shared graphs can expand the scan cost. Canonical object-cycle comparison changed from 2.813 to 4.209 microseconds; the other measured canonical cases stayed within 3% of baseline. This change prevents fatal recursion on the reproduced cyclic inputs; it is not a performance improvement.
