### PR TITLE
chore(docs): reject newlines in example names

### DIFF
--- a/src/Documentation/PhpExample/Extractor.php
+++ b/src/Documentation/PhpExample/Extractor.php
@@ -295,7 +295,7 @@ final readonly class Extractor
 
     private function validateExample(string $example, string $path, int $openingIndex): void
     {
-        if (\preg_match('/^[a-z0-9][a-z0-9._-]*$/', $example) !== 1) {
+        if (\preg_match('/^[a-z0-9][a-z0-9._-]*$/D', $example) !== 1) {
             throw DocumentationExampleError::invalidExampleName($path, $openingIndex, $example);
         }
     }

--- a/tests/Acceptance/DocsPhpCheckTest.php
+++ b/tests/Acceptance/DocsPhpCheckTest.php
@@ -287,6 +287,29 @@ final readonly class DocsPhpCheckTest
         );
     }
 
+    #[Test]
+    public function rejectsATrailingNewlineInAnExampleNameBeforeWritingFiles(): void
+    {
+        $project = $this->project('example-name-newline');
+        $project->write('docs/example.md', <<<'MARKDOWN'
+            <!-- php-example {"example":"example\n","file":"example.php","mode":"file","tools":[]} -->
+            ```php
+            return true;
+            ```
+            MARKDOWN);
+
+        $result = $this->run($project, 'extract');
+
+        Expect::that($result->exitCode)
+            ->because('example names must reject characters outside the documented slug alphabet')
+            ->toBe(1);
+        Expect::that($result->stderr)
+            ->toContain('must contain lowercase letters, digits, dots, underscores, or hyphens.');
+        Expect::that(\file_exists($project->path("build/docs-php/example\n/example.php")))
+            ->because('invalid metadata must not create a generated example file')
+            ->toBeFalse();
+    }
+
     private function project(string $name): ProjectFiles
     {
         return ProjectFiles::create($this->tempDirectory, $name . '/project');


### PR DESCRIPTION
The PHP example extractor accepts a trailing newline in the JSON `example` name. Its regular expression uses `$`, which also matches before a final newline. The decoded name then becomes part of the generated directory path, so extraction succeeds and creates a directory outside the documented name alphabet.

Require the regular expression to reach the actual end of the name. The new acceptance case fails before the fix because extraction returns success. It now checks the failure diagnostic and confirms that no example file is written under the invalid name. All nine documentation-tool acceptance tests pass with 29 expectations. Valid example names retain their existing behavior.
