### PR TITLE
fix(phpstan): honor explicit null data attribute arguments

### DIFF
--- a/src/PhpStan/DataProviderSignatureRule.php
+++ b/src/PhpStan/DataProviderSignatureRule.php
@@ -98,7 +98,7 @@ final readonly class DataProviderSignatureRule implements Rule
                 $labels = $labelType?->getConstantStrings() ?? [];
                 $key = \count($labels) === 1
                     ? $labels[0]->getValue()
-                    : ($labelType === null || $labelType->isNull()->yes() ? \sprintf('#%d', $position) : null);
+                    : (!$labelType instanceof Type || $labelType->isNull()->yes() ? \sprintf('#%d', $position) : null);
 
                 if ($key !== null && isset($keys[$key])) {
                     $errors[] = $this->error(

--- a/src/PhpStan/DataProviderSignatureRule.php
+++ b/src/PhpStan/DataProviderSignatureRule.php
@@ -94,12 +94,11 @@ final readonly class DataProviderSignatureRule implements Rule
                 }
 
                 $label = $this->attributeArgument($attribute, 1, 'label');
-                $labels = $label instanceof Node\Expr
-                    ? $scope->getType($label)->getConstantStrings()
-                    : [];
+                $labelType = $label instanceof Node\Expr ? $scope->getType($label) : null;
+                $labels = $labelType?->getConstantStrings() ?? [];
                 $key = \count($labels) === 1
                     ? $labels[0]->getValue()
-                    : ($label instanceof Node\Expr ? null : \sprintf('#%d', $position));
+                    : ($labelType === null || $labelType->isNull()->yes() ? \sprintf('#%d', $position) : null);
 
                 if ($key !== null && isset($keys[$key])) {
                     $errors[] = $this->error(
@@ -171,7 +170,7 @@ final readonly class DataProviderSignatureRule implements Rule
 
         $providerClass = $class;
 
-        if ($methodExpression instanceof Node\Expr) {
+        if ($methodExpression instanceof Node\Expr && !$scope->getType($methodExpression)->isNull()->yes()) {
             $providerClasses = $scope->getType($providerExpression)->getConstantStrings();
 
             if (\count($providerClasses) !== 1) {

--- a/tests/Acceptance/PhpStanDataRowNullLabelTest.php
+++ b/tests/Acceptance/PhpStanDataRowNullLabelTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\PhpStanProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class PhpStanDataRowNullLabelTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function explicitNullLabelsUsePositionKeysForDuplicateChecks(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace GreenlightNullRowLabelProbe;
+
+            use Greenlight\Attribute\DataRow;
+            use Greenlight\Attribute\Test;
+
+            final class GoodNullRowLabelProbe
+            {
+                private const POSITION_LABEL = null;
+
+                #[Test]
+                #[DataRow([1], null)]
+                #[DataRow(label: null, arguments: [2])]
+                #[DataRow([3], self::POSITION_LABEL)]
+                public function uniquePositions(int $value): void
+                {
+                    echo $value;
+                }
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace GreenlightNullRowLabelProbe;
+
+            use Greenlight\Attribute\DataRow;
+            use Greenlight\Attribute\Test;
+
+            final class BadNullRowLabelProbe
+            {
+                private const POSITION_LABEL = null;
+
+                #[Test]
+                #[DataRow([1], null)]
+                #[DataRow([2], '#0')]
+                public function positionalNull(int $value): void
+                {
+                    echo $value;
+                }
+
+                #[Test]
+                #[DataRow([1], '#1')]
+                #[DataRow(label: null, arguments: [2])]
+                public function namedNull(int $value): void
+                {
+                    echo $value;
+                }
+
+                #[Test]
+                #[DataRow([1], self::POSITION_LABEL)]
+                #[DataRow([2], '#0')]
+                public function constantNull(int $value): void
+                {
+                    echo $value;
+                }
+            }
+            PHP,
+        );
+
+        Expect::that($probe->goodErrors)->toBe([]);
+        Expect::that($probe->exitCode)->toBe(1);
+        Expect::that($probe->errors)->toBe([
+            '#[DataRow] key "#0" occurs more than once on positionalNull().',
+            '#[DataRow] key "#1" occurs more than once on namedNull().',
+            '#[DataRow] key "#0" occurs more than once on constantNull().',
+        ]);
+    }
+}

--- a/tests/Acceptance/PhpStanDataSetNullMethodTest.php
+++ b/tests/Acceptance/PhpStanDataSetNullMethodTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Acceptance;
+
+use Greenlight\Attribute\RequiresResource;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\Sandbox\TemporaryDirectory;
+use Greenlight\Tests\Support\PhpStanProbe;
+
+#[RequiresResource('analysis-process')]
+final readonly class PhpStanDataSetNullMethodTest
+{
+    public function __construct(private TemporaryDirectory $tempDirectory) {}
+
+    #[Test]
+    public function explicitNullMethodsSelectAndValidateLocalProviders(): void
+    {
+        $probe = PhpStanProbe::analyze(
+            $this->tempDirectory,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace GreenlightNullProviderMethodProbe;
+
+            use Greenlight\Attribute\DataSet;
+            use Greenlight\Attribute\Test;
+
+            final class GoodNullProviderMethodProbe
+            {
+                private const LOCAL_METHOD = null;
+
+                #[Test]
+                #[DataSet('rows', null)]
+                public function positionalNull(int $value): void
+                {
+                    echo $value;
+                }
+
+                #[Test]
+                #[DataSet(method: null, provider: 'rows')]
+                public function namedNull(int $value): void
+                {
+                    echo $value;
+                }
+
+                #[Test]
+                #[DataSet('rows', self::LOCAL_METHOD)]
+                public function constantNull(int $value): void
+                {
+                    echo $value;
+                }
+
+                /** @return array{array{int}} */
+                public static function rows(): array
+                {
+                    return [[1]];
+                }
+            }
+            PHP,
+            <<<'PHP'
+            <?php
+
+            declare(strict_types=1);
+
+            namespace GreenlightNullProviderMethodProbe;
+
+            use Greenlight\Attribute\DataSet;
+            use Greenlight\Attribute\Test;
+
+            final class BadNullProviderMethodProbe
+            {
+                #[Test]
+                #[DataSet('rows', method: null)]
+                public function incompatibleRow(string $value): void
+                {
+                    echo $value;
+                }
+
+                /** @return array{array{int}} */
+                public static function rows(): array
+                {
+                    return [[1]];
+                }
+            }
+            PHP,
+        );
+
+        Expect::that($probe->goodErrors)->toBe([]);
+        Expect::that($probe->exitCode)->toBe(1);
+        Expect::that($probe->errors)->toBe([
+            'Data provider rows() row argument #1 for incompatibleRow() has type int, but the parameter requires string.',
+        ]);
+    }
+}


### PR DESCRIPTION
PHPStan treated an explicit `null` argument differently from an omitted argument in data attributes. `#[DataSet('rows', method: null)]` selects a local provider at runtime, but analysis reported that the provider class `rows` did not exist. `#[DataRow([1], label: null)]` generates a position key at runtime, but analysis skipped that key and missed collisions with an explicit label such as `#0`.

Use the resolved null type for both defaults. Local providers still receive signature checks, and generated row keys still participate in duplicate checks. External provider methods and explicit string labels keep their current behavior.

Both regression cases failed before their fixes. The five related acceptance tests now pass with 32 expectations, including positional, named and constant-null arguments, a rejected local provider row type, and collisions in both declaration orders. Full Composer static analysis and the full suite pass: 3,599 tests, 3,580 passed, 19 optional skips, and 9,197 expectations. The documentation check also passes, including 36 pages and 10 browser checks.
