### PR TITLE
test(fixtures): verify complete graph validation precedes provisioning

### DIFF
--- a/tests/Unit/IntegrationFixture/IntegrationFixtureGraphValidationTest.php
+++ b/tests/Unit/IntegrationFixture/IntegrationFixtureGraphValidationTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Greenlight\Tests\Unit\IntegrationFixture;
+
+use Greenlight\Attribute\DataSet;
+use Greenlight\Attribute\Test;
+use Greenlight\Expect\Expect;
+use Greenlight\IntegrationFixture\IntegrationFixtureContext;
+use Greenlight\IntegrationFixture\IntegrationFixtureDefinition;
+use Greenlight\IntegrationFixture\IntegrationFixtureError;
+use Greenlight\IntegrationFixture\IntegrationFixtureManager;
+
+final readonly class IntegrationFixtureGraphValidationTest
+{
+    /** @param list<array{string, list<string>}> $invalidGraph */
+    #[Test]
+    #[DataSet('invalidGraphs')]
+    public function aLaterInvalidDefinitionPreventsEveryProvisionerFromRunning(array $invalidGraph, string $message): void
+    {
+        $trace = [];
+        $provision = static function (IntegrationFixtureContext $context) use (&$trace): void {
+            $trace[] = 'acquired';
+            $context->defer(static function () use (&$trace): void {
+                $trace[] = 'released';
+            });
+        };
+        $definitions = [new IntegrationFixtureDefinition('ready', $provision)];
+
+        foreach ($invalidGraph as [$id, $dependencies]) {
+            $definitions[] = new IntegrationFixtureDefinition($id, $provision, $dependencies);
+        }
+
+        Expect::that(static fn() => IntegrationFixtureManager::provision(
+            $definitions,
+            'invalid-graph',
+            1,
+            1,
+            null,
+        ))->toThrow(IntegrationFixtureError::class, message: $message);
+
+        Expect::that($trace)
+            ->because('the complete graph must be valid before any fixture acquires resources')
+            ->toBe([]);
+    }
+
+    /** @return iterable<string, array{list<array{string, list<string>}>, string}> */
+    public static function invalidGraphs(): iterable
+    {
+        yield 'missing dependency after a valid fixture' => [
+            [['database', ['network']]],
+            'Integration fixture "database" depends on missing fixture "network".',
+        ];
+        yield 'cycle after a valid fixture' => [
+            [['database', ['network']], ['network', ['database']]],
+            'Integration fixture dependency cycle: database -> network -> database.',
+        ];
+        yield 'duplicate after a valid fixture' => [
+            [['database', []], ['database', []]],
+            'Integration fixture "database" is declared more than once.',
+        ];
+    }
+}


### PR DESCRIPTION
The fixture contract requires Greenlight to validate the complete dependency graph before it acquires any resources. Existing missing-dependency, cycle, and duplicate-definition tests only assert the error. Their empty provisioners cannot detect resource acquisition before validation finishes.

Add a valid fixture before each invalid part of the graph and record every acquisition and cleanup. The cases require the expected graph diagnostic and an empty trace. This catches partial provisioning even if cleanup later releases the resource. A temporary mutation that validates and yields one graph root at a time fails both the missing-dependency and cycle cases with an unexpected acquisition; the normal implementation passes all three cases. No production code changes.
