### PR TITLE
test(support): assert complete subprocess output payloads

### DIFF
--- a/tests/Unit/Support/SubprocessTest.php
+++ b/tests/Unit/Support/SubprocessTest.php
@@ -63,8 +63,13 @@ final readonly class SubprocessTest
             ],
         );
 
-        Expect::that($result->stdout)->because('run drains large outputs from both streams')->toHaveLength(131072);
-        Expect::that($result->stderr)->toHaveLength(131072);
+        Expect::that($result->exitCode)->toBe(0);
+        Expect::that($result->stdout)
+            ->because('large stdout MUST preserve every byte in the correct stream')
+            ->toBe(\str_repeat('o', 131072));
+        Expect::that($result->stderr)
+            ->because('large stderr MUST preserve every byte in the correct stream')
+            ->toBe(\str_repeat('e', 131072));
     }
 
     #[Test]


### PR DESCRIPTION
The large-output subprocess test checked only stdout and stderr lengths. Both fixtures have the same length, so swapped or corrupted bytes could pass while acceptance tests received incorrect process output.

Assert the complete, distinct payload in each stream and the successful exit status. A temporary capture mutation changed every `o` byte in stdout to `e` and every `e` byte in stderr to `o`: the former length assertions passed, and the exact payload assertions failed. The mutation was then removed.
