### PR TITLE
test(expect): restore extensions after snapshot checks

### DIFF
--- a/tests/Unit/Expect/ExpectTest.php
+++ b/tests/Unit/Expect/ExpectTest.php
@@ -58,7 +58,7 @@ final readonly class ExpectTest
     #[Test]
     public function chainsCreatedBeforeAnInstallKeepTheirExtensions(): void
     {
-        Expect::install([new EvenNumbersExtension()]);
+        $this->cleanup->defer(Expect::install([new EvenNumbersExtension()]));
         $chain = Expect::that(4);
         Expect::install([]);
 
@@ -72,6 +72,7 @@ final readonly class ExpectTest
     public function installReturnsCleanupThatRestoresThePreviousExtensions(): void
     {
         $restoreEmpty = Expect::install([new EvenNumbersExtension()]);
+        $this->cleanup->defer($restoreEmpty);
         $restoreEvenNumbers = Expect::install([]);
 
         $restoreEvenNumbers();


### PR DESCRIPTION
The extension snapshot test discards the previously installed matcher list. It leaves an empty list after completion, which removes matchers that were present before the test. The restoration test also lacks fallback cleanup if an intermediate operation fails.

Register the original restoration callbacks with the existing per-test `Cleanup` service before either test changes the list again. All existing assertions stay intact. A local reproduction that installs `PositiveNumbersExtension`, runs the snapshot test, and closes its cleanup loses `toBePositive()` on the original test and preserves it with this change. The existing seven `ExpectTest` cases still pass.
